### PR TITLE
New Label: LG Calibration Studio

### DIFF
--- a/fragments/labels/lgcalibrationstudio.sh
+++ b/fragments/labels/lgcalibrationstudio.sh
@@ -1,0 +1,9 @@
+lgcalibrationstudio)
+    name="LG Calibration Studio"
+    type="pkgInZip"
+    packageID="LGSI.TrueColorPro"
+    releaseURL="https://www.lg.com/de/support/software-select-category-result?csSalesCode=34WK95U-W.AEU"
+    appNewVersion=$(curl -sf $releaseURL | grep -m 1 "Mac_LCS_" | sed -E 's/.*LCS_([0-9.]*).zip.*/\1/g')
+    downloadURL=$(curl -sf $releaseURL | grep -m 1 "Mac_LCS_" | sed "s|.*href=\"\(.*\)\" title.*|\\1|")
+    expectedTeamID="5SKT5H4CPQ"
+    ;;


### PR DESCRIPTION
LG Calibration Studio is an application to ensure high color reproduction accuracy with LG monitor. *Note: The LG Calibration Studio is new version of the True Color Pro.

- Supported OS: macOS 11, macOS 12

- Supported Calibrator:
  > LG Electronics
     COLOR CALIBRATION SENSOR
  > X-rite
     ColorMunki Photo
     ColorMunki Design
     i1DISPLAY Pro
     i1DISPLAY Pro Plus
     i1DISPLAY Studio
     i1Pro2
     i1Pro3
  > Data Color
     Spyder5
     SpyderX
  > Colorimeter Research
     CR-100
  > Gamma Scientific
     GS1160B
  > Klein Instruments
     K10A
- Includes: TUSB3410 driver

2022-11-12 17:32:43 : INFO  : lgcalibrationstudio : setting variable from argument NOTIFY=silent
2022-11-12 17:32:43 : INFO  : lgcalibrationstudio : setting variable from argument DEBUG=0
2022-11-12 17:32:43 : REQ   : lgcalibrationstudio : ################## Start Installomator v. 10.0beta3, date 2022-11-12
2022-11-12 17:32:43 : INFO  : lgcalibrationstudio : ################## Version: 10.0beta3
2022-11-12 17:32:43 : INFO  : lgcalibrationstudio : ################## Date: 2022-11-12
2022-11-12 17:32:43 : INFO  : lgcalibrationstudio : ################## lgcalibrationstudio
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : BLOCKING_PROCESS_ACTION=tell_user
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : NOTIFY=silent
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : LOGGING=INFO
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : Label type: pkgInZip
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : archiveName: LG Calibration Studio.zip
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : no blocking processes defined, using LG Calibration Studio as default
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : No version found using packageID LGSI.TrueColorPro
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : name: LG Calibration Studio, appName: LG Calibration Studio.app
2022-11-12 17:32:44 : WARN  : lgcalibrationstudio : No previous app found
2022-11-12 17:32:44 : WARN  : lgcalibrationstudio : could not find LG Calibration Studio.app
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : appversion: 
2022-11-12 17:32:44 : INFO  : lgcalibrationstudio : Latest version of LG Calibration Studio is 6.5.9
2022-11-12 17:32:44 : REQ   : lgcalibrationstudio : Downloading https://gscs-b2c.lge.com/downloadFile?fileId=WdMLAsbsO9ZxSHkhNkscw to LG Calibration Studio.zip
2022-11-12 17:32:56 : REQ   : lgcalibrationstudio : no more blocking processes, continue with update
2022-11-12 17:32:56 : REQ   : lgcalibrationstudio : Installing LG Calibration Studio
2022-11-12 17:32:56 : INFO  : lgcalibrationstudio : Unzipping LG Calibration Studio.zip
2022-11-12 17:32:56 : INFO  : lgcalibrationstudio : found pkg: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2g0l6GBD/LGCalibrationStudio_V6.5.9_signed.pkg
2022-11-12 17:32:56 : INFO  : lgcalibrationstudio : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2g0l6GBD/LGCalibrationStudio_V6.5.9_signed.pkg
2022-11-12 17:32:56 : INFO  : lgcalibrationstudio : Team ID: 5SKT5H4CPQ (expected: 5SKT5H4CPQ )
2022-11-12 17:32:56 : INFO  : lgcalibrationstudio : Installing /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2g0l6GBD/LGCalibrationStudio_V6.5.9_signed.pkg to /
2022-11-12 17:33:11 : INFO  : lgcalibrationstudio : Finishing...
2022-11-12 17:33:15 : INFO  : lgcalibrationstudio : No version found using packageID LGSI.TrueColorPro
2022-11-12 17:33:15 : INFO  : lgcalibrationstudio : App(s) found: /Applications/LG Calibration Studio.app
2022-11-12 17:33:15 : INFO  : lgcalibrationstudio : found app at /Applications/LG Calibration Studio.app, version 6.5.9, on versionKey CFBundleShortVersionString
2022-11-12 17:33:15 : REQ   : lgcalibrationstudio : Installed LG Calibration Studio, version 6.5.9
2022-11-12 17:33:15 : INFO  : lgcalibrationstudio : App not closed, so no reopen.
2022-11-12 17:33:15 : REQ   : lgcalibrationstudio : All done!
2022-11-12 17:33:15 : REQ   : lgcalibrationstudio : ################## End Installomator, exit code 0 