### PR TITLE
Unfo33 drive 1

### DIFF
--- a/fragments/labels/googledrive.sh
+++ b/fragments/labels/googledrive.sh
@@ -1,10 +1,13 @@
 googledrive|\
 googledrivefilestream)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
-    name="Google Drive File Stream"
+    name="Google Drive"
     type="pkgInDmg"
-    packageID="com.google.drivefs"
-    downloadURL="https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg" # downloadURL="https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
+    downloadURL="https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
     blockingProcesses=( "Google Docs" "Google Drive" "Google Sheets" "Google Slides" )
     expectedTeamID="EQHXZ8M8AV"
+    versionKey="CFBundleVersion"
+    updateTool="/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent"
+    updateToolArguments=( -runMode oneshot -userInitiated YES )
+    updateToolRunAsCurrentUser=1
     ;;

--- a/grammarly.sh
+++ b/grammarly.sh
@@ -1,9 +1,0 @@
-grammarly)
-    name="Grammarly Desktop"
-    type="dmg"
-    packageID="com.grammarly.ProjectLlama"
-    downloadURL=$(curl -fsL "https://download-mac.grammarly.com/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@url' 2>/dev/null  | cut -d '"' -f 2)
-    expectedTeamID="W8F64X92K3"
-    appNewVersion=$(curl -is "https://download-mac.grammarly.com/appcast.xml" | grep sparkle:version | tr ',' '\n' | grep sparkle:version | cut -d '"' -f 4)
-    appName="Grammarly Installer.app"
-    ;;


### PR DESCRIPTION
Update drive label for newer Drive name, use version in bundle rather than receipt, and use built in updater tool. 