### PR TITLE
Add blocking process checking to update tool function

### DIFF
--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -169,6 +169,17 @@ fi
 if [[ (-n $appversion && -n "$updateTool") || "$type" == "updateronly" ]]; then
     printlog "appversion & updateTool"
     if [[ $DEBUG -ne 1 ]]; then
+       if [[ $BLOCKING_PROCESS_ACTION == "ignore" ]]; then
+           printlog "ignoring blocking processes"
+       else
+           if [[ $currentUser != "loginwindow" ]]; then
+               if [[ ${#blockingProcesses} -gt 0 ]]; then
+                   if [[ ${blockingProcesses[1]} != "NONE" ]]; then
+                       checkRunningProcesses
+               fi
+           fi
+       fi
+    fi
         if runUpdateTool; then
             finishing
             cleanupAndExit 0 "updateTool has run" REQ


### PR DESCRIPTION
Currently when a defined update tool is used or the label type is updateronly, Blocking Processes are not checked.
Looks like this is because the Update tool function is above the blocking processes function in main.sh.

To get this working I copied the blocking process action function into the update tool function.
This may not be the best way to do this.

This also might cause problems if blocking processes only need to be checked when not using an update tool.