### PR TITLE
further refinement to label idrive

### DIFF
--- a/fragments/labels/idrive.sh
+++ b/fragments/labels/idrive.sh
@@ -2,8 +2,9 @@ idrive)
     name="IDrive"
     type="pkgInDmg"
     pkgName="IDrive.pkg"
-    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/version_mac.js | sed -E 's/.*(https.*dmg).*/\1/g')
-    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/version_mac.js | sed -E 's/.*mac_vernum\=\"Version\ ([0-9.]*).*/\1/g')
+    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/version_mac.js | tr -d '\n\t' | sed -E 's/.*(https.*dmg).*/\1/g')
+    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/version_mac.js | tr -d '\n\t' | sed -E 's/.*mac_vernum\=\"Version\ ([0-9.]*).*/\1/g')
     versionKey="CFBundleVersion"
     expectedTeamID="JWDCNYZ922"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
Installomator/utils/assemble.sh  idrive DEBUG=1
2022-10-12 17:12:46 : INFO  : idrive : setting variable from argument DEBUG=1
2022-10-12 17:12:46 : REQ   : idrive : ################## Start Installomator v. 10.0beta3, date 2022-10-12
2022-10-12 17:12:46 : INFO  : idrive : ################## Version: 10.0beta3
2022-10-12 17:12:46 : INFO  : idrive : ################## Date: 2022-10-12
2022-10-12 17:12:46 : INFO  : idrive : ################## idrive
2022-10-12 17:12:46 : DEBUG : idrive : DEBUG mode 1 enabled.
2022-10-12 17:12:47 : DEBUG : idrive : name=IDrive
2022-10-12 17:12:47 : DEBUG : idrive : appName=
2022-10-12 17:12:47 : DEBUG : idrive : type=pkgInDmg
2022-10-12 17:12:47 : DEBUG : idrive : archiveName=
2022-10-12 17:12:47 : DEBUG : idrive : downloadURL=https://static.idriveonlinebackup.com/downloads/100622/IDrive.dmg
2022-10-12 17:12:47 : DEBUG : idrive : curlOptions=
2022-10-12 17:12:47 : DEBUG : idrive : appNewVersion=3.5.10.33
2022-10-12 17:12:47 : DEBUG : idrive : appCustomVersion function: Not defined
2022-10-12 17:12:47 : DEBUG : idrive : versionKey=CFBundleVersion
2022-10-12 17:12:47 : DEBUG : idrive : packageID=
2022-10-12 17:12:47 : DEBUG : idrive : pkgName=IDrive.pkg
2022-10-12 17:12:47 : DEBUG : idrive : choiceChangesXML=
2022-10-12 17:12:47 : DEBUG : idrive : expectedTeamID=JWDCNYZ922
2022-10-12 17:12:47 : DEBUG : idrive : blockingProcesses=NONE
2022-10-12 17:12:47 : DEBUG : idrive : installerTool=
2022-10-12 17:12:47 : DEBUG : idrive : CLIInstaller=
2022-10-12 17:12:47 : DEBUG : idrive : CLIArguments=
2022-10-12 17:12:47 : DEBUG : idrive : updateTool=
2022-10-12 17:12:47 : DEBUG : idrive : updateToolArguments=
2022-10-12 17:12:47 : DEBUG : idrive : updateToolRunAsCurrentUser=
2022-10-12 17:12:47 : INFO  : idrive : BLOCKING_PROCESS_ACTION=tell_user
2022-10-12 17:12:47 : INFO  : idrive : NOTIFY=success
2022-10-12 17:12:47 : INFO  : idrive : LOGGING=DEBUG
2022-10-12 17:12:47 : INFO  : idrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-12 17:12:47 : INFO  : idrive : Label type: pkgInDmg
2022-10-12 17:12:47 : INFO  : idrive : archiveName: IDrive.dmg
2022-10-12 17:12:47 : DEBUG : idrive : Changing directory to /Users/john/Documents/GitHub/Installomator/build
2022-10-12 17:12:47 : INFO  : idrive : name: IDrive, appName: IDrive.app
2022-10-12 17:12:47 : INFO  : idrive : App(s) found: /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app
2022-10-12 17:12:47 : INFO  : idrive : found app at /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app, version 1, on versionKey CFBundleVersion
2022-10-12 17:12:47 : INFO  : idrive : appversion: 1
2022-10-12 17:12:47 : INFO  : idrive : Latest version of IDrive is 3.5.10.33
2022-10-12 17:12:47 : INFO  : idrive : IDrive.dmg exists and DEBUG mode 1 enabled, skipping download
2022-10-12 17:12:47 : REQ   : idrive : Installing IDrive
2022-10-12 17:12:47 : INFO  : idrive : Mounting /Users/john/Documents/GitHub/Installomator/build/IDrive.dmg
2022-10-12 17:12:47 : DEBUG : idrive : Debugging enabled, dmgmount output was:
expected CRC32 $CDB02E0B
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/IDrive 1

2022-10-12 17:12:47 : INFO  : idrive : Mounted: /Volumes/IDrive 1 2022-10-12 17:12:47 : INFO  : idrive : found pkg: /Volumes/IDrive 1/IDrive.pkg 2022-10-12 17:12:47 : INFO  : idrive : Verifying: /Volumes/IDrive 1/IDrive.pkg
2022-10-12 17:12:47 : DEBUG : idrive : File list: -rw-r--r--  1 john  staff    28M  6 Oct 07:46 /Volumes/IDrive 1/IDrive.pkg
2022-10-12 17:12:47 : DEBUG : idrive : File type: /Volumes/IDrive 1/IDrive.pkg: xar archive compressed TOC: 5277, SHA-1 checksum
2022-10-12 17:12:47 : DEBUG : idrive : spctlOut is /Volumes/IDrive 1/IDrive.pkg: accepted
2022-10-12 17:12:47 : DEBUG : idrive : source=Notarized Developer ID
2022-10-12 17:12:47 : DEBUG : idrive : origin=Developer ID Installer: IDrive Incorporated (JWDCNYZ922)
2022-10-12 17:12:47 : INFO  : idrive : Team ID: JWDCNYZ922 (expected: JWDCNYZ922 )
2022-10-12 17:12:47 : DEBUG : idrive : DEBUG enabled, skipping installation
2022-10-12 17:12:47 : INFO  : idrive : Finishing...
2022-10-12 17:12:50 : INFO  : idrive : name: IDrive, appName: IDrive.app
2022-10-12 17:12:50 : INFO  : idrive : App(s) found: /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app
2022-10-12 17:12:50 : INFO  : idrive : found app at /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app, version 1, on versionKey CFBundleVersion
2022-10-12 17:12:50 : REQ   : idrive : Installed IDrive, version 1
2022-10-12 17:12:50 : INFO  : idrive : notifying
2022-10-12 17:12:51 : DEBUG : idrive : Unmounting /Volumes/IDrive 1
2022-10-12 17:12:51 : DEBUG : idrive : Debugging enabled, Unmounting output was:
"disk5" ejected.
2022-10-12 17:12:51 : DEBUG : idrive : DEBUG mode 1, not reopening anything
2022-10-12 17:12:51 : REQ   : idrive : All done!
2022-10-12 17:12:51 : REQ   : idrive : ################## End Installomator, exit code 0