### PR TITLE
Change app quitting/killing behaviour 

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1727,7 +1727,6 @@ axurerp10)
     expectedTeamID="HUMW6UU796"
     versionKey="CFBundleVersion"
     appName="Axure RP 10.app"
-    blockingProcesses=( "Axure RP 10" )
     ;;
 balenaetcher)
     name="balenaEtcher"
@@ -1847,7 +1846,6 @@ caffeine)
     downloadURL=$(downloadURLFromGit IntelliScape caffeine)
     appNewVersion=$(versionFromGit IntelliScape caffeine)
     expectedTeamID="YD6LEYT6WZ"
-    blockingProcesses=( Caffeine )
     ;;
 cakebrew)
     name="Cakebrew"
@@ -2204,7 +2202,6 @@ drawio)
     downloadURL="$(downloadURLFromGit jgraph drawio-desktop)"
     appNewVersion="$(versionFromGit jgraph drawio-desktop)"
     expectedTeamID="UZEUFB4N53"
-    blockingProcesses=( draw.io )
     ;;
 drift)
     # credit Elena Ackley (@elenaelago)
@@ -2261,7 +2258,6 @@ egnytewebedit)
     appName="Egnyte WebEdit.app"
     blockingProcesses=( NONE )
     ;;
-
 element)
     name="Element"
     type="dmg"
@@ -2501,7 +2497,6 @@ flux)
     downloadURL="https://justgetflux.com/mac/Flux.zip"
     expectedTeamID="VZKSA7H9J9"
     ;;
-
 flycut)
     name="Flycut"
     type="zip"
@@ -3153,9 +3148,7 @@ linear)
     expectedTeamID="7VZ2S3V9RV"
     versionKey="CFBundleShortVersionString"
     appName="Linear.app"
-    blockingProcesses=( "Linear" )
     ;;
-
 logioptions|\
 logitechoptions)
     name="Logi Options"
@@ -3337,7 +3330,6 @@ azuredatastudio)
     appNewVersion=$(versionFromGit microsoft azuredatastudio )
     expectedTeamID="UBF8T346G9"
     appName="Azure Data Studio.app"
-    blockingProcesses=( "Azure Data Studio" )
     ;;
 microsoftazurestorageexplorer)
     name="Microsoft Azure Storage Explorer"
@@ -4161,7 +4153,6 @@ remotedesktopmanagerenterprise)
     downloadURL=$(curl -fs https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacbin | grep -oe "http.*\.dmg" | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
     expectedTeamID="N592S9ASDB"
-    blockingProcesses=( "$name" )
     ;;
 remotedesktopmanagerfree)
     name="Remote Desktop Manager Free"
@@ -4215,14 +4206,12 @@ ringcentralapp)
         downloadURL="https://app.ringcentral.com/download/RingCentral.pkg"
     fi
     expectedTeamID="M932RC5J66"
-    blockingProcesses=( "Ringcentral" )
     ;;
 ringcentralclassicapp)
     name="Glip"
     type="dmg"
     downloadURL="https://downloads.ringcentral.com/glip/rc/GlipForMac"
     expectedTeamID="M932RC5J66"
-    blockingProcesses=( "Glip" )
     #blockingProcessesMaxCPU="5"
     ;;
 ringcentralmeetings)
@@ -4253,7 +4242,6 @@ rocketchat)
     downloadURL=$(downloadURLFromGit RocketChat Rocket.Chat.Electron)
     appNewVersion=$(versionFromGit RocketChat Rocket.Chat.Electron)
     expectedTeamID="S6UPZG7ZR3"
-    blockingProcesses=( Rocket.Chat )
     ;;
 rodeconnect)
     name="RODE Connect"
@@ -4292,7 +4280,6 @@ scaleft)
     downloadURL="https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg"
     appNewVersion=$(curl -sf "https://dist.scaleft.com/client-tools/mac/" | awk '/dir/{i++}i==2' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
     expectedTeamID="HV2G9Z3RP5"
-    blockingProcesses=( ScaleFT )
     ;;
 screamingfrogseospider)
     name="Screaming Frog SEO Spider"
@@ -4329,7 +4316,6 @@ secretive)
     appNewVersion=$(versionFromGit maxgoedjen secretive)
     expectedTeamID="Z72PRUAWF6"
     ;;
