### PR TITLE
New Label: Java SE 19

### DIFF
--- a/fragments/labels/jdk19.sh
+++ b/fragments/labels/jdk19.sh
@@ -1,0 +1,13 @@
+jdk19)
+    name="Java SE Development Kit 19"
+    type="pkgInDmg"
+    versionKey="CFBundleShortVersionString"
+    appNewVersion=$(curl -sf https://www.oracle.com/java/technologies/javase/jdk19-archive-downloads.html | grep -m 1 "Java SE Development Kit" | sed "s|.*Kit \(.*\)\<.*|\\1|")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.oracle.com/java/19/archive/jdk-"$appNewVersion"_macos-aarch64_bin.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.oracle.com/java/19/archive/jdk-"$appNewVersion"_macos-x64_bin.dmg"
+    fi
+    appCustomVersion(){ java --version | grep java | awk '{print $2}' }
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
sudo ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels jdk19
2023-01-29 13:53:25 : REQ   : jdk19 : ################## Start Installomator v. 10.2, date 2023-01-29
2023-01-29 13:53:25 : INFO  : jdk19 : ################## Version: 10.2
2023-01-29 13:53:25 : INFO  : jdk19 : ################## Date: 2023-01-29
2023-01-29 13:53:25 : INFO  : jdk19 : ################## jdk19
2023-01-29 13:53:25 : DEBUG : jdk19 : DEBUG mode 1 enabled.
2023-01-29 13:53:26 : DEBUG : jdk19 : name=Java SE Development Kit 19
2023-01-29 13:53:26 : DEBUG : jdk19 : appName=
2023-01-29 13:53:26 : DEBUG : jdk19 : type=pkgInDmg
2023-01-29 13:53:26 : DEBUG : jdk19 : archiveName=
2023-01-29 13:53:26 : DEBUG : jdk19 : downloadURL=https://download.oracle.com/java/19/archive/jdk-19.0.2_macos-aarch64_bin.dmg
2023-01-29 13:53:26 : DEBUG : jdk19 : curlOptions=
2023-01-29 13:53:26 : DEBUG : jdk19 : appNewVersion=19.0.2
2023-01-29 13:53:26 : DEBUG : jdk19 : appCustomVersion function: Defined.
2023-01-29 13:53:26 : DEBUG : jdk19 : versionKey=CFBundleShortVersionString
2023-01-29 13:53:26 : DEBUG : jdk19 : packageID=
2023-01-29 13:53:26 : DEBUG : jdk19 : pkgName=
2023-01-29 13:53:26 : DEBUG : jdk19 : choiceChangesXML=
2023-01-29 13:53:26 : DEBUG : jdk19 : expectedTeamID=VB5E2TV963
2023-01-29 13:53:26 : DEBUG : jdk19 : blockingProcesses=
2023-01-29 13:53:26 : DEBUG : jdk19 : installerTool=
2023-01-29 13:53:26 : DEBUG : jdk19 : CLIInstaller=
2023-01-29 13:53:26 : DEBUG : jdk19 : CLIArguments=
2023-01-29 13:53:26 : DEBUG : jdk19 : updateTool=
2023-01-29 13:53:26 : DEBUG : jdk19 : updateToolArguments=
2023-01-29 13:53:26 : DEBUG : jdk19 : updateToolRunAsCurrentUser=
2023-01-29 13:53:26 : INFO  : jdk19 : BLOCKING_PROCESS_ACTION=tell_user
2023-01-29 13:53:26 : INFO  : jdk19 : NOTIFY=success
2023-01-29 13:53:26 : INFO  : jdk19 : LOGGING=DEBUG
2023-01-29 13:53:26 : INFO  : jdk19 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-01-29 13:53:26 : INFO  : jdk19 : Label type: pkgInDmg
2023-01-29 13:53:26 : INFO  : jdk19 : archiveName: Java SE Development Kit 19.dmg
2023-01-29 13:53:26 : INFO  : jdk19 : no blocking processes defined, using Java SE Development Kit 19 as default
2023-01-29 13:53:26 : DEBUG : jdk19 : Changing directory to /Users/savvas/Desktop/Mosyle/Resources/Installomator-main/build
2023-01-29 13:53:26 : INFO  : jdk19 : Custom App Version detection is used, found 18.0.2.1
2023-01-29 13:53:26 : INFO  : jdk19 : appversion: 18.0.2.1
2023-01-29 13:53:26 : INFO  : jdk19 : Latest version of Java SE Development Kit 19 is 19.0.2
2023-01-29 13:53:26 : INFO  : jdk19 : Java SE Development Kit 19.dmg exists and DEBUG mode 1 enabled, skipping download
2023-01-29 13:53:26 : DEBUG : jdk19 : DEBUG mode 1, not checking for blocking processes
2023-01-29 13:53:26 : REQ   : jdk19 : Installing Java SE Development Kit 19
2023-01-29 13:53:26 : INFO  : jdk19 : Mounting /Users/savvas/Desktop/Mosyle/Resources/Installomator-main/build/Java SE Development Kit 19.dmg
2023-01-29 13:53:27 : DEBUG : jdk19 : Debugging enabled, dmgmount output was:
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/JDK 19.0.2 1

2023-01-29 13:53:27 : INFO  : jdk19 : Mounted: /Volumes/JDK 19.0.2 1 2023-01-29 13:53:27 : DEBUG : jdk19 : Found pkg(s): /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg
2023-01-29 13:53:27 : INFO  : jdk19 : found pkg: /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg 2023-01-29 13:53:27 : INFO  : jdk19 : Verifying: /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg
2023-01-29 13:53:27 : DEBUG : jdk19 : File list: -rw-r--r--  1 savvas  10668   176M 30 Nov 19:42 /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg
2023-01-29 13:53:27 : DEBUG : jdk19 : File type: /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg: xar archive compressed TOC: 5892, SHA-1 checksum
2023-01-29 13:53:27 : DEBUG : jdk19 : spctlOut is /Volumes/JDK 19.0.2 1/JDK 19.0.2.pkg: accepted
2023-01-29 13:53:27 : DEBUG : jdk19 : source=Notarized Developer ID
2023-01-29 13:53:27 : DEBUG : jdk19 : override=security disabled
2023-01-29 13:53:27 : DEBUG : jdk19 : origin=Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
2023-01-29 13:53:27 : INFO  : jdk19 : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2023-01-29 13:53:27 : DEBUG : jdk19 : DEBUG enabled, skipping installation
2023-01-29 13:53:27 : INFO  : jdk19 : Finishing...
2023-01-29 13:53:30 : INFO  : jdk19 : Custom App Version detection is used, found 18.0.2.1
2023-01-29 13:53:30 : REQ   : jdk19 : Installed Java SE Development Kit 19, version 18.0.2.1
2023-01-29 13:53:30 : INFO  : jdk19 : notifying
2023-01-29 13:53:31 : DEBUG : jdk19 : Unmounting /Volumes/JDK 19.0.2 1
2023-01-29 13:53:31 : DEBUG : jdk19 : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-01-29 13:53:31 : DEBUG : jdk19 : DEBUG mode 1, not reopening anything
2023-01-29 13:53:31 : REQ   : jdk19 : All done!
2023-01-29 13:53:31 : REQ   : jdk19 : ################## End Installomator, exit code 0