### PR TITLE
added parallels desktop

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -203,6 +203,16 @@ longversion)
     ;;
 
 # label descriptions start here
+
+# TODO: parallels installation process needs testing
+# parallels)
+#     # credit: Alexander Duffner (@aduffner)
+#     name="Parallels Desktop"
+#     type="dmg"
+#     downloadURL="https://parallels.com/directdownload/pd15/"
+#     expectedTeamID="4C6364ACXT"
+#     ;;
+
 autodmg)
     # credit: Mischa van der Bent (@mischavdbent)
     name="AutoDMG"


### PR DESCRIPTION
Added the label "parallels" for Parallels Desktop (business edition) in version 15 (downloads the latest of version 15) - could add some logic to find out if 16 exists or greater