### PR TITLE
Prevent unnecessary application restart when no new version is found

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -315,6 +315,14 @@ checkRunningProcesses() {
         return
     fi
 
+    if [[ $BLOCKING_PROCESS_ACTION == "ignore" \
+       || $currentUser == "loginwindow" \
+       || ${#blockingProcesses} -eq 0 \
+       || ${blockingProcesses[1]} == "NONE" ]]; then
+        printlog "ignoring blocking processes"
+        return
+    fi
+
     # try at most 3 times
     for i in {1..4}; do
         countedProcesses=0
@@ -515,6 +523,8 @@ installAppWithPath() { # $1: path to app to install in $targetDir
         cleanupAndExit 0
     fi
 
+    checkRunningProcesses
+
     # Test if variable CLIInstaller is set
     if [[ -z $CLIInstaller ]]; then
 
@@ -665,6 +675,8 @@ installFromPKG() {
     if [ "$DEBUG" -eq 2 ]; then
         cleanupAndExit 0 "DEBUG mode 2 enabled, exiting" DEBUG
     fi
+
+    checkRunningProcesses
 
     # install pkg
     printlog "Installing $archiveName to $targetDir"

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -272,19 +272,6 @@ else
     printlog "curl output was:\n$logoutput" DEBUG
 fi
 
-# MARK: when user is logged in, and app is running, prompt user to quit app
-if [[ $BLOCKING_PROCESS_ACTION == "ignore" ]]; then
-    printlog "ignoring blocking processes"
-else
-    if [[ $currentUser != "loginwindow" ]]; then
-        if [[ ${#blockingProcesses} -gt 0 ]]; then
-            if [[ ${blockingProcesses[1]} != "NONE" ]]; then
-                checkRunningProcesses
-            fi
-        fi
-    fi
-fi
-
 # MARK: install the download
 printlog "Installing $name" REQ
 if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then


### PR DESCRIPTION
On updates the current workflow closes and restarts the applications even when no new version has to be installed. The close happens when an application has appNewVersion not set and packaged in a dmg. This PR moves the call to the checkRunningProcess  to a later point in the workflow to prevent the unnecessary application close. 

1password8 is an example for an application getting unnecessary restarted on updates.