### PR TITLE
Nudge: Update Team ID

### DIFF
--- a/fragments/labels/nudge.sh
+++ b/fragments/labels/nudge.sh
@@ -4,5 +4,5 @@ nudge)
     archiveName="Nudge-[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
-    expectedTeamID="9GQZ7KUFR6"
+    expectedTeamID="T4SK8ZXCXG"
     ;;

--- a/fragments/labels/nudge.sh
+++ b/fragments/labels/nudge.sh
@@ -1,8 +1,8 @@
 nudge)
     name="Nudge"
     type="pkg"
-    archiveName="Nudge-[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
+    archiveName="Nudge-$appNewVersion.pkg"
     expectedTeamID="T4SK8ZXCXG"
     ;;

--- a/fragments/labels/nudgesuite.sh
+++ b/fragments/labels/nudgesuite.sh
@@ -2,9 +2,9 @@ nudgesuite)
     name="Nudge Suite"
     appName="Nudge.app"
     type="pkg"
-    archiveName="Nudge_Suite-[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
+    archiveName="Nudge-$appNewVersion.pkg"
     expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( "Nudge" )
     ;;

--- a/fragments/labels/nudgesuite.sh
+++ b/fragments/labels/nudgesuite.sh
@@ -4,7 +4,7 @@ nudgesuite)
     type="pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
-    archiveName="Nudge-$appNewVersion.pkg"
+    archiveName="Nudge_Suite-$appNewVersion.pkg"
     expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( "Nudge" )
     ;;

--- a/fragments/labels/nudgesuite.sh
+++ b/fragments/labels/nudgesuite.sh
@@ -5,6 +5,6 @@ nudgesuite)
     archiveName="Nudge_Suite-[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
-    expectedTeamID="9GQZ7KUFR6"
+    expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( "Nudge" )
     ;;


### PR DESCRIPTION
per #886 Nudge has new Team ID

Update: fix archiveName to print out actual version number instead of 'Nudge-[0-9.]*.pkg' for all downloads

