### PR TITLE
Improved Isaac Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@
 - Added variable `SYSTEMOWNER` that is used when copying files when installing. Default `0` is to change owner of the app to the current user on the Mac, like this user was installing this app themselves. When using `1` we will put “root:wheel” on the app, which can be useful for shared machines.
 
 Big changes to logging:
-- Logging levels as DEBUG 0 INFO 1 WARN 2 ERROR 3 REQ 4
+- Introducing variable `LOGGING`, that can be either of the logging levels
+- Logging levels:
+    0: DEBUG     Everything is logged
+    1: INFO      Normal logging behavior
+    2: WARN
+    3: ERROR
+    4: REQ
 - External logging to Datadog
-- A function to shorten duplicate lines in installation logs
+- A function to shorten duplicate lines in installation logs or output of longer commands
 - Ability to extract install.log in the time when Installomator was running, if further investigations needs to be done to logs
 
 ## v8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Changed logic if `IGNORE_APP_STORE_APPS=yes`. Before this version a label like `microsoftonedrive` that was installed from App Store, and that we want to replace with the “ordinary” version, Installomator would still use `updateTool`, even though `IGNORE_APP_STORE_APPS=yes`. So we would have to have `INSTALL=force` in order to have the app replaced, as `updateTool` would be used. But now if `IGNORE_APP_STORE_APPS=yes` then `updateTool` will be not set, and the App Store app will be replaced. BUT if the installed software was not from App Store, then `updateTool` will not be used, and it would be a kind of a forced install (in the example of `microsoftonedrive`), except if the version is the same (where installation is skipped).
 - Added variable `SYSTEMOWNER` that is used when copying files when installing. Default `0` is to change owner of the app to the current user on the Mac, like this user was installing this app themselves. When using `1` we will put “root:wheel” on the app, which can be useful for shared machines.
 
+Big changes to logging:
+- Logging levels as DEBUG 0 INFO 1 WARN 2 ERROR 3 REQ 4
+- External logging to Datadog
+- A function to shorten duplicate lines in installation logs
+- Ability to extract install.log in the time when Installomator was running, if further investigations needs to be done to logs
+
 ## v8.0
 
 - removed leading `0` from the version because it has lost all meaning (thanks to @grahampugh for the inspiration)

--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -43,10 +43,10 @@ if [[ $label == "version" ]]; then
     exit 0
 fi
 
-printlog "################## Start Installomator" REQ
-printlog "################## Version: $VERSION" REQ
-printlog "################## Date: $VERSIONDATE" REQ
-printlog "################## $label" REQ
+printlog "################## Start Installomator v. $VERSION, date $VERSIONDATE" REQ
+printlog "################## Version: $VERSION" INFO
+printlog "################## Date: $VERSIONDATE" INFO
+printlog "################## $label" INFO
 
 # Check for DEBUG mode
 if [[ $DEBUG -gt 0 ]]; then

--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -43,12 +43,14 @@ if [[ $label == "version" ]]; then
     exit 0
 fi
 
-printlog "################## Start Installomator v. $VERSION"
-printlog "################## $label"
+printlog "################## Start Installomator" REQ
+printlog "################## Version: $VERSION" REQ
+printlog "################## Date: $VERSIONDATE" REQ
+printlog "################## $label" REQ
 
 # Check for DEBUG mode
 if [[ $DEBUG -gt 0 ]]; then
