### PR TITLE
Update audacity label to check for arch

### DIFF
--- a/fragments/labels/audacity.sh
+++ b/fragments/labels/audacity.sh
@@ -1,7 +1,13 @@
 audacity)
     name="Audacity"
     type="dmg"
-    downloadURL=$(downloadURLFromGit audacity audacity)
+    if [[ $(arch) == "arm64" ]]; then
+      archiveName="audacity-macOS-[0-9.]*-arm64.dmg"
+      downloadURL=$(downloadURLFromGit audacity audacity)
+    elif [[ $(arch) == "i386" ]]; then
+      archiveName="audacity-macOS-[0-9.]*-x86_64.dmg"
+      downloadURL=$(downloadURLFromGit audacity audacity)
+    fi
     appNewVersion=$(versionFromGit audacity audacity)
     expectedTeamID="AWEYX923UX"
     ;;


### PR DESCRIPTION
previous version of label was downloading the arm64 version every time