nudgesuite
```
2023-02-09 11:44:23 : REQ   : nudgesuite : ################## Start Installomator v. 10.3beta, date 2023-02-09
2023-02-09 11:44:23 : INFO  : nudgesuite : ################## Version: 10.3beta
2023-02-09 11:44:23 : INFO  : nudgesuite : ################## Date: 2023-02-09
2023-02-09 11:44:23 : INFO  : nudgesuite : ################## nudgesuite
2023-02-09 11:44:23 : DEBUG : nudgesuite : DEBUG mode 1 enabled.
2023-02-09 11:44:28 : DEBUG : nudgesuite : name=Nudge Suite
2023-02-09 11:44:28 : DEBUG : nudgesuite : appName=Nudge.app
2023-02-09 11:44:28 : DEBUG : nudgesuite : type=pkg
2023-02-09 11:44:28 : DEBUG : nudgesuite : archiveName=Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:28 : DEBUG : nudgesuite : downloadURL=https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg
2023-02-09 11:44:28 : DEBUG : nudgesuite : curlOptions=
2023-02-09 11:44:28 : DEBUG : nudgesuite : appNewVersion=1.1.11.81465
2023-02-09 11:44:28 : DEBUG : nudgesuite : appCustomVersion function: Not defined
2023-02-09 11:44:28 : DEBUG : nudgesuite : versionKey=CFBundleShortVersionString
2023-02-09 11:44:28 : DEBUG : nudgesuite : packageID=
2023-02-09 11:44:28 : DEBUG : nudgesuite : pkgName=
2023-02-09 11:44:28 : DEBUG : nudgesuite : choiceChangesXML=
2023-02-09 11:44:28 : DEBUG : nudgesuite : expectedTeamID=T4SK8ZXCXG
2023-02-09 11:44:28 : DEBUG : nudgesuite : blockingProcesses=Nudge
2023-02-09 11:44:28 : DEBUG : nudgesuite : installerTool=
2023-02-09 11:44:28 : DEBUG : nudgesuite : CLIInstaller=
2023-02-09 11:44:28 : DEBUG : nudgesuite : CLIArguments=
2023-02-09 11:44:28 : DEBUG : nudgesuite : updateTool=
2023-02-09 11:44:28 : DEBUG : nudgesuite : updateToolArguments=
2023-02-09 11:44:28 : DEBUG : nudgesuite : updateToolRunAsCurrentUser=
2023-02-09 11:44:28 : INFO  : nudgesuite : BLOCKING_PROCESS_ACTION=tell_user
2023-02-09 11:44:28 : INFO  : nudgesuite : NOTIFY=success
2023-02-09 11:44:28 : INFO  : nudgesuite : LOGGING=DEBUG
2023-02-09 11:44:28 : INFO  : nudgesuite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-09 11:44:28 : INFO  : nudgesuite : Label type: pkg
2023-02-09 11:44:28 : INFO  : nudgesuite : archiveName: Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:28 : DEBUG : nudgesuite : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-02-09 11:44:28 : INFO  : nudgesuite : App(s) found: /Applications/Utilities/Nudge.app
2023-02-09 11:44:28 : INFO  : nudgesuite : found app at /Applications/Utilities/Nudge.app, version 1.1.10.81462, on versionKey CFBundleShortVersionString
2023-02-09 11:44:28 : INFO  : nudgesuite : appversion: 1.1.10.81462
2023-02-09 11:44:28 : INFO  : nudgesuite : Latest version of Nudge Suite is 1.1.11.81465
2023-02-09 11:44:28 : REQ   : nudgesuite : Downloading https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg to Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:29 : DEBUG : nudgesuite : No Dialog connection, just download
2023-02-09 11:44:30 : DEBUG : nudgesuite : File list: -rw-r--r--  1 asri  staff   1.6M Feb  9 11:44 Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:30 : DEBUG : nudgesuite : File type: Nudge_Suite-1.1.11.81465.pkg: xar archive compressed TOC: 4688, SHA-1 checksum
2023-02-09 11:44:30 : DEBUG : nudgesuite : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f8f8c00ee00)
> GET /macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg HTTP/2
> Host: github.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 09 Feb 2023 03:44:30 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T034430Z&X-Amz-Expires=300&X-Amz-Signature=915ad6a387c3aaba6c04a012ce78932821be34344c247257b200245469f0f2fb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: C52A:C2A8:2BD9ACB:2D7A018:63E46C1D
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T034430Z&X-Amz-Expires=300&X-Amz-Signature=915ad6a387c3aaba6c04a012ce78932821be34344c247257b200245469f0f2fb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 18 00:00:00 2022 GMT
*  expire date: Mar 21 23:59:59 2023 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T034430Z&X-Amz-Expires=300&X-Amz-Signature=915ad6a387c3aaba6c04a012ce78932821be34344c247257b200245469f0f2fb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f8f8c00ee00)
> GET /github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T034430Z&X-Amz-Expires=300&X-Amz-Signature=915ad6a387c3aaba6c04a012ce78932821be34344c247257b200245469f0f2fb&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: vhyQkpfLCGLSdToP86AVBw==
< last-modified: Wed, 08 Feb 2023 04:15:09 GMT
< etag: "0x8DB098B10FFB910"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 574b1cc0-501e-005b-6437-3c1b5e000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Wed, 08 Feb 2023 04:15:09 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Nudge-1.1.11.81465.pkg
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< date: Thu, 09 Feb 2023 03:44:30 GMT
< via: 1.1 varnish
< age: 391
< x-served-by: cache-qpg1282-QPG
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1675914270.403736,VS0,VE247
< content-length: 1648420
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-02-09 11:44:30 : DEBUG : nudgesuite : DEBUG mode 1, not checking for blocking processes
2023-02-09 11:44:30 : REQ   : nudgesuite : Installing Nudge Suite
2023-02-09 11:44:30 : INFO  : nudgesuite : Verifying: Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:30 : DEBUG : nudgesuite : File list: -rw-r--r--  1 asri  staff   1.6M Feb  9 11:44 Nudge_Suite-1.1.11.81465.pkg
2023-02-09 11:44:30 : DEBUG : nudgesuite : File type: Nudge_Suite-1.1.11.81465.pkg: xar archive compressed TOC: 4688, SHA-1 checksum
2023-02-09 11:44:31 : DEBUG : nudgesuite : spctlOut is Nudge_Suite-1.1.11.81465.pkg: accepted
2023-02-09 11:44:31 : DEBUG : nudgesuite : source=Notarized Developer ID
2023-02-09 11:44:31 : DEBUG : nudgesuite : origin=Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
2023-02-09 11:44:31 : INFO  : nudgesuite : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2023-02-09 11:44:31 : DEBUG : nudgesuite : DEBUG enabled, skipping installation
2023-02-09 11:44:31 : INFO  : nudgesuite : Finishing...
2023-02-09 11:44:34 : INFO  : nudgesuite : App(s) found: /Applications/Utilities/Nudge.app
2023-02-09 11:44:35 : INFO  : nudgesuite : found app at /Applications/Utilities/Nudge.app, version 1.1.10.81462, on versionKey CFBundleShortVersionString
2023-02-09 11:44:35 : REQ   : nudgesuite : Installed Nudge Suite, version 1.1.10.81462
2023-02-09 11:44:35 : INFO  : nudgesuite : notifying
2023-02-09 11:44:35 : DEBUG : nudgesuite : DEBUG mode 1, not reopening anything
2023-02-09 11:44:35 : REQ   : nudgesuite : All done!
2023-02-09 11:44:35 : REQ   : nudgesuite : ################## End Installomator, exit code 0
```

