### PR TITLE
Added label for Microsoft Azure Data Studio

### DIFF
--- a/fragments/labels/microsoftazuredatastudio.sh
+++ b/fragments/labels/microsoftazuredatastudio.sh
@@ -1,0 +1,10 @@
+microsoftazuredatastudio|\
+azuredatastudio)
+    name="Azure Data Studio"
+    type="zip"
+    downloadURL=$( curl -sL https://github.com/microsoft/azuredatastudio/releases/latest | grep 'macOS ZIP' | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" )
+    appNewVersion=$(versionFromGit microsoft azuredatastudio )
+    expectedTeamID="UBF8T346G9"
+    appName="Azure Data Studio.app"
+    blockingProcesses=( "Azure Data Studio" )
+    ;;


### PR DESCRIPTION
Any feedback on the URL grep would be welcome.  This was an odd one as they use Github, but the download is hosted by Microsoft. 

Used Github Versioning and Releases, then pull the new download link from that page.