### PR TITLE
Update musescore.sh

### DIFF
--- a/fragments/labels/musescore.sh
+++ b/fragments/labels/musescore.sh
@@ -1,5 +1,5 @@
 musescore)
-    name="MuseScore 3"
+    name="MuseScore 4"
     type="dmg"
     downloadURL=$(downloadURLFromGit musescore MuseScore)
     appNewVersion=$(versionFromGit musescore MuseScore)


### PR DESCRIPTION
musescore released version 4, the name musescore 3 produces an exit code of 8. Path not found.