### PR TITLE
New Label: WhatRoute

### DIFF
--- a/fragments/labels/whatroute.sh
+++ b/fragments/labels/whatroute.sh
@@ -1,0 +1,7 @@
+whatroute)
+    name="WhatRoute"
+    type="zip"
+    downloadURL="$(curl -fs https://www.whatroute.net/whatroute2appcast.xml | xpath '(//rss/channel/item/enclosure/@url)' 2>/dev/null | cut -d '"' -f 2)"
+    appNewVersion="$(curl -fs "https://www.whatroute.net/whatroute2appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)' 2>/dev/null | cut -d '"' -f 2)"
+    expectedTeamID="H5879E8LML"
+    ;;


### PR DESCRIPTION
 ./assemble.sh -l Mosyle/Resources/InstallomatorLabels whatroute
2022-05-22 15:55:05 : REQ   : whatroute : ################## Start Installomator v. 9.2, date 2022-05-22
2022-05-22 15:55:05 : INFO  : whatroute : ################## Version: 9.2
2022-05-22 15:55:05 : INFO  : whatroute : ################## Date: 2022-05-22
2022-05-22 15:55:05 : INFO  : whatroute : ################## whatroute
2022-05-22 15:55:05 : DEBUG : whatroute : DEBUG mode 1 enabled.
2022-05-22 15:55:10 : INFO  : whatroute : BLOCKING_PROCESS_ACTION=tell_user
2022-05-22 15:55:10 : INFO  : whatroute : NOTIFY=success
2022-05-22 15:55:10 : INFO  : whatroute : LOGGING=DEBUG
2022-05-22 15:55:10 : INFO  : whatroute : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-22 15:55:10 : INFO  : whatroute : Label type: zip
2022-05-22 15:55:10 : INFO  : whatroute : archiveName: WhatRoute.zip
2022-05-22 15:55:10 : INFO  : whatroute : no blocking processes defined, using WhatRoute as default
2022-05-22 15:55:10 : DEBUG : whatroute : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-05-22 15:55:10 : INFO  : whatroute : App(s) found: /Applications/WhatRoute.app
2022-05-22 15:55:10 : INFO  : whatroute : found app at /Applications/WhatRoute.app, version 2.5.0, on versionKey CFBundleShortVersionString
2022-05-22 15:55:10 : INFO  : whatroute : appversion: 2.5.0
2022-05-22 15:55:10 : INFO  : whatroute : Latest version of WhatRoute is 2.5.0
2022-05-22 15:55:10 : WARN  : whatroute : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-22 15:55:10 : REQ   : whatroute : Downloading https://www.whatroute.net/software/whatroute-2.5.0.zip to WhatRoute.zip
2022-05-22 15:56:09 : DEBUG : whatroute : File list: -rw-r--r--  1 savvas  staff    38M 22 Mai 15:56 WhatRoute.zip
2022-05-22 15:56:09 : DEBUG : whatroute : File type: WhatRoute.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-05-22 15:56:09 : DEBUG : whatroute : curl output was:
*   Trying 222.154.233.147:443...
* Connected to www.whatroute.net (222.154.233.147) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4423 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=bryanc.co.nz
*  start date: May 15 06:02:07 2022 GMT
*  expire date: Aug 13 06:02:06 2022 GMT
*  subjectAltName: host "www.whatroute.net" matched cert's "www.whatroute.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /software/whatroute-2.5.0.zip HTTP/1.1
> Host: www.whatroute.net
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Sun, 22 May 2022 13:55:11 GMT
< Server: Apache
< Last-Modified: Thu, 31 Mar 2022 01:31:34 GMT
< ETag: "2586bfd-5db799f55fabc"
< Accept-Ranges: bytes
< Content-Length: 39349245
< Content-Type: application/zip
<
{ [7964 bytes data]
* Connection #0 to host www.whatroute.net left intact

2022-05-22 15:56:09 : DEBUG : whatroute : DEBUG mode 1, not checking for blocking processes
2022-05-22 15:56:09 : REQ   : whatroute : Installing WhatRoute
2022-05-22 15:56:09 : INFO  : whatroute : Unzipping WhatRoute.zip
2022-05-22 15:56:10 : INFO  : whatroute : Verifying: /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/WhatRoute.app
2022-05-22 15:56:10 : DEBUG : whatroute : App size:  60M	/Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/WhatRoute.app
2022-05-22 15:56:11 : DEBUG : whatroute : Debugging enabled, App Verification output was:
/Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/WhatRoute.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Bryan Christianson (H5879E8LML)

2022-05-22 15:56:11 : INFO  : whatroute : Team ID matching: H5879E8LML (expected: H5879E8LML )
2022-05-22 15:56:11 : INFO  : whatroute : Downloaded version of WhatRoute is 2.5.0 on versionKey CFBundleShortVersionString, same as installed.
2022-05-22 15:56:12 : DEBUG : whatroute : DEBUG mode 1, not reopening anything
2022-05-22 15:56:12 : REG   : whatroute : No new version to install
2022-05-22 15:56:12 : REQ   : whatroute : ################## End Installomator, exit code 0