### PR TITLE
macports: add support for macOS Ventura

### DIFF
--- a/fragments/labels/macports.sh
+++ b/fragments/labels/macports.sh
@@ -3,6 +3,9 @@ macports)
     type="pkg"
     #buildVersion=$(uname -r | cut -d '.' -f 1)
     case $(uname -r | cut -d '.' -f 1) in
+        22)
+            archiveName="Ventura.pkg"
+            ;;
         21)
             archiveName="Monterey.pkg"
             ;;


### PR DESCRIPTION
Update label to add support for macOS Ventura per #879 

```
2023-02-06 14:52:35 : REQ   : macports : ################## Start Installomator v. 10.3beta, date 2023-02-06
2023-02-06 14:52:35 : INFO  : macports : ################## Version: 10.3beta
2023-02-06 14:52:35 : INFO  : macports : ################## Date: 2023-02-06
2023-02-06 14:52:35 : INFO  : macports : ################## macports
2023-02-06 14:52:35 : DEBUG : macports : DEBUG mode 1 enabled.
2023-02-06 14:52:40 : DEBUG : macports : name=MacPorts
2023-02-06 14:52:40 : DEBUG : macports : appName=
2023-02-06 14:52:40 : DEBUG : macports : type=pkg
2023-02-06 14:52:40 : DEBUG : macports : archiveName=Ventura.pkg
2023-02-06 14:52:40 : DEBUG : macports : downloadURL=https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg
2023-02-06 14:52:40 : DEBUG : macports : curlOptions=
2023-02-06 14:52:40 : DEBUG : macports : appNewVersion=2.8.1
2023-02-06 14:52:40 : DEBUG : macports : appCustomVersion function: Defined. 
2023-02-06 14:52:40 : DEBUG : macports : versionKey=CFBundleShortVersionString
2023-02-06 14:52:40 : DEBUG : macports : packageID=
2023-02-06 14:52:40 : DEBUG : macports : pkgName=
2023-02-06 14:52:40 : DEBUG : macports : choiceChangesXML=
2023-02-06 14:52:40 : DEBUG : macports : expectedTeamID=QTA3A3B7F3
2023-02-06 14:52:40 : DEBUG : macports : blockingProcesses=
2023-02-06 14:52:40 : DEBUG : macports : installerTool=
2023-02-06 14:52:40 : DEBUG : macports : CLIInstaller=
2023-02-06 14:52:40 : DEBUG : macports : CLIArguments=
2023-02-06 14:52:40 : DEBUG : macports : updateTool=
2023-02-06 14:52:40 : DEBUG : macports : updateToolArguments=
2023-02-06 14:52:40 : DEBUG : macports : updateToolRunAsCurrentUser=
2023-02-06 14:52:40 : INFO  : macports : BLOCKING_PROCESS_ACTION=tell_user
2023-02-06 14:52:40 : INFO  : macports : NOTIFY=success
2023-02-06 14:52:40 : INFO  : macports : LOGGING=DEBUG
2023-02-06 14:52:40 : INFO  : macports : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-06 14:52:40 : INFO  : macports : Label type: pkg
2023-02-06 14:52:40 : INFO  : macports : archiveName: Ventura.pkg
2023-02-06 14:52:40 : INFO  : macports : no blocking processes defined, using MacPorts as default
2023-02-06 14:52:40 : DEBUG : macports : Changing directory to /Users/asri/Documents/dev/Installomator/build
appCustomVersion: command not found: 0
2023-02-06 14:52:40 : INFO  : macports : Custom App Version detection is used, found 
2023-02-06 14:52:40 : INFO  : macports : appversion: 
2023-02-06 14:52:40 : INFO  : macports : Latest version of MacPorts is 2.8.1
2023-02-06 14:52:40 : REQ   : macports : Downloading https://github.com/macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg to Ventura.pkg
2023-02-06 14:52:40 : DEBUG : macports : No Dialog connection, just download
2023-02-06 14:52:43 : DEBUG : macports : File list: -rw-r--r--  1 asri  staff   6.5M Feb  6 14:52 Ventura.pkg
2023-02-06 14:52:43 : DEBUG : macports : File type: Ventura.pkg: xar archive compressed TOC: 4926, SHA-1 checksum
2023-02-06 14:52:43 : DEBUG : macports : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fb0c2011000)
> GET /macports/macports-base/releases/download/v2.8.1/MacPorts-2.8.1-13-Ventura.pkg HTTP/2
> Host: github.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Mon, 06 Feb 2023 06:52:41 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/70365092/45f80206-2d6a-437a-a522-5108b97f3a41?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230206T065241Z&X-Amz-Expires=300&X-Amz-Signature=fd3986c6139eb86fc937b4b198c4e749da27ec5bbc5f5f371a1e0f3510f8f6a2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=70365092&response-content-disposition=attachment%3B%20filename%3DMacPorts-2.8.1-13-Ventura.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: D762:0B01:854A6B:8C13E6:63E0A3B9
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/70365092/45f80206-2d6a-437a-a522-5108b97f3a41?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230206T065241Z&X-Amz-Expires=300&X-Amz-Signature=fd3986c6139eb86fc937b4b198c4e749da27ec5bbc5f5f371a1e0f3510f8f6a2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=70365092&response-content-disposition=attachment%3B%20filename%3DMacPorts-2.8.1-13-Ventura.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 18 00:00:00 2022 GMT
*  expire date: Mar 21 23:59:59 2023 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/70365092/45f80206-2d6a-437a-a522-5108b97f3a41?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230206T065241Z&X-Amz-Expires=300&X-Amz-Signature=fd3986c6139eb86fc937b4b198c4e749da27ec5bbc5f5f371a1e0f3510f8f6a2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=70365092&response-content-disposition=attachment%3B%20filename%3DMacPorts-2.8.1-13-Ventura.pkg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fb0c2011000)
> GET /github-production-release-asset-2e65be/70365092/45f80206-2d6a-437a-a522-5108b97f3a41?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230206T065241Z&X-Amz-Expires=300&X-Amz-Signature=fd3986c6139eb86fc937b4b198c4e749da27ec5bbc5f5f371a1e0f3510f8f6a2&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=70365092&response-content-disposition=attachment%3B%20filename%3DMacPorts-2.8.1-13-Ventura.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: mHvlb3zWp9yJy5tnSMUTLA==
< last-modified: Tue, 31 Jan 2023 02:04:17 GMT
< etag: "0x8DB032F75CDF9A8"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 460c1374-b01e-0043-3bf7-39c439000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Tue, 31 Jan 2023 02:04:17 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=MacPorts-2.8.1-13-Ventura.pkg
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Mon, 06 Feb 2023 06:52:43 GMT
< via: 1.1 varnish
< x-served-by: cache-qpg1246-QPG
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1675666363.510212,VS0,VE531
< content-length: 6859991
< 
{ [865 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-02-06 14:52:43 : DEBUG : macports : DEBUG mode 1, not checking for blocking processes
2023-02-06 14:52:43 : REQ   : macports : Installing MacPorts
2023-02-06 14:52:44 : INFO  : macports : Verifying: Ventura.pkg
2023-02-06 14:52:44 : DEBUG : macports : File list: -rw-r--r--  1 asri  staff   6.5M Feb  6 14:52 Ventura.pkg
2023-02-06 14:52:44 : DEBUG : macports : File type: Ventura.pkg: xar archive compressed TOC: 4926, SHA-1 checksum
2023-02-06 14:52:46 : DEBUG : macports : spctlOut is Ventura.pkg: accepted
2023-02-06 14:52:46 : DEBUG : macports : source=Notarized Developer ID
2023-02-06 14:52:46 : DEBUG : macports : origin=Developer ID Installer: Joshua Root (QTA3A3B7F3)
2023-02-06 14:52:46 : INFO  : macports : Team ID: QTA3A3B7F3 (expected: QTA3A3B7F3 )
2023-02-06 14:52:46 : DEBUG : macports : DEBUG enabled, skipping installation
2023-02-06 14:52:46 : INFO  : macports : Finishing...
appCustomVersion: command not found: 0
2023-02-06 14:52:49 : INFO  : macports : Custom App Version detection is used, found 
2023-02-06 14:52:49 : REQ   : macports : Installed MacPorts
2023-02-06 14:52:49 : INFO  : macports : notifying
2023-02-06 14:52:51 : DEBUG : macports : DEBUG mode 1, not reopening anything
2023-02-06 14:52:51 : REQ   : macports : All done!
2023-02-06 14:52:51 : REQ   : macports : ################## End Installomator, exit code 0 
```