### PR TITLE
audacity - switch to universal app

### DIFF
--- a/fragments/labels/audacity.sh
+++ b/fragments/labels/audacity.sh
@@ -1,13 +1,8 @@
 audacity)
     name="Audacity"
     type="dmg"
-    if [[ $(arch) == "arm64" ]]; then
-      archiveName="audacity-macOS-[0-9.]*-arm64.dmg"
-      downloadURL=$(downloadURLFromGit audacity audacity)
-    elif [[ $(arch) == "i386" ]]; then
-      archiveName="audacity-macOS-[0-9.]*-x86_64.dmg"
-      downloadURL=$(downloadURLFromGit audacity audacity)
-    fi
+    archiveName="audacity-macOS-[0-9.]*-universal.dmg"
+    downloadURL=$(downloadURLFromGit audacity audacity)
     appNewVersion=$(versionFromGit audacity audacity)
     expectedTeamID="AWEYX923UX"
     ;;


### PR DESCRIPTION
output:
```
% sudo ./assemble.sh audacity INSTALL=force DEBUG=0
Password:
2023-01-04 10:52:31 : INFO  : audacity : setting variable from argument INSTALL=force
2023-01-04 10:52:31 : INFO  : audacity : setting variable from argument DEBUG=0
2023-01-04 10:52:31 : REQ   : audacity : ################## Start Installomator v. 10.1, date 2023-01-04
2023-01-04 10:52:31 : INFO  : audacity : ################## Version: 10.1
2023-01-04 10:52:31 : INFO  : audacity : ################## Date: 2023-01-04
2023-01-04 10:52:31 : INFO  : audacity : ################## audacity
2023-01-04 10:52:32 : INFO  : audacity : BLOCKING_PROCESS_ACTION=tell_user
2023-01-04 10:52:32 : INFO  : audacity : NOTIFY=success
2023-01-04 10:52:32 : INFO  : audacity : LOGGING=INFO
2023-01-04 10:52:32 : INFO  : audacity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-04 10:52:32 : INFO  : audacity : Label type: dmg
2023-01-04 10:52:32 : INFO  : audacity : archiveName: audacity-macOS-[0-9.]*-universal.dmg
2023-01-04 10:52:32 : INFO  : audacity : no blocking processes defined, using Audacity as default
2023-01-04 10:52:32 : INFO  : audacity : App(s) found: /Applications/Audacity.app
2023-01-04 10:52:32 : INFO  : audacity : found app at /Applications/Audacity.app, version 3.2.3.0, on versionKey CFBundleShortVersionString
2023-01-04 10:52:32 : INFO  : audacity : appversion: 3.2.3.0
2023-01-04 10:52:32 : INFO  : audacity : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-01-04 10:52:32 : INFO  : audacity : Latest version of Audacity is 3.2.3
2023-01-04 10:52:32 : REQ   : audacity : Downloading https://github.com/audacity/audacity/releases/download/Audacity-3.2.3/audacity-macOS-3.2.3-universal.dmg to audacity-macOS-[0-9.]*-universal.dmg
2023-01-04 10:52:32 : REQ   : audacity : no more blocking processes, continue with update
2023-01-04 10:52:32 : REQ   : audacity : Installing Audacity
2023-01-04 10:52:32 : INFO  : audacity : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2oBPYZhB/audacity-macOS-[0-9.]*-universal.dmg
2023-01-04 10:52:36 : INFO  : audacity : Mounted: /Volumes/Audacity
2023-01-04 10:52:36 : INFO  : audacity : Verifying: /Volumes/Audacity/Audacity.app
2023-01-04 10:52:38 : INFO  : audacity : Team ID matching: AWEYX923UX (expected: AWEYX923UX )
2023-01-04 10:52:38 : INFO  : audacity : Downloaded version of Audacity is 3.2.3.0 on versionKey CFBundleShortVersionString, same as installed.
2023-01-04 10:52:38 : INFO  : audacity : Using force to install anyway.
2023-01-04 10:52:38 : INFO  : audacity : App has LSMinimumSystemVersion: 10.13
2023-01-04 10:52:38 : WARN  : audacity : Removing existing /Applications/Audacity.app
2023-01-04 10:52:38 : INFO  : audacity : Copy /Volumes/Audacity/Audacity.app to /Applications
2023-01-04 10:52:39 : WARN  : audacity : Changing owner to dnikles
2023-01-04 10:52:39 : INFO  : audacity : Finishing...
2023-01-04 10:52:42 : INFO  : audacity : App(s) found: /Applications/Audacity.app
2023-01-04 10:52:42 : INFO  : audacity : found app at /Applications/Audacity.app, version 3.2.3.0, on versionKey CFBundleShortVersionString
2023-01-04 10:52:42 : REQ   : audacity : Installed Audacity, version 3.2.3.0
2023-01-04 10:52:42 : INFO  : audacity : notifying
2023-01-04 10:52:42 : INFO  : audacity : App not closed, so no reopen.
2023-01-04 10:52:42 : REQ   : audacity : All done!
2023-01-04 10:52:42 : REQ   : audacity : ################## End Installomator, exit code 0
```