### PR TITLE
Fix for RStudio label

### DIFF
--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -1,7 +1,7 @@
 rstudio)
     name="RStudio"
     type="dmg"
-    downloadURL=$(curl -s -L "https://rstudio.com/products/rstudio/download/" | grep -m 1 -Eio 'href="https://download1.rstudio.org/desktop/macos/RStudio-(.*).dmg"' | cut -c7- | sed -e 's/"$//')
+    downloadURL=$(curl -s -L "https://posit.co/download/rstudio-desktop/" | grep -m 1 -Eio 'href="https://download1.rstudio.org/electron/macos/RStudio-(.*).dmg"' | cut -c7- | sed -e 's/"$//')
     appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.-]*)\..*/\1/g' | sed 's/-/+/' )
     expectedTeamID="FYF2F5GFX4"
     ;;


### PR DESCRIPTION
Changed the download URL in order to fix label problem. Fixes #822.

2022-12-20 09:16:07 : INFO  : rstudio : setting variable from argument DEBUG=0
2022-12-20 09:16:07 : REQ   : rstudio : ################## Start Installomator v. 10.1, date 2022-12-20
2022-12-20 09:16:07 : INFO  : rstudio : ################## Version: 10.1
2022-12-20 09:16:07 : INFO  : rstudio : ################## Date: 2022-12-20
2022-12-20 09:16:07 : INFO  : rstudio : ################## rstudio
2022-12-20 09:16:07 : INFO  : rstudio : SwiftDialog is not installed, clear cmd file var
2022-12-20 09:16:08 : INFO  : rstudio : BLOCKING_PROCESS_ACTION=tell_user
2022-12-20 09:16:08 : INFO  : rstudio : NOTIFY=success
2022-12-20 09:16:08 : INFO  : rstudio : LOGGING=INFO
2022-12-20 09:16:08 : INFO  : rstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-12-20 09:16:08 : INFO  : rstudio : Label type: dmg
2022-12-20 09:16:08 : INFO  : rstudio : archiveName: RStudio.dmg
2022-12-20 09:16:08 : INFO  : rstudio : no blocking processes defined, using RStudio as default
2022-12-20 09:16:08 : INFO  : rstudio : name: RStudio, appName: RStudio.app
2022-12-20 09:16:08.205 mdfind[18638:388611] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2022-12-20 09:16:08.206 mdfind[18638:388611] [UserQueryParser] Loading keywords and predicates for locale "en"
2022-12-20 09:16:08.267 mdfind[18638:388611] Couldn't determine the mapping between prefab keywords and predicates.
2022-12-20 09:16:08 : WARN  : rstudio : No previous app found
2022-12-20 09:16:08 : WARN  : rstudio : could not find RStudio.app
2022-12-20 09:16:08 : INFO  : rstudio : appversion: 
2022-12-20 09:16:08 : INFO  : rstudio : Latest version of RStudio is 2022.12.0+353
2022-12-20 09:16:08 : REQ   : rstudio : Downloading https://download1.rstudio.org/electron/macos/RStudio-2022.12.0-353.dmg to RStudio.dmg
2022-12-20 09:16:18 : REQ   : rstudio : no more blocking processes, continue with update
2022-12-20 09:16:18 : REQ   : rstudio : Installing RStudio
2022-12-20 09:16:18 : INFO  : rstudio : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aFyVKpns/RStudio.dmg
2022-12-20 09:16:24 : INFO  : rstudio : Mounted: /Volumes/RStudio-2022.12.0-353 1
2022-12-20 09:16:24 : INFO  : rstudio : Verifying: /Volumes/RStudio-2022.12.0-353 1/RStudio.app
2022-12-20 09:16:29 : INFO  : rstudio : Team ID matching: FYF2F5GFX4 (expected: FYF2F5GFX4 )
2022-12-20 09:16:29 : INFO  : rstudio : Installing RStudio version 2022.12.0+353 on versionKey CFBundleShortVersionString.
2022-12-20 09:16:30 : INFO  : rstudio : App has LSMinimumSystemVersion: 10.11.0
2022-12-20 09:16:30 : INFO  : rstudio : Copy /Volumes/RStudio-2022.12.0-353 1/RStudio.app to /Applications
2022-12-20 09:16:35 : WARN  : rstudio : Changing owner to kryptonit
2022-12-20 09:16:35 : INFO  : rstudio : Finishing...
2022-12-20 09:16:38 : INFO  : rstudio : App(s) found: /Applications/RStudio.app
2022-12-20 09:16:38 : INFO  : rstudio : found app at /Applications/RStudio.app, version 2022.12.0+353, on versionKey CFBundleShortVersionString
2022-12-20 09:16:38 : REQ   : rstudio : Installed RStudio, version 2022.12.0+353
2022-12-20 09:16:38 : INFO  : rstudio : notifying
2022-12-20 09:16:39 : INFO  : rstudio : App not closed, so no reopen.
2022-12-20 09:16:39 : REQ   : rstudio : All done!
2022-12-20 09:16:39 : REQ   : rstudio : ################## End Installomator, exit code 0 