### PR TITLE
Add JetBrains DataGrip

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1878,6 +1878,18 @@ jamfreenroller)
     #appNewVersion=$(versionFromGit jamf ReEnroller)
     expectedTeamID="PS2F6S478M"
     ;;
+jetbrainsdatagrip)
+    # credit: AP Orlebeke (@apizz)
+    name="DataGrip"
+    type="dmg"
+    appNewVersion=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release" | grep -o 'version*.*,' | cut -d '"' -f3)
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release" | grep -o 'macM1*.*,' | cut -d '"' -f5)
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fs "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release" | grep -o 'mac*.*,' | cut -d '"' -f5)
+    fi
+    expectedTeamID="2ZEFAR8TH3"
+    ;;
 jetbrainsintellijidea)
     # credit: Gabe Marchan (gabemarchan.com - @darklink87)
     name="IntelliJ IDEA"


### PR DESCRIPTION
Successful output from DEBUG run for Intel:

```
~/Doc/g/help-device-provisioning main *1 > zsh ~/Downloads/installomator.sh jetbrainsdatagrip 11:54:10
2021-07-23 11:54:28 jetbrainsdatagrip ################## Start Installomator v. 0.6.0
2021-07-23 11:54:28 jetbrainsdatagrip ################## jetbrainsdatagrip
2021-07-23 11:54:30 jetbrainsdatagrip BLOCKING_PROCESS_ACTION=prompt_user
2021-07-23 11:54:30 jetbrainsdatagrip NOTIFY=success
2021-07-23 11:54:30 jetbrainsdatagrip LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-07-23 11:54:30 jetbrainsdatagrip no blocking processes defined, using DataGrip as default
2021-07-23 11:54:30 jetbrainsdatagrip Changing directory to /Users/testuser/Downloads
2021-07-23 11:54:30 jetbrainsdatagrip App(s) found: 
2021-07-23 11:54:30 jetbrainsdatagrip could not find DataGrip.app
2021-07-23 11:54:30 jetbrainsdatagrip appversion: 
2021-07-23 11:54:30 jetbrainsdatagrip Latest version of DataGrip is 2021.1.3
2021-07-23 11:54:30 jetbrainsdatagrip Downloading https://download.jetbrains.com/datagrip/datagrip-2021.1.3.dmg to DataGrip.dmg
2021-07-23 11:54:38 jetbrainsdatagrip DEBUG mode, not checking for blocking processes
2021-07-23 11:54:38 jetbrainsdatagrip Installing DataGrip
2021-07-23 11:54:38 jetbrainsdatagrip Mounting /Users/testuser/Downloads/DataGrip.dmg
2021-07-23 11:54:41 jetbrainsdatagrip Mounted: /Volumes/DataGrip
2021-07-23 11:54:41 jetbrainsdatagrip Verifying: /Volumes/DataGrip/DataGrip.app
2021-07-23 11:54:48 jetbrainsdatagrip Team ID matching: 2ZEFAR8TH3 (expected: 2ZEFAR8TH3 )
2021-07-23 11:54:48 jetbrainsdatagrip Downloaded version of DataGrip is 2021.1.3 (replacing version ).
2021-07-23 11:54:49 jetbrainsdatagrip DEBUG enabled, skipping remove, copy and chown steps
2021-07-23 11:54:49 jetbrainsdatagrip Finishing…
2021-07-23 11:54:59 jetbrainsdatagrip App(s) found: 
2021-07-23 11:54:59 jetbrainsdatagrip could not find DataGrip.app
2021-07-23 11:54:59 jetbrainsdatagrip Installed DataGrip
2021-07-23 11:54:59 jetbrainsdatagrip notifying
2021-07-23 11:55:00 jetbrainsdatagrip Unmounting /Volumes/DataGrip
"disk2" ejected.
2021-07-23 11:55:01 jetbrainsdatagrip DEBUG mode, not reopening anything
2021-07-23 11:55:01 jetbrainsdatagrip ################## End Installomator, exit code 0 
```

Successful output from DEBUG run from Apple Silicon:
```
~/Doc/g/help-device-provisioning main *1 > zsh ~/Downloads/installomator.sh jetbrainsdatagrip
2021-07-23 11:59:41 jetbrainsdatagrip ################## Start Installomator v. 0.6.0
2021-07-23 11:59:41 jetbrainsdatagrip ################## jetbrainsdatagrip
2021-07-23 11:59:43 jetbrainsdatagrip BLOCKING_PROCESS_ACTION=prompt_user
2021-07-23 11:59:43 jetbrainsdatagrip NOTIFY=success
2021-07-23 11:59:43 jetbrainsdatagrip LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-07-23 11:59:43 jetbrainsdatagrip no blocking processes defined, using DataGrip as default
2021-07-23 11:59:43 jetbrainsdatagrip Changing directory to /Users/testuser/Downloads
2021-07-23 11:59:43 jetbrainsdatagrip App(s) found: 
2021-07-23 11:59:43 jetbrainsdatagrip could not find DataGrip.app
2021-07-23 11:59:43 jetbrainsdatagrip appversion: 
2021-07-23 11:59:43 jetbrainsdatagrip Latest version of DataGrip is 2021.1.3
2021-07-23 11:59:43 jetbrainsdatagrip Downloading https://download.jetbrains.com/datagrip/datagrip-2021.1.3-aarch64.dmg to DataGrip.dmg
2021-07-23 11:59:52 jetbrainsdatagrip DEBUG mode, not checking for blocking processes
2021-07-23 11:59:52 jetbrainsdatagrip Installing DataGrip
2021-07-23 11:59:52 jetbrainsdatagrip Mounting /Users/testuser/Downloads/DataGrip.dmg
2021-07-23 11:59:56 jetbrainsdatagrip Mounted: /Volumes/DataGrip 1
2021-07-23 11:59:56 jetbrainsdatagrip Verifying: /Volumes/DataGrip 1/DataGrip.app
2021-07-23 12:00:03 jetbrainsdatagrip Team ID matching: 2ZEFAR8TH3 (expected: 2ZEFAR8TH3 )
2021-07-23 12:00:03 jetbrainsdatagrip Downloaded version of DataGrip is 2021.1.3 (replacing version ).
2021-07-23 12:00:03 jetbrainsdatagrip DEBUG enabled, skipping remove, copy and chown steps
2021-07-23 12:00:03 jetbrainsdatagrip Finishing…
2021-07-23 12:00:14 jetbrainsdatagrip App(s) found: 
2021-07-23 12:00:14 jetbrainsdatagrip could not find DataGrip.app
2021-07-23 12:00:14 jetbrainsdatagrip Installed DataGrip
2021-07-23 12:00:14 jetbrainsdatagrip notifying
2021-07-23 12:00:14 jetbrainsdatagrip Unmounting /Volumes/DataGrip 1
"disk3" ejected.
2021-07-23 12:00:14 jetbrainsdatagrip DEBUG mode, not reopening anything
2021-07-23 12:00:14 jetbrainsdatagrip ################## End Installomator, exit code 0
```