### PR TITLE
Add Pareto Security

### DIFF
--- a/fragments/labels/paretosecurity.sh
+++ b/fragments/labels/paretosecurity.sh
@@ -1,0 +1,7 @@
+paretosecurity)
+    name="Pareto Security"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit ParetoSecurity pareto-mac)
+    appNewVersion=$(versionFromGit ParetoSecurity pareto-mac)
+    expectedTeamID="PM784W7B8X"
+    ;;

--- a/fragments/paretosecurity.sh
+++ b/fragments/paretosecurity.sh
@@ -1,0 +1,7 @@
+paretosecurity)
+    name="Pareto Security"
+    type="dmg"
+    downloadURL=$(curl -fs "https://api.github.com/repos/ParetoSecurity/pareto-mac/releases/latest" \
+      | awk -F '"' '/browser_download_url/ && /dmg/ { print $4 }')
+    expectedTeamID="PM784W7B8X"
+    ;;

--- a/fragments/paretosecurity.sh
+++ b/fragments/paretosecurity.sh
@@ -1,7 +1,0 @@
-paretosecurity)
-    name="Pareto Security"
-    type="dmg"
-    downloadURL=$(curl -fs "https://api.github.com/repos/ParetoSecurity/pareto-mac/releases/latest" \
-      | awk -F '"' '/browser_download_url/ && /dmg/ { print $4 }')
-    expectedTeamID="PM784W7B8X"
-    ;;


### PR DESCRIPTION
Pareto Security is open source app that scans macOS for misconfigured security preferences. It would be great if you could accept the PR so that we can suggest easier installation via Jamf. 

```
2021-11-30 16:42:06 paretosecurity ################## Start Installomator v. 9.0dev
2021-11-30 16:42:06 paretosecurity ################## paretosecurity
2021-11-30 16:42:06 paretosecurity DEBUG mode 1 enabled.
2021-11-30 16:42:06 paretosecurity BLOCKING_PROCESS_ACTION=tell_user
2021-11-30 16:42:06 paretosecurity NOTIFY=success
2021-11-30 16:42:06 paretosecurity LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-11-30 16:42:06 paretosecurity no blocking processes defined, using Pareto Security as default
2021-11-30 16:42:06 paretosecurity Changing directory to /Users/dz0ny/Installomator/build
2021-11-30 16:42:06 paretosecurity App(s) found: /Applications/Pareto Security.app
2021-11-30 16:42:06 paretosecurity found app at /Applications/Pareto Security.app, version 1.6.1
2021-11-30 16:42:06 paretosecurity appversion: 1.6.1
2021-11-30 16:42:06 paretosecurity Latest version not specified.
2021-11-30 16:42:06 paretosecurity Downloading https://github.com/ParetoSecurity/pareto-mac/releases/download/1.5.1/ParetoSecurity.dmg to Pareto Security.dmg
2021-11-30 16:42:08 paretosecurity DEBUG mode 1, not checking for blocking processes
2021-11-30 16:42:08 paretosecurity Installing Pareto Security
2021-11-30 16:42:08 paretosecurity Mounting /Users/dz0ny/Installomator/build/Pareto Security.dmg
2021-11-30 16:42:12 paretosecurity Mounted: /Volumes/Pareto Security 1
2021-11-30 16:42:12 paretosecurity Verifying: /Volumes/Pareto Security 1/Pareto Security.app
2021-11-30 16:42:12 paretosecurity Team ID matching: PM784W7B8X (expected: PM784W7B8X )
2021-11-30 16:42:12 paretosecurity Downloaded version of Pareto Security is 1.5.1 (replacing version 1.6.1).
2021-11-30 16:42:12 paretosecurity DEBUG mode 1 enabled, skipping remove, copy and chown steps
2021-11-30 16:42:12 paretosecurity Finishing...
2021-11-30 16:42:22 paretosecurity App(s) found: /Applications/Pareto Security.app
2021-11-30 16:42:22 paretosecurity found app at /Applications/Pareto Security.app, version 1.6.1
2021-11-30 16:42:22 paretosecurity Installed Pareto Security, version 1.6.1
2021-11-30 16:42:22 paretosecurity notifying
2021-11-30 16:42:22 paretosecurity Unmounting /Volumes/Pareto Security 1
"disk9" ejected.
2021-11-30 16:42:22 paretosecurity DEBUG mode 1, not reopening anything
2021-11-30 16:42:22 paretosecurity ################## End Installomator, exit code 0
```

Ref: https://github.com/ParetoSecurity/pareto-mac