### PR TITLE
Add "valueFromJSON" to eventually replace "getJSONValue"

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -156,7 +156,7 @@ valueFromJSON() { # Version 2023.2.26-1 - Copyright (c) 2023 Pico Mitchell - MIT
         -e 'parse(json); (i === 0 ? argv.shift() : (i === 1 && argv.pop())); break } catch (e) {} } if (out === undefined) throw "Failed to parse JSON."; argv.forEach(key => {' \
         -e 'out = (Array.isArray(out) ? (/^-?\d+$/.test(key) ? (key = +key, out[key < 0 ? (out.length + key) : key]) : (key === "=" ? out.length : undefined)) : (out instanceof' \
         -e 'Object ? out[key] : undefined)); if (out === undefined) throw "Failed to retrieve key/index: " + key }); return (out instanceof Object ? JSON.stringify(out, null, 2)' \
-        -e ': out) }' -- "$@" 2>&1 >&3)"; } 3>&1; [ "${1##* }" != '(-2700)' ] || { set -- "json_value ERROR${1#*Error}"; >&2 printf '%s\n' "${1% *}"; false; }
+        -e ': out) }' -- "$@" 2>&1 >&3)"; } 3>&1; [ "${1##* }" != '(-2700)' ] || { set -- "valueFromJSON ERROR${1#*Error}"; >&2 printf '%s\n' "${1% *}"; false; }
 }
 
 # will get the latest release download from a github repo

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -148,6 +148,17 @@ deduplicatelogs() {
     done <<< "$loginput"
 }
 
