### PR TITLE
Proxy Server Connectivity Optional Paramters

### DIFF
--- a/MDM/Jamf/00_PrepareInstall_SwiftDialog.sh
+++ b/MDM/Jamf/00_PrepareInstall_SwiftDialog.sh
@@ -15,6 +15,22 @@ icon=${6:-"/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"}
 # see Dan Snelson's advice on how to get a URL to an icon in Self Service
 # https://rumble.com/v119x6y-harvesting-self-service-icons.html
 
+# Optional Setting for Proxy to be configured, JAMF Paramter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
+# If Paramters not set then blank values are put in for HTTP and HTTPS Proxy
+
+# Parameter 7: Proxy Server
+proxyserv=${7:-""} #eg. 192.168.1.20
+#
+# Parameter 8: Proxy Server Port
+proxyport=${8:-""} #eg. 8080
+#
+export HTTP_PROXY=$proxyserv:$proxyport
+export HTTPS_PROXY=$proxyserv:$proxyport
+export http_proxy=$proxyserv:$proxyport
+export https_proxy=$proxyserv:$proxyport
+#
+
+
 # MARK: Constants
 
 dialogApp="/Library/Application Support/Dialog/Dialog.app"

--- a/MDM/Jamf/00_PrepareInstall_SwiftDialog.sh
+++ b/MDM/Jamf/00_PrepareInstall_SwiftDialog.sh
@@ -15,19 +15,19 @@ icon=${6:-"/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"}
 # see Dan Snelson's advice on how to get a URL to an icon in Self Service
 # https://rumble.com/v119x6y-harvesting-self-service-icons.html
 
-# Optional Setting for Proxy to be configured, JAMF Paramter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
-# If Paramters not set then blank values are put in for HTTP and HTTPS Proxy
+# Optional Setting for Proxy to be configured, JAMF Parameter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
+# If Parameters not set then blank values are put in for HTTP and HTTPS Proxy
 
 # Parameter 7: Proxy Server
-proxyserv=${7:-""} #eg. 192.168.1.20
+PROXYSERV=${7:-""} #eg. 192.168.1.20
 #
 # Parameter 8: Proxy Server Port
-proxyport=${8:-""} #eg. 8080
+PROXYPORT=${8:-""} #eg. 8080
 #
-export HTTP_PROXY=$proxyserv:$proxyport
-export HTTPS_PROXY=$proxyserv:$proxyport
-export http_proxy=$proxyserv:$proxyport
-export https_proxy=$proxyserv:$proxyport
+export HTTP_PROXY=$PROXYSERV:$PROXYPORT
+export HTTPS_PROXY=$PROXYSERV:$PROXYPORT
+export http_proxy=$PROXYSERV:$PROXYPORT
+export https_proxy=$PROXYSERV:$PROXYPORT
 #
 
 

--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -7,6 +7,16 @@ if ! is-at-least 10.14 $installedOSversion; then
     exit 98
 fi
 
