### PR TITLE
IBM Notifier

### DIFF
--- a/fragments/labels/ibmnotifier.sh
+++ b/fragments/labels/ibmnotifier.sh
@@ -2,6 +2,7 @@ ibmnotifier)
     name="IBM Notifier"
     type="zip"
     downloadURL="$(downloadURLFromGit IBM mac-ibm-notifications)"
-    appNewVersion="$(versionFromGit IBM mac-ibm-notifications)"
+    #appNewVersion="$(versionFromGit IBM mac-ibm-notifications)"
+    appNewVersion="$(curl -sLI "https://github.com/IBM/mac-ibm-notifications/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | cut -d "-" -f2 | sed 's/[^0-9\.]//g')"
     expectedTeamID="PETKK2G752"
     ;;

--- a/fragments/labels/ibmnotifier.sh
+++ b/fragments/labels/ibmnotifier.sh
@@ -1,0 +1,7 @@
+ibmnotifier)
+    name="IBM Notifier"
+    type="zip"
+    downloadURL="$(downloadURLFromGit IBM mac-ibm-notifications)"
+    appNewVersion="$(versionFromGit IBM mac-ibm-notifications)"
+    expectedTeamID="PETKK2G752"
+    ;;


### PR DESCRIPTION
IBM for some reason is adding too much to the “tag” on Github, so they have “Version 2.9.1 Build 96” for the current latest version. That ends up being read as 2.9.196, and not only 2.9.1 that the app version is.

I upload this, so we have it ready, but not sure if `appNewVersion` should stay or be commented out.