-    printlog "DEBUG mode $DEBUG enabled."
+    printlog "DEBUG mode $DEBUG enabled." DEBUG
 fi
 
 # How we get version number from app

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -112,10 +112,10 @@ printlog(){
 
     # Once we finally stop getting duplicate logs output the number of times we got a duplicate.
     if [[ $logrepeat -gt 1 ]];then
-        echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : Last Log repeated ${logrepeat} times" | tee -a $log_location
+        echo "$timestamp" : "${log_priority} : Last Log repeated ${logrepeat} times" | tee -a $log_location
 
         if [[ ! -z $datadogAPI ]]; then
-            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSIONDATE : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
+            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSION : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
         fi
         logrepeat=0
     fi
@@ -132,18 +132,12 @@ printlog(){
     if [[ ${levels[$log_priority]} -ge ${levels[$LOGGING]} ]]; then
         while IFS= read -r logmessage; do
             if [[ "$(whoami)" == "root" ]]; then
-                echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : ${logmessage}" | tee -a $log_location
+                echo "$timestamp" : "${log_priority} : ${logmessage}" | tee -a $log_location
             else
-                echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : ${logmessage}"
+                echo "$timestamp" : "${log_priority} : ${logmessage}"
             fi
         done <<< "$log_message"
     fi
-
-#    if [[ "$(whoami)" == "root" ]]; then
-#        echo "$timestamp" "$label" "$1" | tee -a $log_location
-#    else
-#        echo "$timestamp" "$label" "$1"
-#    fi
 }
 
 # Used to remove dupplicate lines in large log output, for example from msupdate command

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -114,7 +114,7 @@ printlog(){
 
     # Once we finally stop getting duplicate logs output the number of times we got a duplicate.
     if [[ $logrepeat -gt 1 ]];then
-        echo "$timestamp" : "${log_priority} : Last Log repeated ${logrepeat} times" | tee -a $log_location
+        echo "$timestamp" : "${log_priority} : $label : Last Log repeated ${logrepeat} times" | tee -a $log_location
 
         if [[ ! -z $datadogAPI ]]; then
             curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSION : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
@@ -134,9 +134,9 @@ printlog(){
     if [[ ${levels[$log_priority]} -ge ${levels[$LOGGING]} ]]; then
         while IFS= read -r logmessage; do
             if [[ "$(whoami)" == "root" ]]; then
-                echo "$timestamp" : "${log_priority} : ${logmessage}" | tee -a $log_location
+                echo "$timestamp" : "${log_priority} : $label : ${logmessage}" | tee -a $log_location
             else
-                echo "$timestamp" : "${log_priority} : ${logmessage}"
+                echo "$timestamp" : "${log_priority} : $label : ${logmessage}"
             fi
         done <<< "$log_message"
     fi

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -113,10 +113,11 @@ printlog(){
     if [[ $logrepeat -gt 1 ]];then
         echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : Last Log repeated ${logrepeat} times" | tee -a $log_location
 
-    if [[ ! -z $datadogAPI ]]; then
-        curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSIONDATE : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
+        if [[ ! -z $datadogAPI ]]; then
+            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSIONDATE : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
+        fi
+        logrepeat=0
     fi
-    logrepeat=0
 
     # If the datadogAPI key value is set and our logging level is greaterthan or equal to our set level
     # then post to Datadog's HTTPs endpoint.

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -67,15 +67,104 @@ displaynotification() { # $1: message $2: title
 # MARK: Logging
 log_location="/private/var/log/Installomator.log"
 
-printlog(){
+# Check if we're in debug mode, if so then set logging to DEBUG, otherwise default to INFO
+# if no log level is specified.
+if [[ $DEBUG -ne 0 ]]; then
+    LOGGING=DEBUG
+elif [[ -z $LOGGING ]]; then
+    LOGGING=INFO
+    datadogLoggingLevel=INFO
+fi
 
+# Associate logging levels with a numerical value so that we are able to identify what
+# should be removed. For example if the LOGGING=ERROR only printlog statements with the
+# level REQ and ERROR will be displayed. LOGGING=DEBUG will show all printlog statements.
+# If a printlog statement has no level set it's automatically assigned INFO.
+
+declare -A levels=(DEBUG 0 INFO 1 WARN 2 ERROR 3 REQ 4)
+
+# If we are able to detect an MDM URL (Jamf Pro) or another identifier for a customer/instance we grab it here, this is useful if we're centrally logging multiple MDM instances.
+if [[ -f /Library/Preferences/com.jamfsoftware.jamf.plist ]]; then
+    mdmURL=$(defaults read /Library/Preferences/com.jamfsoftware.jamf.plist jss_url)
+elif [[ -n "$MDMProfileName" ]]; then
+    mdmURL=$(sudo profiles show | grep -A3 "$MDMProfileName" | sed -n -e 's/^.*organization: //p')
+else
+    mdmURL="Unknown"
+fi
+
+# Generate a session key for this run, this is useful to idenify streams when we're centrally logging.
+SESSION=$RANDOM
+
+printlog(){
+    [ -z "$2" ] && 2=INFO
+    log_message=$1
+    log_priority=$2
     timestamp=$(date +%F\ %T)
 
-    if [[ "$(whoami)" == "root" ]]; then
-        echo "$timestamp" "$label" "$1" | tee -a $log_location
-    else
-        echo "$timestamp" "$label" "$1"
+    # Check to make sure that the log isn't the same as the last, if it is then don't log and increment a timer.
+    if [[ ${log_message} == ${previous_log_message} ]];then
+        let logrepeat=$logrepeat+1
+        return
     fi
+
+    previous_log_message=$log_message
+
+    # Once we finally stop getting duplicate logs output the number of times we got a duplicate.
+    if [[ $logrepeat -gt 1 ]];then
+        echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : Last Log repeated ${logrepeat} times" | tee -a $log_location
+
+    if [[ ! -z $datadogAPI ]]; then
+        curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : $APPLICATION : $VERSIONDATE : $SESSION : Last Log repeated ${logrepeat} times" > /dev/null
+    fi
+    logrepeat=0
+
+    # If the datadogAPI key value is set and our logging level is greaterthan or equal to our set level
+    # then post to Datadog's HTTPs endpoint.
+    if [[ -n $datadogAPI && ${levels[$log_priority]} -ge ${levels[$datadogLoggingLevel]} ]]; then
+        while IFS= read -r logmessage; do
+            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : Installomator-${label} : ${VERSIONDATE//-/} : $SESSION : ${logmessage}" > /dev/null
+        done <<< "$log_message"
+    fi
+
+    # If our logging level is greaterthan or equal to our set level then output locally.
+    if [[ ${levels[$log_priority]} -ge ${levels[$LOGGING]} ]]; then
+        while IFS= read -r logmessage; do
+            if [[ "$(whoami)" == "root" ]]; then
+                echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : ${logmessage}" | tee -a $log_location
+            else
+                echo "$timestamp" : "${log_priority} : ${VERSIONDATE//-/} : ${logmessage}"
+            fi
+        done <<< "$log_message"
+    fi
+
+#    if [[ "$(whoami)" == "root" ]]; then
+#        echo "$timestamp" "$label" "$1" | tee -a $log_location
+#    else
+#        echo "$timestamp" "$label" "$1"
+#    fi
+}
+
+# Used to remove dupplicate lines in large log output, for example from msupdate command
+# after it finishes running.
+deduplicatelogs() {
+    loginput=${1:-"Log"}
+    logoutput=""
+    # Read each line of the incoming log individually, match it with the previous.
+    # If it matches increment logrepeate then skip to the next line.
+    while read log; do
+        if [[ $log == $previous_log ]];then
+            let logrepeat=$logrepeat+1
+            continue
+        fi
+
+        previous_log="$log"
+        if [[ $logrepeat -gt 1 ]];then
+            logoutput+="Last Log repeated ${logrepeat} times\n"
+            logrepeat=0
+        fi
+
+        logoutput+="$log\n"
+    done <<< "$loginput"
 }
 
 # will get the latest release download from a github repo

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -239,3 +239,40 @@ REOPEN="yes"
 #   installer that should be located after mounting/expanding the downloaded archive.
 #   See label adobecreativeclouddesktop
 #
+### Logging
+# Logging behavior
+LOGGING=""
+# options:
+#   - DEBUG     Everything is logged
+#   - INFO      (default) normal logging level
+#   - WARN      only warning
+#   - ERROR     only errors
+#   - REQ       ????
+
+# MDM profile name
+MDMProfileName=""
+# options:
+#   - MDM Profile               Addigy has this name on the profile
+#   - Mosyle Corporation MDM    Mosyle uses this name on the profile
+# From the LOGO variable we can know if Addigy og Mosyle is used, so if that variable
+# is either of these, and this variable is empty, then we can will auto detect this.
+
+# Datadog logging used
+datadogAPI=""
+# Simply add your own API key for this in order to have logs sent to Datadog
+# See more here: https://www.datadoghq.com/product/log-management/
+
+# Log Date format used when parsing logs for debugging, this is the default used by
+# install.log, override this in the case statements if you need something custom per
+# application (See adobeillustrator).  Using stadard GNU Date formatting.
+LogDateFormat="%Y-%m-%d %H:%M:%S"
+
+# Get the start time for parsing install.log if we fail.
+starttime=$(date "+$LogDateFormat")
+
+# Check if we have rosetta installed
+if [[ $(/usr/bin/arch) == "arm64" ]]; then
+    if ! arch -x86_64 /usr/bin/true >/dev/null 2>&1; then # pgrep oahd >/dev/null 2>&1
+        rosetta2=no
+    fi
+fi

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -255,7 +255,7 @@ MDMProfileName=""
 #   - MDM Profile               Addigy has this name on the profile
 #   - Mosyle Corporation MDM    Mosyle uses this name on the profile
 # From the LOGO variable we can know if Addigy og Mosyle is used, so if that variable
-# is either of these, and this variable is empty, then we can will auto detect this.
+# is either of these, and this variable is empty, then we will auto detect this.
 
 # Datadog logging used
 datadogAPI=""

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -35,14 +35,17 @@ case $LOGO in
     mosyleb)
         # Mosyle Business
         LOGO="/Applications/Self-Service.app/Contents/Resources/AppIcon.icns"
+        if [[ -z $MDMProfileName ]]; then; MDMProfileName="Mosyle Corporation MDM"; fi
         ;;
     mosylem)
         # Mosyle Manager (education)
         LOGO="/Applications/Manager.app/Contents/Resources/AppIcon.icns"
+        if [[ -z $MDMProfileName ]]; then; MDMProfileName="Mosyle Corporation MDM"; fi
         ;;
     addigy)
         # Addigy
         LOGO="/Library/Addigy/macmanage/MacManage.app/Contents/Resources/atom.icns"
+        if [[ -z $MDMProfileName ]]; then; MDMProfileName="MDM Profile"; fi
         ;;
 esac
 if [[ ! -a "${LOGO}" ]]; then
@@ -112,7 +115,7 @@ else
 fi
 
 # MARK: change directory to temporary working directory
-printlog "Changing directory to $tmpDir"
+printlog "Changing directory to $tmpDir" DEBUG
 if ! cd "$tmpDir"; then
     printlog "error changing directory $tmpDir"
     cleanupAndExit 1
@@ -178,7 +181,12 @@ else
             displaynotification "Downloading new $name" "Download in progress …"
         fi
     fi
-    if ! curl --location --fail --silent "$downloadURL" -o "$archiveName"; then
+    curlDownload=$(curl -v -fsL --show-error "$downloadURL" -o "$archiveName" 2>&1)
+    curlDownloadStatus=$(echo $?)
+    deduplicatelogs "$curlDownload"
+    printlog "curl output was: $logoutput" DEBUG
+    if [[ $curlDownloadStatus -ne 0 ]]; then
+    #if ! curl --location --fail --silent "$downloadURL" -o "$archiveName"; then
         printlog "error downloading $downloadURL"
         message="$name update/installation failed. This will be logged, so IT can follow up."
         if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then
@@ -189,7 +197,7 @@ else
                 displaynotification "$message" "Error installing $name"
             fi
         fi
-        cleanupAndExit 2
+        cleanupAndExit 2 "Error downloading $downloadURL error: $logoutput" ERROR
     fi
 fi
 

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -172,7 +172,7 @@ if [ -f "$archiveName" ] && [ "$DEBUG" -eq 1 ]; then
     printlog "$archiveName exists and DEBUG mode 1 enabled, skipping download"
 else
     # download the dmg
-    printlog "Downloading $downloadURL to $archiveName"
+    printlog "Downloading $downloadURL to $archiveName" REQ
     if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then
         printlog "notifying"
         if [[ $updateDetected == "YES" ]]; then
@@ -181,7 +181,7 @@ else
             displaynotification "Downloading new $name" "Download in progress …"
         fi
     fi
-    curlDownload=$(curl -v -fsL --show-error "$downloadURL" -o "$archiveName" 2>&1)
+    curlDownload=$(curl -v -fsL --show-error ${curlOptions} "$downloadURL" -o "$archiveName" 2>&1)
     curlDownloadStatus=$(echo $?)
     deduplicatelogs "$curlDownload"
     printlog "curl output was: $logoutput" DEBUG
@@ -192,9 +192,9 @@ else
         if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then
             printlog "notifying"
             if [[ $updateDetected == "YES" ]]; then
-                displaynotification "$message" "Error updating $name"
+                displaynotification "$message" "Error updating $name" ERROR
             else
-                displaynotification "$message" "Error installing $name"
+                displaynotification "$message" "Error installing $name" ERROR
             fi
         fi
         cleanupAndExit 2 "Error downloading $downloadURL error: $logoutput" ERROR
@@ -215,7 +215,7 @@ else
 fi
 
 # MARK: install the download
-printlog "Installing $name"
+printlog "Installing $name" REQ
 if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then
     printlog "notifying"
     if [[ $updateDetected == "YES" ]]; then
@@ -227,7 +227,7 @@ fi
 
 if [ -n "$installerTool" ]; then
     # installerTool defined, and we use that for installation
-    printlog "installerTool used: $installerTool"
+    printlog "installerTool used: $installerTool" REQ
     appName="$installerTool"
 fi
 


### PR DESCRIPTION
Improvements to logging:
- Logging levels as DEBUG 0 INFO 1 WARN 2 ERROR 3 REQ 4
- External logging to Datadog
- A function to shorten duplicate lines in installation logs
- Ability to extract install.log in the time when Installomator was running, if further investigations needs to be done to logs