### PR TITLE
updates for ringcentral app

### DIFF
--- a/fragments/labels/ringcentralapp.sh
+++ b/fragments/labels/ringcentralapp.sh
@@ -1,8 +1,12 @@
 ringcentralapp)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
-    name="Glip"
-    type="dmg"
-    downloadURL="https://downloads.ringcentral.com/glip/rc/GlipForMac"
+    name="Ringcentral"
+    type="pkg"
+    if [[ $(arch) != "i386" ]]; then
+        downloadURL="https://app.ringcentral.com/download/RingCentral-arm64.pkg"
+    else
+        downloadURL="https://app.ringcentral.com/download/RingCentral.pkg"
+    fi
     expectedTeamID="M932RC5J66"
-    blockingProcesses=( "Glip" )
+    blockingProcesses=( "Ringcentral" )
     ;;


### PR DESCRIPTION
 * update installers to install latest version
 * add arm installer (no universal installer yet)


Ringcentral renamed their chat app from glip to ringcentral, a few years ago they renamed the .app file to ringcentral.  Recently they also added a arm build of their chat app.