### PR TITLE
openvpnconnect v3 fix

### DIFF
--- a/fragments/labels/openvpnconnectv3.sh
+++ b/fragments/labels/openvpnconnectv3.sh
@@ -3,7 +3,7 @@ openvpnconnectv3)
     name="OpenVPN Connect"
     type="pkgInDmg"
     if [[ $(arch) == "arm64" ]]; then
-        pkgName="/OpenVPN_Connect_[0-9_()]*_arm64_Installer_signed.pkg"
+        pkgName="OpenVPN_Connect_[0-9_()]*_arm64_Installer_signed.pkg"
     elif [[ $(arch) == "i386" ]]; then
         pkgName="OpenVPN_Connect_[0-9_()]*_x86_64_Installer_signed.pkg"
     fi


### PR DESCRIPTION
removed extraneous / from the pkgName as per #784
