### PR TITLE
Revert "Update gpgsuite blockingProcesses for GPG Keychain & add DaisyDisk label"

### DIFF
--- a/daisydisk.sh
+++ b/daisydisk.sh
@@ -1,7 +1,0 @@
-daisydisk)
-    name="DaisyDisk"
-    type="zip"
-    downloadURL="https://daisydiskapp.com/downloads/DaisyDisk.zip"
-    appNewVersion=$( curl -fs 'https://daisydiskapp.com/downloads/appcastReleaseNotes.php?appEdition=Standard' | grep Version | head -1 | cut -d \> -f 3 | cut -d \< -f 1 | awk '{print $2}' )
-    expectedTeamID="4CBU3JHV97"
-    ;;

--- a/fragments/labels/gpgsuite.sh
+++ b/fragments/labels/gpgsuite.sh
@@ -5,5 +5,4 @@ gpgsuite)
     pkgName="Install.pkg"
     downloadURL=$(curl -s https://gpgtools.org/ | grep https://releases.gpgtools.org/GPG_Suite- | grep Download | cut -d'"' -f4)
     expectedTeamID="PKV8ZPD836"
-    blockingProcesses=( "GPG Keychain" )
     ;;


### PR DESCRIPTION
Reverts Installomator/Installomator#370, DaisyDisk was committed to the root of the repo and not into it's own Labels folder.