### PR TITLE
New Label: Archiware P5 Backup2Go

### DIFF
--- a/fragments/labels/archiwareb2go.sh
+++ b/fragments/labels/archiwareb2go.sh
@@ -1,4 +1,4 @@
-awb2go)
+archiwareb2go)
     name="P5 Workstation"
     type="pkgInDmg"
     packageID="com.archiware.presstore"

--- a/fragments/labels/awb2go.sh
+++ b/fragments/labels/awb2go.sh
@@ -1,0 +1,10 @@
+awb2go)
+    name="P5 Workstation"
+    type="pkgInDmg"
+    packageID="com.archiware.presstore"
+    appNewVersion=$(curl -sf https://www.archiware.com/download-p5 | grep -m 1 "ARCHIWARE P5 Version" | sed "s|.*Version \(.*\) -.*|\\1|")
+    downloadURL=$(appNrVersion=`sed 's/[^0-9]//g' <<< $appNewVersion` && echo https://p5-downloads.s3.amazonaws.com/awpst"$appNrVersion"-darwin.dmg)
+    pkgName=$(appNrVersion=`sed 's/[^0-9]//g' <<< $appNewVersion` && echo P5-Workstation-"$appNrVersion"-Install.pkg)
+    expectedTeamID="5H5EU6F965"
+    # blockingProcesses=( nsd )
+    ;;


### PR DESCRIPTION
"P5 Backup2Go is the ideal tool to backup workstations – regardless of their location.

In the office, on the road or at home, P5 works cross-platform and allows mobile backups of laptops and desktops on central disk storage."

sudo ./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels awb2go NOTIFY=silent DEBUG=0
2022-07-13 18:11:07 : WARN  : awb2go : setting variable from argument NOTIFY=silent
2022-07-13 18:11:07 : WARN  : awb2go : setting variable from argument DEBUG=0
2022-07-13 18:11:07 : REQ   : awb2go : ################## Start Installomator v. 10.0beta, date 2022-07-13
2022-07-13 18:11:07 : INFO  : awb2go : ################## Version: 10.0beta
2022-07-13 18:11:07 : INFO  : awb2go : ################## Date: 2022-07-13
2022-07-13 18:11:07 : INFO  : awb2go : ################## awb2go
2022-07-13 18:11:07 : INFO  : awb2go : BLOCKING_PROCESS_ACTION=tell_user
2022-07-13 18:11:07 : INFO  : awb2go : NOTIFY=silent
2022-07-13 18:11:07 : INFO  : awb2go : LOGGING=INFO
2022-07-13 18:11:07 : INFO  : awb2go : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-07-13 18:11:07 : INFO  : awb2go : Label type: pkgInDmg
2022-07-13 18:11:07 : INFO  : awb2go : archiveName: P5 Workstation.dmg
2022-07-13 18:11:07 : INFO  : awb2go : no blocking processes defined, using P5 Workstation as default
2022-07-13 18:11:08 : INFO  : awb2go : found packageID com.archiware.presstore installed, version 7.0.6
2022-07-13 18:11:08 : INFO  : awb2go : appversion: 7.0.6
2022-07-13 18:11:08 : INFO  : awb2go : Latest version of P5 Workstation is 7.0.7
2022-07-13 18:11:08 : REQ   : awb2go : Downloading https://p5-downloads.s3.amazonaws.com/awpst707-darwin.dmg to P5 Workstation.dmg
2022-07-13 18:11:27 : REQ   : awb2go : no more blocking processes, continue with update
2022-07-13 18:11:27 : REQ   : awb2go : Installing P5 Workstation
2022-07-13 18:11:27 : INFO  : awb2go : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lw7ac9Pw/P5 Workstation.dmg
2022-07-13 18:11:28 : INFO  : awb2go : Mounted: /Volumes/P5-707
2022-07-13 18:11:28 : INFO  : awb2go : found pkg: /Volumes/P5-707/B2Go-Workstation/P5-Workstation-707-Install.pkg
2022-07-13 18:11:28 : INFO  : awb2go : Verifying: /Volumes/P5-707/B2Go-Workstation/P5-Workstation-707-Install.pkg
2022-07-13 18:11:28 : INFO  : awb2go : Team ID: 5H5EU6F965 (expected: 5H5EU6F965 )
2022-07-13 18:11:28 : INFO  : awb2go : Checking package version.
2022-07-13 18:11:28 : INFO  : awb2go : Downloaded package com.archiware.presstore version
2022-07-13 18:11:28 : INFO  : awb2go : Installing /Volumes/P5-707/B2Go-Workstation/P5-Workstation-707-Install.pkg to /
2022-07-13 18:12:01 : INFO  : awb2go : Finishing...
2022-07-13 18:12:11 : INFO  : awb2go : found packageID com.archiware.presstore installed, version 7.0.7
2022-07-13 18:12:11 : REQ   : awb2go : Installed P5 Workstation, version 7.0.7
2022-07-13 18:12:12 : INFO  : awb2go : App not closed, so no reopen.
2022-07-13 18:12:12 : REQ   : awb2go : All done!
2022-07-13 18:12:12 : REQ   : awb2go : ################## End Installomator, exit code 0