### PR TITLE
Marathon Trilogy with `versionKey` added to the labels.

### DIFF
--- a/fragments/labels/marathon.sh
+++ b/fragments/labels/marathon.sh
@@ -2,6 +2,7 @@ marathon)
     name="Marathon"
     type="dmg"
     archiveName="Marathon-[0-9.]*-Mac.dmg"
+    versionKey="CFBundleVersion"
     downloadURL="$(downloadURLFromGit Aleph-One-Marathon alephone)"
     appNewVersion="$(versionFromGit Aleph-One-Marathon alephone)"
     expectedTeamID="E8K89CXZE7"

--- a/fragments/labels/marathon2.sh
+++ b/fragments/labels/marathon2.sh
@@ -2,6 +2,7 @@ marathon2)
     name="Marathon 2"
     type="dmg"
     archiveName="Marathon2-[0-9.]*-Mac.dmg"
+    versionKey="CFBundleVersion"
     downloadURL="$(downloadURLFromGit Aleph-One-Marathon alephone)"
     appNewVersion="$(versionFromGit Aleph-One-Marathon alephone)"
     expectedTeamID="E8K89CXZE7"

--- a/fragments/labels/marathoninfinity.sh
+++ b/fragments/labels/marathoninfinity.sh
@@ -2,6 +2,7 @@ marathoninfinity)
     name="Marathon Infinity"
     type="dmg"
     archiveName="MarathonInfinity-[0-9.]*-Mac.dmg"
+    versionKey="CFBundleVersion"
     downloadURL="$(downloadURLFromGit Aleph-One-Marathon alephone)"
     appNewVersion="$(versionFromGit Aleph-One-Marathon alephone)"
     expectedTeamID="E8K89CXZE7"


