### PR TITLE
XCreds label

### DIFF
--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -1,0 +1,8 @@
+xcreds)
+    name="XCreds"
+    type="pkgInZip"
+    #packageID="com.twocanoes.pkg.secureremoteaccess"
+    downloadURL=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -ioE "https://.*\.zip" | head -1)
+    appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -io "Current Version:.*" | sed -E 's/.*XCreds *([0-9.]*)<.*/\1/g')
+    expectedTeamID="UXP6YEHSPW"
+    ;;

--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -1,8 +1,11 @@
 xcreds)
     name="XCreds"
-    type="pkgInZip"
+    #type="pkgInZip"
     #packageID="com.twocanoes.pkg.secureremoteaccess"
-    downloadURL=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -ioE "https://.*\.zip" | head -1)
-    appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -io "Current Version:.*" | sed -E 's/.*XCreds *([0-9.]*)<.*/\1/g')
+    #downloadURL=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -ioE "https://.*\.zip" | head -1)
+    #appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -io "Current Version:.*" | sed -E 's/.*XCreds *([0-9.]*)<.*/\1/g')
+    type="pkg"
+    downloadURL="$(downloadURLFromGit twocanoes xcreds)"
+    appNewVersion="$(versionFromGit twocanoes xcreds)"
     expectedTeamID="UXP6YEHSPW"
     ;;


### PR DESCRIPTION
```
% GitHub/Installomator-theile/utils/assemble.sh xcreds DEBUG=2
2022-09-01 13:00:21 : INFO  : xcreds : setting variable from argument DEBUG=2
2022-09-01 13:00:21 : REQ   : xcreds : ################## Start Installomator v. 10.0beta1, date 2022-09-01
2022-09-01 13:00:21 : INFO  : xcreds : ################## Version: 10.0beta1
2022-09-01 13:00:21 : INFO  : xcreds : ################## Date: 2022-09-01
2022-09-01 13:00:21 : INFO  : xcreds : ################## xcreds
2022-09-01 13:00:21 : DEBUG : xcreds : DEBUG mode 2 enabled.
2022-09-01 13:00:22 : INFO  : xcreds : BLOCKING_PROCESS_ACTION=tell_user
2022-09-01 13:00:22 : INFO  : xcreds : NOTIFY=success
2022-09-01 13:00:22 : INFO  : xcreds : LOGGING=DEBUG
2022-09-01 13:00:22 : INFO  : xcreds : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-09-01 13:00:22 : INFO  : xcreds : Label type: pkgInZip
2022-09-01 13:00:22 : INFO  : xcreds : archiveName: XCreds.zip
2022-09-01 13:00:22 : INFO  : xcreds : no blocking processes defined, using XCreds as default
2022-09-01 13:00:22 : DEBUG : xcreds : Changing directory to /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b
2022-09-01 13:00:22 : INFO  : xcreds : App(s) found: /Applications/XCreds.app
2022-09-01 13:00:22 : INFO  : xcreds : found app at /Applications/XCreds.app, version 1.0, on versionKey CFBundleShortVersionString
2022-09-01 13:00:22 : INFO  : xcreds : appversion: 1.0
2022-09-01 13:00:22 : INFO  : xcreds : Latest version of XCreds is 2.0
2022-09-01 13:00:22 : REQ   : xcreds : Downloading https://twocanoes-software-updates.s3.amazonaws.com/xcreds/XCreds2.zip to XCreds.zip
2022-09-01 13:00:22 : DEBUG : xcreds : No Dialog connection, just download
2022-09-01 13:00:23 : DEBUG : xcreds : File list: -rw-r--r--  1 st  staff   2,2M  1 Sep 13:00 XCreds.zip
2022-09-01 13:00:23 : DEBUG : xcreds : File type: XCreds.zip: Zip archive data, at least v2.0 to extract, compression method=store
2022-09-01 13:00:23 : DEBUG : xcreds : curl output was:
*   Trying 52.216.27.92:443...
* Connected to twocanoes-software-updates.s3.amazonaws.com (52.216.27.92) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [348 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [106 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4960 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Dec 15 00:00:00 2021 GMT
*  expire date: Dec  3 23:59:59 2022 GMT
*  subjectAltName: host "twocanoes-software-updates.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
*  SSL certificate verify ok.
> GET /xcreds/XCreds2.zip HTTP/1.1
> Host: twocanoes-software-updates.s3.amazonaws.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< x-amz-id-2: zpibNPiaMcUDxjERKPuwezj2NFmFylFdjsNCFRrAvu6wq13iFiatThxKgoRm4EOi6TLongUrdW8=
< x-amz-request-id: GEM1A4AV0HBMPPDT
< Date: Thu, 01 Sep 2022 11:00:23 GMT
< Last-Modified: Tue, 30 Aug 2022 22:26:04 GMT
< ETag: "fe639f47a7e6a07604165864755276f5"
< Accept-Ranges: bytes
< Content-Type: application/zip
< Server: AmazonS3
< Content-Length: 2323121
<
{ [7826 bytes data]
* Connection #0 to host twocanoes-software-updates.s3.amazonaws.com left intact

2022-09-01 13:00:23 : REQ   : xcreds : no more blocking processes, continue with update
2022-09-01 13:00:23 : REQ   : xcreds : Installing XCreds
2022-09-01 13:00:23 : INFO  : xcreds : Unzipping XCreds.zip
2022-09-01 13:00:23 : DEBUG : xcreds : Found pkg(s):
/var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg
2022-09-01 13:00:23 : INFO  : xcreds : found pkg: /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg
2022-09-01 13:00:23 : INFO  : xcreds : Verifying: /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg
updateDialog:26: no such file or directory:
2022-09-01 13:00:23 : DEBUG : xcreds : File list: -rw-r--r--@ 1 st  staff   2,2M 31 Aug 00:18 /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg
2022-09-01 13:00:23 : DEBUG : xcreds : File type: /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg: xar archive compressed TOC: 5980, SHA-1 checksum
2022-09-01 13:00:23 : DEBUG : xcreds : spctlOut is /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg: accepted
2022-09-01 13:00:23 : DEBUG : xcreds : source=Notarized Developer ID
2022-09-01 13:00:23 : DEBUG : xcreds : origin=Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)
2022-09-01 13:00:23 : INFO  : xcreds : Team ID: UXP6YEHSPW (expected: UXP6YEHSPW )
2022-09-01 13:00:23 : DEBUG : xcreds : Deleting /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b
2022-09-01 13:00:23 : DEBUG : xcreds : Debugging enabled, Deleting tmpDir output was:
/var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds.zip
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/XCreds_Build-3261_Version-2.0.pkg
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/xcreds_example_azure.mobileconfig
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/com.twocanoes.xcreds.plist
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2/xcreds_example_google.mobileconfig
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b/XCreds2
2022-09-01 13:00:23 : DEBUG : xcreds : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.FhnTIS2b
2022-09-01 13:00:23 : INFO  : xcreds : App not closed, so no reopen.
2022-09-01 13:00:23 : DEBUG : xcreds : DEBUG mode 2 enabled, exiting
2022-09-01 13:00:23 : REQ   : xcreds : ################## End Installomator, exit code 0
```