### PR TITLE
Add a label for Sketchup Viewer

### DIFF
--- a/fragments/labels/sketchupviewer.sh
+++ b/fragments/labels/sketchupviewer.sh
@@ -1,0 +1,6 @@
+sketchupviewer)
+    name="SketchUpViewer"
+    type="dmg"
+    downloadURL="$(curl -fs https://www.sketchup.com/sketchup/SketchUpViewer-en-dmg | grep "<a href=" | sed 's/.*href="//' | sed 's/".*//')"
+    expectedTeamID="J8PVMCY7KL"
+    ;;


### PR DESCRIPTION
This label will download the latest Sketchup Viewer app. I couldn't find a way to add 'appNewVersion' as the page that publishes the release notes for Sketchup Viewer hasn't been updated for some time (we're at version 21.1 but the release notes mention version 18);
https://help.sketchup.com/en/sketchup-viewer/sketchup-viewer-release-notes

The major and minor Sketchup Viewer version numbering does seem to be alligned with Sketchup Pro.
Current Sketchup Viewer version: 21.1.331
Current Sketchup Pro version: 21.1.2

However, extracting the most recent version number of Sketchup Pro seems complicated;
https://help.sketchup.com/en/release-notes (we have to extract the major version from this page)
https://help.sketchup.com/en/release-notes/sketchup-desktop-20210 (we have to extract the minor and patch from this page).
 


Installomator % ./assemble.sh -l myLabel sketchupviewer
2021-11-07 09:20:31 sketchupviewer ################## Start Installomator v. 0.7.0
2021-11-07 09:20:31 sketchupviewer ################## sketchupviewer
2021-11-07 09:20:32 sketchupviewer BLOCKING_PROCESS_ACTION=tell_user
2021-11-07 09:20:32 sketchupviewer NOTIFY=success
2021-11-07 09:20:32 sketchupviewer LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-07 09:20:32 sketchupviewer no blocking processes defined, using SketchUpViewer as default
2021-11-07 09:20:32 sketchupviewer Changing directory to /Users/Admin/Downloads/Installomator/build
2021-11-07 09:20:33 sketchupviewer App(s) found: 
2021-11-07 09:20:33 sketchupviewer could not find SketchUpViewer.app
2021-11-07 09:20:33 sketchupviewer appversion: 
2021-11-07 09:20:33 sketchupviewer Latest version not specified.
2021-11-07 09:20:33 sketchupviewer Downloading https://flex1540-esd.flexnetoperations.com/flexnet/operations/AnonymousDownload?systemFileID=18379637&amp;eccnNum=5D002&amp;leEnc=TSU&amp;ccats=&amp;nlr=F to SketchUpViewer.dmg
2021-11-07 09:21:07 sketchupviewer DEBUG mode, not checking for blocking processes
2021-11-07 09:21:07 sketchupviewer Installing SketchUpViewer
2021-11-07 09:21:07 sketchupviewer Mounting /Users/Admin/Downloads/Installomator/build/SketchUpViewer.dmg
2021-11-07 09:21:19 sketchupviewer Mounted: /Volumes/SketchUp Viewer 2021 1
2021-11-07 09:21:19 sketchupviewer Verifying: /Volumes/SketchUp Viewer 2021 1/SketchUpViewer.app
2021-11-07 09:21:33 sketchupviewer Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2021-11-07 09:21:33 sketchupviewer Downloaded version of SketchUpViewer is 21.1 (replacing version ).
2021-11-07 09:21:33 sketchupviewer DEBUG enabled, skipping remove, copy and chown steps
2021-11-07 09:21:33 sketchupviewer Finishing…
2021-11-07 09:21:44 sketchupviewer App(s) found: 
2021-11-07 09:21:44 sketchupviewer could not find SketchUpViewer.app
2021-11-07 09:21:44 sketchupviewer Installed SketchUpViewer
2021-11-07 09:21:44 sketchupviewer notifying
2021-11-07 09:21:44 sketchupviewer Unmounting /Volumes/SketchUp Viewer 2021 1
"disk5" ejected.
2021-11-07 09:21:45 sketchupviewer DEBUG mode, not reopening anything
2021-11-07 09:21:45 sketchupviewer ################## End Installomator, exit code 0 