+valueFromJSON() { # Version 2023.2.26-1 - Copyright (c) 2023 Pico Mitchell - MIT License - Full license and help info at https://github.com/RandomApplications/JSON-Shell-Tools-for-macOS/blob/main/json_value.sh
+    { set -- "$(/usr/bin/osascript -l 'JavaScript' -e 'function run(argv) { const stdin = $.NSFileHandle.fileHandleWithStandardInput; let out; for (let i = 0; i < 3; i ++) {' \
+        -e 'let json = (i === 0 ? argv[0] : (i === 1 ? argv[argv.length - 1] : $.NSString.alloc.initWithDataEncoding((stdin.respondsToSelector("readDataToEndOfFileAndReturnError:")' \
+        -e '? stdin.readDataToEndOfFileAndReturnError(ObjC.wrap()) : stdin.readDataToEndOfFile), $.NSUTF8StringEncoding).js.replace(/\n$/, ""))); if ($.NSFileManager.defaultManager' \
+        -e '.fileExistsAtPath(json)) json = $.NSString.stringWithContentsOfFileEncodingError(json, $.NSUTF8StringEncoding, ObjC.wrap()).js; if (/[{[]/.test(json)) try { out = JSON.' \
+        -e 'parse(json); (i === 0 ? argv.shift() : (i === 1 && argv.pop())); break } catch (e) {} } if (out === undefined) throw "Failed to parse JSON."; argv.forEach(key => {' \
+        -e 'out = (Array.isArray(out) ? (/^-?\d+$/.test(key) ? (key = +key, out[key < 0 ? (out.length + key) : key]) : (key === "=" ? out.length : undefined)) : (out instanceof' \
+        -e 'Object ? out[key] : undefined)); if (out === undefined) throw "Failed to retrieve key/index: " + key }); return (out instanceof Object ? JSON.stringify(out, null, 2)' \
+        -e ': out) }' -- "$@" 2>&1 >&3)"; } 3>&1; [ "${1##* }" != '(-2700)' ] || { set -- "json_value ERROR${1#*Error}"; >&2 printf '%s\n' "${1% *}"; false; }
+}
+
 # will get the latest release download from a github repo
 downloadURLFromGit() { # $1 git user name, $2 git repo name
     gitusername=${1?:"no git user name"}

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -148,15 +148,15 @@ deduplicatelogs() {
     done <<< "$loginput"
 }
 
-valueFromJSON() { # Version 2023.2.26-1 - Copyright (c) 2023 Pico Mitchell - MIT License - Full license and help info at https://github.com/RandomApplications/JSON-Shell-Tools-for-macOS/blob/main/json_value.sh
-    { set -- "$(/usr/bin/osascript -l 'JavaScript' -e 'function run(argv) { const stdin = $.NSFileHandle.fileHandleWithStandardInput; let out; for (let i = 0; i < 3; i ++) {' \
-        -e 'let json = (i === 0 ? argv[0] : (i === 1 ? argv[argv.length - 1] : $.NSString.alloc.initWithDataEncoding((stdin.respondsToSelector("readDataToEndOfFileAndReturnError:")' \
-        -e '? stdin.readDataToEndOfFileAndReturnError(ObjC.wrap()) : stdin.readDataToEndOfFile), $.NSUTF8StringEncoding).js.replace(/\n$/, ""))); if ($.NSFileManager.defaultManager' \
-        -e '.fileExistsAtPath(json)) json = $.NSString.stringWithContentsOfFileEncodingError(json, $.NSUTF8StringEncoding, ObjC.wrap()).js; if (/[{[]/.test(json)) try { out = JSON.' \
-        -e 'parse(json); (i === 0 ? argv.shift() : (i === 1 && argv.pop())); break } catch (e) {} } if (out === undefined) throw "Failed to parse JSON."; argv.forEach(key => {' \
-        -e 'out = (Array.isArray(out) ? (/^-?\d+$/.test(key) ? (key = +key, out[key < 0 ? (out.length + key) : key]) : (key === "=" ? out.length : undefined)) : (out instanceof' \
-        -e 'Object ? out[key] : undefined)); if (out === undefined) throw "Failed to retrieve key/index: " + key }); return (out instanceof Object ? JSON.stringify(out, null, 2)' \
-        -e ': out) }' -- "$@" 2>&1 >&3)"; } 3>&1; [ "${1##* }" != '(-2700)' ] || { set -- "valueFromJSON ERROR${1#*Error}"; >&2 printf '%s\n' "${1% *}"; false; }
+valueFromJSON() { # Version 2023.3.4-1 - Copyright (c) 2023 Pico Mitchell - MIT License - Full license and help info at https://randomapplications.com/json_value
+	{ set -- "$(/usr/bin/osascript -l 'JavaScript' -e 'ObjC.import("unistd"); function run(argv) { const stdin = $.NSFileHandle.fileHandleWithStandardInput; let out; for (let i = 0;' \
+		-e 'i < 3; i ++) { let json = (i === 0 ? argv[0] : (i === 1 ? argv[argv.length - 1] : ($.isatty(0) ? "" : $.NSString.alloc.initWithDataEncoding((stdin.respondsToSelector("re"' \
+		-e '+ "adDataToEndOfFileAndReturnError:") ? stdin.readDataToEndOfFileAndReturnError(ObjC.wrap()) : stdin.readDataToEndOfFile), $.NSUTF8StringEncoding).js.replace(/\n$/, ""))))' \
+		-e 'if ($.NSFileManager.defaultManager.fileExistsAtPath(json)) json = $.NSString.stringWithContentsOfFileEncodingError(json, $.NSUTF8StringEncoding, ObjC.wrap()).js; if (/[{[]/' \
+		-e '.test(json)) try { out = JSON.parse(json); (i === 0 ? argv.shift() : (i === 1 && argv.pop())); break } catch (e) {} } if (out === undefined) throw "Failed to parse JSON."' \
+		-e 'argv.forEach(key => { out = (Array.isArray(out) ? (/^-?\d+$/.test(key) ? (key = +key, out[key < 0 ? (out.length + key) : key]) : (key === "=" ? out.length : undefined)) :' \
+		-e '(out instanceof Object ? out[key] : undefined)); if (out === undefined) throw "Failed to retrieve key/index: " + key }); return (out instanceof Object ? JSON.stringify(' \
+		-e 'out, null, 2) : out) }' -- "$@" 2>&1 >&3)"; } 3>&1; [ "${1##* }" != '(-2700)' ] || { set -- "valueFromJSON ERROR${1#*Error}"; >&2 printf '%s\n' "${1% *}"; false; }
 }
 
 # will get the latest release download from a github repo


### PR DESCRIPTION
This `valueFromJSON` function is my latest `json_value` (Version 2023.2.26-1) function (https://github.com/RandomApplications/JSON-Shell-Tools-for-macOS/blob/main/json_value.sh) but renamed to match the Installomator function naming style.

It is intentionally NOT yet replacing the existing `getJSONValue` function because both need to exist simultaneously until all labels have been updated to use the new `valueFromJSON` function. I plan to work through those and submit PRs for each label that is currently using `getJSONValue`, and then will submit a PR to remove `getJSONValue` when Installomator and all labels have been updated and merged. I think giving this function a new name is graceful way to handle this transition while also still having a function name that is intuitive and fits in with other functions in Installomator.

This new `valueFromJSON` function has a handful of benefits over the existing `getJSONValue` function and the only drawback is it's a bit more code, and retrieving nested values is not backwards compatible with the current `getJSONValue` function.

Some of the benefits are of `valueFromJSON` are:

- Can accept stdin so that is can be used like `curl ... | valueFromJSON ...` which can make the code in some labels cleaner and simpler.

- Can accept JSON as the first or last argument so it's flexible for different users styles in labels.

- Does not parse any key or index arguments passed to it directly has JXA code like the current `getJSONValue` function does. This means advanced JavaScript methods cannot be used in `valueFromJSON`, but that is not currently being taken advantage of in Installomator and should not be needed for basic version or URL retrievals from JSON, and the way `valueFromJSON` handles arguments is safer overall.

- No knowledge of JavaScript dot or bracket notation is required to use `valueFromJSON` like it is for `getJSONValue` to retrieve nested values or complex key name. To retrieve a value value from a dictionary that is nested in an array with `getJSONValue` the expression `getJSONValue '[0].keyName'` needs to be passed as a single argument. But, with `valueFromJSON` each index or key is simply passed as its own argument like `valueFromJSON '0' 'keyName'`. This also means there are no possible characters that could exist in valid key names that would need to be escaped or placed in bracket notation to properly retrieve a key. One example would be a period in a key would need to be retrieved with bracket notation like `getJSONValue '["key.name"]'` which could be confusing for some users when `getJSONValue 'key.name'` does not work as expected (this would also apply for any possible key names that contain spaces). With `valueFromJSON`, using `valueFromJSON 'key.name'` would properly retrieve the key with the literal name `key.name`.

- Negative array indexes can specified be used when someone needs to retrieve the last value of an array.

- `valueFromJSON` has much better error handling and would output an error to stderr with the name of the key or index that was not retrieved rather than outputting nothing like `getJSONValue` would in some cases.

- Detailed help information is documented at https://github.com/RandomApplications/JSON-Shell-Tools-for-macOS/blob/main/json_value.sh and this URL is commented in the function which may be helpful for users who haven't worked with JSON parsing tools before.