### PR TITLE
don't reopen app on silent_fail

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -374,6 +374,7 @@ checkRunningProcesses() {
                       fi
                       ;;
                     silent_fail)
+                      appClosed=0
                       cleanupAndExit 12 "blocking process '$x' found, aborting" ERROR
                       ;;
                 esac


### PR DESCRIPTION
When calling silent_fail, we are not closing the app, so mark that the app was not closed. Then it will not reopen when cleanupAndExit calls reopenClosedProcess