### PR TITLE
appClosed being set prematurely

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -649,12 +649,12 @@ checkRunningProcesses() {
     fi
 
     # try at most 3 times
-    
     for i in {1..4}; do
         countedProcesses=0
         for x in ${blockingProcesses}; do
             if pgrep -xq "$x"; then
                 printlog "found blocking process $x"
+                
                 case $BLOCKING_PROCESS_ACTION in
                     quit|quit_kill)
                         quitApp $x

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -636,8 +636,9 @@ getAppVersion() {
 }
 
 quitApp() { # $1 = app name
-    printlog "telling app $ to quit"
-    runAsUser osascript -e "tell app \"$x\" to quit"
+    name=$1
+    printlog "telling app $name to quit"
+    runAsUser osascript -e "tell app \"$name\" to quit"
     appClosed=1
 }
 
@@ -718,8 +719,7 @@ checkRunningProcesses() {
                       fi
                       ;;
                     silent_fail)
-                      printlog "blocking process '$x' found, aborting" ERROR
-                      cleanupAndExit 12
+                      cleanupAndExit 12 "blocking process '$x' found, aborting" ERROR
                       ;;
                 esac
 

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -655,7 +655,6 @@ checkRunningProcesses() {
         for x in ${blockingProcesses}; do
             if pgrep -xq "$x"; then
                 printlog "found blocking process $x"
-                
                 case $BLOCKING_PROCESS_ACTION in
                     quit|quit_kill)
                         quitApp $x


### PR DESCRIPTION
The variable `appClosed` is being set to `1` if a blocking process is found, but before any processes are actually closed. This has unintended behavior in the case where `BLOCKING_PROCESS_ACTION` is `silent_fail` since nothing is actually closed in this case statement, only the `cleanupAndExit` function is called.

This function calls `reopenClosedProcess` which checks whether `appClosed` is set and tries to reopen the app if so. Because the app was already open (which is why we entered this case statement in the first place) and the variable was set prematurely, all this does is instead pop the app into focus on the user's screen, interrupting whatever it was they were doing.

This was noticed due to any app that we attempted to update with this method popping into focus one or more times a day.

I added an additional function to set this value in cases where Apple Script is being used to try and closed the app, so that this variable gets set correctly in each case. I also set the variable for the case where instead of Apple Script, the `pkill` command is used.