### PR TITLE
Added label clipy

### DIFF
--- a/fragments/labels/clipy.sh
+++ b/fragments/labels/clipy.sh
@@ -1,0 +1,7 @@
+clipy)
+	name="Clipy"
+	type="dmg"
+    downloadURL=$(downloadURLFromGit Clipy Clipy)
+    appNewVersion=$(versionFromGit Clipy Clipy)
+    expectedTeamID="BBCHAJ584H"
+    ;;


### PR DESCRIPTION
Support Clipy
https://github.com/Clipy/Clipy

The assemble.sh result is below(exit code is 0 so I think it works)
```
~/t/I/utils (clipy-label|✔) $ ./assemble.sh clipy
2022-02-09 14:14:10 : REQ   : clipy : ################## Start Installomator v. 9.1beta, date 2022-02-09
2022-02-09 14:14:10 : INFO  : clipy : ################## Version: 9.1beta
2022-02-09 14:14:10 : INFO  : clipy : ################## Date: 2022-02-09
2022-02-09 14:14:10 : INFO  : clipy : ################## clipy
2022-02-09 14:14:10 : DEBUG : clipy : DEBUG mode 1 enabled.
2022-02-09 14:14:11 : INFO  : clipy : BLOCKING_PROCESS_ACTION=tell_user
2022-02-09 14:14:11 : INFO  : clipy : NOTIFY=success
2022-02-09 14:14:11 : INFO  : clipy : LOGGING=DEBUG
2022-02-09 14:14:11 : INFO  : clipy : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-02-09 14:14:11 : INFO  : clipy : Label type: dmg
2022-02-09 14:14:11 : DEBUG : clipy : archiveName: Clipy.dmg
2022-02-09 14:14:11 : INFO  : clipy : no blocking processes defined, using Clipy as default
2022-02-09 14:14:11 : DEBUG : clipy : Changing directory to /Users/stomita/test/Installomator/build
2022-02-09 14:14:11 : DEBUG : clipy : App(s) found: /Applications/Clipy.app
2022-02-09 14:14:11 : INFO  : clipy : found app at /Applications/Clipy.app, version 1.2.1, on versionKey CFBundleShortVersionString
2022-02-09 14:14:11 : INFO  : clipy : appversion: 1.2.1
2022-02-09 14:14:11 : INFO  : clipy : Latest version of Clipy is 1.2.1
2022-02-09 14:14:11 : INFO  : clipy : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-02-09 14:14:11 : REQ   : clipy : Downloading https://github.com/Clipy/Clipy/releases/download/1.2.1/Clipy_1.2.1.dmg to Clipy.dmg
2022-02-09 14:14:16 : DEBUG : clipy : File list: -rw-r--r--  1 stomita  staff    11M  2  9 14:14 Clipy.dmg
2022-02-09 14:14:16 : DEBUG : clipy : File type: Clipy.dmg: zlib compressed data
2022-02-09 14:14:16 : DEBUG : clipy : curl output was:
*   Trying 13.114.40.48:443...
* Connected to github.com (13.114.40.48) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [224 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2358 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [115 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-ECDSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 25 00:00:00 2021 GMT
*  expire date: Mar 30 23:59:59 2022 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert, Inc.; CN=DigiCert High Assurance TLS Hybrid ECC SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13b812800)
> GET /Clipy/Clipy/releases/download/1.2.1/Clipy_1.2.1.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.77.0
> accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Wed, 09 Feb 2022 05:14:12 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Accept-Encoding, Accept, X-Requested-With
< permissions-policy: interest-cohort=()
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/37778564/4758b700-cd0f-11e8-8f19-2b50c895b989?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220209T051412Z&X-Amz-Expires=300&X-Amz-Signature=7a19e8f4b7a2b0b4de9f5b6de122293b51ebd8abe5b4100961f1b239a08e9d69&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=37778564&response-content-disposition=attachment%3B%20filename%3DClipy_1.2.1.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< expect-ct: max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.githubapp.com collector.github.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events translator.github.com wss://alive.github.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations raw.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src render.githubusercontent.com viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com collector.githubapp.com collector.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 652
< x-github-request-id: F4C1:50F7:30457E:47FE54:62034DA3
<
* Ignoring the response-body
{ [79 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/37778564/4758b700-cd0f-11e8-8f19-2b50c895b989?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220209T051412Z&X-Amz-Expires=300&X-Amz-Signature=7a19e8f4b7a2b0b4de9f5b6de122293b51ebd8abe5b4100961f1b239a08e9d69&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=37778564&response-content-disposition=attachment%3B%20filename%3DClipy_1.2.1.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [243 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3062 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=www.github.com
*  start date: May  6 00:00:00 2020 GMT
*  expire date: Apr 14 12:00:00 2022 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13b812800)
> GET /github-production-release-asset-2e65be/37778564/4758b700-cd0f-11e8-8f19-2b50c895b989?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220209T051412Z&X-Amz-Expires=300&X-Amz-Signature=7a19e8f4b7a2b0b4de9f5b6de122293b51ebd8abe5b4100961f1b239a08e9d69&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=37778564&response-content-disposition=attachment%3B%20filename%3DClipy_1.2.1.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.77.0
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Tue, 07 Dec 2021 23:41:17 GMT
< etag: "0x8D9B9DB105DF074"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: f047f71c-201e-0041-6673-1d7a81000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Tue, 17 Aug 2021 22:18:58 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Clipy_1.2.1.dmg
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Wed, 09 Feb 2022 05:14:13 GMT
< via: 1.1 varnish
< x-served-by: cache-tyo11950-TYO
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1644383652.276537,VS0,VE852
< content-length: 11088346
<
{ [896 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2022-02-09 14:14:16 : DEBUG : clipy : DEBUG mode 1, not checking for blocking processes
2022-02-09 14:14:16 : REQ   : clipy : Installing Clipy
2022-02-09 14:14:16 : INFO  : clipy : Mounting /Users/stomita/test/Installomator/build/Clipy.dmg
2022-02-09 14:14:16 : DEBUG : clipy : Debugging enabled, dmgmount output was:
Checksumming ディスク全体（Apple_HFS: 0）…
ディスク全体（Apple_HFS: 0）: verified   CRC32 $F1B00196
verified   CRC32 $DAB757FE
/dev/disk4          	                               	/Volumes/Clipy_1.2.1

2022-02-09 14:14:16 : INFO  : clipy : Mounted: /Volumes/Clipy_1.2.1
2022-02-09 14:14:16 : INFO  : clipy : Verifying: /Volumes/Clipy_1.2.1/Clipy.app
2022-02-09 14:14:16 : DEBUG : clipy : App size:  30M	/Volumes/Clipy_1.2.1/Clipy.app
2022-02-09 14:14:17 : DEBUG : clipy : Debugging enabled, App Verification output was:
/Volumes/Clipy_1.2.1/Clipy.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Shunsuke Furubayashi (BBCHAJ584H)

2022-02-09 14:14:17 : INFO  : clipy : Team ID matching: BBCHAJ584H (expected: BBCHAJ584H )
2022-02-09 14:14:17 : INFO  : clipy : Downloaded version of Clipy is 1.2.1 on versionKey CFBundleShortVersionString, same as installed.
2022-02-09 14:14:17 : DEBUG : clipy : Unmounting /Volumes/Clipy_1.2.1
2022-02-09 14:14:17 : DEBUG : clipy : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-02-09 14:14:17 : DEBUG : clipy : DEBUG mode 1, not reopening anything
2022-02-09 14:14:17 : REQ   : clipy : ################## End Installomator, exit code 0
```