### PR TITLE
Updated URL

### DIFF
--- a/fragments/labels/zulujdk15.sh
+++ b/fragments/labels/zulujdk15.sh
@@ -3,9 +3,9 @@ zulujdk15)
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.15"
     if [[ $(arch) == i386 ]]; then
-        downloadURL=$(curl -fs "https://www.azul.com/downloads/zulu-community/" | xmllint --html --format - 2>/dev/null | tr , '\n' | grep -o "https:.*/zulu15.*ca-jdk15.*x64.dmg" | sed 's/\\//g')
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu15.*ca-jdk15.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
     elif [[ $(arch) == arm64 ]]; then
-        downloadURL=$(curl -fs "https://www.azul.com/downloads/zulu-community/" | xmllint --html --format - 2>/dev/null | tr , '\n' | grep -o "https:.*/zulu15.*ca-jdk15.*aarch64.dmg" | sed 's/\\//g')
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu15.*ca-jdk15.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
     fi
     expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }


### PR DESCRIPTION
Updated URL to match Zulu JDK 8 style

Example output:

Installomator - zulu-jdk-15-urlupdate! ❯ ./assemble.sh zulujdk15
2021-11-24 05:54:37 zulujdk15 ################## Start Installomator v. 9.0dev
2021-11-24 05:54:37 zulujdk15 ################## zulujdk15
2021-11-24 05:54:37 zulujdk15 DEBUG mode 1 enabled.
2021-11-24 05:54:37 zulujdk15 BLOCKING_PROCESS_ACTION=tell_user
2021-11-24 05:54:37 zulujdk15 NOTIFY=success
2021-11-24 05:54:37 zulujdk15 LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-24 05:54:37 zulujdk15 no blocking processes defined, using Zulu JDK 15 as default
2021-11-24 05:54:37 zulujdk15 Changing directory to /Users/john/Documents/Source/Installomator/build
2021-11-24 05:54:37 zulujdk15 Custom App Version detection is used, found be
2021-11-24 05:54:37 zulujdk15 appversion: be
2021-11-24 05:54:37 zulujdk15 Latest version of Zulu JDK 15 is 15.36.13
2021-11-24 05:54:37 zulujdk15 Downloading https://cdn.azul.com/zulu/bin/zulu15.36.13-ca-jdk15.0.5-macosx_aarch64.dmg to Zulu JDK 15.dmg
2021-11-24 05:54:42 zulujdk15 DEBUG mode, not checking for blocking processes
2021-11-24 05:54:42 zulujdk15 Installing Zulu JDK 15
2021-11-24 05:54:42 zulujdk15 Mounting /Users/john/Documents/Source/Installomator/build/Zulu JDK 15.dmg
2021-11-24 05:54:50 zulujdk15 Mounted: /Volumes/Azul Zulu JDK 15.36+13
2021-11-24 05:54:50 zulujdk15 found pkg: /Volumes/Azul Zulu JDK 15.36+13/Double-Click to Install Azul Zulu JDK 15.pkg
2021-11-24 05:54:50 zulujdk15 Verifying: /Volumes/Azul Zulu JDK 15.36+13/Double-Click to Install Azul Zulu JDK 15.pkg
2021-11-24 05:54:50 zulujdk15 Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2021-11-24 05:54:50 zulujdk15 Checking package version.
Error encountered while creating /Volumes/Azul Zulu JDK 15.36+13/Double-Click to Install Azul Zulu JDK 15.pkg_pkg. Error 30: Read-only file system
cat: /Volumes/Azul Zulu JDK 15.36+13/Double-Click to Install Azul Zulu JDK 15.pkg_pkg/Distribution: No such file or directory
rm: /Volumes/Azul Zulu JDK 15.36+13/Double-Click to Install Azul Zulu JDK 15.pkg_pkg: No such file or directory
2021-11-24 05:54:50 zulujdk15 Downloaded package com.azulsystems.zulu.15 version
2021-11-24 05:54:50 zulujdk15 DEBUG enabled, skipping installation
2021-11-24 05:54:50 zulujdk15 Finishing...
2021-11-24 05:55:00 zulujdk15 Custom App Version detection is used, found be
2021-11-24 05:55:00 zulujdk15 Installed Zulu JDK 15, version be
2021-11-24 05:55:00 zulujdk15 notifying
2021-11-24 05:55:00 zulujdk15 Unmounting /Volumes/Azul Zulu JDK 15.36+13
"disk4" ejected.
2021-11-24 05:55:00 zulujdk15 DEBUG mode, not reopening anything
2021-11-24 05:55:00 zulujdk15 ################## End Installomator, exit code 0