### PR TITLE
Proxy Patch

### DIFF
--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -110,6 +110,22 @@ if [[ ! -x $DIALOG_CMD ]]; then
     DIALOG_CMD_FILE=""
 fi
 
+# check for proxy and set
+if [[ -z $PROXYSERVER ]];then
+	printlog "Proxy IP Address not Set, Skipping Set Proxy" INFO
+else
+    printlog "Proxy value set to $PROXYSERVER:$PROXYPORT" INFO
+	if ping -q -c 1 -W 5 $PROXYSERVER; then 
+    	printlog "Proxy Reachable and will be set to $PROXYSERVER:$PROXYPORT" INFO
+    	export HTTP_PROXY=$PROXYSERVER:$PROXYPORT
+    	export HTTPS_PROXY=$PROXYSERVER:$PROXYPORT
+    	export http_proxy=$PROXYSERVER:$PROXYPORT
+    	export https_proxy=$PROXYSERVER:$PROXYPORT
+	else
+    	printlog "Proxy value is Set, But its not contactable, Skipping Set Proxy" INFO 
+	fi
+fi
+
 # MARK: labels in case statement
 case $label in
 longversion)

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -157,6 +157,12 @@ DIALOG_LIST_ITEM_NAME=""
 # listitem.
 # When the variable is unset, progress will be sent to Swift Dialog's main progress bar.
 
+PROXYSERVER=""
+PROXYPORT=""
+#When this variable is set, proxy will be applied providing a ping success within 5 Seconds.
+#When variable unset, not proxy will be applied
+#If a proxy is applied but does not return a succesful ping, proxy will not be applied.
+#Setting these settings in MDM (JAMF) can be done via Paramter 6 PROXYSERVER=X.X.X.X & Parameter 7 PROXYPORT=8080
 
 
 # NOTE: How labels work


### PR DESCRIPTION
I have added two variables PROXYPORT and PROXYSERVER.

If these values are set then a ping test will be performed, if ping is success then proxy will be set as per variables.

Setting the proxy is inserted after JAMF Parameter 1380 Parsing Parameters in Arguments.sh and Shifting so that you can set the following values in JAMF and it function correctly. 

The Variables are declared in the Header.sh

Parameter 6 - PROXYSERVER=192.168.10.20
Parameter 7 - PROXYPORT=8080

Printlog has been added to provide more information of when and if the script is applying the proxy settings.