### PR TITLE
Jamf recon on success

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -7,7 +7,7 @@ label="" # if no label is sent to the script, this will be used
 # 2020-2021 Installomator
 #
 # inspired by the download scripts from William Smith and Sander Schram
-# 
+#
 # Contributers:
 #    Armin Briegel - @scriptingosx
 #    Isaac Ordonez - @issacatmann
@@ -23,7 +23,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # set to 0 for production, 1 or 2 for debugging
 # while debugging, items will be downloaded to the parent directory of this script
 # also no actual installation will be performed
-# debug mode 1 will download to the directory the script is run in, but will not check the version 
+# debug mode 1 will download to the directory the script is run in, but will not check the version
 # debug mode 2 will download to the temp directory, check for blocking processes, check the version, but will not install anything or remove the current version
 DEBUG=1
 
@@ -138,6 +138,11 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
+#Should jamf recon after success
+JAMF_RECON_ON_SUCCESS="no"
+# options:
+#  - no           Script will not run a jamf recon on success.
+#  - yes          Script will run a jamf recon on success.
 
 # NOTE: How labels work
 
@@ -184,7 +189,7 @@ IGNORE_DND_APPS=""
 #   How we get version number from app. Possible values:
 #     - CFBundleShortVersionString
 #     - CFBundleVersion
-#   Not all software titles uses fields the same. 
+#   Not all software titles uses fields the same.
 #   See Opera label.
 #
 # - appCustomVersion(){}: (optional function)
@@ -329,7 +334,7 @@ cleanupAndExit() { # $1 = exit code, $2 message, $3 level
         printlog "$2" $3
     fi
     printlog "################## End Installomator, exit code $1 \n" REQ
-    
+
     # if label is wrong and we wanted name of the label, then return ##################
     if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
         1=0 # If only label name should be returned we exit without any errors
@@ -1134,6 +1139,13 @@ finishing() {
             displaynotification "$message" "$name update complete!"
         else
             displaynotification "$message" "$name installation complete!"
+        fi
+    fi
+
+    if [[ $JAMF_RECON_ON_SUCCESS == "yes" ]]; then
+        if [[ -f /usr/local/bin/jamf ]]; then
+            printlog "running jamf recon"
+            jamf recon
         fi
     fi
 }
@@ -2220,7 +2232,7 @@ egnytewebedit)
     appName="Egnyte WebEdit.app"
     blockingProcesses=( NONE )
     ;;
-    
+
 element)
     name="Element"
     type="dmg"
@@ -2460,7 +2472,7 @@ flux)
     downloadURL="https://justgetflux.com/mac/Flux.zip"
     expectedTeamID="VZKSA7H9J9"
     ;;
-    
+
 flycut)
     name="Flycut"
     type="zip"
@@ -3114,7 +3126,7 @@ linear)
     appName="Linear.app"
     blockingProcesses=( "Linear" )
     ;;
-    
+
 logioptions|\
 logitechoptions)
     name="Logi Options"
@@ -4288,7 +4300,7 @@ secretive)
     appNewVersion=$(versionFromGit maxgoedjen secretive)
     expectedTeamID="Z72PRUAWF6"
     ;;
-    
+
 sequelpro)
     name="Sequel Pro"
     type="dmg"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -138,7 +138,7 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
-#Should jamf recon after success
+# Run jamf recon after success
 JAMF_RECON_ON_SUCCESS="no"
 # options:
 #  - no           Script will not run a jamf recon on success.

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1145,7 +1145,7 @@ finishing() {
     if [[ $JAMF_RECON_ON_SUCCESS == "yes" ]]; then
         if [[ -f /usr/local/bin/jamf ]]; then
             printlog "running jamf recon"
-            /usr/local/bin/jamf recon
+            jamf recon
         fi
     fi
 }

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -7,7 +7,7 @@ label="" # if no label is sent to the script, this will be used
 # 2020-2021 Installomator
 #
 # inspired by the download scripts from William Smith and Sander Schram
