### PR TITLE
Virtualbox: add architecture specific downloadURL

### DIFF
--- a/fragments/labels/virtualbox.sh
+++ b/fragments/labels/virtualbox.sh
@@ -3,8 +3,12 @@ virtualbox)
     name="VirtualBox"
     type="pkgInDmg"
     pkgName="VirtualBox.pkg"
-    downloadURL=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" \
-        | awk -F '"' "/OSX.dmg/ { print \$4 }")
-    appNewVersion=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" | awk -F '"' "/OSX.dmg/ { print \$4 }" | sed -E 's/.*virtualbox\/([0-9.]*)\/.*/\1/')
+    if [[ $(arch) == i386 ]]; then
+        platform="OSX"
+    elif [[ $(arch) == arm64 ]]; then
+        platform="macOSArm64"
+    fi
+    downloadURL=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" | awk -F '"' "/$platform.dmg/ { print \$4 }")
+    appNewVersion=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" | awk -F '"' "/$platform.dmg/ { print \$4 }" | sed -E 's/.*virtualbox\/([0-9.]*)\/.*/\1/')
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
as per #902 

```
2023-02-20 12:12:03 : REQ   : virtualbox : ################## Start Installomator v. 10.4beta, date 2023-02-20
2023-02-20 12:12:03 : INFO  : virtualbox : ################## Version: 10.4beta
2023-02-20 12:12:03 : INFO  : virtualbox : ################## Date: 2023-02-20
2023-02-20 12:12:03 : INFO  : virtualbox : ################## virtualbox
2023-02-20 12:12:03 : DEBUG : virtualbox : DEBUG mode 1 enabled.
2023-02-20 12:12:06 : DEBUG : virtualbox : name=VirtualBox
2023-02-20 12:12:06 : DEBUG : virtualbox : appName=
2023-02-20 12:12:06 : DEBUG : virtualbox : type=pkgInDmg
2023-02-20 12:12:06 : DEBUG : virtualbox : archiveName=
2023-02-20 12:12:06 : DEBUG : virtualbox : downloadURL=https://download.virtualbox.org/virtualbox/7.0.6/VirtualBox-7.0.6-155176-OSX.dmg
2023-02-20 12:12:06 : DEBUG : virtualbox : curlOptions=
2023-02-20 12:12:06 : DEBUG : virtualbox : appNewVersion=7.0.6
2023-02-20 12:12:06 : DEBUG : virtualbox : appCustomVersion function: Not defined
2023-02-20 12:12:06 : DEBUG : virtualbox : versionKey=CFBundleShortVersionString
2023-02-20 12:12:06 : DEBUG : virtualbox : packageID=
2023-02-20 12:12:06 : DEBUG : virtualbox : pkgName=VirtualBox.pkg
2023-02-20 12:12:06 : DEBUG : virtualbox : choiceChangesXML=
2023-02-20 12:12:06 : DEBUG : virtualbox : expectedTeamID=VB5E2TV963
2023-02-20 12:12:06 : DEBUG : virtualbox : blockingProcesses=
2023-02-20 12:12:06 : DEBUG : virtualbox : installerTool=
2023-02-20 12:12:06 : DEBUG : virtualbox : CLIInstaller=
2023-02-20 12:12:06 : DEBUG : virtualbox : CLIArguments=
2023-02-20 12:12:06 : DEBUG : virtualbox : updateTool=
2023-02-20 12:12:06 : DEBUG : virtualbox : updateToolArguments=
2023-02-20 12:12:06 : DEBUG : virtualbox : updateToolRunAsCurrentUser=
2023-02-20 12:12:06 : INFO  : virtualbox : BLOCKING_PROCESS_ACTION=tell_user
2023-02-20 12:12:06 : INFO  : virtualbox : NOTIFY=success
2023-02-20 12:12:06 : INFO  : virtualbox : LOGGING=DEBUG
2023-02-20 12:12:07 : INFO  : virtualbox : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-20 12:12:07 : INFO  : virtualbox : Label type: pkgInDmg
2023-02-20 12:12:07 : INFO  : virtualbox : archiveName: VirtualBox.dmg
2023-02-20 12:12:07 : INFO  : virtualbox : no blocking processes defined, using VirtualBox as default
2023-02-20 12:12:07 : DEBUG : virtualbox : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-02-20 12:12:07 : INFO  : virtualbox : name: VirtualBox, appName: VirtualBox.app
2023-02-20 12:12:07.119 mdfind[26575:324364] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-20 12:12:07.235 mdfind[26575:324364] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-20 12:12:07 : INFO  : virtualbox : App(s) found: /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.VirtualBox-pkg-upload/unpack/VirtualBox.pkg.unpacked/VirtualBox.app
2023-02-20 12:12:07 : INFO  : virtualbox : found app at /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.VirtualBox-pkg-upload/unpack/VirtualBox.pkg.unpacked/VirtualBox.app, version 7.0.6, on versionKey CFBundleShortVersionString
2023-02-20 12:12:07 : INFO  : virtualbox : appversion: 7.0.6
2023-02-20 12:12:07 : INFO  : virtualbox : Latest version of VirtualBox is 7.0.6
2023-02-20 12:12:07 : WARN  : virtualbox : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-02-20 12:12:07 : REQ   : virtualbox : Downloading https://download.virtualbox.org/virtualbox/7.0.6/VirtualBox-7.0.6-155176-OSX.dmg to VirtualBox.dmg
2023-02-20 12:12:07 : DEBUG : virtualbox : No Dialog connection, just download
2023-02-20 12:12:21 : DEBUG : virtualbox : File list: -rw-r--r--  1 asri  staff   127M Feb 20 12:12 VirtualBox.dmg
2023-02-20 12:12:21 : DEBUG : virtualbox : File type: VirtualBox.dmg: bzip2 compressed data, block size = 100k
2023-02-20 12:12:21 : DEBUG : virtualbox : curl output was:
*   Trying 2.17.172.82:443...
* Connected to download.virtualbox.org (2.17.172.82) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2961 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Oracle Corporation; CN=download.oracle.com
*  start date: Sep  8 00:00:00 2022 GMT
*  expire date: Sep 10 23:59:59 2023 GMT
*  subjectAltName: host "download.virtualbox.org" matched cert's "download.virtualbox.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
> GET /virtualbox/7.0.6/VirtualBox-7.0.6-155176-OSX.dmg HTTP/1.1
> Host: download.virtualbox.org
> User-Agent: curl/7.86.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AkamaiNetStorage
< Last-Modified: Wed, 11 Jan 2023 19:24:04 GMT
< ETag: "7a7787c61b5dd23826c10e6020f3338f:1673970875.833869"
< Content-Length: 132974423
< Date: Mon, 20 Feb 2023 04:12:09 GMT
< Connection: keep-alive
< 
{ [16083 bytes data]
* Connection #0 to host download.virtualbox.org left intact

2023-02-20 12:12:21 : DEBUG : virtualbox : DEBUG mode 1, not checking for blocking processes
2023-02-20 12:12:21 : REQ   : virtualbox : Installing VirtualBox
2023-02-20 12:12:21 : INFO  : virtualbox : Mounting /Users/asri/Documents/dev/Installomator/build/VirtualBox.dmg
2023-02-20 12:12:31 : DEBUG : virtualbox : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $08BB948D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $E4F78070
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $48FB2791
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $5940DD15
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $48FB2791
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $DC3231CC
verified CRC32 $B0C536AE
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_APFS
/dev/disk6              EF57347C-0000-11AA-AA11-0030654
/dev/disk6s1            41504653-0000-11AA-AA11-0030654 /Volumes/VirtualBox 1

2023-02-20 12:12:31 : INFO  : virtualbox : Mounted: /Volumes/VirtualBox 1
2023-02-20 12:12:31 : INFO  : virtualbox : found pkg: /Volumes/VirtualBox 1/VirtualBox.pkg
2023-02-20 12:12:31 : INFO  : virtualbox : Verifying: /Volumes/VirtualBox 1/VirtualBox.pkg
2023-02-20 12:12:31 : DEBUG : virtualbox : File list: -rw-r--r--  1 asri  staff   120M Jan 12 00:59 /Volumes/VirtualBox 1/VirtualBox.pkg
2023-02-20 12:12:31 : DEBUG : virtualbox : File type: /Volumes/VirtualBox 1/VirtualBox.pkg: xar archive compressed TOC: 5362, SHA-1 checksum, contains  Dyalog APL version 104.55
2023-02-20 12:12:32 : DEBUG : virtualbox : spctlOut is /Volumes/VirtualBox 1/VirtualBox.pkg: accepted
2023-02-20 12:12:32 : DEBUG : virtualbox : source=Notarized Developer ID
2023-02-20 12:12:32 : DEBUG : virtualbox : origin=Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
2023-02-20 12:12:32 : INFO  : virtualbox : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2023-02-20 12:12:32 : DEBUG : virtualbox : DEBUG enabled, skipping installation
2023-02-20 12:12:32 : INFO  : virtualbox : Finishing...
2023-02-20 12:12:35 : INFO  : virtualbox : name: VirtualBox, appName: VirtualBox.app
2023-02-20 12:12:36.010 mdfind[26710:325075] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-20 12:12:36.133 mdfind[26710:325075] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-20 12:12:36 : INFO  : virtualbox : App(s) found: /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.VirtualBox-pkg-upload/unpack/VirtualBox.pkg.unpacked/VirtualBox.app
2023-02-20 12:12:36 : INFO  : virtualbox : found app at /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.VirtualBox-pkg-upload/unpack/VirtualBox.pkg.unpacked/VirtualBox.app, version 7.0.6, on versionKey CFBundleShortVersionString
2023-02-20 12:12:36 : REQ   : virtualbox : Installed VirtualBox, version 7.0.6
2023-02-20 12:12:36 : INFO  : virtualbox : notifying
2023-02-20 12:12:36 : DEBUG : virtualbox : Unmounting /Volumes/VirtualBox 1
2023-02-20 12:12:37 : DEBUG : virtualbox : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-02-20 12:12:37 : DEBUG : virtualbox : DEBUG mode 1, not reopening anything
2023-02-20 12:12:37 : REQ   : virtualbox : All done!
2023-02-20 12:12:37 : REQ   : virtualbox : ################## End Installomator, exit code 0
```