### PR TITLE
Added install logic for BlueJeans Events - "bluejeansevents"

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1717,6 +1717,13 @@ bluejeans)
     appNewVersion=$(echo $downloadURL | cut -d '/' -f6)
     expectedTeamID="HE4P42JBGN"
     ;;
+bluejeansevents)
+    name="BlueJeans Events"
+    type="pkg"
+    downloadURL=$(curl -fs "https://www.bluejeans.com/downloads" | xmllint --html --format - 2>/dev/null | grep -o "https://swdl.bluejeans.com/events/release/beta/downloads/BlueJeans_Events.pkg" )
+    appNewVersion=$(echo $downloadURL | cut -d '/' -f6)
+    expectedTeamID="HE4P42JBGN"
+    ;;
 boxdrive)
     name="Box"
     type="pkg"


### PR DESCRIPTION
Added install logic for currently available version of BlueJeans Events client by Verizon. This application only has one .pkg URL currently and does not have architecture specific download URLs.

Added as "bluejeansevents" after existing logic for "bluejeans", beginning on like 1720