### PR TITLE
Microsoft Teams Download URLs and new blocking process functionality

### DIFF
--- a/fragments/labels/microsoftteams.sh
+++ b/fragments/labels/microsoftteams.sh
@@ -2,8 +2,8 @@ microsoftteams)
     name="Microsoft Teams"
     type="pkg"
     packageID="com.microsoft.teams"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869428"
-    appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.teams.standalone"]/version' 2>/dev/null | sed -E 's/<version>([0-9.]*) .*/\1/')
+    downloadURL=$(curl -fs https://teams.microsoft.com/desktopclient/installer/osx)
+    appNewVersion=$(echo ${downloadURL} | egrep -o '([0-9]+\.?){1,4}')
     # Looks like macadmin.software has package ID version. At least on 202105-28 version 1.00.411161 is matched on installed version and homepage.
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams "Microsoft Teams Helper" )

--- a/fragments/labels/microsoftteams.sh
+++ b/fragments/labels/microsoftteams.sh
@@ -3,7 +3,7 @@ microsoftteams)
     type="pkg"
     packageID="com.microsoft.teams"
     downloadURL=$(curl -fs https://teams.microsoft.com/desktopclient/installer/osx)
-    appNewVersion=$(echo ${downloadURL} | egrep -o '([0-9]+\.?){1,4}')
+    appNewVersion=$(echo ${downloadURL} | egrep -o '([0-9]+\.?){1,4}' | sed -E 's/([0-9]+)\.?([0-9]*)\.?([0-9]*)\.?([0-9]*)\.?/\1.\3.\2\4/')
     # Looks like macadmin.software has package ID version. At least on 202105-28 version 1.00.411161 is matched on installed version and homepage.
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams "Microsoft Teams Helper" )

--- a/fragments/labels/microsoftteams.sh
+++ b/fragments/labels/microsoftteams.sh
@@ -7,6 +7,7 @@ microsoftteams)
     # Looks like macadmin.software has package ID version. At least on 202105-28 version 1.00.411161 is matched on installed version and homepage.
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams "Microsoft Teams Helper" )
+    blockingProcessesAltName=( [Teams]="Microsoft Teams")
     # Commenting out msupdate as it is not really supported *yet* for teams
     # updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate --list; /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
     # updateToolArguments=( --install --apps TEAM01 )


### PR DESCRIPTION
Using the current source of macadmins for the version number appears to be inconsistent with what version Microsoft is publically providing based on https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning

I've changed the download URL to a static link that provides a link to the latest download of the macOS package and used the URL found to determine the `newAppVersion`

Additionally, Microsoft Teams does not close properly when you choose to quit the software. I created an additional PR to add functionality to fix that using the `blockingProcessesAltName` parameter. That PR is #757 