### PR TITLE
Update authydesktop.sh

### DIFF
--- a/fragments/labels/authydesktop.sh
+++ b/fragments/labels/authydesktop.sh
@@ -1,7 +1,8 @@
 authydesktop)
     name="Authy Desktop"
     type="dmg"
-    downloadURL="https://electron.authy.com/download?channel=stable&arch=x64&platform=darwin&version=latest&product=authy"
+    #downloadURL="https://electron.authy.com/download?channel=stable&arch=x64&platform=darwin&version=latest&product=authy" # redirect from this URL fails on Catalina due to curl version
+    downloadURL=$(/usr/bin/curl -s -w '%{redirect_url}' -o /dev/null "https://electron.authy.com/download?channel=stable&arch=x64&platform=darwin&version=latest&product=authy" | sed 's/\ /%20/g')
     appNewVersion="$(curl -sfL --output /dev/null -r 0-0 "${downloadURL}" --remote-header-name --remote-name -w "%{url_effective}\n" | grep -o -E '([a-zA-Z0-9\_.%-]*)\.(dmg|pkg|zip|tbz)$' | sed -E 's/.*-([0-9.]*)\.dmg/\1/g')"
     expectedTeamID="9EVH78F4V4"
     ;;


### PR DESCRIPTION
Due to Issue 309, where the `downloadURL` will fail on Catalina, the URL will now have spces replaced with `%20` and that works in the old `curl`command on Catalina.

Test here is on M1 monterey, and it still works:
```
Installomator/utils/assemble.sh authydesktop
2022-01-15 07:35:45 authydesktop ################## Start Installomator v. 9.0dev
2022-01-15 07:35:45 authydesktop ################## authydesktop
2022-01-15 07:35:45 authydesktop DEBUG mode 1 enabled.
2022-01-15 07:35:47 authydesktop BLOCKING_PROCESS_ACTION=tell_user
2022-01-15 07:35:47 authydesktop NOTIFY=success
2022-01-15 07:35:47 authydesktop LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-01-15 07:35:47 authydesktop no blocking processes defined, using Authy Desktop as default
2022-01-15 07:35:47 authydesktop Changing directory to /Users/st/Documents/GitHub/Installomator/build
2022-01-15 07:35:47 authydesktop App(s) found:
2022-01-15 07:35:47 authydesktop could not find Authy Desktop.app
2022-01-15 07:35:47 authydesktop appversion:
2022-01-15 07:35:47 authydesktop Latest version of Authy Desktop is 1.9.0
2022-01-15 07:35:47 authydesktop Downloading https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.9.0/darwin/x64/Authy%20Desktop-1.9.0.dmg to Authy Desktop.dmg
2022-01-15 07:37:32 authydesktop DEBUG mode 1, not checking for blocking processes
2022-01-15 07:37:32 authydesktop Installing Authy Desktop
2022-01-15 07:37:32 authydesktop Mounting /Users/st/Documents/GitHub/Installomator/build/Authy Desktop.dmg
2022-01-15 07:37:36 authydesktop Mounted: /Volumes/Authy Desktop 1.9.0 1
2022-01-15 07:37:36 authydesktop Verifying: /Volumes/Authy Desktop 1.9.0 1/Authy Desktop.app
2022-01-15 07:37:37 authydesktop Team ID matching: 9EVH78F4V4 (expected: 9EVH78F4V4 )
2022-01-15 07:37:37 authydesktop Downloaded version of Authy Desktop is 1.9.0 (replacing version ).
2022-01-15 07:37:38 authydesktop App has LSMinimumSystemVersion: 10.10.0
2022-01-15 07:37:38 authydesktop DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-01-15 07:37:38 authydesktop Finishing...
2022-01-15 07:37:48 authydesktop App(s) found:
2022-01-15 07:37:48 authydesktop could not find Authy Desktop.app
2022-01-15 07:37:48 authydesktop Installed Authy Desktop
2022-01-15 07:37:48 authydesktop notifying
2022-01-15 07:37:48 authydesktop Unmounting /Volumes/Authy Desktop 1.9.0 1
"disk6" ejected.
2022-01-15 07:37:48 authydesktop DEBUG mode 1, not reopening anything
2022-01-15 07:37:48 authydesktop ################## End Installomator, exit code 0
```