### PR TITLE
Update 'rancherdesktop' to support arm64

### DIFF
--- a/fragments/labels/rancherdesktop.sh
+++ b/fragments/labels/rancherdesktop.sh
@@ -1,8 +1,13 @@
 rancherdesktop)
-    name="Rancher.Desktop-1.0.0-mac"
+    name="Rancher Desktop"
     type="zip"
-    archiveName="Rancher.Desktop-[0-9.]*-mac.zip"
-    downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
+    if [[ $(arch) == "arm64" ]]; then
+      archiveName="Rancher.Desktop-[0-9.]*-mac.aarch64.zip"
+      downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
+    elif [[ $(arch) == "i386" ]]; then
+      archiveName="Rancher.Desktop-[0-9.]*-mac.x86_64.zip"
+      downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
+    fi
     appNewVersion="$(versionFromGit rancher-sandbox rancher-desktop)"
     expectedTeamID="2Q6FHJR3H3"
     appName="Rancher Desktop.app"


### PR DESCRIPTION
The `archiveName` was no longer valid. Added support for i386 and arm64. Also made `name` look more beautiful :-)