### PR TITLE
Update talkdeskcallbar label

### DIFF
--- a/fragments/labels/talkdeskcallbar.sh
+++ b/fragments/labels/talkdeskcallbar.sh
@@ -1,7 +1,7 @@
 talkdeskcallbar)
     name="Callbar"
     type="dmg"
-    downloadURL=https://downloadcallbar.talkdesk.com/Callbar-$(curl -fsL https://downloadcallbar.talkdesk.com/release_metadata.json | sed -n 's/^.*"version":"\([^"]*\)".*$/\1/p').dmg
-    appNewVersion=$(curl -fsL https://downloadcallbar.talkdesk.com/release_metadata.json | sed -n 's/^.*"version":"\([^"]*\)".*$/\1/p')
+    appNewVersion=$(curl -fsL https://downloadcallbar.talkdesk.com/release_metadata.json | sed -n 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
+    downloadURL=https://downloadcallbar.talkdesk.com/Callbar-${appNewVersion}.dmg
     expectedTeamID="YGGJX44TB8"
     ;;


### PR DESCRIPTION
Updating this label to not query for the current version number twice, and to make the regex for finding the version string more compatible with spaces in the JSON.

Test run output:
```
% utils/assemble.sh talkdeskcallbar
2022-03-21 17:04:46 : REQ   : talkdeskcallbar : ################## Start Installomator v. 9.2beta, date 2022-03-21
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : ################## Version: 9.2beta
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : ################## Date: 2022-03-21
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : ################## talkdeskcallbar
2022-03-21 17:04:46 : DEBUG : talkdeskcallbar : DEBUG mode 1 enabled.
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : BLOCKING_PROCESS_ACTION=tell_user
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : NOTIFY=success
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : LOGGING=DEBUG
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : Label type: dmg
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : archiveName: Callbar.dmg
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : no blocking processes defined, using Callbar as default
2022-03-21 17:04:46 : DEBUG : talkdeskcallbar : Changing directory to /Users/liam.steckler/Installomator/build
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : name: Callbar, appName: Callbar.app
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : App(s) found:
2022-03-21 17:04:46 : WARN  : talkdeskcallbar : could not find Callbar.app
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : appversion:
2022-03-21 17:04:46 : INFO  : talkdeskcallbar : Latest version of Callbar is 1.46.11-electron
2022-03-21 17:04:46 : REQ   : talkdeskcallbar : Downloading https://downloadcallbar.talkdesk.com/Callbar-1.46.11-electron.dmg to Callbar.dmg
2022-03-21 17:04:52 : DEBUG : talkdeskcallbar : File list: -rw-r--r--  1 liam.steckler  staff    77M Mar 21 17:04 Callbar.dmg
2022-03-21 17:04:52 : DEBUG : talkdeskcallbar : File type: Callbar.dmg: zlib compressed data
2022-03-21 17:04:52 : DEBUG : talkdeskcallbar : curl output was:
*   Trying 99.86.38.8:443...
* Connected to downloadcallbar.talkdesk.com (99.86.38.8) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4955 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=talkdesk.com
*  start date: Feb 14 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "downloadcallbar.talkdesk.com" matched cert's "*.talkdesk.com"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x135011400)
> GET /Callbar-1.46.11-electron.dmg HTTP/2
> Host: downloadcallbar.talkdesk.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 80677039
< date: Tue, 22 Mar 2022 00:04:48 GMT
< last-modified: Thu, 24 Feb 2022 11:10:08 GMT
< etag: "10d2f22b7667f197ac3cb7eefe0c8428-16"
< x-amz-version-id: 5mkr4JoXXqAkdQTW8TWwFSPCem_oezqB
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 e5147bed59b539c23be4f2e01cf6f6f4.cloudfront.net (CloudFront)
< x-amz-cf-pop: SEA19-C1
< x-amz-cf-id: h04VwGr7lREwF_JOYakEnvVXLsw7VFWBx6MC7MEWyyclsbYWWCRNUw==
<
{ [423 bytes data]
* Connection #0 to host downloadcallbar.talkdesk.com left intact

2022-03-21 17:04:52 : DEBUG : talkdeskcallbar : DEBUG mode 1, not checking for blocking processes
2022-03-21 17:04:52 : REQ   : talkdeskcallbar : Installing Callbar
2022-03-21 17:04:52 : INFO  : talkdeskcallbar : Mounting /Users/liam.steckler/Installomator/build/Callbar.dmg
2022-03-21 17:04:54 : DEBUG : talkdeskcallbar : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $82D7F1C0
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $198AB916
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $3E31410B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $3265F251
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $3E31410B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CACC87C3
verified   CRC32 $1A924DCA
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Callbar 1.46.11-electron

2022-03-21 17:04:54 : INFO  : talkdeskcallbar : Mounted: /Volumes/Callbar 1.46.11-electron
2022-03-21 17:04:54 : INFO  : talkdeskcallbar : Verifying: /Volumes/Callbar 1.46.11-electron/Callbar.app
2022-03-21 17:04:54 : DEBUG : talkdeskcallbar : App size: 207M	/Volumes/Callbar 1.46.11-electron/Callbar.app
2022-03-21 17:04:56 : DEBUG : talkdeskcallbar : Debugging enabled, App Verification output was:
/Volumes/Callbar 1.46.11-electron/Callbar.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Talkdesk, Inc. (YGGJX44TB8)

2022-03-21 17:04:56 : INFO  : talkdeskcallbar : Team ID matching: YGGJX44TB8 (expected: YGGJX44TB8 )
2022-03-21 17:04:56 : INFO  : talkdeskcallbar : Installing Callbar version 1.46.11-electron on versionKey CFBundleShortVersionString.
2022-03-21 17:04:56 : INFO  : talkdeskcallbar : App has LSMinimumSystemVersion: 10.10.0
2022-03-21 17:04:56 : DEBUG : talkdeskcallbar : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-03-21 17:04:56 : INFO  : talkdeskcallbar : Finishing...
2022-03-21 17:05:06 : INFO  : talkdeskcallbar : name: Callbar, appName: Callbar.app
2022-03-21 17:05:06 : INFO  : talkdeskcallbar : App(s) found:
2022-03-21 17:05:06 : WARN  : talkdeskcallbar : could not find Callbar.app
2022-03-21 17:05:06 : REQ   : talkdeskcallbar : Installed Callbar
2022-03-21 17:05:06 : INFO  : talkdeskcallbar : notifying
2022-03-21 17:05:07 : DEBUG : talkdeskcallbar : Unmounting /Volumes/Callbar 1.46.11-electron
2022-03-21 17:05:07 : DEBUG : talkdeskcallbar : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-03-21 17:05:07 : DEBUG : talkdeskcallbar : DEBUG mode 1, not reopening anything
2022-03-21 17:05:07 : REQ   : talkdeskcallbar : All done!
2022-03-21 17:05:07 : REQ   : talkdeskcallbar : ################## End Installomator, exit code 0
```