### PR TITLE
Prompt timeout

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -334,6 +334,7 @@ checkRunningProcesses() {
                       if [[ $button = "Not Now" ]]; then
                         cleanupAndExit 10 "user aborted update" ERROR
                       elif [[ $button = "" ]]; then
+                        appClosed=0
                         cleanupAndExit 25 "timed out waiting for user response" ERROR
                       else
                         if [[ $i > 2 && $BLOCKING_PROCESS_ACTION = "prompt_user_then_kill" ]]; then

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -51,7 +51,7 @@ reloadAsUser() {
 displaydialog() { # $1: message $2: title
     message=${1:-"Message"}
     title=${2:-"Installomator"}
-    runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Not Now\", \"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\")"
+    runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Not Now\", \"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\" giving up after $PROMPT_TIMEOUT)"
 }
 
 displaydialogContinue() { # $1: message $2: title
@@ -333,6 +333,8 @@ checkRunningProcesses() {
                       button=$(displaydialog "Quit “$x” to continue updating? (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")
                       if [[ $button = "Not Now" ]]; then
                         cleanupAndExit 10 "user aborted update" ERROR
+                      elif [[ $button = "" ]]; then
+                        cleanupAndExit 25 "timed out waiting for user response" ERROR
                       else
                         if [[ $i > 2 && $BLOCKING_PROCESS_ACTION = "prompt_user_then_kill" ]]; then
                           printlog "Changing BLOCKING_PROCESS_ACTION to kill"

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -34,6 +34,15 @@ NOTIFY=success
 #   - silent       no notifications
 #   - all          all notifications (great for Self Service installation)
 
+# time in seconds to wait for a prompt to be answered before exiting the script
+PROMPT_TIMEOUT=86400
+# Common times translated into seconds
+# 60    =  1 minute
+# 300   =  5 minutes
+# 600   = 10 minutes
+# 3600  =  1 hour
+# 86400 = 24 hours (default)
+
 # behavior when blocking processes are found
 BLOCKING_PROCESS_ACTION=tell_user
 # options:


### PR DESCRIPTION
This was originally #682 but I messed something up where I can't commit to that anymore
If prompt_user or prompt_user_then_kill is used and the user does not respond to the prompt after PROMPT_TIMEOUT seconds, exit the script. The behavior is similar to hitting "not now". Default timeout is set to 24 hours.

output:
```
Installomator v10 % sudo ./Installomator.sh slack DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user LOGO=jamf SYSTEMOWNER=1 NOTIFY=all INSTALL=force PROMPT_TIMEOUT=5
Password:
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument DEBUG=0
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument LOGO=jamf
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument SYSTEMOWNER=1
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument NOTIFY=all
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument INSTALL=force
2022-11-18 09:15:58 : INFO  : slack : setting variable from argument PROMPT_TIMEOUT=5
2022-11-18 09:15:58 : REQ   : slack : ################## Start Installomator v. 10.0, date 2022-11-18
2022-11-18 09:15:58 : INFO  : slack : ################## Version: 10.0
2022-11-18 09:15:58 : INFO  : slack : ################## Date: 2022-11-18
2022-11-18 09:15:58 : INFO  : slack : ################## slack
2022-11-18 09:15:58 : INFO  : slack : BLOCKING_PROCESS_ACTION=prompt_user
2022-11-18 09:15:58 : INFO  : slack : NOTIFY=all
2022-11-18 09:15:58 : INFO  : slack : LOGGING=INFO
2022-11-18 09:15:58 : INFO  : slack : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2022-11-18 09:15:58 : INFO  : slack : Label type: dmg
2022-11-18 09:15:58 : INFO  : slack : archiveName: Slack.dmg
2022-11-18 09:15:58 : INFO  : slack : no blocking processes defined, using Slack as default
2022-11-18 09:15:59 : INFO  : slack : App(s) found: /Applications/Slack.app
2022-11-18 09:15:59 : INFO  : slack : found app at /Applications/Slack.app, version 4.29.149, on versionKey CFBundleShortVersionString
2022-11-18 09:15:59 : INFO  : slack : appversion: 4.29.149
2022-11-18 09:15:59 : INFO  : slack : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2022-11-18 09:15:59 : INFO  : slack : Latest version of Slack is 4.29.149
2022-11-18 09:15:59 : INFO  : slack : There is no newer version available.
2022-11-18 09:15:59 : REQ   : slack : Downloading https://slack.com/ssb/download-osx-universal to Slack.dmg
2022-11-18 09:15:59 : INFO  : slack : notifying
2022-11-18 09:16:07 : INFO  : slack : found blocking process Slack
2022-11-18 09:16:13 : INFO  : slack : App not closed, so no reopen.
2022-11-18 09:16:13 : ERROR : slack : ERROR: timed out waiting for user response
2022-11-18 09:16:13 : REQ   : slack : ################## End Installomator, exit code 25 
```