### PR TITLE
Added label for 'managedappschemabuilder'

### DIFF
--- a/fragments/labels/managedappschemabuilder.sh
+++ b/fragments/labels/managedappschemabuilder.sh
@@ -1,0 +1,7 @@
+managedappschemabuilder)
+    name="Managed App Schema Builder"
+    type="zip"
+    downloadURL=$(downloadURLFromGit BIG-RAT Managed-App-Schema-Builder)
+    appNewVersion=$(versionFromGit BIG-RAT Managed-App-Schema-Builder)
+    expectedTeamID="PS2F6S478M"
+    ;;


### PR DESCRIPTION
Install log:

```
$ sudo zsh Installomator.sh managedappschemabuilder DEBUG=0

2022-01-13 18:52:55 managedappschemabuilder setting variable from argument DEBUG=0
2022-01-13 18:52:55 managedappschemabuilder ################## Start Installomator v. 8.0
2022-01-13 18:52:55 managedappschemabuilder ################## managedappschemabuilder
2022-01-13 18:52:55 managedappschemabuilder BLOCKING_PROCESS_ACTION=tell_user
2022-01-13 18:52:55 managedappschemabuilder NOTIFY=success
2022-01-13 18:52:55 managedappschemabuilder LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-13 18:52:55 managedappschemabuilder no blocking processes defined, using Managed App Schema Builder as default
2022-01-13 18:52:55 managedappschemabuilder Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.i5daAYvs
2022-01-13 18:52:56 managedappschemabuilder App(s) found:
2022-01-13 18:52:56 managedappschemabuilder could not find Managed App Schema Builder.app
2022-01-13 18:52:56 managedappschemabuilder appversion:
2022-01-13 18:52:56 managedappschemabuilder Latest version of Managed App Schema Builder is 2022-01-13 18:52:55 managedappschemabuilder could not retrieve version number for BIG-RAT/Managed-App-Schema-Builder
2022-01-13 18:52:56 managedappschemabuilder Downloading https://github.com/BIG-RAT/Managed-App-Schema-Builder/releases/download/current/Managed.App.Schema.Builder.zip to Managed App Schema Builder.zip
2022-01-13 18:52:57 managedappschemabuilder no more blocking processes, continue with update
2022-01-13 18:52:57 managedappschemabuilder Installing Managed App Schema Builder
2022-01-13 18:52:57 managedappschemabuilder Unzipping Managed App Schema Builder.zip
2022-01-13 18:52:57 managedappschemabuilder Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.i5daAYvs/Managed App Schema Builder.app
2022-01-13 18:52:57 managedappschemabuilder Team ID matching: PS2F6S478M (expected: PS2F6S478M )
2022-01-13 18:52:57 managedappschemabuilder Downloaded version of Managed App Schema Builder is 0.9.7 (replacing version ).
2022-01-13 18:52:57 managedappschemabuilder Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.i5daAYvs/Managed App Schema Builder.app to /Applications
2022-01-13 18:52:57 managedappschemabuilder Changing owner to tonystark
2022-01-13 18:52:57 managedappschemabuilder Finishing...
2022-01-13 18:53:07 managedappschemabuilder App(s) found: /Applications/Managed App Schema Builder.app
2022-01-13 18:53:07 managedappschemabuilder found app at /Applications/Managed App Schema Builder.app, version 0.9.7
2022-01-13 18:53:07 managedappschemabuilder Installed Managed App Schema Builder, version 0.9.7
2022-01-13 18:53:07 managedappschemabuilder notifying
2022-01-13 18:53:08 managedappschemabuilder Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.i5daAYvs
2022-01-13 18:53:08 managedappschemabuilder App not closed, so no reopen.
2022-01-13 18:53:08 managedappschemabuilder ################## End Installomator, exit code 0
```