### PR TITLE
New Label: Java SE 17

### DIFF
--- a/fragments/labels/jdk17.sh
+++ b/fragments/labels/jdk17.sh
@@ -1,0 +1,13 @@
+jdk17)
+    name="Java SE Development Kit 17"
+    type="pkgInDmg"
+    versionKey="CFBundleShortVersionString"
+    appNewVersion=$(curl -sf https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html | grep -m 1 "Java SE Development Kit" | sed "s|.*Kit \(.*\)\<.*|\\1|")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.oracle.com/java/17/archive/jdk-"$appNewVersion"_macos-aarch64_bin.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.oracle.com/java/17/archive/jdk-"$appNewVersion"_macos-x64_bin.dmg"
+    fi
+    appCustomVersion(){ java --version | grep java | awk '{print $2}' }
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
sudo ./assemble.sh -l //Mosyle/Resources/InstallomatorLabels jdk17
2023-01-29 13:53:45 : REQ   : jdk17 : ################## Start Installomator v. 10.2, date 2023-01-29
2023-01-29 13:53:45 : INFO  : jdk17 : ################## Version: 10.2
2023-01-29 13:53:45 : INFO  : jdk17 : ################## Date: 2023-01-29
2023-01-29 13:53:45 : INFO  : jdk17 : ################## jdk17
2023-01-29 13:53:45 : DEBUG : jdk17 : DEBUG mode 1 enabled.
2023-01-29 13:53:47 : DEBUG : jdk17 : name=Java SE Development Kit 17
2023-01-29 13:53:47 : DEBUG : jdk17 : appName=
2023-01-29 13:53:47 : DEBUG : jdk17 : type=pkgInDmg
2023-01-29 13:53:47 : DEBUG : jdk17 : archiveName=
2023-01-29 13:53:47 : DEBUG : jdk17 : downloadURL=https://download.oracle.com/java/17/archive/jdk-17.0.6_macos-aarch64_bin.dmg
2023-01-29 13:53:47 : DEBUG : jdk17 : curlOptions=
2023-01-29 13:53:47 : DEBUG : jdk17 : appNewVersion=17.0.6
2023-01-29 13:53:47 : DEBUG : jdk17 : appCustomVersion function: Defined.
2023-01-29 13:53:47 : DEBUG : jdk17 : versionKey=CFBundleShortVersionString
2023-01-29 13:53:47 : DEBUG : jdk17 : packageID=
2023-01-29 13:53:47 : DEBUG : jdk17 : pkgName=
2023-01-29 13:53:47 : DEBUG : jdk17 : choiceChangesXML=
2023-01-29 13:53:47 : DEBUG : jdk17 : expectedTeamID=VB5E2TV963
2023-01-29 13:53:47 : DEBUG : jdk17 : blockingProcesses=
2023-01-29 13:53:47 : DEBUG : jdk17 : installerTool=
2023-01-29 13:53:47 : DEBUG : jdk17 : CLIInstaller=
2023-01-29 13:53:47 : DEBUG : jdk17 : CLIArguments=
2023-01-29 13:53:47 : DEBUG : jdk17 : updateTool=
2023-01-29 13:53:47 : DEBUG : jdk17 : updateToolArguments=
2023-01-29 13:53:47 : DEBUG : jdk17 : updateToolRunAsCurrentUser=
2023-01-29 13:53:47 : INFO  : jdk17 : BLOCKING_PROCESS_ACTION=tell_user
2023-01-29 13:53:47 : INFO  : jdk17 : NOTIFY=success
2023-01-29 13:53:47 : INFO  : jdk17 : LOGGING=DEBUG
2023-01-29 13:53:47 : INFO  : jdk17 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-29 13:53:47 : INFO  : jdk17 : Label type: pkgInDmg
2023-01-29 13:53:47 : INFO  : jdk17 : archiveName: Java SE Development Kit 17.dmg
2023-01-29 13:53:47 : INFO  : jdk17 : no blocking processes defined, using Java SE Development Kit 17 as default
2023-01-29 13:53:47 : DEBUG : jdk17 : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main/build
2023-01-29 13:53:47 : INFO  : jdk17 : Custom App Version detection is used, found 18.0.2.1
2023-01-29 13:53:47 : INFO  : jdk17 : appversion: 18.0.2.1
2023-01-29 13:53:47 : INFO  : jdk17 : Latest version of Java SE Development Kit 17 is 17.0.6
2023-01-29 13:53:47 : INFO  : jdk17 : Java SE Development Kit 17.dmg exists and DEBUG mode 1 enabled, skipping download
2023-01-29 13:53:47 : DEBUG : jdk17 : DEBUG mode 1, not checking for blocking processes
2023-01-29 13:53:47 : REQ   : jdk17 : Installing Java SE Development Kit 17
2023-01-29 13:53:47 : INFO  : jdk17 : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main/build/Java SE Development Kit 17.dmg
2023-01-29 13:53:47 : DEBUG : jdk17 : Debugging enabled, dmgmount output was:
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/JDK 17.0.6

2023-01-29 13:53:47 : INFO  : jdk17 : Mounted: /Volumes/JDK 17.0.6 2023-01-29 13:53:47 : DEBUG : jdk17 : Found pkg(s): /Volumes/JDK 17.0.6/JDK 17.0.6.pkg
2023-01-29 13:53:47 : INFO  : jdk17 : found pkg: /Volumes/JDK 17.0.6/JDK 17.0.6.pkg 2023-01-29 13:53:47 : INFO  : jdk17 : Verifying: /Volumes/JDK 17.0.6/JDK 17.0.6.pkg
2023-01-29 13:53:47 : DEBUG : jdk17 : File list: -rw-r--r--  1 savvas  10668   168M  6 Dez 17:00 /Volumes/JDK 17.0.6/JDK 17.0.6.pkg
2023-01-29 13:53:47 : DEBUG : jdk17 : File type: /Volumes/JDK 17.0.6/JDK 17.0.6.pkg: xar archive compressed TOC: 5638, SHA-1 checksum
2023-01-29 13:53:47 : DEBUG : jdk17 : spctlOut is /Volumes/JDK 17.0.6/JDK 17.0.6.pkg: accepted
2023-01-29 13:53:47 : DEBUG : jdk17 : source=Notarized Developer ID
2023-01-29 13:53:47 : DEBUG : jdk17 : override=security disabled
2023-01-29 13:53:47 : DEBUG : jdk17 : origin=Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
2023-01-29 13:53:47 : INFO  : jdk17 : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2023-01-29 13:53:47 : DEBUG : jdk17 : DEBUG enabled, skipping installation
2023-01-29 13:53:47 : INFO  : jdk17 : Finishing...
2023-01-29 13:53:50 : INFO  : jdk17 : Custom App Version detection is used, found 18.0.2.1
2023-01-29 13:53:50 : REQ   : jdk17 : Installed Java SE Development Kit 17, version 18.0.2.1
2023-01-29 13:53:51 : INFO  : jdk17 : notifying
2023-01-29 13:53:51 : DEBUG : jdk17 : Unmounting /Volumes/JDK 17.0.6
2023-01-29 13:53:51 : DEBUG : jdk17 : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-01-29 13:53:51 : DEBUG : jdk17 : DEBUG mode 1, not reopening anything
2023-01-29 13:53:51 : REQ   : jdk17 : All done!
2023-01-29 13:53:51 : REQ   : jdk17 : ################## End Installomator, exit code 0