### PR TITLE
add snagit2023 to latest and add snagit2022 label

### DIFF
--- a/fragments/labels/snagit.sh
+++ b/fragments/labels/snagit.sh
@@ -1,8 +1,8 @@
 snagit|\
-snagit2022)
-    name="Snagit 2022"
+snagit2023)
+    name="Snagit 2023"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2022" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2022" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2023" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2023" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/snagit2022.sh
+++ b/fragments/labels/snagit2022.sh
@@ -1,0 +1,7 @@
+snagit2022)
+    name="Snagit 2022"
+    type="dmg"
+    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2022" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2022" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    expectedTeamID="7TQL462TU8"
+    ;;


### PR DESCRIPTION
### move snagit2023 to latest label
```
2023-02-24 20:00:05 : REQ   : snagit : ################## Start Installomator v. 10.4beta, date 2023-02-24
2023-02-24 20:00:05 : INFO  : snagit : ################## Version: 10.4beta
2023-02-24 20:00:05 : INFO  : snagit : ################## Date: 2023-02-24
2023-02-24 20:00:05 : INFO  : snagit : ################## snagit
2023-02-24 20:00:05 : DEBUG : snagit : DEBUG mode 1 enabled.
2023-02-24 20:00:07 : DEBUG : snagit : name=Snagit 2023
2023-02-24 20:00:07 : DEBUG : snagit : appName=
2023-02-24 20:00:07 : DEBUG : snagit : type=dmg
2023-02-24 20:00:07 : DEBUG : snagit : archiveName=
2023-02-24 20:00:07 : DEBUG : snagit : downloadURL=https://download.techsmith.com/snagitmac/releases/snagit.dmg
2023-02-24 20:00:07 : DEBUG : snagit : curlOptions=
2023-02-24 20:00:07 : DEBUG : snagit : appNewVersion=2023.0.4
2023-02-24 20:00:07 : DEBUG : snagit : appCustomVersion function: Not defined
2023-02-24 20:00:07 : DEBUG : snagit : versionKey=CFBundleShortVersionString
2023-02-24 20:00:07 : DEBUG : snagit : packageID=
2023-02-24 20:00:07 : DEBUG : snagit : pkgName=
2023-02-24 20:00:07 : DEBUG : snagit : choiceChangesXML=
2023-02-24 20:00:07 : DEBUG : snagit : expectedTeamID=7TQL462TU8
2023-02-24 20:00:07 : DEBUG : snagit : blockingProcesses=
2023-02-24 20:00:07 : DEBUG : snagit : installerTool=
2023-02-24 20:00:07 : DEBUG : snagit : CLIInstaller=
2023-02-24 20:00:07 : DEBUG : snagit : CLIArguments=
2023-02-24 20:00:07 : DEBUG : snagit : updateTool=
2023-02-24 20:00:07 : DEBUG : snagit : updateToolArguments=
2023-02-24 20:00:07 : DEBUG : snagit : updateToolRunAsCurrentUser=
2023-02-24 20:00:07 : INFO  : snagit : BLOCKING_PROCESS_ACTION=tell_user
2023-02-24 20:00:07 : INFO  : snagit : NOTIFY=success
2023-02-24 20:00:07 : INFO  : snagit : LOGGING=DEBUG
2023-02-24 20:00:07 : INFO  : snagit : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-24 20:00:07 : INFO  : snagit : Label type: dmg
2023-02-24 20:00:07 : INFO  : snagit : archiveName: Snagit 2023.dmg
2023-02-24 20:00:07 : INFO  : snagit : no blocking processes defined, using Snagit 2023 as default
2023-02-24 20:00:07 : DEBUG : snagit : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-02-24 20:00:07 : INFO  : snagit : name: Snagit 2023, appName: Snagit 2023.app
2023-02-24 20:00:07.770 mdfind[2336:25958] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-24 20:00:07.913 mdfind[2336:25958] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-24 20:00:08 : WARN  : snagit : No previous app found
2023-02-24 20:00:08 : WARN  : snagit : could not find Snagit 2023.app
2023-02-24 20:00:08 : INFO  : snagit : appversion: 
2023-02-24 20:00:08 : INFO  : snagit : Latest version of Snagit 2023 is 2023.0.4
2023-02-24 20:00:08 : REQ   : snagit : Downloading https://download.techsmith.com/snagitmac/releases/snagit.dmg to Snagit 2023.dmg
2023-02-24 20:00:08 : DEBUG : snagit : No Dialog connection, just download
2023-02-24 20:00:16 : DEBUG : snagit : File list: -rw-r--r--  1 asri  staff   211M Feb 24 20:00 Snagit 2023.dmg
2023-02-24 20:00:16 : DEBUG : snagit : File type: Snagit 2023.dmg: zlib compressed data
2023-02-24 20:00:16 : DEBUG : snagit : curl output was:
*   Trying 23.49.22.192:443...
* Connected to download.techsmith.com (23.49.22.192) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3026 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Michigan; L=Okemos; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 11 00:00:00 2022 GMT
*  expire date: Aug 18 23:59:59 2023 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /snagitmac/releases/snagit.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.techsmith.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f937800ba00)
> GET /snagitmac/releases/snagit.dmg HTTP/2
> Host: download.techsmith.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Wed, 18 Jan 2023 18:56:20 GMT
< accept-ranges: bytes
< etag: "9641848d6e2bd91:0"
< server: Microsoft-IIS/8.5
< content-length: 220987796
< cache-control: max-age=14352
< date: Fri, 24 Feb 2023 12:00:09 GMT
< 
{ [2404 bytes data]
* Connection #0 to host download.techsmith.com left intact

2023-02-24 20:00:16 : DEBUG : snagit : DEBUG mode 1, not checking for blocking processes
2023-02-24 20:00:16 : REQ   : snagit : Installing Snagit 2023
2023-02-24 20:00:16 : INFO  : snagit : Mounting /Users/asri/Documents/dev/Installomator/build/Snagit 2023.dmg
2023-02-24 20:00:18 : DEBUG : snagit : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified CRC32 $3C7378EC
verified CRC32 $835413A1
/dev/disk2                                              /Volumes/Snagit

2023-02-24 20:00:18 : INFO  : snagit : Mounted: /Volumes/Snagit
2023-02-24 20:00:18 : INFO  : snagit : Verifying: /Volumes/Snagit/Snagit 2023.app
2023-02-24 20:00:18 : DEBUG : snagit : App size: 485M   /Volumes/Snagit/Snagit 2023.app
2023-02-24 20:00:27 : DEBUG : snagit : Debugging enabled, App Verification output was:
/Volumes/Snagit/Snagit 2023.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2023-02-24 20:00:27 : INFO  : snagit : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2023-02-24 20:00:28 : INFO  : snagit : Installing Snagit 2023 version 2023.0.4 on versionKey CFBundleShortVersionString.
2023-02-24 20:00:28 : INFO  : snagit : App has LSMinimumSystemVersion: 11.0
2023-02-24 20:00:28 : DEBUG : snagit : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-02-24 20:00:28 : INFO  : snagit : Finishing...
2023-02-24 20:00:31 : INFO  : snagit : name: Snagit 2023, appName: Snagit 2023.app
2023-02-24 20:00:31.634 mdfind[2454:26550] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-24 20:00:31.763 mdfind[2454:26550] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-24 20:00:31 : WARN  : snagit : No previous app found
2023-02-24 20:00:31 : WARN  : snagit : could not find Snagit 2023.app
2023-02-24 20:00:31 : REQ   : snagit : Installed Snagit 2023
2023-02-24 20:00:32 : INFO  : snagit : notifying
2023-02-24 20:00:32 : DEBUG : snagit : Unmounting /Volumes/Snagit
2023-02-24 20:00:32 : DEBUG : snagit : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-02-24 20:00:32 : DEBUG : snagit : DEBUG mode 1, not reopening anything
2023-02-24 20:00:32 : REQ   : snagit : All done!
2023-02-24 20:00:32 : REQ   : snagit : ################## End Installomator, exit code 0
```

