### PR TITLE
GIMP label update

### DIFF
--- a/fragments/labels/gimp.sh
+++ b/fragments/labels/gimp.sh
@@ -1,7 +1,11 @@
 gimp)
-    name="GIMP-2.10"
+    name="GIMP"
     type="dmg"
-    downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*.dmg")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-arm64.dmg")
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-x86_64.dmg")
+    fi
     appNewVersion=$(echo $downloadURL | cut -d "-" -f 2)
     expectedTeamID="T25BQ8HSJF"
     ;;


### PR DESCRIPTION
App name has changed from "GIMP-2.10.app" to "GIMP.app". The application is also available for Apple Silicon now, so I added logic for that.

2022-12-09 12:31:00 : INFO  : gimp : setting variable from argument DEBUG=0
2022-12-09 12:31:00 : REQ   : gimp : ################## Start Installomator v. 10.1beta, date 2022-12-09
2022-12-09 12:31:00 : INFO  : gimp : ################## Version: 10.1beta
2022-12-09 12:31:00 : INFO  : gimp : ################## Date: 2022-12-09
2022-12-09 12:31:00 : INFO  : gimp : ################## gimp
2022-12-09 12:31:00 : INFO  : gimp : SwiftDialog is not installed, clear cmd file var
2022-12-09 12:31:01 : INFO  : gimp : BLOCKING_PROCESS_ACTION=tell_user
2022-12-09 12:31:01 : INFO  : gimp : NOTIFY=success
2022-12-09 12:31:01 : INFO  : gimp : LOGGING=INFO
2022-12-09 12:31:01 : INFO  : gimp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-12-09 12:31:01 : INFO  : gimp : Label type: dmg
2022-12-09 12:31:01 : INFO  : gimp : archiveName: GIMP.dmg
2022-12-09 12:31:01 : INFO  : gimp : no blocking processes defined, using GIMP as default
2022-12-09 12:31:01 : INFO  : gimp : name: GIMP, appName: GIMP.app
2022-12-09 12:31:01.296 mdfind[3739:8304184] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2022-12-09 12:31:01.296 mdfind[3739:8304184] [UserQueryParser] Loading keywords and predicates for locale "en"
2022-12-09 12:31:01.349 mdfind[3739:8304184] Couldn't determine the mapping between prefab keywords and predicates.
2022-12-09 12:31:01 : WARN  : gimp : No previous app found
2022-12-09 12:31:01 : WARN  : gimp : could not find GIMP.app
2022-12-09 12:31:01 : INFO  : gimp : appversion:
2022-12-09 12:31:01 : INFO  : gimp : Latest version of GIMP is 2.10.32
2022-12-09 12:31:01 : REQ   : gimp : Downloading https://download.gimp.org/gimp/v2.10/macos/gimp-2.10.32-1-arm64.dmg to GIMP.dmg
2022-12-09 12:31:09 : REQ   : gimp : no more blocking processes, continue with update
2022-12-09 12:31:09 : REQ   : gimp : Installing GIMP
2022-12-09 12:31:09 : INFO  : gimp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tJDTCW2E/GIMP.dmg
2022-12-09 12:31:25 : INFO  : gimp : Mounted: /Volumes/GIMP 2.10 Install
2022-12-09 12:31:25 : INFO  : gimp : Verifying: /Volumes/GIMP 2.10 Install/GIMP.app
2022-12-09 12:33:00 : INFO  : gimp : Team ID matching: T25BQ8HSJF (expected: T25BQ8HSJF )
2022-12-09 12:33:00 : INFO  : gimp : Installing GIMP version 2.10.32 on versionKey CFBundleShortVersionString.
2022-12-09 12:33:00 : INFO  : gimp : App has LSMinimumSystemVersion: 10.12
2022-12-09 12:33:00 : INFO  : gimp : Copy /Volumes/GIMP 2.10 Install/GIMP.app to /Applications
2022-12-09 12:34:48 : WARN  : gimp : Changing owner to kryptonit
2022-12-09 12:34:50 : INFO  : gimp : Finishing...
2022-12-09 12:34:53 : INFO  : gimp : App(s) found: /Applications/GIMP.app
2022-12-09 12:34:53 : INFO  : gimp : found app at /Applications/GIMP.app, version 2.10.32, on versionKey CFBundleShortVersionString
2022-12-09 12:34:53 : REQ   : gimp : Installed GIMP, version 2.10.32
2022-12-09 12:34:53 : INFO  : gimp : notifying
2022-12-09 12:34:54 : INFO  : gimp : App not closed, so no reopen.
2022-12-09 12:34:54 : REQ   : gimp : All done!
2022-12-09 12:34:54 : REQ   : gimp : ################## End Installomator, exit code 0