### PR TITLE
New Label: Fujifilmwebcam

### DIFF
--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -2,6 +2,6 @@ fujifilmwebcam)
      name="FUJIFILM X Webcam 2"
      type="pkg"
      downloadURL=$(curl -fs "https://fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
-     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' )
+     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' )
      expectedTeamID="34LRP8AV2M"
      ;;

--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -1,0 +1,7 @@
+fujifilmwebcam)
+     name="FUJIFILM X Webcam 2"
+     type="pkg"
+     downloadURL=$(curl -fs "https://fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
+     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' )
+     expectedTeamID="34LRP8AV2M"
+     ;;

--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -2,6 +2,6 @@ fujifilmwebcam)
      name="FUJIFILM X Webcam 2"
      type="pkg"
      downloadURL=$(curl -fs "https://fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
-     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g'
+     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g')
      expectedTeamID="34LRP8AV2M"
      ;;

--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -2,6 +2,6 @@ fujifilmwebcam)
      name="FUJIFILM X Webcam 2"
      type="pkg"
      downloadURL=$(curl -fs "https://fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
-     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' )
+     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g'
      expectedTeamID="34LRP8AV2M"
      ;;


### PR DESCRIPTION
ran test with `sudo ./assemble.sh fujifilmwebcam NOTIFY=silent DEBUG=0`

Log output for install:
```
2022-06-28 15:40:46 : WARN  : fujifilmwebcam : setting variable from argument NOTIFY=silent
2022-06-28 15:40:47 : WARN  : fujifilmwebcam : setting variable from argument DEBUG=0
2022-06-28 15:40:47 : REQ   : fujifilmwebcam : ################## Start Installomator v. 10.0beta, date 2022-06-28
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : ################## Version: 10.0beta
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : ################## Date: 2022-06-28
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : ################## fujifilmwebcam
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : BLOCKING_PROCESS_ACTION=tell_user
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : NOTIFY=silent
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : LOGGING=INFO
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : Label type: pkg
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : archiveName: FUJIFILM X Webcam 2.pkg
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : no blocking processes defined, using FUJIFILM X Webcam 2 as default
2022-06-28 15:40:47 : INFO  : fujifilmwebcam : name: FUJIFILM X Webcam 2, appName: FUJIFILM X Webcam 2.app
2022-06-28 15:40:48 : WARN  : fujifilmwebcam : No previous app found
2022-06-28 15:40:48 : WARN  : fujifilmwebcam : could not find FUJIFILM X Webcam 2.app
2022-06-28 15:40:48 : INFO  : fujifilmwebcam : appversion:
2022-06-28 15:40:48 : INFO  : fujifilmwebcam : Latest version of FUJIFILM X Webcam 2 is “https://dl.fujifilm-x.com/support/software/x-webcam-mac210-z0lr203j/XWebcamIns210.pkg”
2022-06-28 15:40:48 : REQ   : fujifilmwebcam : Downloading https://dl.fujifilm-x.com/support/software/x-webcam-mac210-z0lr203j/XWebcamIns210.pkg to FUJIFILM X Webcam 2.pkg
2022-06-28 15:40:50 : REQ   : fujifilmwebcam : no more blocking processes, continue with update
2022-06-28 15:40:50 : REQ   : fujifilmwebcam : Installing FUJIFILM X Webcam 2
2022-06-28 15:40:50 : INFO  : fujifilmwebcam : Verifying: FUJIFILM X Webcam 2.pkg
2022-06-28 15:40:51 : INFO  : fujifilmwebcam : Team ID: 34LRP8AV2M (expected: 34LRP8AV2M )
2022-06-28 15:40:51 : INFO  : fujifilmwebcam : Installing FUJIFILM X Webcam 2.pkg to /
2022-06-28 15:40:57 : DEBUG : fujifilmwebcam : Last Log repeated 2 times
2022-06-28 15:40:57 : INFO  : fujifilmwebcam : Finishing...
2022-06-28 15:41:07 : INFO  : fujifilmwebcam : App(s) found: /Applications/FUJIFILM X Webcam 2.app
2022-06-28 15:41:07 : INFO  : fujifilmwebcam : found app at /Applications/FUJIFILM X Webcam 2.app, version 2.1, on versionKey CFBundleShortVersionString
2022-06-28 15:41:07 : REQ   : fujifilmwebcam : Installed FUJIFILM X Webcam 2, version 2.1
2022-06-28 15:41:07 : INFO  : fujifilmwebcam : App not closed, so no reopen.
2022-06-28 15:41:07 : REQ   : fujifilmwebcam : All done!
2022-06-28 15:41:07 : REQ   : fujifilmwebcam : ################## End Installomator, exit code 0
```

attempting reinstall on top of previous install: 
```
2022-06-28 16:45:22 : WARN  : fujifilmwebcam : setting variable from argument NOTIFY=silent
2022-06-28 16:45:22 : WARN  : fujifilmwebcam : setting variable from argument DEBUG=0
2022-06-28 16:45:22 : REQ   : fujifilmwebcam : ################## Start Installomator v. 10.0beta, date 2022-06-28
2022-06-28 16:45:22 : INFO  : fujifilmwebcam : ################## Version: 10.0beta
2022-06-28 16:45:22 : INFO  : fujifilmwebcam : ################## Date: 2022-06-28
2022-06-28 16:45:22 : INFO  : fujifilmwebcam : ################## fujifilmwebcam
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : BLOCKING_PROCESS_ACTION=tell_user
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : NOTIFY=silent
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : LOGGING=INFO
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : Label type: pkg
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : archiveName: FUJIFILM X Webcam 2.pkg
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : no blocking processes defined, using FUJIFILM X Webcam 2 as default
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : App(s) found: /Applications/FUJIFILM X Webcam 2.app
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : found app at /Applications/FUJIFILM X Webcam 2.app, version 2.1, on versionKey CFBundleShortVersionString
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : appversion: 2.1
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : Latest version of FUJIFILM X Webcam 2 is 2.1
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : There is no newer version available.
2022-06-28 16:45:23 : INFO  : fujifilmwebcam : App not closed, so no reopen.
2022-06-28 16:45:23 : REQ   : fujifilmwebcam : No newer version.
2022-06-28 16:45:23 : REQ   : fujifilmwebcam : ################## End Installomator, exit code 0
```


Might consider leaving out appnewversion due to the app version naming in the package name