### move snagit2022 to own label
```
2023-02-24 20:01:23 : REQ   : snagit2022 : ################## Start Installomator v. 10.4beta, date 2023-02-24
2023-02-24 20:01:23 : INFO  : snagit2022 : ################## Version: 10.4beta
2023-02-24 20:01:23 : INFO  : snagit2022 : ################## Date: 2023-02-24
2023-02-24 20:01:23 : INFO  : snagit2022 : ################## snagit2022
2023-02-24 20:01:23 : DEBUG : snagit2022 : DEBUG mode 1 enabled.
2023-02-24 20:01:24 : DEBUG : snagit2022 : name=Snagit 2022
2023-02-24 20:01:24 : DEBUG : snagit2022 : appName=
2023-02-24 20:01:24 : DEBUG : snagit2022 : type=dmg
2023-02-24 20:01:24 : DEBUG : snagit2022 : archiveName=
2023-02-24 20:01:24 : DEBUG : snagit2022 : downloadURL=https://download.techsmith.com/snagitmac/releases/2225/snagit.dmg
2023-02-24 20:01:24 : DEBUG : snagit2022 : curlOptions=
2023-02-24 20:01:24 : DEBUG : snagit2022 : appNewVersion=2022.2.5
2023-02-24 20:01:25 : DEBUG : snagit2022 : appCustomVersion function: Not defined
2023-02-24 20:01:25 : DEBUG : snagit2022 : versionKey=CFBundleShortVersionString
2023-02-24 20:01:25 : DEBUG : snagit2022 : packageID=
2023-02-24 20:01:25 : DEBUG : snagit2022 : pkgName=
2023-02-24 20:01:25 : DEBUG : snagit2022 : choiceChangesXML=
2023-02-24 20:01:25 : DEBUG : snagit2022 : expectedTeamID=7TQL462TU8
2023-02-24 20:01:25 : DEBUG : snagit2022 : blockingProcesses=
2023-02-24 20:01:25 : DEBUG : snagit2022 : installerTool=
2023-02-24 20:01:25 : DEBUG : snagit2022 : CLIInstaller=
2023-02-24 20:01:25 : DEBUG : snagit2022 : CLIArguments=
2023-02-24 20:01:25 : DEBUG : snagit2022 : updateTool=
2023-02-24 20:01:25 : DEBUG : snagit2022 : updateToolArguments=
2023-02-24 20:01:25 : DEBUG : snagit2022 : updateToolRunAsCurrentUser=
2023-02-24 20:01:25 : INFO  : snagit2022 : BLOCKING_PROCESS_ACTION=tell_user
2023-02-24 20:01:25 : INFO  : snagit2022 : NOTIFY=success
2023-02-24 20:01:25 : INFO  : snagit2022 : LOGGING=DEBUG
2023-02-24 20:01:25 : INFO  : snagit2022 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-02-24 20:01:25 : INFO  : snagit2022 : Label type: dmg
2023-02-24 20:01:25 : INFO  : snagit2022 : archiveName: Snagit 2022.dmg
2023-02-24 20:01:25 : INFO  : snagit2022 : no blocking processes defined, using Snagit 2022 as default
2023-02-24 20:01:25 : DEBUG : snagit2022 : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-02-24 20:01:25 : INFO  : snagit2022 : name: Snagit 2022, appName: Snagit 2022.app
2023-02-24 20:01:25.426 mdfind[2682:27736] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-24 20:01:25.548 mdfind[2682:27736] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-24 20:01:25 : WARN  : snagit2022 : No previous app found
2023-02-24 20:01:25 : WARN  : snagit2022 : could not find Snagit 2022.app
2023-02-24 20:01:25 : INFO  : snagit2022 : appversion: 
2023-02-24 20:01:25 : INFO  : snagit2022 : Latest version of Snagit 2022 is 2022.2.5
2023-02-24 20:01:25 : REQ   : snagit2022 : Downloading https://download.techsmith.com/snagitmac/releases/2225/snagit.dmg to Snagit 2022.dmg
2023-02-24 20:01:25 : DEBUG : snagit2022 : No Dialog connection, just download
2023-02-24 20:01:37 : DEBUG : snagit2022 : File list: -rw-r--r--  1 asri  staff   234M Feb 24 20:01 Snagit 2022.dmg
2023-02-24 20:01:37 : DEBUG : snagit2022 : File type: Snagit 2022.dmg: zlib compressed data
2023-02-24 20:01:37 : DEBUG : snagit2022 : curl output was:
*   Trying 23.49.22.192:443...
* Connected to download.techsmith.com (23.49.22.192) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3026 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Michigan; L=Okemos; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 11 00:00:00 2022 GMT
*  expire date: Aug 18 23:59:59 2023 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /snagitmac/releases/2225/snagit.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.techsmith.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fce7600a800)
> GET /snagitmac/releases/2225/snagit.dmg HTTP/2
> Host: download.techsmith.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Wed, 11 Jan 2023 13:57:24 GMT
< accept-ranges: bytes
< etag: "577ca8a1c425d91:0"
< server: Microsoft-IIS/8.5
< content-length: 245742932
< cache-control: max-age=14400
< date: Fri, 24 Feb 2023 12:01:26 GMT
< 
{ [1804 bytes data]
* Connection #0 to host download.techsmith.com left intact

2023-02-24 20:01:37 : DEBUG : snagit2022 : DEBUG mode 1, not checking for blocking processes
2023-02-24 20:01:37 : REQ   : snagit2022 : Installing Snagit 2022
2023-02-24 20:01:37 : INFO  : snagit2022 : Mounting /Users/asri/Documents/dev/Installomator/build/Snagit 2022.dmg
2023-02-24 20:01:39 : DEBUG : snagit2022 : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified CRC32 $2738973D
verified CRC32 $50B1AC7F
/dev/disk2                                              /Volumes/Snagit

2023-02-24 20:01:39 : INFO  : snagit2022 : Mounted: /Volumes/Snagit
2023-02-24 20:01:39 : INFO  : snagit2022 : Verifying: /Volumes/Snagit/Snagit 2022.app
2023-02-24 20:01:39 : DEBUG : snagit2022 : App size: 510M       /Volumes/Snagit/Snagit 2022.app
2023-02-24 20:01:48 : DEBUG : snagit2022 : Debugging enabled, App Verification output was:
/Volumes/Snagit/Snagit 2022.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2023-02-24 20:01:48 : INFO  : snagit2022 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2023-02-24 20:01:48 : INFO  : snagit2022 : Installing Snagit 2022 version 2022.2.5 on versionKey CFBundleShortVersionString.
2023-02-24 20:01:48 : INFO  : snagit2022 : App has LSMinimumSystemVersion: 11.0
2023-02-24 20:01:48 : DEBUG : snagit2022 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-02-24 20:01:48 : INFO  : snagit2022 : Finishing...
2023-02-24 20:01:51 : INFO  : snagit2022 : name: Snagit 2022, appName: Snagit 2022.app
2023-02-24 20:01:51.832 mdfind[2809:28322] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-02-24 20:01:51.951 mdfind[2809:28322] Couldn't determine the mapping between prefab keywords and predicates.
2023-02-24 20:01:52 : WARN  : snagit2022 : No previous app found
2023-02-24 20:01:52 : WARN  : snagit2022 : could not find Snagit 2022.app
2023-02-24 20:01:52 : REQ   : snagit2022 : Installed Snagit 2022
2023-02-24 20:01:52 : INFO  : snagit2022 : notifying
2023-02-24 20:01:52 : DEBUG : snagit2022 : Unmounting /Volumes/Snagit
2023-02-24 20:01:52 : DEBUG : snagit2022 : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-02-24 20:01:52 : DEBUG : snagit2022 : DEBUG mode 1, not reopening anything
2023-02-24 20:01:52 : REQ   : snagit2022 : All done!
2023-02-24 20:01:52 : REQ   : snagit2022 : ################## End Installomator, exit code 0 
```