### PR TITLE
New Label: NetSpot

### DIFF
--- a/fragments/labels/netspot.sh
+++ b/fragments/labels/netspot.sh
@@ -1,0 +1,7 @@
+netspot)
+    name="NetSpot"
+    type="dmg"
+    downloadURL="https://cdn.netspotapp.com/download/NetSpot.dmg"
+    appNewVersion=$(curl -fs "https://www.netspotapp.com/updates/netspot2-appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null | cut -d '"' -f 2)
+    expectedTeamID="5QLDY8TU83"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels netspot
2022-05-22 15:46:11 : REQ   : netspot : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 15:46:11 : INFO  : netspot : ################## Version: 9.2
2022-05-22 15:46:11 : INFO  : netspot : ################## Date: 2022-05-22
2022-05-22 15:46:11 : INFO  : netspot : ################## netspot
2022-05-22 15:46:11 : DEBUG : netspot : DEBUG mode 1 enabled.
2022-05-22 15:46:12 : INFO  : netspot : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 15:46:12 : INFO  : netspot : NOTIFY=success
2022-05-22 15:46:12 : INFO  : netspot : LOGGING=DEBUG
2022-05-22 15:46:12 : INFO  : netspot : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 15:46:12 : INFO  : netspot : Label type: dmg
2022-05-22 15:46:12 : INFO  : netspot : archiveName: NetSpot.dmg
2022-05-22 15:46:12 : INFO  : netspot : no blocking processes defined, using NetSpot as default
2022-05-22 15:46:12 : DEBUG : netspot : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 15:46:12 : INFO  : netspot : App(s) found: /Applications/NetSpot.app
2022-05-22 15:46:12 : INFO  : netspot : found app at /Applications/NetSpot.app, version 2.14.1037, on versionKey CFBundleShortVersionString
2022-05-22 15:46:12 : INFO  : netspot : appversion: 2.14.1037
2022-05-22 15:46:12 : INFO  : netspot : Latest version of NetSpot is 2.14.1037
2022-05-22 15:46:12 : WARN  : netspot : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-22 15:46:12 : REQ   : netspot : Downloading https://cdn.netspotapp.com/download/NetSpot.dmg to NetSpot.dmg
2022-05-22 15:46:14 : DEBUG : netspot : File list: -rw-r--r--  1 savvas  staff    14M 22 Mai 15:46 NetSpot.dmg
2022-05-22 15:46:14 : DEBUG : netspot : File type: NetSpot.dmg: zlib compressed data
2022-05-22 15:46:14 : DEBUG : netspot : curl output was:
*   Trying 195.181.174.6:443...
* Connected to cdn.netspotapp.com (195.181.174.6) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4519 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=cdn.netspotapp.com
*  start date: Aug 16 00:00:00 2021 GMT
*  expire date: Aug 16 23:59:59 2022 GMT
*  subjectAltName: host "cdn.netspotapp.com" matched cert's "cdn.netspotapp.com"
*  issuer: C=LV; L=Riga; O=GoGetSSL; CN=GoGetSSL RSA DV CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fd99f00d400)
> GET /download/NetSpot.dmg HTTP/2
> Host: cdn.netspotapp.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< date: Sun, 22 May 2022 13:46:12 GMT
< content-type: application/octet-stream
< content-length: 14205239
< last-modified: Mon, 01 Nov 2021 11:52:37 GMT
< etag: "617fd505-d8c137"
< access-control-allow-origin: *
< x-accel-expires: @1653227772
< server: CDN77-Turbo
< x-77-nzt: AcO1rgUdD4PeTyMAAA
< x-77-nzt-ray: 4MvfbNRBJzs
< x-cache: REVALIDATED
< x-age: 9039
< x-77-pop: frankfurtDE
< x-77-cache: HIT
< accept-ranges: bytes
<
{ [16065 bytes data]
* Connection #0 to host cdn.netspotapp.com left intact

2022-05-22 15:46:14 : DEBUG : netspot : DEBUG mode 1, not checking for blocking processes
2022-05-22 15:46:14 : REQ   : netspot : Installing NetSpot
2022-05-22 15:46:14 : INFO  : netspot : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/NetSpot.dmg
2022-05-22 15:46:17 : DEBUG : netspot : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $F3D13A57
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $94095ED1
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $1ECC5766
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $A09406C9
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $1ECC5766
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $9DC9CAF0
Die überprüfte CRC32-Prüfsumme ist $DF172160
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/NetSpot

2022-05-22 15:46:17 : INFO  : netspot : Mounted: /Volumes/NetSpot
2022-05-22 15:46:17 : INFO  : netspot : Verifying: /Volumes/NetSpot/NetSpot.app
2022-05-22 15:46:17 : DEBUG : netspot : App size:  27M	/Volumes/NetSpot/NetSpot.app
2022-05-22 15:46:18 : DEBUG : netspot : Debugging enabled, App Verification output was:
/Volumes/NetSpot/NetSpot.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Etwok Inc (5QLDY8TU83)

2022-05-22 15:46:18 : INFO  : netspot : Team ID matching: 5QLDY8TU83 (expected: 5QLDY8TU83 )
2022-05-22 15:46:18 : INFO  : netspot : Downloaded version of NetSpot is 2.14.1037 on versionKey CFBundleShortVersionString, same as installed.
2022-05-22 15:46:18 : DEBUG : netspot : Unmounting /Volumes/NetSpot
2022-05-22 15:46:18 : DEBUG : netspot : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-22 15:46:18 : DEBUG : netspot : DEBUG mode 1, not reopening anything
2022-05-22 15:46:18 : REG   : netspot : No new version to install
2022-05-22 15:46:18 : REQ   : netspot : ################## End Installomator, exit code 0