-
 sequelpro)
     name="Sequel Pro"
     type="dmg"
@@ -4529,14 +4515,12 @@ sqlpropostgres)
     type="zip"
     downloadURL="https://macpostgresclient.com/download.php"
     expectedTeamID="LKJB72232C"
-    blockingProcesses=( "SQLPro for Postgres" )
     ;;
 sqlprostudio)
     name="SQLPro Studio"
     type="zip"
     downloadURL="https://www.sqlprostudio.com/download.php"
     expectedTeamID="LKJB72232C"
-    blockingProcesses=( "SQLPro Studio" )
     ;;
 steelseriesengine)
     name="SteelSeries GG"
@@ -4857,7 +4841,6 @@ unnaturalscrollwheels)
     downloadURL="$(downloadURLFromGit ther0n UnnaturalScrollWheels)"
     appNewVersion="$(versionFromGit ther0n UnnaturalScrollWheels)"
     expectedTeamID="D6H5W2T379"
-    blockingProcesses=( UnnaturalScrollWheels )
     ;;
 utm)
     name="UTM"
@@ -5158,7 +5141,6 @@ zoomclient)
     fi
     expectedTeamID="BJ4HAAB9B3"
     #appNewVersion=$(curl -is "https://beta2.communitypatch.com/jamf/v1/ba1efae22ae74a9eb4e915c31fef5dd2/patch/zoom.us" | grep currentVersion | tr ',' '\n' | grep currentVersion | cut -d '"' -f 4) # Does not match packageID
