### PR TITLE
Version check to filter by PackageID

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -633,7 +633,7 @@ installFromPKG() {
         baseArchiveName=$(basename $archiveName)
         expandedPkg="$tmpDir/${baseArchiveName}_pkg"
         pkgutil --expand "$archiveName" "$expandedPkg"
-        appNewVersion=$(cat "$expandedPkg"/Distribution | xpath 'string(//installer-gui-script/pkg-ref[@id][@version]/@version)' 2>/dev/null )
+        appNewVersion=$(cat "$expandedPkg"/Distribution | xpath "string(//installer-gui-script/pkg-ref[@id='$packageID'][@version]/@version)" 2>/dev/null )
         rm -r "$expandedPkg"
         printlog "Downloaded package $packageID version $appNewVersion"
         if [[ $appversion == $appNewVersion ]]; then


### PR DESCRIPTION
A pkg can contain multiple applications. The version check has to filter by PackageID. An example where this is required to prevent repeatedly reinstalling the same version is 1password8.