### PR TITLE
Added autodeskfusion360admininstall.sh label

### DIFF
--- a/fragments/labels/autodeskfusion360admininstall.sh
+++ b/fragments/labels/autodeskfusion360admininstall.sh
@@ -1,0 +1,10 @@
+autodeskfusion360admininstall)
+    name="Autodesk%20Fusion%20360%20Admin%20Install"
+    type="pkg"
+    packageID="com.autodesk.edu.fusion360"
+    downloadURL="https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20360%20Admin%20Install.pkg"
+    appNewVersion=$(curl -fs "https://dl.appstreaming.autodesk.com/production/97e6dd95735340d6ad6e222a520454db/73e72ada57b7480280f7a6f4a289729f/full.json" | sed -E 's/.*build-version":"([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*/\1/g')
+    expectedTeamID="XXKJ396S2Y"
+    appName="Autodesk Fusion 360.app"
+    blockingProcesses=( "Autodesk Fusion 360" "Fusion 360" )
+    ;;


### PR DESCRIPTION
This is for Autodesk Fusion 360 administration install for labs.
Code is included to check app appNewVersion.
Is this how you want pull request to look?

```
glowlace@glowlacer Installomator % ./assemble.sh -l ~/Documents/gitprojects/installomator_labels  autodeskfusion360admininstall
2022-03-18 00:14:53 : REQ   : autodeskfusion360admininstall : ################## Start Installomator v. 10.0dev, date 2022-03-18
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : ################## Version: 10.0dev
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : ################## Date: 2022-03-18
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : ################## autodeskfusion360admininstall
2022-03-18 00:14:53 : DEBUG : autodeskfusion360admininstall : DEBUG mode 1 enabled.
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : BLOCKING_PROCESS_ACTION=tell_user
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : NOTIFY=success
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : LOGGING=DEBUG
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : Label type: pkg
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : archiveName: Autodesk%20Fusion%20360%20Admin%20Install.pkg
2022-03-18 00:14:53 : DEBUG : autodeskfusion360admininstall : Changing directory to /Users/glowlace/Documents/gitprojects/Installomator/build
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : No version found using packageID com.autodesk.edu.fusion360
2022-03-18 00:14:53 : INFO  : autodeskfusion360admininstall : name: Autodesk%20Fusion%20360%20Admin%20Install, appName: Autodesk Fusion 360.app
2022-03-18 00:14:54 : INFO  : autodeskfusion360admininstall : App(s) found: 
2022-03-18 00:14:54 : WARN  : autodeskfusion360admininstall : could not find Autodesk Fusion 360.app
2022-03-18 00:14:54 : INFO  : autodeskfusion360admininstall : appversion: 
2022-03-18 00:14:54 : INFO  : autodeskfusion360admininstall : Latest version of Autodesk%20Fusion%20360%20Admin%20Install is 2.0.12392
2022-03-18 00:14:54 : REQ   : autodeskfusion360admininstall : Downloading https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20360%20Admin%20Install.pkg to Autodesk%20Fusion%20360%20Admin%20Install.pkg
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : File list: -rw-r--r--  1 glowlace  staff   1.3G Mar 18 00:16 Autodesk%20Fusion%20360%20Admin%20Install.pkg
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : File type: Autodesk%20Fusion%20360%20Admin%20Install.pkg: xar archive compressed TOC: 4196, SHA-1 checksum
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : curl output was:
*   Trying 23.11.4.21:443...
* Connected to dl.appstreaming.autodesk.com (23.11.4.21) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2725 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [147 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-ECDSA-CHACHA20-POLY1305
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=San Rafael; O=Autodesk Inc; CN=dl.appstreaming.autodesk.com
*  start date: Jun 14 00:00:00 2021 GMT
*  expire date: Jun 22 23:59:59 2022 GMT
*  subjectAltName: host "dl.appstreaming.autodesk.com" matched cert's "dl.appstreaming.autodesk.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert SHA2 Secure Server CA
*  SSL certificate verify ok.
> GET /production/installers/Autodesk%20Fusion%20360%20Admin%20Install.pkg HTTP/1.1
> Host: dl.appstreaming.autodesk.com
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AkamaiNetStorage
< Last-Modified: Wed, 16 Feb 2022 17:56:04 GMT
< ETag: "5ad84377605358139e8ff29fb35e8171:1645033953.496351"
< Content-Length: 1386141846
< Expires: Fri, 18 Mar 2022 05:14:54 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Fri, 18 Mar 2022 05:14:54 GMT
< Connection: keep-alive
< 
{ [1347 bytes data]
* Connection #0 to host dl.appstreaming.autodesk.com left intact

2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : DEBUG mode 1, not checking for blocking processes
2022-03-18 00:16:55 : REQ   : autodeskfusion360admininstall : Installing Autodesk%20Fusion%20360%20Admin%20Install
2022-03-18 00:16:55 : INFO  : autodeskfusion360admininstall : Verifying: Autodesk%20Fusion%20360%20Admin%20Install.pkg
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : File list: -rw-r--r--  1 glowlace  staff   1.3G Mar 18 00:16 Autodesk%20Fusion%20360%20Admin%20Install.pkg
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : File type: Autodesk%20Fusion%20360%20Admin%20Install.pkg: xar archive compressed TOC: 4196, SHA-1 checksum
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : spctlOut is Autodesk%20Fusion%20360%20Admin%20Install.pkg: accepted
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : source=Notarized Developer ID
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : origin=Developer ID Installer: Autodesk (XXKJ396S2Y)
2022-03-18 00:16:55 : INFO  : autodeskfusion360admininstall : Team ID: XXKJ396S2Y (expected: XXKJ396S2Y )
2022-03-18 00:16:55 : DEBUG : autodeskfusion360admininstall : DEBUG enabled, skipping installation
2022-03-18 00:16:55 : INFO  : autodeskfusion360admininstall : Finishing...
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : No version found using packageID com.autodesk.edu.fusion360
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : name: Autodesk%20Fusion%20360%20Admin%20Install, appName: Autodesk Fusion 360.app
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : App(s) found: 
2022-03-18 00:17:06 : WARN  : autodeskfusion360admininstall : could not find Autodesk Fusion 360.app
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : Installed Autodesk%20Fusion%20360%20Admin%20Install
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : notifying
2022-03-18 00:17:06 : DEBUG : autodeskfusion360admininstall : DEBUG mode 1, not reopening anything
2022-03-18 00:17:06 : INFO  : autodeskfusion360admininstall : 
2022-03-18 00:17:06 : REQ   : autodeskfusion360admininstall : ################## End Installomator, exit code 0 
```
