### PR TITLE
Version check switched to CFBundleVersion

### DIFF
--- a/fragments/labels/synologydriveclient.sh
+++ b/fragments/labels/synologydriveclient.sh
@@ -1,8 +1,10 @@
 synologydriveclient)
     name="Synology Drive Client"
     type="pkgInDmg"
-    packageID="com.synology.CloudStation"
+    # packageID="com.synology.CloudStation"
+    versionKey="CFBundleVersion"
     downloadURL=$(appVersion=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)<.*|\\1|"` && appShortVersion=`sed 's#.*-\(\)#\1#' <<< $appVersion` && echo https://global.download.synology.com/download/Utility/SynologyDriveClient/"$appVersion"/Mac/Installer/synology-drive-client-"${appShortVersion}".dmg)
-    appNewVersion=$(appVersionP1=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)-.*|\\1|"` && sed 's/\(.\{0\}\)./\17/' <<< $appVersionP1)
+    # appNewVersion=$(appVersionP1=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)-.*|\\1|"` && sed 's/\(.\{0\}\)./\17/' <<< $appVersionP1)
+    appNewVersion=$(curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)<.*|\\1|" | sed "s#.*-\(\)#\1#")
     expectedTeamID="X85BAK35Y4"
     ;;


### PR DESCRIPTION
2022-11-29 18:36:57 : INFO  : synologydriveclient : setting variable from argument NOTIFY=silent
2022-11-29 18:36:57 : INFO  : synologydriveclient : setting variable from argument DEBUG=0
2022-11-29 18:36:57 : REQ   : synologydriveclient : ################## Start Installomator v. 10.1beta, date 2022-11-29
2022-11-29 18:36:57 : INFO  : synologydriveclient : ################## Version: 10.1beta
2022-11-29 18:36:57 : INFO  : synologydriveclient : ################## Date: 2022-11-29
2022-11-29 18:36:57 : INFO  : synologydriveclient : ################## synologydriveclient
2022-11-29 18:36:57 : INFO  : synologydriveclient : BLOCKING_PROCESS_ACTION=tell_user
2022-11-29 18:36:57 : INFO  : synologydriveclient : NOTIFY=silent
2022-11-29 18:36:57 : INFO  : synologydriveclient : LOGGING=INFO
2022-11-29 18:36:57 : INFO  : synologydriveclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-11-29 18:36:57 : INFO  : synologydriveclient : Label type: pkgInDmg
2022-11-29 18:36:57 : INFO  : synologydriveclient : archiveName: Synology Drive Client.dmg
2022-11-29 18:36:57 : INFO  : synologydriveclient : no blocking processes defined, using Synology Drive Client as default
2022-11-29 18:36:57 : INFO  : synologydriveclient : App(s) found: /Applications/Synology Drive Client.app
2022-11-29 18:36:57 : INFO  : synologydriveclient : found app at /Applications/Synology Drive Client.app, version 13258, on versionKey CFBundleVersion
2022-11-29 18:36:57 : INFO  : synologydriveclient : appversion: 13258
2022-11-29 18:36:57 : INFO  : synologydriveclient : Latest version of Synology Drive Client is 13258
2022-11-29 18:36:57 : INFO  : synologydriveclient : There is no newer version available.
2022-11-29 18:36:57 : INFO  : synologydriveclient : App not closed, so no reopen.
2022-11-29 18:36:57 : REQ   : synologydriveclient : No newer version.
2022-11-29 18:36:57 : REQ   : synologydriveclient : ################## End Installomator, exit code 0 
