### PR TITLE
Only tell user once on tell_user_then_kill

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -383,7 +383,7 @@ checkRunningProcesses() {
                       # give the user a bit of time to quit apps
                       printlog "waiting 30 seconds for processes to quit"
                       sleep 30
-                      if [[ $i > 1 && $BLOCKING_PROCESS_ACTION = tell_user_then_kill ]]; then
+                      if [[ $BLOCKING_PROCESS_ACTION = tell_user_then_kill ]]; then
                           printlog "Changing BLOCKING_PROCESS_ACTION to kill"
                           BLOCKING_PROCESS_ACTION=kill
                       fi


### PR DESCRIPTION
Try to quit app, then kill if it doesn't quit. Don't loop around and tell them again and try to quit again.

previous behavior:
```
2022-12-02 11:33:00 : INFO  : adobereaderdc-update : found blocking process AdobeReader
2022-12-02 11:33:05 : INFO  : adobereaderdc-update : telling app AdobeReader to quit
2022-12-02 11:33:05 : INFO  : adobereaderdc-update : waiting 30 seconds for processes to quit
2022-12-02 11:33:35 : INFO  : adobereaderdc-update : found blocking process AdobeReader
2022-12-02 11:33:39 : INFO  : adobereaderdc-update : telling app AdobeReader to quit
2022-12-02 11:33:39 : INFO  : adobereaderdc-update : waiting 30 seconds for processes to quit
2022-12-02 11:34:09 : INFO  : adobereaderdc-update : Changing BLOCKING_PROCESS_ACTION to kill
2022-12-02 11:34:09 : INFO  : adobereaderdc-update : found blocking process AdobeReader
2022-12-02 11:34:09 : INFO  : adobereaderdc-update : killing process AdobeReader
2022-12-02 11:34:14 : REQ   : adobereaderdc-update : no more blocking processes, continue with update
```

new behavior:
```
2022-12-02 11:36:23 : INFO  : adobereaderdc-update : found blocking process AdobeReader
2022-12-02 11:36:26 : INFO  : adobereaderdc-update : telling app AdobeReader to quit
2022-12-02 11:36:26 : INFO  : adobereaderdc-update : waiting 30 seconds for processes to quit
2022-12-02 11:36:56 : INFO  : adobereaderdc-update : Changing BLOCKING_PROCESS_ACTION to kill
2022-12-02 11:36:56 : INFO  : adobereaderdc-update : found blocking process AdobeReader
2022-12-02 11:36:56 : INFO  : adobereaderdc-update : killing process AdobeReader
2022-12-02 11:37:01 : REQ   : adobereaderdc-update : no more blocking processes, continue with update
```