### PR TITLE
Added downloadURL for ARM

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,7 +1,11 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Intel%2064.dmg"
+    if [[ $(arch) == i386 ]]; then
+      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Intel%2064.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Arm%2064.dmg"
+    fi
     appNewVersion=$(curl -fs https://www.wireshark.org/download.html | grep "Stable Release" | grep -o "(.*.)" | cut -f2 | head -1 | awk -F '[()]' '{print $2}')
     expectedTeamID="7Z6EMTD2C6"
     ;;


### PR DESCRIPTION
Added Download URL to the Apple Silicon DMG.

Example run for ARM:

```
$ sudo zsh Installomator.sh wireshark DEBUG=0

2022-01-14 14:56:15 wireshark setting variable from argument DEBUG=0
2022-01-14 14:56:15 wireshark ################## Start Installomator v. 8.0
2022-01-14 14:56:15 wireshark ################## wireshark
2022-01-14 14:56:15 wireshark BLOCKING_PROCESS_ACTION=tell_user
2022-01-14 14:56:15 wireshark NOTIFY=success
2022-01-14 14:56:15 wireshark LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-14 14:56:15 wireshark no blocking processes defined, using Wireshark as default
2022-01-14 14:56:15 wireshark Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WfCaxmey
2022-01-14 14:56:15 wireshark App(s) found:
2022-01-14 14:56:15 wireshark could not find Wireshark.app
2022-01-14 14:56:15 wireshark appversion:
2022-01-14 14:56:15 wireshark Latest version of Wireshark is 3.6.1
2022-01-14 14:56:15 wireshark Downloading https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Arm%2064.dmg to Wireshark.dmg
2022-01-14 14:56:34 wireshark no more blocking processes, continue with update
2022-01-14 14:56:34 wireshark Installing Wireshark
2022-01-14 14:56:34 wireshark Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WfCaxmey/Wireshark.dmg
2022-01-14 14:56:45 wireshark Mounted: /Volumes/Wireshark 3.6.1
2022-01-14 14:56:45 wireshark Verifying: /Volumes/Wireshark 3.6.1/Wireshark.app
2022-01-14 14:57:00 wireshark Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2022-01-14 14:57:00 wireshark Downloaded version of Wireshark is 3.6.1 (replacing version ).
2022-01-14 14:57:00 wireshark Copy /Volumes/Wireshark 3.6.1/Wireshark.app to /Applications
2022-01-14 14:57:11 wireshark Changing owner to odinsson
2022-01-14 14:57:11 wireshark Finishing...
2022-01-14 14:57:21 wireshark App(s) found: /Applications/Wireshark.app
2022-01-14 14:57:21 wireshark found app at /Applications/Wireshark.app, version 3.6.1
2022-01-14 14:57:21 wireshark Installed Wireshark, version 3.6.1
2022-01-14 14:57:21 wireshark notifying
2022-01-14 14:57:21 wireshark Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WfCaxmey
2022-01-14 14:57:21 wireshark Unmounting /Volumes/Wireshark 3.6.1
"disk4" ejected.
2022-01-14 14:57:21 wireshark App not closed, so no reopen.
2022-01-14 14:57:21 wireshark ################## End Installomator, exit code 0
```