### PR TITLE
`RETURN_LABEL_NAME` implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v9?
 
 - We have moved the root check to the beginning of the script, and improved DEBUG handling with two different modes. `DEBUG=0` is still for production, and `1` is still for the DEBUG we previously knew downloading to the directory it is running from, but `2` will download to temporary folder, will detect updates, but will not install anything, but it will notify the user (almost as running the script without root before).
+- New variable `RETURN_LABEL_NAME`. If given the value `1`, like `RETURN_LABEL_NAME=1` then Installomator only returns the name of the label. It makes for a better user friendly message for displaying in DEPNotify if that is integrated.
 
 ## v8.0
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -18,6 +18,10 @@ cleanupAndExit() { # $1 = exit code, $2 message
     # If we closed any processes, reopen the app again
     reopenClosedProcess
     printlog "################## End Installomator, exit code $1 \n\n"
+    # if label is wrong and we wanted name of the label, then return ##################
+    if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
+        echo "##################"
+    fi
     exit "$1"
 }
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -20,7 +20,7 @@ cleanupAndExit() { # $1 = exit code, $2 message
     printlog "################## End Installomator, exit code $1 \n\n"
     # if label is wrong and we wanted name of the label, then return ##################
     if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
-        echo "##################"
+        echo "#"
     fi
     exit "$1"
 }

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -103,6 +103,14 @@ REOPEN="yes"
 #  - yes           App wil be reopened if it was closed
 #  - no            App not reopened
 
+# Only let Installomator return the name of the label
+# RETURN_LABEL_NAME=0
+# options:
+#   - 1      Installomator will return the name of the label and exit, so last line of
+#            output will be that name. When Installomator is locally installed and we
+#            use DEPNotify, then DEPNotify can present a more nice name to the user,
+#            instead of just the label name.
+
 
 # NOTE: How labels work
 

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -5,6 +5,13 @@
     ;;
 esac
 
+# Are we only asked to return label name
+if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
+    printlog "Only returning label name."
+    printlog "$name"
+    echo "$name"
+    exit
+fi
 
 # MARK: application download and installation starts here
 


### PR DESCRIPTION
When using DEPNotify I would like Installomator to return a nice name for the label to show as status in DEPNotify, instead of only the label name.
This way we can do that.
And maybe in the future include a description of the software, if people are seeking inspiration to software by looking at Installomator (that contains a lot of preferred solution for many organisations).

Example:
```
➜  Downloads /Users/st/Documents/GitHub/Installomator/utils/assemble.sh 1password RETURN_LABEL_NAME=1 
2022-01-07 09:47:20 1password setting variable from argument RETURN_LABEL_NAME=1
2022-01-07 09:47:20 1password ################## Start Installomator v. 9.0dev
2022-01-07 09:47:20 1password ################## 1password
2022-01-07 09:47:20 1password DEBUG mode 1 enabled.
2022-01-07 09:47:20 1password ERROR: unknown label 1password
2022-01-07 09:47:20 1password DEBUG mode 1, not reopening anything
2022-01-07 09:47:20 1password ################## End Installomator, exit code 1 


##################
➜  Downloads /Users/st/Documents/GitHub/Installomator/utils/assemble.sh 1password7 RETURN_LABEL_NAME=1
2022-01-07 09:47:37 1password7 setting variable from argument RETURN_LABEL_NAME=1
2022-01-07 09:47:37 1password7 ################## Start Installomator v. 9.0dev
2022-01-07 09:47:37 1password7 ################## 1password7
2022-01-07 09:47:37 1password7 DEBUG mode 1 enabled.
2022-01-07 09:47:38 1password7 Only returning label name.
2022-01-07 09:47:38 1password7 1Password 7
1Password 7
```

So the idea is to use `tail -1` for the output, and that will be the name, unless the label was wrong.