### PR TITLE
Update versionFromGit function

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -513,12 +513,17 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
 versionFromGit() {
     # credit: Søren Theilgaard (@theilgaard)
-    # $1 git user name, $2 git repo name
+    # $1 git user name, $2 git repo name, $3 filtered/unfiltered (optional, default filtered (limits version to numbers and dots only))
     gitusername=${1?:"no git user name"}
     gitreponame=${2?:"no git repo name"}
-
+    gitfiltered=${3?:"filtered"}
+    
     #appNewVersion=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/[^0-9\.]//g')
-    appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
+    #appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
+    appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1)
+    if [ ! "$gitfiltered" = "unfiltered" ]; then # not every developer adheres to limiting version numbers to only numbers and dots
+        appNewVersion=$(echo $appNewVersion | sed 's/[^0-9\.]//g')
+    fi      
     if [ -z "$appNewVersion" ]; then
         printlog "could not retrieve version number for $gitusername/$gitreponame" WARN
         appNewVersion=""


### PR DESCRIPTION
As not every developer adheres to version numbers containing only numbers and dots, the sed filter should be optional. However as there may be labels that require the sed filter already, this provides the option to ask the function to skip the sed filter.