### PR TITLE
New Label: SynologyAssistant

### DIFF
--- a/fragments/labels/synologyassistant.sh
+++ b/fragments/labels/synologyassistant.sh
@@ -1,0 +1,8 @@
+synologyassistant)
+    name="SynologyAssistant"
+    type="dmg"
+    packageID="com.synology.DSAssistant"
+    appNewVersion="$(curl -sf https://archive.synology.com/download/Utility/Assistant | grep -m 1 /download/Utility/Assistant/ | sed "s|.*>\(.*\)<.*|\\1|")"
+    downloadURL="https://global.download.synology.com/download/Utility/Assistant/${appNewVersion}/Mac/synology-assistant-${appNewVersion}.dmg"
+    expectedTeamID="X85BAK35Y4"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels synologyassistant
2022-05-22 15:50:07 : REQ   : synologyassistant : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 15:50:07 : INFO  : synologyassistant : ################## Version: 9.2
2022-05-22 15:50:07 : INFO  : synologyassistant : ################## Date: 2022-05-22
2022-05-22 15:50:07 : INFO  : synologyassistant : ################## synologyassistant
2022-05-22 15:50:07 : DEBUG : synologyassistant : DEBUG mode 1 enabled.
2022-05-22 15:50:07 : INFO  : synologyassistant : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 15:50:07 : INFO  : synologyassistant : NOTIFY=success
2022-05-22 15:50:07 : INFO  : synologyassistant : LOGGING=DEBUG
2022-05-22 15:50:08 : INFO  : synologyassistant : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 15:50:08 : INFO  : synologyassistant : Label type: dmg
2022-05-22 15:50:08 : INFO  : synologyassistant : archiveName: SynologyAssistant.dmg
2022-05-22 15:50:08 : INFO  : synologyassistant : no blocking processes defined, using SynologyAssistant as default
2022-05-22 15:50:08 : DEBUG : synologyassistant : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 15:50:08 : INFO  : synologyassistant : No version found using packageID com.synology.DSAssistant
2022-05-22 15:50:08 : INFO  : synologyassistant : App(s) found: /Applications/SynologyAssistant.app
2022-05-22 15:50:08.721 defaults[13210:199987]
The domain/default pair of (/Applications/SynologyAssistant.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2022-05-22 15:50:08 : INFO  : synologyassistant : found app at /Applications/SynologyAssistant.app, version , on versionKey CFBundleShortVersionString
2022-05-22 15:50:08 : INFO  : synologyassistant : appversion:
2022-05-22 15:50:08 : INFO  : synologyassistant : Latest version of SynologyAssistant is 7.0.3-50049
2022-05-22 15:50:08 : REQ   : synologyassistant : Downloading https://global.download.synology.com/download/Utility/Assistant/7.0.3-50049/Mac/synology-assistant-7.0.3-50049.dmg to SynologyAssistant.dmg
2022-05-22 15:50:11 : DEBUG : synologyassistant : File list: -rw-r--r--  1 savvas  staff    18M 22 Mai 15:50 SynologyAssistant.dmg
2022-05-22 15:50:11 : DEBUG : synologyassistant : File type: SynologyAssistant.dmg: zlib compressed data
2022-05-22 15:50:11 : DEBUG : synologyassistant : curl output was:
*   Trying 13.225.80.21:443...
* Connected to global.download.synology.com (13.225.80.21) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5175 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=global.download.synology.com
*  start date: Apr 29 07:21:41 2022 GMT
*  expire date: May 31 07:21:41 2023 GMT
*  subjectAltName: host "global.download.synology.com" matched cert's "global.download.synology.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7f7c9b00bc00)
> GET /download/Utility/Assistant/7.0.3-50049/Mac/synology-assistant-7.0.3-50049.dmg HTTP/2
> Host: global.download.synology.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 19155257
< date: Thu, 19 May 2022 09:02:41 GMT
< last-modified: Tue, 26 Apr 2022 18:33:58 GMT
< etag: "5f132f58c5ab0b776ef49dbb654c1537-4"
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 6c9a2d99a25484f38efa27d58a726b2c.cloudfront.net (CloudFront)
< x-amz-cf-pop: FRA2-C2
< x-amz-cf-id: H4CRHnyudj_GtrQCJxMOq7TDWr3nptzEUr3qFy9ezPu3j0UsuyZ_fw==
< age: 276448
<
{ [16042 bytes data]
* Connection #0 to host global.download.synology.com left intact

2022-05-22 15:50:11 : DEBUG : synologyassistant : DEBUG mode 1, not checking for blocking processes
2022-05-22 15:50:11 : REQ   : synologyassistant : Installing SynologyAssistant
2022-05-22 15:50:11 : INFO  : synologyassistant : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/SynologyAssistant.dmg
2022-05-22 15:50:14 : DEBUG : synologyassistant : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $95B941F8
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $D85F8F1F
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $0F713C62
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $0772429B
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $0F713C62
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $0FF7183C
Die überprüfte CRC32-Prüfsumme ist $F223F8EC
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/synology-assistant-7.0.3-50049

2022-05-22 15:50:14 : INFO  : synologyassistant : Mounted: /Volumes/synology-assistant-7.0.3-50049
2022-05-22 15:50:14 : INFO  : synologyassistant : Verifying: /Volumes/synology-assistant-7.0.3-50049/SynologyAssistant.app
2022-05-22 15:50:14 : DEBUG : synologyassistant : App size:  40M	/Volumes/synology-assistant-7.0.3-50049/SynologyAssistant.app
2022-05-22 15:50:15 : DEBUG : synologyassistant : Debugging enabled, App Verification output was:
/Volumes/synology-assistant-7.0.3-50049/SynologyAssistant.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Synology Inc. (X85BAK35Y4)

2022-05-22 15:50:15 : INFO  : synologyassistant : Team ID matching: X85BAK35Y4 (expected: X85BAK35Y4 )
2022-05-22 15:50:15.860 defaults[13280:200237]
The domain/default pair of (/Volumes/synology-assistant-7.0.3-50049/SynologyAssistant.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2022-05-22 15:50:15 : INFO  : synologyassistant : Installing SynologyAssistant version  on versionKey CFBundleShortVersionString.
2022-05-22 15:50:15 : INFO  : synologyassistant : App has LSMinimumSystemVersion: 10.7
2022-05-22 15:50:15 : DEBUG : synologyassistant : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-05-22 15:50:16 : INFO  : synologyassistant : Finishing...
2022-05-22 15:50:26 : INFO  : synologyassistant : No version found using packageID com.synology.DSAssistant
2022-05-22 15:50:26 : INFO  : synologyassistant : App(s) found: /Applications/SynologyAssistant.app
2022-05-22 15:50:26.241 defaults[13304:200361]
The domain/default pair of (/Applications/SynologyAssistant.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2022-05-22 15:50:26 : INFO  : synologyassistant : found app at /Applications/SynologyAssistant.app, version , on versionKey CFBundleShortVersionString
2022-05-22 15:50:26 : REQ   : synologyassistant : Installed SynologyAssistant
2022-05-22 15:50:26 : INFO  : synologyassistant : notifying
2022-05-22 15:50:26 : DEBUG : synologyassistant : Unmounting /Volumes/synology-assistant-7.0.3-50049
2022-05-22 15:50:26 : DEBUG : synologyassistant : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-05-22 15:50:26 : DEBUG : synologyassistant : DEBUG mode 1, not reopening anything
2022-05-22 15:50:26 : REQ   : synologyassistant : All done!
2022-05-22 15:50:26 : REQ   : synologyassistant : ################## End Installomator, exit code 0