### PR TITLE
Fix identifier of Zoom installer

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3281,7 +3281,7 @@ zoom)
 zoomclient)
     name="zoom.us"
     type="pkg"
-    packageID="us.zoom.pkg.videmeeting"
+    packageID="us.zoom.pkg.videomeeting"
     if [[ $(arch) == i386 ]]; then
        downloadURL="https://zoom.us/client/latest/Zoom.pkg"
     elif [[ $(arch) == arm64 ]]; then

--- a/fragments/labels/zoomclient.sh
+++ b/fragments/labels/zoomclient.sh
@@ -1,7 +1,7 @@
 zoomclient)
     name="zoom.us"
     type="pkg"
-    packageID="us.zoom.pkg.videmeeting"
+    packageID="us.zoom.pkg.videomeeting"
     if [[ $(arch) == i386 ]]; then
        downloadURL="https://zoom.us/client/latest/Zoom.pkg"
     elif [[ $(arch) == arm64 ]]; then


### PR DESCRIPTION
Adjusts the package identifier used for Zoom to match the latest download:

![Screen Shot 2021-10-12 at 9 18 02 PM](https://user-images.githubusercontent.com/7801391/137066500-b20d0b93-8aa3-4e3d-af72-5a184b01e32d.png)

![Screen Shot 2021-10-12 at 9 18 05 PM](https://user-images.githubusercontent.com/7801391/137066506-386834c5-ca60-46ed-a399-cf3b5f65f59f.png)

