### PR TITLE
Add ARM version of Miro

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -3569,7 +3569,11 @@ miro)
     # credit: @matins
     name="Miro"
     type="dmg"
-    downloadURL="https://desktop.miro.com/platforms/darwin/Miro.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://desktop.miro.com/platforms/darwin-arm64/Miro.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://desktop.miro.com/platforms/darwin/Miro.dmg"
+    fi    
     expectedTeamID="M3GM7MFY7U"
     ;;
 mobikinassistantforandroid)


### PR DESCRIPTION
Recently Miro published ARM version of their desktop application. This changes enables download of a native ARM application on capable MacBook's.