### PR TITLE
Create jamfcpr.sh

### DIFF
--- a/fragments/labels/jamfcpr.sh
+++ b/fragments/labels/jamfcpr.sh
@@ -1,0 +1,7 @@
+jamfcpr)
+    name="jamfcpr"
+    type="zip"
+    downloadURL="$(downloadURLFromGit BIG-RAT jamfcpr)"
+    appNewVersion="$(versionFromGit BIG-RAT jamfcpr)"
+    expectedTeamID="PS2F6S478M"
+    ;;

--- a/fragments/labels/jamfcpr.sh
+++ b/fragments/labels/jamfcpr.sh
@@ -1,5 +1,5 @@
 jamfcpr)
-    name="Jamf Cloud Package Replicator"
+    name="jamfcpr"
     type="zip"
     downloadURL="$(downloadURLFromGit BIG-RAT jamfcpr)"
     appNewVersion="$(versionFromGit BIG-RAT jamfcpr)"

--- a/fragments/labels/jamfcpr.sh
+++ b/fragments/labels/jamfcpr.sh
@@ -1,5 +1,5 @@
 jamfcpr)
-    name="jamfcpr"
+    name="Jamf Cloud Package Replicator"
     type="zip"
     downloadURL="$(downloadURLFromGit BIG-RAT jamfcpr)"
     appNewVersion="$(versionFromGit BIG-RAT jamfcpr)"


