### PR TITLE
Add simple, no prerequisite install script installInstallomator.sh

### DIFF
--- a/MDM/InstallInstallomator.sh
+++ b/MDM/InstallInstallomator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script is meant to povide the simplest MDM/management platform agnostic way to install Installomator
 # The only requirement is an Internet connection
@@ -15,7 +15,6 @@ exitCode=0
 if [ ! -e "/usr/local/Installomator/Installomator.sh" ]; then
   echo "Installomator not found. Installing."
   # Create temporary working directory
-  workDirectory=$( basename "$0" )
   tempDirectory=$( mktemp -d )
   echo "Created working directory '$tempDirectory'"
   # Download the installer package

--- a/MDM/InstallInstallomator.sh
+++ b/MDM/InstallInstallomator.sh
@@ -3,6 +3,8 @@
 # This script is meant to povide the simplest MDM/management platform agnostic way to install Installomator
 # The only requirement is an Internet connection
 
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
 # Get the URL of the latest PKG From the Installomator GitHub repo
 url=$(curl --silent --fail "https://api.github.com/repos/Installomator/Installomator/releases/latest" | awk -F '"' "/browser_download_url/ && /pkg\"/ { print \$4; exit }")
 # Expected Team ID of the downloaded PKG
@@ -13,20 +15,20 @@ exitCode=0
 if [ ! -e "/usr/local/Installomator/Installomator.sh" ]; then
   echo "Installomator not found. Installing."
   # Create temporary working directory
-  workDirectory=$( /usr/bin/basename "$0" )
-  tempDirectory=$( /usr/bin/mktemp -d "/private/tmp/$workDirectory.XXXXXX" )
+  workDirectory=$( basename "$0" )
+  tempDirectory=$( mktemp -d )
   echo "Created working directory '$tempDirectory'"
   # Download the installer package
   echo "Downloading Installomator package"
-  /usr/bin/curl --location --silent "$url" -o "$tempDirectory/Installomator.pkg"
+  curl --location --silent "$url" -o "$tempDirectory/Installomator.pkg"
   # Verify the download
-  teamID=$(/usr/sbin/spctl -a -vv -t install "$tempDirectory/Installomator.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()')
+  teamID=$(spctl -a -vv -t install "$tempDirectory/Installomator.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()')
   echo "Team ID for downloaded package: $teamID"
   # Install the package if Team ID validates
   if [ "$expectedTeamID" = "$teamID" ] || [ "$expectedTeamID" = "" ]; then
     echo "Package verified. Installing package Installomator.pkg"
-    /usr/sbin/installer -pkg "$tempDirectory/Installomator.pkg" -target /
-    exitCode=0
+    installer -pkg "$tempDirectory/Installomator.pkg" -target / -verbose
+    exitCode=$?
   else
     echo "Package verification failed before package installation could start. Download link may be invalid. Aborting."
     exitCode=1
@@ -34,7 +36,7 @@ if [ ! -e "/usr/local/Installomator/Installomator.sh" ]; then
   fi
   # Remove the temporary working directory when done
   echo "Deleting working directory '$tempDirectory' and its contents"
-  /bin/rm -Rf "$tempDirectory"
+  rm -Rf "$tempDirectory"
 else
   echo "Installomator already installed."
 fi

--- a/MDM/InstallInstallomator.sh
+++ b/MDM/InstallInstallomator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This script is an MDM/management platform agnostic way to install Installomator
-# The only requirement is an Internet connection.
+# This script is meant to povide the simplest MDM/management platform agnostic way to install Installomator
+# The only requirement is an Internet connection
 
 # Get the URL of the latest PKG From the Installomator GitHub repo
 url=$(curl --silent --fail "https://api.github.com/repos/Installomator/Installomator/releases/latest" | awk -F '"' "/browser_download_url/ && /pkg\"/ { print \$4; exit }")

--- a/MDM/installInstallomator.sh
+++ b/MDM/installInstallomator.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script is an MDM/management platform agnostic way to install Installomator
+# The only requirement is an Internet connection.
+
+# Get the URL of the latest PKG From the Installomator GitHub repo
+url=$(curl --silent --fail "https://api.github.com/repos/Installomator/Installomator/releases/latest" | awk -F '"' "/browser_download_url/ && /pkg\"/ { print \$4; exit }")
+# Expected Team ID of the downloaded PKG
+expectedTeamID="JME5BW3F3R"
+exitCode=0
+
+# Check for Installomator and install if not found
+if [ ! -e "/usr/local/Installomator/Installomator.sh" ]; then
+  echo "Installomator not found. Installing."
+  # Create temporary working directory
+  workDirectory=$( /usr/bin/basename "$0" )
+  tempDirectory=$( /usr/bin/mktemp -d "/private/tmp/$workDirectory.XXXXXX" )
+  echo "Created working directory '$tempDirectory'"
+  # Download the installer package
+  echo "Downloading Installomator package"
+  /usr/bin/curl --location --silent "$url" -o "$tempDirectory/Installomator.pkg"
+  # Verify the download
+  teamID=$(/usr/sbin/spctl -a -vv -t install "$tempDirectory/Installomator.pkg" 2>&1 | awk '/origin=/ {print $NF }' | tr -d '()')
+  echo "Team ID for downloaded package: $teamID"
+  # Install the package if Team ID validates
+  if [ "$expectedTeamID" = "$teamID" ] || [ "$expectedTeamID" = "" ]; then
+    echo "Package verified. Installing package Installomator.pkg"
+    /usr/sbin/installer -pkg "$tempDirectory/Installomator.pkg" -target /
+    exitCode=0
+  else
+    echo "Package verification failed before package installation could start. Download link may be invalid. Aborting."
+    exitCode=1
+    exit $exitCode
+  fi
+  # Remove the temporary working directory when done
+  echo "Deleting working directory '$tempDirectory' and its contents"
+  /bin/rm -Rf "$tempDirectory"
+else
+  echo "Installomator already installed."
+fi
+
+exit $exitCode


### PR DESCRIPTION
It would be useful to have a script available to perform an Installomator install in a platform/MDM agnostic way with no app installs after. The script also can be used as a function in a larger deployment script.