### PR TITLE
possibility to have root:wheel on copied apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v9?
 
 - We have moved the root check to the beginning of the script, and improved DEBUG handling with two different modes. `DEBUG=0` is still for production, and `1` is still for the DEBUG we previously knew downloading to the directory it is running from, but `2` will download to temporary folder, will detect updates, but will not install anything, but it will notify the user (almost as running the script without root before).
+- Added variable `SYSTEMOWNER` that is used when copying files when installing. Default `0` is to change owner of the app to the current user on the Mac, like this user was installing this app themselves. When using `1` we will put “root:wheel” on the app, which can be useful for shared machines.
 
 ## v8.0
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ __options:__
 - `no`: If installed app is from App Store (which include VPP installed apps) it will not be touched, no matter it's version (default)
 - `yes`: Replace App Store (and VPP) version of app and handle future updates using Installomator, even if latest version. Shouldn’t give any problems for the user in most cases. Known bad example: Slack will loose all settings.
 
+### Owner of copied apps
+Default is `SYSTEMOWNER=0`
+__options:__
+- `0`: Current user will be owner of copied apps, just like if they installed it themselves (default).
+- `1`: root:wheel will be set on the copied app. Useful for shared machines.
+
 ### Install behavior (force installation)
 
 Since we now make a version checking, and only installs the software if the version is different, an `INSTALL` variable can be used to force the installation:

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -392,11 +392,12 @@ installAppWithPath() { # $1: path to app to install in $targetDir
         fi
 
         # set ownership to current user
-        if [ "$currentUser" != "loginwindow" ]; then
+        if [[ "$currentUser" != "loginwindow" && $SYSTEMOWNER -ne 1 ]]; then
             printlog "Changing owner to $currentUser"
             chown -R "$currentUser" "$targetDir/$appName"
         else
-            printlog "No user logged in, not changing user"
+            printlog "No user logged in or SYSTEMOWNER=1, setting owner to root:wheel"
+            chown -R root:wheel "$targetDir/$appName"
         fi
 
     elif [[ ! -z $CLIInstaller ]]; then

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -88,6 +88,13 @@ IGNORE_APP_STORE_APPS=no
 #                  Shouldn’t give any problems for the user in most cases.
 #                  Known bad example: Slack will loose all settings.
 
+# Owner of copied apps
+SYSTEMOWNER=0
+# options:
+#  - 0             Current user will be owner of copied apps, just like if they
+#                  installed it themselves (default).
+#  - 1             root:wheel will be set on the copied app.
+#                  Useful for shared machines.
 
 # install behavior
 INSTALL=""


### PR DESCRIPTION
On shared machines it can be better to have root:whell as owner of the copied app, rather than using the currently logged in user.

`SYSTEMOWNER=1` will user root:wheel as owner.
`SYSTEMOWNER=0` is default where the current user will be set.