### PR TITLE
relatel label

### DIFF
--- a/fragments/labels/relatel.sh
+++ b/fragments/labels/relatel.sh
@@ -1,0 +1,7 @@
+relatel)
+    name="Relatel"
+    type="dmg"
+    downloadURL="https://cdn.rela.tel/www/public/junotron/Relatel.dmg"
+    appNewVersion="$(curl -fs "https://cdn.firmafon.dk/www/public/junotron/latest-mac.yml" | grep -i "version" | cut -w -f2)"
+    expectedTeamID="B9358QF55B"
+    ;;

--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -1,0 +1,8 @@
+xcreds)
+    name="XCreds"
+    type="pkg"
+    packageID="com.twocanoes.pkg.secureremoteaccess"
+    downloadURL="$(downloadURLFromGit twocanoes xcreds)"
+    appNewVersion="$(versionFromGit twocanoes xcreds)"
+    expectedTeamID="UXP6YEHSPW"
+    ;;


### PR DESCRIPTION
Output from DEBUG mode and full installer (with force):
```
% Installomator/utils/assemble.sh relatel
2022-07-11 16:23:16 : REQ   : relatel : ################## Start Installomator v. 10.0beta, date 2022-07-11
2022-07-11 16:23:16 : INFO  : relatel : ################## Version: 10.0beta
2022-07-11 16:23:16 : INFO  : relatel : ################## Date: 2022-07-11
2022-07-11 16:23:16 : INFO  : relatel : ################## relatel
2022-07-11 16:23:16 : DEBUG : relatel : DEBUG mode 1 enabled.
2022-07-11 16:23:16 : INFO  : relatel : BLOCKING_PROCESS_ACTION=tell_user
2022-07-11 16:23:16 : INFO  : relatel : NOTIFY=success
2022-07-11 16:23:16 : INFO  : relatel : LOGGING=DEBUG
2022-07-11 16:23:16 : INFO  : relatel : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-11 16:23:16 : INFO  : relatel : Label type: dmg
2022-07-11 16:23:16 : INFO  : relatel : archiveName: Relatel.dmg
2022-07-11 16:23:16 : INFO  : relatel : no blocking processes defined, using Relatel as default
2022-07-11 16:23:16 : DEBUG : relatel : Changing directory to /Users/st/Documents/GitHub/Installomator/build
2022-07-11 16:23:16 : INFO  : relatel : App(s) found: /Applications/Relatel.app
2022-07-11 16:23:16 : INFO  : relatel : found app at /Applications/Relatel.app, version 1.3.1, on versionKey CFBundleShortVersionString
2022-07-11 16:23:16 : INFO  : relatel : appversion: 1.3.1
2022-07-11 16:23:16 : INFO  : relatel : Latest version of Relatel is 1.3.1
2022-07-11 16:23:16 : WARN  : relatel : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-07-11 16:23:16 : REQ   : relatel : Downloading https://cdn.rela.tel/www/public/junotron/Relatel.dmg to Relatel.dmg
2022-07-11 16:23:17 : DEBUG : relatel : File list: -rw-r--r--  1 aa  staff    83M Jul 11 16:23 Relatel.dmg
2022-07-11 16:23:17 : DEBUG : relatel : File type: Relatel.dmg: zlib compressed data
2022-07-11 16:23:17 : DEBUG : relatel : curl output was:
*   Trying 13.33.141.16:443...
* Connected to cdn.rela.tel (13.33.141.16) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4960 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=cdn.firmafon.dk
*  start date: Sep 29 00:00:00 2021 GMT
*  expire date: Oct 28 23:59:59 2022 GMT
*  subjectAltName: host "cdn.rela.tel" matched cert's "cdn.rela.tel"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x124810a00)
> GET /www/public/junotron/Relatel.dmg HTTP/2
> Host: cdn.rela.tel
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 301
< content-length: 0
< date: Mon, 11 Jul 2022 14:13:48 GMT
< location: /www/public/junotron/Relatel-1.3.1.dmg
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 7e5377bfdf5e6ef7597f63d6648e4e9a.cloudfront.net (CloudFront)
< x-amz-cf-pop: CPH50-C2
< x-amz-cf-id: thNWMtxDW2IJefosMKa0ESJTenG4AC9I5aZrCy-sTD9YSiGFtVRqgg==
< age: 569
<
{ [0 bytes data]
* Connection #0 to host cdn.rela.tel left intact
* Issue another request to this URL: 'https://cdn.rela.tel/www/public/junotron/Relatel-1.3.1.dmg'
* Found bundle for host cdn.rela.tel: 0x600001f207b0 [can multiplex]
* Re-using existing connection! (#0) with host cdn.rela.tel
* Connected to cdn.rela.tel (13.33.141.16) port 443 (#0)
* Using Stream ID: 3 (easy handle 0x124810a00)
> GET /www/public/junotron/Relatel-1.3.1.dmg HTTP/2
> Host: cdn.rela.tel
> user-agent: curl/7.79.1
> accept: */*
>
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 86919409
< date: Mon, 11 Jul 2022 14:13:48 GMT
< last-modified: Fri, 06 May 2022 12:35:41 GMT
< x-amz-version-id: efBkRS8bwIqXqI2Z6qnBgVxSZzwUHByN
< etag: "7d26b868f87f72b3fcee9788f1cd512d-6"
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 7e5377bfdf5e6ef7597f63d6648e4e9a.cloudfront.net (CloudFront)
< x-amz-cf-pop: CPH50-C2
< x-amz-cf-id: 4tPa-qwrw0EK3XG2vb6eQrC9cV8anQvW9yNcjKvgtWdXk_-3VjWkyA==
< age: 569
<
{ [2896 bytes data]
* Connection #0 to host cdn.rela.tel left intact

2022-07-11 16:23:17 : DEBUG : relatel : DEBUG mode 1, not checking for blocking processes
2022-07-11 16:23:17 : REQ   : relatel : Installing Relatel
2022-07-11 16:23:17 : INFO  : relatel : Mounting Relatel.dmg
2022-07-11 16:23:22 : DEBUG : relatel : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $B84BD009
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $06438A51
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $1232986F
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $D4C0AB37
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified CRC32 $1232986F
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified CRC32 $A2E62118
verified CRC32 $B53E5AB9
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Relatel 1.3.1

2022-07-11 16:23:22 : INFO  : relatel : Mounted: /Volumes/Relatel 1.3.1
2022-07-11 16:23:22 : INFO  : relatel : Verifying: /Volumes/Relatel 1.3.1/Relatel.app
2022-07-11 16:23:22 : DEBUG : relatel : App size: 195M	/Volumes/Relatel 1.3.1/Relatel.app
2022-07-11 16:23:23 : DEBUG : relatel : Debugging enabled, App Verification output was:
/Volumes/Relatel 1.3.1 1/Relatel.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Firmafon ApS (B9358QF55B)

2022-07-11 16:23:23 : INFO  : relatel : Team ID matching: B9358QF55B (expected: B9358QF55B )
2022-07-11 16:23:23 : INFO  : relatel : Downloaded version of Relatel is 1.3.1 on versionKey CFBundleShortVersionString, same as installed.
2022-07-11 16:23:23 : DEBUG : relatel : Unmounting /Volumes/Relatel 1.3.1
2022-07-11 16:23:24 : DEBUG : relatel : Debugging enabled, Unmounting output was:
"disk6" ejected.
2022-07-11 16:23:24 : DEBUG : relatel : DEBUG mode 1, not reopening anything
2022-07-11 16:23:24 : REG   : relatel : No new version to install
2022-07-11 16:23:24 : REQ   : relatel : ################## End Installomator, exit code 0

% sudo Installomator/utils/assemble.sh relatel DEBUG=0 INSTALL=force
Password:
2022-07-11 16:23:56 : WARN  : relatel : setting variable from argument DEBUG=0
2022-07-11 16:23:56 : WARN  : relatel : setting variable from argument INSTALL=force
2022-07-11 16:23:56 : REQ   : relatel : ################## Start Installomator v. 10.0beta, date 2022-07-11
2022-07-11 16:23:56 : INFO  : relatel : ################## Version: 10.0beta
2022-07-11 16:23:56 : INFO  : relatel : ################## Date: 2022-07-11
2022-07-11 16:23:56 : INFO  : relatel : ################## relatel
2022-07-11 16:23:56 : INFO  : relatel : BLOCKING_PROCESS_ACTION=tell_user
2022-07-11 16:23:56 : INFO  : relatel : NOTIFY=success
2022-07-11 16:23:56 : INFO  : relatel : LOGGING=INFO
2022-07-11 16:23:56 : INFO  : relatel : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-11 16:23:56 : INFO  : relatel : Label type: dmg
2022-07-11 16:23:56 : INFO  : relatel : archiveName: Relatel.dmg
2022-07-11 16:23:56 : INFO  : relatel : no blocking processes defined, using Relatel as default
2022-07-11 16:23:56 : INFO  : relatel : App(s) found: /Applications/Relatel.app
2022-07-11 16:23:56 : INFO  : relatel : found app at /Applications/Relatel.app, version 1.3.1, on versionKey CFBundleShortVersionString
2022-07-11 16:23:56 : INFO  : relatel : appversion: 1.3.1
2022-07-11 16:23:56 : INFO  : relatel : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-07-11 16:23:56 : INFO  : relatel : Latest version of Relatel is 1.3.1
2022-07-11 16:23:56 : INFO  : relatel : There is no newer version available.
2022-07-11 16:23:56 : REQ   : relatel : Downloading https://cdn.rela.tel/www/public/junotron/Relatel.dmg to Relatel.dmg
2022-07-11 16:23:57 : REQ   : relatel : no more blocking processes, continue with update
2022-07-11 16:23:57 : REQ   : relatel : Installing Relatel
2022-07-11 16:23:57 : INFO  : relatel : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.l86iLb4m/Relatel.dmg
2022-07-11 16:24:00 : INFO  : relatel : Mounted: /Volumes/Relatel 1.3.1
2022-07-11 16:24:00 : INFO  : relatel : Verifying: /Volumes/Relatel 1.3.1/Relatel.app
2022-07-11 16:24:01 : INFO  : relatel : Team ID matching: B9358QF55B (expected: B9358QF55B )
2022-07-11 16:24:01 : INFO  : relatel : Downloaded version of Relatel is 1.3.1 on versionKey CFBundleShortVersionString, same as installed.
2022-07-11 16:24:01 : INFO  : relatel : Using force to install anyway.
2022-07-11 16:24:01 : INFO  : relatel : App has LSMinimumSystemVersion: 10.11.0
2022-07-11 16:24:01 : WARN  : relatel : Removing existing /Applications/Relatel.app
2022-07-11 16:24:01 : INFO  : relatel : Copy /Volumes/Relatel 1.3.1/Relatel.app to /Applications
2022-07-11 16:24:02 : WARN  : relatel : Changing owner to aa
2022-07-11 16:24:02 : INFO  : relatel : Finishing...
2022-07-11 16:24:12 : INFO  : relatel : App(s) found: /Applications/Relatel.app
2022-07-11 16:24:12 : INFO  : relatel : found app at /Applications/Relatel.app, version 1.3.1, on versionKey CFBundleShortVersionString
2022-07-11 16:24:12 : REQ   : relatel : Installed Relatel, version 1.3.1
2022-07-11 16:24:12 : INFO  : relatel : notifying
2022-07-11 16:24:12 : INFO  : relatel : App not closed, so no reopen.
2022-07-11 16:24:12 : REQ   : relatel : All done!
2022-07-11 16:24:12 : REQ   : relatel : ################## End Installomator, exit code 0
```