### PR TITLE
New Label for Zulu JDK 18

### DIFF
--- a/fragments/labels/zulujdk18.sh
+++ b/fragments/labels/zulujdk18.sh
@@ -1,0 +1,13 @@
+zulujdk18)
+    name="Zulu JDK 18"
+    type="pkgInDmg"
+    packageID="com.azulsystems.zulu.18"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    fi
+    expectedTeamID="TDTHCUPYFR"
+    appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
+    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    ;;


### PR DESCRIPTION
New label for Zulu JDK 18. Test Deployment below;

./assemble.sh zulujdk18
2022-07-05 09:14:29 : REQ   : zulujdk18 : ################## Start Installomator v. 9.2, date 2022-07-05
2022-07-05 09:14:29 : INFO  : zulujdk18 : ################## Version: 9.2
2022-07-05 09:14:29 : INFO  : zulujdk18 : ################## Date: 2022-07-05
2022-07-05 09:14:29 : INFO  : zulujdk18 : ################## zulujdk18
2022-07-05 09:14:29 : DEBUG : zulujdk18 : DEBUG mode 1 enabled.
2022-07-05 09:14:30 : INFO  : zulujdk18 : BLOCKING_PROCESS_ACTION=tell_user
2022-07-05 09:14:30 : INFO  : zulujdk18 : NOTIFY=success
2022-07-05 09:14:30 : INFO  : zulujdk18 : LOGGING=DEBUG
2022-07-05 09:14:30 : INFO  : zulujdk18 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-05 09:14:30 : INFO  : zulujdk18 : Label type: pkgInDmg
2022-07-05 09:14:30 : INFO  : zulujdk18 : archiveName: Zulu JDK 18.dmg
2022-07-05 09:14:30 : INFO  : zulujdk18 : no blocking processes defined, using Zulu JDK 18 as default
2022-07-05 09:14:30 : DEBUG : zulujdk18 : Changing directory to /Users/john/Documents/Source/Installomator/build
2022-07-05 09:14:30 : INFO  : zulujdk18 : Custom App Version detection is used, found 18.30.11
2022-07-05 09:14:30 : INFO  : zulujdk18 : appversion: 18.30.11
2022-07-05 09:14:30 : INFO  : zulujdk18 : Latest version of Zulu JDK 18 is 18.30.11
2022-07-05 09:14:30 : WARN  : zulujdk18 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-07-05 09:14:30 : REQ   : zulujdk18 : Downloading https://cdn.azul.com/zulu/bin/zulu18.30.11-ca-jdk18.0.1-macosx_aarch64.dmg to Zulu JDK 18.dmg
2022-07-05 09:14:39 : DEBUG : zulujdk18 : File list: -rw-r--r--  1 john  staff   186M Jul  5 09:14 Zulu JDK 18.dmg
2022-07-05 09:14:39 : DEBUG : zulujdk18 : File type: Zulu JDK 18.dmg: bzip2 compressed data, block size = 100k
2022-07-05 09:14:39 : DEBUG : zulujdk18 : curl output was:
*   Trying 104.18.21.159:443...
* Connected to cdn.azul.com (104.18.21.159) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2325 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Apr  3 00:00:00 2022 GMT
*  expire date: Apr  3 23:59:59 2023 GMT
*  subjectAltName: host "cdn.azul.com" matched cert's "*.azul.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13d011400)
> GET /zulu/bin/zulu18.30.11-ca-jdk18.0.1-macosx_aarch64.dmg HTTP/2
> Host: cdn.azul.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
< HTTP/2 200
< date: Tue, 05 Jul 2022 13:14:30 GMT
< content-type: application/x-apple-diskimage
< content-length: 194730464
< last-modified: Fri, 22 Apr 2022 11:16:32 GMT
< etag: "b9b59e0-5dd3c5bdad2c8"
< cache-control: max-age=2592000
< expires: Wed, 06 Jul 2022 15:18:26 GMT
< vary: Origin
< cf-cache-status: HIT
< age: 2498164
< accept-ranges: bytes
< expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
< server: cloudflare
< cf-ray: 72605d35a87178d0-EWR
< alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
<
{ [1029 bytes data]
* Connection #0 to host cdn.azul.com left intact

2022-07-05 09:14:39 : DEBUG : zulujdk18 : DEBUG mode 1, not checking for blocking processes
2022-07-05 09:14:39 : REQ   : zulujdk18 : Installing Zulu JDK 18
2022-07-05 09:14:39 : INFO  : zulujdk18 : Mounting /Users/john/Documents/Source/Installomator/build/Zulu JDK 18.dmg
2022-07-05 09:14:48 : DEBUG : zulujdk18 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8667CA94
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $997E8BC9
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $78938419
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $8B1E5839
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $78938419
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $F309C9FC
verified   CRC32 $FAED0B8A
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Azul Zulu JDK 18.30+11 1

2022-07-05 09:14:48 : INFO  : zulujdk18 : Mounted: /Volumes/Azul Zulu JDK 18.30+11 1
2022-07-05 09:14:48 : DEBUG : zulujdk18 : Found pkg(s):
/Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg
2022-07-05 09:14:48 : INFO  : zulujdk18 : found pkg: /Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg
2022-07-05 09:14:48 : INFO  : zulujdk18 : Verifying: /Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg
2022-07-05 09:14:48 : DEBUG : zulujdk18 : File list: -rw-r--r--  1 john  staff   183M Apr 21 12:16 /Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg
2022-07-05 09:14:48 : DEBUG : zulujdk18 : File type: /Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg: xar archive compressed TOC: 4884, SHA-1 checksum
2022-07-05 09:14:48 : DEBUG : zulujdk18 : spctlOut is /Volumes/Azul Zulu JDK 18.30+11 1/Double-Click to Install Azul Zulu JDK 18.pkg: accepted
2022-07-05 09:14:48 : DEBUG : zulujdk18 : source=Notarized Developer ID
2022-07-05 09:14:48 : DEBUG : zulujdk18 : origin=Developer ID Installer: Azul Systems, Inc. (TDTHCUPYFR)
2022-07-05 09:14:48 : INFO  : zulujdk18 : Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2022-07-05 09:14:48 : INFO  : zulujdk18 : Checking package version.
2022-07-05 09:14:55 : INFO  : zulujdk18 : Downloaded package com.azulsystems.zulu.18 version
2022-07-05 09:14:55 : DEBUG : zulujdk18 : DEBUG enabled, skipping installation
2022-07-05 09:14:55 : INFO  : zulujdk18 : Finishing...
2022-07-05 09:15:06 : INFO  : zulujdk18 : Custom App Version detection is used, found 18.30.11
2022-07-05 09:15:06 : REQ   : zulujdk18 : Installed Zulu JDK 18, version 18.30.11
2022-07-05 09:15:06 : INFO  : zulujdk18 : notifying
2022-07-05 09:15:06 : DEBUG : zulujdk18 : Unmounting /Volumes/Azul Zulu JDK 18.30+11 1
2022-07-05 09:15:07 : DEBUG : zulujdk18 : Debugging enabled, Unmounting output was:
"disk6" ejected.
2022-07-05 09:15:07 : DEBUG : zulujdk18 : DEBUG mode 1, not reopening anything
2022-07-05 09:15:07 : REQ   : zulujdk18 : All done!
2022-07-05 09:15:07 : REQ   : zulujdk18 : ################## End Installomator, exit code 0