### PR TITLE
Update code for Google Ads Editor (googleadseditor)

### DIFF
--- a/fragments/labels/googleadseditor.sh
+++ b/fragments/labels/googleadseditor.sh
@@ -2,8 +2,7 @@ googleadseditor)
     name="Google Ads Editor"
     type="dmg"
     downloadURL="https://dl.google.com/adwords_editor/google_ads_editor.dmg"
-    # Version not found in installed app, but on we it is here
-    #appNewVersion="$(curl -fs "https://support.google.com/google-ads/editor/answer/30513" | grep "Current Mac version" | sed -E 's/.*Current Mac version: *([0-9.]*)<.*/\1/')"
-    #appCustomVersion(){  }
+    appNewVersion="$(curl -s "https://support.google.com/google-ads/editor/topic/13728" | grep -E -o "Google Ads Editor version.{1,4}" | head -1 | tail -c 4)"
+    appCustomVersion(){cat /Applications/Google\ Ads\ Editor.app/Contents/Versions/*/Google\ Ads\ Editor.app/Contents/locale/content/welcome1/welcome1-en-US.htm | grep -o -E " about version.{0,4}" | tail -c 4}
     expectedTeamID="EQHXZ8M8AV"
     ;;


### PR DESCRIPTION
Updated code for version checking of Google Ads Editor. This will check online version and local version. Slightly hackish, but works for now. :-) 