### PR TITLE
resubmit #846 - branch closed by accident

### DIFF
--- a/fragments/labels/openvpnconnectv3.sh
+++ b/fragments/labels/openvpnconnectv3.sh
@@ -9,5 +9,7 @@ openvpnconnectv3)
     fi
     appNewVersion=$(curl -fs "https://openvpn.net/client-connect-vpn-for-mac-os/" | grep -i "Release notes for " | grep -vx -m 1 '.*beta.*' | sed "s|.*for \(.*\) .*|\\1|")
     downloadURL="https://openvpn.net/downloads/openvpn-connect-v3-macos.dmg"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
     expectedTeamID="ACV7L3WCD8"
     ;;
+    


### PR DESCRIPTION
add curlOptions to resolve issue where script is not able to download pkg via curl command.

> 2023-01-20 14:55:10 : REQ   : openvpnconnectv3 : ################## Start Installomator v. 10.3beta, date 2023-01-20
> 2023-01-20 14:55:10 : INFO  : openvpnconnectv3 : ################## Version: 10.3beta
> 2023-01-20 14:55:10 : INFO  : openvpnconnectv3 : ################## Date: 2023-01-20
> 2023-01-20 14:55:10 : INFO  : openvpnconnectv3 : ################## openvpnconnectv3
> 2023-01-20 14:55:10 : DEBUG : openvpnconnectv3 : DEBUG mode 1 enabled.
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : name=OpenVPN Connect
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : appName=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : type=pkgInDmg
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : archiveName=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : downloadURL=https://openvpn.net/downloads/openvpn-connect-v3-macos.dmg
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : appNewVersion=3.4.1
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : appCustomVersion function: Not defined
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : versionKey=CFBundleShortVersionString
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : packageID=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : pkgName=OpenVPN_Connect_[0-9_()]*_x86_64_Installer_signed.pkg
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : choiceChangesXML=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : expectedTeamID=ACV7L3WCD8
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : blockingProcesses=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : installerTool=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : CLIInstaller=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : CLIArguments=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : updateTool=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : updateToolArguments=
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : updateToolRunAsCurrentUser=
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : BLOCKING_PROCESS_ACTION=tell_user
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : NOTIFY=success
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : LOGGING=DEBUG
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : Label type: pkgInDmg
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : archiveName: OpenVPN Connect.dmg
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : no blocking processes defined, using OpenVPN Connect as default
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : Changing directory to /Users/asri/Documents/dev/Installomator/build
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : App(s) found: /Applications/OpenVPN Connect.app
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : found app at /Applications/OpenVPN Connect.app, version 3.4.1, on versionKey CFBundleShortVersionString
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : appversion: 3.4.1
> 2023-01-20 14:55:13 : INFO  : openvpnconnectv3 : Latest version of OpenVPN Connect is 3.4.1
> 2023-01-20 14:55:13 : WARN  : openvpnconnectv3 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
> 2023-01-20 14:55:13 : REQ   : openvpnconnectv3 : Downloading https://openvpn.net/downloads/openvpn-connect-v3-macos.dmg to OpenVPN Connect.dmg
> 2023-01-20 14:55:13 : DEBUG : openvpnconnectv3 : No Dialog connection, just download
> 2023-01-20 14:55:22 : DEBUG : openvpnconnectv3 : File list: -rw-r--r--  1 asri  staff   184M 20 Jan 14:55 OpenVPN Connect.dmg
> 2023-01-20 14:55:22 : DEBUG : openvpnconnectv3 : File type: OpenVPN Connect.dmg: DOS/MBR boot sector; partition 1 : ID=0xee, start-CHS (0x3ff,254,63), end-CHS (0x3ff,254,63), startsector 1, 381706 sectors, extended partition table (last)
> 2023-01-20 14:55:22 : DEBUG : openvpnconnectv3 : curl output was:
> *   Trying 104.18.109.96:443...
> * Connected to openvpn.net (104.18.109.96) port 443 (#0)
> * ALPN, offering h2
> * ALPN, offering http/1.1
> * successfully set certificate verify locations:
> *  CAfile: /etc/ssl/cert.pem
> *  CApath: none
> * (304) (OUT), TLS handshake, Client hello (1):
> } [316 bytes data]
> * (304) (IN), TLS handshake, Server hello (2):
> { [122 bytes data]
> * (304) (IN), TLS handshake, Unknown (8):
> { [19 bytes data]
> * (304) (IN), TLS handshake, Certificate (11):
> { [4752 bytes data]
> * (304) (IN), TLS handshake, CERT verify (15):
> { [264 bytes data]
> * (304) (IN), TLS handshake, Finished (20):
> { [52 bytes data]
> * (304) (OUT), TLS handshake, Finished (20):
> } [52 bytes data]
> * SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
> * ALPN, server accepted to use h2
> * Server certificate:
> *  subject: C=US; ST=California; O=OpenVPN Inc.; CN=*.openvpn.net
> *  start date: Mar 21 00:00:00 2022 GMT
> *  expire date: Apr 20 23:59:59 2023 GMT
> *  subjectAltName: host "openvpn.net" matched cert's "openvpn.net"
> *  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Organization Validation Secure Server CA
> *  SSL certificate verify ok.
> * Using HTTP2, server supports multiplexing
> * Connection state changed (HTTP/2 confirmed)
> * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
> * Using Stream ID: 1 (easy handle 0x7fd17800d400)
> > GET /downloads/openvpn-connect-v3-macos.dmg HTTP/2
> > Host: openvpn.net
> > accept: */*
> > user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
> > 
> * Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
> < HTTP/2 301 
> < date: Fri, 20 Jan 2023 06:55:14 GMT
> < content-type: text/html; charset=UTF-8
> < location: https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.4.1.4522_signed.dmg
> < expires: Wed, 11 Jan 1984 05:00:00 GMT
> < cache-control: no-cache, must-revalidate, max-age=0
> < x-redirect-by: redirection
> < cf-cache-status: MISS
> < server: cloudflare
> < cf-ray: 78c5e7442f184a17-SIN
> < 
> { [0 bytes data]
> * Connection #0 to host openvpn.net left intact
> * Issue another request to this URL: 'https://swupdate.openvpn.net/downloads/connect/openvpn-connect-3.4.1.4522_signed.dmg'
> *   Trying 104.18.110.96:443...
> * Connected to swupdate.openvpn.net (104.18.110.96) port 443 (#1)
> * ALPN, offering h2
> * ALPN, offering http/1.1
> * successfully set certificate verify locations:
> *  CAfile: /etc/ssl/cert.pem
> *  CApath: none
> * (304) (OUT), TLS handshake, Client hello (1):
> } [325 bytes data]
> * (304) (IN), TLS handshake, Server hello (2):
> { [122 bytes data]
> * (304) (IN), TLS handshake, Unknown (8):
> { [19 bytes data]
> * (304) (IN), TLS handshake, Certificate (11):
> { [4752 bytes data]
> * (304) (IN), TLS handshake, CERT verify (15):
> { [264 bytes data]
> * (304) (IN), TLS handshake, Finished (20):
> { [52 bytes data]
> * (304) (OUT), TLS handshake, Finished (20):
> } [52 bytes data]
> * SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
> * ALPN, server accepted to use h2
> * Server certificate:
> *  subject: C=US; ST=California; O=OpenVPN Inc.; CN=*.openvpn.net
> *  start date: Mar 21 00:00:00 2022 GMT
> *  expire date: Apr 20 23:59:59 2023 GMT
> *  subjectAltName: host "swupdate.openvpn.net" matched cert's "*.openvpn.net"
> *  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Organization Validation Secure Server CA
> *  SSL certificate verify ok.
> * Using HTTP2, server supports multiplexing
> * Connection state changed (HTTP/2 confirmed)
> * Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
> * Using Stream ID: 1 (easy handle 0x7fd17800d400)
> > GET /downloads/connect/openvpn-connect-3.4.1.4522_signed.dmg HTTP/2
> > Host: swupdate.openvpn.net
> > accept: */*
> > user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
> > 
> * Connection state changed (MAX_CONCURRENT_STREAMS == 256)!
> < HTTP/2 200 
> < date: Fri, 20 Jan 2023 06:55:15 GMT
> < content-type: application/x-apple-diskimage
> < content-length: 192813583
> < last-modified: Mon, 28 Nov 2022 14:08:18 GMT
> < x-amz-version-id: lNFByBkoMHIoHzkFaMvwl4vd.CiEu8bR
> < etag: "661234934ab38be0153d405f3cb8e0bd-12"
> < x-cache: Hit from cloudfront
> < via: 1.1 c905ab1a35f5719106f2992ea51e1a76.cloudfront.net (CloudFront)
> < x-amz-cf-pop: MRS52-C2
> < x-amz-cf-id: jWuAePnzj-9rPzBR4J5_WyeYtTj-f2tWZ7f9sHFdPrNF9BZEQbEzgQ==
> < cf-cache-status: HIT
> < age: 219469
> < expires: Mon, 20 Feb 2023 06:55:15 GMT
> < cache-control: public, max-age=2678400
> < accept-ranges: bytes
> < server: cloudflare
> < cf-ray: 78c5e7489c7c4852-SIN
> < 
> { [948 bytes data]
> * Connection #1 to host swupdate.openvpn.net left intact
> 
> 2023-01-20 14:55:22 : DEBUG : openvpnconnectv3 : DEBUG mode 1, not checking for blocking processes
> 2023-01-20 14:55:22 : REQ   : openvpnconnectv3 : Installing OpenVPN Connect
> 2023-01-20 14:55:22 : INFO  : openvpnconnectv3 : Mounting /Users/asri/Documents/dev/Installomator/build/OpenVPN Connect.dmg
> 2023-01-20 14:55:26 : DEBUG : openvpnconnectv3 : Debugging enabled, dmgmount output was:
> Checksumming Protective Master Boot Record (MBR : 0)…
> Protective Master Boot Record (MBR :: verified CRC32 $13DB2E7F
> Checksumming GPT Header (Primary GPT Header : 1)…
> GPT Header (Primary GPT Header : 1): verified CRC32 $B50E7EDF
> Checksumming GPT Partition Data (Primary GPT Table : 2)…
> GPT Partition Data (Primary GPT Tabl: verified CRC32 $A9224396
> Checksumming  (Apple_Free : 3)…
> (Apple_Free : 3): verified CRC32 $00000000
> Checksumming disk image (Apple_HFS : 4)…
> disk image (Apple_HFS : 4): verified CRC32 $60FF7BD7
> Checksumming  (Apple_Free : 5)…
> (Apple_Free : 5): verified CRC32 $00000000
> Checksumming GPT Partition Data (Backup GPT Table : 6)…
> GPT Partition Data (Backup GPT Table: verified CRC32 $A9224396
> Checksumming GPT Header (Backup GPT Header : 7)…
> GPT Header (Backup GPT Header : 7): verified CRC32 $C2DBF90B
> verified CRC32 $C7A457C0
> /dev/disk4              GUID_partition_scheme
> /dev/disk4s1            Apple_HFS                       /Volumes/OpenVPN Connect
> 
> 2023-01-20 14:55:26 : INFO  : openvpnconnectv3 : Mounted: /Volumes/OpenVPN Connect
> 2023-01-20 14:55:26 : DEBUG : openvpnconnectv3 : Found pkg(s):
> /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg
> 2023-01-20 14:55:26 : INFO  : openvpnconnectv3 : found pkg: /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg
> 2023-01-20 14:55:26 : INFO  : openvpnconnectv3 : Verifying: /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg
> 2023-01-20 14:55:26 : DEBUG : openvpnconnectv3 : File list: -rw-r--r--@ 1 asri  staff    92M 28 Nov 22:05 /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg
> 2023-01-20 14:55:26 : DEBUG : openvpnconnectv3 : File type: /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg: xar archive compressed TOC: 6111, SHA-1 checksum
> 2023-01-20 14:55:29 : DEBUG : openvpnconnectv3 : spctlOut is /Volumes/OpenVPN Connect/OpenVPN_Connect_3_4_1(4522)_x86_64_Installer_signed.pkg: accepted
> 2023-01-20 14:55:29 : DEBUG : openvpnconnectv3 : source=Notarized Developer ID
> 2023-01-20 14:55:29 : DEBUG : openvpnconnectv3 : origin=Developer ID Installer: OPENVPN TECHNOLOGIES, INC. (ACV7L3WCD8)
> 2023-01-20 14:55:29 : INFO  : openvpnconnectv3 : Team ID: ACV7L3WCD8 (expected: ACV7L3WCD8 )
> 2023-01-20 14:55:29 : DEBUG : openvpnconnectv3 : DEBUG enabled, skipping installation
> 2023-01-20 14:55:29 : INFO  : openvpnconnectv3 : Finishing...
> 2023-01-20 14:55:32 : INFO  : openvpnconnectv3 : App(s) found: /Applications/OpenVPN Connect.app
> 2023-01-20 14:55:32 : INFO  : openvpnconnectv3 : found app at /Applications/OpenVPN Connect.app, version 3.4.1, on versionKey CFBundleShortVersionString
> 2023-01-20 14:55:32 : REQ   : openvpnconnectv3 : Installed OpenVPN Connect, version 3.4.1
> 2023-01-20 14:55:32 : INFO  : openvpnconnectv3 : notifying
> 2023-01-20 14:55:32 : DEBUG : openvpnconnectv3 : Unmounting /Volumes/OpenVPN Connect
> 2023-01-20 14:55:33 : DEBUG : openvpnconnectv3 : Debugging enabled, Unmounting output was:
> "disk4" ejected.
> 2023-01-20 14:55:33 : DEBUG : openvpnconnectv3 : DEBUG mode 1, not reopening anything
> 2023-01-20 14:55:33 : REQ   : openvpnconnectv3 : All done!
> 2023-01-20 14:55:33 : REQ   : openvpnconnectv3 : ################## End Installomator, exit code 0