### PR TITLE
New Label: FLEXOPTIX App

### DIFF
--- a/fragments/labels/flexoptixapp.sh
+++ b/fragments/labels/flexoptixapp.sh
@@ -1,0 +1,7 @@
+flexoptixapp)
+    name="FLEXOPTIX App"
+    type="dmg"
+    downloadURL="https://flexbox.reconfigure.me/download/electron/mac/x64/current"
+    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*-([0-9.]*)\.dmg/\1/g')
+    expectedTeamID="C5JETSFPHL"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels flexoptixapp
2022-05-22 15:24:14 : REQ   : flexoptixapp : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 15:24:14 : INFO  : flexoptixapp : ################## Version: 9.2
2022-05-22 15:24:14 : INFO  : flexoptixapp : ################## Date: 2022-05-22
2022-05-22 15:24:14 : INFO  : flexoptixapp : ################## flexoptixapp
2022-05-22 15:24:14 : DEBUG : flexoptixapp : DEBUG mode 1 enabled.
2022-05-22 15:24:14 : INFO  : flexoptixapp : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 15:24:14 : INFO  : flexoptixapp : NOTIFY=success
2022-05-22 15:24:14 : INFO  : flexoptixapp : LOGGING=DEBUG
2022-05-22 15:24:14 : INFO  : flexoptixapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 15:24:14 : INFO  : flexoptixapp : Label type: dmg
2022-05-22 15:24:14 : INFO  : flexoptixapp : archiveName: FLEXOPTIX App.dmg
2022-05-22 15:24:14 : INFO  : flexoptixapp : no blocking processes defined, using FLEXOPTIX App as default
2022-05-22 15:24:14 : DEBUG : flexoptixapp : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 15:24:14 : INFO  : flexoptixapp : App(s) found: /Applications/FLEXOPTIX App.app
2022-05-22 15:24:14 : INFO  : flexoptixapp : found app at /Applications/FLEXOPTIX App.app, version 5.11.0, on versionKey CFBundleShortVersionString
2022-05-22 15:24:14 : INFO  : flexoptixapp : appversion: 5.11.0
2022-05-22 15:24:14 : INFO  : flexoptixapp : Latest version of FLEXOPTIX App is 5.11.0
2022-05-22 15:24:14 : WARN  : flexoptixapp : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-22 15:24:14 : REQ   : flexoptixapp : Downloading https://flexbox.reconfigure.me/download/electron/mac/x64/current to FLEXOPTIX App.dmg
2022-05-22 15:24:26 : DEBUG : flexoptixapp : File list: -rw-r--r--  1 savvas  staff    83M 22 Mai 15:24 FLEXOPTIX App.dmg
2022-05-22 15:24:26 : DEBUG : flexoptixapp : File type: FLEXOPTIX App.dmg: zlib compressed data
2022-05-22 15:24:26 : DEBUG : flexoptixapp : curl output was:
*   Trying 162.55.184.232:443...
* Connected to flexbox.reconfigure.me (162.55.184.232) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4202 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=reconfigure.me
*  start date: Apr  1 21:52:26 2022 GMT
*  expire date: Jun 30 21:52:25 2022 GMT
*  subjectAltName: host "flexbox.reconfigure.me" matched cert's "flexbox.reconfigure.me"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /download/electron/mac/x64/current HTTP/1.1
> Host: flexbox.reconfigure.me
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Moved Temporarily
< Server: nginx
< Date: Sun, 22 May 2022 13:24:14 GMT
< Content-Type: text/html
< Content-Length: 138
< Connection: keep-alive
< Location: /download/electron/mac/x64//FLEXOPTIX App-5.11.0.dmg
<
* Ignoring the response-body
{ [140 bytes data]
* Connection #0 to host flexbox.reconfigure.me left intact
* Issue another request to this URL: 'https://flexbox.reconfigure.me/download/electron/mac/x64//FLEXOPTIX%20App-5.11.0.dmg'
* Found bundle for host flexbox.reconfigure.me: 0x6000036886f0 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#0) with host flexbox.reconfigure.me
* Connected to flexbox.reconfigure.me (162.55.184.232) port 443 (#0)
> GET /download/electron/mac/x64//FLEXOPTIX%20App-5.11.0.dmg HTTP/1.1
> Host: flexbox.reconfigure.me
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx
< Date: Sun, 22 May 2022 13:24:14 GMT
< Content-Type: application/octet-stream
< Content-Length: 86705875
< Last-Modified: Fri, 25 Jun 2021 15:08:54 GMT
< Connection: keep-alive
< ETag: "60d5f186-52b06d3"
< Accept-Ranges: bytes
<
{ [16129 bytes data]
* Connection #0 to host flexbox.reconfigure.me left intact

2022-05-22 15:24:26 : DEBUG : flexoptixapp : DEBUG mode 1, not checking for blocking processes
2022-05-22 15:24:26 : REQ   : flexoptixapp : Installing FLEXOPTIX App
2022-05-22 15:24:26 : INFO  : flexoptixapp : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/FLEXOPTIX App.dmg
2022-05-22 15:24:29 : DEBUG : flexoptixapp : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $F896513C
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $2A26FF3A
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $C7EAE15F
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $20C222C3
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $C7EAE15F
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $A017024D
Die überprüfte CRC32-Prüfsumme ist $00C1C1BD
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/FLEXOPTIX App 5.11.0

2022-05-22 15:24:29 : INFO  : flexoptixapp : Mounted: /Volumes/FLEXOPTIX App 5.11.0
2022-05-22 15:24:29 : INFO  : flexoptixapp : Verifying: /Volumes/FLEXOPTIX App 5.11.0/FLEXOPTIX App.app
2022-05-22 15:24:29 : DEBUG : flexoptixapp : App size: 190M	/Volumes/FLEXOPTIX App 5.11.0/FLEXOPTIX App.app
2022-05-22 15:24:32 : DEBUG : flexoptixapp : Debugging enabled, App Verification output was:
/Volumes/FLEXOPTIX App 5.11.0/FLEXOPTIX App.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Flexoptix GmbH (C5JETSFPHL)

2022-05-22 15:24:32 : INFO  : flexoptixapp : Team ID matching: C5JETSFPHL (expected: C5JETSFPHL )
2022-05-22 15:24:32 : INFO  : flexoptixapp : Downloaded version of FLEXOPTIX App is 5.11.0 on versionKey CFBundleShortVersionString, same as installed.
2022-05-22 15:24:32 : DEBUG : flexoptixapp : Unmounting /Volumes/FLEXOPTIX App 5.11.0
2022-05-22 15:24:32 : DEBUG : flexoptixapp : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-22 15:24:32 : DEBUG : flexoptixapp : DEBUG mode 1, not reopening anything
2022-05-22 15:24:32 : REG   : flexoptixapp : No new version to install
2022-05-22 15:24:32 : REQ   : flexoptixapp : ################## End Installomator, exit code 0