-#
+# 
 # Contributers:
 #    Armin Briegel - @scriptingosx
 #    Isaac Ordonez - @issacatmann
@@ -23,7 +23,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # set to 0 for production, 1 or 2 for debugging
 # while debugging, items will be downloaded to the parent directory of this script
 # also no actual installation will be performed
-# debug mode 1 will download to the directory the script is run in, but will not check the version
+# debug mode 1 will download to the directory the script is run in, but will not check the version 
 # debug mode 2 will download to the temp directory, check for blocking processes, check the version, but will not install anything or remove the current version
 DEBUG=1
 
@@ -138,11 +138,6 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
-#Should jamf recon after success
-JAMF_RECON_ON_SUCCESS="no"
-# options:
-#  - no           Script will not run a jamf recon on success.
-#  - yes          Script will run a jamf recon on success.
 
 # NOTE: How labels work
 
@@ -189,7 +184,7 @@ JAMF_RECON_ON_SUCCESS="no"
 #   How we get version number from app. Possible values:
 #     - CFBundleShortVersionString
 #     - CFBundleVersion
-#   Not all software titles uses fields the same.
+#   Not all software titles uses fields the same. 
 #   See Opera label.
 #
 # - appCustomVersion(){}: (optional function)
@@ -334,7 +329,7 @@ cleanupAndExit() { # $1 = exit code, $2 message, $3 level
         printlog "$2" $3
     fi
     printlog "################## End Installomator, exit code $1 \n" REQ
-
+    
     # if label is wrong and we wanted name of the label, then return ##################
     if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
         1=0 # If only label name should be returned we exit without any errors
@@ -1139,13 +1134,6 @@ finishing() {
             displaynotification "$message" "$name update complete!"
         else
             displaynotification "$message" "$name installation complete!"
-        fi
-    fi
-
-    if [[ $JAMF_RECON_ON_SUCCESS == "yes" ]]; then
-        if [[ -f /usr/local/bin/jamf ]]; then
-            printlog "running jamf recon"
-            jamf recon
         fi
     fi
 }
@@ -2232,7 +2220,7 @@ egnytewebedit)
     appName="Egnyte WebEdit.app"
     blockingProcesses=( NONE )
     ;;
-
+    
 element)
     name="Element"
     type="dmg"
@@ -2472,7 +2460,7 @@ flux)
     downloadURL="https://justgetflux.com/mac/Flux.zip"
     expectedTeamID="VZKSA7H9J9"
     ;;
-
+    
 flycut)
     name="Flycut"
     type="zip"
@@ -3126,7 +3114,7 @@ linear)
     appName="Linear.app"
     blockingProcesses=( "Linear" )
     ;;
-
+    
 logioptions|\
 logitechoptions)
     name="Logi Options"
@@ -4300,7 +4288,7 @@ secretive)
     appNewVersion=$(versionFromGit maxgoedjen secretive)
     expectedTeamID="Z72PRUAWF6"
     ;;
-
+    
 sequelpro)
     name="Sequel Pro"
     type="dmg"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -138,7 +138,7 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
