### PR TITLE
Adding a label for VPNTracker365

### DIFF
--- a/fragments/labels/vpntracker365.sh
+++ b/fragments/labels/vpntracker365.sh
@@ -1,0 +1,9 @@
+vpntracker365)
+	#credit BigMacAdmin @ Second Son Consulting
+	name="VPN Tracker 365"
+	type="zip"
+	downloadURL="https://www.vpntracker.com/goto/HPdownload/VPNT365Latest"
+	appNewVersion="$(curl -fsIL ${downloadURL}  | grep -i ^location | grep -i ".zip" | tail -1 | sed 's/.*VPN Tracker 365 - //g'| awk '{print $1}')"
+	expectedTeamID="MJMRT6WJ8S"
+	blockingProcesses=( "VPN Tracker 365" )
+	;;


### PR DESCRIPTION
 /bin/zsh Installomator/utils/assemble.sh vpntracker365 DEBUG=1
2022-11-06 08:01:21 : INFO  : vpntracker365 : setting variable from argument DEBUG=1
2022-11-06 08:01:21 : REQ   : vpntracker365 : ################## Start Installomator v. 10.0beta3, date 2022-11-06
2022-11-06 08:01:21 : INFO  : vpntracker365 : ################## Version: 10.0beta3
2022-11-06 08:01:21 : INFO  : vpntracker365 : ################## Date: 2022-11-06
2022-11-06 08:01:21 : INFO  : vpntracker365 : ################## vpntracker365
2022-11-06 08:01:21 : DEBUG : vpntracker365 : DEBUG mode 1 enabled.
2022-11-06 08:01:24 : DEBUG : vpntracker365 : name=VPN Tracker 365
2022-11-06 08:01:24 : DEBUG : vpntracker365 : appName=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : type=zip
2022-11-06 08:01:24 : DEBUG : vpntracker365 : archiveName=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : downloadURL=https://www.vpntracker.com/goto/HPdownload/VPNT365Latest
2022-11-06 08:01:24 : DEBUG : vpntracker365 : curlOptions=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : appNewVersion=22.3.1
2022-11-06 08:01:24 : DEBUG : vpntracker365 : appCustomVersion function: Not defined
2022-11-06 08:01:24 : DEBUG : vpntracker365 : versionKey=CFBundleShortVersionString
2022-11-06 08:01:24 : DEBUG : vpntracker365 : packageID=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : pkgName=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : choiceChangesXML=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : expectedTeamID=MJMRT6WJ8S
2022-11-06 08:01:24 : DEBUG : vpntracker365 : blockingProcesses=VPN Tracker 365
2022-11-06 08:01:24 : DEBUG : vpntracker365 : installerTool=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : CLIInstaller=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : CLIArguments=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : updateTool=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : updateToolArguments=
2022-11-06 08:01:24 : DEBUG : vpntracker365 : updateToolRunAsCurrentUser=
2022-11-06 08:01:24 : INFO  : vpntracker365 : BLOCKING_PROCESS_ACTION=tell_user
2022-11-06 08:01:24 : INFO  : vpntracker365 : NOTIFY=success
2022-11-06 08:01:25 : INFO  : vpntracker365 : LOGGING=DEBUG
2022-11-06 08:01:25 : INFO  : vpntracker365 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-06 08:01:25 : INFO  : vpntracker365 : Label type: zip
2022-11-06 08:01:25 : INFO  : vpntracker365 : archiveName: VPN Tracker 365.zip
2022-11-06 08:01:25 : DEBUG : vpntracker365 : Changing directory to /Users/Shared/scripts/_GithubRepos/Installomator/build
2022-11-06 08:01:25 : INFO  : vpntracker365 : App(s) found: /Applications/VPN Tracker 365.app
2022-11-06 08:01:25 : INFO  : vpntracker365 : found app at /Applications/VPN Tracker 365.app, version 22.1.1, on versionKey CFBundleShortVersionString
2022-11-06 08:01:25 : INFO  : vpntracker365 : appversion: 22.1.1
2022-11-06 08:01:25 : INFO  : vpntracker365 : Latest version of VPN Tracker 365 is 22.3.1
2022-11-06 08:01:25 : REQ   : vpntracker365 : Downloading https://www.vpntracker.com/goto/HPdownload/VPNT365Latest to VPN Tracker 365.zip
2022-11-06 08:01:25 : DEBUG : vpntracker365 : No Dialog connection, just download
2022-11-06 08:01:36 : DEBUG : vpntracker365 : File list: -rw-r--r--  1 root  staff    74M Nov  6 08:01 VPN Tracker 365.zip
2022-11-06 08:01:36 : DEBUG : vpntracker365 : File type: VPN Tracker 365.zip: Zip archive data, at least v1.0 to extract, compression method=store
2022-11-06 08:01:36 : DEBUG : vpntracker365 : curl output was:
*   Trying 194.145.236.10:443...
* Connected to www.vpntracker.com (194.145.236.10) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4288 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=vpntracker.com
*  start date: Sep 12 07:16:16 2022 GMT
*  expire date: Dec 11 07:16:15 2022 GMT
*  subjectAltName: host "www.vpntracker.com" matched cert's "www.vpntracker.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /goto/HPdownload/VPNT365Latest HTTP/1.1
> Host: www.vpntracker.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse < HTTP/1.1 301 Moved Permanently
< Server: nginx
< Date: Sun, 06 Nov 2022 16:01:24 GMT
< Content-Type: text/html; charset=iso-8859-1
< Content-Length: 261
< Connection: keep-alive
< X-LB-Response: lb-1
< X-Backend-Response: vpntrackercom_origin_1
< Location: https://www.equinux.com/goto/HPdownload/VPNT365Latest < Age: 0
< X-Cache: MISS
< X-Cache-Hits: 0
< Access-Control-Expose-Headers: Status
< Content-Security-Policy: frame-ancestors 'self' equinux.com *.equinux.com equinux.net *.equinux.net tizi.tv *.tizi.tv maildesigner365.com *.maildesigner365.com vpntracker.com *.vpntracker.com tvproapp.de *.tvproapp.de; <
* Ignoring the response-body { [261 bytes data]
* Connection #0 to host www.vpntracker.com left intact
* Issue another request to this URL: 'https://www.equinux.com/goto/HPdownload/VPNT365Latest'
*   Trying 194.145.236.10:443...
* Connected to www.equinux.com (194.145.236.10) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4508 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=equinux.com
*  start date: Oct 27 10:55:46 2022 GMT
*  expire date: Jan 25 10:55:45 2023 GMT
*  subjectAltName: host "www.equinux.com" matched cert's "www.equinux.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /goto/HPdownload/VPNT365Latest HTTP/1.1
> Host: www.equinux.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse < HTTP/1.1 302 Found
< Server: nginx
< Date: Sun, 06 Nov 2022 16:01:25 GMT
< Content-Type: text/html; charset=iso-8859-1
< Content-Length: 0
< Connection: keep-alive
< Set-Cookie: PHPSESSID=pqgsn28jm3jojs1h2e7g232or8dmda5k; path=/ < Expires: Sun, 06 Nov 2022 16:06:25 GMT
< Cache-Control: max-age=300
< Pragma: cache
< Set-Cookie: referrer=Goto+keyword+HPDOWNLOAD%2FVPNT365LATEST; expires=Tue, 05-Nov-2024 16:01:25 GMT; Max-Age=63072000; path=/ < Set-Cookie: referrer=Goto+keyword+HPDOWNLOAD%2FVPNT365LATEST; expires=Tue, 05-Nov-2024 16:01:25 GMT; Max-Age=63072000; path=/; domain=equinux.com < Set-Cookie: referrer2=no+referer; expires=Tue, 05-Nov-2024 16:01:25 GMT; Max-Age=63072000; path=/ < Set-Cookie: referrer2=no+referer; expires=Tue, 05-Nov-2024 16:01:25 GMT; Max-Age=63072000; path=/; domain=equinux.com < X-LB-Response: lb-1
< X-Backend-Response: www_origin_1
< Location: https://www.equinux.com/dlc/?l=/x/products/vpntracker/download.html&cc=com.equinux.VPNTracker&v=365&d < Age: 0
< X-Cache: MISS
< X-Cache-Hits: 0
< Content-Security-Policy: frame-ancestors 'self' equinux.com *.equinux.com equinux.net *.equinux.net tizi.tv *.tizi.tv maildesigner365.com *.maildesigner365.com vpntracker.com *.vpntracker.com tvproapp.de *.tvproapp.de; < Access-Control-Expose-Headers: Status
<
* Connection #1 to host www.equinux.com left intact
* Issue another request to this URL: 'https://www.equinux.com/dlc/?l=/x/products/vpntracker/download.html&cc=com.equinux.VPNTracker&v=365&d'
* Found bundle for host www.equinux.com: 0x600002b30b40 [serially]
* Can not multiplex, even if we wanted to!
* Re-using existing connection! (#1) with host www.equinux.com
* Connected to www.equinux.com (194.145.236.10) port 443 (#1)
> GET /dlc/?l=/x/products/vpntracker/download.html&cc=com.equinux.VPNTracker&v=365&d HTTP/1.1
> Host: www.equinux.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse < HTTP/1.1 302 Found
< Server: nginx
< Date: Sun, 06 Nov 2022 16:01:26 GMT
< Content-Type: text/html; charset=iso-8859-1
< Content-Length: 0
< Connection: keep-alive
< Set-Cookie: PHPSESSID=teg1k1dd44bub3r2lva2r3h9dmqgp77d; path=/ < Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0 < Pragma: no-cache
< X-LB-Response: lb-1
< X-Backend-Response: www_origin_1
< Location: https://download.equinux.com/files/other/VPN Tracker 365 - 22.3.1 220310.zip < Age: 0
< X-Cache: MISS
< X-Cache-Hits: 0
< Content-Security-Policy: frame-ancestors 'self' equinux.com *.equinux.com equinux.net *.equinux.net tizi.tv *.tizi.tv maildesigner365.com *.maildesigner365.com vpntracker.com *.vpntracker.com tvproapp.de *.tvproapp.de; < Access-Control-Expose-Headers: Status
<
* Connection #1 to host www.equinux.com left intact
* Issue another request to this URL: 'https://download.equinux.com/files/other/VPN%20Tracker%20365%20-%2022.3.1%20220310.zip'
*   Trying 194.145.236.10:443...
* Connected to download.equinux.com (194.145.236.10) port 443 (#2)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4508 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=equinux.com
*  start date: Oct 27 10:55:46 2022 GMT
*  expire date: Jan 25 10:55:45 2023 GMT
*  subjectAltName: host "download.equinux.com" matched cert's "download.equinux.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
> GET /files/other/VPN%20Tracker%20365%20-%2022.3.1%20220310.zip HTTP/1.1
> Host: download.equinux.com
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse < HTTP/1.1 200 OK
< Server: nginx
< Date: Sun, 06 Nov 2022 16:01:27 GMT
< Content-Type: application/zip
< Content-Length: 77971012
< Connection: keep-alive
< Last-Modified: Fri, 28 Oct 2022 13:05:05 GMT
< ETag: "635bd381-4a5be44"
< Expires: Sun, 06 Nov 2022 16:02:19 GMT
< Cache-Control: max-age=60
< Accept-Ranges: bytes
< X-LB-Response: lb-1
<
{ [16050 bytes data]
* Connection #2 to host download.equinux.com left intact

2022-11-06 08:01:36 : DEBUG : vpntracker365 : DEBUG mode 1, not checking for blocking processes
2022-11-06 08:01:36 : REQ   : vpntracker365 : Installing VPN Tracker 365
2022-11-06 08:01:36 : INFO  : vpntracker365 : Unzipping VPN Tracker 365.zip
2022-11-06 08:01:37 : INFO  : vpntracker365 : Verifying: /Users/Shared/scripts/_GithubRepos/Installomator/build/VPN Tracker 365.app
2022-11-06 08:01:38 : DEBUG : vpntracker365 : App size: 126M	/Users/Shared/scripts/_GithubRepos/Installomator/build/VPN Tracker 365.app
2022-11-06 08:01:38 : DEBUG : vpntracker365 : Debugging enabled, App Verification output was:
/Users/Shared/scripts/_GithubRepos/Installomator/build/VPN Tracker 365.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: equinux AG (MJMRT6WJ8S)

2022-11-06 08:01:38 : INFO  : vpntracker365 : Team ID matching: MJMRT6WJ8S (expected: MJMRT6WJ8S )
2022-11-06 08:01:38 : INFO  : vpntracker365 : Downloaded version of VPN Tracker 365 is 22.3.1 on versionKey CFBundleShortVersionString (replacing version 22.1.1).
2022-11-06 08:01:39 : INFO  : vpntracker365 : App has LSMinimumSystemVersion: 10.11
2022-11-06 08:01:39 : DEBUG : vpntracker365 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2022-11-06 08:01:39 : INFO  : vpntracker365 : Finishing...
2022-11-06 08:01:42 : INFO  : vpntracker365 : App(s) found: /Applications/VPN Tracker 365.app
2022-11-06 08:01:42 : INFO  : vpntracker365 : found app at /Applications/VPN Tracker 365.app, version 22.1.1, on versionKey CFBundleShortVersionString
2022-11-06 08:01:42 : REQ   : vpntracker365 : Installed VPN Tracker 365, version 22.1.1
2022-11-06 08:01:42 : INFO  : vpntracker365 : notifying
2022-11-06 08:01:42 : DEBUG : vpntracker365 : DEBUG mode 1, not reopening anything
2022-11-06 08:01:42 : REQ   : vpntracker365 : All done!
2022-11-06 08:01:42 : REQ   : vpntracker365 : ################## End Installomator, exit code 0