### PR TITLE
new label: ClickUp

### DIFF
--- a/fragments/labels/clickup.sh
+++ b/fragments/labels/clickup.sh
@@ -1,0 +1,12 @@
+clickup)
+	name="ClickUp"
+	type="dmg"
+	if [[ $(arch) == "arm64" ]]; then
+		appNewVersion=$(curl -sD /dev/stdout https://desktop.clickup.com/mac/dmg/arm64 | grep filename | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+		downloadURL="https://desktop.clickup.com/mac/dmg/arm64"
+	elif [[ $(arch) == "i386" ]]; then
+        appNewVersion=$(curl -sD /dev/stdout https://desktop.clickup.com/mac | grep filename | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
+        downloadURL="https://desktop.clickup.com/mac"
+	fi
+	expectedTeamID="5RJWFAUGXQ"
+	;;


### PR DESCRIPTION
```
Installomator % sudo ./assemble.sh clickup DEBUG=0
2023-02-13 12:54:36 : INFO  : clickup : setting variable from argument DEBUG=0
2023-02-13 12:54:36 : REQ   : clickup : ################## Start Installomator v. 10.1, date 2023-02-13
2023-02-13 12:54:36 : INFO  : clickup : ################## Version: 10.1
2023-02-13 12:54:36 : INFO  : clickup : ################## Date: 2023-02-13
2023-02-13 12:54:36 : INFO  : clickup : ################## clickup
2023-02-13 12:54:39 : INFO  : clickup : BLOCKING_PROCESS_ACTION=tell_user
2023-02-13 12:54:39 : INFO  : clickup : NOTIFY=success
2023-02-13 12:54:39 : INFO  : clickup : LOGGING=INFO
2023-02-13 12:54:39 : INFO  : clickup : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-13 12:54:39 : INFO  : clickup : Label type: dmg
2023-02-13 12:54:39 : INFO  : clickup : archiveName: ClickUp.dmg
2023-02-13 12:54:39 : INFO  : clickup : no blocking processes defined, using ClickUp as default
2023-02-13 12:54:39 : INFO  : clickup : name: ClickUp, appName: ClickUp.app
2023-02-13 12:54:39.487 mdfind[11338:225723] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-02-13 12:54:39.487 mdfind[11338:225723] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-02-13 12:54:39.528 mdfind[11338:225723] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-13 12:54:39 : WARN  : clickup : No previous app found
2023-02-13 12:54:39 : WARN  : clickup : could not find ClickUp.app
2023-02-13 12:54:39 : INFO  : clickup : appversion:
2023-02-13 12:54:39 : INFO  : clickup : Latest version of ClickUp is 3.1.2
2023-02-13 12:54:39 : REQ   : clickup : Downloading https://desktop.clickup.com/mac/dmg/arm64 to ClickUp.dmg
2023-02-13 12:54:42 : REQ   : clickup : no more blocking processes, continue with update
2023-02-13 12:54:42 : REQ   : clickup : Installing ClickUp
2023-02-13 12:54:42 : INFO  : clickup : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5MHkRVGx/ClickUp.dmg
2023-02-13 12:54:47 : INFO  : clickup : Mounted: /Volumes/ClickUp 3.1.2-arm64
2023-02-13 12:54:47 : INFO  : clickup : Verifying: /Volumes/ClickUp 3.1.2-arm64/ClickUp.app
2023-02-13 12:54:48 : INFO  : clickup : Team ID matching: 5RJWFAUGXQ (expected: 5RJWFAUGXQ )
2023-02-13 12:54:48 : INFO  : clickup : Installing ClickUp version 3.1.2 on versionKey CFBundleShortVersionString.
2023-02-13 12:54:48 : INFO  : clickup : App has LSMinimumSystemVersion: 10.11.0
2023-02-13 12:54:48 : INFO  : clickup : Copy /Volumes/ClickUp 3.1.2-arm64/ClickUp.app to /Applications
2023-02-13 12:54:49 : WARN  : clickup : Changing owner to dnikles
2023-02-13 12:54:49 : INFO  : clickup : Finishing...
2023-02-13 12:54:52 : INFO  : clickup : App(s) found: /Applications/ClickUp.app
2023-02-13 12:54:52 : INFO  : clickup : found app at /Applications/ClickUp.app, version 3.1.2, on versionKey CFBundleShortVersionString
2023-02-13 12:54:52 : REQ   : clickup : Installed ClickUp, version 3.1.2
2023-02-13 12:54:52 : INFO  : clickup : notifying
2023-02-13 12:54:53 : INFO  : clickup : App not closed, so no reopen.
2023-02-13 12:54:53 : REQ   : clickup : All done!
2023-02-13 12:54:53 : REQ   : clickup : ################## End Installomator, exit code 0
```