### PR TITLE
Adding hype (4)

### DIFF
--- a/fragments/labels/hype.sh
+++ b/fragments/labels/hype.sh
@@ -1,0 +1,9 @@
+hype)
+    name="Hype4"
+    type="dmg"
+    packageID="com.tumult.Hype4"
+    downloadURL="https://static.tumult.com/hype/download/Hype.dmg"
+    appNewVersion=$( curl -fsL https://tumult.com/hype/download/all/ | grep Ongoing | awk -F '<' '{print $4}' | sed 's/[^0-9.]//g' )
+    expectedTeamID="8J356DM772"
+    blockingProcesses=( NONE )
+    ;;


### PR DESCRIPTION
2022-05-13 09:32:43 : REQ   : hype : ################## Start Installomator v. 9.2beta, date 2022-05-13
2022-05-13 09:32:43 : INFO  : hype : ################## Version: 9.2beta
2022-05-13 09:32:43 : INFO  : hype : ################## Date: 2022-05-13
2022-05-13 09:32:43 : INFO  : hype : ################## hype
2022-05-13 09:32:43 : DEBUG : hype : DEBUG mode 1 enabled.
2022-05-13 09:32:43 : INFO  : hype : BLOCKING_PROCESS_ACTION=tell_user
2022-05-13 09:32:43 : INFO  : hype : NOTIFY=success
2022-05-13 09:32:43 : INFO  : hype : LOGGING=DEBUG
2022-05-13 09:32:43 : INFO  : hype : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-13 09:32:43 : INFO  : hype : Label type: dmg
2022-05-13 09:32:43 : INFO  : hype : archiveName: Hype4.dmg
2022-05-13 09:32:44 : DEBUG : hype : Changing directory to /Users/thijs/gits/Installomator/build
2022-05-13 09:32:44 : INFO  : hype : No version found using packageID com.tumult.Hype4
2022-05-13 09:32:44 : INFO  : hype : App(s) found: /Applications/Hype4.app
2022-05-13 09:32:44 : INFO  : hype : found app at /Applications/Hype4.app, version 4.1.8, on versionKey CFBundleShortVersionString
2022-05-13 09:32:44 : INFO  : hype : appversion: 4.1.8
2022-05-13 09:32:44 : INFO  : hype : Latest version of Hype4 is 4.1.8
2022-05-13 09:32:44 : WARN  : hype : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-13 09:32:44 : INFO  : hype : Hype4.dmg exists and DEBUG mode 1 enabled, skipping download
2022-05-13 09:32:44 : REQ   : hype : Installing Hype4
2022-05-13 09:32:44 : INFO  : hype : Mounting /Users/thijs/gits/Installomator/build/Hype4.dmg
2022-05-13 09:32:44 : DEBUG : hype : Debugging enabled, dmgmount output was:
/dev/disk2          	Apple_partition_scheme
/dev/disk2s1        	Apple_partition_map
/dev/disk2s2        	Apple_HFS                      	/Volumes/Hype 4.1.8

2022-05-13 09:32:44 : INFO  : hype : Mounted: /Volumes/Hype 4.1.8
2022-05-13 09:32:44 : INFO  : hype : Verifying: /Volumes/Hype 4.1.8/Hype4.app
2022-05-13 09:32:44 : DEBUG : hype : App size:  50M	/Volumes/Hype 4.1.8/Hype4.app
2022-05-13 09:32:47 : DEBUG : hype : Debugging enabled, App Verification output was:
/Volumes/Hype 4.1.8/Hype4.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Tumult Inc. (8J356DM772)

2022-05-13 09:32:47 : INFO  : hype : Team ID matching: 8J356DM772 (expected: 8J356DM772 )
2022-05-13 09:32:47 : INFO  : hype : Downloaded version of Hype4 is 4.1.8 on versionKey CFBundleShortVersionString, same as installed.
2022-05-13 09:32:47 : DEBUG : hype : Unmounting /Volumes/Hype 4.1.8
2022-05-13 09:32:47 : DEBUG : hype : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-13 09:32:47 : DEBUG : hype : DEBUG mode 1, not reopening anything
2022-05-13 09:32:47 : REG   : hype : No new version to install
2022-05-13 09:32:47 : REQ   : hype : ################## End Installomator, exit code 0