### PR TITLE
New Label: JetBrains Rider

### DIFF
--- a/fragments/labels/jetbrainsrider.sh
+++ b/fragments/labels/jetbrainsrider.sh
@@ -1,0 +1,13 @@
+jetbrainsrider)
+    name="Rider"
+    type="dmg"
+    jetbrainscode="RD"
+    if [[ $(arch) == i386 ]]; then
+        jetbrainsdistribution="mac"
+    elif [[ $(arch) == arm64 ]]; then
+        jetbrainsdistribution="macM1"
+    fi
+    downloadURL="https://download.jetbrains.com/product?code=${jetbrainscode}&latest&distribution=${jetbrainsdistribution}"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "location" | tail -1 | sed -E 's/.*\/[a-zA-Z-]*-([0-9.]*).*[-.].*dmg/\1/g' )
+    expectedTeamID="2ZEFAR8TH3"
+    ;;


### PR DESCRIPTION
Rider is cross-platform .NET IDE from JetBrains

Log:
```
2022-11-21 22:00:44 : INFO  : jetbrainsrider : setting variable from argument DEBUG=0
2022-11-21 22:00:44 : REQ   : jetbrainsrider : ################## Start Installomator v. 10.1beta, date 2022-11-21
2022-11-21 22:00:44 : INFO  : jetbrainsrider : ################## Version: 10.1beta
2022-11-21 22:00:44 : INFO  : jetbrainsrider : ################## Date: 2022-11-21
2022-11-21 22:00:44 : INFO  : jetbrainsrider : ################## jetbrainsrider
2022-11-21 22:00:44 : INFO  : jetbrainsrider : BLOCKING_PROCESS_ACTION=tell_user
2022-11-21 22:00:44 : INFO  : jetbrainsrider : NOTIFY=success
2022-11-21 22:00:44 : INFO  : jetbrainsrider : LOGGING=INFO
2022-11-21 22:00:44 : INFO  : jetbrainsrider : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-21 22:00:44 : INFO  : jetbrainsrider : Label type: dmg
2022-11-21 22:00:44 : INFO  : jetbrainsrider : archiveName: Rider.dmg
2022-11-21 22:00:44 : INFO  : jetbrainsrider : no blocking processes defined, using Rider as default
2022-11-21 22:00:44 : INFO  : jetbrainsrider : name: Rider, appName: Rider.app
2022-11-21 22:00:44.933 mdfind[75227:2194985] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2022-11-21 22:00:44.933 mdfind[75227:2194985] [UserQueryParser] Loading keywords and predicates for locale "en"
2022-11-21 22:00:45.002 mdfind[75227:2194985] Couldn't determine the mapping between prefab keywords and predicates.
2022-11-21 22:00:45 : WARN  : jetbrainsrider : No previous app found
2022-11-21 22:00:45 : WARN  : jetbrainsrider : could not find Rider.app
2022-11-21 22:00:45 : INFO  : jetbrainsrider : appversion:
2022-11-21 22:00:45 : INFO  : jetbrainsrider : Latest version of Rider is
2022-11-21 22:00:45 : REQ   : jetbrainsrider : Downloading https://download.jetbrains.com/product?code=RD&latest&distribution=macM1 to Rider.dmg
2022-11-21 22:02:49 : REQ   : jetbrainsrider : no more blocking processes, continue with update
2022-11-21 22:02:49 : REQ   : jetbrainsrider : Installing Rider
2022-11-21 22:02:49 : INFO  : jetbrainsrider : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.47MXsIgW/Rider.dmg
2022-11-21 22:02:55 : INFO  : jetbrainsrider : Mounted: /Volumes/Rider
2022-11-21 22:02:55 : INFO  : jetbrainsrider : Verifying: /Volumes/Rider/Rider.app
2022-11-21 22:03:04 : INFO  : jetbrainsrider : Team ID matching: 2ZEFAR8TH3 (expected: 2ZEFAR8TH3 )
2022-11-21 22:03:04 : INFO  : jetbrainsrider : Installing Rider version 2022.2.4 on versionKey CFBundleShortVersionString.
2022-11-21 22:03:04 : INFO  : jetbrainsrider : App has LSMinimumSystemVersion: 10.8
2022-11-21 22:03:04 : INFO  : jetbrainsrider : Copy /Volumes/Rider/Rider.app to /Applications
2022-11-21 22:03:17 : WARN  : jetbrainsrider : Changing owner to dipierro
2022-11-21 22:03:18 : INFO  : jetbrainsrider : Finishing...
2022-11-21 22:03:21 : INFO  : jetbrainsrider : App(s) found: /Applications/Rider.app
2022-11-21 22:03:21 : INFO  : jetbrainsrider : found app at /Applications/Rider.app, version 2022.2.4, on versionKey CFBundleShortVersionString
2022-11-21 22:03:21 : REQ   : jetbrainsrider : Installed Rider, version 2022.2.4
2022-11-21 22:03:21 : INFO  : jetbrainsrider : notifying
2022-11-21 22:03:21 : INFO  : jetbrainsrider : App not closed, so no reopen.
2022-11-21 22:03:21 : REQ   : jetbrainsrider : All done!
2022-11-21 22:03:21 : REQ   : jetbrainsrider : ################## End Installomator, exit code 0
```