### PR TITLE
Add label for BlueJeans Events - "bluejeansevents"

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -53,6 +53,7 @@ bettertouchtool
 bitwarden
 blender
 bluejeans
+bluejeansevents
 boxdrive
 boxsync
 boxtools


### PR DESCRIPTION
Add label for the application BlueJeans Events by Verizon, label "bluejeansevents"
Added after existing label for bluejeans, at line 56.