### PR TITLE
Create microsoftonedrive-rollingout.sh

### DIFF
--- a/fragments/labels/microsoftonedrive-rollingout.sh
+++ b/fragments/labels/microsoftonedrive-rollingout.sh
@@ -1,0 +1,14 @@
+microsoftonedrive-rollingout)
+    name="OneDrive"
+    type="pkg"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=861011"
+    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.onedrive.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | cut -d "/" -f 6 | cut -d "." -f 1-3)
+    expectedTeamID="UBF8T346G9"
+    #if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
+    #    printlog "Running msupdate --list"
+    #    "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+    #fi
+    #updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+    #updateToolArguments=( --install --apps ONDR18 )
+    ;;

--- a/fragments/labels/microsoftonedrive.sh
+++ b/fragments/labels/microsoftonedrive.sh
@@ -4,6 +4,14 @@ microsoftonedrive)
     downloadURL="https://go.microsoft.com/fwlink/?linkid=823060"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.onedrive.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | cut -d "/" -f 6 | cut -d "." -f 1-3)
+    if [[ $1 == "/" ]]; then
+        printlog "Running through Jamf: $0." INFO
+        $0 $1 $2 $3 microsoftonedrive-rollingout ${5} ${6} ${7} ${8} ${9} ${10} ${11}
+        exit
+    #else
+        #printlog "Installomator running locally: $0." INFO
+        #$0 microsoftonedrive-rollingout ${2} ${3} ${4} ${5} ${6} ${7} ${8} ${9} ${10} ${11}
+    fi
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"

--- a/fragments/labels/microsoftonedrive.sh
+++ b/fragments/labels/microsoftonedrive.sh
@@ -4,14 +4,6 @@ microsoftonedrive)
     downloadURL="https://go.microsoft.com/fwlink/?linkid=823060"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.onedrive.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | cut -d "/" -f 6 | cut -d "." -f 1-3)
-    if [[ $1 == "/" ]]; then
-        printlog "Running through Jamf: $0." INFO
-        $0 $1 $2 $3 microsoftonedrive-rollingout ${5} ${6} ${7} ${8} ${9} ${10} ${11}
-        exit
-    #else
-        #printlog "Installomator running locally: $0." INFO
-        #$0 microsoftonedrive-rollingout ${2} ${3} ${4} ${5} ${6} ${7} ${8} ${9} ${10} ${11}
-    fi
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"


### PR DESCRIPTION
Seems like Jamf Pro is using a later version than the current released latest version in their Patch management system. OneDrive app itself does not know about this version, and it has a different download URL. 

The version Jamf Pro uses is "Rolling out" from this web page: https://support.microsoft.com/en-us/office/onedrive-release-notes-845dcf18-f921-435e-bf28-4e24b95e5fc0

Here the download URL is: https://go.microsoft.com/fwlink/?linkid=861011
