### PR TITLE
new label pgadmin4

### DIFF
--- a/fragments/labels/pgadmin4.sh
+++ b/fragments/labels/pgadmin4.sh
@@ -1,0 +1,9 @@
+pgadmin4)
+    name="pgAdmin 4"
+    type="dmg"
+    downloadParent="https://www.postgresql.org/ftp/pgadmin/pgadmin4/"
+    appNewVersion=$(curl -fs "${downloadParent}" | grep -oE 'v[0-9]+.[0-9]+' | sort -V | tail -n 1 | sed 's/v//g')
+    downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion.dmg"
+    expectedTeamID="26QKX55P9K"
+    ;;
+    


### PR DESCRIPTION
this installs fine with no errors, only download time is longer than ideal but it's the same on browser so out of our control.

> 2023-01-20 13:57:05 : REQ   : pgadmin4 : ################## Start Installomator v. 10.3beta, date 2023-01-20
> 2023-01-20 13:57:05 : INFO  : pgadmin4 : ################## Version: 10.3beta
> 2023-01-20 13:57:05 : INFO  : pgadmin4 : ################## Date: 2023-01-20
> 2023-01-20 13:57:05 : INFO  : pgadmin4 : ################## pgadmin4
> 2023-01-20 13:57:05 : DEBUG : pgadmin4 : DEBUG mode 1 enabled.
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : name=pgAdmin 4
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : appName=
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : type=dmg
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : archiveName=
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : downloadURL=https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v6.19/macos/pgadmin4-6.19.dmg
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : curlOptions=
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : appNewVersion=6.19
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : appCustomVersion function: Not defined
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : versionKey=CFBundleShortVersionString
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : packageID=
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : pkgName=
> 2023-01-20 13:57:06 : DEBUG : pgadmin4 : choiceChangesXML=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : expectedTeamID=26QKX55P9K
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : blockingProcesses=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : installerTool=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : CLIInstaller=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : CLIArguments=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : updateTool=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : updateToolArguments=
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : updateToolRunAsCurrentUser=
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : BLOCKING_PROCESS_ACTION=tell_user
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : NOTIFY=success
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : LOGGING=DEBUG
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : Label type: dmg
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : archiveName: pgAdmin 4.dmg
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : no blocking processes defined, using pgAdmin 4 as default
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : Changing directory to /Users/asri/Documents/dev/Installomator/build
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app
> 2023-01-20 13:57:07 : WARN  : pgadmin4 : No previous app found
> 2023-01-20 13:57:07 : WARN  : pgadmin4 : could not find pgAdmin 4.app
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : appversion: 
> 2023-01-20 13:57:07 : INFO  : pgadmin4 : Latest version of pgAdmin 4 is 6.19
> 2023-01-20 13:57:07 : REQ   : pgadmin4 : Downloading https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v6.19/macos/pgadmin4-6.19.dmg to pgAdmin 4.dmg
> 2023-01-20 13:57:07 : DEBUG : pgadmin4 : No Dialog connection, just download
> 2023-01-20 13:57:24 : DEBUG : pgadmin4 : File list: -rw-r--r--  1 asri  staff   183M 20 Jan 13:57 pgAdmin 4.dmg
> 2023-01-20 13:57:24 : DEBUG : pgadmin4 : File type: pgAdmin 4.dmg: bzip2 compressed data, block size = 900k
> 2023-01-20 13:57:24 : DEBUG : pgadmin4 : curl output was:
> *   Trying 72.32.157.246:443...
> * Connected to ftp.postgresql.org (72.32.157.246) port 443 (#0)
> * ALPN, offering h2
> * ALPN, offering http/1.1
> * successfully set certificate verify locations:
> *  CAfile: /etc/ssl/cert.pem
> *  CApath: none
> * (304) (OUT), TLS handshake, Client hello (1):
> } [323 bytes data]
> * (304) (IN), TLS handshake, Server hello (2):
> { [88 bytes data]
> * (304) (OUT), TLS handshake, Client hello (1):
> } [388 bytes data]
> * (304) (IN), TLS handshake, Server hello (2):
> { [187 bytes data]
> * (304) (IN), TLS handshake, Unknown (8):
> { [19 bytes data]
> * (304) (IN), TLS handshake, Certificate (11):
> { [4359 bytes data]
> * (304) (IN), TLS handshake, CERT verify (15):
> { [520 bytes data]
> * (304) (IN), TLS handshake, Finished (20):
> { [52 bytes data]
> * (304) (OUT), TLS handshake, Finished (20):
> } [52 bytes data]
> * SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
> * ALPN, server accepted to use h2
> * Server certificate:
> *  subject: CN=ftp.postgresql.org
> *  start date: Dec  2 02:08:21 2022 GMT
> *  expire date: Mar  2 02:08:20 2023 GMT
> *  subjectAltName: host "ftp.postgresql.org" matched cert's "ftp.postgresql.org"
> *  issuer: C=US; O=Let's Encrypt; CN=R3
> *  SSL certificate verify ok.
> * Using HTTP2, server supports multiplexing
> * Connection state changed (HTTP/2 confirmed)
> * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
> * Using Stream ID: 1 (easy handle 0x7f8de700b600)
> > GET /pub/pgadmin/pgadmin4/v6.19/macos/pgadmin4-6.19.dmg HTTP/2
> > Host: ftp.postgresql.org
> > user-agent: curl/7.79.1
> > accept: */*
> > 
> * Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
> < HTTP/2 200 
> < server: nginx
> < date: Fri, 20 Jan 2023 05:57:08 GMT
> < content-type: application/octet-stream
> < content-length: 191725483
> < last-modified: Tue, 17 Jan 2023 10:50:26 GMT
> < etag: "63c67d72-b6d7fab"
> < strict-transport-security: max-age=31536000
> < accept-ranges: bytes
> < 
> { [16366 bytes data]
> * Connection #0 to host ftp.postgresql.org left intact
> 
> 2023-01-20 13:57:24 : DEBUG : pgadmin4 : DEBUG mode 1, not checking for blocking processes
> 2023-01-20 13:57:24 : REQ   : pgadmin4 : Installing pgAdmin 4
> 2023-01-20 13:57:24 : INFO  : pgadmin4 : Mounting /Users/asri/Documents/dev/Installomator/build/pgAdmin 4.dmg
> 2023-01-20 13:57:48 : DEBUG : pgadmin4 : Debugging enabled, dmgmount output was:
> Checksumming Protective Master Boot Record (MBR : 0)…
> Protective Master Boot Record (MBR :: verified CRC32 $26950D29
> Checksumming GPT Header (Primary GPT Header : 1)…
> GPT Header (Primary GPT Header : 1): verified CRC32 $4FF34EC0
> Checksumming GPT Partition Data (Primary GPT Table : 2)…
> GPT Partition Data (Primary GPT Tabl: verified CRC32 $45C21899
> Checksumming  (Apple_Free : 3)…
> (Apple_Free : 3): verified CRC32 $00000000
> Checksumming disk image (Apple_HFS : 4)…
> disk image (Apple_HFS : 4): verified CRC32 $11368A88
> Checksumming  (Apple_Free : 5)…
> (Apple_Free : 5): verified CRC32 $00000000
> Checksumming GPT Partition Data (Backup GPT Table : 6)…
> GPT Partition Data (Backup GPT Table: verified CRC32 $45C21899
> Checksumming GPT Header (Backup GPT Header : 7)…
> GPT Header (Backup GPT Header : 7): verified CRC32 $34A03204
> verified CRC32 $4683BF87
> /dev/disk4              GUID_partition_scheme
> /dev/disk4s1            Apple_HFS                       /Volumes/pgAdmin 4 2
> 
> 2023-01-20 13:57:48 : INFO  : pgadmin4 : Mounted: /Volumes/pgAdmin 4 2
> 2023-01-20 13:57:48 : INFO  : pgadmin4 : Verifying: /Volumes/pgAdmin 4 2/pgAdmin 4.app
> 2023-01-20 13:57:48 : DEBUG : pgadmin4 : App size: 607M /Volumes/pgAdmin 4 2/pgAdmin 4.app
> 2023-01-20 13:59:37 : DEBUG : pgadmin4 : Debugging enabled, App Verification output was:
> /Volumes/pgAdmin 4 2/pgAdmin 4.app: accepted
> source=Notarized Developer ID
> origin=Developer ID Application: EnterpriseDB Corporation (26QKX55P9K)
> 
> 2023-01-20 13:59:37 : INFO  : pgadmin4 : Team ID matching: 26QKX55P9K (expected: 26QKX55P9K )
> 2023-01-20 13:59:37 : INFO  : pgadmin4 : Installing pgAdmin 4 version 6.19 on versionKey CFBundleShortVersionString.
> 2023-01-20 13:59:37 : INFO  : pgadmin4 : App has LSMinimumSystemVersion: 10.10.0
> 2023-01-20 13:59:37 : DEBUG : pgadmin4 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
> 2023-01-20 13:59:37 : INFO  : pgadmin4 : Finishing...
> 2023-01-20 13:59:40 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app
> 2023-01-20 13:59:40 : WARN  : pgadmin4 : No previous app found
> 2023-01-20 13:59:40 : WARN  : pgadmin4 : could not find pgAdmin 4.app
> 2023-01-20 13:59:40 : REQ   : pgadmin4 : Installed pgAdmin 4
> 2023-01-20 13:59:40 : INFO  : pgadmin4 : notifying
> 2023-01-20 13:59:40 : DEBUG : pgadmin4 : Unmounting /Volumes/pgAdmin 4 2
> 2023-01-20 13:59:41 : DEBUG : pgadmin4 : Debugging enabled, Unmounting output was:
> "disk4" ejected.
> 2023-01-20 13:59:41 : DEBUG : pgadmin4 : DEBUG mode 1, not reopening anything
> 2023-01-20 13:59:41 : REQ   : pgadmin4 : All done!
> 2023-01-20 13:59:41 : REQ   : pgadmin4 : ################## End Installomator, exit code 0