-    blockingProcesses=( zoom.us )
     #blockingProcessesMaxCPU="5"
     ;;
 zoomgov)

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -592,7 +592,7 @@ getAppVersion() {
 
 QuitOrKillGently() {
 	# function that gets called with process name as $1
-	printlog "telling app $1 to quit"
+	printlog "telling app \"$1\" to quit"
 	runAsUser osascript -e "tell app \"$1\" to quit"
 	sleep 5
 	if pgrep -xq "$1"; then
@@ -605,15 +605,17 @@ QuitOrKillGently() {
 	RemainingPIDs=($(pgrep "$1"))
 	Iteration=0
 	while [ ${#RemainingPIDs[@]} -gt 0 -a ${Iteration} -lt 3 ] ; do
-		for PID in $(seq 0 $(( ${#RemainingPIDs[@]} -1 )) ) ; do
-			printlog "sending SIGTERM to PID ${RemainingPIDs[$PID]} associated with process $1"
-			kill ${RemainingPIDs[$PID]}
+		for PID in ${RemainingPIDs} ; do
+			Process="$(ps ${PID} | awk -F" /" "/${PID}/ {print \"/\"\$2}")"
+			printlog "sending SIGTERM to PID ${PID}: ${Process}"
+			kill ${PID}
 		done
-		sleep 3
+		sleep 5
 		RemainingPIDs=($(pgrep "$1"))
-		for PID in $(seq 0 $(( ${#RemainingPIDs[@]} -1 )) ) ; do
-			printlog "sending SIGKILL to PID ${RemainingPIDs[$PID]} associated with process $1"
-			kill -9 ${RemainingPIDs[$PID]}
+		for PID in ${RemainingPIDs} ; do
+			Process="$(ps ${PID} | awk -F" /" "/${PID}/ {print \"/\"\$2}")"
+			printlog "sending SIGKILL to PID ${PID}: ${Process}"
+			kill -9 ${PID}
 		done
 		sleep 3
 		RemainingPIDs=($(pgrep "$1"))
@@ -1337,7 +1339,7 @@ valuesfromarguments)
     downloadURL="https://app-updates.agilebits.com/download/OPM7"
     appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | sed -E 's/.*\/[0-9a-zA-Z]*-([0-9.]*)\..*/\1/g' )
     expectedTeamID="2BUA8C4S2C"
-    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    blockingProcesses=( "Safari" "1Password (Safari)" "1PasswordSafariAppExtension" "Google Chrome" "Firefox" "1Password 7" "1Password Extension Helper" )
     #forcefulQuit=YES
     ;;
 1password8)
@@ -1352,7 +1354,7 @@ valuesfromarguments)
         downloadURL="https://downloads.1password.com/mac/1Password-latest-x86_64.zip"
     fi
     expectedTeamID="2BUA8C4S2C"
-    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password" "1Password (Safari)" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES
     ;;
 1passwordcli)


### PR DESCRIPTION
(continuing #573)

Change app quitting/killing behaviour and additionally invent new `$LaunchDaemonsToUnload` variable that will be handled by `DealWithLaunchDaemon` function.

The latter is a new addition with zero consequences since not changing anything. The purpose is to define background tasks that might interfere with installations (at our place we have a daemon watching every minute whether a VoIP application is running and restarts if needed)

The more serious or 'disruptive' change is introducing the `QuitOrKillGently` to quit and kill apps in a different way than before. With the new functionality per string in `$blockingProcesses` the following happens:

  * send a `quit` event, wait 5 seconds, recheck using `pgrep -xq`, send another `quit` event, wait another 5 seconds
  * create a list of matching PIDs using `pgrep`, walk through them and send a `SIGTERM` signal to each, wait 5 seconds
  * again create a list of matching PIDs using `pgrep`, walk through them and send a `SIGKILL` signal to each, wait 3 seconds
  * iterate through the two steps above for max 3 times and return in any case
  * if there are remaining processes the `checkRunningProcesses` function will catch them via `pgrep -xq` and exit as before

The purpose of this 3 step attempt to quit an app as gently as possible while also saving some time (not waiting multiple times 30 seconds for nothing).

But unfortunately this change is disruptive in the following way.

The old way `checkRunningProcesses` worked was partially broken if processes were immediately restarted. One such example is `1PasswordNativeMessageHost` as member of `$blockingProcesses` for both `1password7` and `1password8`. You can quit or kill `1PasswordNativeMessageHost` in any possible way but to no avail since immediately restarted with a new PID.

Quoting the log:

    found blocking process 1PasswordNativeMessageHost
    telling app "1PasswordNativeMessageHost" to quit
    sending SIGTERM to PID 11166: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost
    sending SIGKILL to PID 12263: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost
    sending SIGTERM to PID 12273: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost
    sending SIGKILL to PID 12284: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost
    sending SIGTERM to PID 12294: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost
    sending SIGKILL to PID 12305: /Applications/1Password 7.app/Contents/Library/LoginItems/1Password Extension Helper.app/Contents/MacOS/1PasswordNativeMessageHost

And then this starts over and over again. The only way to 'fix' this is either removing the task in question from `$blockingProcesses` in the app definition (safe since it never worked before) or to take special precautins and onload the LaunchAgent first (this will be part of another PR to deal not only with LaunchDaemons but also LaunchAgents):

    launchctl asuser launchctl stop 2BUA8C4S2C.com.agilebits.onepassword7-helper
    launchctl asuser launchctl remove 2BUA8C4S2C.com.agilebits.onepassword7-helper

Only after unloading the LaunchDaemon the corresponding process `1PasswordNativeMessageHost` can really be stopped. In this case the solution is simply (since stopping never really worked removing the string from the `$blockingProcesses` list) but this could be disruptive for other apps as well.

I searched through the current definitions and found the following entries that might be candidates for troubles:

    blockingProcesses=( "Autodesk Fusion 360" "Fusion 360" )
    blockingProcesses=( "Google Docs" "Google Drive" "Google Sheets" "Google Slides" )
    blockingProcesses=( "iStat Menus" "iStatMenusAgent" "iStat Menus Status" )
    blockingProcesses=( "Keyboard Maestro Engine" "Keyboard Maestro" )
    blockingProcesses=( "Mattermost Helper.app" "Mattermost Helper (Renderer).app" "Mattermost Helper (GPU).app" "Mattermost Helper (Plugin).app" )
    blockingProcesses=( "Microsoft AutoUpdate" "Microsoft Word" "Microsoft PowerPoint" "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "OneDrive" )
    blockingProcesses=( "Microsoft AutoUpdate" "Microsoft Word" "Microsoft PowerPoint" "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "OneDrive" "Teams")
    blockingProcesses=( NVivo NVivoHelper )

So without testing with the corresponding apps this PR might introduce failing updates if one of those strings above is also the result of a process being fired up (and restarted immediately) by a LaunchDaemon or LaunchAgent.