### PR TITLE
Create lowprofile.sh

### DIFF
--- a/fragments/labels/lowprofile.sh
+++ b/fragments/labels/lowprofile.sh
@@ -1,0 +1,7 @@
+lowprofile)
+    name="Low Profile"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit ninxsoft LowProfile)"
+    appNewVersion="$(versionFromGit ninxsoft LowProfile)"
+    expectedTeamID="7K3HVCLV7Z"
+    ;;


### PR DESCRIPTION
Installing app with force to replace currently installed version:
```
Installomator/utils/assemble.sh lowprofile DEBUG=0 INSTALL=force
2022-01-14 21:24:43 lowprofile setting variable from argument DEBUG=0
2022-01-14 21:24:43 lowprofile setting variable from argument INSTALL=force
2022-01-14 21:24:43 lowprofile ################## Start Installomator v. 9.0dev
2022-01-14 21:24:43 lowprofile ################## lowprofile
2022-01-14 21:24:43 lowprofile BLOCKING_PROCESS_ACTION=tell_user
2022-01-14 21:24:43 lowprofile NOTIFY=success
2022-01-14 21:24:43 lowprofile LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-14 21:24:43 lowprofile no blocking processes defined, using Low Profile as default
2022-01-14 21:24:43 lowprofile Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.sTvDinhT
2022-01-14 21:24:43 lowprofile App(s) found: /Applications/Low Profile.app
2022-01-14 21:24:43 lowprofile found app at /Applications/Low Profile.app, version 2.0
2022-01-14 21:24:43 lowprofile appversion: 2.0
2022-01-14 21:24:43 lowprofile Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-01-14 21:24:43 lowprofile Latest version of Low Profile is 2.0
2022-01-14 21:24:43 lowprofile There is no newer version available.
2022-01-14 21:24:43 lowprofile Downloading https://github.com/ninxsoft/LowProfile/releases/download/v2.0/Low.Profile.2.0.dmg to Low Profile.dmg
2022-01-14 21:24:45 lowprofile no more blocking processes, continue with update
2022-01-14 21:24:45 lowprofile Installing Low Profile
2022-01-14 21:24:45 lowprofile Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.sTvDinhT/Low Profile.dmg
2022-01-14 21:24:48 lowprofile Mounted: /Volumes/Low Profile 1
2022-01-14 21:24:48 lowprofile Verifying: /Volumes/Low Profile 1/Low Profile.app
2022-01-14 21:24:48 lowprofile Team ID matching: 7K3HVCLV7Z (expected: 7K3HVCLV7Z )
2022-01-14 21:24:48 lowprofile Downloaded version of Low Profile is 2.0, same as installed.
2022-01-14 21:24:48 lowprofile Using force to install anyway.
2022-01-14 21:24:48 lowprofile App has LSMinimumSystemVersion: 12.0
2022-01-14 21:24:48 lowprofile Removing existing /Applications/Low Profile.app
2022-01-14 21:24:48 lowprofile Copy /Volumes/Low Profile 1/Low Profile.app to /Applications
2022-01-14 21:24:48 lowprofile Changing owner to st
2022-01-14 21:24:48 lowprofile Finishing...
2022-01-14 21:24:58 lowprofile App(s) found: /Applications/Low Profile.app
2022-01-14 21:24:58 lowprofile found app at /Applications/Low Profile.app, version 2.0
2022-01-14 21:24:58 lowprofile Installed Low Profile, version 2.0
2022-01-14 21:24:58 lowprofile notifying
2022-01-14 21:24:58 lowprofile Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.sTvDinhT
2022-01-14 21:24:58 lowprofile Unmounting /Volumes/Low Profile 1
"disk5" ejected.
2022-01-14 21:24:58 lowprofile App not closed, so no reopen.
2022-01-14 21:24:58 lowprofile ################## End Installomator, exit code 0
```