### PR TITLE
Added BlueJeans Events by Verizon label

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1717,6 +1717,13 @@ bluejeans)
     appNewVersion=$(echo $downloadURL | cut -d '/' -f6)
     expectedTeamID="HE4P42JBGN"
     ;;
+bluejeansevents)
+    name="BlueJeans Events"
+    type="pkg"
+    downloadURL=$(curl -fs "https://www.bluejeans.com/downloads" | xmllint --html --format - 2>/dev/null | grep -o "https://swdl.bluejeans.com/events/release/beta/downloads/BlueJeans_Events.pkg" )
+    appNewVersion=$(echo $downloadURL | cut -d '/' -f6)
+    expectedTeamID="HE4P42JBGN"
+    ;;
 boxdrive)
     name="Box"
     type="pkg"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1721,7 +1721,6 @@ bluejeansevents)
     name="BlueJeans Events"
     type="pkg"
     downloadURL=$(curl -fs "https://www.bluejeans.com/downloads" | xmllint --html --format - 2>/dev/null | grep -o "https://swdl.bluejeans.com/events/release/beta/downloads/BlueJeans_Events.pkg" )
-    appNewVersion=$(echo $downloadURL | cut -d '/' -f6)
     expectedTeamID="HE4P42JBGN"
     ;;
 boxdrive)

--- a/Labels.txt
+++ b/Labels.txt
@@ -53,6 +53,7 @@ bettertouchtool
 bitwarden
 blender
 bluejeans
+bluejeansevents
 boxdrive
 boxsync
 boxtools


### PR DESCRIPTION
Added install logic and tag to install the latest version of the BlueJeans Events client by Verizon.
https://www.bluejeans.com/downloads
https://support.bluejeans.com/s/article/BlueJeans-Events-App-Centralized-Deployment