### PR TITLE
Add ScreenCloud Player

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2489,6 +2489,13 @@ screamingfrogseospider)
     downloadURL="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.3.dmg"
     expectedTeamID="CAHEVC3HZC"
     ;;
+screencloudplayer)
+    # credit: AP Orlebeke (@apizz)
+    name="ScreenCloud Player"
+    type="dmg"
+    downloadURL=$(curl -sL "https://screencloud.com/download" | sed -n 's/^.*"url":"\([^"]*\)".*$/\1/p')
+    expectedTeamID="3C4F953K6P"
+    ;;
 screenflick)
     # credit: Gabe Marchan (gabemarchan.com - @darklink87)
     name="Screenflick"


### PR DESCRIPTION
Successful output run based on current 0.6 dev version:

```
sh ~/Downloads/installomator.sh screencloudplayer        11:34:07
2021-08-06 11:34:26 screencloudplayer ################## Start Installomator v. 0.6.0
2021-08-06 11:34:26 screencloudplayer ################## screencloudplayer
2021-08-06 11:34:26 screencloudplayer BLOCKING_PROCESS_ACTION=prompt_user
2021-08-06 11:34:26 screencloudplayer NOTIFY=success
2021-08-06 11:34:26 screencloudplayer LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-08-06 11:34:26 screencloudplayer no blocking processes defined, using ScreenCloud Player as default
2021-08-06 11:34:26 screencloudplayer Changing directory to /Users/test/Downloads
2021-08-06 11:34:27 screencloudplayer App(s) found: 
/Users/apo/Downloads/installomator.sh: line 359: ${(0)applist}: bad substitution
2021-08-06 11:34:27 screencloudplayer appversion: 
2021-08-06 11:34:27 screencloudplayer Latest version not specified.
2021-08-06 11:34:27 screencloudplayer Downloading https://release.screen.cloud/uploaded/player/ScreenCloud%20Player-2.11.12.dmg to ScreenCloud Player.dmg
2021-08-06 11:34:37 screencloudplayer DEBUG mode, not checking for blocking processes
2021-08-06 11:34:37 screencloudplayer Installing ScreenCloud Player
2021-08-06 11:34:37 screencloudplayer Mounting /Users/apo/Downloads/ScreenCloud Player.dmg
2021-08-06 11:34:42 screencloudplayer Mounted: /Volumes/ScreenCloud Player 2.11.12 1
2021-08-06 11:34:42 screencloudplayer Verifying: /Volumes/ScreenCloud Player 2.11.12 1/ScreenCloud Player.app
2021-08-06 11:34:46 screencloudplayer Team ID matching: 3C4F953K6P (expected: 3C4F953K6P )
2021-08-06 11:34:46.927 defaults[39424:3594095] 
The domain/default pair of (/Volumes/ScreenCloud, Player) does not exist
2021-08-06 11:34:46 screencloudplayer Downloaded version of ScreenCloud Player is , same as installed.
2021-08-06 11:34:46 screencloudplayer Unmounting /Volumes/ScreenCloud Player 2.11.12 1
"disk3" ejected.
2021-08-06 11:34:47 screencloudplayer DEBUG mode, not reopening anything
2021-08-06 11:34:47 screencloudplayer ################## End Installomator, exit code 0
```

FWIW, I had to escape all instances of `#appCustomVersion(){}` due to errors:

```
sh ~/Downloads/installomator.sh screencloudplayer        11:27:00
/Users/test/Downloads/installomator.sh: line 803: autoload: command not found
2021-08-06 11:27:20 screencloudplayer ################## Start Installomator v. 0.6.0
2021-08-06 11:27:20 screencloudplayer ################## screencloudplayer
/Users/test/Downloads/installomator.sh: line 2141: syntax error near unexpected token `{defaults'
/Users/test/Downloads/installomator.sh: line 2141: `    appCustomVersion(){defaults read /Applications/nextcloud.app/Contents/Info.plist CFBundleShortVersionString | sed -E 's/^([0-9.]*)git.*/\1/g'}'
```