### PR TITLE
Add Visual Studio Code Label

### DIFF
--- a/fragments/labels/vscode.sh
+++ b/fragments/labels/vscode.sh
@@ -1,0 +1,7 @@
+vscode)
+    name="Visual Studio Code"
+    type="zip"
+    downloadURL="https://code.visualstudio.com/sha/download?build=stable&os=darwin-universal"
+    appNewVersion=$(curl -fsL "https://code.visualstudio.com/updates" | grep -Eo "https?://\S+?\"" | sed 's/&.*//' | grep -i "darwin-universal" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+    expectedTeamID="UBF8T346G9"
+    ;;


### PR DESCRIPTION
````
sudo ./assemble.sh -l ~/Documents/Installomator-1/fragments/labels vscode 
2022-03-28 11:53:15 : REQ   : vscode : ################## Start Installomator v. 9.2beta, date 2022-03-28
2022-03-28 11:53:15 : INFO  : vscode : ################## Version: 9.2beta
2022-03-28 11:53:15 : INFO  : vscode : ################## Date: 2022-03-28
2022-03-28 11:53:15 : INFO  : vscode : ################## vscode
2022-03-28 11:53:15 : DEBUG : vscode : DEBUG mode 1 enabled.
2022-03-28 11:53:16 : INFO  : vscode : BLOCKING_PROCESS_ACTION=tell_user
2022-03-28 11:53:16 : INFO  : vscode : NOTIFY=success
2022-03-28 11:53:16 : INFO  : vscode : LOGGING=DEBUG
2022-03-28 11:53:16 : INFO  : vscode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-03-28 11:53:16 : INFO  : vscode : Label type: zip
2022-03-28 11:53:16 : INFO  : vscode : archiveName: Visual Studio Code.zip
2022-03-28 11:53:16 : INFO  : vscode : no blocking processes defined, using Visual Studio Code as default
2022-03-28 11:53:16 : DEBUG : vscode : Changing directory to /Users/bbenkle/Documents/Installomator-1/build
2022-03-28 11:53:16 : INFO  : vscode : App(s) found: /Applications/Visual Studio Code.app
2022-03-28 11:53:16 : INFO  : vscode : found app at /Applications/Visual Studio Code.app, version 1.65.2, on versionKey CFBundleShortVersionString
2022-03-28 11:53:16 : INFO  : vscode : appversion: 1.65.2
2022-03-28 11:53:16 : INFO  : vscode : Latest version of Visual Studio Code is 1.65.2
2022-03-28 11:53:16 : WARN  : vscode : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-03-28 11:53:16 : REQ   : vscode : Downloading https://code.visualstudio.com/sha/download?build=stable&os=darwin-universal to Visual Studio Code.zip
2022-03-28 11:54:09 : DEBUG : vscode : File list: -rw-r--r--  1 root  staff   167M Mar 28 11:54 Visual Studio Code.zip
2022-03-28 11:54:09 : DEBUG : vscode : File type: Visual Studio Code.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-03-28 11:54:09 : DEBUG : vscode : curl output was:
*   Trying 40.71.11.152:443...
* Connected to code.visualstudio.com (40.71.11.152) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [235 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [96 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3687 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=code.visualstudio.com
*  start date: Mar 21 17:58:53 2022 GMT
*  expire date: Sep 17 17:58:53 2022 GMT
*  subjectAltName: host "code.visualstudio.com" matched cert's "code.visualstudio.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure TLS Issuing CA 05
*  SSL certificate verify ok.
> GET /sha/download?build=stable&os=darwin-universal HTTP/1.1
> Host: code.visualstudio.com
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Content-Length: 128
< Content-Type: text/plain; charset=utf-8
< Date: Mon, 28 Mar 2022 15:53:17 GMT
< Server: Microsoft-IIS/10.0
< Location: https://az764295.vo.msecnd.net/stable/c722ca6c7eed3d7987c0d5c3df5c45f6b15e77d1/VSCode-darwin-universal.zip
< Vary: Accept, Accept-Encoding
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Powered-By: ASP.NET
< Strict-Transport-Security: max-age=31536000
< 
* Ignoring the response-body
{ [128 bytes data]
* Connection #0 to host code.visualstudio.com left intact
* Issue another request to this URL: 'https://az764295.vo.msecnd.net/stable/c722ca6c7eed3d7987c0d5c3df5c45f6b15e77d1/VSCode-darwin-universal.zip'
*   Trying 152.199.4.33:443...
* Connected to az764295.vo.msecnd.net (152.199.4.33) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [236 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [98 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [6370 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=Washington; L=Redmond; O=Microsoft Corporation; CN=*.vo.msecnd.net
*  start date: Aug  6 00:00:00 2021 GMT
*  expire date: Aug  6 23:59:59 2022 GMT
*  subjectAltName: host "az764295.vo.msecnd.net" matched cert's "*.vo.msecnd.net"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert SHA2 Secure Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x14c011600)
> GET /stable/c722ca6c7eed3d7987c0d5c3df5c45f6b15e77d1/VSCode-darwin-universal.zip HTTP/2
> Host: az764295.vo.msecnd.net
> user-agent: curl/7.77.0
> accept: */*
> 
< HTTP/2 200 
< accept-ranges: bytes
< access-control-allow-origin: *
< access-control-expose-headers: x-ms-request-id,x-ms-version,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type
< age: 1544203
< cache-control: max-age=31536000, public
< content-disposition: attachment; filename="VSCode-darwin-universal.zip"
< content-md5: /kZygJidrlV309GKdo12GQ==
< content-type: application/zip
< date: Mon, 28 Mar 2022 15:53:17 GMT
< etag: "0x8DA02B3B9A18511"
< last-modified: Thu, 10 Mar 2022 16:33:36 GMT
< server: ECAcc (bsa/EB25)
< x-cache: HIT
< x-ms-blob-type: BlockBlob
< x-ms-lease-state: available
< x-ms-lease-status: unlocked
< x-ms-request-id: 96dde958-c01e-002b-51b0-34a5d5000000
< x-ms-version: 2013-08-15
< content-length: 175236522
< 
{ [16383 bytes data]
* Connection #1 to host az764295.vo.msecnd.net left intact

2022-03-28 11:54:09 : DEBUG : vscode : DEBUG mode 1, not checking for blocking processes
2022-03-28 11:54:09 : REQ   : vscode : Installing Visual Studio Code
2022-03-28 11:54:09 : INFO  : vscode : Unzipping Visual Studio Code.zip
2022-03-28 11:54:11 : INFO  : vscode : Verifying: /Users/bbenkle/Documents/Installomator-1/build/Visual Studio Code.app
2022-03-28 11:54:11 : DEBUG : vscode : App size: 443M	/Users/bbenkle/Documents/Installomator-1/build/Visual Studio Code.app
2022-03-28 11:54:12 : DEBUG : vscode : Debugging enabled, App Verification output was:
/Users/bbenkle/Documents/Installomator-1/build/Visual Studio Code.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Microsoft Corporation (UBF8T346G9)

2022-03-28 11:54:12 : INFO  : vscode : Team ID matching: UBF8T346G9 (expected: UBF8T346G9 )
2022-03-28 11:54:12 : INFO  : vscode : Downloaded version of Visual Studio Code is 1.65.2 on versionKey CFBundleShortVersionString, same as installed.
2022-03-28 11:54:12 : DEBUG : vscode : DEBUG mode 1, not reopening anything
2022-03-28 11:54:12 : REG   : vscode : No new version to install
2022-03-28 11:54:12 : REQ   : vscode : ################## End Installomator, exit code 0 
````