### PR TITLE
Github fix in v10beta1, and label Cocoapods and bz2 compressed file support

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -160,7 +160,7 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
     if [ -n "$archiveName" ]; then
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*")
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*" | tail -1)
     else
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
         downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype")

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -160,10 +160,10 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
     if [ -n "$archiveName" ]; then
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName" | tail -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*$archiveName" | head -1)
     else
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype" | tail -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*\.$filetype" | head -1)
     fi
     if [ -z "$downloadURL" ]; then
         cleanupAndExit 14 "could not retrieve download URL for $gitusername/$gitreponame" ERROR

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -160,10 +160,10 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
     if [ -n "$archiveName" ]; then
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*$archiveName" | head -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*$archiveName" | head -1)
     else
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*\.$filetype" | head -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)
     fi
     if [ -z "$downloadURL" ]; then
         cleanupAndExit 14 "could not retrieve download URL for $gitusername/$gitreponame" ERROR

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -163,7 +163,7 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
         downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*" | tail -1)
     else
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype")
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype" | tail -1)
     fi
     if [ -z "$downloadURL" ]; then
         cleanupAndExit 14 "could not retrieve download URL for $gitusername/$gitreponame" ERROR

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -160,7 +160,7 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
     if [ -n "$archiveName" ]; then
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*" | tail -1)
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName" | tail -1)
     else
         #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
         downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype" | tail -1)

--- a/fragments/labels/cocoapods.sh
+++ b/fragments/labels/cocoapods.sh
@@ -1,0 +1,7 @@
+cocoapods)
+    name="CocoaPods"
+    type="bz2"
+    downloadURL="$(downloadURLFromGit CocoaPods CocoaPods-app)"
+    appNewVersion="$(versionFromGit CocoaPods CocoaPods-app)"
+    expectedTeamID="AX2Q2BH2XR"
+    ;;

--- a/fragments/labels/cocoapods.sh
+++ b/fragments/labels/cocoapods.sh
@@ -1,7 +1,6 @@
 cocoapods)
     name="CocoaPods"
     type="bz2"
-    archiveName="CocoaPods.app-[0-9.]*.tar.bz2"
     downloadURL="$(downloadURLFromGit CocoaPods CocoaPods-app)"
     appNewVersion="$(versionFromGit CocoaPods CocoaPods-app)"
     expectedTeamID="AX2Q2BH2XR"

--- a/fragments/labels/cocoapods.sh
+++ b/fragments/labels/cocoapods.sh
@@ -1,6 +1,7 @@
 cocoapods)
     name="CocoaPods"
     type="bz2"
+    archiveName="CocoaPods.app-[0-9.]*.tar.bz2"
     downloadURL="$(downloadURLFromGit CocoaPods CocoaPods-app)"
     appNewVersion="$(versionFromGit CocoaPods CocoaPods-app)"
     expectedTeamID="AX2Q2BH2XR"

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -75,7 +75,7 @@ printlog "Label type: $type" INFO
 # MARK: extract info from data
 if [ -z "$archiveName" ]; then
     case $type in
-        dmg|pkg|zip|tbz)
+        dmg|pkg|zip|tbz|bz2)
             archiveName="${name}.$type"
             ;;
         pkgInDmg)
@@ -101,7 +101,7 @@ fi
 
 if [ -z "$targetDir" ]; then
     case $type in
-        dmg|zip|tbz|app*)
+        dmg|zip|tbz|bz2|app*)
             targetDir="/Applications"
             ;;
         pkg*)
@@ -282,7 +282,7 @@ case $type in
     zip)
         installFromZIP
         ;;
-    tbz)
+    tbz|bz2)
         installFromTBZ
         ;;
     pkgInDmg)

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -15,6 +15,29 @@ fi
 
 # MARK: application download and installation starts here
 
