### PR TITLE
gfxCardStatus label

### DIFF
--- a/fragments/labels/gfxcardstatus.sh
+++ b/fragments/labels/gfxcardstatus.sh
@@ -1,0 +1,7 @@
+gfxcardstatus)
+    name="gfxCardStatus"
+    type="zip"
+    downloadURL="$(downloadURLFromGit codykrieger gfxCardStatus)"
+    appNewVersion="$(versionFromGit codykrieger gfxCardStatus)"
+    expectedTeamID="LF22FTQC25"
+    ;;


### PR DESCRIPTION
Text run:
```
% utils/assemble.sh gfxcardstatus DEBUG=2
2022-09-14 10:26:07 : INFO  : gfxcardstatus : setting variable from argument DEBUG=2
2022-09-14 10:26:07 : REQ   : gfxcardstatus : ################## Start Installomator v. 10.0beta3, date 2022-09-14
2022-09-14 10:26:07 : INFO  : gfxcardstatus : ################## Version: 10.0beta3
2022-09-14 10:26:07 : INFO  : gfxcardstatus : ################## Date: 2022-09-14
2022-09-14 10:26:07 : INFO  : gfxcardstatus : ################## gfxcardstatus
2022-09-14 10:26:07 : DEBUG : gfxcardstatus : DEBUG mode 2 enabled.
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : name=gfxCardStatus
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : appName=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : type=zip
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : archiveName=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : downloadURL=https://github.com/codykrieger/gfxCardStatus/releases/download/v2.5/gfxCardStatus-2.5.zip
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : curlOptions=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : appNewVersion=2.5
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : appCustomVersion function: Not defined
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : versionKey=CFBundleShortVersionString
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : packageID=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : pkgName=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : choiceChangesXML=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : expectedTeamID=LF22FTQC25
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : blockingProcesses=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : installerTool=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : CLIInstaller=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : CLIArguments=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : updateTool=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : updateToolArguments=
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : updateToolRunAsCurrentUser=
2022-09-14 10:26:08 : INFO  : gfxcardstatus : BLOCKING_PROCESS_ACTION=tell_user
2022-09-14 10:26:08 : INFO  : gfxcardstatus : NOTIFY=success
2022-09-14 10:26:08 : INFO  : gfxcardstatus : LOGGING=DEBUG
2022-09-14 10:26:08 : INFO  : gfxcardstatus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-09-14 10:26:08 : INFO  : gfxcardstatus : Label type: zip
2022-09-14 10:26:08 : INFO  : gfxcardstatus : archiveName: gfxCardStatus.zip
2022-09-14 10:26:08 : INFO  : gfxcardstatus : no blocking processes defined, using gfxCardStatus as default
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : Changing directory to /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6
2022-09-14 10:26:08 : INFO  : gfxcardstatus : name: gfxCardStatus, appName: gfxCardStatus.app
2022-09-14 10:26:08 : INFO  : gfxcardstatus : App(s) found: /Users/st/Downloads/2022-09-14-10-21-02/gfxCardStatus.app
2022-09-14 10:26:08 : WARN  : gfxcardstatus : could not determine location of gfxCardStatus.app
2022-09-14 10:26:08 : INFO  : gfxcardstatus : appversion:
2022-09-14 10:26:08 : INFO  : gfxcardstatus : Latest version of gfxCardStatus is 2.5
2022-09-14 10:26:08 : REQ   : gfxcardstatus : Downloading https://github.com/codykrieger/gfxCardStatus/releases/download/v2.5/gfxCardStatus-2.5.zip to gfxCardStatus.zip
2022-09-14 10:26:08 : DEBUG : gfxcardstatus : No Dialog connection, just download
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : File list: -rw-r--r--  1 st  staff   2,2M 14 Sep 10:26 gfxCardStatus.zip
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : File type: gfxCardStatus.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : curl output was:
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
…
* Connection #1 to host objects.githubusercontent.com left intact

2022-09-14 10:26:10 : REQ   : gfxcardstatus : no more blocking processes, continue with update
2022-09-14 10:26:10 : REQ   : gfxcardstatus : Installing gfxCardStatus
2022-09-14 10:26:10 : INFO  : gfxcardstatus : Unzipping gfxCardStatus.zip
2022-09-14 10:26:10 : INFO  : gfxcardstatus : Verifying: /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.app
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : App size: 5,5M	/var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.app
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : Debugging enabled, App Verification output was:
/var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Cody Krieger (LF22FTQC25)

2022-09-14 10:26:10 : INFO  : gfxcardstatus : Team ID matching: LF22FTQC25 (expected: LF22FTQC25 )
2022-09-14 10:26:10 : INFO  : gfxcardstatus : Installing gfxCardStatus version 2.5 on versionKey CFBundleShortVersionString.
2022-09-14 10:26:10 : INFO  : gfxcardstatus : App has LSMinimumSystemVersion: 10.9
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : DEBUG mode 2 enabled, not installing anything, exiting
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : Deleting /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : Debugging enabled, Deleting tmpDir output was:
/var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.app/Contents/CodeResources
…
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.app
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6/gfxCardStatus.zip
2022-09-14 10:26:10 : DEBUG : gfxcardstatus : /var/folders/gy/vrjt7sl52t9ghzn1lnttjtg40000gp/T/tmp.cR1129g6
2022-09-14 10:26:11 : INFO  : gfxcardstatus : App not closed, so no reopen.
2022-09-14 10:26:11 : INFO  : gfxcardstatus :
2022-09-14 10:26:11 : REQ   : gfxcardstatus : ################## End Installomator, exit code 0
```