### PR TITLE
New Label: OnScreen Control

### DIFF
--- a/fragments/labels/onscreencontrol.sh
+++ b/fragments/labels/onscreencontrol.sh
@@ -2,7 +2,8 @@ onscreencontrol)
     name="OnScreen Control"
     type="pkgInZip"
     packageID="com.LGSI.OnScreen-Control"
-    downloadURL=$(currentFileName=`curl -s https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControlLatestVersion.txt` && echo https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/"$currentFileName")
-    appNewVersion=$(curl -s https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControlLatestVersion.txt | sed -E 's/.*_([0-9.]*)\.zip/\1/g')
+    releaseURL="https://www.lg.com/de/support/software-select-category-result?csSalesCode=34WK95U-W.AEU"
+    appNewVersion=$(curl -sf $releaseURL | grep -m 1 "Mac_OSC_" | sed -E 's/.*OSC_([0-9.]*).zip.*/\1/g')
+    downloadURL=$(curl -sf $releaseURL | grep -m 1 "Mac_OSC_" | sed "s|.*href=\"\(.*\)\" title.*|\\1|")
     expectedTeamID="5SKT5H4CPQ"
     ;;

--- a/fragments/labels/onscreencontrol.sh
+++ b/fragments/labels/onscreencontrol.sh
@@ -1,0 +1,8 @@
+onscreencontrol)
+    name="OnScreen Control"
+    type="pkgInZip"
+    packageID="com.LGSI.OnScreen-Control"
+    downloadURL=$(currentFileName=`curl -s https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControlLatestVersion.txt` && echo https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/"$currentFileName")
+    appNewVersion=$(curl -s https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControlLatestVersion.txt | sed -E 's/.*_([0-9.]*)\.zip/\1/g')
+    expectedTeamID="5SKT5H4CPQ"
+    ;;


### PR DESCRIPTION
An LG Monitor Utility

"OnScreen Control is an application used to manage a single monitor or a group of monitor with useful features such as Monitor Control, My Display Presets and Screen Split. OnScreen Control displays all connected LG monitor information. This software is compatible with LG monitors only."

