### PR TITLE
Add aText Legacy which provides aText 2 for those with older licenses.

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1564,6 +1564,13 @@ atext)
     downloadURL="https://trankynam.com/atext/downloads/aText.dmg"
     expectedTeamID="KHEMQ2FD9E"
     ;;
+atextlegacy)
+    # credit: Gabe Marchan (gabemarchan.com - @darklink87)
+    name="aText"
+    type="dmg"
+    downloadURL="https://trankynam.com/atext/downloads/aTextLegacy.dmg"
+    expectedTeamID="KHEMQ2FD9E"
+    ;;
 atom)
     name="Atom"
     type="zip"


### PR DESCRIPTION
The link used for "atext" was updated a few months ago to include aText 3 which drastically changed their licensing model to be subscription based and does not accept aText 2 licenses. aText 2 is still supported until further notice, but is now called "aText Legacy" and available through a different link.