### PR TITLE
Update musescore.sh

### DIFF
--- a/fragments/labels/musescore.sh
+++ b/fragments/labels/musescore.sh
@@ -1,5 +1,5 @@
 musescore)
-    name="MuseScore 3"
+    name="MuseScore 4"
     type="dmg"
     downloadURL=$(downloadURLFromGit musescore MuseScore)
     appNewVersion=$(versionFromGit musescore MuseScore)

--- a/fragments/labels/ultimakercura.sh
+++ b/fragments/labels/ultimakercura.sh
@@ -1,5 +1,5 @@
 ultimakercura)
-    name="Ultimaker-Cura"
+    name="Ultimaker Cura"
     type="dmg"
     downloadURL="$(downloadURLFromGit Ultimaker Cura)"
     archiveName="Ultimaker_Cura-[0-9].*-mac.dmg"


### PR DESCRIPTION
MuseScore released version 4, the name MuseScore 3 produces an exit code of 8. Path not found.