### PR TITLE
New Label: Filemaker Pro

### DIFF
--- a/fragments/labels/filemakerpro.sh
+++ b/fragments/labels/filemakerpro.sh
@@ -1,0 +1,8 @@
+filemakerpro)
+    name="FileMaker Pro"
+    type="dmg"
+    versionKey="BuildVersion"
+    downloadURL=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO..MAC\"' | tail -1 | sed "s|.*url\":\"\(.*\)\".*|\\1|")
+    appNewVersion=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO..MAC\"' | tail -1 | sed "s|.*fmp_\(.*\).dmg.*|\\1|")
+    expectedTeamID="J6K4T76U7W"
+    ;;


### PR DESCRIPTION
"FileMaker is a cross-platform relational database application from Claris International, a subsidiary of Apple Inc. It integrates a database engine with a graphical user interface (GUI) and security features, allowing users to modify a database by dragging new elements into layouts, screens, or forms. It is available in desktop, server, iOS and web-delivery configurations"

./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels filemakerpro
2022-07-04 15:35:36 : REQ   : filemakerpro : ################## Start Installomator v. 10.0beta, date 2022-07-04
2022-07-04 15:35:36 : INFO  : filemakerpro : ################## Version: 10.0beta
2022-07-04 15:35:36 : INFO  : filemakerpro : ################## Date: 2022-07-04
2022-07-04 15:35:36 : INFO  : filemakerpro : ################## filemakerpro
2022-07-04 15:35:37 : DEBUG : filemakerpro : DEBUG mode 1 enabled.
2022-07-04 15:35:37 : INFO  : filemakerpro : BLOCKING_PROCESS_ACTION=tell_user
2022-07-04 15:35:37 : INFO  : filemakerpro : NOTIFY=success
2022-07-04 15:35:37 : INFO  : filemakerpro : LOGGING=DEBUG
2022-07-04 15:35:37 : INFO  : filemakerpro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-04 15:35:37 : INFO  : filemakerpro : Label type: dmg
2022-07-04 15:35:37 : INFO  : filemakerpro : archiveName: FileMaker Pro.dmg
2022-07-04 15:35:37 : INFO  : filemakerpro : no blocking processes defined, using FileMaker Pro as default
2022-07-04 15:35:37 : DEBUG : filemakerpro : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build
2022-07-04 15:35:37 : INFO  : filemakerpro : App(s) found: /Applications/FileMaker Pro.app
2022-07-04 15:35:37 : INFO  : filemakerpro : found app at /Applications/FileMaker Pro.app, version 19.5.1.36, on versionKey BuildVersion
2022-07-04 15:35:37 : INFO  : filemakerpro : appversion: 19.5.1.36
2022-07-04 15:35:37 : INFO  : filemakerpro : Latest version of FileMaker Pro is 19.5.1.36
2022-07-04 15:35:37 : WARN  : filemakerpro : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-07-04 15:35:37 : INFO  : filemakerpro : FileMaker Pro.dmg exists and DEBUG mode 1 enabled, skipping download
2022-07-04 15:35:37 : DEBUG : filemakerpro : DEBUG mode 1, not checking for blocking processes
2022-07-04 15:35:37 : REQ   : filemakerpro : Installing FileMaker Pro
2022-07-04 15:35:37 : INFO  : filemakerpro : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main original/build/FileMaker Pro.dmg
2022-07-04 15:35:38 : DEBUG : filemakerpro : Debugging enabled, dmgmount output was:
Die erwartete CRC32-Prüfsumme ist $4150F8F9
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/FileMaker Pro 19

2022-07-04 15:35:38 : INFO  : filemakerpro : Mounted: /Volumes/FileMaker Pro 19
2022-07-04 15:35:38 : INFO  : filemakerpro : Verifying: /Volumes/FileMaker Pro 19/FileMaker Pro.app
2022-07-04 15:35:38 : DEBUG : filemakerpro : App size: 966M	/Volumes/FileMaker Pro 19/FileMaker Pro.app
2022-07-04 15:38:04 : DEBUG : filemakerpro : Debugging enabled, App Verification output was:
/Volumes/FileMaker Pro 19/FileMaker Pro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Claris International Inc. (J6K4T76U7W)

2022-07-04 15:38:04 : INFO  : filemakerpro : Team ID matching: J6K4T76U7W (expected: J6K4T76U7W )
2022-07-04 15:38:04 : INFO  : filemakerpro : Downloaded version of FileMaker Pro is 19.5.1.36 on versionKey BuildVersion, same as installed.
2022-07-04 15:38:04 : DEBUG : filemakerpro : Unmounting /Volumes/FileMaker Pro 19
2022-07-04 15:38:05 : DEBUG : filemakerpro : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-07-04 15:38:05 : DEBUG : filemakerpro : DEBUG mode 1, not reopening anything
2022-07-04 15:38:05 : REG   : filemakerpro : No new version to install
2022-07-04 15:38:05 : REQ   : filemakerpro : ################## End Installomator, exit code 0