### PR TITLE
Remove "archivename" as was causing invalid dmg

### DIFF
--- a/fragments/labels/drawio.sh
+++ b/fragments/labels/drawio.sh
@@ -1,7 +1,6 @@
 drawio)
     name="draw.io"
     type="dmg"
-    archiveName="draw.io-universal-[0-9.]*.dmg$"
     downloadURL="$(downloadURLFromGit jgraph drawio-desktop)"
     appNewVersion="$(versionFromGit jgraph drawio-desktop)"
     expectedTeamID="UZEUFB4N53"


### PR DESCRIPTION
At present the draw.io label fails:
2022-10-12 10:12:10 : REQ   : drawio : ################## Start Installomator v. 10.0beta3, date 2022-10-03
2022-10-12 10:12:10 : INFO  : drawio : ################## Version: 10.0beta3
2022-10-12 10:12:10 : INFO  : drawio : ################## Date: 2022-10-03
2022-10-12 10:12:10 : INFO  : drawio : ################## drawio
2022-10-12 10:12:10 : DEBUG : drawio : DEBUG mode 1 enabled.
2022-10-12 10:12:14 : DEBUG : drawio : name=draw.io
2022-10-12 10:12:14 : DEBUG : drawio : appName=
2022-10-12 10:12:14 : DEBUG : drawio : type=dmg
2022-10-12 10:12:14 : DEBUG : drawio : archiveName=draw.io-universal-[0-9.]*.dmg$
2022-10-12 10:12:14 : DEBUG : drawio : downloadURL=2022-10-12 10:12:11 : INFO  : drawio : GitHub API not returning URL, trying https://github.com/jgraph/drawio-desktop/releases/latest.
2022-10-12 10:12:14 : DEBUG : drawio : https://github.com/jgraph/drawio-desktop/releases/download/v20.3.0/draw.io-universal-20.3.0.dmg
2022-10-12 10:12:14 : DEBUG : drawio : curlOptions=
2022-10-12 10:12:14 : DEBUG : drawio : appNewVersion=20.3.0
2022-10-12 10:12:14 : DEBUG : drawio : appCustomVersion function: Not defined
2022-10-12 10:12:14 : DEBUG : drawio : versionKey=CFBundleShortVersionString
2022-10-12 10:12:14 : DEBUG : drawio : packageID=
2022-10-12 10:12:14 : DEBUG : drawio : pkgName=
2022-10-12 10:12:14 : DEBUG : drawio : choiceChangesXML=
2022-10-12 10:12:14 : DEBUG : drawio : expectedTeamID=UZEUFB4N53
2022-10-12 10:12:14 : DEBUG : drawio : blockingProcesses=draw.io
2022-10-12 10:12:14 : DEBUG : drawio : installerTool=
2022-10-12 10:12:15 : DEBUG : drawio : CLIInstaller=
2022-10-12 10:12:15 : DEBUG : drawio : CLIArguments=
2022-10-12 10:12:15 : DEBUG : drawio : updateTool=
2022-10-12 10:12:15 : DEBUG : drawio : updateToolArguments=
2022-10-12 10:12:15 : DEBUG : drawio : updateToolRunAsCurrentUser=
2022-10-12 10:12:15 : INFO  : drawio : BLOCKING_PROCESS_ACTION=tell_user
2022-10-12 10:12:15 : INFO  : drawio : NOTIFY=success
2022-10-12 10:12:15 : INFO  : drawio : LOGGING=DEBUG
2022-10-12 10:12:15 : INFO  : drawio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-12 10:12:15 : INFO  : drawio : Label type: dmg
2022-10-12 10:12:15 : INFO  : drawio : archiveName: draw.io-universal-[0-9.]*.dmg$
2022-10-12 10:12:15 : DEBUG : drawio : Changing directory to .
2022-10-12 10:12:15 : INFO  : drawio : name: draw.io, appName: draw.io.app
2022-10-12 10:12:15 : WARN  : drawio : No previous app found
2022-10-12 10:12:15 : WARN  : drawio : could not find draw.io.app
2022-10-12 10:12:15 : INFO  : drawio : appversion: 
2022-10-12 10:12:15 : INFO  : drawio : Latest version of draw.io is 20.3.0
2022-10-12 10:12:16 : REQ   : drawio : Downloading 2022-10-12 10:12:11 : INFO  : drawio : GitHub API not returning URL, trying https://github.com/jgraph/drawio-desktop/releases/latest.
2022-10-12 10:12:16 : REQ   : drawio : https://github.com/jgraph/drawio-desktop/releases/download/v20.3.0/draw.io-universal-20.3.0.dmg to draw.io-universal-[0-9.]*.dmg$
2022-10-12 10:12:16 : DEBUG : drawio : No Dialog connection, just download
2022-10-12 10:12:16 : ERROR : drawio : error downloading 2022-10-12 10:12:11 : INFO  : drawio : GitHub API not returning URL, trying https://github.com/jgraph/drawio-desktop/releases/latest.
2022-10-12 10:12:16 : ERROR : drawio : https://github.com/jgraph/drawio-desktop/releases/download/v20.3.0/draw.io-universal-20.3.0.dmg
2022-10-12 10:12:16 : ERROR : drawio : File list: 
2022-10-12 10:12:16 : ERROR : drawio : File type: draw.io-universal-[0-9.]*.dmg$: cannot open `draw.io-universal-[0-9.]*.dmg$' (No such file or directory)
2022-10-12 10:12:16 : DEBUG : drawio : DEBUG mode 1, not reopening anything
2022-10-12 10:12:16 : ERROR : drawio : ERROR: Error downloading 2022-10-12 10:12:11 : INFO  : drawio : GitHub API not returning URL, trying https://github.com/jgraph/drawio-desktop/releases/latest.
2022-10-12 10:12:16 : ERROR : drawio : https://github.com/jgraph/drawio-desktop/releases/download/v20.3.0/draw.io-universal-20.3.0.dmg error:
* Closing connection -1
curl: (3) URL using bad/illegal format or missing URL

2022-10-12 10:12:16 : REQ   : drawio : ################## End Installomator, exit code 2 

Removing the "archivename" variable allows it to complete as it creates a valid .dmg file:

2022-10-12 10:15:47 : REQ   : drawio : ################## Start Installomator v. 10.0beta3, date 2022-10-12
2022-10-12 10:15:47 : INFO  : drawio : ################## Version: 10.0beta3
2022-10-12 10:15:47 : INFO  : drawio : ################## Date: 2022-10-12
2022-10-12 10:15:47 : INFO  : drawio : ################## drawio
2022-10-12 10:15:47 : DEBUG : drawio : DEBUG mode 1 enabled.
2022-10-12 10:15:48 : DEBUG : drawio : name=draw.io
2022-10-12 10:15:48 : DEBUG : drawio : appName=
2022-10-12 10:15:48 : DEBUG : drawio : type=dmg
2022-10-12 10:15:48 : DEBUG : drawio : archiveName=
2022-10-12 10:15:48 : DEBUG : drawio : downloadURL=https://github.com/jgraph/drawio-desktop/releases/download/v20.3.0/draw.io-arm64-20.3.0.dmg
2022-10-12 10:15:48 : DEBUG : drawio : curlOptions=
2022-10-12 10:15:48 : DEBUG : drawio : appNewVersion=20.3.0
2022-10-12 10:15:48 : DEBUG : drawio : appCustomVersion function: Not defined
2022-10-12 10:15:48 : DEBUG : drawio : versionKey=CFBundleShortVersionString
2022-10-12 10:15:48 : DEBUG : drawio : packageID=
2022-10-12 10:15:48 : DEBUG : drawio : pkgName=
2022-10-12 10:15:48 : DEBUG : drawio : choiceChangesXML=
2022-10-12 10:15:48 : DEBUG : drawio : expectedTeamID=UZEUFB4N53
2022-10-12 10:15:48 : DEBUG : drawio : blockingProcesses=draw.io
2022-10-12 10:15:48 : DEBUG : drawio : installerTool=
2022-10-12 10:15:48 : DEBUG : drawio : CLIInstaller=
2022-10-12 10:15:48 : DEBUG : drawio : CLIArguments=
2022-10-12 10:15:48 : DEBUG : drawio : updateTool=
2022-10-12 10:15:48 : DEBUG : drawio : updateToolArguments=
2022-10-12 10:15:48 : DEBUG : drawio : updateToolRunAsCurrentUser=
2022-10-12 10:15:48 : INFO  : drawio : BLOCKING_PROCESS_ACTION=tell_user
2022-10-12 10:15:48 : INFO  : drawio : NOTIFY=success
2022-10-12 10:15:48 : INFO  : drawio : LOGGING=DEBUG
2022-10-12 10:15:48 : INFO  : drawio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-12 10:15:48 : INFO  : drawio : Label type: dmg
2022-10-12 10:15:48 : INFO  : drawio : archiveName: draw.io.dmg
2022-10-12 10:15:48 : DEBUG : drawio : Changing directory to /Users/mark/Dev/Jamf/Installomator/build
2022-10-12 10:15:48 : INFO  : drawio : name: draw.io, appName: draw.io.app
2022-10-12 10:15:48 : WARN  : drawio : No previous app found
2022-10-12 10:15:48 : WARN  : drawio : could not find draw.io.app
2022-10-12 10:15:48 : INFO  : drawio : appversion: 
2022-10-12 10:15:48 : INFO  : drawio : Latest version of draw.io is 20.3.0
2022-10-12 10:15:48 : INFO  : drawio : draw.io.dmg exists and DEBUG mode 1 enabled, skipping download
2022-10-12 10:15:48 : DEBUG : drawio : DEBUG mode 1, not checking for blocking processes
2022-10-12 10:15:49 : REQ   : drawio : Installing draw.io
2022-10-12 10:15:49 : INFO  : drawio : Mounting /Users/mark/Dev/Jamf/Installomator/build/draw.io.dmg
2022-10-12 10:15:49 : DEBUG : drawio : Debugging enabled, dmgmount output was:
expected CRC32 $9C9B3975
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/draw.io 20.3.0-arm64

2022-10-12 10:15:49 : INFO  : drawio : Mounted: /Volumes/draw.io 20.3.0-arm64
2022-10-12 10:15:49 : INFO  : drawio : Verifying: /Volumes/draw.io 20.3.0-arm64/draw.io.app
2022-10-12 10:15:49 : DEBUG : drawio : App size: 371M	/Volumes/draw.io 20.3.0-arm64/draw.io.app
2022-10-12 10:15:54 : DEBUG : drawio : Debugging enabled, App Verification output was:
/Volumes/draw.io 20.3.0-arm64/draw.io.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: JGraph Ltd (UZEUFB4N53)

2022-10-12 10:15:54 : INFO  : drawio : Team ID matching: UZEUFB4N53 (expected: UZEUFB4N53 )
2022-10-12 10:15:54 : INFO  : drawio : Installing draw.io version 20.3.0 on versionKey CFBundleShortVersionString.
2022-10-12 10:15:54 : INFO  : drawio : App has LSMinimumSystemVersion: 10.13
2022-10-12 10:15:54 : DEBUG : drawio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-10-12 10:15:54 : INFO  : drawio : Finishing...
2022-10-12 10:15:57 : INFO  : drawio : name: draw.io, appName: draw.io.app
2022-10-12 10:15:58 : WARN  : drawio : No previous app found
2022-10-12 10:15:58 : WARN  : drawio : could not find draw.io.app
2022-10-12 10:15:58 : REQ   : drawio : Installed draw.io
2022-10-12 10:15:58 : INFO  : drawio : notifying
2022-10-12 10:15:58 : DEBUG : drawio : Unmounting /Volumes/draw.io 20.3.0-arm64
2022-10-12 10:15:58 : DEBUG : drawio : Debugging enabled, Unmounting output was:
"disk2" ejected.
2022-10-12 10:15:58 : DEBUG : drawio : DEBUG mode 1, not reopening anything
2022-10-12 10:15:58 : REQ   : drawio : All done!
2022-10-12 10:15:58 : REQ   : drawio : ################## End Installomator, exit code 0 



