### PR TITLE
Adding label connectfonts.sh

### DIFF
--- a/fragments/labels/connectfonts.sh
+++ b/fragments/labels/connectfonts.sh
@@ -1,0 +1,7 @@
+connectfonts)
+name="Connect Fonts"
+type="dmg"
+downloadURL="https://links.extensis.com/connect_fonts/cf_latest?language=en&platform=mac"
+appNewVersion=$( curl -fs "https://www.extensis.com/support/connect-fonts" | grep version: | head -n 1 | cut -c 104-109 )
+expectedTeamID="J6MMHGD9D6"
+;;


### PR DESCRIPTION
Adding the Connect Fonts label to install the Extensis Connect Fonts app.

Assemble.sh output:

GitHub/Installomator/assemble.sh connectfonts
2022-12-20 09:41:30 : REQ   : connectfonts : ################## Start Installomator v. 10.1, date 2022-12-20
2022-12-20 09:41:30 : INFO  : connectfonts : ################## Version: 10.1
2022-12-20 09:41:30 : INFO  : connectfonts : ################## Date: 2022-12-20
2022-12-20 09:41:30 : INFO  : connectfonts : ################## connectfonts
2022-12-20 09:41:30 : DEBUG : connectfonts : DEBUG mode 1 enabled.
2022-12-20 09:41:30 : INFO  : connectfonts : SwiftDialog is not installed, clear cmd file var
2022-12-20 09:41:32 : DEBUG : connectfonts : name=Connect Fonts
2022-12-20 09:41:32 : DEBUG : connectfonts : appName=
2022-12-20 09:41:32 : DEBUG : connectfonts : type=dmg
2022-12-20 09:41:32 : DEBUG : connectfonts : archiveName=
2022-12-20 09:41:32 : DEBUG : connectfonts : downloadURL=https://links.extensis.com/connect_fonts/cf_latest?language=en&platform=mac
2022-12-20 09:41:32 : DEBUG : connectfonts : curlOptions=
2022-12-20 09:41:32 : DEBUG : connectfonts : appNewVersion=24.0.1
2022-12-20 09:41:32 : DEBUG : connectfonts : appCustomVersion function: Not defined
2022-12-20 09:41:32 : DEBUG : connectfonts : versionKey=CFBundleShortVersionString
2022-12-20 09:41:32 : DEBUG : connectfonts : packageID=
2022-12-20 09:41:32 : DEBUG : connectfonts : pkgName=
2022-12-20 09:41:32 : DEBUG : connectfonts : choiceChangesXML=
2022-12-20 09:41:32 : DEBUG : connectfonts : expectedTeamID=J6MMHGD9D6
2022-12-20 09:41:32 : DEBUG : connectfonts : blockingProcesses=
2022-12-20 09:41:32 : DEBUG : connectfonts : installerTool=
2022-12-20 09:41:32 : DEBUG : connectfonts : CLIInstaller=
2022-12-20 09:41:32 : DEBUG : connectfonts : CLIArguments=
2022-12-20 09:41:32 : DEBUG : connectfonts : updateTool=
2022-12-20 09:41:32 : DEBUG : connectfonts : updateToolArguments=
2022-12-20 09:41:32 : DEBUG : connectfonts : updateToolRunAsCurrentUser=
2022-12-20 09:41:32 : INFO  : connectfonts : BLOCKING_PROCESS_ACTION=tell_user
2022-12-20 09:41:32 : INFO  : connectfonts : NOTIFY=success
2022-12-20 09:41:32 : INFO  : connectfonts : LOGGING=DEBUG
2022-12-20 09:41:32 : INFO  : connectfonts : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2022-12-20 09:41:32 : INFO  : connectfonts : Label type: dmg
2022-12-20 09:41:32 : INFO  : connectfonts : archiveName: Connect Fonts.dmg
2022-12-20 09:41:32 : INFO  : connectfonts : no blocking processes defined, using Connect Fonts as default
2022-12-20 09:41:32 : DEBUG : connectfonts : Changing directory to /Users/davisbr/Documents/GitHub/Installomator/build
2022-12-20 09:41:32 : INFO  : connectfonts : App(s) found: /Applications/Connect Fonts.app
2022-12-20 09:41:32 : INFO  : connectfonts : found app at /Applications/Connect Fonts.app, version 24.0.1, on versionKey CFBundleShortVersionString
2022-12-20 09:41:32 : INFO  : connectfonts : appversion: 24.0.1
2022-12-20 09:41:32 : INFO  : connectfonts : Latest version of Connect Fonts is 24.0.1
2022-12-20 09:41:32 : WARN  : connectfonts : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2022-12-20 09:41:32 : REQ   : connectfonts : Downloading https://links.extensis.com/connect_fonts/cf_latest?language=en&platform=mac to Connect Fonts.dmg
2022-12-20 09:41:32 : DEBUG : connectfonts : No Dialog connection, just download
2022-12-20 09:41:33 : DEBUG : connectfonts : File list: -rw-r--r--  1 davisbr  INTRA\Domain Users    59M Dec 20 09:41 Connect Fonts.dmg
2022-12-20 09:41:33 : DEBUG : connectfonts : File type: Connect Fonts.dmg: zlib compressed data
2022-12-20 09:41:33 : DEBUG : connectfonts : curl output was:
*   Trying 13.249.39.14:443...
* Connected to links.extensis.com (13.249.39.14) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4953 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=*.extensis.com
*  start date: Dec  7 00:00:00 2022 GMT
*  expire date: Jan  5 23:59:59 2024 GMT
*  subjectAltName: host "links.extensis.com" matched cert's "*.extensis.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fe48a012600)
> GET /connect_fonts/cf_latest?language=en&platform=mac HTTP/2
> Host: links.extensis.com
> user-agent: curl/7.79.1
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 302 
< content-type: application/json
< content-length: 0
< location: https://bin.extensis.com/ConnectFonts-M-24-0-1.dmg
< date: Tue, 20 Dec 2022 14:41:33 GMT
< x-amzn-requestid: 4a876d00-2f09-48d2-8474-613c4fefbbd1
< x-amz-apigw-id: dcxwjFhqPHcFiNg=
< x-amzn-trace-id: Root=1-63a1c99c-6c5f8a73072f84d225fac234;Sampled=0
< x-cache: Miss from cloudfront
< via: 1.1 baddfcb4f2a6876b4fcc03bcd62427ee.cloudfront.net (CloudFront)
< x-amz-cf-pop: IAD89-C1
< x-amz-cf-id: _VfA6vpMW1xLuRGwBsTFj4kh4u1ONoKjR_oqgR02fDN0AgSdEhxUMA==
< 
{ [0 bytes data]
* Connection #0 to host links.extensis.com left intact
* Issue another request to this URL: 'https://bin.extensis.com/ConnectFonts-M-24-0-1.dmg'
*   Trying 99.84.191.54:443...
* Connected to bin.extensis.com (99.84.191.54) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3912 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: C=US; ST=Oregon; L=Portland; O=Extensis; CN=*.extensis.com
*  start date: Dec  2 00:00:00 2021 GMT
*  expire date: Jan  2 23:59:59 2023 GMT
*  subjectAltName: host "bin.extensis.com" matched cert's "*.extensis.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
> GET /ConnectFonts-M-24-0-1.dmg HTTP/1.1
> Host: bin.extensis.com
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 62383548
< Connection: keep-alive
< Last-Modified: Mon, 28 Nov 2022 19:17:28 GMT
< Accept-Ranges: bytes
< Server: AmazonS3
< Date: Tue, 20 Dec 2022 13:09:05 GMT
< ETag: "772bcf38ffd83687096b6158ba7b7c67-8"
< X-Cache: Hit from cloudfront
< Via: 1.1 6d4ee90b03b8194eed74421e603ee2a8.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: IAD89-C2
< X-Amz-Cf-Id: lM7Tnu9peclXJSi59aBrO_vrF8jJYIGfq3Wej3RBg0VNmjXktBKMvA==
< Age: 52305
< 
{ [15895 bytes data]
* Connection #1 to host bin.extensis.com left intact

2022-12-20 09:41:33 : DEBUG : connectfonts : DEBUG mode 1, not checking for blocking processes
2022-12-20 09:41:33 : REQ   : connectfonts : Installing Connect Fonts
2022-12-20 09:41:33 : INFO  : connectfonts : Mounting /Users/davisbr/Documents/GitHub/Installomator/build/Connect Fonts.dmg
2022-12-20 09:41:38 : DEBUG : connectfonts : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $00000672
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B24EC035
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9839D44C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $0DA0B939
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9839D44C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $5A9BB418
verified   CRC32 $69488623
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Connect Fonts 1

2022-12-20 09:41:38 : INFO  : connectfonts : Mounted: /Volumes/Connect Fonts 1
2022-12-20 09:41:38 : INFO  : connectfonts : Verifying: /Volumes/Connect Fonts 1/Connect Fonts.app
2022-12-20 09:41:38 : DEBUG : connectfonts : App size: 197M	/Volumes/Connect Fonts 1/Connect Fonts.app
2022-12-20 09:41:40 : DEBUG : connectfonts : Debugging enabled, App Verification output was:
/Volumes/Connect Fonts 1/Connect Fonts.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Extensis (J6MMHGD9D6)

2022-12-20 09:41:40 : INFO  : connectfonts : Team ID matching: J6MMHGD9D6 (expected: J6MMHGD9D6 )
2022-12-20 09:41:40 : INFO  : connectfonts : Downloaded version of Connect Fonts is 24.0.1 on versionKey CFBundleShortVersionString, same as installed.
2022-12-20 09:41:40 : DEBUG : connectfonts : Unmounting /Volumes/Connect Fonts 1
2022-12-20 09:41:40 : DEBUG : connectfonts : Debugging enabled, Unmounting output was:
"disk4" ejected.
2022-12-20 09:41:40 : DEBUG : connectfonts : DEBUG mode 1, not reopening anything
2022-12-20 09:41:40 : REG   : connectfonts : No new version to install
2022-12-20 09:41:40 : REQ   : connectfonts : ################## End Installomator, exit code 0