nudge
```
2023-02-09 11:32:58 : REQ   : nudge : ################## Start Installomator v. 10.3beta, date 2023-02-09
2023-02-09 11:32:58 : INFO  : nudge : ################## Version: 10.3beta
2023-02-09 11:32:58 : INFO  : nudge : ################## Date: 2023-02-09
2023-02-09 11:32:58 : INFO  : nudge : ################## nudge
2023-02-09 11:32:58 : DEBUG : nudge : DEBUG mode 1 enabled.
2023-02-09 11:33:02 : DEBUG : nudge : name=Nudge
2023-02-09 11:33:02 : DEBUG : nudge : appName=
2023-02-09 11:33:02 : DEBUG : nudge : type=pkg
2023-02-09 11:33:02 : DEBUG : nudge : archiveName=Nudge-1.1.11.81465.pkg
2023-02-09 11:33:02 : DEBUG : nudge : downloadURL=https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg
2023-02-09 11:33:02 : DEBUG : nudge : curlOptions=
2023-02-09 11:33:02 : DEBUG : nudge : appNewVersion=1.1.11.81465
2023-02-09 11:33:02 : DEBUG : nudge : appCustomVersion function: Not defined
2023-02-09 11:33:02 : DEBUG : nudge : versionKey=CFBundleShortVersionString
2023-02-09 11:33:02 : DEBUG : nudge : packageID=
2023-02-09 11:33:02 : DEBUG : nudge : pkgName=
2023-02-09 11:33:02 : DEBUG : nudge : choiceChangesXML=
2023-02-09 11:33:02 : DEBUG : nudge : expectedTeamID=T4SK8ZXCXG
2023-02-09 11:33:02 : DEBUG : nudge : blockingProcesses=
2023-02-09 11:33:02 : DEBUG : nudge : installerTool=
2023-02-09 11:33:02 : DEBUG : nudge : CLIInstaller=
2023-02-09 11:33:02 : DEBUG : nudge : CLIArguments=
2023-02-09 11:33:02 : DEBUG : nudge : updateTool=
2023-02-09 11:33:02 : DEBUG : nudge : updateToolArguments=
2023-02-09 11:33:02 : DEBUG : nudge : updateToolRunAsCurrentUser=
2023-02-09 11:33:02 : INFO  : nudge : BLOCKING_PROCESS_ACTION=tell_user
2023-02-09 11:33:02 : INFO  : nudge : NOTIFY=success
2023-02-09 11:33:02 : INFO  : nudge : LOGGING=DEBUG
2023-02-09 11:33:02 : INFO  : nudge : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-09 11:33:02 : INFO  : nudge : Label type: pkg
2023-02-09 11:33:02 : INFO  : nudge : archiveName: Nudge-1.1.11.81465.pkg
2023-02-09 11:33:03 : INFO  : nudge : no blocking processes defined, using Nudge as default
2023-02-09 11:33:03 : DEBUG : nudge : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-02-09 11:33:03 : INFO  : nudge : App(s) found: /Applications/Utilities/Nudge.app
2023-02-09 11:33:03 : INFO  : nudge : found app at /Applications/Utilities/Nudge.app, version 1.1.10.81462, on versionKey CFBundleShortVersionString
2023-02-09 11:33:03 : INFO  : nudge : appversion: 1.1.10.81462
2023-02-09 11:33:03 : INFO  : nudge : Latest version of Nudge is 1.1.11.81465
2023-02-09 11:33:03 : REQ   : nudge : Downloading https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg to Nudge-1.1.11.81465.pkg
2023-02-09 11:33:03 : DEBUG : nudge : No Dialog connection, just download
2023-02-09 11:33:04 : DEBUG : nudge : File list: -rw-r--r--  1 asri  staff   1.6M Feb  9 11:33 Nudge-1.1.11.81465.pkg
2023-02-09 11:33:04 : DEBUG : nudge : File type: Nudge-1.1.11.81465.pkg: xar archive compressed TOC: 4688, SHA-1 checksum
2023-02-09 11:33:04 : DEBUG : nudge : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fa9b200a800)
> GET /macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg HTTP/2
> Host: github.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 09 Feb 2023 03:31:32 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T033132Z&X-Amz-Expires=300&X-Amz-Signature=17261dce3f8eb96b4b15972a31c28c81c1b40c92a77be5153adab7adf9575bef&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: C4C2:A48E:2B25720:2CC19B0:63E46970
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T033132Z&X-Amz-Expires=300&X-Amz-Signature=17261dce3f8eb96b4b15972a31c28c81c1b40c92a77be5153adab7adf9575bef&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 18 00:00:00 2022 GMT
*  expire date: Mar 21 23:59:59 2023 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T033132Z&X-Amz-Expires=300&X-Amz-Signature=17261dce3f8eb96b4b15972a31c28c81c1b40c92a77be5153adab7adf9575bef&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fa9b200a800)
> GET /github-production-release-asset-2e65be/335457412/7169b90f-204e-40bf-891b-4101ea4bf6ca?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230209T033132Z&X-Amz-Expires=300&X-Amz-Signature=17261dce3f8eb96b4b15972a31c28c81c1b40c92a77be5153adab7adf9575bef&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=335457412&response-content-disposition=attachment%3B%20filename%3DNudge-1.1.11.81465.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: vhyQkpfLCGLSdToP86AVBw==
< last-modified: Wed, 08 Feb 2023 04:15:09 GMT
< etag: "0x8DB098B10FFB910"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: cdd0c6b6-d01e-0055-2035-3c32ee000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Wed, 08 Feb 2023 04:15:09 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Nudge-1.1.11.81465.pkg
< x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< date: Thu, 09 Feb 2023 03:33:05 GMT
< via: 1.1 varnish
< age: 576
< x-served-by: cache-qpg1259-QPG
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1675913585.874439,VS0,VE310
< content-length: 1648420
< 
{ [16375 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-02-09 11:33:04 : DEBUG : nudge : DEBUG mode 1, not checking for blocking processes
2023-02-09 11:33:05 : REQ   : nudge : Installing Nudge
2023-02-09 11:33:05 : INFO  : nudge : Verifying: Nudge-1.1.11.81465.pkg
2023-02-09 11:33:05 : DEBUG : nudge : File list: -rw-r--r--  1 asri  staff   1.6M Feb  9 11:33 Nudge-1.1.11.81465.pkg
2023-02-09 11:33:05 : DEBUG : nudge : File type: Nudge-1.1.11.81465.pkg: xar archive compressed TOC: 4688, SHA-1 checksum
2023-02-09 11:33:06 : DEBUG : nudge : spctlOut is Nudge-1.1.11.81465.pkg: accepted
2023-02-09 11:33:06 : DEBUG : nudge : source=Notarized Developer ID
2023-02-09 11:33:06 : DEBUG : nudge : origin=Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
2023-02-09 11:33:06 : INFO  : nudge : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2023-02-09 11:33:06 : DEBUG : nudge : DEBUG enabled, skipping installation
2023-02-09 11:33:06 : INFO  : nudge : Finishing...
2023-02-09 11:33:09 : INFO  : nudge : App(s) found: /Applications/Utilities/Nudge.app
2023-02-09 11:33:09 : INFO  : nudge : found app at /Applications/Utilities/Nudge.app, version 1.1.10.81462, on versionKey CFBundleShortVersionString
2023-02-09 11:33:09 : REQ   : nudge : Installed Nudge, version 1.1.10.81462
2023-02-09 11:33:09 : INFO  : nudge : notifying
2023-02-09 11:33:10 : DEBUG : nudge : DEBUG mode 1, not reopening anything
2023-02-09 11:33:10 : REQ   : nudge : All done!
2023-02-09 11:33:10 : REQ   : nudge : ################## End Installomator, exit code 0
```