### PR TITLE
Update textexpander download URL

### DIFF
--- a/fragments/labels/textexpander.sh
+++ b/fragments/labels/textexpander.sh
@@ -1,7 +1,7 @@
 textexpander)
     name="TextExpander"
     type="dmg"
-    downloadURL="https://textexpander.com/cgi-bin/redirect.pl?cmd=download&platform=osx"
-    appNewVersion=$( curl -fsIL "https://textexpander.com/cgi-bin/redirect.pl?cmd=download&platform=osx" | grep -i "^location" | awk '{print $2}' | tail -1 | cut -d "_" -f2 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
+    downloadURL="https://cgi.textexpander.com/cgi-bin/redirect.pl?cmd=download&platform=osx"
+    appNewVersion=$( curl -fsIL "https://cgi.textexpander.com/cgi-bin/redirect.pl?cmd=download&platform=osx" | grep -i "^location" | awk '{print $2}' | tail -1 | cut -d "_" -f2 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
     expectedTeamID="7PKJ6G4DXL"
     ;;


### PR DESCRIPTION
Successful test run:

It also appears the compiled version of the script in the repo still refers to when this was previously distributed as a ZIP but is now a dmg.  The label was updated but not the "combined" script.

```
zsh assemble.sh -l ~/Documents/git/Installomator/fragments/labels textexpander
2022-01-05 15:26:02 textexpander ################## Start Installomator v. 9.0dev
2022-01-05 15:26:02 textexpander ################## textexpander
2022-01-05 15:26:02 textexpander DEBUG mode 1 enabled.
2022-01-05 15:26:03 textexpander BLOCKING_PROCESS_ACTION=tell_user
2022-01-05 15:26:03 textexpander NOTIFY=success
2022-01-05 15:26:03 textexpander LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-05 15:26:03 textexpander no blocking processes defined, using TextExpander as default
2022-01-05 15:26:03 textexpander Changing directory to /Users/installomator/Documents/git/Installomator/build
2022-01-05 15:26:03 textexpander App(s) found: 
2022-01-05 15:26:03 textexpander could not find TextExpander.app
2022-01-05 15:26:03 textexpander appversion: 
2022-01-05 15:26:03 textexpander Latest version of TextExpander is 7.1
2022-01-05 15:26:03 textexpander TextExpander.dmg exists and DEBUG mode 1 enabled, skipping download
2022-01-05 15:26:03 textexpander DEBUG mode 1, not checking for blocking processes
2022-01-05 15:26:03 textexpander Installing TextExpander
2022-01-05 15:26:03 textexpander Mounting /Users/installomator/Documents/git/Installomator/build/TextExpander.dmg
2022-01-05 15:26:06 textexpander Mounted: /Volumes/TextExpander
2022-01-05 15:26:06 textexpander Verifying: /Volumes/TextExpander/TextExpander.app
2022-01-05 15:26:06 textexpander Team ID matching: 7PKJ6G4DXL (expected: 7PKJ6G4DXL )
2022-01-05 15:26:07 textexpander Downloaded version of TextExpander is 7.1 (replacing version ).
2022-01-05 15:26:07 textexpander DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-01-05 15:26:07 textexpander Finishing...
2022-01-05 15:26:17 textexpander App(s) found: 
2022-01-05 15:26:17 textexpander could not find TextExpander.app
2022-01-05 15:26:17 textexpander Installed TextExpander
2022-01-05 15:26:17 textexpander notifying
2022-01-05 15:26:17 textexpander Unmounting /Volumes/TextExpander
"disk4" ejected.
2022-01-05 15:26:17 textexpander DEBUG mode 1, not reopening anything
2022-01-05 15:26:17 textexpander ################## End Installomator, exit code 0 
```