### PR TITLE
New Label: Parallels Client

### DIFF
--- a/fragments/labels/parallelsrasclient sh
+++ b/fragments/labels/parallelsrasclient sh
@@ -1,4 +1,4 @@
-rasclient)
+parallelsrasclient)
     name="Parallels Client"
     type="pkg"
     appNewVersion=$(curl -sf "https://download.parallels.com/ras/v18/RAS%20Client%20for%20Mac%20Changelog.txt" | grep -m 1 "Parallels Client for Mac Version" | sed "s|.*Version \(.*\) -.*|\\1|" | sed 's/ /./g' | sed 's/[^0-9.]//g')

--- a/fragments/labels/rasclient.sh
+++ b/fragments/labels/rasclient.sh
@@ -1,0 +1,7 @@
+rasclient)
+    name="Parallels Client"
+    type="pkg"
+    appNewVersion=$(curl -sf "https://download.parallels.com/ras/v18/RAS%20Client%20for%20Mac%20Changelog.txt" | grep -m 1 "Parallels Client for Mac Version" | sed "s|.*Version \(.*\) -.*|\\1|" | sed 's/ /./g' | sed 's/[^0-9.]//g')
+    downloadURL=$(appMajorVersion=`sed 's/\..*//' <<< $appNewVersion` && appHyphenVersion=`curl -sf "https://download.parallels.com/ras/v18/RAS%20Client%20for%20Mac%20Changelog.txt" | grep -m 1 "Parallels Client for Mac Version" | sed "s|.*Version \(.*\) -.*|\\1|" | sed 's/ /-/g' | sed 's/[^0-9.-]//g'` && echo https://download.parallels.com/ras/v"$appMajorVersion"/"$appNewVersion"/RasClient-Mac-Notarized-"$appHyphenVersion".pkg)
+    expectedTeamID="4C6364ACXT"
+    ;;


### PR DESCRIPTION
"Access Windows Applications, Desktops, or Data on Any Device

Parallels® Client is a lightweight software that enables end-users to securely access virtual applications and desktops from Windows, Mac, Linux, iOS/iPadOS, Android, Google Chromebook and any HTML5 web browser."

./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels rasclient NOTIFY=silent DEBUG=0
Password:
2022-07-04 12:59:53 : WARN  : rasclient : setting variable from argument NOTIFY=silent
2022-07-04 12:59:53 : WARN  : rasclient : setting variable from argument DEBUG=0
2022-07-04 12:59:53 : REQ   : rasclient : ################## Start Installomator v. 10.0beta, date 2022-07-04
2022-07-04 12:59:53 : INFO  : rasclient : ################## Version: 10.0beta
2022-07-04 12:59:53 : INFO  : rasclient : ################## Date: 2022-07-04
2022-07-04 12:59:53 : INFO  : rasclient : ################## rasclient
2022-07-04 12:59:53 : INFO  : rasclient : BLOCKING_PROCESS_ACTION=tell_user
2022-07-04 12:59:53 : INFO  : rasclient : NOTIFY=silent
2022-07-04 12:59:53 : INFO  : rasclient : LOGGING=INFO
2022-07-04 12:59:53 : INFO  : rasclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-04 12:59:53 : INFO  : rasclient : Label type: pkg
2022-07-04 12:59:53 : INFO  : rasclient : archiveName: Parallels Client.pkg
2022-07-04 12:59:53 : INFO  : rasclient : no blocking processes defined, using Parallels Client as default
2022-07-04 12:59:53 : INFO  : rasclient : App(s) found: /Applications/Parallels Client.app
2022-07-04 12:59:53 : INFO  : rasclient : found app at /Applications/Parallels Client.app, version 18.3.22907, on versionKey CFBundleShortVersionString
2022-07-04 12:59:53 : INFO  : rasclient : appversion: 18.3.22907
2022-07-04 12:59:53 : INFO  : rasclient : Latest version of Parallels Client is 18.3.1.22907
2022-07-04 12:59:53 : REQ   : rasclient : Downloading https://download.parallels.com/ras/v18/18.3.1.22907/RasClient-Mac-Notarized-18.3.1-22907.pkg to Parallels Client.pkg
2022-07-04 12:59:55 : REQ   : rasclient : no more blocking processes, continue with update
2022-07-04 12:59:55 : REQ   : rasclient : Installing Parallels Client
2022-07-04 12:59:55 : INFO  : rasclient : Verifying: Parallels Client.pkg
2022-07-04 12:59:55 : INFO  : rasclient : Team ID: 4C6364ACXT (expected: 4C6364ACXT )
2022-07-04 12:59:55 : INFO  : rasclient : Installing Parallels Client.pkg to /
2022-07-04 13:00:02 : INFO  : rasclient : Finishing...
2022-07-04 13:00:12 : INFO  : rasclient : App(s) found: /Applications/Parallels Client.app
2022-07-04 13:00:12 : INFO  : rasclient : found app at /Applications/Parallels Client.app, version 18.3.22907, on versionKey CFBundleShortVersionString
2022-07-04 13:00:12 : REQ   : rasclient : Installed Parallels Client, version 18.3.22907
2022-07-04 13:00:12 : INFO  : rasclient : App not closed, so no reopen.
2022-07-04 13:00:12 : REQ   : rasclient : All done!
2022-07-04 13:00:12 : REQ   : rasclient : ################## End Installomator, exit code 0