### PR TITLE
Create firefoxdeveloperedition.sh

### DIFF
--- a/fragments/labels/firefoxdeveloperedition.sh
+++ b/fragments/labels/firefoxdeveloperedition.sh
@@ -1,0 +1,7 @@
+firefoxdeveloperedition)
+    name="Firefox Developer Edition"
+    type="dmg"
+    downloadURL="https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US"
+    appNewVersion=$(curl -fsIL "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US&_gl=1*1g4sufp*_ga*OTAwNTc3MjE4LjE2NTM2MDIwODM.*_ga_MQ7767QQQW*MTY1NDcyNTYyNy40LjEuMTY1NDcyNzA2MS4w" | grep -i ^location | cut -d "/" -f7)
+    expectedTeamID="43AQ936H96"
+    ;;


### PR DESCRIPTION
2023-01-09 12:10:39 : REQ   : firefoxdeveloperedition : ################## Start Installomator v. 10.3beta, date 2023-01-09
2023-01-09 12:10:39 : INFO  : firefoxdeveloperedition : ################## Version: 10.3beta
2023-01-09 12:10:39 : INFO  : firefoxdeveloperedition : ################## Date: 2023-01-09
2023-01-09 12:10:39 : INFO  : firefoxdeveloperedition : ################## firefoxdeveloperedition
2023-01-09 12:10:39 : DEBUG : firefoxdeveloperedition : DEBUG mode 1 enabled.
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : name=Firefox Developer Edition
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : appName=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : type=dmg
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : archiveName=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : downloadURL=https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : curlOptions=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : appNewVersion=109.0b9
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : appCustomVersion function: Not defined
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : versionKey=CFBundleShortVersionString
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : packageID=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : pkgName=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : choiceChangesXML=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : expectedTeamID=43AQ936H96
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : blockingProcesses=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : installerTool=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : CLIInstaller=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : CLIArguments=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : updateTool=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : updateToolArguments=
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : updateToolRunAsCurrentUser=
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : BLOCKING_PROCESS_ACTION=tell_user
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : NOTIFY=success
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : LOGGING=DEBUG
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : Label type: dmg
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : archiveName: Firefox Developer Edition.dmg
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : no blocking processes defined, using Firefox Developer Edition as default
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : Changing directory to /Users/jordan.noovao/Documents/GitHub/Installomator/build
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : name: Firefox Developer Edition, appName: Firefox Developer Edition.app
2023-01-09 12:10:40.877 mdfind[12628:477190] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-01-09 12:10:40.877 mdfind[12628:477190] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-01-09 12:10:40.924 mdfind[12628:477190] Couldn't determine the mapping between prefab keywords and predicates.
2023-01-09 12:10:40 : WARN  : firefoxdeveloperedition : No previous app found
2023-01-09 12:10:40 : WARN  : firefoxdeveloperedition : could not find Firefox Developer Edition.app
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : appversion: 
2023-01-09 12:10:40 : INFO  : firefoxdeveloperedition : Latest version of Firefox Developer Edition is 109.0b9
2023-01-09 12:10:40 : REQ   : firefoxdeveloperedition : Downloading https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=en-US to Firefox Developer Edition.dmg
2023-01-09 12:10:40 : DEBUG : firefoxdeveloperedition : No Dialog connection, just download
2023-01-09 12:10:44 : DEBUG : firefoxdeveloperedition : File list: -rw-r--r--  1 root  staff   138M  9 Jan 12:10 Firefox Developer Edition.dmg
2023-01-09 12:10:44 : DEBUG : firefoxdeveloperedition : File type: Firefox Developer Edition.dmg: bzip2 compressed data, block size = 900k
2023-01-09 12:10:44 : DEBUG : firefoxdeveloperedition : curl output was:
*   Trying 35.160.168.0:443...
* Connected to download.mozilla.org (35.160.168.0) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3039 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=Mountain View; O=Mozilla Corporation; CN=download.mozilla.org
*  start date: Mar  2 00:00:00 2022 GMT
*  expire date: Mar  9 23:59:59 2023 GMT
*  subjectAltName: host "download.mozilla.org" matched cert's "download.mozilla.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
> GET /?product=firefox-devedition-latest-ssl&os=osx&lang=en-US HTTP/1.1
> Host: download.mozilla.org
> User-Agent: curl/7.85.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Cache-Control: max-age=60
< Content-Type: text/html; charset=utf-8
< Date: Sun, 08 Jan 2023 23:10:41 GMT
< Location: https://download-installer.cdn.mozilla.net/pub/devedition/releases/109.0b9/mac/en-US/Firefox%20109.0b9.dmg
< Content-Length: 129
< Connection: keep-alive
< 
* Ignoring the response-body
{ [129 bytes data]
* Connection #0 to host download.mozilla.org left intact
* Issue another request to this URL: 'https://download-installer.cdn.mozilla.net/pub/devedition/releases/109.0b9/mac/en-US/Firefox%20109.0b9.dmg'
*   Trying 34.117.35.28:443...
* Connected to download-installer.cdn.mozilla.net (34.117.35.28) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [339 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4068 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download-installer.cdn.mozilla.net
*  start date: Nov 22 04:03:38 2022 GMT
*  expire date: Feb 20 04:03:37 2023 GMT
*  subjectAltName: host "download-installer.cdn.mozilla.net" matched cert's "download-installer.cdn.mozilla.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /pub/devedition/releases/109.0b9/mac/en-US/Firefox%20109.0b9.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download-installer.cdn.mozilla.net]
* h2h3 [user-agent: curl/7.85.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14a812400)
> GET /pub/devedition/releases/109.0b9/mac/en-US/Firefox%20109.0b9.dmg HTTP/2
> Host: download-installer.cdn.mozilla.net
> user-agent: curl/7.85.0
> accept: */*
> 
< HTTP/2 200 
< server: nginx
< x-guploader-uploadid: ADPycdux30prPGVNd-nBNDpev9Yl8ikduXO9lDEiaZ4pX5uwW8Tn0rGNLo8uR8lO0VquxxjFpwTffNb6anQyNGo3V_otD71hqdlK
< x-goog-generation: 1672968007328967
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 145070097
< x-goog-hash: crc32c=uXYSlg==
< x-goog-hash: md5=y+Olkbm+HHHfRjvuozNZhQ==
< x-goog-storage-class: STANDARD
< accept-ranges: bytes
< vary: Origin
< strict-transport-security: max-age=31536000
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
< alt-svc: clear
< via: 1.1 google, 1.1 google
< date: Sat, 07 Jan 2023 18:40:54 GMT
< expires: Thu, 12 Jan 2023 18:40:54 GMT
< cache-control: max-age=432000
< last-modified: Fri, 06 Jan 2023 01:20:07 GMT
< etag: "cbe3a591b9be1c71df463beea3335985"
< content-type: application/x-iso9660-image
< content-length: 145070097
< age: 102588
< 
{ [1369 bytes data]
* Connection #1 to host download-installer.cdn.mozilla.net left intact

2023-01-09 12:10:44 : DEBUG : firefoxdeveloperedition : DEBUG mode 1, not checking for blocking processes
2023-01-09 12:10:44 : REQ   : firefoxdeveloperedition : Installing Firefox Developer Edition
2023-01-09 12:10:44 : INFO  : firefoxdeveloperedition : Mounting /Users/jordan.noovao/Documents/GitHub/Installomator/build/Firefox Developer Edition.dmg
2023-01-09 12:10:54 : DEBUG : firefoxdeveloperedition : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $BFF35963
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $114C9F6C
Checksumming Macintosh (Apple_Driver_ATAPI : 2)…
Macintosh (Apple_Driver_ATAPI : 2): verified   CRC32 $C71C0011
Checksumming Mac_OS_X (Apple_HFSX : 3)…
Mac_OS_X (Apple_HFSX : 3): verified   CRC32 $3E12ED5E
Checksumming  (Apple_Free : 4)…
(Apple_Free : 4): verified   CRC32 $00000000
verified   CRC32 $79936ACA
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_Driver_ATAPI
/dev/disk4s3        	Apple_HFSX                     	/Volumes/Firefox Developer Edition

2023-01-09 12:10:54 : INFO  : firefoxdeveloperedition : Mounted: /Volumes/Firefox Developer Edition
2023-01-09 12:10:54 : INFO  : firefoxdeveloperedition : Verifying: /Volumes/Firefox Developer Edition/Firefox Developer Edition.app
2023-01-09 12:10:54 : DEBUG : firefoxdeveloperedition : App size: 431M	/Volumes/Firefox Developer Edition/Firefox Developer Edition.app
2023-01-09 12:11:05 : DEBUG : firefoxdeveloperedition : Debugging enabled, App Verification output was:
/Volumes/Firefox Developer Edition/Firefox Developer Edition.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mozilla Corporation (43AQ936H96)

2023-01-09 12:11:05 : INFO  : firefoxdeveloperedition : Team ID matching: 43AQ936H96 (expected: 43AQ936H96 )
2023-01-09 12:11:05 : INFO  : firefoxdeveloperedition : Installing Firefox Developer Edition version 109.0 on versionKey CFBundleShortVersionString.
2023-01-09 12:11:05 : INFO  : firefoxdeveloperedition : App has LSMinimumSystemVersion: 10.12.0
2023-01-09 12:11:05 : DEBUG : firefoxdeveloperedition : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-01-09 12:11:05 : INFO  : firefoxdeveloperedition : Finishing...
2023-01-09 12:11:08 : INFO  : firefoxdeveloperedition : name: Firefox Developer Edition, appName: Firefox Developer Edition.app
2023-01-09 12:11:08.947 mdfind[12761:477901] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-01-09 12:11:08.947 mdfind[12761:477901] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-01-09 12:11:09.004 mdfind[12761:477901] Couldn't determine the mapping between prefab keywords and predicates.
2023-01-09 12:11:09 : WARN  : firefoxdeveloperedition : No previous app found
2023-01-09 12:11:09 : WARN  : firefoxdeveloperedition : could not find Firefox Developer Edition.app
2023-01-09 12:11:09 : REQ   : firefoxdeveloperedition : Installed Firefox Developer Edition
2023-01-09 12:11:09 : INFO  : firefoxdeveloperedition : notifying
2023-01-09 12:11:09 : DEBUG : firefoxdeveloperedition : Unmounting /Volumes/Firefox Developer Edition
2023-01-09 12:11:09 : DEBUG : firefoxdeveloperedition : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-01-09 12:11:09 : DEBUG : firefoxdeveloperedition : DEBUG mode 1, not reopening anything
2023-01-09 12:11:09 : REQ   : firefoxdeveloperedition : All done!
2023-01-09 12:11:09 : REQ   : firefoxdeveloperedition : ################## End Installomator, exit code 0 