### PR TITLE
Version fix for the Skype label

### DIFF
--- a/fragments/labels/skype.sh
+++ b/fragments/labels/skype.sh
@@ -2,7 +2,8 @@ skype)
     name="Skype"
     type="dmg"
     downloadURL="https://get.skype.com/go/getskype-skypeformac"
-    appNewVersion=$(curl -is "https://get.skype.com/go/getskype-skypeformac" | grep ocation: | grep -o "Skype-.*dmg" | cut -d "-" -f 2 | cut -d "." -f1-2)
+    appNewVersion=$(curl -is "https://get.skype.com/go/getskype-skypeformac" | grep ocation: | grep -o "Skype-.*dmg" | cut -d "-" -f 2 | sed 's/.dmg//')
+    versionKey="CFBundleVersion"
     expectedTeamID="AL798K98FX"
     Company="Microsoft"
     ;;


### PR DESCRIPTION
The current Skype label only checks for version x.xx (e.g. 8.90), which means it does not detect more minor version updates like the current latest version 8.90.0.407. I've changed the code in the appNewVersion variable and added a versionKey variable that fixes this problem.

2022-11-10 08:26:43 : REQ   : skype : ################## Start Installomator v. 10.0beta3, date 2022-11-10
2022-11-10 08:26:43 : INFO  : skype : ################## Version: 10.0beta3
2022-11-10 08:26:43 : INFO  : skype : ################## Date: 2022-11-10
2022-11-10 08:26:43 : INFO  : skype : ################## skype
2022-11-10 08:26:43 : INFO  : skype : SwiftDialog is not installed, clear cmd file var
2022-11-10 08:26:43 : INFO  : skype : BLOCKING_PROCESS_ACTION=tell_user
2022-11-10 08:26:43 : INFO  : skype : NOTIFY=success
2022-11-10 08:26:43 : INFO  : skype : LOGGING=INFO
2022-11-10 08:26:43 : INFO  : skype : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-10 08:26:43 : INFO  : skype : Label type: dmg
2022-11-10 08:26:43 : INFO  : skype : archiveName: Skype.dmg
2022-11-10 08:26:43 : INFO  : skype : no blocking processes defined, using Skype as default
2022-11-10 08:26:43 : INFO  : skype : App(s) found: /Applications/Skype.app
2022-11-10 08:26:43 : INFO  : skype : found app at /Applications/Skype.app, version 8.90.0.405, on versionKey CFBundleVersion
2022-11-10 08:26:43 : INFO  : skype : appversion: 8.90.0.405
2022-11-10 08:26:43 : INFO  : skype : Latest version of Skype is 8.90.0.407
2022-11-10 08:26:43 : REQ   : skype : Downloading https://get.skype.com/go/getskype-skypeformac to Skype.dmg
2022-11-10 08:26:45 : REQ   : skype : no more blocking processes, continue with update
2022-11-10 08:26:45 : REQ   : skype : Installing Skype
2022-11-10 08:26:45 : INFO  : skype : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.C1ZzJtXF/Skype.dmg
2022-11-10 08:26:50 : INFO  : skype : Mounted: /Volumes/Skype
2022-11-10 08:26:50 : INFO  : skype : Verifying: /Volumes/Skype/Skype.app
2022-11-10 08:26:52 : INFO  : skype : Team ID matching: AL798K98FX (expected: AL798K98FX )
2022-11-10 08:26:52 : INFO  : skype : Downloaded version of Skype is 8.90.0.407 on versionKey CFBundleVersion (replacing version 8.90.0.405).
2022-11-10 08:26:52 : INFO  : skype : App has LSMinimumSystemVersion: 10.11
2022-11-10 08:26:52 : WARN  : skype : Removing existing /Applications/Skype.app
2022-11-10 08:26:52 : INFO  : skype : Copy /Volumes/Skype/Skype.app to /Applications
2022-11-10 08:26:53 : WARN  : skype : Changing owner to kryptonit
2022-11-10 08:26:53 : INFO  : skype : Finishing...
2022-11-10 08:26:56 : INFO  : skype : App(s) found: /Applications/Skype.app
2022-11-10 08:26:56 : INFO  : skype : found app at /Applications/Skype.app, version 8.90.0.407, on versionKey CFBundleVersion
2022-11-10 08:26:56 : REQ   : skype : Installed Skype, version 8.90.0.407
2022-11-10 08:26:56 : INFO  : skype : notifying
2022-11-10 08:26:57 : INFO  : skype : App not closed, so no reopen.
2022-11-10 08:26:57 : REQ   : skype : All done!
2022-11-10 08:26:57 : REQ   : skype : ################## End Installomator, exit code 0