### PR TITLE
Docker: Changed xpath to use 'last()'

### DIFF
--- a/fragments/labels/docker.sh
+++ b/fragments/labels/docker.sh
@@ -3,10 +3,10 @@ docker)
     type="dmg"
     if [[ $(arch) == arm64 ]]; then
      downloadURL="https://desktop.docker.com/mac/stable/arm64/Docker.dmg"
-     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/arm64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[1]' 2>/dev/null | cut -d '"' -f2 )
+     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/arm64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
     elif [[ $(arch) == i386 ]]; then
      downloadURL="https://desktop.docker.com/mac/stable/amd64/Docker.dmg"
-     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[1]' 2>/dev/null | cut -d '"' -f2 )
+     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
     fi
     expectedTeamID="9BNSXJN65R"
     ;;


### PR DESCRIPTION
When I opened PR #374, the sparkle feed had just one entry. Turns out, that Docker uses the last entry of the feed for the latest version.
With simply changing xpath to use `[last()]`, the version checking now behaves as expected.