### PR TITLE
New Label: cricutdesignspace

### DIFF
--- a/fragments/labels/cricutdesignspace.sh
+++ b/fragments/labels/cricutdesignspace.sh
@@ -1,0 +1,7 @@
+cricutdesignspace)
+    name="Cricut Design Space"
+    type="dmg"
+    appNewVersion=$(curl -fsL https://s3-us-west-2.amazonaws.com/staticcontent.cricut.com/a/software/osx-native/latest.json | sed -n 's/^.*"rolloutVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
+    downloadURL=https://staticcontent.cricut.com/a/software/osx-native/CricutDesignSpace-Install-v${appNewVersion}.dmg
+    expectedTeamID="25627ZFVT7"
+    ;;

--- a/fragments/labels/cricutdesignspace.sh
+++ b/fragments/labels/cricutdesignspace.sh
@@ -1,7 +1,7 @@
 cricutdesignspace)
     name="Cricut Design Space"
     type="dmg"
-    appNewVersion=$(curl -fsL https://s3-us-west-2.amazonaws.com/staticcontent.cricut.com/a/software/osx-native/latest.json | sed -n 's/^.*"rolloutVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
-    downloadURL=$(curl -fsL "https://apis.cricut.com/desktopdownload/InstallerFile?shard=a&operatingSystem=osxnative&fileName=CricutDesignSpace-Install-v${appNewVersion}.dmg" | sed -n 's/^.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
+    appNewVersion=$(getJSONValue "$(curl -fsL https://s3-us-west-2.amazonaws.com/staticcontent.cricut.com/a/software/osx-native/latest.json)" "rolloutVersion")
+    downloadURL=$(getJSONValue $(curl  -fsL "https://apis.cricut.com/desktopdownload/InstallerFile?shard=a&operatingSystem=osxnative&fileName=CricutDesignSpace-Install-v${appNewVersion}.dmg") "result")
     expectedTeamID="25627ZFVT7"
     ;;

--- a/fragments/labels/cricutdesignspace.sh
+++ b/fragments/labels/cricutdesignspace.sh
@@ -2,6 +2,6 @@ cricutdesignspace)
     name="Cricut Design Space"
     type="dmg"
     appNewVersion=$(curl -fsL https://s3-us-west-2.amazonaws.com/staticcontent.cricut.com/a/software/osx-native/latest.json | sed -n 's/^.*"rolloutVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
-    downloadURL=https://staticcontent.cricut.com/a/software/osx-native/CricutDesignSpace-Install-v${appNewVersion}.dmg
+    downloadURL=$(curl -fsL "https://apis.cricut.com/desktopdownload/InstallerFile?shard=a&operatingSystem=osxnative&fileName=CricutDesignSpace-Install-v${appNewVersion}.dmg" | sed -n 's/^.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p')
     expectedTeamID="25627ZFVT7"
     ;;


### PR DESCRIPTION
Output:
```
2022-05-26 10:54:52 : WARN  : cricutdesignspace : setting variable from argument DEBUG=0
2022-05-26 10:54:52 : WARN  : cricutdesignspace : setting variable from argument INSTALL=force
2022-05-26 10:54:52 : REQ   : cricutdesignspace : ################## Start Installomator v. 10.0beta, date 2022-05-26
2022-05-26 10:54:52 : INFO  : cricutdesignspace : ################## Version: 10.0beta
2022-05-26 10:54:52 : INFO  : cricutdesignspace : ################## Date: 2022-05-26
2022-05-26 10:54:52 : INFO  : cricutdesignspace : ################## cricutdesignspace
2022-05-26 10:54:52 : INFO  : cricutdesignspace : BLOCKING_PROCESS_ACTION=tell_user
2022-05-26 10:54:52 : INFO  : cricutdesignspace : NOTIFY=success
2022-05-26 10:54:52 : INFO  : cricutdesignspace : LOGGING=INFO
2022-05-26 10:54:52 : INFO  : cricutdesignspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-26 10:54:53 : INFO  : cricutdesignspace : Label type: dmg
2022-05-26 10:54:53 : INFO  : cricutdesignspace : archiveName: Cricut Design Space.dmg
2022-05-26 10:54:53 : INFO  : cricutdesignspace : no blocking processes defined, using Cricut Design Space as default
2022-05-26 10:54:53 : INFO  : cricutdesignspace : App(s) found: /Applications/Cricut Design Space.app
2022-05-26 10:54:53 : INFO  : cricutdesignspace : found app at /Applications/Cricut Design Space.app, version 7.9.158, on versionKey CFBundleShortVersionString
2022-05-26 10:54:53 : INFO  : cricutdesignspace : appversion: 7.9.158
2022-05-26 10:54:53 : INFO  : cricutdesignspace : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-05-26 10:54:53 : INFO  : cricutdesignspace : Latest version of Cricut Design Space is 7.9.158
2022-05-26 10:54:53 : INFO  : cricutdesignspace : There is no newer version available.
2022-05-26 10:54:53 : REQ   : cricutdesignspace : Downloading https://staticcontent.cricut.com/a/software/osx-native/CricutDesignSpace-Install-v7.9.158.dmg to Cricut Design Space.dmg
2022-05-26 10:54:55 : REQ   : cricutdesignspace : no more blocking processes, continue with update
2022-05-26 10:54:55 : REQ   : cricutdesignspace : Installing Cricut Design Space
2022-05-26 10:54:55 : INFO  : cricutdesignspace : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.LLI066bN/Cricut Design Space.dmg
2022-05-26 10:54:58 : INFO  : cricutdesignspace : Mounted: /Volumes/Cricut Design Space Install
2022-05-26 10:54:58 : INFO  : cricutdesignspace : Verifying: /Volumes/Cricut Design Space Install/Cricut Design Space.app
2022-05-26 10:54:59 : INFO  : cricutdesignspace : Team ID matching: 25627ZFVT7 (expected: 25627ZFVT7 )
2022-05-26 10:54:59 : INFO  : cricutdesignspace : Downloaded version of Cricut Design Space is 7.9.158 on versionKey CFBundleShortVersionString, same as installed.
2022-05-26 10:54:59 : INFO  : cricutdesignspace : Using force to install anyway.
2022-05-26 10:54:59 : INFO  : cricutdesignspace : App has LSMinimumSystemVersion: 10.11.0
2022-05-26 10:54:59 : WARN  : cricutdesignspace : Removing existing /Applications/Cricut Design Space.app
2022-05-26 10:54:59 : INFO  : cricutdesignspace : Copy /Volumes/Cricut Design Space Install/Cricut Design Space.app to /Applications
2022-05-26 10:55:00 : WARN  : cricutdesignspace : Changing owner to dnikles
2022-05-26 10:55:00 : INFO  : cricutdesignspace : Finishing...
2022-05-26 10:55:10 : INFO  : cricutdesignspace : App(s) found: /Applications/Cricut Design Space.app
2022-05-26 10:55:10 : INFO  : cricutdesignspace : found app at /Applications/Cricut Design Space.app, version 7.9.158, on versionKey CFBundleShortVersionString
2022-05-26 10:55:10 : REQ   : cricutdesignspace : Installed Cricut Design Space, version 7.9.158
2022-05-26 10:55:10 : INFO  : cricutdesignspace : notifying
2022-05-26 10:55:10 : INFO  : cricutdesignspace : App not closed, so no reopen.
2022-05-26 10:55:10 : REQ   : cricutdesignspace : All done!
2022-05-26 10:55:10 : REQ   : cricutdesignspace : ################## End Installomator, exit code 0
```