### PR TITLE
change mdfind criteria to determine location of application

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -225,25 +225,29 @@ getAppVersion() {
         applist="$targetDir/$appName"
     elif [[ -d "/Applications/$appName" ]]; then
         applist="/Applications/$appName"
-        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
-            targetDir="/Applications"
-        fi
+#        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
+#            targetDir="/Applications"
+#        fi
     elif [[ -d "/Applications/Utilities/$appName" ]]; then
         applist="/Applications/Utilities/$appName"
-        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
-            targetDir="/Applications/Utilities"
-        fi
-    #else
+#        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
+#            targetDir="/Applications/Utilities"
+#        fi
+    else
     #    applist=$(mdfind "kind:application $appName" -0 )
+        printlog "name: $name, appName: $appName"
+        applist=$(mdfind "kind:application AND name:$name" -0 )
+#        printlog "App(s) found: ${applist}" DEBUG
+#        applist=$(mdfind "kind:application AND name:$appName" -0 )
     fi
     if [[ -z applist ]]; then
         printlog "No previous app found" DEBUG
     else
         printlog "App(s) found: ${applist}" DEBUG
     fi
-    if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
-        printlog "targetDir for installation: $targetDir" INFO
-    fi
+#    if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
+#        printlog "targetDir for installation: $targetDir" INFO
+#    fi
 
     appPathArray=( ${(0)applist} )
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -220,13 +220,21 @@ getAppVersion() {
         fi
     fi
 
-    # get app in /Applications, or /Applications/Utilities, or find using Spotlight
-    if [[ -d "/Applications/$appName" ]]; then
+    # get app in targetDir, /Applications, or /Applications/Utilities
+    if [[ -d "$targetDir/$appName" ]]; then
+        applist="$targetDir/$appName"
+    elif [[ -d "/Applications/$appName" ]]; then
         applist="/Applications/$appName"
+        if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+            targetDir="/Applications"
+        fi
     elif [[ -d "/Applications/Utilities/$appName" ]]; then
         applist="/Applications/Utilities/$appName"
-    else
-        applist=$(mdfind "kind:application $appName" -0 )
+        if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+            targetDir="/Applications/Utilities"
+        fi
+    #else
+    #    applist=$(mdfind "kind:application $appName" -0 )
     fi
     if [[ -z applist ]]; then
         printlog "No previous app found" DEBUG

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -225,12 +225,12 @@ getAppVersion() {
         applist="$targetDir/$appName"
     elif [[ -d "/Applications/$appName" ]]; then
         applist="/Applications/$appName"
-        if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
             targetDir="/Applications"
         fi
     elif [[ -d "/Applications/Utilities/$appName" ]]; then
         applist="/Applications/Utilities/$appName"
-        if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+        if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
             targetDir="/Applications/Utilities"
         fi
     #else
@@ -241,7 +241,7 @@ getAppVersion() {
     else
         printlog "App(s) found: ${applist}" DEBUG
     fi
-    if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+    if [[ $type =~ '^(dmg|zip|tbz|app.*)$' ]]; then
         printlog "targetDir for installation: $targetDir" INFO
     fi
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -241,6 +241,9 @@ getAppVersion() {
     else
         printlog "App(s) found: ${applist}" DEBUG
     fi
+    if [[ $type =~ '^(dmg|zip|tbz|app.*)$']]; then
+        printlog "targetDir for installation: $targetDir" INFO
+    fi
 
     appPathArray=( ${(0)applist} )
 


### PR DESCRIPTION
Change to how we locate currently installed app. Basically will look for the name in `targetDir`, in `/Applications`, and in `/Applications/Utilities`. Not using Spotlight.

Fixes #401.