### PR TITLE
Add Wally EZ Flash Tool

### DIFF
--- a/fragments/labels/wallyezflash.sh
+++ b/fragments/labels/wallyezflash.sh
@@ -1,8 +1,8 @@
 wallyezflash)
-    # credit AP Orlebeke (@apizz)
     name="Wally"
     type="dmg"
     downloadURL="https://configure.zsa.io/wally/osx"
+    #appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | head -1 | sed -E 's/.*\/[a-zA-Z\-]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="V32BWKSNYH"
-    versionKey="CFBundleVersion"
+    #versionKey="CFBundleVersion"
     ;;

--- a/fragments/labels/wallyezflash.sh
+++ b/fragments/labels/wallyezflash.sh
@@ -1,0 +1,8 @@
+wallyezflash)
+    # credit AP Orlebeke (@apizz)
+    name="Wally"
+    type="dmg"
+    downloadURL="https://configure.zsa.io/wally/osx"
+    expectedTeamID="V32BWKSNYH"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Output from successful testing per wiki:

```
./assemble.sh -l ~/Documents/git/InstallomatorLabels wallyezflash
label_paths: /Users/admin/Documents/git/InstallomatorLabels /Users/admin/Documents/git/Installomator/fragments/labels
2021-08-29 23:59:56 wallyezflash ################## Start Installomator v. 0.7.0b1
2021-08-29 23:59:56 wallyezflash ################## wallyezflash
2021-08-29 23:59:56 wallyezflash BLOCKING_PROCESS_ACTION=prompt_user
2021-08-29 23:59:56 wallyezflash NOTIFY=success
2021-08-29 23:59:56 wallyezflash LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-08-29 23:59:56 wallyezflash no blocking processes defined, using Wally as default
2021-08-29 23:59:56 wallyezflash Changing directory to /Users/admin/Documents/git/Installomator/build
2021-08-29 23:59:56 wallyezflash App(s) found: 
2021-08-29 23:59:56 wallyezflash could not find Wally.app
2021-08-29 23:59:56 wallyezflash appversion: 
2021-08-29 23:59:56 wallyezflash Latest version not specified.
2021-08-29 23:59:56 wallyezflash Wally.dmg exists and DEBUG enabled, skipping download
2021-08-29 23:59:56 wallyezflash DEBUG mode, not checking for blocking processes
2021-08-29 23:59:56 wallyezflash Installing Wally
2021-08-29 23:59:56 wallyezflash Mounting /Users/admin/Documents/git/Installomator/build/Wally.dmg
2021-08-29 23:59:57 wallyezflash Mounted: /Volumes/Wally
2021-08-29 23:59:57 wallyezflash Verifying: /Volumes/Wally/Wally.app
2021-08-29 23:59:57 wallyezflash Team ID matching: V32BWKSNYH (expected: V32BWKSNYH )
2021-08-29 23:59:57 wallyezflash Downloaded version of Wally is 2.0.0 (replacing version ).
2021-08-29 23:59:57 wallyezflash DEBUG enabled, skipping remove, copy and chown steps
2021-08-29 23:59:57 wallyezflash Finishing…
2021-08-30 00:00:08 wallyezflash App(s) found: 
2021-08-30 00:00:08 wallyezflash could not find Wally.app
2021-08-30 00:00:08 wallyezflash Installed Wally
2021-08-30 00:00:08 wallyezflash notifying
2021-08-30 00:00:09 wallyezflash Unmounting /Volumes/Wally
"disk2" ejected.
2021-08-30 00:00:09 wallyezflash DEBUG mode, not reopening anything
2021-08-30 00:00:09 wallyezflash ################## End Installomator, exit code 0 
```