### PR TITLE
Updated URL

### DIFF
--- a/fragments/labels/zulujdk11.sh
+++ b/fragments/labels/zulujdk11.sh
@@ -3,9 +3,9 @@ zulujdk11)
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.11"
     if [[ $(arch) == i386 ]]; then
-      downloadURL=$(curl -fs "https://www.azul.com/downloads/zulu-community/" | xmllint --html --format - 2>/dev/null | tr , '\n' | grep -o "https:.*/zulu11.*ca-jdk11.*x64.dmg" | sed 's/\\//g')
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu11.*ca-jdk11.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
     elif [[ $(arch) == arm64 ]]; then
-      downloadURL=$(curl -fs "https://www.azul.com/downloads/zulu-community/" | xmllint --html --format - 2>/dev/null | tr , '\n' | grep -o "https:.*/zulu11.*ca-jdk11.*aarch64.dmg" | sed 's/\\//g')
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu11.*ca-jdk11.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
     fi
     expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }


### PR DESCRIPTION
Updated URL to match Zulu JDK8 style.

Test output:

Installomator - zulu-jdk-11-urlupdate! ❯ ./assemble.sh zulujdk11
2021-11-24 05:50:02 zulujdk11 ################## Start Installomator v. 9.0dev
2021-11-24 05:50:02 zulujdk11 ################## zulujdk11
2021-11-24 05:50:02 zulujdk11 DEBUG mode 1 enabled.
2021-11-24 05:50:02 zulujdk11 BLOCKING_PROCESS_ACTION=tell_user
2021-11-24 05:50:02 zulujdk11 NOTIFY=success
2021-11-24 05:50:02 zulujdk11 LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-24 05:50:02 zulujdk11 no blocking processes defined, using Zulu JDK 11 as default
2021-11-24 05:50:02 zulujdk11 Changing directory to /Users/john/Documents/Source/Installomator/build
2021-11-24 05:50:02 zulujdk11 Custom App Version detection is used, found be
2021-11-24 05:50:02 zulujdk11 appversion: be
2021-11-24 05:50:02 zulujdk11 Latest version of Zulu JDK 11 is 11.52.13
2021-11-24 05:50:02 zulujdk11 Downloading https://cdn.azul.com/zulu/bin/zulu11.52.13-ca-jdk11.0.13-macosx_aarch64.dmg to Zulu JDK 11.dmg
2021-11-24 05:50:07 zulujdk11 DEBUG mode, not checking for blocking processes
2021-11-24 05:50:07 zulujdk11 Installing Zulu JDK 11
2021-11-24 05:50:07 zulujdk11 Mounting /Users/john/Documents/Source/Installomator/build/Zulu JDK 11.dmg
2021-11-24 05:50:15 zulujdk11 Mounted: /Volumes/Azul Zulu JDK 11.52+13
2021-11-24 05:50:15 zulujdk11 found pkg: /Volumes/Azul Zulu JDK 11.52+13/Double-Click to Install Azul Zulu JDK 11.pkg
2021-11-24 05:50:15 zulujdk11 Verifying: /Volumes/Azul Zulu JDK 11.52+13/Double-Click to Install Azul Zulu JDK 11.pkg
2021-11-24 05:50:15 zulujdk11 Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2021-11-24 05:50:15 zulujdk11 Checking package version.
Error encountered while creating /Volumes/Azul Zulu JDK 11.52+13/Double-Click to Install Azul Zulu JDK 11.pkg_pkg. Error 30: Read-only file system
cat: /Volumes/Azul Zulu JDK 11.52+13/Double-Click to Install Azul Zulu JDK 11.pkg_pkg/Distribution: No such file or directory
rm: /Volumes/Azul Zulu JDK 11.52+13/Double-Click to Install Azul Zulu JDK 11.pkg_pkg: No such file or directory
2021-11-24 05:50:15 zulujdk11 Downloaded package com.azulsystems.zulu.11 version
2021-11-24 05:50:15 zulujdk11 DEBUG enabled, skipping installation
2021-11-24 05:50:15 zulujdk11 Finishing...
2021-11-24 05:50:25 zulujdk11 Custom App Version detection is used, found be
2021-11-24 05:50:25 zulujdk11 Installed Zulu JDK 11, version be
2021-11-24 05:50:25 zulujdk11 notifying
2021-11-24 05:50:26 zulujdk11 Unmounting /Volumes/Azul Zulu JDK 11.52+13
"disk4" ejected.
2021-11-24 05:50:26 zulujdk11 DEBUG mode, not reopening anything
2021-11-24 05:50:26 zulujdk11 ################## End Installomator, exit code 0