### PR TITLE
add cloudflare warp

### DIFF
--- a/fragments/labels/cloudflarewarp.sh
+++ b/fragments/labels/cloudflarewarp.sh
@@ -1,0 +1,8 @@
+cloudflarewarp)
+    name="Cloudflare_WARP"
+    type="pkgInZip"
+    packageID="com.cloudflare.1dot1dot1dot1.macos"
+    downloadURL="https://1111-releases.cloudflareclient.com/mac/Cloudflare_WARP.zip"
+    appNewVersion=""
+    expectedTeamID="68WVV388M8"
+    ;;


### PR DESCRIPTION
Could not find a reliable way to get the version from the [download](https://1.1.1.1/) or [changelog](https://docs.warp.dev/getting-started/changelog) page.

[assembly output](https://github.com/Installomator/Installomator/files/10372402/cloudflarewarp.txt)
