### PR TITLE
bbeditpkg (new label)

### DIFF
--- a/fragments/labels/bbeditpkg.sh
+++ b/fragments/labels/bbeditpkg.sh
@@ -1,0 +1,7 @@
+bbeditpkg)
+    name="BBEdit"
+    type="pkg"
+    downloadURL=$(curl -s https://versioncheck.barebones.com/BBEdit.xml | grep dmg | sort | tail -n1 | cut -d">" -f2 | cut -d"<" -f1 | sed 's/dmg/pkg/')
+    appNewVersion=$(curl -s https://versioncheck.barebones.com/BBEdit.xml | grep dmg | sort  | tail -n1 | sed -E 's/.*BBEdit_([0-9 .]*)\.dmg.*/\1/')
+    expectedTeamID="W52GZAXT98"
+    ;;


### PR DESCRIPTION
BareBones Software support mentioned that beneath the DMG a PKG for deployment purposes exists.

Result when not installed:
```
mac-yb √ Documents/GitHub > sudo Installomator/utils/assemble.sh bbeditpkg DEBUG=0          
2022-10-07 11:08:32 : INFO  : bbeditpkg : setting variable from argument DEBUG=0
2022-10-07 11:08:32 : REQ   : bbeditpkg : ################## Start Installomator v. 10.0beta3, date 2022-10-07
2022-10-07 11:08:32 : INFO  : bbeditpkg : ################## Version: 10.0beta3
2022-10-07 11:08:32 : INFO  : bbeditpkg : ################## Date: 2022-10-07
2022-10-07 11:08:32 : INFO  : bbeditpkg : ################## bbeditpkg
2022-10-07 11:08:32 : INFO  : bbeditpkg : SwiftDialog is not installed, clear cmd file var
2022-10-07 11:08:35 : INFO  : bbeditpkg : BLOCKING_PROCESS_ACTION=tell_user
2022-10-07 11:08:35 : INFO  : bbeditpkg : NOTIFY=success
2022-10-07 11:08:35 : INFO  : bbeditpkg : LOGGING=INFO
2022-10-07 11:08:35 : INFO  : bbeditpkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-07 11:08:35 : INFO  : bbeditpkg : Label type: pkg
2022-10-07 11:08:35 : INFO  : bbeditpkg : archiveName: BBEdit.pkg
2022-10-07 11:08:35 : INFO  : bbeditpkg : no blocking processes defined, using BBEdit as default
2022-10-07 11:08:35 : INFO  : bbeditpkg : name: BBEdit, appName: BBEdit.app
2022-10-07 11:08:35 : WARN  : bbeditpkg : No previous app found
2022-10-07 11:08:35 : WARN  : bbeditpkg : could not find BBEdit.app
2022-10-07 11:08:35 : INFO  : bbeditpkg : appversion: 
2022-10-07 11:08:35 : INFO  : bbeditpkg : Latest version of BBEdit is 14.6
2022-10-07 11:08:35 : REQ   : bbeditpkg : Downloading https://s3.amazonaws.com/BBSW-download/BBEdit_14.6.pkg to BBEdit.pkg
2022-10-07 11:08:37 : REQ   : bbeditpkg : no more blocking processes, continue with update
2022-10-07 11:08:37 : REQ   : bbeditpkg : Installing BBEdit
2022-10-07 11:08:37 : INFO  : bbeditpkg : Verifying: BBEdit.pkg
2022-10-07 11:08:38 : INFO  : bbeditpkg : Team ID: W52GZAXT98 (expected: W52GZAXT98 )
2022-10-07 11:08:38 : INFO  : bbeditpkg : Installing BBEdit.pkg to /
2022-10-07 11:08:42 : INFO  : bbeditpkg : Finishing...
2022-10-07 11:08:45 : INFO  : bbeditpkg : App(s) found: /Applications/BBEdit.app
2022-10-07 11:08:45 : INFO  : bbeditpkg : found app at /Applications/BBEdit.app, version 14.6, on versionKey CFBundleShortVersionString
2022-10-07 11:08:45 : REQ   : bbeditpkg : Installed BBEdit, version 14.6
2022-10-07 11:08:45 : INFO  : bbeditpkg : notifying
2022-10-07 11:08:45 : INFO  : bbeditpkg : App not closed, so no reopen.
2022-10-07 11:08:45 : REQ   : bbeditpkg : All done!
2022-10-07 11:08:45 : REQ   : bbeditpkg : ################## End Installomator, exit code 0
```

Result when existing:
```
mac-yb √ Documents/GitHub > sudo Installomator/utils/assemble.sh bbeditpkg DEBUG=0
2022-10-06 14:35:13 : INFO  : bbeditpkg : setting variable from argument DEBUG=0
2022-10-06 14:35:13 : REQ   : bbeditpkg : ################## Start Installomator v. 10.0beta3, date 2022-10-06
2022-10-06 14:35:13 : INFO  : bbeditpkg : ################## Version: 10.0beta3
2022-10-06 14:35:13 : INFO  : bbeditpkg : ################## Date: 2022-10-06
2022-10-06 14:35:13 : INFO  : bbeditpkg : ################## bbeditpkg
2022-10-06 14:35:13 : INFO  : bbeditpkg : SwiftDialog is not installed, clear cmd file var
2022-10-06 14:35:14 : INFO  : bbeditpkg : BLOCKING_PROCESS_ACTION=tell_user
2022-10-06 14:35:14 : INFO  : bbeditpkg : NOTIFY=success
2022-10-06 14:35:14 : INFO  : bbeditpkg : LOGGING=INFO
2022-10-06 14:35:14 : INFO  : bbeditpkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-06 14:35:15 : INFO  : bbeditpkg : Label type: pkg
2022-10-06 14:35:15 : INFO  : bbeditpkg : archiveName: BBEdit.pkg
2022-10-06 14:35:15 : INFO  : bbeditpkg : no blocking processes defined, using BBEdit as default
2022-10-06 14:35:15 : INFO  : bbeditpkg : App(s) found: /Applications/BBEdit.app
2022-10-06 14:35:15 : INFO  : bbeditpkg : found app at /Applications/BBEdit.app, version 14.6, on versionKey CFBundleShortVersionString
2022-10-06 14:35:15 : INFO  : bbeditpkg : appversion: 14.6
2022-10-06 14:35:15 : INFO  : bbeditpkg : Latest version of BBEdit is 14.6
2022-10-06 14:35:15 : INFO  : bbeditpkg : There is no newer version available.
2022-10-06 14:35:15 : INFO  : bbeditpkg : App not closed, so no reopen.
2022-10-06 14:35:15 : REQ   : bbeditpkg : No newer version.
2022-10-06 14:35:15 : REQ   : bbeditpkg : ################## End Installomator, exit code 0
```