./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels onscreencontrol
2022-06-17 20:58:28 : REQ   : onscreencontrol : ################## Start Installomator v. 9.2, date 2022-06-17
2022-06-17 20:58:28 : INFO  : onscreencontrol : ################## Version: 9.2
2022-06-17 20:58:28 : INFO  : onscreencontrol : ################## Date: 2022-06-17
2022-06-17 20:58:28 : INFO  : onscreencontrol : ################## onscreencontrol
2022-06-17 20:58:28 : DEBUG : onscreencontrol : DEBUG mode 1 enabled.
2022-06-17 20:58:28 : INFO  : onscreencontrol : BLOCKING_PROCESS_ACTION=tell_user
2022-06-17 20:58:28 : INFO  : onscreencontrol : NOTIFY=success
2022-06-17 20:58:28 : INFO  : onscreencontrol : LOGGING=DEBUG
2022-06-17 20:58:28 : INFO  : onscreencontrol : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-06-17 20:58:28 : INFO  : onscreencontrol : Label type: pkgInZip
2022-06-17 20:58:28 : INFO  : onscreencontrol : archiveName: OnScreen Control.zip
2022-06-17 20:58:28 : INFO  : onscreencontrol : no blocking processes defined, using OnScreen Control as default
2022-06-17 20:58:28 : DEBUG : onscreencontrol : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-06-17 20:58:29 : INFO  : onscreencontrol : No version found using packageID com.LGSI.OnScreen-Control
2022-06-17 20:58:29 : INFO  : onscreencontrol : App(s) found: /Applications/OnScreen Control.app
2022-06-17 20:58:29 : INFO  : onscreencontrol : found app at /Applications/OnScreen Control.app, version 5.47, on versionKey CFBundleShortVersionString
2022-06-17 20:58:29 : INFO  : onscreencontrol : appversion: 5.47
2022-06-17 20:58:29 : INFO  : onscreencontrol : Latest version of OnScreen Control is 5.47
2022-06-17 20:58:29 : WARN  : onscreencontrol : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-06-17 20:58:29 : REQ   : onscreencontrol : Downloading https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControl_5.47.zip to OnScreen Control.zip
2022-06-17 20:58:37 : DEBUG : onscreencontrol : File list: -rw-r--r--  1 savvas  staff    56M 17 Jun 20:58 OnScreen Control.zip
2022-06-17 20:58:37 : DEBUG : onscreencontrol : File type: OnScreen Control.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2022-06-17 20:58:37 : DEBUG : onscreencontrol : curl output was:
*   Trying 23.48.23.5:443...
* Connected to lmu.lge.com (23.48.23.5) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4021 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=lmu.lge.com
*  start date: May 29 23:40:15 2022 GMT
*  expire date: Aug 27 23:40:14 2022 GMT
*  subjectAltName: host "lmu.lge.com" matched cert's "lmu.lge.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /ExternalService/onscreencontrol/mac/2.0/OnScreenControl_5.47.zip HTTP/1.1
> Host: lmu.lge.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/zip
< ETag: "723d7988a59767c9a2aef6c274d5e5c1:1653637134.542227"
< Last-Modified: Fri, 27 May 2022 07:38:54 GMT
< Server: AkamaiNetStorage
< Content-Length: 59160965
< Expires: Fri, 17 Jun 2022 18:58:29 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Fri, 17 Jun 2022 18:58:29 GMT
< Connection: keep-alive
<
{ [15989 bytes data]
* Connection #0 to host lmu.lge.com left intact

2022-06-17 20:58:37 : DEBUG : onscreencontrol : DEBUG mode 1, not checking for blocking processes
2022-06-17 20:58:37 : REQ   : onscreencontrol : Installing OnScreen Control
2022-06-17 20:58:37 : INFO  : onscreencontrol : Unzipping OnScreen Control.zip
2022-06-17 20:58:37 : DEBUG : onscreencontrol : Found pkg(s):
/Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg
2022-06-17 20:58:37 : INFO  : onscreencontrol : found pkg: /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg
2022-06-17 20:58:37 : INFO  : onscreencontrol : Verifying: /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg
2022-06-17 20:58:37 : DEBUG : onscreencontrol : File list: -rw-r--r--@ 1 savvas  staff    56M 27 Mai 05:53 /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg
2022-06-17 20:58:37 : DEBUG : onscreencontrol : File type: /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg: xar archive compressed TOC: 8499, SHA-1 checksum
2022-06-17 20:58:38 : DEBUG : onscreencontrol : spctlOut is /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/OSC_V5.47_signed.pkg: accepted
2022-06-17 20:58:38 : DEBUG : onscreencontrol : source=Notarized Developer ID
2022-06-17 20:58:38 : DEBUG : onscreencontrol : override=security disabled
2022-06-17 20:58:38 : DEBUG : onscreencontrol : origin=Developer ID Installer: LG Electronics (5SKT5H4CPQ)
2022-06-17 20:58:38 : INFO  : onscreencontrol : Team ID: 5SKT5H4CPQ (expected: 5SKT5H4CPQ )
2022-06-17 20:58:38 : INFO  : onscreencontrol : Checking package version.
2022-06-17 20:58:39 : INFO  : onscreencontrol : Downloaded package com.LGSI.OnScreen-Control version 5.47
2022-06-17 20:58:39 : INFO  : onscreencontrol : Downloaded version of OnScreen Control is the same as installed.
2022-06-17 20:58:39 : DEBUG : onscreencontrol : DEBUG mode 1, not reopening anything
2022-06-17 20:58:39 : REQ   : onscreencontrol : No new version to install
2022-06-17 20:58:39 : REQ   : onscreencontrol : ################## End Installomator, exit code 0