### PR TITLE
Changed Sparkle URL for 'sourcetree'

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2444,10 +2444,10 @@ sonoss2)
 sourcetree)
     name="Sourcetree"
     type="zip"
-    downloadURL=$(curl -fs https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastAlpha.xml \
+    downloadURL=$(curl -fs https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastGroup0.xml \
         | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null \
         | cut -d '"' -f 2 )
-    appNewVersion=$(curl -fs https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastAlpha.xml | xpath '//rss/channel/item[last()]/title' 2>/dev/null | sed -n -e 's/^.*Version //p' | sed 's/\<\/title\>//' | sed $'s/[^[:print:]\t]//g')
+    appNewVersion=$(curl -fs https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastGroup0.xml | xpath '//rss/channel/item[last()]/title' 2>/dev/null | sed -n -e 's/^.*Version //p' | sed 's/\<\/title\>//' | sed $'s/[^[:print:]\t]//g')
     expectedTeamID="UPXU4CQZ5P"
     ;;
 spotify)


### PR DESCRIPTION
`https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastAlpha.xml` no longer includes the latest versions of Sourcetree.
Changed `downloadURL` and `appNewVersion` to `https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcastGroup0.xml` instead.

Fixes issue #159