### PR TITLE
Update OBS Label

### DIFF
--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -1,7 +1,12 @@
 obs)
-    # credit: Gabe Marchan (gabemarchan.com - @darklink87)
     name="OBS"
     type="dmg"
-    downloadURL=$(curl -fs "https://obsproject.com/download" | awk -F '"' "/dmg/ {print \$10}")
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="obs-studio-[0-9.]*-macos-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="obs-studio-[0-9.]*-macos-x86_64.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit obsproject obs-studio )
+    appNewVersion=$(versionFromGit obsproject obs-studio )
     expectedTeamID="2MMRE5MTB8"
     ;;


### PR DESCRIPTION
Current label does not work because of the ARM version download.
Updated label to use releases from GitHub
```
2022-09-14 16:23:44 : INFO  : obs : setting variable from argument DEBUG=0
2022-09-14 16:23:44 : INFO  : obs : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2022-09-14 16:23:44 : INFO  : obs : setting variable from argument INSTALL=force
2022-09-14 16:23:44 : REQ   : obs : ################## Start Installomator v. 10.0beta3, date 2022-09-14
2022-09-14 16:23:44 : INFO  : obs : ################## Version: 10.0beta3
2022-09-14 16:23:44 : INFO  : obs : ################## Date: 2022-09-14
2022-09-14 16:23:44 : INFO  : obs : ################## obs
2022-09-14 16:23:44 : INFO  : obs : SwiftDialog is not installed, clear cmd file var
2022-09-14 16:23:45 : INFO  : obs : BLOCKING_PROCESS_ACTION=kill
2022-09-14 16:23:45 : INFO  : obs : NOTIFY=success
2022-09-14 16:23:45 : INFO  : obs : LOGGING=INFO
2022-09-14 16:23:45 : INFO  : obs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-09-14 16:23:45 : INFO  : obs : Label type: dmg
2022-09-14 16:23:45 : INFO  : obs : archiveName: obs-studio-[0-9.]*-macos-x86_64.dmg
2022-09-14 16:23:45 : INFO  : obs : no blocking processes defined, using OBS as default
2022-09-14 16:23:45 : INFO  : obs : App(s) found: /Applications/OBS.app
2022-09-14 16:23:45 : INFO  : obs : found app at /Applications/OBS.app, version 27.2.4, on versionKey CFBundleShortVersionString
2022-09-14 16:23:45 : INFO  : obs : appversion: 27.2.4
2022-09-14 16:23:45 : INFO  : obs : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-09-14 16:23:45 : INFO  : obs : Latest version of OBS is 28.0.1
2022-09-14 16:23:45 : REQ   : obs : Downloading https://github.com/obsproject/obs-studio/releases/download/28.0.1/obs-studio-28.0.1-macos-x86_64.dmg to obs-studio-[0-9.]*-macos-x86_64.dmg
2022-09-14 16:23:47 : REQ   : obs : no more blocking processes, continue with update
2022-09-14 16:23:47 : REQ   : obs : Installing OBS
2022-09-14 16:23:47 : INFO  : obs : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZF35Ivic/obs-studio-[0-9.]*-macos-x86_64.dmg
2022-09-14 16:23:50 : INFO  : obs : Mounted: /Volumes/OBS-28.0.1-macOS-Intel
2022-09-14 16:23:50 : INFO  : obs : Verifying: /Volumes/OBS-28.0.1-macOS-Intel/OBS.app
2022-09-14 16:23:59 : INFO  : obs : Team ID matching: 2MMRE5MTB8 (expected: 2MMRE5MTB8 )
2022-09-14 16:23:59 : INFO  : obs : Downloaded version of OBS is 28.0.1 on versionKey CFBundleShortVersionString (replacing version 27.2.4).
2022-09-14 16:23:59 : INFO  : obs : App has LSMinimumSystemVersion: 10.15
2022-09-14 16:23:59 : WARN  : obs : Removing existing /Applications/OBS.app
2022-09-14 16:24:00 : INFO  : obs : Copy /Volumes/OBS-28.0.1-macOS-Intel/OBS.app to /Applications
2022-09-14 16:24:03 : WARN  : obs : Changing owner to user
2022-09-14 16:24:03 : INFO  : obs : Finishing...
2022-09-14 16:24:06 : INFO  : obs : App(s) found: /Applications/OBS.app
2022-09-14 16:24:06 : INFO  : obs : found app at /Applications/OBS.app, version 28.0.1, on versionKey CFBundleShortVersionString
2022-09-14 16:24:06 : REQ   : obs : Installed OBS, version 28.0.1
2022-09-14 16:24:06 : INFO  : obs : notifying
2022-09-14 16:24:07 : INFO  : obs : App not closed, so no reopen.
2022-09-14 16:24:07 : REQ   : obs : All done!
2022-09-14 16:24:07 : REQ   : obs : ################## End Installomator, exit code 0 
```