### PR TITLE
New Label: Duo Device Health

### DIFF
--- a/fragments/labels/duodevicehealth.sh
+++ b/fragments/labels/duodevicehealth.sh
@@ -1,0 +1,9 @@
+duodevicehealth)
+    name="Duo Device Health"
+    type="pkgInDmg"
+    downloadURL="https://dl.duosecurity.com/DuoDeviceHealth-latest.dmg"
+    appNewVersion=$(curl -fsLIXGET "https://dl.duosecurity.com/DuoDeviceHealth-latest.dmg" | grep -i "^content-disposition" | sed -e 's/.*filename\=\"DuoDeviceHealth\-\(.*\)\.dmg\".*/\1/')
+    appName="Duo Device Health.app"
+    expectedTeamID="FNN8Z5JMFP"
+    ;;
+


### PR DESCRIPTION
```
2022-05-19 22:17:40 : WARN  : duodevicehealth : setting variable from argument DEBUG=0
2022-05-19 22:17:40 : WARN  : duodevicehealth : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2022-05-19 22:17:40 : WARN  : duodevicehealth : setting variable from argument INSTALL=force
2022-05-19 22:17:40 : REQ   : duodevicehealth : ################## Start Installomator v. 10.0beta, date 2022-05-19
2022-05-19 22:17:40 : INFO  : duodevicehealth : ################## Version: 10.0beta
2022-05-19 22:17:40 : INFO  : duodevicehealth : ################## Date: 2022-05-19
2022-05-19 22:17:40 : INFO  : duodevicehealth : ################## duodevicehealth
2022-05-19 22:17:40 : INFO  : duodevicehealth : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2022-05-19 22:17:41 : INFO  : duodevicehealth : NOTIFY=success
2022-05-19 22:17:41 : INFO  : duodevicehealth : LOGGING=INFO
2022-05-19 22:17:41 : INFO  : duodevicehealth : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-19 22:17:41 : INFO  : duodevicehealth : Label type: pkgInDmg
2022-05-19 22:17:41 : INFO  : duodevicehealth : archiveName: Duo Device Health.dmg
2022-05-19 22:17:41 : INFO  : duodevicehealth : no blocking processes defined, using Duo Device Health as default
2022-05-19 22:17:41 : INFO  : duodevicehealth : App(s) found: /Applications/Duo Device Health.app
2022-05-19 22:17:41 : INFO  : duodevicehealth : found app at /Applications/Duo Device Health.app, version 2.25.0.0, on versionKey CFBundleShortVersionString
2022-05-19 22:17:41 : INFO  : duodevicehealth : appversion: 2.25.0.0
2022-05-19 22:17:41 : INFO  : duodevicehealth : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-05-19 22:17:41 : INFO  : duodevicehealth : Latest version of Duo Device Health is 2.25.0.0
2022-05-19 22:17:41 : INFO  : duodevicehealth : There is no newer version available.
2022-05-19 22:17:41 : REQ   : duodevicehealth : Downloading https://dl.duosecurity.com/DuoDeviceHealth-latest.dmg to Duo Device Health.dmg
2022-05-19 22:17:41 : INFO  : duodevicehealth : found blocking process Duo Device Health
2022-05-19 22:17:45 : INFO  : duodevicehealth : telling app Duo Device Health to quit
2022-05-19 22:17:46 : INFO  : duodevicehealth : waiting 30 seconds for processes to quit
2022-05-19 22:18:16 : REQ   : duodevicehealth : no more blocking processes, continue with update
2022-05-19 22:18:16 : REQ   : duodevicehealth : Installing Duo Device Health
2022-05-19 22:18:16 : INFO  : duodevicehealth : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.0h3MOHD3/Duo Device Health.dmg
2022-05-19 22:18:19 : INFO  : duodevicehealth : Mounted: /Volumes/DuoDeviceHealth
2022-05-19 22:18:19 : INFO  : duodevicehealth : found pkg: /Volumes/DuoDeviceHealth/Install-DuoDeviceHealth.pkg
2022-05-19 22:18:19 : INFO  : duodevicehealth : Verifying: /Volumes/DuoDeviceHealth/Install-DuoDeviceHealth.pkg
2022-05-19 22:18:19 : INFO  : duodevicehealth : Team ID: FNN8Z5JMFP (expected: FNN8Z5JMFP )
2022-05-19 22:18:19 : INFO  : duodevicehealth : Installing /Volumes/DuoDeviceHealth/Install-DuoDeviceHealth.pkg to /
2022-05-19 22:18:24 : INFO  : duodevicehealth : Finishing...
2022-05-19 22:18:34 : INFO  : duodevicehealth : App(s) found: /Applications/Duo Device Health.app
2022-05-19 22:18:34 : INFO  : duodevicehealth : found app at /Applications/Duo Device Health.app, version 2.25.0.0, on versionKey CFBundleShortVersionString
2022-05-19 22:18:34 : REQ   : duodevicehealth : Installed Duo Device Health, version 2.25.0.0
2022-05-19 22:18:34 : INFO  : duodevicehealth : notifying
2022-05-19 22:18:34 : INFO  : duodevicehealth : Telling app Duo Device Health.app to open
2022-05-19 22:18:35 : INFO  : duodevicehealth : Reopened Duo Device Health.app as user
2022-05-19 22:18:35 : REQ   : duodevicehealth : All done!
2022-05-19 22:18:35 : REQ   : duodevicehealth : ################## End Installomator, exit code 0 
```