### PR TITLE
New Label: Java SE Development Kit 18

### DIFF
--- a/fragments/labels/jdk18.sh
+++ b/fragments/labels/jdk18.sh
@@ -1,0 +1,13 @@
+jdk18)
+    name="Java SE Development Kit 18"
+    type="pkgInDmg"
+    versionKey="CFBundleShortVersionString"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.oracle.com/java/18/latest/jdk-18_macos-aarch64_bin.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.oracle.com/java/18/latest/jdk-18_macos-x64_bin.dmg"
+    fi
+    appCustomVersion(){ java --version | grep java | awk '{print $2}' }
+    appNewVersion=$(curl -sf "https://www.oracle.com/java/technologies/downloads/#jdk18-mac" | grep -m 1 "Java SE Development Kit" | sed "s|.*Kit \(.*\) downloads.*|\\1|")
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels jdk18
2022-07-04 13:21:27 : REQ   : jdk18 : ################## Start Installomator v. 10.0beta, date 2022-07-04
2022-07-04 13:21:27 : INFO  : jdk18 : ################## Version: 10.0beta
2022-07-04 13:21:27 : INFO  : jdk18 : ################## Date: 2022-07-04
2022-07-04 13:21:27 : INFO  : jdk18 : ################## jdk18
2022-07-04 13:21:27 : DEBUG : jdk18 : DEBUG mode 1 enabled.
2022-07-04 13:21:27 : INFO  : jdk18 : BLOCKING_PROCESS_ACTION=tell_user
2022-07-04 13:21:27 : INFO  : jdk18 : NOTIFY=success
2022-07-04 13:21:27 : INFO  : jdk18 : LOGGING=DEBUG
2022-07-04 13:21:28 : INFO  : jdk18 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-04 13:21:28 : INFO  : jdk18 : Label type: pkgInDmg
2022-07-04 13:21:28 : INFO  : jdk18 : archiveName: Java SE Development Kit 18.dmg
2022-07-04 13:21:28 : INFO  : jdk18 : no blocking processes defined, using Java SE Development Kit 18 as default
2022-07-04 13:21:28 : DEBUG : jdk18 : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-07-04 13:21:28 : INFO  : jdk18 : Custom App Version detection is used, found 18.0.1.1
2022-07-04 13:21:28 : INFO  : jdk18 : appversion: 18.0.1.1
2022-07-04 13:21:28 : INFO  : jdk18 : Latest version of Java SE Development Kit 18 is 18.0.1.1
2022-07-04 13:21:28 : WARN  : jdk18 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-07-04 13:21:28 : REQ   : jdk18 : Downloading https://download.oracle.com/java/18/latest/jdk-18_macos-x64_bin.dmg to Java SE Development Kit 18.dmg
2022-07-04 13:21:53 : DEBUG : jdk18 : File list: -rw-r--r--  1 savvas  staff   170M  4 Jul 13:21 Java SE Development Kit 18.dmg
2022-07-04 13:21:53 : DEBUG : jdk18 : File type: Java SE Development Kit 18.dmg: zlib compressed data
2022-07-04 13:21:53 : DEBUG : jdk18 : curl output was:
*   Trying 104.76.200.85:443...
* Connected to download.oracle.com (104.76.200.85) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2926 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Oracle Corporation; CN=download.oracle.com
*  start date: Sep 13 00:00:00 2021 GMT
*  expire date: Sep 13 23:59:59 2022 GMT
*  subjectAltName: host "download.oracle.com" matched cert's "download.oracle.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert SHA2 Secure Server CA
*  SSL certificate verify ok.
> GET /java/18/latest/jdk-18_macos-x64_bin.dmg HTTP/1.1
> Host: download.oracle.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AkamaiNetStorage
< Last-Modified: Tue, 26 Apr 2022 18:40:47 GMT
< ETag: "a5314d086c18af3e93121e11fc25f5af:1650998873.170204"
< Content-Length: 178108545
< Date: Mon, 04 Jul 2022 11:21:28 GMT
< Connection: keep-alive
<
{ [16083 bytes data]
* Connection #0 to host download.oracle.com left intact

2022-07-04 13:21:53 : DEBUG : jdk18 : DEBUG mode 1, not checking for blocking processes
2022-07-04 13:21:53 : REQ   : jdk18 : Installing Java SE Development Kit 18
2022-07-04 13:21:53 : INFO  : jdk18 : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/Java SE Development Kit 18.dmg
2022-07-04 13:21:56 : DEBUG : jdk18 : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $A63E199D
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $4CAA2C48
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $D15A79FE
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $0F56211E
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $D15A79FE
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $D36773E6
Die überprüfte CRC32-Prüfsumme ist $EF324497
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/JDK 18.0.1.1

2022-07-04 13:21:56 : INFO  : jdk18 : Mounted: /Volumes/JDK 18.0.1.1
2022-07-04 13:21:56 : DEBUG : jdk18 : Found pkg(s):
/Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg
2022-07-04 13:21:56 : INFO  : jdk18 : found pkg: /Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg
2022-07-04 13:21:56 : INFO  : jdk18 : Verifying: /Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg
2022-07-04 13:21:56 : DEBUG : jdk18 : File list: -rw-r--r--  1 savvas  staff   171M 25 Apr 23:09 /Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg
2022-07-04 13:21:56 : DEBUG : jdk18 : File type: /Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg: xar archive compressed TOC: 5557, SHA-1 checksum
2022-07-04 13:21:56 : DEBUG : jdk18 : spctlOut is /Volumes/JDK 18.0.1.1/JDK 18.0.1.1.pkg: accepted
2022-07-04 13:21:56 : DEBUG : jdk18 : source=Notarized Developer ID
2022-07-04 13:21:56 : DEBUG : jdk18 : origin=Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
2022-07-04 13:21:56 : INFO  : jdk18 : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2022-07-04 13:21:56 : DEBUG : jdk18 : DEBUG enabled, skipping installation
2022-07-04 13:21:56 : INFO  : jdk18 : Finishing...
2022-07-04 13:22:06 : INFO  : jdk18 : Custom App Version detection is used, found 18.0.1.1
2022-07-04 13:22:06 : REQ   : jdk18 : Installed Java SE Development Kit 18, version 18.0.1.1
2022-07-04 13:22:06 : INFO  : jdk18 : notifying
2022-07-04 13:22:06 : DEBUG : jdk18 : Unmounting /Volumes/JDK 18.0.1.1
2022-07-04 13:22:07 : DEBUG : jdk18 : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-07-04 13:22:07 : DEBUG : jdk18 : DEBUG mode 1, not reopening anything
2022-07-04 13:22:07 : REQ   : jdk18 : All done!
2022-07-04 13:22:07 : REQ   : jdk18 : ################## End Installomator, exit code 0