### PR TITLE
macports

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -168,6 +168,7 @@ loom
 lucifer
 lulu
 macfuse
+macports
 malwarebytes
 mattermost
 menumeters

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -164,6 +164,8 @@ REOPEN="yes"
 # - archiveName: (optional)
 #   The name of the downloaded file.
 #   When not given the archiveName is derived from the $name.
+#   Note: This has to be defined BEFORE calling downloadURLFromGit or
+#   versionFromGit functions in the label.
 #
 # - appName: (optional)
 #   File name of the app bundle in the dmg to verify and copy (include .app).

--- a/fragments/labels/macports.sh
+++ b/fragments/labels/macports.sh
@@ -1,0 +1,23 @@
+macports)
+    name="MacPorts"
+    type="pkg"
+    #buildVersion=$(uname -r | cut -d '.' -f 1)
+    case $(uname -r | cut -d '.' -f 1) in
+        21)
+            archiveName="Monterey.pkg"
+            ;;
+        20)
+            archiveName="BigSur.pkg"
+            ;;
+        19)
+            archiveName="Catalina.pkg"
+            ;;
+        *)
+            cleanupAndExit 1 "macOS 10.14 or earlier not supported by Installomator."
+            ;;
+    esac
+    downloadURL=$(downloadURLFromGit macports macports-base)
+    appNewVersion=$(versionFromGit macports macports-base)
+    appCustomVersion(){ if [ -x /opt/local/bin/port ]; then /opt/local/bin/port version | awk '{print $2}'; else "0"; fi }
+    expectedTeamID="QTA3A3B7F3"
+    ;;


### PR DESCRIPTION
Added a bit to explanation of archiveName variable as well.
```
sudo /Users/st/Documents/GitHub/Installomator/utils/assemble.sh -r macports DEBUG=0 INSTALL=force
Password:
2021-11-02 09:55:12 macports setting variable from argument DEBUG=0
2021-11-02 09:55:12 macports setting variable from argument INSTALL=force
2021-11-02 09:55:12 macports ################## Start Installomator v. 0.8.0
2021-11-02 09:55:12 macports ################## macports
2021-11-02 09:55:13 macports BLOCKING_PROCESS_ACTION=tell_user
2021-11-02 09:55:13 macports NOTIFY=success
2021-11-02 09:55:14 macports LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-02 09:55:14 macports no blocking processes defined, using MacPorts as default
2021-11-02 09:55:14 macports Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4KnOGDkl
2021-11-02 09:55:14 macports Custom App Version detection is used, found 2.7.1
2021-11-02 09:55:14 macports appversion: 2.7.1
2021-11-02 09:55:14 macports Latest version of MacPorts is 2.7.1
2021-11-02 09:55:14 macports There is no newer version available.
2021-11-02 09:55:14 macports Using force to install anyway. Not using updateTool.
2021-11-02 09:55:14 macports Downloading https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-12-Monterey.pkg to Monterey.pkg
2021-11-02 09:55:15 macports no more blocking processes, continue with update
2021-11-02 09:55:15 macports Installing MacPorts
2021-11-02 09:55:16 macports Verifying: Monterey.pkg
2021-11-02 09:55:16 macports Team ID: QTA3A3B7F3 (expected: QTA3A3B7F3 )
2021-11-02 09:55:16 macports Installing Monterey.pkg to /
installer: Package name is MacPorts
installer: Upgrading at base path /
installer: The upgrade was successful.
2021-11-02 09:56:03 macports Finishing…
2021-11-02 09:56:13 macports Custom App Version detection is used, found 2.7.1
2021-11-02 09:56:13 macports Installed MacPorts, version 2.7.1
2021-11-02 09:56:13 macports notifying
2021-11-02 09:56:14 macports Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4KnOGDkl
2021-11-02 09:56:14 macports App not closed, so no reopen.
2021-11-02 09:56:14 macports ################## End Installomator, exit code 0
```