### PR TITLE
updated code42 download url's with new hostname 

### DIFF
--- a/fragments/labels/code42.sh
+++ b/fragments/labels/code42.sh
@@ -2,9 +2,9 @@ code42)
     name="Code42"
     type="pkgInDmg"
     if [[ $(arch) == i386 ]]; then
-       downloadURL="https://download.code42.com/installs/agent/latest-mac.dmg"
+       downloadURL="https://download-preservation.code42.com/installs/agent/latest-mac.dmg"
     elif [[ $(arch) == arm64 ]]; then
-       downloadURL="https://download.code42.com/installs/agent/latest-mac-arm64.dmg"
+       downloadURL="https://download-preservation.code42.com/installs/agent/latest-mac-arm64.dmg"
     fi
     expectedTeamID="9YV9435DHD"
     blockingProcesses=( NONE )


### PR DESCRIPTION
Code42 adjusted their download hostname to be https://download-preservation.code42.com making the old hostname in the "downloadurl" no longer valid. This will still pull down an older version as noted in #572 but will allow the workflow to still function for organizations with the option to upgrade via the cloud. 