### PR TITLE
Updated Edge Enterprise Download Link

### DIFF
--- a/fragments/labels/microsoftedgeenterprisestable.sh
+++ b/fragments/labels/microsoftedgeenterprisestable.sh
@@ -1,7 +1,7 @@
 microsoftedgeenterprisestable)
     name="Microsoft Edge"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=2093438"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=2093504"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.edge"]/version' 2>/dev/null | sed -E 's/<version>([0-9.]*) .*/\1/')
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/MicrosoftEdge.*pkg" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="UBF8T346G9"


### PR DESCRIPTION
Test output:
Installomator - edge-enterprise-stable-update! ❯ ./assemble.sh -l fragments/labels microsoftedgeenterprisestable
2021-11-09 09:21:38 microsoftedgeenterprisestable ################## Start Installomator v. 0.8.0
2021-11-09 09:21:38 microsoftedgeenterprisestable ################## microsoftedgeenterprisestable
2021-11-09 09:21:38 microsoftedgeenterprisestable BLOCKING_PROCESS_ACTION=tell_user
2021-11-09 09:21:38 microsoftedgeenterprisestable NOTIFY=success
2021-11-09 09:21:38 microsoftedgeenterprisestable LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-09 09:21:38 microsoftedgeenterprisestable no blocking processes defined, using Microsoft Edge as default
2021-11-09 09:21:38 microsoftedgeenterprisestable Changing directory to /Users/john/Documents/Source/Installomator/build
2021-11-09 09:21:38 microsoftedgeenterprisestable App(s) found: /Applications/Microsoft Edge.app
2021-11-09 09:21:39 microsoftedgeenterprisestable found app at /Applications/Microsoft Edge.app, version 95.0.1020.44
2021-11-09 09:21:39 microsoftedgeenterprisestable appversion: 95.0.1020.44
2021-11-09 09:21:39 microsoftedgeenterprisestable Latest version of Microsoft Edge is 95.0.1020.44
2021-11-09 09:21:39 microsoftedgeenterprisestable DEBUG mode enabled, not exiting, but there is no new version of app.
2021-11-09 09:21:39 microsoftedgeenterprisestable appversion & updateTool
2021-11-09 09:21:39 microsoftedgeenterprisestable DEBUG mode enabled, not running update tool
2021-11-09 09:21:39 microsoftedgeenterprisestable Downloading https://go.microsoft.com/fwlink/?linkid=2093504 to Microsoft Edge.pkg
2021-11-09 09:21:53 microsoftedgeenterprisestable DEBUG mode, not checking for blocking processes
2021-11-09 09:21:53 microsoftedgeenterprisestable Installing Microsoft Edge
2021-11-09 09:21:53 microsoftedgeenterprisestable Verifying: Microsoft Edge.pkg
2021-11-09 09:21:53 microsoftedgeenterprisestable Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2021-11-09 09:21:53 microsoftedgeenterprisestable DEBUG enabled, skipping installation
2021-11-09 09:21:53 microsoftedgeenterprisestable Finishing…
2021-11-09 09:22:03 microsoftedgeenterprisestable App(s) found: /Applications/Microsoft Edge.app
2021-11-09 09:22:03 microsoftedgeenterprisestable found app at /Applications/Microsoft Edge.app, version 95.0.1020.44
2021-11-09 09:22:03 microsoftedgeenterprisestable Installed Microsoft Edge, version 95.0.1020.44
2021-11-09 09:22:03 microsoftedgeenterprisestable notifying
2021-11-09 09:22:03 microsoftedgeenterprisestable DEBUG mode, not reopening anything
2021-11-09 09:22:03 microsoftedgeenterprisestable ################## End Installomator, exit code 0