### PR TITLE
Added 'webex' to 'webexteams'

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2714,8 +2714,8 @@ vscodium)
 webexmeetings)
     # credit: Erik Stam (@erikstam)
     name="Cisco Webex Meetings"
-    type="pkgInDmg"
-    downloadURL="https://akamaicdn.webex.com/client/webexapp.dmg"
+    type="pkg"
+    downloadURL="https://akamaicdn.webex.com/client/Cisco_Webex_Meetings.pkg"
     expectedTeamID="DE8Y96K9QP"
     targetDir="/Applications"
     #blockingProcessesMaxCPU="5"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2714,13 +2714,14 @@ vscodium)
 webexmeetings)
     # credit: Erik Stam (@erikstam)
     name="Cisco Webex Meetings"
-    type="pkg"
-    downloadURL="https://akamaicdn.webex.com/client/Cisco_Webex_Meetings.pkg"
+    type="pkgInDmg"
+    downloadURL="https://akamaicdn.webex.com/client/webexapp.dmg"
     expectedTeamID="DE8Y96K9QP"
     targetDir="/Applications"
     #blockingProcessesMaxCPU="5"
     blockingProcesses=( Webex )
     ;;
+webex|\
 webexteams)
     # credit: Erik Stam (@erikstam)
     name="Webex"


### PR DESCRIPTION
Replaces #192.
Added `webex` as Label to `webexteams`, since those are identical.

NOTE: As of a reply I got from Cisco support, Cisco is consolidating "Cisco Webex Meetings" and "Cisco Webex Teams" into just "Webex".
The download of the Apple Silicon version of Webex Meetings does not work reliably (fails most of the time). So I will no longer consider this one.