+# Debug output of all variables in a label
+printlog "name=${name}" DEBUG
+printlog "appName=${appName}" DEBUG
+printlog "type=${type}" DEBUG
+printlog "archiveName=${archiveName}" DEBUG
+printlog "downloadURL=${downloadURL}" DEBUG
+printlog "curlOptions=${curlOptions}" DEBUG
+printlog "appNewVersion=${appNewVersion}" DEBUG
+printlog "appCustomVersion function: $(if type 'appCustomVersion' 2>/dev/null | grep -q 'function'; then echo "Defined. ${appCustomVersion}"; else; echo "Not defined"; fi)" DEBUG
+printlog "versionKey=${versionKey}" DEBUG
+printlog "packageID=${packageID}" DEBUG
+printlog "pkgName=${pkgName}" DEBUG
+printlog "choiceChangesXML=${choiceChangesXML}" DEBUG
+printlog "expectedTeamID=${expectedTeamID}" DEBUG
+printlog "blockingProcesses=${blockingProcesses}" DEBUG
+printlog "installerTool=${installerTool}" DEBUG
+printlog "CLIInstaller=${CLIInstaller}" DEBUG
+printlog "CLIArguments=${CLIArguments}" DEBUG
+printlog "updateTool=${updateTool}" DEBUG
+printlog "updateToolArguments=${updateToolArguments}" DEBUG
+printlog "updateToolRunAsCurrentUser=${updateToolRunAsCurrentUser}" DEBUG
+#printlog "Company=${Company}" DEBUG # Not used
+
 if [[ ${INTERRUPT_DND} = "no" ]]; then
     # Check if a fullscreen app is active
     if hasDisplaySleepAssertion; then

--- a/utils/buildLabel.sh
+++ b/utils/buildLabel.sh
@@ -265,7 +265,7 @@ echo "archivePath: $archivePath"
 # So we want to investigate which one has the filename
 try1archiveName=${${archiveTempName##*/}%%\?*}
 try2archiveName=${${archivePath##*/}%%\?*}
-fileName_re='^([a-zA-Z0-9\_.%-]*)\.(dmg|pkg|zip|tbz|gz)$' # regular expression for matching
+fileName_re='^([a-zA-Z0-9\_.%-]*)\.(dmg|pkg|zip|tbz|gz|bz2)$' # regular expression for matching
 if [[ "${try1archiveName}" =~ $fileName_re ]]; then
     archiveName=${try1archiveName}
 elif [[ "${try2archiveName}" =~ $fileName_re ]]; then
@@ -293,7 +293,7 @@ if [ "$archiveExt" = "pkg" ]; then
 elif [ "$archiveExt" = "dmg" ]; then
     echo "Diskimage found"
     dmgInvestigation
-elif [ "$archiveExt" = "zip" ] || [ "$archiveExt" = "tbz" ]; then
+elif [ "$archiveExt" = "zip" ] || [ "$archiveExt" = "tbz" ] || [ "$archiveExt" = "bz2" ]; then
     echo "Compressed file found"
     # unzip the archive
     tar -xf "$archiveName"

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -64,9 +64,9 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     #echo "$githubPart"
     #downloadURL="https://github.com/$gitusername/$gitreponame/releases/latest"
     if [ -n "$archiveName" ]; then
-        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*$archiveName" | head -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*$archiveName" | head -1)
     else
-        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*\.$filetype" | head -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)
     fi
     echo "$downloadURL"
     return 0
@@ -195,6 +195,7 @@ for fixedArch in i386 arm64; do
         
         #caseLabel
         if cat "${labels_dir}/${label}.sh" | grep -v -E '^[a-z0-9\_-]*(\)|\|\\)$' | grep -v ";;" > checkLabelCurrent.sh; then
+            INSTALL=force # This is only to prevent various Microsoft labels from running "msupdate --list"
             source checkLabelCurrent.sh
 
             echo "Name: $name"

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -63,7 +63,7 @@ versionFromGit() { # $1 git user name, $2 git repo name
     gitusername=${1?:"no git user name"}
     gitreponame=${2?:"no git repo name"}
     
-    appNewVersion=$(curl --silent --fail "https://github.com/$gitusername/$gitreponame/releases/latest" | sed -E 's/.*tag\/(.*)\">.*/\1/g' | sed 's/[^0-9\.]//g')
+    appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
     if [ -z "$appNewVersion" ]; then
         printlog "could not retrieve version number for $gitusername/$gitreponame: $appNewVersion"
         exit 9

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -52,13 +52,21 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     gitusername=${1?:"no git user name"}
     gitreponame=${2?:"no git repo name"}
     
+    if [[ $type == "pkgInDmg" ]]; then
+        filetype="dmg"
+    elif [[ $type == "pkgInZip" ]]; then
+        filetype="zip"
+    else
+        filetype=$type
+    fi
+
     #githubPart="$gitusername/$gitreponame/releases/download"
     #echo "$githubPart"
     #downloadURL="https://github.com/$gitusername/$gitreponame/releases/latest"
     if [ -n "$archiveName" ]; then
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName" | tail -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*$archiveName" | head -1)
     else
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$type" | tail -1)
+        downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "\/releases\/download\/.*\.$filetype" | head -1)
     fi
     echo "$downloadURL"
     return 0

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -54,7 +54,14 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     
     #githubPart="$gitusername/$gitreponame/releases/download"
     #echo "$githubPart"
-    downloadURL="https://github.com/$gitusername/$gitreponame/releases/latest"
+    #downloadURL="https://github.com/$gitusername/$gitreponame/releases/latest"
+    if [ -n "$archiveName" ]; then
+        #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*" | tail -1)
+    else
+        #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype" | tail -1)
+    fi
     echo "$downloadURL"
     return 0
 }
@@ -188,7 +195,7 @@ for fixedArch in i386 arm64; do
             echo "Download URL: $downloadURL"
             echo "Type: $type"
             case $type in
-                dmg|pkg|zip|tbz)
+                dmg|pkg|zip|tbz|bz2)
                     expectedExtension="$type"
                     ;;
                 pkgInDmg)

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -247,9 +247,6 @@ for fixedArch in i386 arm64; do
                         fi
                     else
                         githubPart="$(echo "$downloadURL" | cut -d "/" -f4-6)"
