### PR TITLE
Add ignore-update-tool option to the INSTALL parameter

### DIFF
--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -110,6 +110,9 @@ INSTALL=""
 #  -               When not set, the software will only be installed
 #                  if it is newer/different in version
 #  - force         Install even if it’s the same version
+#  - ignore-update-tool
+#                  If an internal updatetool is defined it will be ignored and the 
+#                  regular installer will be used.
 
 
 # Re-opening of closed app

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -167,6 +167,12 @@ fi
 getAppVersion
 printlog "appversion: $appversion"
 
+# Mark: unset updateTool if ignore-update-tool is specified
+ if [[ $INSTALL == "ignore-update-tool" ]]; then
+     printlog "Ignoring updatetool, using full installer instead."
+     updateTool=""
+ fi
+
 # MARK: Exit if new version is the same as installed version (appNewVersion specified)
 if [[ "$type" != "updateronly" && ($INSTALL == "force" || $IGNORE_APP_STORE_APPS == "yes") ]]; then
     printlog "Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool."


### PR DESCRIPTION
This option allows you to ignore the update tool when it is defined in a label like googlechromepkg.

It can be useful if you want to make sure updates are applied and don't want to depend on the end user restarting the application.