### PR TITLE
Update to Alfred 5

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -1451,7 +1451,7 @@ alfred)
     type="dmg"
     downloadURL=$(curl -fs https://www.alfredapp.com | awk -F '"' "/dmg/ {print \$2}" | head -1)
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*Alfred_([0-9.]*)_.*/\1/')
-    appName="Alfred 4.app"
+    appName="Alfred 5.app"
     expectedTeamID="XZZXE9SED4"
     ;;
 alttab)


### PR DESCRIPTION
"downloadURL" variable regex pulls down the latest version of Alfred 5. Updated the "appName" variable to reflect the new app bundle name of "Alfred 5.app".