### PR TITLE
Adding Box Sync, Cisdem Document Reader & FlowJo

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -346,7 +346,7 @@ getAppVersion() {
         fi
     fi
     
-    # get app from /Applications or find using Spotify
+    # get app in /Applications, or /Applications/Utilities, or find using Spotify
     if [[ -d "/Applications/$appName" ]]; then
         applist="/Applications/$appName"
     elif [[ -d "/Applications/Utilities/$appName" ]]; then

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1780,6 +1780,11 @@ hpeasystart)
 hyper)
     name="Hyper"
     type="dmg"
+    if [[ $(arch) == i386 ]]; then
+      archiveName="mac-x64.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+      archiveName="mac-arm64.dmg"
+    fi
     downloadURL=$(downloadURLFromGit vercel hyper )
     appNewVersion=$(versionFromGit vercel hyper)
     expectedTeamID="JW6Y669B67"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1216,6 +1216,14 @@ brave)
     appNewVersion=$(curl --location --fail --silent "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:shortVersionString' 2>/dev/null  | cut -d '"' -f 2)
     expectedTeamID="KL8N8XSYF4"
     ;;
+caffeine)
+    name="Caffeine"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit IntelliScape caffeine)
+    appNewVersion=$(versionFromGit IntelliScape caffeine)
+    expectedTeamID="YD6LEYT6WZ"
+    blockingProcesses=( Caffeine )
+    ;;
 cakebrew)
     name="Cakebrew"
     type="zip"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3006,6 +3006,15 @@ zoomclient)
     blockingProcesses=( zoom.us )
     #blockingProcessesMaxCPU="5"
     ;;
+zoomrooms)
+    name="ZoomRooms"
+    type="pkg"
+    packageID="us.zoom.pkg.zp"
+    downloadURL="https://zoom.us/client/latest/ZoomRooms.pkg"
+    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i location | cut -d "/" -f5)"
+    expectedTeamID="BJ4HAAB9B3"
+    blockingProcesses=( "ZoomPresence" )
+    ;;
 zulujdk11)
     name="Zulu JDK 11"
     type="pkgInDmg"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -346,7 +346,7 @@ getAppVersion() {
         fi
     fi
     
-    # get app in /Applications, or /Applications/Utilities, or find using Spotify
+    # get app in /Applications, or /Applications/Utilities, or find using Spotlight
     if [[ -d "/Applications/$appName" ]]; then
         applist="/Applications/$appName"
     elif [[ -d "/Applications/Utilities/$appName" ]]; then

--- a/Labels.txt
+++ b/Labels.txt
@@ -297,6 +297,7 @@ yubikeymanagerqt
 zappy
 zoom
 zoomclient
+zoomrooms
 zulujdk11
 zulujdk13
 zulujdk15


### PR DESCRIPTION
Please see 3 items to add.
The last item FlowJo needs some work as its grabbing the exit version not latest.

```
    boxsync)
    name="Box Sync"
    type="dmg"
    downloadURL="https://e3.boxcdn.net/box-installers/sync/Sync+4+External/Box%20Sync%20Installer.dmg"
    expectedTeamID="M683GB7CPW"
    ;;
cisdem-documentreader)
    name="cisdem-documentreader"
    type="dmg"
    downloadURL="https://download.cisdem.com/cisdem-documentreader.dmg"
    expectedTeamID="5HGV8EX6BQ"
    appName="Cisdem Document Reader.app"
    ;;
flowjo-osx64-10.8.0)
    name="FlowJo-OSX64-10.8.0"
    type="dmg"
    downloadURL="https://fjinstallers.s3.amazonaws.com/FlowJo/FlowJo-OSX64-10.8.0.dmg"
    expectedTeamID="C79HU5AD9V"
    appName="FlowJo.app"
    ;;
```