### PR TITLE
Change to App Store replacement logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## v9?
 
 - We have moved the root check to the beginning of the script, and improved DEBUG handling with two different modes. `DEBUG=0` is still for production, and `1` is still for the DEBUG we previously knew downloading to the directory it is running from, but `2` will download to temporary folder, will detect updates, but will not install anything, but it will notify the user (almost as running the script without root before).
+- Changed logic if `IGNORE_APP_STORE_APPS=yes`. Before this version a label like `microsoftonedrive` that was installed from App Store, and that we want to replace with the “ordinary” version, Installomator would still use `updateTool`, even though `IGNORE_APP_STORE_APPS=yes`. So we would have to have `INSTALL=force` in order to have the app replaced, as `updateTool` would be used. But now if `IGNORE_APP_STORE_APPS=yes` then `updateTool` will be not set, and the App Store app will be replaced. BUT if the installed software was not from App Store, then `updateTool` will not be used, and it would be a kind of a forced install (in the example of `microsoftonedrive`), except if the version is the same (where installation is skipped).
+
+
 
 ## v8.0
 

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -116,9 +116,8 @@ getAppVersion
 printlog "appversion: $appversion"
 
 # MARK: Exit if new version is the same as installed version (appNewVersion specified)
-# credit: Søren Theilgaard (@theilgaard)
-if [[ $INSTALL == "force" ]]; then
-    printlog "Using force to install, so not using updateTool."
+if [[ "$type" != "updateronly" && ($INSTALL == "force" || $IGNORE_APP_STORE_APPS == "yes") ]]; then
+    printlog "Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool."
     updateTool=""
 fi
 if [[ -n $appNewVersion ]]; then


### PR DESCRIPTION
Currently (before this patch) a label like `microsoftonedrive` that was installed from App Store, and that we want to replace with the “ordinary” version, Installomator would use updateTool, even though `IGNORE_APP_STORE_APPS=yes`. So we would have to have `INSTALL=force` in order to have the app replaced, as `updateTool` would be used.

With this patch, if `IGNORE_APP_STORE_APPS=yes` then `updateTool` will be not set, and the App Store app would be replaced. But if the installed software was not from App Store, then `updateTool` would not be used, and it would be a kind of a forced install (except if the version is the same).

I have this output:
```
➜  Downloads sudo Installomator/utils/assemble.sh microsoftonedrive DEBUG=0
2021-11-30 10:12:11 microsoftonedrive setting variable from argument DEBUG=0
2021-11-30 10:12:11 microsoftonedrive ################## Start Installomator v. 9.0dev
2021-11-30 10:12:11 microsoftonedrive ################## microsoftonedrive
2021-11-30 10:12:13 microsoftonedrive Running msupdate --list
Checking for updates...
Update Assistant is available.
Update Assistant is checking for updates.
Update Assistant is available.
No updates available
2021-11-30 10:12:27 microsoftonedrive BLOCKING_PROCESS_ACTION=tell_user
2021-11-30 10:12:27 microsoftonedrive NOTIFY=success
2021-11-30 10:12:27 microsoftonedrive LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-30 10:12:27 microsoftonedrive no blocking processes defined, using OneDrive as default
2021-11-30 10:12:27 microsoftonedrive Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5kJ1YWMy
2021-11-30 10:12:27 microsoftonedrive App(s) found: /Applications/OneDrive.app
2021-11-30 10:12:27 microsoftonedrive found app at /Applications/OneDrive.app, version 21.220.1024
2021-11-30 10:12:27 microsoftonedrive Installed OneDrive.app is from App Store, use “IGNORE_APP_STORE_APPS=yes” to replace.
2021-11-30 10:12:27 microsoftonedrive ERROR: App previously installed from App Store, and we respect that
2021-11-30 10:12:27 microsoftonedrive Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5kJ1YWMy
2021-11-30 10:12:27 microsoftonedrive App not closed, so no reopen.
2021-11-30 10:12:27 microsoftonedrive ################## End Installomator, exit code 1

➜  Downloads sudo Installomator/utils/assemble.sh microsoftonedrive DEBUG=0 IGNORE_APP_STORE_APPS=yes
2021-11-30 10:12:50 microsoftonedrive setting variable from argument DEBUG=0
2021-11-30 10:12:50 microsoftonedrive setting variable from argument IGNORE_APP_STORE_APPS=yes
2021-11-30 10:12:50 microsoftonedrive ################## Start Installomator v. 9.0dev
2021-11-30 10:12:50 microsoftonedrive ################## microsoftonedrive
2021-11-30 10:12:51 microsoftonedrive Running msupdate --list
Checking for updates...
Update Assistant is available.
Update Assistant is checking for updates.
Update Assistant is available.
No updates available
2021-11-30 10:13:06 microsoftonedrive BLOCKING_PROCESS_ACTION=tell_user
2021-11-30 10:13:06 microsoftonedrive NOTIFY=success
2021-11-30 10:13:06 microsoftonedrive LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-30 10:13:06 microsoftonedrive no blocking processes defined, using OneDrive as default
2021-11-30 10:13:06 microsoftonedrive Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OXbBLX0y
2021-11-30 10:13:06 microsoftonedrive App(s) found: /Applications/OneDrive.app
2021-11-30 10:13:06 microsoftonedrive found app at /Applications/OneDrive.app, version 21.220.1024
2021-11-30 10:13:06 microsoftonedrive Installed OneDrive.app is from App Store, use “IGNORE_APP_STORE_APPS=yes” to replace.
2021-11-30 10:13:06 microsoftonedrive Replacing App Store apps, no matter the version
2021-11-30 10:13:06 microsoftonedrive appversion: 0
2021-11-30 10:13:06 microsoftonedrive Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2021-11-30 10:13:06 microsoftonedrive Latest version of OneDrive is 21.205.1003
2021-11-30 10:13:06 microsoftonedrive Downloading https://go.microsoft.com/fwlink/?linkid=823060 to OneDrive.pkg
2021-11-30 10:15:01 microsoftonedrive no more blocking processes, continue with update
2021-11-30 10:15:01 microsoftonedrive Installing OneDrive
2021-11-30 10:15:01 microsoftonedrive Verifying: OneDrive.pkg
2021-11-30 10:15:02 microsoftonedrive Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2021-11-30 10:15:02 microsoftonedrive Installing OneDrive.pkg to /
installer: Package name is Microsoft OneDrive
installer: Upgrading at base path /
installer: The upgrade was successful.
2021-11-30 10:15:08 microsoftonedrive Finishing...
2021-11-30 10:15:18 microsoftonedrive App(s) found: /Applications/OneDrive.app
2021-11-30 10:15:18 microsoftonedrive found app at /Applications/OneDrive.app, version 21.220.1024
2021-11-30 10:15:18 microsoftonedrive Installed OneDrive.app is from App Store, use “IGNORE_APP_STORE_APPS=yes” to replace.
2021-11-30 10:15:18 microsoftonedrive Replacing App Store apps, no matter the version
2021-11-30 10:15:18 microsoftonedrive Installed OneDrive, version 0
2021-11-30 10:15:18 microsoftonedrive notifying
2021-11-30 10:15:18 microsoftonedrive Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OXbBLX0y
2021-11-30 10:15:18 microsoftonedrive App not closed, so no reopen.
2021-11-30 10:15:18 microsoftonedrive ################## End Installomator, exit code 0
```