### PR TITLE
Create new label idrivethin

### DIFF
--- a/fragments/labels/idrivethin.sh
+++ b/fragments/labels/idrivethin.sh
@@ -1,0 +1,9 @@
+idrivethin)
+    name="IDrive"
+    type="pkgInDmg"
+    pkgName="IDriveThin.pkg"
+    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thinclient-mac\([^;]*\).*/\1/' | sed 's/.*\(https.*dmg\).*/\1/g')
+    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thin_mac_ver=\([^;]*\).*/\1/' | sed 's/.*Version \([0-9.]*\).*/\1/')
+    versionKey="CFBundleVersion"
+    expectedTeamID="JWDCNYZ922"
+    ;;

--- a/fragments/labels/idrivethin.sh
+++ b/fragments/labels/idrivethin.sh
@@ -1,9 +1,0 @@
-idrivethin)
-    name="IDrive"
-    type="pkgInDmg"
-    pkgName="IDriveThin.pkg"
-    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thinclient-mac\([^;]*\).*/\1/' | sed 's/.*\(https.*dmg\).*/\1/g')
-    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thin_mac_ver=\([^;]*\).*/\1/' | sed 's/.*Version \([0-9.]*\).*/\1/')
-    versionKey="CFBundleVersion"
-    expectedTeamID="JWDCNYZ922"
-    ;;

--- a/fragments/labels/idrivethin.sh
+++ b/fragments/labels/idrivethin.sh
@@ -2,8 +2,8 @@ idrivethin)
     name="IDrive"
     type="pkgInDmg"
     pkgName="IDriveThin.pkg"
-    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thinclient-mac\([^;]*\).*/\1/' | sed 's/.*\(https.*dmg\).*/\1/g')
-    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed 's/.*thin_mac_ver=\([^;]*\).*/\1/' | sed 's/.*Version \([0-9.]*\).*/\1/')
+    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed -E 's/.*thinclient-mac([^;]*).*/\1/g' | sed -E 's/.*(https.*dmg).*/\1/g')
+    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed -E 's/.*thin\_mac\_ver\=\"Version\ ([0-9.]*).*/\1/g')
     versionKey="CFBundleVersion"
     expectedTeamID="JWDCNYZ922"
     ;;


### PR DESCRIPTION
sudo /usr/local/Installomator/Installomator.sh idrivethin DEBUG=1
2022-05-03 16:26:58 : WARN  : idrivethin : setting variable from argument DEBUG=1
2022-05-03 16:26:58 : REQ   : idrivethin : ################## Start Installomator v. 9.2beta, date 2022-05-03
2022-05-03 16:26:58 : INFO  : idrivethin : ################## Version: 9.2beta
2022-05-03 16:26:58 : INFO  : idrivethin : ################## Date: 2022-05-03
2022-05-03 16:26:58 : INFO  : idrivethin : ################## idrivethin
2022-05-03 16:26:58 : DEBUG : idrivethin : DEBUG mode 1 enabled.
2022-05-03 16:26:58 : INFO  : idrivethin : BLOCKING_PROCESS_ACTION=tell_user
2022-05-03 16:26:58 : INFO  : idrivethin : NOTIFY=success
2022-05-03 16:26:58 : INFO  : idrivethin : LOGGING=DEBUG
2022-05-03 16:26:58 : INFO  : idrivethin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-03 16:26:58 : INFO  : idrivethin : Label type: pkgInDmg
2022-05-03 16:26:58 : INFO  : idrivethin : archiveName: IDrive.dmg
2022-05-03 16:26:58 : INFO  : idrivethin : no blocking processes defined, using IDrive as default
2022-05-03 16:26:58 : DEBUG : idrivethin : Changing directory to /usr/local/Installomator
2022-05-03 16:26:58 : INFO  : idrivethin : name: IDrive, appName: IDrive.app
2022-05-03 16:26:58 : INFO  : idrivethin : App(s) found: 
2022-05-03 16:26:58 : WARN  : idrivethin : could not find IDrive.app
2022-05-03 16:26:59 : INFO  : idrivethin : appversion: 
2022-05-03 16:26:59 : INFO  : idrivethin : Latest version of IDrive is 3.5.10.9
2022-05-03 16:26:59 : INFO  : idrivethin : IDrive.dmg exists and DEBUG mode 1 enabled, skipping download
2022-05-03 16:26:59 : DEBUG : idrivethin : DEBUG mode 1, not checking for blocking processes
2022-05-03 16:26:59 : REQ   : idrivethin : Installing IDrive
2022-05-03 16:26:59 : INFO  : idrivethin : Mounting /usr/local/Installomator/IDrive.dmg
2022-05-03 16:26:59 : DEBUG : idrivethin : Debugging enabled, dmgmount output was:
expected CRC32 $86831734
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/IDrive

2022-05-03 16:26:59 : INFO  : idrivethin : Mounted: /Volumes/IDrive
2022-05-03 16:26:59 : INFO  : idrivethin : found pkg: /Volumes/IDrive/IDriveThin.pkg
2022-05-03 16:26:59 : INFO  : idrivethin : Verifying: /Volumes/IDrive/IDriveThin.pkg
2022-05-03 16:26:59 : DEBUG : idrivethin : File list: -rw-r--r--  1 john  staff    25M  2 Feb 06:21 /Volumes/IDrive/IDriveThin.pkg
2022-05-03 16:26:59 : DEBUG : idrivethin : File type: /Volumes/IDrive/IDriveThin.pkg: xar archive compressed TOC: 5626, SHA-1 checksum
2022-05-03 16:26:59 : DEBUG : idrivethin : spctlOut is /Volumes/IDrive/IDriveThin.pkg: accepted
2022-05-03 16:26:59 : DEBUG : idrivethin : source=Notarized Developer ID
2022-05-03 16:26:59 : DEBUG : idrivethin : origin=Developer ID Installer: IDrive Incorporated (JWDCNYZ922)
2022-05-03 16:26:59 : INFO  : idrivethin : Team ID: JWDCNYZ922 (expected: JWDCNYZ922 )
2022-05-03 16:26:59 : DEBUG : idrivethin : DEBUG enabled, skipping installation
2022-05-03 16:26:59 : INFO  : idrivethin : Finishing...
2022-05-03 16:27:09 : INFO  : idrivethin : name: IDrive, appName: IDrive.app
2022-05-03 16:27:09 : INFO  : idrivethin : App(s) found: 
2022-05-03 16:27:09 : WARN  : idrivethin : could not find IDrive.app
2022-05-03 16:27:09 : REQ   : idrivethin : Installed IDrive
2022-05-03 16:27:09 : INFO  : idrivethin : notifying
2022-05-03 16:27:09 : DEBUG : idrivethin : Unmounting /Volumes/IDrive
2022-05-03 16:27:10 : DEBUG : idrivethin : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-05-03 16:27:10 : DEBUG : idrivethin : DEBUG mode 1, not reopening anything
2022-05-03 16:27:10 : REQ   : idrivethin : All done!
2022-05-03 16:27:10 : REQ   : idrivethin : ################## End Installomator, exit code 0 