### PR TITLE
strongsync

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -278,6 +278,7 @@ sonoss2
 sourcetree
 splashtopsos
 spotify
+strongsync
 sublimetext
 supportapp
 suspiciouspackage

--- a/fragments/labels/strongsync.sh
+++ b/fragments/labels/strongsync.sh
@@ -1,0 +1,9 @@
+strongsync)
+    name="Strongsync"
+    type="dmg"
+    #downloadURL="https://updates.expandrive.com/apps/strongsync/download_latest"
+    downloadURL=$(curl -fs "https://updates.expandrive.com/appcast/strongsync.xml" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | head -1 | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://updates.expandrive.com/appcast/strongsync.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:version)[1]' 2>/dev/null | head -1 | cut -d '"' -f 2)
+    versionKey="CFBundleVersion"
+    expectedTeamID="CH86M498V4"
+    ;;


### PR DESCRIPTION
```
% sudo /Users/st/Documents/GitHub/Installomator/utils/assemble.sh -r strongsync DEBUG=0
2021-10-28 19:40:43 strongsync setting variable from argument DEBUG=0
2021-10-28 19:40:43 strongsync ################## Start Installomator v. 0.8.0
2021-10-28 19:40:43 strongsync ################## strongsync
2021-10-28 19:40:44 strongsync BLOCKING_PROCESS_ACTION=tell_user
2021-10-28 19:40:44 strongsync NOTIFY=success
2021-10-28 19:40:44 strongsync LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-10-28 19:40:44 strongsync no blocking processes defined, using Strongsync as default
2021-10-28 19:40:44 strongsync Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1bFmmj9p
2021-10-28 19:40:45 strongsync App(s) found:
2021-10-28 19:40:45 strongsync could not find Strongsync.app
2021-10-28 19:40:45 strongsync appversion:
2021-10-28 19:40:45 strongsync Latest version of Strongsync is 2021.9.1
2021-10-28 19:40:45 strongsync Downloading https://updates.expandrive.com/apps/strongsync/v/2021-9-1/download.dmg to Strongsync.dmg
2021-10-28 19:40:47 strongsync no more blocking processes, continue with update
2021-10-28 19:40:47 strongsync Installing Strongsync
2021-10-28 19:40:47 strongsync Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1bFmmj9p/Strongsync.dmg
2021-10-28 19:40:51 strongsync Mounted: /Volumes/Strongsync 1
2021-10-28 19:40:51 strongsync Verifying: /Volumes/Strongsync 1/Strongsync.app
2021-10-28 19:40:52 strongsync Team ID matching: CH86M498V4 (expected: CH86M498V4 )
2021-10-28 19:40:52 strongsync Downloaded version of Strongsync is 2021.9.1 (replacing version ).
2021-10-28 19:40:52 strongsync Copy /Volumes/Strongsync 1/Strongsync.app to /Applications
2021-10-28 19:40:52 strongsync Changing owner to st
2021-10-28 19:40:52 strongsync Finishing…
2021-10-28 19:41:02 strongsync App(s) found: /Applications/Strongsync.app
2021-10-28 19:41:02 strongsync found app at /Applications/Strongsync.app, version 2021.9.1
2021-10-28 19:41:02 strongsync Installed Strongsync, version 2021.9.1
2021-10-28 19:41:02 strongsync notifying
2021-10-28 19:41:03 strongsync Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1bFmmj9p
2021-10-28 19:41:03 strongsync Unmounting /Volumes/Strongsync 1
"disk5" ejected.
2021-10-28 19:41:03 strongsync App not closed, so no reopen.
2021-10-28 19:41:03 strongsync ################## End Installomator, exit code 0

% sudo /Users/st/Documents/GitHub/Installomator/utils/assemble.sh -r strongsync DEBUG=0
2021-10-28 19:41:27 strongsync setting variable from argument DEBUG=0
2021-10-28 19:41:27 strongsync ################## Start Installomator v. 0.8.0
2021-10-28 19:41:27 strongsync ################## strongsync
2021-10-28 19:41:28 strongsync BLOCKING_PROCESS_ACTION=tell_user
2021-10-28 19:41:28 strongsync NOTIFY=success
2021-10-28 19:41:28 strongsync LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-10-28 19:41:28 strongsync no blocking processes defined, using Strongsync as default
2021-10-28 19:41:28 strongsync Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.H3bgidQy
2021-10-28 19:41:28 strongsync App(s) found: /Applications/Strongsync.app
2021-10-28 19:41:28 strongsync found app at /Applications/Strongsync.app, version 2021.9.1
2021-10-28 19:41:28 strongsync appversion: 2021.9.1
2021-10-28 19:41:28 strongsync Latest version of Strongsync is 2021.9.1
2021-10-28 19:41:28 strongsync There is no newer version available.
2021-10-28 19:41:28 strongsync Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.H3bgidQy
2021-10-28 19:41:28 strongsync App not closed, so no reopen.
2021-10-28 19:41:28 strongsync ################## End Installomator, exit code 0
```