### PR TITLE
Update Google Drive Label

### DIFF
--- a/fragments/labels/googledrive.sh
+++ b/fragments/labels/googledrive.sh
@@ -3,8 +3,13 @@ googledrivefilestream)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
     name="Google Drive File Stream"
     type="pkgInDmg"
-    packageID="com.google.drivefs"
+    if [[ $(arch) == "arm64" ]]; then
+       packageID="com.google.drivefs.arm64"
+    elif [[ $(arch) == "i386" ]]; then
+       packageID="com.google.drivefs.x86_64"
+    fi    
     downloadURL="https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg" # downloadURL="https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
     blockingProcesses=( "Google Docs" "Google Drive" "Google Sheets" "Google Slides" )
+    appName="Google Drive.app"
     expectedTeamID="EQHXZ8M8AV"
     ;;


### PR DESCRIPTION
Package ID is longer correct for the current version of Google Drive.

Update Package ID and add app name because it differs from the label