### PR TITLE
Create mist.sh

### DIFF
--- a/fragments/mist.sh
+++ b/fragments/mist.sh
@@ -1,0 +1,9 @@
+mist)
+    name="Mist"
+    type="pkg"
+    packageID="com.ninxsoft.pkg.mist"
+    downloadURL=$(downloadURLFromGit "ninxsoft" "mist")
+    appNewVersion=$(versionFromGit "ninxsoft" "mist")
+    expectedTeamID="7K3HVCLV7Z"
+    blockingProcesses=( NONE )
+    ;;


### PR DESCRIPTION
2022-10-20 16:39:44 : REQ   : mist : ################## Start Installomator v. 10.0beta3, date 2022-10-03
2022-10-20 16:39:44 : INFO  : mist : ################## Version: 10.0beta3
2022-10-20 16:39:44 : INFO  : mist : ################## Date: 2022-10-03
2022-10-20 16:39:44 : INFO  : mist : ################## mist
2022-10-20 16:39:44 : DEBUG : mist : DEBUG mode 1 enabled.
2022-10-20 16:39:45 : DEBUG : mist : name=mist
2022-10-20 16:39:45 : DEBUG : mist : appName=
2022-10-20 16:39:45 : DEBUG : mist : type=pkg
2022-10-20 16:39:45 : DEBUG : mist : archiveName=
2022-10-20 16:39:45 : DEBUG : mist : downloadURL=https://github.com/ninxsoft/Mist/releases/download/v0.3/Mist.0.3.pkg
2022-10-20 16:39:45 : DEBUG : mist : curlOptions=
2022-10-20 16:39:45 : DEBUG : mist : appNewVersion=0.3
2022-10-20 16:39:45 : DEBUG : mist : appCustomVersion function: Not defined
2022-10-20 16:39:45 : DEBUG : mist : versionKey=CFBundleShortVersionString
2022-10-20 16:39:45 : DEBUG : mist : packageID=com.ninxsoft.mist
2022-10-20 16:39:45 : DEBUG : mist : pkgName=
2022-10-20 16:39:45 : DEBUG : mist : choiceChangesXML=
2022-10-20 16:39:45 : DEBUG : mist : expectedTeamID=7K3HVCLV7Z
2022-10-20 16:39:45 : DEBUG : mist : blockingProcesses=NONE
2022-10-20 16:39:45 : DEBUG : mist : installerTool=
2022-10-20 16:39:45 : DEBUG : mist : CLIInstaller=
2022-10-20 16:39:45 : DEBUG : mist : CLIArguments=
2022-10-20 16:39:45 : DEBUG : mist : updateTool=
2022-10-20 16:39:45 : DEBUG : mist : updateToolArguments=
2022-10-20 16:39:45 : DEBUG : mist : updateToolRunAsCurrentUser=
2022-10-20 16:39:45 : INFO  : mist : BLOCKING_PROCESS_ACTION=tell_user
2022-10-20 16:39:45 : INFO  : mist : NOTIFY=success
2022-10-20 16:39:45 : INFO  : mist : LOGGING=DEBUG
2022-10-20 16:39:45 : INFO  : mist : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-10-20 16:39:45 : INFO  : mist : Label type: pkg
2022-10-20 16:39:45 : INFO  : mist : archiveName: mist.pkg
2022-10-20 16:39:45 : DEBUG : mist : Changing directory to /usr/local/Installomator
2022-10-20 16:39:45 : INFO  : mist : No version found using packageID com.ninxsoft.mist
2022-10-20 16:39:45 : INFO  : mist : name: mist, appName: mist.app
2022-10-20 16:39:45 : WARN  : mist : No previous app found
2022-10-20 16:39:45 : WARN  : mist : could not find mist.app
2022-10-20 16:39:45 : INFO  : mist : appversion: 
2022-10-20 16:39:45 : INFO  : mist : Latest version of mist is 0.3
2022-10-20 16:39:45 : REQ   : mist : Downloading https://github.com/ninxsoft/Mist/releases/download/v0.3/Mist.0.3.pkg to mist.pkg
2022-10-20 16:39:45 : DEBUG : mist : No Dialog connection, just download
2022-10-20 16:39:46 : DEBUG : mist : File list: -rw-r--r--  1 root  wheel   6.6M Oct 20 16:39 mist.pkg
2022-10-20 16:39:46 : DEBUG : mist : File type: mist.pkg: xar archive compressed TOC: 4233, SHA-1 checksum
2022-10-20 16:39:46 : DEBUG : mist : curl output was:
*   Trying 140.82.112.4:443...
* Connected to github.com (140.82.112.4) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13d811a00)
> GET /ninxsoft/Mist/releases/download/v0.3/Mist.0.3.pkg HTTP/2
> Host: github.com
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 20 Oct 2022 21:39:45 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/509050256/e869a680-9c29-48d8-b652-c8616722461d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221020%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221020T213945Z&X-Amz-Expires=300&X-Amz-Signature=d6407317fe04fc844445e4764cf8f0d9bd1d5e73628dbef5d4681330ebd9c2b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=509050256&response-content-disposition=attachment%3B%20filename%3DMist.0.3.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< expect-ct: max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: EB9F:36FF:1F17D53:2E5923C:6351C021
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/509050256/e869a680-9c29-48d8-b652-c8616722461d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221020%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221020T213945Z&X-Amz-Expires=300&X-Amz-Signature=d6407317fe04fc844445e4764cf8f0d9bd1d5e73628dbef5d4681330ebd9c2b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=509050256&response-content-disposition=attachment%3B%20filename%3DMist.0.3.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 18 00:00:00 2022 GMT
*  expire date: Mar 21 23:59:59 2023 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13d811a00)
> GET /github-production-release-asset-2e65be/509050256/e869a680-9c29-48d8-b652-c8616722461d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221020%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221020T213945Z&X-Amz-Expires=300&X-Amz-Signature=d6407317fe04fc844445e4764cf8f0d9bd1d5e73628dbef5d4681330ebd9c2b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=509050256&response-content-disposition=attachment%3B%20filename%3DMist.0.3.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: zMnLFp5alo8QfJJrx50tkw==
< last-modified: Mon, 26 Sep 2022 04:24:22 GMT
< etag: "0x8DA9F76FCF4D749"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 85cdf7ca-d01e-006a-07cc-e4fa4d000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Mon, 26 Sep 2022 04:24:22 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Mist.0.3.pkg
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Thu, 20 Oct 2022 21:39:46 GMT
< via: 1.1 varnish
< x-served-by: cache-msp11848-MSP
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1666301986.858459,VS0,VE262
< content-length: 6869970
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2022-10-20 16:39:46 : REQ   : mist : Installing mist
2022-10-20 16:39:46 : INFO  : mist : Verifying: mist.pkg
2022-10-20 16:39:46 : DEBUG : mist : File list: -rw-r--r--  1 root  wheel   6.6M Oct 20 16:39 mist.pkg
2022-10-20 16:39:46 : DEBUG : mist : File type: mist.pkg: xar archive compressed TOC: 4233, SHA-1 checksum
2022-10-20 16:39:46 : DEBUG : mist : spctlOut is mist.pkg: accepted
2022-10-20 16:39:46 : DEBUG : mist : source=Notarized Developer ID
2022-10-20 16:39:46 : DEBUG : mist : origin=Developer ID Installer: Nindi Gill (7K3HVCLV7Z)
2022-10-20 16:39:46 : INFO  : mist : Team ID: 7K3HVCLV7Z (expected: 7K3HVCLV7Z )
2022-10-20 16:39:46 : DEBUG : mist : DEBUG enabled, skipping installation
2022-10-20 16:39:46 : INFO  : mist : Finishing...
2022-10-20 16:39:49 : INFO  : mist : No version found using packageID com.ninxsoft.mist
2022-10-20 16:39:49 : INFO  : mist : name: mist, appName: mist.app
2022-10-20 16:39:49 : WARN  : mist : No previous app found
2022-10-20 16:39:49 : WARN  : mist : could not find mist.app
2022-10-20 16:39:49 : REQ   : mist : Installed mist
2022-10-20 16:39:49 : INFO  : mist : notifying
2022-10-20 16:39:50 : DEBUG : mist : DEBUG mode 1, not reopening anything
2022-10-20 16:39:50 : REQ   : mist : All done!
2022-10-20 16:39:50 : REQ   : mist : ################## End Installomator, exit code 0 