-# Run jamf recon after success
+#Should jamf recon after success
 JAMF_RECON_ON_SUCCESS="no"
 # options:
 #  - no           Script will not run a jamf recon on success.

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1145,7 +1145,7 @@ finishing() {
     if [[ $JAMF_RECON_ON_SUCCESS == "yes" ]]; then
         if [[ -f /usr/local/bin/jamf ]]; then
             printlog "running jamf recon"
-            jamf recon
+            /usr/local/bin/jamf recon
         fi
     fi
 }

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -22,7 +22,7 @@ cleanupAndExit() { # $1 = exit code, $2 message, $3 level
         printlog "$2" $3
     fi
     printlog "################## End Installomator, exit code $1 \n" REQ
-    
+
     # if label is wrong and we wanted name of the label, then return ##################
     if [[ $RETURN_LABEL_NAME -eq 1 ]]; then
         1=0 # If only label name should be returned we exit without any errors
@@ -829,6 +829,13 @@ finishing() {
             displaynotification "$message" "$name installation complete!"
         fi
     fi
+
+    if [[ $JAMF_RECON_ON_SUCCESS == "yes" ]]; then
+        if [[ -f /usr/local/bin/jamf ]]; then
+            printlog "running jamf recon"
+            /usr/local/bin/jamf recon
+        fi
+    fi
 }
 
 # Detect if there is an app actively making a display sleep assertion, e.g.
@@ -857,4 +864,3 @@ hasDisplaySleepAssertion() {
     # No relevant display sleep assertion detected
     return 1
 }
-

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -7,7 +7,7 @@ label="" # if no label is sent to the script, this will be used
 # 2020-2021 Installomator
 #
 # inspired by the download scripts from William Smith and Sander Schram
-# 
+#
 # Contributers:
 #    Armin Briegel - @scriptingosx
 #    Isaac Ordonez - @issacatmann
@@ -23,7 +23,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # set to 0 for production, 1 or 2 for debugging
 # while debugging, items will be downloaded to the parent directory of this script
 # also no actual installation will be performed
-# debug mode 1 will download to the directory the script is run in, but will not check the version 
+# debug mode 1 will download to the directory the script is run in, but will not check the version
 # debug mode 2 will download to the temp directory, check for blocking processes, check the version, but will not install anything or remove the current version
 DEBUG=1
 
@@ -138,6 +138,11 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
+# Run jamf recon after success
+JAMF_RECON_ON_SUCCESS="no"
+# options:
+#  - no           Script will not run a jamf recon on success.
+#  - yes          Script will run a jamf recon on success.
 
 # NOTE: How labels work
 
@@ -184,7 +189,7 @@ IGNORE_DND_APPS=""
 #   How we get version number from app. Possible values:
 #     - CFBundleShortVersionString
 #     - CFBundleVersion
-#   Not all software titles uses fields the same. 
+#   Not all software titles uses fields the same.
 #   See Opera label.
 #
 # - appCustomVersion(){}: (optional function)


### PR DESCRIPTION
It can be useful for jamf users to update inventory after software is successfully installed. This adds an argument JAMF_RECON_ON_SUCCESS that when set to yes will run a jamf recon. It defaults to no.

```
2022-05-26 15:24:33 : WARN  : zoom : setting variable from argument DEBUG=1
2022-05-26 15:24:34 : WARN  : zoom : setting variable from argument JAMF_RECON_ON_SUCCESS=yes
2022-05-26 15:24:34 : REQ   : zoom : ################## Start Installomator v. 10.0beta, date 2022-05-26
2022-05-26 15:24:34 : INFO  : zoom : ################## Version: 10.0beta
2022-05-26 15:24:34 : INFO  : zoom : ################## Date: 2022-05-26
2022-05-26 15:24:34 : INFO  : zoom : ################## zoom
2022-05-26 15:24:34 : DEBUG : zoom : DEBUG mode 1 enabled.
2022-05-26 15:24:34 : INFO  : zoom : BLOCKING_PROCESS_ACTION=tell_user
2022-05-26 15:24:34 : INFO  : zoom : NOTIFY=success
2022-05-26 15:24:34 : INFO  : zoom : LOGGING=DEBUG
2022-05-26 15:24:34 : INFO  : zoom : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-26 15:24:34 : INFO  : zoom : Label type: pkg
2022-05-26 15:24:34 : INFO  : zoom : archiveName: zoom.us.pkg
2022-05-26 15:24:34 : INFO  : zoom : no blocking processes defined, using zoom.us as default
2022-05-26 15:24:34 : DEBUG : zoom : Changing directory to /Users/dnikles/Documents/GitHub/Installomator/build
2022-05-26 15:24:34 : INFO  : zoom : App(s) found: /Applications/zoom.us.app
2022-05-26 15:24:34 : INFO  : zoom : found app at /Applications/zoom.us.app, version 5.10.6.7526, on versionKey CFBundleVersion
2022-05-26 15:24:34 : INFO  : zoom : appversion: 5.10.6.7526
2022-05-26 15:24:34 : INFO  : zoom : Latest version of zoom.us is 5.10.6.7526
2022-05-26 15:24:34 : WARN  : zoom : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-26 15:24:34 : REQ   : zoom : Downloading https://zoom.us/client/latest/ZoomInstallerIT.pkg to zoom.us.pkg
2022-05-26 15:24:36 : DEBUG : zoom : File list: -rw-r--r--  1 root  staff   112M May 26 15:24 zoom.us.pkg
2022-05-26 15:24:36 : DEBUG : zoom : File type: zoom.us.pkg: xar archive compressed TOC: 4814, SHA-1 checksum
2022-05-26 15:24:36 : DEBUG : zoom : curl output was:
*   Trying 170.114.10.71:443...
* Connected to zoom.us (170.114.10.71) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [312 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3913 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Zoom Video Communications, Inc.; CN=*.zoom.us
*  start date: Apr 29 00:00:00 2022 GMT
*  expire date: May  2 23:59:59 2023 GMT
*  subjectAltName: host "zoom.us" matched cert's "zoom.us"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13b811400)
> GET /client/latest/ZoomInstallerIT.pkg HTTP/2
> Host: zoom.us
> user-agent: curl/7.79.1
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 302 
< date: Thu, 26 May 2022 19:24:35 GMT
< content-length: 0
< location: https://cdn.zoom.us/prod/5.10.6.7526/ZoomInstallerIT.pkg
< x-zm-trackingid: v=2.0;clid=aw1;rid=WEB_08ff13e7765a8a247fba7c2e70228414
< x-content-type-options: nosniff
< content-security-policy: upgrade-insecure-requests; default-src https://*.zoom.us https://zoom.us blob: 'self'; img-src https: about: blob: data: 'self'; style-src https: safari-extension: chrome-extension: 'unsafe-inline' data: 'self'; font-src https: safari-extension: chrome-extension: blob: data: 'self'; connect-src * about: blob: data: 'self'; media-src * rtmp: blob: data: 'self'; frame-src https: ms-appx-web: zoommtg: zoomus: wvjbscheme: data: 'self'; object-src 'none'; base-uri 'none';
< x-frame-options: SAMEORIGIN
< set-cookie: zm_aid=""; Domain=.zoom.us; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly
< set-cookie: zm_haid=""; Domain=.zoom.us; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly
< set-cookie: zm_tmaid=""; Domain=.zoom.us; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly
< set-cookie: zm_htmaid=""; Domain=.zoom.us; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly
< p3p: CP="NOI ADM DEV PSAi COM NAV OUR OTR STP IND DEM"
< set-cookie: _zm_ssid=aw1_c_qu-wXzqHRHSAIBVz5WA7-w; Domain=.zoom.us; Path=/; Secure; HttpOnly
< set-cookie: cred=154AC5D777FC3071FB632C4E44811C74; Path=/; Secure; HttpOnly
< set-cookie: _zm_ctaid=eR84vuzVQ_eRg85bMPuUBg.1653593075446.b98a83d8aa9584456436d77f104b5cc5; Domain=.zoom.us; Expires=Thu, 26-May-2022 21:24:35 GMT; Path=/; Secure; HttpOnly
< set-cookie: _zm_chtaid=917; Domain=.zoom.us; Expires=Thu, 26-May-2022 21:24:35 GMT; Path=/; Secure; HttpOnly
< x-zm-zoneid: VA
< set-cookie: _zm_mtk_guid=c4e3c7c159a145f084a66d0740c7189c; Domain=.zoom.us; Expires=Sat, 25-May-2024 19:24:35 GMT; Path=/; Secure
< strict-transport-security: max-age=31536000; includeSubDomains
< x-xss-protection: 1; mode=block
< referrer-policy: strict-origin-when-cross-origin
< 
{ [0 bytes data]
* Connection #0 to host zoom.us left intact
* Issue another request to this URL: 'https://cdn.zoom.us/prod/5.10.6.7526/ZoomInstallerIT.pkg'
*   Trying 13.224.213.253:443...
* Connected to cdn.zoom.us (13.224.213.253) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3920 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Zoom Video Communications, Inc.; CN=*.zoom.us
*  start date: Apr 29 00:00:00 2022 GMT
*  expire date: May  2 23:59:59 2023 GMT
*  subjectAltName: host "cdn.zoom.us" matched cert's "*.zoom.us"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
> GET /prod/5.10.6.7526/ZoomInstallerIT.pkg HTTP/1.1
> Host: cdn.zoom.us
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/vnd.apple.installer+xml
< Content-Length: 117388549
< Connection: keep-alive
< Date: Thu, 26 May 2022 05:46:41 GMT
< Last-Modified: Mon, 23 May 2022 14:31:42 GMT
< Etag: "6d27a490a1ffce97f45e3fa07a532743-14"
< X-Amz-Server-Side-Encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< Via: 1.1 3a9f76e15ac64134cc339fc4f9fb6a4c.cloudfront.net (CloudFront)
< Age: 49075
< Cross-Origin-Resource-Policy: cross-origin
< X-Cache: Hit from cloudfront
< X-Amz-Cf-Pop: PHL50-C1
< X-Amz-Cf-Id: ToHNfqiW8z5pidaXMNX8DEPhrmuGzQD3bBDq7ykjRq8IDFMaidwz0g==
< 
{ [15805 bytes data]
* Connection #1 to host cdn.zoom.us left intact

2022-05-26 15:24:36 : DEBUG : zoom : DEBUG mode 1, not checking for blocking processes
2022-05-26 15:24:36 : REQ   : zoom : Installing zoom.us
2022-05-26 15:24:36 : INFO  : zoom : Verifying: zoom.us.pkg
2022-05-26 15:24:36 : DEBUG : zoom : File list: -rw-r--r--  1 root  staff   112M May 26 15:24 zoom.us.pkg
2022-05-26 15:24:37 : DEBUG : zoom : File type: zoom.us.pkg: xar archive compressed TOC: 4814, SHA-1 checksum
2022-05-26 15:24:37 : DEBUG : zoom : spctlOut is zoom.us.pkg: accepted
2022-05-26 15:24:37 : DEBUG : zoom : source=Notarized Developer ID
2022-05-26 15:24:37 : DEBUG : zoom : override=security disabled
2022-05-26 15:24:37 : DEBUG : zoom : origin=Developer ID Installer: Zoom Video Communications, Inc. (BJ4HAAB9B3)
2022-05-26 15:24:37 : INFO  : zoom : Team ID: BJ4HAAB9B3 (expected: BJ4HAAB9B3 )
2022-05-26 15:24:37 : DEBUG : zoom : DEBUG enabled, skipping installation
2022-05-26 15:24:37 : INFO  : zoom : Finishing...
2022-05-26 15:24:48 : INFO  : zoom : App(s) found: /Applications/zoom.us.app
2022-05-26 15:24:48 : INFO  : zoom : found app at /Applications/zoom.us.app, version 5.10.6.7526, on versionKey CFBundleVersion
2022-05-26 15:24:48 : REQ   : zoom : Installed zoom.us, version 5.10.6.7526
2022-05-26 15:24:48 : INFO  : zoom : notifying
2022-05-26 15:24:48 : INFO  : zoom : running jamf recon
Retrieving inventory preferences from https://JAMFURL:8443/...
Finding extension attributes...
Locating accounts...
Locating applications...
Locating hard drive information...
Searching path: /System/Applications
Locating package receipts...
Locating printers...
Searching path: /Applications
Locating hardware information (macOS 12.4.0)...
Submitting data to https://JAMFURL:8443/...
<computer_id>123456</computer_id>
2022-05-26 15:25:01 : DEBUG : zoom : DEBUG mode 1, not reopening anything
2022-05-26 15:25:01 : REQ   : zoom : All done!
2022-05-26 15:25:01 : REQ   : zoom : ################## End Installomator, exit code 0 
```