### PR TITLE
Added Tableau Public to labels

### DIFF
--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -3,6 +3,6 @@ tableaupublic)
     type="pkgInDmg"
     packageID="com.tableausoftware.tableaudesktop"
     downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
-    appNewVersion=$(/usr/bin/python -c "import re; url = '$downloadURL'; ver_regex = re.compile(r'([0-9]+(?:-[0-9]+)+)'); ver_regex.findall(url); dashes = ''.join(ver_regex.findall(url)); print(dashes.replace('-', '.'))")
+    appNewVersion=$( echo $downloadURL | sed -E 's/.*TableauPublic-([-0-9]*)\.dmg/\1/g' | tr "-" "." )
     expectedTeamID="QJ4XPRK37C"
     ;;

--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -1,0 +1,8 @@
+tableaupublic)
+    name="Tableau Public"
+    type="pkgInDmg"
+    packageID="com.tableausoftware.tableaudesktop"
+    downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
+    appNewVersion=$(/usr/bin/python -c "import re; url = '$downloadURL'; ver_regex = re.compile(r'([0-9]+(?:-[0-9]+)+)'); ver_regex.findall(url); dashes = ''.join(ver_regex.findall(url)); print(dashes.replace('-', '.'))")
+    expectedTeamID="QJ4XPRK37C"
+    ;;


### PR DESCRIPTION
> Tableau Public is free software that can allow anyone to connect to a spreadsheet or file and create interactive data visualizations for the web.

Wasn't able to figure out `sed` or `awk` to extract the version from `$downloadURL`; substituted legacy Python2.

Welcome feedback on making more bash/zsh-centric regex and happy to refactor if necessary.