### PR TITLE
Barco click share

### DIFF
--- a/fragments/labels/barcoclickshare.sh
+++ b/fragments/labels/barcoclickshare.sh
@@ -1,0 +1,7 @@
+barcoclickshare)
+    name="ClickShare"
+    type="appInDmgInZip"
+    downloadURL="https://www.barco.com$( curl -fs "https://www.barco.com/en/clickshare/app" | grep -A6 -i "macos" | grep -i "FileNumber" | tr '"' "\n" | grep -i "FileNumber" )"
+    appNewVersion="$(eval "$( echo $downloadURL | sed -E 's/.*(MajorVersion.*BuildVersion=[0-9]*).*/\1/' | sed 's/&amp//g' )" ; ((MajorVersion++)) ; ((MajorVersion--)); ((MinorVersion++)) ; ((MinorVersion--)); ((PatchVersion++)) ; ((PatchVersion--)); ((BuildVersion++)) ; ((BuildVersion--)); echo "${MajorVersion}.${MinorVersion}.${PatchVersion}-b${BuildVersion}")"
+    expectedTeamID="P6CDJZR997"
+    ;;

--- a/fragments/labels/barcoclickshare.sh
+++ b/fragments/labels/barcoclickshare.sh
@@ -1,7 +1,0 @@
-barcoclickshare)
-    name="ClickShare"
-    type="appInDmgInZip"
-    downloadURL="https://www.barco.com$( curl -fs "https://www.barco.com/en/clickshare/app" | grep -A6 -i "macos" | grep -i "FileNumber" | tr '"' "\n" | grep -i "FileNumber" )"
-    appNewVersion="$(eval "$( echo $downloadURL | sed -E 's/.*(MajorVersion.*BuildVersion=[0-9]*).*/\1/' | sed 's/&amp//g' )" ; ((MajorVersion++)) ; ((MajorVersion--)); ((MinorVersion++)) ; ((MinorVersion--)); ((PatchVersion++)) ; ((PatchVersion--)); ((BuildVersion++)) ; ((BuildVersion--)); echo "${MajorVersion}.${MinorVersion}.${PatchVersion}-b${BuildVersion}")"
-    expectedTeamID="P6CDJZR997"
-    ;;

--- a/fragments/labels/clickshare.sh
+++ b/fragments/labels/clickshare.sh
@@ -1,7 +1,7 @@
 clickshare)
-    # credit: Søren Theilgaard (@theilgaard)
     name="ClickShare"
     type="appInDmgInZip"
-    downloadURL=https://www.barco.com$(curl -fs "https://www.barco.com/en/clickshare/app" | grep -E -o '(\/\S*Download\?FileNumber=R3306192\S*ShowDownloadPage=False)' | tail -1)
+    downloadURL="https://www.barco.com$( curl -fs "https://www.barco.com/en/clickshare/app" | grep -A6 -i "macos" | grep -i "FileNumber" | tr '"' "\n" | grep -i "FileNumber" )"
+    appNewVersion="$(eval "$( echo $downloadURL | sed -E 's/.*(MajorVersion.*BuildVersion=[0-9]*).*/\1/' | sed 's/&amp//g' )" ; ((MajorVersion++)) ; ((MajorVersion--)); ((MinorVersion++)) ; ((MinorVersion--)); ((PatchVersion++)) ; ((PatchVersion--)); ((BuildVersion++)) ; ((BuildVersion--)); echo "${MajorVersion}.${MinorVersion}.${PatchVersion}-b${BuildVersion}")"
     expectedTeamID="P6CDJZR997"
     ;;


### PR DESCRIPTION
An updated version of the old `clickshare` label.

```
➜  Installomator/utils/assemble.sh clickshare
2022-05-27 13:13:07 : REQ   : clickshare : ################## Start Installomator v. 10.0beta, date 2022-05-27
2022-05-27 13:13:07 : INFO  : clickshare : ################## Version: 10.0beta
2022-05-27 13:13:07 : INFO  : clickshare : ################## Date: 2022-05-27
2022-05-27 13:13:07 : INFO  : clickshare : ################## clickshare
2022-05-27 13:13:07 : DEBUG : clickshare : DEBUG mode 1 enabled.
2022-05-27 13:13:08 : INFO  : clickshare : BLOCKING_PROCESS_ACTION=tell_user
2022-05-27 13:13:08 : INFO  : clickshare : NOTIFY=success
2022-05-27 13:13:08 : INFO  : clickshare : LOGGING=DEBUG
2022-05-27 13:13:08 : INFO  : clickshare : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-05-27 13:13:08 : INFO  : clickshare : Label type: appInDmgInZip
2022-05-27 13:13:08 : INFO  : clickshare : archiveName: ClickShare.zip
2022-05-27 13:13:08 : INFO  : clickshare : no blocking processes defined, using ClickShare as default
2022-05-27 13:13:08 : DEBUG : clickshare : Changing directory to /Users/st/Documents/GitHub/Installomator/build
2022-05-27 13:13:08 : INFO  : clickshare : App(s) found: /Applications/ClickShare.app
2022-05-27 13:13:08 : INFO  : clickshare : found app at /Applications/ClickShare.app, version 4.21.0-b16, on versionKey CFBundleShortVersionString
2022-05-27 13:13:08 : INFO  : clickshare : appversion: 4.21.0-b16
2022-05-27 13:13:08 : INFO  : clickshare : Latest version of ClickShare is 4.21.0-b16
2022-05-27 13:13:08 : WARN  : clickshare : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-05-27 13:13:08 : INFO  : clickshare : ClickShare.zip exists and DEBUG mode 1 enabled, skipping download
2022-05-27 13:13:08 : DEBUG : clickshare : DEBUG mode 1, not checking for blocking processes
2022-05-27 13:13:08 : REQ   : clickshare : Installing ClickShare
2022-05-27 13:13:08 : INFO  : clickshare : Unzipping ClickShare.zip
2022-05-27 13:13:08 : INFO  : clickshare : found dmg: /Users/st/Documents/GitHub/Installomator/build/Marathon2-[0-9.]*-Mac.dmg
2022-05-27 13:13:08 : INFO  : clickshare : Mounting /Users/st/Documents/GitHub/Installomator/build/Marathon2-[0-9.]*-Mac.dmg
2022-05-27 13:13:08 : DEBUG : clickshare : Debugging enabled, dmgmount output was:
expected CRC32 $201C53FC
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Marathon 2

2022-05-27 13:13:08 : INFO  : clickshare : Mounted: /Volumes/Marathon 2
2022-05-27 13:13:08 : DEBUG : clickshare : Unmounting /Volumes/Marathon 2
2022-05-27 13:13:09 : DEBUG : clickshare : Debugging enabled, Unmounting output was:
"disk6" ejected.
2022-05-27 13:13:09 : DEBUG : clickshare : DEBUG mode 1, not reopening anything
2022-05-27 13:13:09 : ERROR : clickshare : ERROR: could not find: /Volumes/Marathon 2/ClickShare.app
2022-05-27 13:13:09 : REQ   : clickshare : ################## End Installomator, exit code 8 
```