### PR TITLE
Omit Label name when used with switftDialog

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -1018,7 +1018,7 @@ updateDialog() {
             echo "progress: $progress" >> $cmd_file
         fi
         if [[ $message != "" ]]; then
-            echo "progresstext: $name - $message" >> $cmd_file
+            echo "progresstext: $message" >> $cmd_file
         fi
     else
         # list item has a value, so we update the progress and text in the list


### PR DESCRIPTION
As [discussed on Slack](https://macadmins.slack.com/archives/C013HFTFQ13/p1665075829543569?thread_ts=1665075120.644189&cid=C013HFTFQ13), this change omits `$name - ` when used with swiftDialog.

<img width="507" alt="Screenshot 2022-10-06 at 10 58 47 AM" src="https://user-images.githubusercontent.com/24623109/194377732-263c096a-9802-403c-88f1-69940b50f94a.png">
