### PR TITLE
drawio: Added archiveName to download the Universal build

### DIFF
--- a/fragments/labels/drawio.sh
+++ b/fragments/labels/drawio.sh
@@ -1,6 +1,7 @@
 drawio)
     name="draw.io"
     type="dmg"
+    archiveName="draw.io-universal-[0-9.]*.dmg"
     downloadURL="$(downloadURLFromGit jgraph drawio-desktop)"
     appNewVersion="$(versionFromGit jgraph drawio-desktop)"
     expectedTeamID="UZEUFB4N53"


### PR DESCRIPTION
Without the addition of archiveName the ARM64 build was downloaded.