### PR TITLE
label screamingfrogspider.sh fix, dmg per arch

### DIFF
--- a/fragments/labels/screamingfrogseospider.sh
+++ b/fragments/labels/screamingfrogseospider.sh
@@ -1,7 +1,12 @@
 screamingfrogseospider)
     name="Screaming Frog SEO Spider"
     type="dmg"
-    downloadURL=$(curl -fs "https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php" | grep -i -o "https.*\.dmg" | head -1)
+    if [[ $(arch) == i386 ]]; then
+        platform="Mac - (intel)"
+    elif [[ $(arch) == arm64 ]]; then
+        platform="Mac - (apple silicon)"
+    fi
+    downloadURL=$(curl -fs "https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php" | grep "${platform}" | grep -i -o "https.*\.dmg" | head -1)
     appNewVersion=$(print "$downloadURL" | sed -E 's/https.*\/[a-zA-Z]*-([0-9.]*)\.dmg/\1/g')".0"
     expectedTeamID="CAHEVC3HZC"
     ;;


### PR DESCRIPTION
ScreamingFrogSpider now has different dmg per CPU arch.
Download page provides 2 dmg links, therefore we must fix downloadURL grep