### PR TITLE
Add Yubico Authenticator

### DIFF
--- a/fragments/labels/yubicoauthenticator.sh
+++ b/fragments/labels/yubicoauthenticator.sh
@@ -1,0 +1,7 @@
+yubicoauthenticator)
+    name="Yubico Authenticator"
+    type="dmg"
+    downloadURL="https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-latest-mac.dmg"
+    appNewVersion=""
+    expectedTeamID="LQA3CS5MM7"
+    ;;


### PR DESCRIPTION
No version information on the download [page](https://www.yubico.com/products/yubico-authenticator/)

2023-01-09 11:50:48 : REQ   : yubicoauthenticator : ################## Start Installomator v. 10.3beta, date 2023-01-09
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : ################## Version: 10.3beta
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : ################## Date: 2023-01-09
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : ################## yubicoauthenticator
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : DEBUG mode 1 enabled.
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : SwiftDialog is not installed, clear cmd file var
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : name=Yubico Authenticator
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : appName=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : type=dmg
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : archiveName=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : downloadURL=https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-latest-mac.dmg
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : curlOptions=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : appNewVersion=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : appCustomVersion function: Not defined
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : versionKey=CFBundleShortVersionString
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : packageID=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : pkgName=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : choiceChangesXML=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : expectedTeamID=LQA3CS5MM7
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : blockingProcesses=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : installerTool=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : CLIInstaller=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : CLIArguments=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : updateTool=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : updateToolArguments=
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : updateToolRunAsCurrentUser=
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : BLOCKING_PROCESS_ACTION=tell_user
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : NOTIFY=success
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : LOGGING=DEBUG
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : Label type: dmg
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : archiveName: Yubico Authenticator.dmg
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : no blocking processes defined, using Yubico Authenticator as default
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : Changing directory to /Users/test/github/Installomator/build
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : App(s) found: /Applications/Yubico Authenticator.app
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : found app at /Applications/Yubico Authenticator.app, version 6.0.2, on versionKey CFBundleShortVersionString
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : appversion: 6.0.2
2023-01-09 11:50:48 : INFO  : yubicoauthenticator : Latest version not specified.
2023-01-09 11:50:48 : REQ   : yubicoauthenticator : Downloading https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-latest-mac.dmg to Yubico Authenticator.dmg
2023-01-09 11:50:48 : DEBUG : yubicoauthenticator : No Dialog connection, just download
2023-01-09 11:50:55 : DEBUG : yubicoauthenticator : File list: -rw-r--r--@ 1 test  staff    79M Jan  9 11:50 Yubico Authenticator.dmg
2023-01-09 11:50:55 : DEBUG : yubicoauthenticator : File type: Yubico Authenticator.dmg: zlib compressed data
2023-01-09 11:50:55 : DEBUG : yubicoauthenticator : curl output was:
*   Trying 2a04:4e42:200::626:443...
* Connected to developers.yubico.com (2a04:4e42:200::626) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3073 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=yubico.com
*  start date: Mar 30 01:36:14 2022 GMT
*  expire date: May  1 01:36:13 2023 GMT
*  subjectAltName: host "developers.yubico.com" matched cert's "developers.yubico.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2022 Q1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /yubioath-flutter/Releases/yubico-authenticator-latest-mac.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: developers.yubico.com]
* h2h3 [user-agent: curl/7.85.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12b013400)
> GET /yubioath-flutter/Releases/yubico-authenticator-latest-mac.dmg HTTP/2
> Host: developers.yubico.com
> user-agent: curl/7.85.0
> accept: */*
> 
< HTTP/2 302 
< location: https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-6.0.2-mac.dmg
< content-type: text/html; charset=iso-8859-1
< accept-ranges: bytes
< date: Mon, 09 Jan 2023 10:50:49 GMT
< via: 1.1 varnish
< age: 2528
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-served-by: cache-ams21059-AMS
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1673261449.181385,VS0,VE1
< content-length: 274
< 
* Ignoring the response-body
{ [274 bytes data]
* Connection #0 to host developers.yubico.com left intact
* Issue another request to this URL: 'https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-6.0.2-mac.dmg'
* Found bundle for host: 0x600003775050 [can multiplex]
* Re-using existing connection #0 with host developers.yubico.com
* Connected to developers.yubico.com (2a04:4e42:200::626) port 443 (#0)
* h2h3 [:method: GET]
* h2h3 [:path: /yubioath-flutter/Releases/yubico-authenticator-6.0.2-mac.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: developers.yubico.com]
* h2h3 [user-agent: curl/7.85.0]
* h2h3 [accept: */*]
* Using Stream ID: 3 (easy handle 0x12b013400)
> GET /yubioath-flutter/Releases/yubico-authenticator-6.0.2-mac.dmg HTTP/2
> Host: developers.yubico.com
> user-agent: curl/7.85.0
> accept: */*
> 
< HTTP/2 200 
< last-modified: Mon, 28 Nov 2022 14:50:53 GMT
< etag: "4f6ff13-5ee88ff7e8d40"
< content-type: application/x-apple-diskimage
< accept-ranges: bytes
< age: 3
< date: Mon, 09 Jan 2023 10:50:52 GMT
< via: 1.1 varnish
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-served-by: cache-ams21059-AMS
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1673261449.224932,VS0,VE2942
< content-length: 83296019
< 
{ [1369 bytes data]
* Connection #0 to host developers.yubico.com left intact

2023-01-09 11:50:55 : DEBUG : yubicoauthenticator : DEBUG mode 1, not checking for blocking processes
2023-01-09 11:50:55 : REQ   : yubicoauthenticator : Installing Yubico Authenticator
2023-01-09 11:50:55 : INFO  : yubicoauthenticator : Mounting /Users/test/github/Installomator/build/Yubico Authenticator.dmg
2023-01-09 11:50:58 : DEBUG : yubicoauthenticator : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D7AF8EC9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $119B0EF5
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $208386BD
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $AFC9BA1C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $208386BD
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $6BDA55BC
verified   CRC32 $C04A80D0
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Yubico Authenticator

2023-01-09 11:50:58 : INFO  : yubicoauthenticator : Mounted: /Volumes/Yubico Authenticator
2023-01-09 11:50:58 : INFO  : yubicoauthenticator : Verifying: /Volumes/Yubico Authenticator/Yubico Authenticator.app
2023-01-09 11:50:58 : DEBUG : yubicoauthenticator : App size: 233M	/Volumes/Yubico Authenticator/Yubico Authenticator.app
2023-01-09 11:51:00 : DEBUG : yubicoauthenticator : Debugging enabled, App Verification output was:
/Volumes/Yubico Authenticator/Yubico Authenticator.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Yubico Limited (LQA3CS5MM7)

2023-01-09 11:51:00 : INFO  : yubicoauthenticator : Team ID matching: LQA3CS5MM7 (expected: LQA3CS5MM7 )
2023-01-09 11:51:00 : INFO  : yubicoauthenticator : Downloaded version of Yubico Authenticator is 6.0.2 on versionKey CFBundleShortVersionString, same as installed.
2023-01-09 11:51:00 : DEBUG : yubicoauthenticator : Unmounting /Volumes/Yubico Authenticator
2023-01-09 11:51:00 : DEBUG : yubicoauthenticator : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-01-09 11:51:00 : DEBUG : yubicoauthenticator : DEBUG mode 1, not reopening anything
2023-01-09 11:51:00 : REG   : yubicoauthenticator : No new version to install
2023-01-09 11:51:00 : REQ   : yubicoauthenticator : ################## End Installomator, exit code 0 



