### PR TITLE
App from App Store

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -173,6 +173,17 @@ getAppVersion() {
             #appversion=$(mdls -name kMDItemVersion -raw $installedAppPath )
             appversion=$(defaults read $installedAppPath/Contents/Info.plist $versionKey) #Not dependant on Spotlight indexing
             printlog "found app at $installedAppPath, version $appversion"
+            # Is current app from App Store
+            if [[ -d "$installedAppPath"/Contents/_MASReceipt ]];then
+                printlog "Installed $appName is from App Store, use INSTALL=force to replace."
+                # INSTALL="force"
+                # Maybe we should exit instead
+                if [[ $INSTALL == "force" ]]; then
+                    printlog "Force is used so continuing"
+                else
+                    cleanupAndExit 1 "App previously installed from App Store"
+                fi
+            fi
         else
             printlog "could not determine location of $appName"
         fi


### PR DESCRIPTION
In this branch I demand that `INSTALL=force` if an App Store app should be replaced. 

Best example is Slack that will loose all settings if it is replaced. But we can still do it and the log will show what we are doing.