### PR TITLE
adding Xerox Workcentre 7800 drivers

### DIFF
--- a/fragments/labels/xeroxworkcentre7800.sh
+++ b/fragments/labels/xeroxworkcentre7800.sh
@@ -1,0 +1,9 @@
+xeroxworkcentre7800)
+    name="XeroxWorkCentre"
+    type="pkgInDmg"
+    appCustomVersion(){ lpinfo -m | grep 783 | tail -n 1 | awk -F ', ' '{print $2}' }
+    appNewVersion=$( curl -fsL "https://www.support.xerox.com/nl-nl/product/workcentre-7800-series/downloads?platform=macOSx11" | grep .dmg | head -n 1 | awk -F '_' '{print $2}' )
+    downloadURL=$( curl -fsL "https://www.support.xerox.com/nl-nl/product/workcentre-7800-series/downloads?platform=macOSx11" | xmllint --html --format - 2>/dev/null | grep -o "https://.*XeroxDrivers.*.dmg" )
+    expectedTeamID="G59Y3XFNFR"
+    blockingProcesses=( NONE )
+;;


### PR DESCRIPTION
2022-05-13 09:43:48 : REQ   : xeroxworkcentre7800 : ################## Start Installomator v. 9.2beta, date 2022-05-13
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : ################## Version: 9.2beta
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : ################## Date: 2022-05-13
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : ################## xeroxworkcentre7800
2022-05-13 09:43:48 : DEBUG : xeroxworkcentre7800 : DEBUG mode 1 enabled.
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : BLOCKING_PROCESS_ACTION=tell_user
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : NOTIFY=success
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : LOGGING=DEBUG
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : Label type: pkgInDmg
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : archiveName: XeroxWorkCentre.dmg
2022-05-13 09:43:48 : DEBUG : xeroxworkcentre7800 : Changing directory to /Users/thijs/gits/Installomator/build
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : Custom App Version detection is used, found 5.10.1
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : appversion: 5.10.1
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : Latest version of XeroxWorkCentre is 5.10.1
2022-05-13 09:43:48 : WARN  : xeroxworkcentre7800 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : XeroxWorkCentre.dmg exists and DEBUG mode 1 enabled, skipping download
2022-05-13 09:43:48 : REQ   : xeroxworkcentre7800 : Installing XeroxWorkCentre
2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : Mounting /Users/thijs/gits/Installomator/build/XeroxWorkCentre.dmg
2022-05-13 09:43:48 : DEBUG : xeroxworkcentre7800 : Debugging enabled, dmgmount output was:
expected CRC32 $562A7F63
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Xerox Drivers 5.10.1

2022-05-13 09:43:48 : INFO  : xeroxworkcentre7800 : Mounted: /Volumes/Xerox Drivers 5.10.1
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : Found pkg(s):
/Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg
2022-05-13 09:43:49 : INFO  : xeroxworkcentre7800 : found pkg: /Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg
2022-05-13 09:43:49 : INFO  : xeroxworkcentre7800 : Verifying: /Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : File list: -rw-r--r--  1 root  staff    85M Apr 19 15:58 /Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : File type: /Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg: xar archive compressed TOC: 31493, SHA-1 checksum
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : spctlOut is /Volumes/Xerox Drivers 5.10.1/Xerox Drivers 5.10.1.pkg: accepted
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : source=Notarized Developer ID
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : origin=Developer ID Installer: Xerox Corporation (G59Y3XFNFR)
2022-05-13 09:43:49 : INFO  : xeroxworkcentre7800 : Team ID: G59Y3XFNFR (expected: G59Y3XFNFR )
2022-05-13 09:43:49 : DEBUG : xeroxworkcentre7800 : DEBUG enabled, skipping installation
2022-05-13 09:43:49 : INFO  : xeroxworkcentre7800 : Finishing...
2022-05-13 09:43:59 : INFO  : xeroxworkcentre7800 : Custom App Version detection is used, found 5.10.1
2022-05-13 09:43:59 : REQ   : xeroxworkcentre7800 : Installed XeroxWorkCentre, version 5.10.1
2022-05-13 09:43:59 : INFO  : xeroxworkcentre7800 : notifying
2022-05-13 09:43:59 : DEBUG : xeroxworkcentre7800 : Unmounting /Volumes/Xerox Drivers 5.10.1
2022-05-13 09:43:59 : DEBUG : xeroxworkcentre7800 : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-13 09:43:59 : DEBUG : xeroxworkcentre7800 : DEBUG mode 1, not reopening anything
2022-05-13 09:43:59 : REQ   : xeroxworkcentre7800 : All done!
2022-05-13 09:43:59 : REQ   : xeroxworkcentre7800 : ################## End Installomator, exit code 0