### PR TITLE
Add Chrome Remote Desktop

### DIFF
--- a/fragments/labels/chromeremotedesktop.sh
+++ b/fragments/labels/chromeremotedesktop.sh
@@ -1,0 +1,8 @@
+chromeremotedesktop)
+    name="chromeremotedesktop"
+    type="pkgInDmg"
+    packageID="com.google.pkg.ChromeRemoteDesktopHost"
+    downloadURL="https://dl.google.com/chrome-remote-desktop/chromeremotedesktop.dmg"
+    appNewVersion=""
+    expectedTeamID="EQHXZ8M8AV"
+    ;;


### PR DESCRIPTION
No version information on the [product page](https://remotedesktop.google.com/)

2023-01-09 11:45:30 : REQ   : chromeremotedesktop : ################## Start Installomator v. 10.3beta, date 2023-01-09
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : ################## Version: 10.3beta
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : ################## Date: 2023-01-09
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : ################## chromeremotedesktop
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : DEBUG mode 1 enabled.
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : SwiftDialog is not installed, clear cmd file var
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : name=chromeremotedesktop
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : appName=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : type=pkgInDmg
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : archiveName=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : downloadURL=https://dl.google.com/chrome-remote-desktop/chromeremotedesktop.dmg
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : curlOptions=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : appNewVersion=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : appCustomVersion function: Not defined
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : versionKey=CFBundleShortVersionString
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : packageID=com.google.pkg.ChromeRemoteDesktopHost
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : pkgName=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : choiceChangesXML=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : expectedTeamID=EQHXZ8M8AV
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : blockingProcesses=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : installerTool=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : CLIInstaller=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : CLIArguments=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : updateTool=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : updateToolArguments=
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : updateToolRunAsCurrentUser=
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : BLOCKING_PROCESS_ACTION=tell_user
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : NOTIFY=success
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : LOGGING=DEBUG
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : Label type: pkgInDmg
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : archiveName: chromeremotedesktop.dmg
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : no blocking processes defined, using chromeremotedesktop as default
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : Changing directory to /Users/test/github/Installomator/build
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : found packageID com.google.pkg.ChromeRemoteDesktopHost installed, version 108.0.5359
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : appversion: 108.0.5359
2023-01-09 11:45:30 : INFO  : chromeremotedesktop : Latest version not specified.
2023-01-09 11:45:30 : REQ   : chromeremotedesktop : Downloading https://dl.google.com/chrome-remote-desktop/chromeremotedesktop.dmg to chromeremotedesktop.dmg
2023-01-09 11:45:30 : DEBUG : chromeremotedesktop : No Dialog connection, just download
2023-01-09 11:45:35 : DEBUG : chromeremotedesktop : File list: -rw-r--r--@ 1 test  staff    94M Jan  9 11:45 chromeremotedesktop.dmg
2023-01-09 11:45:35 : DEBUG : chromeremotedesktop : File type: chromeremotedesktop.dmg: bzip2 compressed data, block size = 900k
2023-01-09 11:45:35 : DEBUG : chromeremotedesktop : curl output was:
*   Trying 2a00:1450:4008:806::200e:443...
* Connected to dl.google.com (2a00:1450:4008:806::200e) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [6455 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.google.com
*  start date: Nov 28 08:17:11 2022 GMT
*  expire date: Feb 20 08:17:10 2023 GMT
*  subjectAltName: host "dl.google.com" matched cert's "*.google.com"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1C3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /chrome-remote-desktop/chromeremotedesktop.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: dl.google.com]
* h2h3 [user-agent: curl/7.85.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12d011e00)
> GET /chrome-remote-desktop/chromeremotedesktop.dmg HTTP/2
> Host: dl.google.com
> user-agent: curl/7.85.0
> accept: */*
> 
< HTTP/2 200 
< accept-ranges: bytes
< content-disposition: attachment
< content-security-policy: default-src 'none'
< server: downloads
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 0
< date: Mon, 09 Jan 2023 10:45:30 GMT
< cache-control: public,max-age=0
< last-modified: Mon, 24 Oct 2022 04:33:07 GMT
< etag: "fdd3d3"
< content-type: application/x-apple-diskimage
< content-length: 98573934
< age: 0
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
< 
{ [1177 bytes data]
* Connection #0 to host dl.google.com left intact

2023-01-09 11:45:35 : DEBUG : chromeremotedesktop : DEBUG mode 1, not checking for blocking processes
2023-01-09 11:45:35 : REQ   : chromeremotedesktop : Installing chromeremotedesktop
2023-01-09 11:45:35 : INFO  : chromeremotedesktop : Mounting /Users/test/github/Installomator/build/chromeremotedesktop.dmg
2023-01-09 11:45:38 : DEBUG : chromeremotedesktop : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $EDB6E07A
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $4EF4B1BD
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified   CRC32 $3F795B2F
verified   CRC32 $DCAFF41D
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/Chrome Remote Desktop Host 108.0.5359.16

2023-01-09 11:45:38 : INFO  : chromeremotedesktop : Mounted: /Volumes/Chrome Remote Desktop Host 108.0.5359.16
2023-01-09 11:45:38 : DEBUG : chromeremotedesktop : Found pkg(s):
/Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg
2023-01-09 11:45:38 : INFO  : chromeremotedesktop : found pkg: /Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg
2023-01-09 11:45:38 : INFO  : chromeremotedesktop : Verifying: /Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg
2023-01-09 11:45:38 : DEBUG : chromeremotedesktop : File list: -rw-r--r--@ 1 test  staff    94M Oct 24 06:17 /Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg
2023-01-09 11:45:38 : DEBUG : chromeremotedesktop : File type: /Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg: xar archive compressed TOC: 6070, SHA-1 checksum
2023-01-09 11:45:39 : DEBUG : chromeremotedesktop : spctlOut is /Volumes/Chrome Remote Desktop Host 108.0.5359.16/Chrome Remote Desktop Host.pkg: accepted
2023-01-09 11:45:39 : DEBUG : chromeremotedesktop : source=Notarized Developer ID
2023-01-09 11:45:39 : DEBUG : chromeremotedesktop : origin=Developer ID Installer: Google LLC (EQHXZ8M8AV)
2023-01-09 11:45:39 : INFO  : chromeremotedesktop : Team ID: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2023-01-09 11:45:39 : INFO  : chromeremotedesktop : Checking package version.
2023-01-09 11:45:42 : INFO  : chromeremotedesktop : Downloaded package com.google.pkg.ChromeRemoteDesktopHost version 108.0.5359.16
2023-01-09 11:45:42 : DEBUG : chromeremotedesktop : DEBUG enabled, skipping installation
2023-01-09 11:45:42 : INFO  : chromeremotedesktop : Finishing...
2023-01-09 11:45:45 : INFO  : chromeremotedesktop : found packageID com.google.pkg.ChromeRemoteDesktopHost installed, version 108.0.5359
2023-01-09 11:45:45 : REQ   : chromeremotedesktop : Installed chromeremotedesktop, version 108.0.5359
2023-01-09 11:45:45 : INFO  : chromeremotedesktop : notifying
2023-01-09 11:45:46 : DEBUG : chromeremotedesktop : Unmounting /Volumes/Chrome Remote Desktop Host 108.0.5359.16
2023-01-09 11:45:46 : DEBUG : chromeremotedesktop : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-01-09 11:45:46 : DEBUG : chromeremotedesktop : DEBUG mode 1, not reopening anything
2023-01-09 11:45:46 : REQ   : chromeremotedesktop : All done!
2023-01-09 11:45:46 : REQ   : chromeremotedesktop : ################## End Installomator, exit code 0 

