### PR TITLE
Fixed 'webexmeetings' URL

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2714,8 +2714,8 @@ vscodium)
 webexmeetings)
     # credit: Erik Stam (@erikstam)
     name="Cisco Webex Meetings"
-    type="pkgInDmg"
-    downloadURL="https://akamaicdn.webex.com/client/webexapp.dmg"
+    type="pkg"
+    downloadURL="https://akamaicdn.webex.com/client/Cisco_Webex_Meetings.pkg"
     expectedTeamID="DE8Y96K9QP"
     targetDir="/Applications"
     #blockingProcessesMaxCPU="5"


### PR DESCRIPTION
The URL for `webexmeetings` appears to have changed yet another time.
Good thing: The downloaded `pkg` contains the versions for Intel and Apple Silicon at the same time. So no additional URL required :-)