### PR TITLE
Support variables from script caller

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -20,10 +20,10 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # set to 0 for production, 1 for debugging
 # while debugging, items will be downloaded to the parent directory of this script
 # also no actual installation will be performed
-DEBUG=1
+DEBUG="${DEBUG:-1}"
 
 # notify behavior
-NOTIFY=success
+NOTIFY="${NOTIFY:-success}"
 # options:
 #   - success      notify the user on success
 #   - silent       no notifications
@@ -31,7 +31,7 @@ NOTIFY=success
 
 
 # behavior when blocking processes are found
-BLOCKING_PROCESS_ACTION=prompt_user
+BLOCKING_PROCESS_ACTION="${BLOCKING_PROCESS_ACTION:-prompt_user}"
 # options:
 #   - ignore       continue even when blocking processes are found
 #   - silent_fail  exit script without prompt or installation
@@ -55,7 +55,7 @@ BLOCKING_PROCESS_ACTION=prompt_user
 
 
 # logo-icon used in dialog boxes if app is blocking
-LOGO=appstore
+LOGO="${LOGO:-appstore}"
 # options:
 #   - appstore      Icon is Apple App Store (default)
 #   - jamf          JAMF Pro
@@ -66,7 +66,7 @@ LOGO=appstore
 
 
 # install behavior
-INSTALL=""
+INSTALL="${INSTALL}"
 # options:
 #  -               When not set, software will only be installed
 #                  if it is newer/different in version
@@ -74,7 +74,7 @@ INSTALL=""
 
 
 # Re-opening of closed app
-REOPEN="yes"
+REOPEN="${REOPEN:-yes}"
 # options:
 #  - yes           App wil be reopened if it was closed
 #  - no            App not reopened

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ When used to install software, Installomator has a single argument: the label or
 
 ```
 ./Installomator.sh firefox
-./Installomator.sh firefox LOGO=jamf BLOCKING_PROCESS_ACTION=tell_user_then_kill NOTIFY=all
+LOGO=jamf BLOCKING_PROCESS_ACTION=tell_user_then_kill NOTIFY=all ./Installomator.sh firefox
 ```
 
 There is a debug mode and one other setting that can be controlled with variables in the code. This simplifies the actual use of the script from within a management system.
@@ -167,7 +167,7 @@ The argument can be `version` or `longversion` which will print the script's ver
 Other than the version arguments, the argument can be any of the labels listed in the Labels.txt file. Each of the labels will download and install the latest version of the application, or suite of applications. Since the script will have to run the `installer` command or copy the application to the `/Applications` folder, it will have to be run as root.
 
 ```
-> sudo ./Installomator.sh desktoppr DEBUG=0
+> DEBUG=0 sudo ./Installomator.sh desktoppr
 ```
 
 (Since Jamf Pro always provides the mount point, computer name, and user name as the first three arguments for policy scripts, the script will use argument `$4` when there are more than three arguments.)
@@ -364,14 +364,14 @@ Depending on the application or pkg there are a few more variables you can or ne
   e.g. `msupdate` (see microsoft installations)
 
 - `updateToolRunAsCurrentUser`:
-  When this variable is set (any value), `$updateTool` will be run as the current user. Default is unset and 
+  When this variable is set (any value), `$updateTool` will be run as the current user. Default is unset and
 
 ### Configuration from Arguments
 
 You can provide a configuration variable, such as `DEBUG` or `NOTIFY` as an argument in the form `VAR=value`. For example:
 
 ```
-./Installomator.sh desktoppr DEBUG=0 NOTIFY=silent
+DEBUG=0 NOTIFY=silent ./Installomator.sh desktoppr
 ```
 
 Providing variables this way will override any variables set in the script.
@@ -379,7 +379,7 @@ Providing variables this way will override any variables set in the script.
 You can even provide _all_ the variables necessary for download and installation. Of course, without a label the argument parsing will fail, so I created a special label `valuesfromarguments` which only checks if the four required values are present:
 
 ```
-./Installomator.sh name=desktoppr type=pkg downloadURL=https://github.com/scriptingosx/desktoppr/releases/download/v0.3/desktoppr-0.3.pkg expectedTeamID=JME5BW3F3R valuesfromarguments
+name=desktoppr type=pkg downloadURL=https://github.com/scriptingosx/desktoppr/releases/download/v0.3/desktoppr-0.3.pkg expectedTeamID=JME5BW3F3R ./Installomator.sh valuesfromarguments
 ```
 
 The order of the variables and label is not relevant. But, when you provide more than one label, all but the _last_ label will be ignored.


### PR DESCRIPTION
According to the readme, you define a global variable like 

```sh
./Installomator.sh firefox LOGO=jamf BLOCKING_PROCESS_ACTION=tell_user_then_kill NOTIFY=all
```

and call the script.

However, in practice, this does not work as expected.

This is because the variables are overwritten inside the script.

Assuming the readme is correct, I made it so that we can set some global variables when calling the script.

And, 

```sh
./Installomator.sh firefox LOGO=jamf BLOCKING_PROCESS_ACTION=tell_user_then_kill NOTIFY=all
```

 is not recognized correctly as a shell variable.
Therefore, I changed this project readme description to recognize variables correctly like 

```sh
LOGO=jamf BLOCKING_PROCESS_ACTION=tell_user_then_kill NOTIFY=all ./Installomator.sh firefox
```

