### PR TITLE
further parsing refinement of url and version data for label idrivethin

### DIFF
--- a/fragments/labels/idrivethin.sh
+++ b/fragments/labels/idrivethin.sh
@@ -2,8 +2,9 @@ idrivethin)
     name="IDrive"
     type="pkgInDmg"
     pkgName="IDriveThin.pkg"
-    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed -E 's/.*thinclient-mac([^;]*).*/\1/g' | sed -E 's/.*(https.*dmg).*/\1/g')
-    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | sed -E 's/.*thin\_mac\_ver\=\"Version\ ([0-9.]*).*/\1/g')
+    downloadURL=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | tr -d '\n\t' | sed -E 's/.*thinclient-mac([^;]*).*/\1/g' | sed -E 's/.*(https.*dmg).*/\1/g')
+    appNewVersion=$(curl -fs https://static.idriveonlinebackup.com/downloads/idrivethin/thin_version.js | tr -d '\n\t' | sed -E 's/.*thin\_mac\_ver\=\"Version\ ([0-9.]*).*/\1/g')
     versionKey="CFBundleVersion"
     expectedTeamID="JWDCNYZ922"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
Installomator/utils/assemble.sh idrivethin DEBUG=1 2022-10-12 18:43:20 : INFO  : idrivethin : setting variable from argument DEBUG=1
2022-10-12 18:43:20 : REQ   : idrivethin : ################## Start Installomator v. 10.0beta3, date 2022-10-12
2022-10-12 18:43:20 : INFO  : idrivethin : ################## Version: 10.0beta3
2022-10-12 18:43:20 : INFO  : idrivethin : ################## Date: 2022-10-12
2022-10-12 18:43:20 : INFO  : idrivethin : ################## idrivethin
2022-10-12 18:43:20 : DEBUG : idrivethin : DEBUG mode 1 enabled.
JOHn
/Users/john/Documents/GitHub
2022-10-12 18:43:20 : DEBUG : idrivethin : name=IDrive
2022-10-12 18:43:20 : DEBUG : idrivethin : appName=
2022-10-12 18:43:20 : DEBUG : idrivethin : type=pkgInDmg
2022-10-12 18:43:20 : DEBUG : idrivethin : archiveName=
2022-10-12 18:43:20 : DEBUG : idrivethin : downloadURL=https://static.idriveonlinebackup.com/downloads/idrivethin/090222/IDrive.dmg
2022-10-12 18:43:20 : DEBUG : idrivethin : curlOptions=
2022-10-12 18:43:20 : DEBUG : idrivethin : appNewVersion=3.5.10.12
2022-10-12 18:43:20 : DEBUG : idrivethin : appCustomVersion function: Not defined
2022-10-12 18:43:20 : DEBUG : idrivethin : versionKey=CFBundleVersion
2022-10-12 18:43:20 : DEBUG : idrivethin : packageID=
2022-10-12 18:43:20 : DEBUG : idrivethin : pkgName=IDriveThin.pkg
2022-10-12 18:43:20 : DEBUG : idrivethin : choiceChangesXML=
2022-10-12 18:43:20 : DEBUG : idrivethin : expectedTeamID=JWDCNYZ922
2022-10-12 18:43:20 : DEBUG : idrivethin : blockingProcesses=NONE
2022-10-12 18:43:20 : DEBUG : idrivethin : installerTool=
2022-10-12 18:43:20 : DEBUG : idrivethin : CLIInstaller=
2022-10-12 18:43:20 : DEBUG : idrivethin : CLIArguments=
2022-10-12 18:43:20 : DEBUG : idrivethin : updateTool=
2022-10-12 18:43:20 : DEBUG : idrivethin : updateToolArguments=
2022-10-12 18:43:20 : DEBUG : idrivethin : updateToolRunAsCurrentUser=
2022-10-12 18:43:20 : INFO  : idrivethin : BLOCKING_PROCESS_ACTION=tell_user
2022-10-12 18:43:20 : INFO  : idrivethin : NOTIFY=success
2022-10-12 18:43:20 : INFO  : idrivethin : LOGGING=DEBUG
2022-10-12 18:43:20 : INFO  : idrivethin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-12 18:43:20 : INFO  : idrivethin : Label type: pkgInDmg
2022-10-12 18:43:20 : INFO  : idrivethin : archiveName: IDrive.dmg
2022-10-12 18:43:20 : DEBUG : idrivethin : Changing directory to /Users/john/Documents/GitHub/Installomator/build
2022-10-12 18:43:20 : INFO  : idrivethin : name: IDrive, appName: IDrive.app
2022-10-12 18:43:20 : INFO  : idrivethin : App(s) found: /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app
2022-10-12 18:43:20 : INFO  : idrivethin : found app at /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app, version 1, on versionKey CFBundleVersion
2022-10-12 18:43:20 : INFO  : idrivethin : appversion: 1
2022-10-12 18:43:20 : INFO  : idrivethin : Latest version of IDrive is 3.5.10.12
2022-10-12 18:43:20 : REQ   : idrivethin : Downloading https://static.idriveonlinebackup.com/downloads/idrivethin/090222/IDrive.dmg to IDrive.dmg
2022-10-12 18:43:20 : DEBUG : idrivethin : No Dialog connection, just download
2022-10-12 18:43:21 : DEBUG : idrivethin : File list: -rw-r--r--  1 john  staff    27M 12 Oct 18:43 IDrive.dmg
2022-10-12 18:43:21 : DEBUG : idrivethin : File type: IDrive.dmg: zlib compressed data
2022-10-12 18:43:21 : DEBUG : idrivethin : curl output was:
*   Trying 104.22.38.202:443...
* Connected to static.idriveonlinebackup.com (104.22.38.202) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2354 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Jun  8 00:00:00 2022 GMT
*  expire date: Jun  7 23:59:59 2023 GMT
*  subjectAltName: host "static.idriveonlinebackup.com" matched cert's "*.idriveonlinebackup.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x134812c00)
> GET /downloads/idrivethin/090222/IDrive.dmg HTTP/2
> Host: static.idriveonlinebackup.com
> user-agent: curl/7.79.1
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)! < HTTP/2 200
< date: Wed, 12 Oct 2022 16:43:20 GMT
< content-type: application/octet-stream
< content-length: 28177937
< last-modified: Fri, 02 Sep 2022 11:49:30 GMT
< etag: "6311edca-1adf611"
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< content-security-policy: default-src 'self' *.idrive.com *.idrivesync.com  https://graph.facebook.com blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://js.zohocdn.com https://salesiq.zoho.com https://embed.tawk.to https://app.chatsupport.co https://*.zendesk.com https://static.zdassets.com https://tagmanager.google.com https://static.idriveonlinebackup.com https://*.facebook.com https://bmrsignal.idrivelite.com https://*.google.com https://apis.google.com https://accounts.google.com https://www.google-analytics.com https://*.criteo.com https://www.google-analytics.com https://ssl.google-analytics.com https://*.criteo.net https://cdn.livechatinc.com https://gum.criteo.com https://sslwidget.criteo.com https://*.livechatinc.com https://ajax.googleapis.com https://html5shim.googlecode.com https://s.adroll.com https://a.adroll.com https://d.adroll.com https://www.google.com https://www.idrivedownloads.com http://ssl.p.jwpcdn.com https://www.youtube.com https://px.spiceworks.com https://connect.facebook.net https://5358683.fls.doubleclick.net https://platform.twitter.com https://www.googleadservices.com https://www.gstatic.com https://ssl.google-analytics.com https://code.jquery.com https://js.stripe.com https://www.googletagmanager.com https://api.maxaccess.io; img-src https://* 'self' data: blob: www.googletagmanager.com https://ssl.gstatic.com https://www.gstatic.com;style-src 'self' 'unsafe-inline' 'unsafe-eval' https://embed.tawk.to https://css.zohocdn.com https://tagmanager.google.com https://static.idriveonlinebackup.com https://fonts.googleapis.com https://ssl.google-analytics.com https://code.jquery.com; font-src https://* https://fonts.gstatic.com data: ; object-src 'self' https://secure.livechatinc.com; frame-src https://* 'self' data: blob:; media-src https://* blob:; worker-src https://* blob:; connect-src wss: https://* blob:; < strict-transport-security: max-age=15768000
< cache-control: max-age=31536000
< cf-cache-status: HIT
< age: 4289
< accept-ranges: bytes
< server: cloudflare
< cf-ray: 75914b3e9b4b1649-MUC
<
{ [1100 bytes data]
* Connection #0 to host static.idriveonlinebackup.com left intact

2022-10-12 18:43:21 : REQ   : idrivethin : Installing IDrive
2022-10-12 18:43:21 : INFO  : idrivethin : Mounting /Users/john/Documents/GitHub/Installomator/build/IDrive.dmg
2022-10-12 18:43:24 : DEBUG : idrivethin : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $8CA47E3D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $1B1ADFF4
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $BEC9EF45
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $AA4E1C8B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $BEC9EF45
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $92455147
verified CRC32 $97E5E93D
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/IDrive

2022-10-12 18:43:24 : INFO  : idrivethin : Mounted: /Volumes/IDrive 2022-10-12 18:43:24 : INFO  : idrivethin : found pkg: /Volumes/IDrive/IDriveThin.pkg 2022-10-12 18:43:24 : INFO  : idrivethin : Verifying: /Volumes/IDrive/IDriveThin.pkg
2022-10-12 18:43:24 : DEBUG : idrivethin : File list: -rw-r--r--  1 john  staff    25M  2 Sep 10:34 /Volumes/IDrive/IDriveThin.pkg
2022-10-12 18:43:24 : DEBUG : idrivethin : File type: /Volumes/IDrive/IDriveThin.pkg: xar archive compressed TOC: 5297, SHA-1 checksum
2022-10-12 18:43:24 : DEBUG : idrivethin : spctlOut is /Volumes/IDrive/IDriveThin.pkg: accepted
2022-10-12 18:43:24 : DEBUG : idrivethin : source=Notarized Developer ID
2022-10-12 18:43:24 : DEBUG : idrivethin : origin=Developer ID Installer: IDrive Incorporated (JWDCNYZ922)
2022-10-12 18:43:24 : INFO  : idrivethin : Team ID: JWDCNYZ922 (expected: JWDCNYZ922 )
2022-10-12 18:43:24 : DEBUG : idrivethin : DEBUG enabled, skipping installation
2022-10-12 18:43:24 : INFO  : idrivethin : Finishing...
2022-10-12 18:43:27 : INFO  : idrivethin : name: IDrive, appName: IDrive.app
2022-10-12 18:43:27 : INFO  : idrivethin : App(s) found: /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app
2022-10-12 18:43:27 : INFO  : idrivethin : found app at /Library/Application Support/IDriveforMac/UninstallerSupport/IDriveUninstaller.app, version 1, on versionKey CFBundleVersion
2022-10-12 18:43:27 : REQ   : idrivethin : Installed IDrive, version 1
2022-10-12 18:43:27 : INFO  : idrivethin : notifying
2022-10-12 18:43:28 : DEBUG : idrivethin : Unmounting /Volumes/IDrive
2022-10-12 18:43:28 : DEBUG : idrivethin : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-10-12 18:43:28 : DEBUG : idrivethin : DEBUG mode 1, not reopening anything
2022-10-12 18:43:28 : REQ   : idrivethin : All done!
2022-10-12 18:43:28 : REQ   : idrivethin : ################## End Installomator, exit code 0