### PR TITLE
Dont download pkg if we are set to silent_fail and there is blockingprocess

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3228,6 +3228,15 @@ fi
 if [ -f "$archiveName" ] && [ "$DEBUG" -ne 0 ]; then
     printlog "$archiveName exists and DEBUG enabled, skipping download"
 else
+    # check for blocking process and exit if we are instructed to silent_fail (prevents excess download)
+    if [[ $BLOCKING_PROCESS_ACTION == "silent_fail" ]]; then
+        if [[ ${#blockingProcesses} -gt 0 ]]; then
+            if [[ ${blockingProcesses[1]} != "NONE" ]]; then
+                checkRunningProcesses
+            fi
+        fi
+    fi
+
     # download the dmg
     printlog "Downloading $downloadURL to $archiveName"
     if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then


### PR DESCRIPTION
Fixes issue where installomator will repeatedly download the pkg each run when set to silent_fail and a blockingprocess is present.