### PR TITLE
Update Duo Device Health label to use PKG URL

### DIFF
--- a/fragments/labels/duodevicehealth.sh
+++ b/fragments/labels/duodevicehealth.sh
@@ -1,9 +1,8 @@
 duodevicehealth)
     name="Duo Device Health"
-    type="pkgInDmg"
-    downloadURL="https://dl.duosecurity.com/DuoDeviceHealth-latest.dmg"
-    appNewVersion=$(curl -fsLIXGET "https://dl.duosecurity.com/DuoDeviceHealth-latest.dmg" | grep -i "^content-disposition" | sed -e 's/.*filename\=\"DuoDeviceHealth\-\(.*\)\.dmg\".*/\1/')
+    type="pkg"
+    downloadURL="https://dl.duosecurity.com/DuoDeviceHealth-latest.pkg"
+    appNewVersion=$(curl -fsLIXGET "https://dl.duosecurity.com/DuoDeviceHealth-latest.pkg" | grep -i "^content-disposition" | sed -e 's/.*filename\=\"DuoDeviceHealth\-\(.*\)\.pkg\".*/\1/')
     appName="Duo Device Health.app"
     expectedTeamID="FNN8Z5JMFP"
     ;;
-


### PR DESCRIPTION
Update label to use new PKG download.
Old DMG URL is no longer being updated.

```
2022-11-08 14:47:30 : INFO  : duodevicehealth : setting variable from argument DEBUG=0
2022-11-08 14:47:30 : INFO  : duodevicehealth : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2022-11-08 14:47:30 : INFO  : duodevicehealth : setting variable from argument INSTALL=force
2022-11-08 14:47:30 : REQ   : duodevicehealth : ################## Start Installomator v. 10.0beta3, date 2022-11-08
2022-11-08 14:47:30 : INFO  : duodevicehealth : ################## Version: 10.0beta3
2022-11-08 14:47:30 : INFO  : duodevicehealth : ################## Date: 2022-11-08
2022-11-08 14:47:30 : INFO  : duodevicehealth : ################## duodevicehealth
2022-11-08 14:47:30 : INFO  : duodevicehealth : SwiftDialog is not installed, clear cmd file var
2022-11-08 14:47:30 : INFO  : duodevicehealth : BLOCKING_PROCESS_ACTION=kill
2022-11-08 14:47:30 : INFO  : duodevicehealth : NOTIFY=success
2022-11-08 14:47:30 : INFO  : duodevicehealth : LOGGING=INFO
2022-11-08 14:47:30 : INFO  : duodevicehealth : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-08 14:47:30 : INFO  : duodevicehealth : Label type: pkg
2022-11-08 14:47:30 : INFO  : duodevicehealth : archiveName: Duo Device Health.pkg
2022-11-08 14:47:30 : INFO  : duodevicehealth : no blocking processes defined, using Duo Device Health as default
2022-11-08 14:47:30 : INFO  : duodevicehealth : App(s) found: /Applications/Duo Device Health.app
2022-11-08 14:47:30 : INFO  : duodevicehealth : found app at /Applications/Duo Device Health.app, version 3.2.0.0, on versionKey CFBundleShortVersionString
2022-11-08 14:47:30 : INFO  : duodevicehealth : appversion: 3.2.0.0
2022-11-08 14:47:30 : INFO  : duodevicehealth : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-11-08 14:47:30 : INFO  : duodevicehealth : Latest version of Duo Device Health is 3.2.0.0
2022-11-08 14:47:30 : INFO  : duodevicehealth : There is no newer version available.
2022-11-08 14:47:30 : REQ   : duodevicehealth : Downloading https://dl.duosecurity.com/DuoDeviceHealth-latest.pkg to Duo Device Health.pkg
2022-11-08 14:47:31 : INFO  : duodevicehealth : found blocking process Duo Device Health
2022-11-08 14:47:31 : INFO  : duodevicehealth : killing process Duo Device Health
2022-11-08 14:47:36 : REQ   : duodevicehealth : no more blocking processes, continue with update
2022-11-08 14:47:36 : REQ   : duodevicehealth : Installing Duo Device Health
2022-11-08 14:47:36 : INFO  : duodevicehealth : Verifying: Duo Device Health.pkg
2022-11-08 14:47:36 : INFO  : duodevicehealth : Team ID: FNN8Z5JMFP (expected: FNN8Z5JMFP )
2022-11-08 14:47:36 : INFO  : duodevicehealth : Installing Duo Device Health.pkg to /
2022-11-08 14:47:43 : INFO  : duodevicehealth : Finishing...
2022-11-08 14:47:46 : INFO  : duodevicehealth : App(s) found: /Applications/Duo Device Health.app
2022-11-08 14:47:46 : INFO  : duodevicehealth : found app at /Applications/Duo Device Health.app, version 3.2.0.0, on versionKey CFBundleShortVersionString
2022-11-08 14:47:46 : REQ   : duodevicehealth : Installed Duo Device Health, version 3.2.0.0
2022-11-08 14:47:46 : INFO  : duodevicehealth : notifying
2022-11-08 14:47:47 : INFO  : duodevicehealth : Telling app Duo Device Health.app to open
2022-11-08 14:47:48 : INFO  : duodevicehealth : Reopened Duo Device Health.app as user
2022-11-08 14:47:48 : REQ   : duodevicehealth : All done!
2022-11-08 14:47:48 : REQ   : duodevicehealth : ################## End Installomator, exit code 0
```