### PR TITLE
jabradirect: Change from packageID to versionKey

### DIFF
--- a/fragments/labels/jabradirect.sh
+++ b/fragments/labels/jabradirect.sh
@@ -1,7 +1,8 @@
 jabradirect)
     name="Jabra Direct"
     type="pkgInDmg"
-    packageID="com.jabra.directonline"
+    # packageID="com.jabra.directonline"
+    versionKey="CFBundleVersion"
     downloadURL="https://jabraxpressonlineprdstor.blob.core.windows.net/jdo/JabraDirectSetup.dmg"
     appNewVersion=$(curl -fs https://www.jabra.com/Support/release-notes/release-note-jabra-direct | grep -oe "Release version:.*[0-9.]*<" | head -1 | cut -d ">" -f2 | cut -d "<" -f1 | sed 's/ //g')
     expectedTeamID="55LV32M29R"


### PR DESCRIPTION
Using the packageID to verify the installed version, the App will not be reinstalled if it is deleted from the Applications folder.

Switching to versionKey installs the App

sudo ./assemble.sh -l Desktop/Mosyle/Resources/InstallomatorLabels jabradirect NOTIFY=silent DEBUG=0 2022-12-10 22:27:18 : INFO  : jabradirect : setting variable from argument NOTIFY=silent 2022-12-10 22:27:18 : INFO  : jabradirect : setting variable from argument DEBUG=0
2022-12-10 22:27:18 : REQ   : jabradirect : ################## Start Installomator v. 10.1, date 2022-12-10
2022-12-10 22:27:18 : INFO  : jabradirect : ################## Version: 10.1
2022-12-10 22:27:18 : INFO  : jabradirect : ################## Date: 2022-12-10
2022-12-10 22:27:18 : INFO  : jabradirect : ################## jabradirect
2022-12-10 22:27:21 : INFO  : jabradirect : BLOCKING_PROCESS_ACTION=tell_user
2022-12-10 22:27:21 : INFO  : jabradirect : NOTIFY=silent
2022-12-10 22:27:21 : INFO  : jabradirect : LOGGING=INFO
2022-12-10 22:27:21 : INFO  : jabradirect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-12-10 22:27:21 : INFO  : jabradirect : Label type: pkgInDmg
2022-12-10 22:27:21 : INFO  : jabradirect : archiveName: Jabra Direct.dmg
2022-12-10 22:27:21 : INFO  : jabradirect : no blocking processes defined, using Jabra Direct as default
2022-12-10 22:27:21 : INFO  : jabradirect : name: Jabra Direct, appName: Jabra Direct.app
2022-12-10 22:27:21 : WARN  : jabradirect : No previous app found
2022-12-10 22:27:21 : WARN  : jabradirect : could not find Jabra Direct.app
2022-12-10 22:27:21 : INFO  : jabradirect : appversion:
2022-12-10 22:27:21 : INFO  : jabradirect : Latest version of Jabra Direct is 6.5.31801
2022-12-10 22:27:21 : REQ   : jabradirect : Downloading https://jabraxpressonlineprdstor.blob.core.windows.net/jdo/JabraDirectSetup.dmg to Jabra Direct.dmg
2022-12-10 22:27:43 : REQ   : jabradirect : no more blocking processes, continue with update
2022-12-10 22:27:43 : REQ   : jabradirect : Installing Jabra Direct
2022-12-10 22:27:43 : INFO  : jabradirect : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UIBDheAB/Jabra Direct.dmg
2022-12-10 22:27:49 : INFO  : jabradirect : Mounted: /Volumes/Jabra Direct Setup 3
2022-12-10 22:27:49 : INFO  : jabradirect : found pkg: /Volumes/Jabra Direct Setup 3/JabraDirectSetup.pkg
2022-12-10 22:27:49 : INFO  : jabradirect : Verifying: /Volumes/Jabra Direct Setup 3/JabraDirectSetup.pkg
2022-12-10 22:27:49 : INFO  : jabradirect : Team ID: 55LV32M29R (expected: 55LV32M29R )
2022-12-10 22:27:49 : INFO  : jabradirect : Installing /Volumes/Jabra Direct Setup 3/JabraDirectSetup.pkg to /
2022-12-10 22:27:58 : INFO  : jabradirect : Finishing...
2022-12-10 22:28:01 : INFO  : jabradirect : App(s) found: /Applications/Jabra Direct.app
2022-12-10 22:28:01 : INFO  : jabradirect : found app at /Applications/Jabra Direct.app, version 6.5.31801, on versionKey CFBundleVersion
2022-12-10 22:28:01 : REQ   : jabradirect : Installed Jabra Direct, version 6.5.31801
2022-12-10 22:28:02 : INFO  : jabradirect : App not closed, so no reopen.
2022-12-10 22:28:02 : REQ   : jabradirect : All done!
2022-12-10 22:28:02 : REQ   : jabradirect : ################## End Installomator, exit code 0

sudo ./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels jabradirect NOTIFY=silent DEBUG=0
2022-12-10 22:28:17 : INFO  : jabradirect : setting variable from argument NOTIFY=silent
2022-12-10 22:28:17 : INFO  : jabradirect : setting variable from argument DEBUG=0
2022-12-10 22:28:17 : REQ   : jabradirect : ################## Start Installomator v. 10.1, date 2022-12-10
2022-12-10 22:28:17 : INFO  : jabradirect : ################## Version: 10.1
2022-12-10 22:28:17 : INFO  : jabradirect : ################## Date: 2022-12-10
2022-12-10 22:28:17 : INFO  : jabradirect : ################## jabradirect
2022-12-10 22:28:20 : INFO  : jabradirect : BLOCKING_PROCESS_ACTION=tell_user
2022-12-10 22:28:20 : INFO  : jabradirect : NOTIFY=silent
2022-12-10 22:28:20 : INFO  : jabradirect : LOGGING=INFO
2022-12-10 22:28:20 : INFO  : jabradirect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-12-10 22:28:20 : INFO  : jabradirect : Label type: pkgInDmg
2022-12-10 22:28:20 : INFO  : jabradirect : archiveName: Jabra Direct.dmg
2022-12-10 22:28:20 : INFO  : jabradirect : no blocking processes defined, using Jabra Direct as default
2022-12-10 22:28:20 : INFO  : jabradirect : App(s) found: /Applications/Jabra Direct.app
2022-12-10 22:28:20 : INFO  : jabradirect : found app at /Applications/Jabra Direct.app, version 6.5.31801, on versionKey CFBundleVersion
2022-12-10 22:28:20 : INFO  : jabradirect : appversion: 6.5.31801
2022-12-10 22:28:20 : INFO  : jabradirect : Latest version of Jabra Direct is 6.5.31801
2022-12-10 22:28:20 : INFO  : jabradirect : There is no newer version available.
2022-12-10 22:28:20 : INFO  : jabradirect : App not closed, so no reopen.
2022-12-10 22:28:20 : REQ   : jabradirect : No newer version.
2022-12-10 22:28:20 : REQ   : jabradirect : ################## End Installomator, exit code 0