### PR TITLE
New label for Azul Zulu JDK 17

### DIFF
--- a/fragments/labels/zulujdk17.sh
+++ b/fragments/labels/zulujdk17.sh
@@ -1,0 +1,13 @@
+zulujdk17)
+    name="Zulu JDK 17"
+    type="pkgInDmg"
+    packageID="com.azulsystems.zulu.17"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    fi
+    expectedTeamID="TDTHCUPYFR"
+    appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
+    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    ;;


### PR DESCRIPTION
Example output:

Installomator - zulu-jdk-15-urlupdate! ❯ ./assemble.sh zulujdk17
2021-11-24 06:00:42 zulujdk17 ################## Start Installomator v. 9.0dev
2021-11-24 06:00:42 zulujdk17 ################## zulujdk17
2021-11-24 06:00:42 zulujdk17 DEBUG mode 1 enabled.
2021-11-24 06:00:44 zulujdk17 BLOCKING_PROCESS_ACTION=tell_user
2021-11-24 06:00:44 zulujdk17 NOTIFY=success
2021-11-24 06:00:44 zulujdk17 LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-24 06:00:44 zulujdk17 no blocking processes defined, using Zulu JDK 17 as default
2021-11-24 06:00:44 zulujdk17 Changing directory to /Users/john/Documents/Source/Installomator/build
2021-11-24 06:00:44 zulujdk17 Custom App Version detection is used, found be
2021-11-24 06:00:44 zulujdk17 appversion: be
2021-11-24 06:00:44 zulujdk17 Latest version of Zulu JDK 17 is 17.30.15
2021-11-24 06:00:44 zulujdk17 Downloading https://cdn.azul.com/zulu/bin/zulu17.30.15-ca-jdk17.0.1-macosx_aarch64.dmg to Zulu JDK 17.dmg
2021-11-24 06:00:49 zulujdk17 DEBUG mode, not checking for blocking processes
2021-11-24 06:00:49 zulujdk17 Installing Zulu JDK 17
2021-11-24 06:00:49 zulujdk17 Mounting /Users/john/Documents/Source/Installomator/build/Zulu JDK 17.dmg
2021-11-24 06:00:57 zulujdk17 Mounted: /Volumes/Azul Zulu JDK 17.30+15
2021-11-24 06:00:57 zulujdk17 found pkg: /Volumes/Azul Zulu JDK 17.30+15/Double-Click to Install Azul Zulu JDK 17.pkg
2021-11-24 06:00:57 zulujdk17 Verifying: /Volumes/Azul Zulu JDK 17.30+15/Double-Click to Install Azul Zulu JDK 17.pkg
2021-11-24 06:00:57 zulujdk17 Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2021-11-24 06:00:57 zulujdk17 Checking package version.
Error encountered while creating /Volumes/Azul Zulu JDK 17.30+15/Double-Click to Install Azul Zulu JDK 17.pkg_pkg. Error 30: Read-only file system
cat: /Volumes/Azul Zulu JDK 17.30+15/Double-Click to Install Azul Zulu JDK 17.pkg_pkg/Distribution: No such file or directory
rm: /Volumes/Azul Zulu JDK 17.30+15/Double-Click to Install Azul Zulu JDK 17.pkg_pkg: No such file or directory
2021-11-24 06:00:57 zulujdk17 Downloaded package com.azulsystems.zulu.17 version
2021-11-24 06:00:57 zulujdk17 DEBUG enabled, skipping installation
2021-11-24 06:00:57 zulujdk17 Finishing...
2021-11-24 06:01:07 zulujdk17 Custom App Version detection is used, found be
2021-11-24 06:01:07 zulujdk17 Installed Zulu JDK 17, version be
2021-11-24 06:01:07 zulujdk17 notifying
2021-11-24 06:01:07 zulujdk17 Unmounting /Volumes/Azul Zulu JDK 17.30+15
"disk4" ejected.
2021-11-24 06:01:07 zulujdk17 DEBUG mode, not reopening anything
2021-11-24 06:01:07 zulujdk17 ################## End Installomator, exit code 0