### PR TITLE
santa and nomad are forced to ignore blocking

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3724,6 +3724,7 @@ nomad)
     downloadURL="https://files.nomad.menu/NoMAD.pkg"
     appNewVersion=$(curl -fs https://nomad.menu/support/ | grep "NoMAD Downloads" | sed -E 's/.*Current Version ([0-9\.]*)<.*/\1/g')
     expectedTeamID="VRPY9KHGX6"
+    blockingProcesses=( NONE )
     ;;
 nomadlogin)
     # credit: Søren Theilgaard (@theilgaard)
@@ -4248,6 +4249,7 @@ santa)
     downloadURL=$(downloadURLFromGit google santa)
     appNewVersion=$(versionFromGit google santa)
     expectedTeamID="EQHXZ8M8AV"
+    blockingProcesses=( NONE )
     ;;
 scaleft)
     name="ScaleFT"


### PR DESCRIPTION
Santa and NoMAD apps are forcibly restarted by the launch agent, resulting in infinite blocking process processing.