### PR TITLE
Always download Chrome universal

### DIFF
--- a/fragments/labels/googlechrome.sh
+++ b/fragments/labels/googlechrome.sh
@@ -1,14 +1,7 @@
 googlechrome)
     name="Google Chrome"
     type="dmg"
-    if [[ $(arch) != "i386" ]]; then
-        printlog "Architecture: arm64 (not i386)"
-        downloadURL="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
-        appNewVersion=$(curl -s https://omahaproxy.appspot.com/history | awk -F',' '/mac_arm64,stable/{print $3; exit}')
-    else
-        printlog "Architecture: i386"
-        downloadURL="https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"
-        appNewVersion=$(curl -s https://omahaproxy.appspot.com/history | awk -F',' '/mac,stable/{print $3; exit}')
-    fi
+    downloadURL="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
+    appNewVersion=$(curl -s https://omahaproxy.appspot.com/history | awk -F',' '/mac_arm64,stable/{print $3; exit}')
     expectedTeamID="EQHXZ8M8AV"
     ;;


### PR DESCRIPTION
Google doesn't seem to update the Chrome intel download fast enough. This may cause installomator to see there is a new version available, but still download an older version.

We can use the universal download for all platforms anyway.