### PR TITLE
Update Label: Grammarly

### DIFF
--- a/fragments/labels/grammarly.sh
+++ b/fragments/labels/grammarly.sh
@@ -1,9 +1,11 @@
 grammarly)
-    name="Grammarly Desktop"
-    type="dmg"
-    packageID="com.grammarly.ProjectLlama"
-    downloadURL=$(curl -fsL "https://download-mac.grammarly.com/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@url' 2>/dev/null  | cut -d '"' -f 2)
-    expectedTeamID="W8F64X92K3"
-    appNewVersion=$(curl -is "https://download-mac.grammarly.com/appcast.xml" | grep sparkle:version | tr ',' '\n' | grep sparkle:version | cut -d '"' -f 4)
-    appName="Grammarly Installer.app"
-    ;;
+     name="Grammarly Desktop"
+     type="dmg"
+     packageID="com.grammarly.ProjectLlama"
+     downloadURL=$(curl -fsL "https://download-mac.grammarly.com/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@url' 2>/dev/null  | cut -d '"' -f 2)
+     expectedTeamID="W8F64X92K3"
+     appNewVersion=$(curl -is "https://download-mac.grammarly.com/appcast.xml" | grep sparkle:version | tr ',' '\n' | grep sparkle:version | cut -d '"' -f 4)
+     # appName="Grammarly Installer.app"
+     installerTool="Grammarly Installer.app"
+     CLIInstaller="Grammarly Installer.app/Contents/MacOS/Grammarly Desktop"
+;;


### PR DESCRIPTION
Grammarly Desktop ships with a DMG containing Grammarly Installer.app need to call the actual app to move to the Applications folder with the correct name.