### PR TITLE
Added a label for Wacom Tablet drivers.

### DIFF
--- a/fragments/labels/wacomdrivers.sh
+++ b/fragments/labels/wacomdrivers.sh
@@ -1,0 +1,8 @@
+wacomdrivers)
+    name="Wacom Desktop Center"
+    type="pkgInDmg"
+    downloadURL="$(curl -fs https://www.wacom.com/en-us/support/product-support/drivers | grep -e "drivers/mac/professional.*dmg" | head -1 | sed -e 's/data-download-link="//g' -e 's/"//' | awk '{$1=$1}{ print }' | sed 's/\r//')"
+    expectedTeamID="EG27766DY7"
+    pkgName="Install Wacom Tablet.pkg"
+    appNewVersion="$(curl -fs https://www.wacom.com/en-us/support/product-support/drivers | grep mac/professional/releasenotes | head -1 | awk -F"|" '{print $1}' | awk -F"Driver" '{print $3}' | sed -e 's/ (.*//g' | tr -d ' ')"
+    ;;


### PR DESCRIPTION
This label downloads the latest Wacom tablet drivers as found here;
https://www.wacom.com/en-nl/support/product-support/drivers

Installomator % ./assemble.sh -l myLabel wacomdrivers
2021-11-03 22:53:41 wacomdrivers ################## Start Installomator v. 0.8.0
2021-11-03 22:53:41 wacomdrivers ################## wacomdrivers
2021-11-03 22:53:51 wacomdrivers BLOCKING_PROCESS_ACTION=tell_user
2021-11-03 22:53:51 wacomdrivers NOTIFY=success
2021-11-03 22:53:51 wacomdrivers LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-03 22:53:51 wacomdrivers no blocking processes defined, using Wacom Desktop Center as default
2021-11-03 22:53:51 wacomdrivers Changing directory to /Users/Admin/Downloads/Installomator/build
2021-11-03 22:53:52 wacomdrivers App(s) found: 
2021-11-03 22:53:52 wacomdrivers could not find Wacom Desktop Center.app
2021-11-03 22:53:52 wacomdrivers appversion: 
2021-11-03 22:53:52 wacomdrivers Latest version of Wacom Desktop Center is 6.3.44-2
2021-11-03 22:53:52 wacomdrivers Downloading https://cdn.wacom.com/u/productsupport/drivers/mac/professional/WacomTablet_6.3.44-2.dmg to Wacom Desktop Center.dmg
2021-11-03 22:54:28 wacomdrivers DEBUG mode, not checking for blocking processes
2021-11-03 22:54:28 wacomdrivers Installing Wacom Desktop Center
2021-11-03 22:54:28 wacomdrivers Mounting /Users/Admin/Downloads/Installomator/build/Wacom Desktop Center.dmg
2021-11-03 22:54:32 wacomdrivers Mounted: /Volumes/WacomTablet
2021-11-03 22:54:32 wacomdrivers Verifying: /Volumes/WacomTablet/Install Wacom Tablet.pkg
2021-11-03 22:54:32 wacomdrivers Team ID: EG27766DY7 (expected: EG27766DY7 )
2021-11-03 22:54:32 wacomdrivers DEBUG enabled, skipping installation
2021-11-03 22:54:32 wacomdrivers Finishing…
2021-11-03 22:54:43 wacomdrivers App(s) found: 
2021-11-03 22:54:43 wacomdrivers could not find Wacom Desktop Center.app
2021-11-03 22:54:43 wacomdrivers Installed Wacom Desktop Center
2021-11-03 22:54:43 wacomdrivers notifying
2021-11-03 22:54:43 wacomdrivers Unmounting /Volumes/WacomTablet
"disk4" ejected.
2021-11-03 22:54:44 wacomdrivers DEBUG mode, not reopening anything
2021-11-03 22:54:44 wacomdrivers ################## End Installomator, exit code 0 

