### PR TITLE
continue running the script even if management action hangs

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -67,7 +67,7 @@ displaynotification() { # $1: message $2: title
     hubcli="/usr/local/bin/hubcli"
 
     if [[ -x "$manageaction" ]]; then
-         "$manageaction" -message "$message" -title "$title"
+         "$manageaction" -message "$message" -title "$title" &
     elif [[ -x "$hubcli" ]]; then
          "$hubcli" notify -t "$title" -i "$message" -c "Dismiss"
     else


### PR DESCRIPTION
I've seen this happen in several logs
```
2022-12-03 09:13:11 : INFO  : firefoxpkg : notifying
2022-12-13 08:18:36 : INFO  : firefoxpkg : App not closed, so no reopen.
2022-12-13 08:18:36 : REQ   : firefoxpkg : All done!
2022-12-13 08:18:36 : REQ   : firefoxpkg : ################## End Installomator, exit code 0
```
Installomator notifies that the app is installed, and just hangs there, preventing any further jamf policies from running. In this example, 10 days later I killed "Management Action" and it proceeded to finish the script. Adding the `&` when Management Action is called should prevent this possible hang.
This won't prevent Management Action from hanging, but will prevent Installomator from hanging and preventing further jamf policies from running.