### PR TITLE
Use swiftDialog for notifications (if installed)

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -65,11 +65,14 @@ displaynotification() { # $1: message $2: title
     title=${2:-"Notification"}
     manageaction="/Library/Application Support/JAMF/bin/Management Action.app/Contents/MacOS/Management Action"
     hubcli="/usr/local/bin/hubcli"
+    swiftdialog="/usr/local/bin/dialog"
 
     if [[ -x "$manageaction" ]]; then
          "$manageaction" -message "$message" -title "$title"
     elif [[ -x "$hubcli" ]]; then
          "$hubcli" notify -t "$title" -i "$message" -c "Dismiss"
+    elif [[ -x "$swiftdialog" ]]; then
+         "$swiftdialog" --notification --title "$title" --message "$message"
     else
         runAsUser osascript -e "display notification \"$message\" with title \"$title\""
     fi


### PR DESCRIPTION
If `/usr/local/bin/dialog` exist then we can use that for notifications

Could be neat to use `icon=` to show the icon if the app that the notification is about, but currently we have no variable for that.