### PR TITLE
Swap Adobe URL parsing filter

### DIFF
--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -1,15 +1,19 @@
 adobecreativeclouddesktop)
     name="Adobe Creative Cloud"
-    #appName="Install.app"
     type="dmg"
+    if pgrep -q "Adobe Installer"; then
+        printlog "Adobe Installer is running, not a good time to update." WARN
+        printlog "################## End $APPLICATION \n\n" INFO
+        exit 75
+    fi
     adobeurl="https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html"
     if [[ $(arch) == "arm64" ]]; then
         downloadURL=$(curl -fs "$adobeurl" | xmllint -html -xpath "string(//a[contains(@href,'macarm64')][contains(text(),'Download')]/@href)" - 2> /dev/null)
     elif [[ $(arch) == "i386" ]]; then
         downloadURL=$(curl -fs "$adobeurl" | xmllint -html -xpath "string(//a[contains(@href,'osx10')][contains(text(),'Download')]/@href)" - 2> /dev/null)
     fi
-    #downloadURL=$(curl -fs "https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o "https*.*dmg" | head -1)
     appNewVersion=$(curl -fs "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html" | grep "mandatory" | head -1 | grep -o "Version *.* released" | cut -d " " -f2)
+    #appNewVersion=$(echo "$downloadURL" | grep -o '[^x]*$' | cut -d '.' -f 1 | sed 's/_/\./g')
     installerTool="Install.app"
     CLIInstaller="Install.app/Contents/MacOS/Install"
     CLIArguments=(--mode=silent)

--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -4,9 +4,9 @@ adobecreativeclouddesktop)
     type="dmg"
     adobeurl="https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -fs "$adobeurl" | xmllint -html -xpath "string(//a[contains(@href,'osx10')][contains(text(),'Download')]/@href)" - 2> /dev/null)
-    elif [[ $(arch) == "i386" ]]; then
         downloadURL=$(curl -fs "$adobeurl" | xmllint -html -xpath "string(//a[contains(@href,'macarm64')][contains(text(),'Download')]/@href)" - 2> /dev/null)
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fs "$adobeurl" | xmllint -html -xpath "string(//a[contains(@href,'osx10')][contains(text(),'Download')]/@href)" - 2> /dev/null)
     fi
     #downloadURL=$(curl -fs "https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o "https*.*dmg" | head -1)
     appNewVersion=$(curl -fs "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html" | grep "mandatory" | head -1 | grep -o "Version *.* released" | cut -d " " -f2)


### PR DESCRIPTION
The filters for ARM and Intel were swapped by accident, this correctly returns the ARM URL for ARM and Intel URL for Intel.