### PR TITLE
Updated 'onlyofficedesktop'

### DIFF
--- a/fragments/labels/onlyofficedesktop.sh
+++ b/fragments/labels/onlyofficedesktop.sh
@@ -1,6 +1,11 @@
 onlyofficedesktop)
     name="ONLYOFFICE"
     type="dmg"
-    downloadURL="https://download.onlyoffice.com/install/desktop/editors/mac/distrib/onlyoffice/ONLYOFFICE.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+    downloadURL="https://download.onlyoffice.com/install/desktop/editors/mac/arm/distrib/ONLYOFFICE.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+    downloadURL="https://download.onlyoffice.com/install/desktop/editors/mac/x86_64/distrib/ONLYOFFICE.dmg"
+    fi
+    appNewVersion=$(versionFromGit ONLYOFFICE DesktopEditors)
     expectedTeamID="2WH24U26GJ"
     ;;


### PR DESCRIPTION
Added `downloadURL` for ARM.
Fixed `downloadURL` for x86_64 as well.
Unfortunately I could not find any other version source for `appNewVersion`.
Should work just fine tho.