### PR TITLE
Fixed Microsoft Defender label

### DIFF
--- a/fragments/labels/microsoftdefender.sh
+++ b/fragments/labels/microsoftdefender.sh
@@ -1,5 +1,6 @@
+microsoftdefender|\
 microsoftdefenderatp)
-    name="Microsoft Defender ATP"
+    name="Microsoft Defender"
     type="pkg"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=2097502"
     appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.defender.standalone"]/version' 2>/dev/null | sed -E 's/<version>([0-9.]*) .*/\1/')


### PR DESCRIPTION
Change applications name to Microsoft Defender and added microsoftdefender as label.

Tested with Intel and Apple Silicon