### PR TITLE
Update talkdeskcxcloud to use JSON parsing

### DIFF
--- a/fragments/labels/talkdeskcxcloud.sh
+++ b/fragments/labels/talkdeskcxcloud.sh
@@ -1,7 +1,8 @@
 talkdeskcxcloud)
     name="Talkdesk"
     type="dmg"
-    appNewVersion=$(curl -fs https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-latest-metadata.json | sed -n -e 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' | head -n 1)
+    talkdeskcxcloudVersions=$(curl -fs "https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-latest-metadata.json")
+    appNewVersion=$(getJSONValue "$talkdeskcxcloudVersions" "[0].version")
     downloadURL="https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-${appNewVersion}.dmg"
     expectedTeamID="YGGJX44TB8"
     ;;


### PR DESCRIPTION
Updating this label to use the the new `getJSONValue` function from https://github.com/Installomator/Installomator/pull/529

Test run output (with `getJSONValue` function available):
```
% utils/assemble.sh talkdeskcxcloud
2022-05-17 14:29:04 : REQ   : talkdeskcxcloud : ################## Start Installomator v. 9.2beta, date 2022-05-17
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : ################## Version: 9.2beta
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : ################## Date: 2022-05-17
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : ################## talkdeskcxcloud
2022-05-17 14:29:04 : DEBUG : talkdeskcxcloud : DEBUG mode 1 enabled.
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : BLOCKING_PROCESS_ACTION=tell_user
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : NOTIFY=success
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : LOGGING=DEBUG
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : Label type: dmg
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : archiveName: Talkdesk.dmg
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : no blocking processes defined, using Talkdesk as default
2022-05-17 14:29:04 : DEBUG : talkdeskcxcloud : Changing directory to /Users/liam.steckler/Installomator/build
2022-05-17 14:29:04 : INFO  : talkdeskcxcloud : name: Talkdesk, appName: Talkdesk.app
2022-05-17 14:29:04 : WARN  : talkdeskcxcloud : No previous app found
2022-05-17 14:29:05 : WARN  : talkdeskcxcloud : could not find Talkdesk.app
2022-05-17 14:29:05 : INFO  : talkdeskcxcloud : appversion: 
2022-05-17 14:29:05 : INFO  : talkdeskcxcloud : Latest version of Talkdesk is 1.6.1
2022-05-17 14:29:05 : REQ   : talkdeskcxcloud : Downloading https://td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com/talkdesk-1.6.1.dmg to Talkdesk.dmg
2022-05-17 14:29:14 : DEBUG : talkdeskcxcloud : File list: -rw-r--r--  1 liam.steckler  staff    80M May 17 14:29 Talkdesk.dmg
2022-05-17 14:29:15 : DEBUG : talkdeskcxcloud : File type: Talkdesk.dmg: zlib compressed data
2022-05-17 14:29:15 : DEBUG : talkdeskcxcloud : curl output was:
*   Trying 52.217.192.169:443...
* Connected to td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com (52.217.192.169) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [361 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [91 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4960 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Dec 15 00:00:00 2021 GMT
*  expire date: Dec  3 23:59:59 2022 GMT
*  subjectAltName: host "td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
> GET /talkdesk-1.6.1.dmg HTTP/1.1
> Host: td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-amz-id-2: cgxriXr2SoK8Mz7pXZKwB/dM40PXCjuV1VQ0hxZt9iJwOs+7Zhl0n1mmf6KhY8JSFL7Sgqwyo4w=
< x-amz-request-id: 4FDPKN186YCHHQ26
< Date: Tue, 17 May 2022 21:29:06 GMT
< Last-Modified: Thu, 21 Apr 2022 13:52:42 GMT
< ETag: "40dc8ad27bfc86082048672450ec3385-17"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: FOZdV.flobjk8P.JRVUFf8KVXl2X4Qnu
< Accept-Ranges: bytes
< Content-Type: application/x-apple-diskimage
< Server: AmazonS3
< Content-Length: 84377278
< 
{ [1574 bytes data]
* Connection #0 to host td-infra-prd-us-east-1-s3-atlaselectron.s3.amazonaws.com left intact

2022-05-17 14:29:15 : DEBUG : talkdeskcxcloud : DEBUG mode 1, not checking for blocking processes
2022-05-17 14:29:15 : REQ   : talkdeskcxcloud : Installing Talkdesk
2022-05-17 14:29:15 : INFO  : talkdeskcxcloud : Mounting /Users/liam.steckler/Installomator/build/Talkdesk.dmg
2022-05-17 14:29:18 : DEBUG : talkdeskcxcloud : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8702942E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $79613867
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7209EADC
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $FFDA3B65
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7209EADC
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $20EFC3FA
verified   CRC32 $DB71E3E7
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/Talkdesk 1.6.1

2022-05-17 14:29:18 : INFO  : talkdeskcxcloud : Mounted: /Volumes/Talkdesk 1.6.1
2022-05-17 14:29:18 : INFO  : talkdeskcxcloud : Verifying: /Volumes/Talkdesk 1.6.1/Talkdesk.app
2022-05-17 14:29:18 : DEBUG : talkdeskcxcloud : App size: 188M  /Volumes/Talkdesk 1.6.1/Talkdesk.app
2022-05-17 14:29:20 : DEBUG : talkdeskcxcloud : Debugging enabled, App Verification output was:
/Volumes/Talkdesk 1.6.1/Talkdesk.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Talkdesk, Inc. (YGGJX44TB8)

2022-05-17 14:29:20 : INFO  : talkdeskcxcloud : Team ID matching: YGGJX44TB8 (expected: YGGJX44TB8 )
2022-05-17 14:29:20 : INFO  : talkdeskcxcloud : Installing Talkdesk version 1.6.1 on versionKey CFBundleShortVersionString.
2022-05-17 14:29:20 : INFO  : talkdeskcxcloud : App has LSMinimumSystemVersion: 10.11.0
2022-05-17 14:29:20 : DEBUG : talkdeskcxcloud : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-05-17 14:29:20 : INFO  : talkdeskcxcloud : Finishing...
2022-05-17 14:29:30 : INFO  : talkdeskcxcloud : name: Talkdesk, appName: Talkdesk.app
2022-05-17 14:29:30 : WARN  : talkdeskcxcloud : No previous app found
2022-05-17 14:29:30 : WARN  : talkdeskcxcloud : could not find Talkdesk.app
2022-05-17 14:29:30 : REQ   : talkdeskcxcloud : Installed Talkdesk
2022-05-17 14:29:30 : INFO  : talkdeskcxcloud : notifying
2022-05-17 14:29:31 : DEBUG : talkdeskcxcloud : Unmounting /Volumes/Talkdesk 1.6.1
2022-05-17 14:29:42 : DEBUG : talkdeskcxcloud : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-05-17 14:29:42 : DEBUG : talkdeskcxcloud : DEBUG mode 1, not reopening anything
2022-05-17 14:29:42 : REQ   : talkdeskcxcloud : All done!
2022-05-17 14:29:42 : REQ   : talkdeskcxcloud : ################## End Installomator, exit code 0 
```