### PR TITLE
Add label for logitechoptionsplus.sh

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -1,0 +1,11 @@
+logitechoptionsplus)
+    name="Logi Options+"
+    archiveName="logioptionsplus_installer.zip"
+    appName="logioptionsplus_installer.app"
+    type="zip"
+    downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
+    CLIArguments=(--quiet)
+    expectedTeamID="QED4VVPZWA"
+    ;;


### PR DESCRIPTION
Add label for Logitech Options+ as requested in https://github.com/Installomator/Installomator/issues/683

test:


```
sudo ./assemble.sh -l /Users/bilal.habib/Desktop/downloads/ logitechoptionsplus DEBUG=0
2022-10-07 10:03:41 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=0
2022-10-07 10:03:41 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.0beta3, date 2022-10-07
2022-10-07 10:03:41 : INFO  : logitechoptionsplus : ################## Version: 10.0beta3
2022-10-07 10:03:41 : INFO  : logitechoptionsplus : ################## Date: 2022-10-07
2022-10-07 10:03:41 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : NOTIFY=success
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : LOGGING=INFO
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : Label type: zip
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : archiveName: logioptionsplus_installer.zip
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : name: Logi Options+, appName: logioptionsplus_installer.app
2022-10-07 10:03:42.456 mdfind[55939:868842] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2022-10-07 10:03:42.500 mdfind[55939:868842] Couldn't determine the mapping between prefab keywords and predicates.
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : App(s) found: /Users/bilal.habib/source/Installomator/build/logioptionsplus_installer.app/Library/Application Support/Logitech.localized/LogiOptionsPlus/logioptionsplus_agent.app
2022-10-07 10:03:42 : WARN  : logitechoptionsplus : could not determine location of logioptionsplus_installer.app
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : appversion:
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 1.24.2581
2022-10-07 10:03:42 : REQ   : logitechoptionsplus : Downloading https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip to logioptionsplus_installer.zip
2022-10-07 10:03:42 : REQ   : logitechoptionsplus : no more blocking processes, continue with update
2022-10-07 10:03:42 : REQ   : logitechoptionsplus : Installing Logi Options+
2022-10-07 10:03:42 : INFO  : logitechoptionsplus : Unzipping logioptionsplus_installer.zip
2022-10-07 10:03:43 : INFO  : logitechoptionsplus : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mSYSdLAj/logioptionsplus_installer.app
2022-10-07 10:03:43 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2022-10-07 10:03:43.459 defaults[56005:869006]
The domain/default pair of (/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mSYSdLAj/logioptionsplus_installer.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2022-10-07 10:03:43 : INFO  : logitechoptionsplus : Installing Logi Options+ version  on versionKey CFBundleShortVersionString.
2022-10-07 10:03:43 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 10.14
2022-10-07 10:03:43 : INFO  : logitechoptionsplus : CLIInstaller exists, running installer command /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mSYSdLAj/logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer --quiet
2022-10-07 10:04:03 : INFO  : logitechoptionsplus : Succesfully ran /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mSYSdLAj/logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer --quiet
2022-10-07 10:04:03 : INFO  : logitechoptionsplus : Finishing...
2022-10-07 10:04:06 : INFO  : logitechoptionsplus : name: Logi Options+, appName: logioptionsplus_installer.app
2022-10-07 10:04:06.464 mdfind[56082:870159] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2022-10-07 10:04:06.510 mdfind[56082:870159] Couldn't determine the mapping between prefab keywords and predicates.
2022-10-07 10:04:06 : INFO  : logitechoptionsplus : App(s) found: /Users/bilal.habib/source/Installomator/build/logioptionsplus_installer.app/Applications/logioptionsplus.app/Library/Application Support/Logitech.localized/LogiOptionsPlus/logioptionsplus_agent.app
2022-10-07 10:04:06 : INFO  : logitechoptionsplus : found app at /Applications/logioptionsplus.app, version 1.24.2581, on versionKey CFBundleShortVersionString
2022-10-07 10:04:06 : REQ   : logitechoptionsplus : Installed Logi Options+, version 1.24.2581
2022-10-07 10:04:06 : INFO  : logitechoptionsplus : notifying
2022-10-07 10:04:06 : INFO  : logitechoptionsplus : App not closed, so no reopen.
2022-10-07 10:04:06 : REQ   : logitechoptionsplus : All done!
2022-10-07 10:04:06 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0
```

![image](https://user-images.githubusercontent.com/22709115/194517485-1e80548b-79a8-4ed2-9a48-2b8c77ec199b.png)
