### PR TITLE
Add ipswupdater label using JSON parsing

### DIFF
--- a/fragments/labels/ipswupdater.sh
+++ b/fragments/labels/ipswupdater.sh
@@ -1,0 +1,8 @@
+ipswupdater)
+    name="IPSW Updater"
+    type="zip"
+    ipswupdaterVersions=$(curl -fs "https://ipsw.app/download/updates.php?current_version=0.9.16")
+    downloadURL=$(getJSONValue "$ipswupdaterVersions" "[0].url")
+    appNewVersion=$(getJSONValue "$ipswupdaterVersions" "[0].version")
+    expectedTeamID="YRW6NUGA63"
+    ;;


### PR DESCRIPTION
Adding a new label for IPSW Updater (https://ipsw.app), using the new `getJSONValue` function from #529.

Label contains a hardcoded version number, as without passing this to the updates.php function, it only returns versions up to 0.9.15 (maybe a change to how the auto-update function inside the app worked?)

Test run output (with `getJSONValue function` available):
```
% utils/assemble.sh ipswupdater
2022-05-18 08:59:24 : REQ   : ipswupdater : ################## Start Installomator v. 9.2, date 2022-05-18
2022-05-18 08:59:24 : INFO  : ipswupdater : ################## Version: 9.2
2022-05-18 08:59:24 : INFO  : ipswupdater : ################## Date: 2022-05-18
2022-05-18 08:59:24 : INFO  : ipswupdater : ################## ipswupdater
2022-05-18 08:59:24 : DEBUG : ipswupdater : DEBUG mode 1 enabled.
2022-05-18 08:59:24 : INFO  : ipswupdater : BLOCKING_PROCESS_ACTION=tell_user
2022-05-18 08:59:24 : INFO  : ipswupdater : NOTIFY=success
2022-05-18 08:59:24 : INFO  : ipswupdater : LOGGING=DEBUG
2022-05-18 08:59:24 : INFO  : ipswupdater : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-18 08:59:24 : INFO  : ipswupdater : Label type: zip
2022-05-18 08:59:24 : INFO  : ipswupdater : archiveName: IPSW Updater.zip
2022-05-18 08:59:24 : INFO  : ipswupdater : no blocking processes defined, using IPSW Updater as default
2022-05-18 08:59:24 : DEBUG : ipswupdater : Changing directory to /Users/liam.steckler/Installomator/build
2022-05-18 08:59:24 : INFO  : ipswupdater : name: IPSW Updater, appName: IPSW Updater.app
2022-05-18 08:59:24 : WARN  : ipswupdater : No previous app found
2022-05-18 08:59:24 : WARN  : ipswupdater : could not find IPSW Updater.app
2022-05-18 08:59:24 : INFO  : ipswupdater : appversion: 
2022-05-18 08:59:25 : INFO  : ipswupdater : Latest version of IPSW Updater is 2022.5.9-2
2022-05-18 08:59:25 : REQ   : ipswupdater : Downloading https://ipsw.app/download/IPSWUpdater-v202205092.zip to IPSW Updater.zip
2022-05-18 08:59:25 : DEBUG : ipswupdater : File list: -rw-r--r--  1 liam.steckler  staff   132K May 18 08:59 IPSW Updater.zip
2022-05-18 08:59:25 : DEBUG : ipswupdater : File type: IPSW Updater.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-05-18 08:59:25 : DEBUG : ipswupdater : curl output was:
*   Trying 69.163.157.245:443...
* Connected to ipsw.app (69.163.157.245) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [313 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4033 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=www.ipsw.app
*  start date: Apr 25 14:51:39 2022 GMT
*  expire date: Jul 24 14:51:38 2022 GMT
*  subjectAltName: host "ipsw.app" matched cert's "ipsw.app"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13f00d400)
> GET /download/IPSWUpdater-v202205092.zip HTTP/2
> Host: ipsw.app
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 200 
< date: Wed, 18 May 2022 15:59:25 GMT
< server: Apache
< last-modified: Mon, 09 May 2022 22:33:07 GMT
< etag: "21015-5de9bcad318fe"
< accept-ranges: bytes
< content-length: 135189
< cache-control: max-age=172800
< expires: Fri, 20 May 2022 15:59:25 GMT
< vary: User-Agent
< strict-transport-security: max-age=31536000
< content-type: application/zip
< 
{ [1120 bytes data]
* Connection #0 to host ipsw.app left intact

2022-05-18 08:59:25 : DEBUG : ipswupdater : DEBUG mode 1, not checking for blocking processes
2022-05-18 08:59:25 : REQ   : ipswupdater : Installing IPSW Updater
2022-05-18 08:59:25 : INFO  : ipswupdater : Unzipping IPSW Updater.zip
2022-05-18 08:59:25 : INFO  : ipswupdater : Verifying: /Users/liam.steckler/Installomator/build/IPSW Updater.app
2022-05-18 08:59:25 : DEBUG : ipswupdater : App size: 348K      /Users/liam.steckler/Installomator/build/IPSW Updater.app
2022-05-18 08:59:25 : DEBUG : ipswupdater : Debugging enabled, App Verification output was:
/Users/liam.steckler/Installomator/build/IPSW Updater.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Pico Mitchell (YRW6NUGA63)

2022-05-18 08:59:25 : INFO  : ipswupdater : Team ID matching: YRW6NUGA63 (expected: YRW6NUGA63 )
2022-05-18 08:59:25 : INFO  : ipswupdater : Installing IPSW Updater version 2022.5.9-2 on versionKey CFBundleShortVersionString.
2022-05-18 08:59:25 : INFO  : ipswupdater : App has LSMinimumSystemVersion: 10.13
2022-05-18 08:59:25 : DEBUG : ipswupdater : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-05-18 08:59:25 : INFO  : ipswupdater : Finishing...
2022-05-18 08:59:35 : INFO  : ipswupdater : name: IPSW Updater, appName: IPSW Updater.app
2022-05-18 08:59:35 : INFO  : ipswupdater : App(s) found: /Users/liam.steckler/Installomator/build/IPSW Updater.app
2022-05-18 08:59:35 : WARN  : ipswupdater : could not determine location of IPSW Updater.app
2022-05-18 08:59:35 : REQ   : ipswupdater : Installed IPSW Updater
2022-05-18 08:59:35 : INFO  : ipswupdater : notifying
2022-05-18 08:59:35 : DEBUG : ipswupdater : DEBUG mode 1, not reopening anything
2022-05-18 08:59:35 : REQ   : ipswupdater : All done!
2022-05-18 08:59:35 : REQ   : ipswupdater : ################## End Installomator, exit code 0
```