### PR TITLE
Update microsoftoffice365.sh

### DIFF
--- a/fragments/labels/microsoftoffice365.sh
+++ b/fragments/labels/microsoftoffice365.sh
@@ -3,7 +3,7 @@ microsoftoffice365)
     type="pkg"
     packageID="com.microsoft.pkg.licensing"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=525133"
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3)
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 5)
     expectedTeamID="UBF8T346G9"
     # using MS PowerPoint as the 'stand-in' for the entire suite
     #appName="Microsoft PowerPoint.app"


### PR DESCRIPTION
Modifying the definition of "appNewVersion" as the new installer name changed and it wasn't returning the version number.

New PKG name: Microsoft_365_and_Office_16.69.23010700_Installer.pkg