### PR TITLE
Add latest version check to firefoxpkg and gpgsuite

### DIFF
--- a/fragments/labels/firefoxpkg.sh
+++ b/fragments/labels/firefoxpkg.sh
@@ -2,6 +2,7 @@ firefoxpkg)
     name="Firefox"
     type="pkg"
     downloadURL="https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang=en-US"
+    appNewVersion=$(curl -fs https://www.mozilla.org/en-US/firefox/releases/ | grep '<html' | grep -o -i -e "data-latest-firefox=\"[0-9.]*\"" | cut -d '"' -f2)
     expectedTeamID="43AQ936H96"
     blockingProcesses=( firefox )
     ;;

--- a/fragments/labels/gpgsuite.sh
+++ b/fragments/labels/gpgsuite.sh
@@ -4,6 +4,7 @@ gpgsuite)
     type="pkgInDmg"
     pkgName="Install.pkg"
     downloadURL=$(curl -s https://gpgtools.org/ | grep https://releases.gpgtools.org/GPG_Suite- | grep Download | cut -d'"' -f4)
+    appNewVersion=$(echo $downloadURL | cut -d "-" -f 2 | cut -d "." -f 1-2)
     expectedTeamID="PKV8ZPD836"
     blockingProcesses=( "GPG Keychain" )
     ;;


### PR DESCRIPTION
Add the appNewVersion check to the firefoxpkg and gpgsuite label so it only installs updates if there is a newer version available.