### PR TITLE
eshareosx label

### DIFF
--- a/fragments/labels/eshareosx.sh
+++ b/fragments/labels/eshareosx.sh
@@ -1,0 +1,9 @@
+eshareosx)
+    name="e-Share"
+    type="pkg"
+    packageID="com.ncryptedcloud.e-Share.pkg"
+    downloadURL=https://www.ncryptedcloud.com/static/downloads/osx/$(curl -fs https://www.ncryptedcloud.com/static/downloads/osx/ | grep -o -i "href.*\".*\"" | cut -d '"' -f2)
+    versionKey="CFBundleVersion"
+    appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z\-]*_([0-9.]*)\.pkg/\1/g' )
+    expectedTeamID="X9MBQS7DDC"
+    ;;


### PR DESCRIPTION
```
% /Users/st/Documents/GitHub/Installomator/utils/assemble.sh -r eshareosx DEBUG=0
2021-11-05 20:02:24 eshareosx setting variable from argument DEBUG=0
2021-11-05 20:02:24 eshareosx ################## Start Installomator v. 0.8.0
2021-11-05 20:02:24 eshareosx ################## eshareosx
2021-11-05 20:02:25 eshareosx BLOCKING_PROCESS_ACTION=tell_user
2021-11-05 20:02:25 eshareosx NOTIFY=success
2021-11-05 20:02:25 eshareosx LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-05 20:02:25 eshareosx no blocking processes defined, using e-Share as default
2021-11-05 20:02:25 eshareosx Changing directory to /var/folders/xy/qf4qbtzs0dx5dgpz2m_y067w0000gp/T/tmp.3h5RgESE
2021-11-05 20:02:25 eshareosx No version found using packageID com.ncryptedcloud.e-Share.pkg
2021-11-05 20:02:26 eshareosx App(s) found: 
2021-11-05 20:02:26 eshareosx could not find e-Share.app
2021-11-05 20:02:26 eshareosx appversion: 
2021-11-05 20:02:26 eshareosx Latest version of e-Share is 1.2.8.3
2021-11-05 20:02:26 eshareosx Downloading https://www.ncryptedcloud.com/static/downloads/osx/e-ShareOSX_1.2.8.3.pkg to e-Share.pkg
2021-11-05 20:02:30 eshareosx no more blocking processes, continue with update
2021-11-05 20:02:30 eshareosx Installing e-Share
2021-11-05 20:02:30 eshareosx Verifying: e-Share.pkg
2021-11-05 20:02:30 eshareosx Team ID: X9MBQS7DDC (expected: X9MBQS7DDC )
2021-11-05 20:02:30 eshareosx ERROR: not running as root, exiting
2021-11-05 20:02:30 eshareosx Deleting /var/folders/xy/qf4qbtzs0dx5dgpz2m_y067w0000gp/T/tmp.3h5RgESE
2021-11-05 20:02:30 eshareosx App not closed, so no reopen.
2021-11-05 20:02:30 eshareosx ################## End Installomator, exit code 6 
```