### PR TITLE
Fixed 'appNewVersion' for 'docker'

### DIFF
--- a/fragments/labels/docker.sh
+++ b/fragments/labels/docker.sh
@@ -1,13 +1,12 @@
 docker)
-    # credit: @securitygeneration
     name="Docker"
     type="dmg"
-    #downloadURL="https://download.docker.com/mac/stable/Docker.dmg"
     if [[ $(arch) == arm64 ]]; then
      downloadURL="https://desktop.docker.com/mac/stable/arm64/Docker.dmg"
+     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/arm64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[1]' 2>/dev/null | cut -d '"' -f2 )
     elif [[ $(arch) == i386 ]]; then
      downloadURL="https://desktop.docker.com/mac/stable/amd64/Docker.dmg"
+     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[1]' 2>/dev/null | cut -d '"' -f2 )
     fi
-    appNewVersion=$(curl -ifs https://docs.docker.com/docker-for-mac/release-notes/ | grep ">Docker Desktop Community" | head -1 | sed -n -e 's/^.*Community //p' | cut -d '<' -f1)
     expectedTeamID="9BNSXJN65R"
     ;;


### PR DESCRIPTION
URLs for version checking have changed. It's now using the `shortVersionString` from the sparkle feed.

Example run for M1:

```
$ sudo zsh Installomator.sh docker DEBUG=0

2022-01-12 18:16:35 docker setting variable from argument DEBUG=0
2022-01-12 18:16:35 docker ################## Start Installomator v. 8.0
2022-01-12 18:16:35 docker ################## docker
2022-01-12 18:16:35 docker BLOCKING_PROCESS_ACTION=tell_user
2022-01-12 18:16:35 docker NOTIFY=success
2022-01-12 18:16:35 docker LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-12 18:16:35 docker no blocking processes defined, using Docker as default
2022-01-12 18:16:35 docker Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t4N46qTN
2022-01-12 18:16:35 docker App(s) found: /Applications/Docker.app
2022-01-12 18:16:35 docker found app at /Applications/Docker.app, version 4.3.2
2022-01-12 18:16:35 docker appversion: 4.3.2
2022-01-12 18:16:35 docker Latest version of Docker is 4.3.2
2022-01-12 18:16:35 docker There is no newer version available.
2022-01-12 18:16:35 docker Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t4N46qTN
2022-01-12 18:16:35 docker App not closed, so no reopen.
2022-01-12 18:16:35 docker ################## End Installomator, exit code 0
```