### PR TITLE
Changed 'aldente' to 'dmg'

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -920,7 +920,7 @@ airserver)
     ;;
 aldente)
     name="AlDente"
-    type="zip"
+    type="dmg"
     downloadURL=$(downloadURLFromGit davidwernhart AlDente)
     appNewVersion=$(versionFromGit davidwernhart AlDente)
     expectedTeamID="3WVC84GB99"


### PR DESCRIPTION
AlDente does now ship as DMG.

```
 $ sudo zsh Installomator.zsh aldente DEBUG=0
2021-07-12 10:57:30 aldente setting variable from argument DEBUG=0
2021-07-12 10:57:30 aldente ################## Start Installomator v. 0.5.0
2021-07-12 10:57:30 aldente ################## aldente
2021-07-12 10:57:31 aldente BLOCKING_PROCESS_ACTION=prompt_user
2021-07-12 10:57:31 aldente NOTIFY=success
2021-07-12 10:57:31 aldente LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-07-12 10:57:31 aldente no blocking processes defined, using AlDente as default
2021-07-12 10:57:31 aldente Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.kyHKEwRH
2021-07-12 10:57:31 aldente found app at /Applications/AlDente.app, version 2.2
2021-07-12 10:57:31 aldente appversion: 2.2
2021-07-12 10:57:31 aldente Latest version of AlDente is 1.04
2021-07-12 10:57:31 aldente Downloading https://github.com/davidwernhart/AlDente/releases/download/1.04/AlDente_1.04.dmg to AlDente.dmg
2021-07-12 10:57:32 aldente no more blocking processes, continue with update
2021-07-12 10:57:32 aldente Installing AlDente
2021-07-12 10:57:32 aldente Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.kyHKEwRH/AlDente.dmg
2021-07-12 10:57:35 aldente Mounted: /Volumes/AlDente
2021-07-12 10:57:35 aldente Verifying: /Volumes/AlDente/AlDente.app
2021-07-12 10:57:39 aldente Team ID matching: 3WVC84GB99 (expected: 3WVC84GB99 )
2021-07-12 10:57:39 aldente Downloaded version of AlDente is 1.04 (replacing version 2.2).
2021-07-12 10:57:39 aldente Removing existing /Applications/AlDente.app
2021-07-12 10:57:39 aldente Copy /Volumes/AlDente/AlDente.app to /Applications
2021-07-12 10:57:39 aldente Changing owner to buehler
2021-07-12 10:57:39 aldente Finishing…
2021-07-12 10:57:49 aldente found app at /Applications/AlDente.app, version 1.04
2021-07-12 10:57:49 aldente Installed AlDente, version 1.04
2021-07-12 10:57:49 aldente notifying
2021-07-12 10:57:50 aldente Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.kyHKEwRH
2021-07-12 10:57:50 aldente Unmounting /Volumes/AlDente
"disk4" ejected.
2021-07-12 10:57:50 aldente App not closed, so no reopen.
2021-07-12 10:57:50 aldente ################## End Installomator, exit code 0
```