+# Proxy Server Check if Set and Verify Contact
+if [[$PROXYSERVER -eq <> "" ]];then
+    printlog "Proxy value Set to $PROXYSERVER" INFO
+        export HTTP_PROXY=$PROXYSERVER
+        export HTTPS_PROXY=$PROXYSERVER
+        export http_proxy=$PROXYSERVER
+        export https_proxy=$PROXYSERVER
+fi
+
+#
 
 # MARK: argument parsing
 if [[ $# -eq 0 ]]; then

--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -7,17 +7,6 @@ if ! is-at-least 10.14 $installedOSversion; then
     exit 98
 fi
 
-# Proxy Server Check if Set and Verify Contact
-if [[$PROXYSERVER -eq <> "" ]];then
-    printlog "Proxy value Set to $PROXYSERVER" INFO
-        export HTTP_PROXY=$PROXYSERVER
-        export HTTPS_PROXY=$PROXYSERVER
-        export http_proxy=$PROXYSERVER
-        export https_proxy=$PROXYSERVER
-fi
-
-#
-
 # MARK: argument parsing
 if [[ $# -eq 0 ]]; then
     if [[ -z $label ]]; then # check if label is set inside script
@@ -44,6 +33,17 @@ while [[ -n $1 ]]; do
     # shift to next argument
     shift 1
 done
+
+# Proxy Server Check if Set and Verify Contact
+if [[ -z $PROXYSERVER ]];then
+	printlog "Proxy value not Set" INFO
+else
+    printlog "Proxy value Set to $PROXYSERVER" INFO
+        export HTTP_PROXY=$PROXYSERVER
+        export HTTPS_PROXY=$PROXYSERVER
+        export http_proxy=$PROXYSERVER
+        export https_proxy=$PROXYSERVER
+fi
 
 # lowercase the label
 label=${label:l}

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -1,20 +1,10 @@
 #!/bin/zsh
 label="" # if no label is sent to the script, this will be used
 
-# Optional Setting for Proxy to be configured, JAMF Parameter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
-# If Parameters not set then blank values are put in for HTTP and HTTPS Proxy
+# Optional Setting for Proxy to be configured. Variable passes through script and runs a function to check if proxy
+# is reachable by ping. If it isthen will set HTTP and HTTPS Proxy
 
-# Parameter 7: Proxy Server
-PROXYSERV=${7:-""} #eg. 192.168.1.20
-#
-# Parameter 8: Proxy Server Port
-PROXYPORT=${8:-""} #eg. 8080
-#
-export HTTP_PROXY=$PROXYSERV:$PROXYPORT
-export HTTPS_PROXY=$PROXYSERV:$PROXYPORT
-export http_proxy=$PROXYSERV:$PROXYPORT
-export https_proxy=$PROXYSERV:$PROXYPORT
-#
+PROXYSERVER=""
 
 # Installomator
 #

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -1,6 +1,21 @@
 #!/bin/zsh
 label="" # if no label is sent to the script, this will be used
 
+# Optional Setting for Proxy to be configured, JAMF Paramter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
+# If Paramters not set then blank values are put in for HTTP and HTTPS Proxy
+
+# Parameter 7: Proxy Server
+proxyserv=${7:-""} #eg. 192.168.1.20
+#
+# Parameter 8: Proxy Server Port
+proxyport=${8:-""} #eg. 8080
+#
+export HTTP_PROXY=$proxyserv:$proxyport
+export HTTPS_PROXY=$proxyserv:$proxyport
+export http_proxy=$proxyserv:$proxyport
+export https_proxy=$proxyserv:$proxyport
+#
+
 # Installomator
 #
 # Downloads and installs Applications

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -1,19 +1,19 @@
 #!/bin/zsh
 label="" # if no label is sent to the script, this will be used
 
-# Optional Setting for Proxy to be configured, JAMF Paramter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
-# If Paramters not set then blank values are put in for HTTP and HTTPS Proxy
+# Optional Setting for Proxy to be configured, JAMF Parameter Options 7 = Proxy Server and Parameter Options 8 = Proxy Port
+# If Parameters not set then blank values are put in for HTTP and HTTPS Proxy
 
 # Parameter 7: Proxy Server
-proxyserv=${7:-""} #eg. 192.168.1.20
+PROXYSERV=${7:-""} #eg. 192.168.1.20
 #
 # Parameter 8: Proxy Server Port
-proxyport=${8:-""} #eg. 8080
+PROXYPORT=${8:-""} #eg. 8080
 #
-export HTTP_PROXY=$proxyserv:$proxyport
-export HTTPS_PROXY=$proxyserv:$proxyport
-export http_proxy=$proxyserv:$proxyport
-export https_proxy=$proxyserv:$proxyport
+export HTTP_PROXY=$PROXYSERV:$PROXYPORT
+export HTTPS_PROXY=$PROXYSERV:$PROXYPORT
+export http_proxy=$PROXYSERV:$PROXYPORT
+export https_proxy=$PROXYSERV:$PROXYPORT
 #
 
 # Installomator


### PR DESCRIPTION
Configured Variable PROXYSERVER for a Proxy Server to be set in this format.

Servername:ServerPort
eg. 192.168.1.10:8080

Placed an If Statement in arguments to get the Parameter if set in JAMF after the argument shifts arguments so that PROXYSERVER variable is set from shifted arguments.
