### PR TITLE
New Label: Synology Drive Client

### DIFF
--- a/fragments/labels/synologydriveclient.sh
+++ b/fragments/labels/synologydriveclient.sh
@@ -1,0 +1,8 @@
+synologydriveclient)
+    name="Synology Drive Client"
+    type="pkgInDmg"
+    packageID="com.synology.CloudStation"
+    downloadURL=$(appVersion=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)<.*|\\1|"` && appShortVersion=`sed 's#.*-\(\)#\1#' <<< $appVersion` && echo https://global.download.synology.com/download/Utility/SynologyDriveClient/"$appVersion"/Mac/Installer/synology-drive-client-"${appShortVersion}".dmg)
+    appNewVersion=$(appVersionP1=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)-.*|\\1|"` && sed 's/\(.\{0\}\)./\17/' <<< $appVersionP1)
+    expectedTeamID="X85BAK35Y4"
+    ;;


### PR DESCRIPTION
"Synology Drive Client desktop application is the desktop utility that provides file syncing and personal computer backup service on multiple client computers to a centralized server, Synology Drive Server."

./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels synologydriveclient
2022-06-17 22:04:10 : REQ   : synologydriveclient : ################## Start Installomator v. 9.2, date 2022-06-17
2022-06-17 22:04:10 : INFO  : synologydriveclient : ################## Version: 9.2
2022-06-17 22:04:10 : INFO  : synologydriveclient : ################## Date: 2022-06-17
2022-06-17 22:04:10 : INFO  : synologydriveclient : ################## synologydriveclient
2022-06-17 22:04:10 : DEBUG : synologydriveclient : DEBUG mode 1 enabled.
2022-06-17 22:04:10 : INFO  : synologydriveclient : BLOCKING_PROCESS_ACTION=tell_user
2022-06-17 22:04:10 : INFO  : synologydriveclient : NOTIFY=success
2022-06-17 22:04:10 : INFO  : synologydriveclient : LOGGING=DEBUG
2022-06-17 22:04:10 : INFO  : synologydriveclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-06-17 22:04:10 : INFO  : synologydriveclient : Label type: pkgInDmg
2022-06-17 22:04:10 : INFO  : synologydriveclient : archiveName: Synology Drive Client.dmg
2022-06-17 22:04:10 : INFO  : synologydriveclient : no blocking processes defined, using Synology Drive Client as default
2022-06-17 22:04:10 : DEBUG : synologydriveclient : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-06-17 22:04:10 : INFO  : synologydriveclient : found packageID com.synology.CloudStation installed, version 7.1.0
2022-06-17 22:04:10 : INFO  : synologydriveclient : appversion: 7.1.0
2022-06-17 22:04:10 : INFO  : synologydriveclient : Latest version of Synology Drive Client is 7.1.0
2022-06-17 22:04:10 : WARN  : synologydriveclient : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-06-17 22:04:10 : REQ   : synologydriveclient : Downloading https://global.download.synology.com/download/Utility/SynologyDriveClient/3.1.0-12923/Mac/Installer/synology-drive-client-12923.dmg to Synology Drive Client.dmg
2022-06-17 22:04:21 : DEBUG : synologydriveclient : File list: -rw-r--r--  1 savvas  staff    71M 17 Jun 22:04 Synology Drive Client.dmg
2022-06-17 22:04:21 : DEBUG : synologydriveclient : File type: Synology Drive Client.dmg: bzip2 compressed data, block size = 100k
2022-06-17 22:04:21 : DEBUG : synologydriveclient : curl output was:
*   Trying 65.9.66.38:443...
* Connected to global.download.synology.com (65.9.66.38) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5175 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=global.download.synology.com
*  start date: Apr 29 07:21:41 2022 GMT
*  expire date: May 31 07:21:41 2023 GMT
*  subjectAltName: host "global.download.synology.com" matched cert's "global.download.synology.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7f88cf80f600)
> GET /download/Utility/SynologyDriveClient/3.1.0-12923/Mac/Installer/synology-drive-client-12923.dmg HTTP/2
> Host: global.download.synology.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 74575228
< date: Tue, 07 Jun 2022 18:38:15 GMT
< last-modified: Thu, 28 Apr 2022 19:03:08 GMT
< etag: "8719eb20e8d6435edf7dfdeac1cf50be-15"
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 579a21a67e4dc50a655a7c0e9675261c.cloudfront.net (CloudFront)
< x-amz-cf-pop: FRA56-C1
< x-amz-cf-id: XWM1zUJtP5srb0NPTx7G-SF0nyJTplNgidIVYimK-CjQ-0HmcTVGQg==
< age: 869157
<
{ [2896 bytes data]
* Connection #0 to host global.download.synology.com left intact

2022-06-17 22:04:21 : DEBUG : synologydriveclient : DEBUG mode 1, not checking for blocking processes
2022-06-17 22:04:21 : REQ   : synologydriveclient : Installing Synology Drive Client
2022-06-17 22:04:21 : INFO  : synologydriveclient : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/Synology Drive Client.dmg
2022-06-17 22:04:25 : DEBUG : synologydriveclient : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record（MBR：0） berechnen …
Protective Master Boot Record（MBR：0）: Die überprüfte CRC32-Prüfsumme ist $A8DB39D3
Prüfsumme für GPT Header（Primary GPT Header：1） berechnen …
GPT Header（Primary GPT Header：1）: Die überprüfte CRC32-Prüfsumme ist $2BEB5693
Prüfsumme für GPT Partition Data（Primary GPT Table：2） berechnen …
GPT Partition Data（Primary GPT Table: Die überprüfte CRC32-Prüfsumme ist $EBAFDA05
Prüfsumme für （Apple_Free：3） berechnen …
（Apple_Free：3）: Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image（Apple_HFS：4） berechnen …
disk image（Apple_HFS：4）: Die überprüfte CRC32-Prüfsumme ist $0307F580
Prüfsumme für （Apple_Free：5） berechnen …
（Apple_Free：5）: Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data（Backup GPT Table：6） berechnen …
GPT Partition Data（Backup GPT Table：: Die überprüfte CRC32-Prüfsumme ist $EBAFDA05
Prüfsumme für GPT Header（Backup GPT Header：7） berechnen …
GPT Header（Backup GPT Header：7）: Die überprüfte CRC32-Prüfsumme ist $AFE9E67E
Die überprüfte CRC32-Prüfsumme ist $74229A79
/dev/disk3          	GUID_partition_scheme
/dev/disk3s1        	Apple_HFS                      	/Volumes/Synology Drive Client

2022-06-17 22:04:25 : INFO  : synologydriveclient : Mounted: /Volumes/Synology Drive Client
2022-06-17 22:04:25 : DEBUG : synologydriveclient : Found pkg(s):
/Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2022-06-17 22:04:25 : INFO  : synologydriveclient : found pkg: /Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2022-06-17 22:04:25 : INFO  : synologydriveclient : Verifying: /Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2022-06-17 22:04:25 : DEBUG : synologydriveclient : File list: -rw-r--r--@ 1 savvas  staff    70M 26 Apr 08:23 /Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2022-06-17 22:04:26 : DEBUG : synologydriveclient : File type: /Volumes/Synology Drive Client/Install Synology Drive Client.pkg: xar archive compressed TOC: 6172, SHA-1 checksum
2022-06-17 22:04:26 : DEBUG : synologydriveclient : spctlOut is /Volumes/Synology Drive Client/Install Synology Drive Client.pkg: accepted
2022-06-17 22:04:26 : DEBUG : synologydriveclient : source=Notarized Developer ID
2022-06-17 22:04:26 : DEBUG : synologydriveclient : override=security disabled
2022-06-17 22:04:26 : DEBUG : synologydriveclient : origin=Developer ID Installer: Synology Inc. (X85BAK35Y4)
2022-06-17 22:04:26 : INFO  : synologydriveclient : Team ID: X85BAK35Y4 (expected: X85BAK35Y4 )
2022-06-17 22:04:26 : INFO  : synologydriveclient : Checking package version.
2022-06-17 22:04:30 : INFO  : synologydriveclient : Downloaded package com.synology.CloudStation version 7.1.0
2022-06-17 22:04:30 : INFO  : synologydriveclient : Downloaded version of Synology Drive Client is the same as installed.
2022-06-17 22:04:30 : DEBUG : synologydriveclient : Unmounting /Volumes/Synology Drive Client
2022-06-17 22:04:30 : DEBUG : synologydriveclient : Debugging enabled, Unmounting output was:
"disk3" ejected.
2022-06-17 22:04:30 : DEBUG : synologydriveclient : DEBUG mode 1, not reopening anything
2022-06-17 22:04:30 : REQ   : synologydriveclient : No new version to install
2022-06-17 22:04:30 : REQ   : synologydriveclient : ################## End Installomator, exit code 0