### PR DESCRIPTION
Output:
```
➜  Installomator/utils/assemble.sh marathoninfinity DEBUG=0
2022-05-18 15:21:53 : WARN  : marathoninfinity : setting variable from argument DEBUG=0
2022-05-18 15:21:53 : REQ   : marathoninfinity : ################## Start Installomator v. 10.0beta, date 2022-05-18
2022-05-18 15:21:53 : INFO  : marathoninfinity : ################## Version: 10.0beta
2022-05-18 15:21:53 : INFO  : marathoninfinity : ################## Date: 2022-05-18
2022-05-18 15:21:53 : INFO  : marathoninfinity : ################## marathoninfinity
2022-05-18 15:21:53 : INFO  : marathoninfinity : BLOCKING_PROCESS_ACTION=tell_user
2022-05-18 15:21:53 : INFO  : marathoninfinity : NOTIFY=success
2022-05-18 15:21:53 : INFO  : marathoninfinity : LOGGING=INFO
2022-05-18 15:21:53 : INFO  : marathoninfinity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-18 15:21:53 : INFO  : marathoninfinity : Label type: dmg
2022-05-18 15:21:53 : INFO  : marathoninfinity : archiveName: MarathonInfinity-[0-9.]*-Mac.dmg
2022-05-18 15:21:53 : INFO  : marathoninfinity : no blocking processes defined, using Marathon Infinity as default
2022-05-18 15:21:53 : INFO  : marathoninfinity : App(s) found: /Applications/Marathon Infinity.app
2022-05-18 15:21:53 : INFO  : marathoninfinity : found app at /Applications/Marathon Infinity.app, version 20220115, on versionKey CFBundleVersion
2022-05-18 15:21:53 : INFO  : marathoninfinity : appversion: 20220115
2022-05-18 15:21:53 : INFO  : marathoninfinity : Latest version of Marathon Infinity is 20220115
2022-05-18 15:21:53 : INFO  : marathoninfinity : There is no newer version available.
2022-05-18 15:21:53 : INFO  : marathoninfinity : App not closed, so no reopen.
2022-05-18 15:21:53 : REQ   : marathoninfinity : No newer version.
2022-05-18 15:21:53 : REQ   : marathoninfinity : ################## End Installomator, exit code 0

➜  Installomator/utils/assemble.sh marathon DEBUG=0
2022-05-18 15:22:04 : WARN  : marathon : setting variable from argument DEBUG=0
2022-05-18 15:22:04 : REQ   : marathon : ################## Start Installomator v. 10.0beta, date 2022-05-18
2022-05-18 15:22:04 : INFO  : marathon : ################## Version: 10.0beta
2022-05-18 15:22:04 : INFO  : marathon : ################## Date: 2022-05-18
2022-05-18 15:22:04 : INFO  : marathon : ################## marathon
2022-05-18 15:22:04 : INFO  : marathon : BLOCKING_PROCESS_ACTION=tell_user
2022-05-18 15:22:04 : INFO  : marathon : NOTIFY=success
2022-05-18 15:22:04 : INFO  : marathon : LOGGING=INFO
2022-05-18 15:22:04 : INFO  : marathon : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-18 15:22:04 : INFO  : marathon : Label type: dmg
2022-05-18 15:22:04 : INFO  : marathon : archiveName: Marathon-[0-9.]*-Mac.dmg
2022-05-18 15:22:04 : INFO  : marathon : no blocking processes defined, using Marathon as default
2022-05-18 15:22:04 : INFO  : marathon : App(s) found: /Applications/Marathon.app
2022-05-18 15:22:04 : INFO  : marathon : found app at /Applications/Marathon.app, version 20220115, on versionKey CFBundleVersion
2022-05-18 15:22:04 : INFO  : marathon : appversion: 20220115
2022-05-18 15:22:04 : INFO  : marathon : Latest version of Marathon is 20220115
2022-05-18 15:22:04 : INFO  : marathon : There is no newer version available.
2022-05-18 15:22:04 : INFO  : marathon : App not closed, so no reopen.
2022-05-18 15:22:04 : REQ   : marathon : No newer version.
2022-05-18 15:22:04 : REQ   : marathon : ################## End Installomator, exit code 0

➜  Installomator/utils/assemble.sh marathon2 DEBUG=0
2022-05-18 15:22:08 : WARN  : marathon2 : setting variable from argument DEBUG=0
2022-05-18 15:22:08 : REQ   : marathon2 : ################## Start Installomator v. 10.0beta, date 2022-05-18
2022-05-18 15:22:08 : INFO  : marathon2 : ################## Version: 10.0beta
2022-05-18 15:22:08 : INFO  : marathon2 : ################## Date: 2022-05-18
2022-05-18 15:22:08 : INFO  : marathon2 : ################## marathon2
2022-05-18 15:22:08 : INFO  : marathon2 : BLOCKING_PROCESS_ACTION=tell_user
2022-05-18 15:22:08 : INFO  : marathon2 : NOTIFY=success
2022-05-18 15:22:08 : INFO  : marathon2 : LOGGING=INFO
2022-05-18 15:22:08 : INFO  : marathon2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-18 15:22:08 : INFO  : marathon2 : Label type: dmg
2022-05-18 15:22:08 : INFO  : marathon2 : archiveName: Marathon2-[0-9.]*-Mac.dmg
2022-05-18 15:22:08 : INFO  : marathon2 : no blocking processes defined, using Marathon 2 as default
2022-05-18 15:22:08 : INFO  : marathon2 : App(s) found: /Applications/Marathon 2.app
2022-05-18 15:22:08 : INFO  : marathon2 : found app at /Applications/Marathon 2.app, version 20220115, on versionKey CFBundleVersion
2022-05-18 15:22:08 : INFO  : marathon2 : appversion: 20220115
2022-05-18 15:22:08 : INFO  : marathon2 : Latest version of Marathon 2 is 20220115
2022-05-18 15:22:08 : INFO  : marathon2 : There is no newer version available.
2022-05-18 15:22:08 : INFO  : marathon2 : App not closed, so no reopen.
2022-05-18 15:22:08 : REQ   : marathon2 : No newer version.
2022-05-18 15:22:08 : REQ   : marathon2 : ################## End Installomator, exit code 0
```