### PR TITLE
New Label: A Better Finder Rename 11

### DIFF
--- a/fragments/labels/abetterfinderrename11.sh
+++ b/fragments/labels/abetterfinderrename11.sh
@@ -1,0 +1,7 @@
+abetterfinderrename11)
+    name="A Better Finder Rename 11"
+    type="dmg"
+    downloadURL="https://www.publicspace.net/download/ABFRX11.dmg"
+    appNewVersion=$(curl -fs "https://www.publicspace.net/app/signed_abfr11.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null | cut -d '"' -f 2)
+    expectedTeamID="7Y9KW4ND8W"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels abetterfinderrename11
2022-05-22 14:29:11 : REQ   : abetterfinderrename11 : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 14:29:11 : INFO  : abetterfinderrename11 : ################## Version: 9.2
2022-05-22 14:29:11 : INFO  : abetterfinderrename11 : ################## Date: 2022-05-22
2022-05-22 14:29:11 : INFO  : abetterfinderrename11 : ################## abetterfinderrename11
2022-05-22 14:29:11 : DEBUG : abetterfinderrename11 : DEBUG mode 1 enabled.
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : NOTIFY=success
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : LOGGING=DEBUG
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : Label type: dmg
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : archiveName: A Better Finder Rename 11.dmg
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : no blocking processes defined, using A Better Finder Rename 11 as default
2022-05-22 14:29:12 : DEBUG : abetterfinderrename11 : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 14:29:12 : INFO  : abetterfinderrename11 : App(s) found: /Applications/A Better Finder Rename 11.app
2022-05-22 14:29:13 : INFO  : abetterfinderrename11 : found app at /Applications/A Better Finder Rename 11.app, version 11.48, on versionKey CFBundleShortVersionString
2022-05-22 14:29:13 : INFO  : abetterfinderrename11 : appversion: 11.48
2022-05-22 14:29:13 : INFO  : abetterfinderrename11 : Latest version of A Better Finder Rename 11 is 11.48
2022-05-22 14:29:13 : WARN  : abetterfinderrename11 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-22 14:29:13 : REQ   : abetterfinderrename11 : Downloading https://www.publicspace.net/download/ABFRX11.dmg to A Better Finder Rename 11.dmg
2022-05-22 14:29:17 : DEBUG : abetterfinderrename11 : File list: -rw-r--r--  1 savvas  staff    13M 22 Mai 14:29 A Better Finder Rename 11.dmg
2022-05-22 14:29:17 : DEBUG : abetterfinderrename11 : File type: A Better Finder Rename 11.dmg: zlib compressed data
2022-05-22 14:29:17 : DEBUG : abetterfinderrename11 : curl output was:
*   Trying 45.76.0.90:443...
* Connected to www.publicspace.net (45.76.0.90) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4042 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=publicspace.net
*  start date: Apr 26 11:06:03 2022 GMT
*  expire date: Jul 25 11:06:02 2022 GMT
*  subjectAltName: host "www.publicspace.net" matched cert's "www.publicspace.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /download/ABFRX11.dmg HTTP/1.1
> Host: www.publicspace.net
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Date: Sun, 22 May 2022 12:29:13 GMT
< Server: Apache/2.2.15 (CentOS)
< Set-Cookie: ps_Xi=fc3532242f71db63f14eec8e38ba7ddc; path=/; expires=Fri, 21 May 2027 12:29:13 GMT
< Set-Cookie: ps_Xt=ja%3D2%3Bjb%3D1%3Bgl%3D0%3Bgo%3D1%3Bgi%3D1%3Bgm%3D1%3Bgj%3D0%3Bod%3D1%3Bof%3D1%3Boc%3D1%3Bob%3D1%3Bog%3D1%3Boa%3D1%3Boe%3D1%3Blw%3D1%3Blz%3D1%3Blc%3D1%3Blb%3D1%3Bla%3D1%3Blx%3D1%3Bly%3D1%3Biz%3D1%3Biv%3D1%3Bit%3D1%3Biu%3D1%3Bix%3D1%3Biy%3D1%3Bis%3D1%3Biw%3D1%3Bfk%3D0%3Bfl%3D0%3Bfo%3D1%3Bfp%3D1%3Bfq%3D0%3Bfs%3D1%3Bnp%3DA%3Bns%3Donly%3Bny%3D1%3Bnt%3D1%3Bnv%3D1%3Bnw%3D1%3Bnx%3D1%3Bnu%3D1%3Bnz%3D1%3Bf%3D1%3Bb%3D0%3Ba%3D0%3Be%3D0%3Bc%3D0%3Bd%3D0%3B; path=/; expires=Fri, 21 May 2027 12:29:13 GMT
< Set-Cookie: ps_Xu=bookmarked%3B%3Cnone%3E%3Bwin; path=/; expires=Tue, 21 Jun 2022 12:29:13 GMT
< location: https://d3k6s0oeufjjjn.cloudfront.net/download0_41ea57282d185/ABFRX11.dmg
< Content-Length: 0
< Connection: close
< Content-Type: application/octet-stream
<
* Closing connection 0
* TLSv1.2 (IN), TLS alert, close notify (256):
{ [2 bytes data]
* TLSv1.2 (OUT), TLS alert, close notify (256):
} [2 bytes data]
* Issue another request to this URL: 'https://d3k6s0oeufjjjn.cloudfront.net/download0_41ea57282d185/ABFRX11.dmg'
*   Trying 13.224.194.186:443...
* Connected to d3k6s0oeufjjjn.cloudfront.net (13.224.194.186) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4963 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Feb  1 00:00:00 2022 GMT
*  expire date: Jan 31 23:59:59 2023 GMT
*  subjectAltName: host "d3k6s0oeufjjjn.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
> GET /download0_41ea57282d185/ABFRX11.dmg HTTP/1.1
> Host: d3k6s0oeufjjjn.cloudfront.net
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=iso-8859-1
< Content-Length: 356
< Connection: keep-alive
< Date: Sat, 21 May 2022 19:30:43 GMT
< Server: Apache/2.2.15 (CentOS)
< Location: https://www.publicspace.net/download0_41ea57282d185/ABFRX11.dmg
< X-Cache: Hit from cloudfront
< Via: 1.1 7a18a0a1d9929dae345690b88b08dd5e.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: FRA2-C1
< X-Amz-Cf-Id: U2_dcxL3hiHNhc2e3kxvUwhreA_DhClBfHdIVe1LB-_Gy2QXk3o6Yw==
< Age: 61110
<
* Ignoring the response-body
{ [356 bytes data]
* Connection #1 to host d3k6s0oeufjjjn.cloudfront.net left intact
* Issue another request to this URL: 'https://www.publicspace.net/download0_41ea57282d185/ABFRX11.dmg'
* Hostname www.publicspace.net was found in DNS cache
*   Trying 45.76.0.90:443...
* Connected to www.publicspace.net (45.76.0.90) port 443 (#2)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* SSL re-using session ID
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [263 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [81 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=publicspace.net
*  start date: Apr 26 11:06:03 2022 GMT
*  expire date: Jul 25 11:06:02 2022 GMT
*  subjectAltName: host "www.publicspace.net" matched cert's "www.publicspace.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /download0_41ea57282d185/ABFRX11.dmg HTTP/1.1
> Host: www.publicspace.net
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Sun, 22 May 2022 12:29:14 GMT
< Server: Apache/2.2.15 (CentOS)
< Last-Modified: Wed, 18 May 2022 10:33:04 GMT
< ETag: "21690-d51308-5df46c8419800"
< Accept-Ranges: bytes
< Content-Length: 13964040
< Connection: close
< Content-Type: text/plain; charset=UTF-8
<
{ [16384 bytes data]
* Closing connection 2
* TLSv1.2 (IN), TLS alert, close notify (256):
{ [2 bytes data]
* TLSv1.2 (OUT), TLS alert, close notify (256):
} [2 bytes data]

2022-05-22 14:29:17 : DEBUG : abetterfinderrename11 : DEBUG mode 1, not checking for blocking processes
2022-05-22 14:29:17 : REQ   : abetterfinderrename11 : Installing A Better Finder Rename 11
2022-05-22 14:29:17 : INFO  : abetterfinderrename11 : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/A Better Finder Rename 11.dmg
2022-05-22 14:29:19 : DEBUG : abetterfinderrename11 : Debugging enabled, dmgmount output was:

Disclaimer of Warranty

This software is sold "as is" and without warranties as to performance
or merchantability or any other warranties whether expressed or
implied. Because of the various hardware and software environments
into which this program may be put, no warranty of fitness for a
particular purpose is offered. Good data processing procedure
dictates that any program be throughly tested with non-critical
data before relying on it. The user must assume the entire risk of
using the program. Any liability of the seller or author of the
program will be limited exclusively to product replacement or refund
of purchase price.
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $5A82F9A7
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $E3975401
Prüfsumme für disk image (Apple_HFS : 2) berechnen …
disk image (Apple_HFS : 2): Die überprüfte CRC32-Prüfsumme ist $1B97C162
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Die überprüfte CRC32-Prüfsumme ist $C5263827
/dev/disk2          	Apple_partition_scheme
/dev/disk2s1        	Apple_partition_map
/dev/disk2s2        	Apple_HFS                      	/Volumes/A Better Finder Rename 11

2022-05-22 14:29:19 : INFO  : abetterfinderrename11 : Mounted: /Volumes/A Better Finder Rename 11
2022-05-22 14:29:19 : INFO  : abetterfinderrename11 : Verifying: /Volumes/A Better Finder Rename 11/A Better Finder Rename 11.app
2022-05-22 14:29:19 : DEBUG : abetterfinderrename11 : App size:  43M	/Volumes/A Better Finder Rename 11/A Better Finder Rename 11.app
2022-05-22 14:29:21 : DEBUG : abetterfinderrename11 : Debugging enabled, App Verification output was:
/Volumes/A Better Finder Rename 11/A Better Finder Rename 11.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Frank Reiff (7Y9KW4ND8W)

2022-05-22 14:29:21 : INFO  : abetterfinderrename11 : Team ID matching: 7Y9KW4ND8W (expected: 7Y9KW4ND8W )
2022-05-22 14:29:21 : INFO  : abetterfinderrename11 : Downloaded version of A Better Finder Rename 11 is 11.48 on versionKey CFBundleShortVersionString, same as installed.
2022-05-22 14:29:21 : DEBUG : abetterfinderrename11 : Unmounting /Volumes/A Better Finder Rename 11
2022-05-22 14:29:21 : DEBUG : abetterfinderrename11 : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-22 14:29:21 : DEBUG : abetterfinderrename11 : DEBUG mode 1, not reopening anything
2022-05-22 14:29:21 : REG   : abetterfinderrename11 : No new version to install
2022-05-22 14:29:21 : REQ   : abetterfinderrename11 : ################## End Installomator, exit code 0