### PR TITLE
Support Google software update

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1575,6 +1575,14 @@ googlejapaneseinput)
     blockingProcesses=( NONE )
     expectedTeamID="EQHXZ8M8AV"
     ;;
+googlesoftwareupdate)
+    name="Install Google Software Update"
+    type="pkgInDmg"
+    pkgName="Install Google Software Update.app/Contents/Resources/GSUInstall.pkg"
+    downloadURL="https://dl.google.com/mac/install/googlesoftwareupdate.dmg"
+    blockingProcesses=( NONE )
+    expectedTeamID="EQHXZ8M8AV"
+    ;;
 gotomeeting)
     # credit: @matins
     name="GoToMeeting"

--- a/Labels.txt
+++ b/Labels.txt
@@ -87,6 +87,7 @@ googledrivebackupandsync
 googledrivefilestream
 googleearth
 googlejapaneseinput
+googlesoftwareupdate
 gotomeeting
 gpgsuite
 gpgsync


### PR DESCRIPTION
Some kind of error may cause Google Chrome to have an error with the update.
In that case, https://support.google.com/chrome/answer/111996 states that installing the Google software update may solve the problem.

Therefore, I thought it would be beneficial for everyone to support the Google software update, so I created this PR.