### PR TITLE
1Password 8

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1304,10 +1304,13 @@ valuesfromarguments)
     ;;
 1password8)
     name="1Password 8"
+    appName="1Password.app"
     type="zip"
     if [[ $(arch) == "arm64" ]]; then
+        archiveName="1Password-latest-aarch64.zip"
         downloadURL="https://downloads.1password.com/mac/1Password-latest-aarch64.zip"
     elif [[ $(arch) == "i386" ]]; then
+        archiveName="1Password-latest-x86_64.zip"
         downloadURL="https://downloads.1password.com/mac/1Password-latest-x86_64.zip"
     fi
     expectedTeamID="2BUA8C4S2C"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1302,6 +1302,18 @@ valuesfromarguments)
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES
     ;;
+1password8)
+    name="1Password 8"
+    type="zip"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://downloads.1password.com/mac/1Password-latest-aarch64.zip"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://downloads.1password.com/mac/1Password-latest-x86_64.zip"
+    fi
+    expectedTeamID="2BUA8C4S2C"
+    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    #forcefulQuit=YES
+    ;;
 1passwordcli)
     name="1Password CLI"
     type="pkg"

--- a/Labels.txt
+++ b/Labels.txt
@@ -1,4 +1,5 @@
 1password7
+1password8
 1passwordcli
 4kvideodownloader
 8x8

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -1,0 +1,15 @@
+1password8)
+    name="1Password 8"
+    appName="1Password.app"
+    type="zip"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="1Password-latest-aarch64.zip"
+        downloadURL="https://downloads.1password.com/mac/1Password-latest-aarch64.zip"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="1Password-latest-x86_64.zip"
+        downloadURL="https://downloads.1password.com/mac/1Password-latest-x86_64.zip"
+    fi
+    expectedTeamID="2BUA8C4S2C"
+    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    #forcefulQuit=YES
+    ;;


### PR DESCRIPTION
1Password 8 was just released, and Installomator.sh only supports 1Password 7 so far. This adds support for the new version as well.