### PR TITLE
Update Wireshark download URL

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,11 +1,11 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    if [[ $(arch) == i386 ]]; then
-      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Intel%2064.dmg"
-    elif [[ $(arch) == arm64 ]]; then
-      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Arm%2064.dmg"
-    fi
     appNewVersion=$(curl -fs https://www.wireshark.org/download.html | grep -i "href.*_stable" | sed -E 's/.*\(([0-9.]*)\).*/\1/g')
+    if [[ $(arch) == i386 ]]; then
+      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20$appNewVersion%20Intel%2064.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20$appNewVersion%20Arm%2064.dmg"
+    fi
     expectedTeamID="7Z6EMTD2C6"
     ;;


### PR DESCRIPTION
Updated the Wireshark downloadURL to fill in the version using the value from appNewVersion. The current "Latest" URL targets 3.7 which is a dev build not a stable build.

```
2022-06-20 10:51:58 : WARN  : wireshark : setting variable from argument DEBUG=0
2022-06-20 10:51:58 : WARN  : wireshark : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2022-06-20 10:51:58 : WARN  : wireshark : setting variable from argument INSTALL=force
2022-06-20 10:51:58 : REQ   : wireshark : ################## Start Installomator v. 10.0beta, date 2022-06-20
2022-06-20 10:51:58 : INFO  : wireshark : ################## Version: 10.0beta
2022-06-20 10:51:58 : INFO  : wireshark : ################## Date: 2022-06-20
2022-06-20 10:51:58 : INFO  : wireshark : ################## wireshark
2022-06-20 10:52:00 : INFO  : wireshark : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2022-06-20 10:52:00 : INFO  : wireshark : NOTIFY=success
2022-06-20 10:52:00 : INFO  : wireshark : LOGGING=INFO
2022-06-20 10:52:00 : INFO  : wireshark : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-06-20 10:52:00 : INFO  : wireshark : Label type: dmg
2022-06-20 10:52:00 : INFO  : wireshark : archiveName: Wireshark.dmg
2022-06-20 10:52:00 : INFO  : wireshark : no blocking processes defined, using Wireshark as default
2022-06-20 10:52:00 : INFO  : wireshark : name: Wireshark, appName: Wireshark.app
2022-06-20 10:52:00 : WARN  : wireshark : No previous app found
2022-06-20 10:52:00 : WARN  : wireshark : could not find Wireshark.app
2022-06-20 10:52:00 : INFO  : wireshark : appversion: 
2022-06-20 10:52:00 : INFO  : wireshark : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-06-20 10:52:00 : INFO  : wireshark : Latest version of Wireshark is 3.6.6
2022-06-20 10:52:00 : REQ   : wireshark : Downloading https://1.as.dl.wireshark.org/osx/Wireshark%203.6.6%20Intel%2064.dmg to Wireshark.dmg
2022-06-20 10:55:17 : REQ   : wireshark : no more blocking processes, continue with update
2022-06-20 10:55:17 : REQ   : wireshark : Installing Wireshark
2022-06-20 10:55:17 : INFO  : wireshark : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aIcWkld2/Wireshark.dmg
2022-06-20 10:55:33 : INFO  : wireshark : Mounted: /Volumes/Wireshark 3.6.6
2022-06-20 10:55:33 : INFO  : wireshark : Verifying: /Volumes/Wireshark 3.6.6/Wireshark.app
2022-06-20 10:56:00 : INFO  : wireshark : Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2022-06-20 10:56:00 : INFO  : wireshark : Installing Wireshark version 3.6.6 on versionKey CFBundleShortVersionString.
2022-06-20 10:56:00 : INFO  : wireshark : App has LSMinimumSystemVersion: 10.13
2022-06-20 10:56:00 : INFO  : wireshark : Copy /Volumes/Wireshark 3.6.6/Wireshark.app to /Applications
2022-06-20 10:56:20 : WARN  : wireshark : Changing owner to user
2022-06-20 10:56:20 : INFO  : wireshark : Finishing...
2022-06-20 10:56:30 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2022-06-20 10:56:30 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 3.6.6, on versionKey CFBundleShortVersionString
2022-06-20 10:56:30 : REQ   : wireshark : Installed Wireshark, version 3.6.6
2022-06-20 10:56:30 : INFO  : wireshark : notifying
2022-06-20 10:56:31 : INFO  : wireshark : App not closed, so no reopen.
2022-06-20 10:56:31 : REQ   : wireshark : All done!
2022-06-20 10:56:31 : REQ   : wireshark : ################## End Installomator, exit code 0 
```