### PR TITLE
New Label: Carbon Copy Cloner

### DIFF
--- a/fragments/labels/carboncopycloner.sh
+++ b/fragments/labels/carboncopycloner.sh
@@ -1,0 +1,7 @@
+carboncopycloner)
+    name="Carbon Copy Cloner"
+    type="zip"
+    downloadURL=$(curl -fsIL "https://bombich.com/software/download_ccc.php?v=latest" | grep -i ^location | sed -E 's/.*(https.*\.zip).*/\1/g')
+    appNewVersion=$(sed -E 's/.*-([0-9.]*)\.zip/\1/g' <<< $downloadURL | sed 's/\.[^.]*$//')
+    expectedTeamID="L4F2DED5Q7"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels carboncopycloner
2022-05-22 15:17:32 : REQ   : carboncopycloner : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 15:17:32 : INFO  : carboncopycloner : ################## Version: 9.2
2022-05-22 15:17:32 : INFO  : carboncopycloner : ################## Date: 2022-05-22
2022-05-22 15:17:32 : INFO  : carboncopycloner : ################## carboncopycloner
2022-05-22 15:17:32 : DEBUG : carboncopycloner : DEBUG mode 1 enabled.
2022-05-22 15:17:33 : INFO  : carboncopycloner : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 15:17:33 : INFO  : carboncopycloner : NOTIFY=success
2022-05-22 15:17:33 : INFO  : carboncopycloner : LOGGING=DEBUG
2022-05-22 15:17:33 : INFO  : carboncopycloner : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 15:17:33 : INFO  : carboncopycloner : Label type: zip
2022-05-22 15:17:33 : INFO  : carboncopycloner : archiveName: Carbon Copy Cloner.zip
2022-05-22 15:17:33 : INFO  : carboncopycloner : no blocking processes defined, using Carbon Copy Cloner as default
2022-05-22 15:17:33 : DEBUG : carboncopycloner : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 15:17:33 : INFO  : carboncopycloner : App(s) found: /Applications/Carbon Copy Cloner.app
2022-05-22 15:17:33 : INFO  : carboncopycloner : found app at /Applications/Carbon Copy Cloner.app, version 6.1.1, on versionKey CFBundleShortVersionString
2022-05-22 15:17:33 : INFO  : carboncopycloner : appversion: 6.1.1
2022-05-22 15:17:34 : INFO  : carboncopycloner : Latest version of Carbon Copy Cloner is 6.1.1
2022-05-22 15:17:34 : WARN  : carboncopycloner : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-22 15:17:34 : REQ   : carboncopycloner : Downloading https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-6.1.1.7323.zip to Carbon Copy Cloner.zip
2022-05-22 15:17:36 : DEBUG : carboncopycloner : File list: -rw-r--r--  1 savvas  staff    19M 22 Mai 15:17 Carbon Copy Cloner.zip
2022-05-22 15:17:36 : DEBUG : carboncopycloner : File type: Carbon Copy Cloner.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-05-22 15:17:36 : DEBUG : carboncopycloner : curl output was:
*   Trying 23.203.70.242:443...
* Connected to bombich.scdn1.secure.raxcdn.com (23.203.70.242) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [336 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2916 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=Texas; L=Windcrest; O=Rackspace US Inc.; CN=*.scdn1.secure.raxcdn.com
*  start date: Dec 11 00:00:00 2021 GMT
*  expire date: Dec 13 23:59:59 2022 GMT
*  subjectAltName: host "bombich.scdn1.secure.raxcdn.com" matched cert's "*.scdn1.secure.raxcdn.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert SHA2 Secure Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fd33e00c600)
> GET /software/files/ccc-6.1.1.7323.zip HTTP/2
> Host: bombich.scdn1.secure.raxcdn.com
> user-agent: curl/7.79.1
> accept: */*
>
< HTTP/2 200
< etag:
< server: LiteSpeed
< content-type: application/zip
< last-modified: Sat, 14 May 2022 14:52:09 GMT
< accept-ranges: bytes
< content-length: 20106063
< cache-control: public, max-age=19010
< expires: Sun, 22 May 2022 18:34:24 GMT
< date: Sun, 22 May 2022 13:17:34 GMT
<
{ [2676 bytes data]
* Connection #0 to host bombich.scdn1.secure.raxcdn.com left intact

2022-05-22 15:17:36 : DEBUG : carboncopycloner : DEBUG mode 1, not checking for blocking processes
2022-05-22 15:17:36 : REQ   : carboncopycloner : Installing Carbon Copy Cloner
2022-05-22 15:17:36 : INFO  : carboncopycloner : Unzipping Carbon Copy Cloner.zip
2022-05-22 15:17:37 : INFO  : carboncopycloner : Verifying: /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/Carbon Copy Cloner.app
2022-05-22 15:17:37 : DEBUG : carboncopycloner : App size:  54M	/Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/Carbon Copy Cloner.app
2022-05-22 15:17:38 : DEBUG : carboncopycloner : Debugging enabled, App Verification output was:
/Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/Carbon Copy Cloner.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Bombich Software, Inc. (L4F2DED5Q7)

2022-05-22 15:17:38 : INFO  : carboncopycloner : Team ID matching: L4F2DED5Q7 (expected: L4F2DED5Q7 )
2022-05-22 15:17:38 : INFO  : carboncopycloner : Downloaded version of Carbon Copy Cloner is 6.1.1 on versionKey CFBundleShortVersionString, same as installed.
2022-05-22 15:17:38 : DEBUG : carboncopycloner : DEBUG mode 1, not reopening anything
2022-05-22 15:17:38 : REG   : carboncopycloner : No new version to install
2022-05-22 15:17:38 : REQ   : carboncopycloner : ################## End Installomator, exit code 0