### PR DESCRIPTION
2022-11-03 19:22:53 : REQ   : jamfcpr : ################## Start Installomator v. 10.0beta3, date 2022-10-03
2022-11-03 19:22:53 : INFO  : jamfcpr : ################## Version: 10.0beta3
2022-11-03 19:22:53 : INFO  : jamfcpr : ################## Date: 2022-10-03
2022-11-03 19:22:53 : INFO  : jamfcpr : ################## jamfcpr
2022-11-03 19:22:53 : DEBUG : jamfcpr : DEBUG mode 1 enabled.
2022-11-03 19:22:54 : DEBUG : jamfcpr : name=jamfcpr
2022-11-03 19:22:54 : DEBUG : jamfcpr : appName=
2022-11-03 19:22:54 : DEBUG : jamfcpr : type=zip
2022-11-03 19:22:54 : DEBUG : jamfcpr : archiveName=
2022-11-03 19:22:54 : DEBUG : jamfcpr : downloadURL=https://github.com/BIG-RAT/jamfcpr/releases/download/v3.3.4/jamfcpr.zip
2022-11-03 19:22:54 : DEBUG : jamfcpr : curlOptions=
2022-11-03 19:22:54 : DEBUG : jamfcpr : appNewVersion=3.3.4
2022-11-03 19:22:54 : DEBUG : jamfcpr : appCustomVersion function: Not defined
2022-11-03 19:22:54 : DEBUG : jamfcpr : versionKey=CFBundleShortVersionString
2022-11-03 19:22:54 : DEBUG : jamfcpr : packageID=
2022-11-03 19:22:54 : DEBUG : jamfcpr : pkgName=
2022-11-03 19:22:54 : DEBUG : jamfcpr : choiceChangesXML=
2022-11-03 19:22:54 : DEBUG : jamfcpr : expectedTeamID=PS2F6S478M
2022-11-03 19:22:54 : DEBUG : jamfcpr : blockingProcesses=
2022-11-03 19:22:54 : DEBUG : jamfcpr : installerTool=
2022-11-03 19:22:54 : DEBUG : jamfcpr : CLIInstaller=
2022-11-03 19:22:54 : DEBUG : jamfcpr : CLIArguments=
2022-11-03 19:22:54 : DEBUG : jamfcpr : updateTool=
2022-11-03 19:22:54 : DEBUG : jamfcpr : updateToolArguments=
2022-11-03 19:22:54 : DEBUG : jamfcpr : updateToolRunAsCurrentUser=
2022-11-03 19:22:54 : INFO  : jamfcpr : BLOCKING_PROCESS_ACTION=tell_user
2022-11-03 19:22:54 : INFO  : jamfcpr : NOTIFY=success
2022-11-03 19:22:54 : INFO  : jamfcpr : LOGGING=DEBUG
2022-11-03 19:22:54 : INFO  : jamfcpr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-03 19:22:54 : INFO  : jamfcpr : Label type: zip
2022-11-03 19:22:54 : INFO  : jamfcpr : archiveName: jamfcpr.zip
2022-11-03 19:22:54 : INFO  : jamfcpr : no blocking processes defined, using jamfcpr as default
2022-11-03 19:22:54 : DEBUG : jamfcpr : Changing directory to /usr/local/Installomator
2022-11-03 19:22:54 : INFO  : jamfcpr : App(s) found: /Applications/jamfcpr.app
2022-11-03 19:22:54 : INFO  : jamfcpr : found app at /Applications/jamfcpr.app, version 3.3.4, on versionKey CFBundleShortVersionString
2022-11-03 19:22:54 : INFO  : jamfcpr : appversion: 3.3.4
2022-11-03 19:22:54 : INFO  : jamfcpr : Latest version of jamfcpr is 3.3.4
2022-11-03 19:22:54 : WARN  : jamfcpr : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-11-03 19:22:54 : REQ   : jamfcpr : Downloading https://github.com/BIG-RAT/jamfcpr/releases/download/v3.3.4/jamfcpr.zip to jamfcpr.zip
2022-11-03 19:22:54 : DEBUG : jamfcpr : No Dialog connection, just download
2022-11-03 19:22:55 : DEBUG : jamfcpr : File list: -rw-r--r--  1 root  wheel   5.1M Nov  3 19:22 jamfcpr.zip
2022-11-03 19:22:55 : DEBUG : jamfcpr : File type: jamfcpr.zip: Zip archive data, at least v2.0 to extract, compression method=store
2022-11-03 19:22:55 : DEBUG : jamfcpr : curl output was:
*   Trying 140.82.114.4:443...
* Connected to github.com (140.82.114.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /BIG-RAT/jamfcpr/releases/download/v3.3.4/jamfcpr.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.84.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x121012400)
> GET /BIG-RAT/jamfcpr/releases/download/v3.3.4/jamfcpr.zip HTTP/2
> Host: github.com
> user-agent: curl/7.84.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Fri, 04 Nov 2022 00:22:54 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/267828085/7c9bbc62-f098-4c87-87e5-b66791b86409?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221104%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221104T002254Z&X-Amz-Expires=300&X-Amz-Signature=5d9999cc2932c297c90e5482bcb30ec73e9dd6513df13a9633ba1fbb02bb4091&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=267828085&response-content-disposition=attachment%3B%20filename%3Djamfcpr.zip&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com identicons.github.com github-cloud.s3.amazonaws.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: D9B2:4A37:1500494:1F570B4:63645B5E
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/267828085/7c9bbc62-f098-4c87-87e5-b66791b86409?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221104%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221104T002254Z&X-Amz-Expires=300&X-Amz-Signature=5d9999cc2932c297c90e5482bcb30ec73e9dd6513df13a9633ba1fbb02bb4091&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=267828085&response-content-disposition=attachment%3B%20filename%3Djamfcpr.zip&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 18 00:00:00 2022 GMT
*  expire date: Mar 21 23:59:59 2023 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/267828085/7c9bbc62-f098-4c87-87e5-b66791b86409?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221104%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221104T002254Z&X-Amz-Expires=300&X-Amz-Signature=5d9999cc2932c297c90e5482bcb30ec73e9dd6513df13a9633ba1fbb02bb4091&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=267828085&response-content-disposition=attachment%3B%20filename%3Djamfcpr.zip&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.84.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x121012400)
> GET /github-production-release-asset-2e65be/267828085/7c9bbc62-f098-4c87-87e5-b66791b86409?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20221104%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221104T002254Z&X-Amz-Expires=300&X-Amz-Signature=5d9999cc2932c297c90e5482bcb30ec73e9dd6513df13a9633ba1fbb02bb4091&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=267828085&response-content-disposition=attachment%3B%20filename%3Djamfcpr.zip&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.84.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: YYJKYl7PHbqgKAE4SycpcQ==
< last-modified: Mon, 18 Jul 2022 07:25:44 GMT
< etag: "0x8DA688EBA0F531C"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 0277e225-a01e-0002-80e3-ef9cdd000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Mon, 18 Jul 2022 07:25:44 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=jamfcpr.zip
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Fri, 04 Nov 2022 00:22:55 GMT
< via: 1.1 varnish
< x-served-by: cache-msp11864-MSP
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1667521375.839403,VS0,VE318
< content-length: 5320576
< 
{ [879 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2022-11-03 19:22:55 : DEBUG : jamfcpr : DEBUG mode 1, not checking for blocking processes
2022-11-03 19:22:55 : REQ   : jamfcpr : Installing jamfcpr
2022-11-03 19:22:55 : INFO  : jamfcpr : Unzipping jamfcpr.zip
2022-11-03 19:22:55 : INFO  : jamfcpr : Verifying: /usr/local/Installomator/jamfcpr.app
2022-11-03 19:22:55 : DEBUG : jamfcpr : App size:  14M	/usr/local/Installomator/jamfcpr.app
2022-11-03 19:22:55 : DEBUG : jamfcpr : Debugging enabled, App Verification output was:
/usr/local/Installomator/jamfcpr.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Leslie Helou (PS2F6S478M)

2022-11-03 19:22:55 : INFO  : jamfcpr : Team ID matching: PS2F6S478M (expected: PS2F6S478M )
2022-11-03 19:22:55 : INFO  : jamfcpr : Downloaded version of jamfcpr is 3.3.4 on versionKey CFBundleShortVersionString, same as installed.
2022-11-03 19:22:55 : DEBUG : jamfcpr : DEBUG mode 1, not reopening anything
2022-11-03 19:22:55 : REG   : jamfcpr : No new version to install
2022-11-03 19:22:55 : REQ   : jamfcpr : ################## End Installomator, exit code 0