### PR TITLE
Update golang.sh with new URL

### DIFF
--- a/fragments/labels/golang.sh
+++ b/fragments/labels/golang.sh
@@ -3,7 +3,7 @@ golang)
     name="GoLang"
     type="pkg"
     packageID="org.golang.go"
-    downloadURL="$(curl -fsIL "https://golang.org$(curl -fs "https://golang.org/dl/" | grep -i "downloadBox" | grep "pkg" | tr '"' '\n' | grep "pkg")" | grep -i "^location" | awk '{print $2}' | tr -d '\r\n')"
+    downloadURL="$(curl -fsIL "https://go.dev$(curl -fs "https://go.dev/dl/" | grep -i "downloadBox" | grep "pkg" | tr '"' '\n' | grep "pkg")" | grep -i "^location" | awk '{print $2}' | tr -d '\r\n')"
     appNewVersion="$( echo "${downloadURL}" | sed -E 's/.*\/(go[0-9.]*)\..*/\1/g' )" # Version includes letters "go"
     expectedTeamID="EQHXZ8M8AV"
     blockingProcesses=( NONE )


### PR DESCRIPTION
Go is now hosted at https://go.dev/