### PR TITLE
Fix downloadURL for Sublime Text

### DIFF
--- a/fragments/labels/sublimetext.sh
+++ b/fragments/labels/sublimetext.sh
@@ -2,7 +2,7 @@ sublimetext)
     # credit: Søren Theilgaard (@theilgaard)
     name="Sublime Text"
     type="zip"
-    downloadURL="$(curl -fs https://www.sublimetext.com/download | grep -io "https://download.*_mac.zip")"
+    downloadURL="$(curl -fs https://www.sublimetext.com/download_thanks | grep -io "https://download.*_mac.zip" | head -1)"
     appNewVersion=$(curl -fs https://www.sublimetext.com/download | grep -i -A 4 "id.*changelog" | grep -io "Build [0-9]*")
     expectedTeamID="Z6D26JE4Y4"
     ;;


### PR DESCRIPTION
Download URL changed and the curl command was returning more than one result, causing the script to exit.
- Updated downloadURL
- Limited curl output to first result only