### PR TITLE
Added 'tidal'

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -328,6 +328,7 @@ textmate
 theunarchiver
 things
 thunderbird
+tidal
 toggltrack
 tom4aconverter
 torbrowser

--- a/fragments/labels/tidal.sh
+++ b/fragments/labels/tidal.sh
@@ -1,0 +1,6 @@
+tidal)
+    name="TIDAL"
+    type="dmg"
+    downloadURL="https://download.tidal.com/desktop/TIDAL.dmg"
+    expectedTeamID="GK2243L7KB"
+    ;;

--- a/fragments/labels/tidal.sh
+++ b/fragments/labels/tidal.sh
@@ -2,5 +2,6 @@ tidal)
     name="TIDAL"
     type="dmg"
     downloadURL="https://download.tidal.com/desktop/TIDAL.dmg"
+    appNewVersion=$(curl -fs https://update.tidal.com/updates/latest\?v\=1 | cut -d '"' -f4 | sed -E 's/https.*\/TIDAL\.([0-9.]*)\.zip/\1/g')
     expectedTeamID="GK2243L7KB"
     ;;


### PR DESCRIPTION
Added 'tidal' to fragments and `Label.txt`.
Unfortunately, I was not able to find a matching URL for `appNewVersion`...

Test run:
```
$ sudo zsh Installomator.zsh tidal DEBUG=0
2021-12-08 15:07:56 tidal setting variable from argument DEBUG=0
2021-12-08 15:07:56 tidal ################## Start Installomator v. 8.0
2021-12-08 15:07:57 tidal ################## tidal
2021-12-08 15:07:57 tidal BLOCKING_PROCESS_ACTION=tell_user
2021-12-08 15:07:57 tidal NOTIFY=success
2021-12-08 15:07:57 tidal LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-12-08 15:07:57 tidal no blocking processes defined, using TIDAL as default
2021-12-08 15:07:57 tidal Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.y57lJivs
2021-12-08 15:07:57 tidal App(s) found: /Applications/TIDAL.app
2021-12-08 15:07:57 tidal found app at /Applications/TIDAL.app, version 2.28.0
2021-12-08 15:07:57 tidal appversion: 2.28.0
2021-12-08 15:07:57 tidal Latest version not specified.
2021-12-08 15:07:57 tidal Downloading https://download.tidal.com/desktop/TIDAL.dmg to TIDAL.dmg
2021-12-08 15:08:00 tidal no more blocking processes, continue with update
2021-12-08 15:08:00 tidal Installing TIDAL
2021-12-08 15:08:00 tidal Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.y57lJivs/TIDAL.dmg
2021-12-08 15:08:04 tidal Mounted: /Volumes/TIDAL
2021-12-08 15:08:04 tidal Verifying: /Volumes/TIDAL/TIDAL.app
2021-12-08 15:08:06 tidal Team ID matching: GK2243L7KB (expected: GK2243L7KB )
2021-12-08 15:08:06 tidal Downloaded version of TIDAL is 2.28.0, same as installed.
2021-12-08 15:08:06 tidal Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.y57lJivs
2021-12-08 15:08:06 tidal Unmounting /Volumes/TIDAL
"disk4" ejected.
2021-12-08 15:08:06 tidal App not closed, so no reopen.
2021-12-08 15:08:06 tidal ################## End Installomator, exit code 0
```