-                        echo "type: $type"
-                        echo "archiveName: $archiveName"
-                        echo "githubPart: $githubPart"
                         if [[ "$(curl -fsL "$downloadURL" | grep -io "${githubPart}.*\.${expectedExtension}")" != "" ]]; then
                             echo "${GREEN}OK: download extension MATCH on ${expectedExtension}${NC}"
                         else

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -56,11 +56,9 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     #echo "$githubPart"
     #downloadURL="https://github.com/$gitusername/$gitreponame/releases/latest"
     if [ -n "$archiveName" ]; then
-        #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName.*" | tail -1)
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*$archiveName" | tail -1)
     else
-        #downloadURL=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
-        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$filetype" | tail -1)
+        downloadURL=https://github.com$(curl -sL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -o "\/$gitusername\/$gitreponame.*\.$type" | tail -1)
     fi
     echo "$downloadURL"
     return 0
@@ -249,6 +247,9 @@ for fixedArch in i386 arm64; do
                         fi
                     else
                         githubPart="$(echo "$downloadURL" | cut -d "/" -f4-6)"
+                        echo "type: $type"
+                        echo "archiveName: $archiveName"
+                        echo "githubPart: $githubPart"
                         if [[ "$(curl -fsL "$downloadURL" | grep -io "${githubPart}.*\.${expectedExtension}")" != "" ]]; then
                             echo "${GREEN}OK: download extension MATCH on ${expectedExtension}${NC}"
                         else


### PR DESCRIPTION
Also a change to labels with `archiveName` where the `grep` will only return the last line with `tail -1` (this label is the first one to return two lines when `archiveName` is used).