### PR TITLE
New Label: Archiware P5

### DIFF
--- a/fragments/labels/archiwarepst.sh
+++ b/fragments/labels/archiwarepst.sh
@@ -1,4 +1,4 @@
-awpst)
+archiwarepst)
     name="P5"
     type="pkgInDmg"
     packageID="com.archiware.presstore"

--- a/fragments/labels/awpst.sh
+++ b/fragments/labels/awpst.sh
@@ -1,0 +1,10 @@
+awpst)
+    name="P5"
+    type="pkgInDmg"
+    packageID="com.archiware.presstore"
+    appNewVersion=$(curl -sf https://www.archiware.com/download-p5 | grep -m 1 "ARCHIWARE P5 Version" | sed "s|.*Version \(.*\) -.*|\\1|")
+    downloadURL=$(appNrVersion=`sed 's/[^0-9]//g' <<< $appNewVersion` && echo https://p5-downloads.s3.amazonaws.com/awpst"$appNrVersion"-darwin.dmg)
+    pkgName=$(appNrVersion=`sed 's/[^0-9]//g' <<< $appNewVersion` && echo P5-"$appNrVersion"-Install.pkg)
+    expectedTeamID="5H5EU6F965"
+    # blockingProcesses=( nsd )
+    ;;


### PR DESCRIPTION
"Archiware's P5 Software Suite is ideal for businesses in the Media and Entertainment industry.
Four modules in the Archiware P5 Suite secure data using the A-B-C of data management: Archive, Backup and Cloning.
All modules can be combined to create multiple-step security concepts to achieve maximum data protection.
Archiware P5 secures data to disk, tape and cloud and has integrations with numerous partners."

sudo ./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels awpst NOTIFY=silent DEBUG=0
Password:
2022-07-13 17:46:07 : WARN  : awpst : setting variable from argument NOTIFY=silent
2022-07-13 17:46:07 : WARN  : awpst : setting variable from argument DEBUG=0
2022-07-13 17:46:07 : REQ   : awpst : ################## Start Installomator v. 10.0beta, date 2022-07-13
2022-07-13 17:46:07 : INFO  : awpst : ################## Version: 10.0beta
2022-07-13 17:46:07 : INFO  : awpst : ################## Date: 2022-07-13
2022-07-13 17:46:07 : INFO  : awpst : ################## awpst
2022-07-13 17:46:07 : INFO  : awpst : BLOCKING_PROCESS_ACTION=tell_user
2022-07-13 17:46:07 : INFO  : awpst : NOTIFY=silent
2022-07-13 17:46:07 : INFO  : awpst : LOGGING=INFO
2022-07-13 17:46:07 : INFO  : awpst : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-13 17:46:07 : INFO  : awpst : Label type: pkgInDmg
2022-07-13 17:46:07 : INFO  : awpst : archiveName: P5.dmg
2022-07-13 17:46:07 : INFO  : awpst : no blocking processes defined, using P5 as default
2022-07-13 17:46:07 : INFO  : awpst : found packageID com.archiware.presstore installed, version 7.0.6
2022-07-13 17:46:07 : INFO  : awpst : appversion: 7.0.6
2022-07-13 17:46:07 : INFO  : awpst : Latest version of P5 is 7.0.7
2022-07-13 17:46:07 : REQ   : awpst : Downloading https://p5-downloads.s3.amazonaws.com/awpst707-darwin.dmg to P5.dmg
2022-07-13 17:46:27 : REQ   : awpst : no more blocking processes, continue with update
2022-07-13 17:46:27 : REQ   : awpst : Installing P5
2022-07-13 17:46:27 : INFO  : awpst : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rwTUoQOZ/P5.dmg
2022-07-13 17:46:27 : INFO  : awpst : Mounted: /Volumes/P5-707
2022-07-13 17:46:27 : INFO  : awpst : found pkg: /Volumes/P5-707/P5-707-Install.pkg
2022-07-13 17:46:27 : INFO  : awpst : Verifying: /Volumes/P5-707/P5-707-Install.pkg
2022-07-13 17:46:28 : INFO  : awpst : Team ID: 5H5EU6F965 (expected: 5H5EU6F965 )
2022-07-13 17:46:28 : INFO  : awpst : Checking package version.
2022-07-13 17:46:28 : INFO  : awpst : Downloaded package com.archiware.presstore version
2022-07-13 17:46:28 : INFO  : awpst : Installing /Volumes/P5-707/P5-707-Install.pkg to /
2022-07-13 17:47:06 : INFO  : awpst : Finishing...
2022-07-13 17:47:16 : INFO  : awpst : found packageID com.archiware.presstore installed, version 7.0.7
2022-07-13 17:47:16 : REQ   : awpst : Installed P5, version 7.0.7
2022-07-13 17:47:16 : INFO  : awpst : App not closed, so no reopen.
2022-07-13 17:47:16 : REQ   : awpst : All done!
2022-07-13 17:47:16 : REQ   : awpst : ################## End Installomator, exit code 0