### PR TITLE
Mattermost: Updated 'archiveName' for i386

### DIFF
--- a/fragments/labels/mattermost.sh
+++ b/fragments/labels/mattermost.sh
@@ -2,7 +2,7 @@ mattermost)
     name="Mattermost"
     type="dmg"
     if [[ $(arch) == i386 ]]; then
-      archiveName="mac.dmg"
+      archiveName="mac-x64.dmg"
     elif [[ $(arch) == arm64 ]]; then
       archiveName="mac-m1.dmg"
     fi


### PR DESCRIPTION
The `archiveName` for i386 has been changed to `mac-x64.dmg`