### PR TITLE
Updated URL for Box Drive

### DIFF
--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -2,11 +2,6 @@ boxdrive)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
     name="Box"
     type="pkg"
-    if [[ $(arch) == "arm64" ]]; then
-        #Note: https://support.box.com/hc/en-us/articles/1500004479962-Box-Drive-support-on-devices-with-M1-chips
-        downloadURL="https://e3.boxcdn.net/desktop/pre-releases/mac/BoxDrive.2.20.140-M1-beta.pkg"
-    elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"
-    fi
+    downloadURL="https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"
     expectedTeamID="M683GB7CPW"
     ;;

--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -1,5 +1,4 @@
 boxdrive)
-    # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
     name="Box"
     type="pkg"
     downloadURL="https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"


### PR DESCRIPTION
Box now makes a universal installer for all architectures. Installomator debug output follows;

./assemble.sh boxdrive
2021-12-23 09:16:22 boxdrive ################## Start Installomator v. 9.0dev
2021-12-23 09:16:22 boxdrive ################## boxdrive
2021-12-23 09:16:22 boxdrive DEBUG mode 1 enabled.
2021-12-23 09:16:23 boxdrive BLOCKING_PROCESS_ACTION=tell_user
2021-12-23 09:16:23 boxdrive NOTIFY=success
2021-12-23 09:16:23 boxdrive LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2021-12-23 09:16:23 boxdrive no blocking processes defined, using Box as default
2021-12-23 09:16:23 boxdrive Changing directory to /Users/john/Documents/Source/Installomator/build
2021-12-23 09:16:23 boxdrive App(s) found:
2021-12-23 09:16:23 boxdrive could not find Box.app
2021-12-23 09:16:23 boxdrive appversion:
2021-12-23 09:16:23 boxdrive Latest version not specified.
2021-12-23 09:16:23 boxdrive Downloading https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg to Box.pkg
2021-12-23 09:16:25 boxdrive DEBUG mode, not checking for blocking processes
2021-12-23 09:16:25 boxdrive Installing Box
2021-12-23 09:16:25 boxdrive Verifying: Box.pkg
2021-12-23 09:16:25 boxdrive Team ID: M683GB7CPW (expected: M683GB7CPW )
2021-12-23 09:16:25 boxdrive DEBUG enabled, skipping installation
2021-12-23 09:16:25 boxdrive Finishing...
2021-12-23 09:16:35 boxdrive App(s) found:
2021-12-23 09:16:35 boxdrive could not find Box.app
2021-12-23 09:16:35 boxdrive Installed Box
2021-12-23 09:16:35 boxdrive notifying
2021-12-23 09:16:35 boxdrive DEBUG mode, not reopening anything
2021-12-23 09:16:35 boxdrive ################## End Installomator, exit code 0