### PR TITLE
Update README.md shields.io badges urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _The one installer script to rule them all._
 
-![](https://img.shields.io/github/v/release/scriptingosx/Installomator)&nbsp;![](https://img.shields.io/github/downloads/scriptingosx/Installomator/latest/total)&nbsp;![](https://img.shields.io/badge/macOS-10.14%2B-success)&nbsp;![](https://img.shields.io/github/license/scriptingosx/Installomator)
+![](https://img.shields.io/github/v/release/Installomator/Installomator)&nbsp;![](https://img.shields.io/github/downloads/Installomator/Installomator/latest/total)&nbsp;![](https://img.shields.io/badge/macOS-10.14%2B-success)&nbsp;![](https://img.shields.io/github/license/Installomator/Installomator)
 
 This script is in the “we find it useful, it is working for us” stage.
 


### PR DESCRIPTION
Now pointed to Installomator/Installomator instead of scriptingosx/Installomator
Fixes Release and Downloads badges showing "no releases or repo found" error