### PR TITLE
Revert "New label: Google Ads Editor"

### DIFF
--- a/googleadseditor.sh
+++ b/googleadseditor.sh
@@ -1,7 +1,0 @@
-googleadseditor)
-    name="Google Ads Editor"
-    type="dmg"
-    downloadURL="https://dl.google.com/adwords_editor/google_ads_editor.dmg"
-    appNewVersion=""
-    expectedTeamID="EQHXZ8M8AV"
-    ;;


### PR DESCRIPTION
Reverts Installomator/Installomator#541, which was accidentally committed to the repo root and not to the fragments/labels folder.