### PR TITLE
Add Label for Talkdesk CX Cloud Desktop

### DIFF
--- a/fragments/labels/talkdeskcxcloud.sh
+++ b/fragments/labels/talkdeskcxcloud.sh
@@ -1,7 +1,7 @@
 talkdeskcxcloud)
     name="Talkdesk"
     type="dmg"
-    appNewVersion=$(curl -fsL https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-latest-metadata.json | sed -n -e 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' | head -n 1)
+    appNewVersion=$(curl -fs https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-latest-metadata.json | sed -n -e 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' | head -n 1)
     downloadURL="https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-${appNewVersion}.dmg"
     expectedTeamID="YGGJX44TB8"
     ;;

--- a/fragments/labels/talkdeskcxcloud.sh
+++ b/fragments/labels/talkdeskcxcloud.sh
@@ -1,0 +1,7 @@
+talkdeskcxcloud)
+    name="Talkdesk"
+    type="dmg"
+    appNewVersion=$(curl -fsL https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-latest-metadata.json | sed -n -e 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' | head -n 1)
+    downloadURL="https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-${appNewVersion}.dmg"
+    expectedTeamID="YGGJX44TB8"
+    ;;


### PR DESCRIPTION
Adding a new label for the [Talkdesk CX Cloud Label/Agent Workspace Desktop App](https://support.talkdesk.com/hc/en-us/articles/4407110764443-Upgrading-to-Talkdesk-Agent-Workspace), which [will eventually replace (Mar 31, 2023) the existing Callbar application](https://support.talkdesk.com/hc/en-us/articles/4442064538779-Product-Announcement-End-of-Life-Talkdesk-Callbar-Main-Dialer-Agent-Tabs), which has an existing Installomator label.

Test run output:
```
% utils/assemble.sh talkdeskcxcloud
2022-03-21 16:53:15 : REQ   : talkdeskcxcloud : ################## Start Installomator v. 9.2beta, date 2022-03-21
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : ################## Version: 9.2beta
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : ################## Date: 2022-03-21
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : ################## talkdeskcxcloud
2022-03-21 16:53:15 : DEBUG : talkdeskcxcloud : DEBUG mode 1 enabled.
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : BLOCKING_PROCESS_ACTION=tell_user
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : NOTIFY=success
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : LOGGING=DEBUG
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : Label type: dmg
2022-03-21 16:53:15 : INFO  : talkdeskcxcloud : archiveName: Talkdesk.dmg
2022-03-21 16:53:16 : INFO  : talkdeskcxcloud : no blocking processes defined, using Talkdesk as default
2022-03-21 16:53:16 : DEBUG : talkdeskcxcloud : Changing directory to /Users/liam.steckler/Installomator/build
2022-03-21 16:53:16 : INFO  : talkdeskcxcloud : name: Talkdesk, appName: Talkdesk.app
2022-03-21 16:53:16 : INFO  : talkdeskcxcloud : App(s) found:
2022-03-21 16:53:16 : WARN  : talkdeskcxcloud : could not find Talkdesk.app
2022-03-21 16:53:16 : INFO  : talkdeskcxcloud : appversion:
2022-03-21 16:53:16 : INFO  : talkdeskcxcloud : Latest version of Talkdesk is 1.4.0
2022-03-21 16:53:16 : REQ   : talkdeskcxcloud : Downloading https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-1.4.0.dmg to Talkdesk.dmg
2022-03-21 16:53:48 : DEBUG : talkdeskcxcloud : File list: -rw-r--r--  1 liam.steckler  staff    83M Mar 21 16:53 Talkdesk.dmg
2022-03-21 16:53:48 : DEBUG : talkdeskcxcloud : File type: Talkdesk.dmg: zlib compressed data
2022-03-21 16:53:48 : DEBUG : talkdeskcxcloud : curl output was:
*   Trying 52.217.79.140:443...
* Connected to td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com (52.217.79.140) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [361 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [91 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2886 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=Washington; L=Seattle; O=Amazon.com, Inc.; CN=*.s3.amazonaws.com
*  start date: Dec 13 00:00:00 2021 GMT
*  expire date: Dec 13 23:59:59 2022 GMT
*  subjectAltName: host "td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert Baltimore CA-2 G2
*  SSL certificate verify ok.
> GET /talkdesk-1.4.0.dmg HTTP/1.1
> Host: td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-amz-id-2: QzZX78WUvOp9ldgTdVjglRTa+mlKhJ0HYMIe/wroVJ+7ILtRohpOy2LVFkua1n8FROJGhYf4QBw=
< x-amz-request-id: F6B6F0HKF7YRHKPN
< Date: Mon, 21 Mar 2022 23:53:17 GMT
< Last-Modified: Wed, 15 Dec 2021 17:49:10 GMT
< ETag: "9e3e7109c22b50c90a25bb9e8a97f84b-17"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: CpAGgNuH5ayB05enQ.2f17fuhpAs8bfc
< Accept-Ranges: bytes
< Content-Type: application/x-apple-diskimage
< Server: AmazonS3
< Content-Length: 86950717
<
{ [15910 bytes data]
* Connection #0 to host td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com left intact

2022-03-21 16:53:48 : DEBUG : talkdeskcxcloud : DEBUG mode 1, not checking for blocking processes
2022-03-21 16:53:48 : REQ   : talkdeskcxcloud : Installing Talkdesk
2022-03-21 16:53:48 : INFO  : talkdeskcxcloud : Mounting /Users/liam.steckler/Installomator/build/Talkdesk.dmg
2022-03-21 16:53:50 : DEBUG : talkdeskcxcloud : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $14377BF4
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ED0ECFA5
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2570D6F5
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $51F7FAE5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2570D6F5
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $31240DEE
verified   CRC32 $8860212E
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Talkdesk 1.4.0

2022-03-21 16:53:50 : INFO  : talkdeskcxcloud : Mounted: /Volumes/Talkdesk 1.4.0
2022-03-21 16:53:50 : INFO  : talkdeskcxcloud : Verifying: /Volumes/Talkdesk 1.4.0/Talkdesk.app
2022-03-21 16:53:50 : DEBUG : talkdeskcxcloud : App size: 196M	/Volumes/Talkdesk 1.4.0/Talkdesk.app
2022-03-21 16:53:52 : DEBUG : talkdeskcxcloud : Debugging enabled, App Verification output was:
/Volumes/Talkdesk 1.4.0/Talkdesk.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Talkdesk, Inc. (YGGJX44TB8)

2022-03-21 16:53:52 : INFO  : talkdeskcxcloud : Team ID matching: YGGJX44TB8 (expected: YGGJX44TB8 )
2022-03-21 16:53:52 : INFO  : talkdeskcxcloud : Installing Talkdesk version 1.4.0 on versionKey CFBundleShortVersionString.
2022-03-21 16:53:52 : INFO  : talkdeskcxcloud : App has LSMinimumSystemVersion: 10.11.0
2022-03-21 16:53:52 : DEBUG : talkdeskcxcloud : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-03-21 16:53:52 : INFO  : talkdeskcxcloud : Finishing...
2022-03-21 16:54:02 : INFO  : talkdeskcxcloud : name: Talkdesk, appName: Talkdesk.app
2022-03-21 16:54:03 : INFO  : talkdeskcxcloud : App(s) found:
2022-03-21 16:54:03 : WARN  : talkdeskcxcloud : could not find Talkdesk.app
2022-03-21 16:54:03 : REQ   : talkdeskcxcloud : Installed Talkdesk
2022-03-21 16:54:03 : INFO  : talkdeskcxcloud : notifying
2022-03-21 16:54:03 : DEBUG : talkdeskcxcloud : Unmounting /Volumes/Talkdesk 1.4.0
2022-03-21 16:54:03 : DEBUG : talkdeskcxcloud : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-03-21 16:54:03 : DEBUG : talkdeskcxcloud : DEBUG mode 1, not reopening anything
2022-03-21 16:54:03 : REQ   : talkdeskcxcloud : All done!
2022-03-21 16:54:03 : REQ   : talkdeskcxcloud : ################## End Installomator, exit code 0
```