### PR TITLE
Replace "defaults read" with "PlistBuddy -c Print" commands when reading non-preferences plists.

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -283,7 +283,8 @@ getAppVersion() {
         if [[ ${#filteredAppPaths} -eq 1 ]]; then
             installedAppPath=$filteredAppPaths[1]
             #appversion=$(mdls -name kMDItemVersion -raw $installedAppPath )
-            appversion=$(defaults read $installedAppPath/Contents/Info.plist $versionKey) #Not dependant on Spotlight indexing
+            #appversion=$(defaults read $installedAppPath/Contents/Info.plist $versionKey) #Not dependant on Spotlight indexing
+            appversion=$(/usr/libexec/PlistBuddy -c "Print :$versionKey" $installedAppPath/Contents/Info.plist) # "defaults" should only be used for reading preferences domains (documented as a warning in "man defaults").
             printlog "found app at $installedAppPath, version $appversion, on versionKey $versionKey"
             updateDetected="YES"
             # Is current app from App Store
@@ -465,7 +466,8 @@ installAppWithPath() { # $1: path to app to install in $targetDir
     fi
 
     # app versioncheck
-    appNewVersion=$(defaults read $appPath/Contents/Info.plist $versionKey)
+    # appNewVersion=$(defaults read $appPath/Contents/Info.plist $versionKey)
+    appNewVersion=$(/usr/libexec/PlistBuddy -c "Print :$versionKey" $appPath/Contents/Info.plist) # "defaults" should only be used for reading preferences domains (documented as a warning in "man defaults").
     if [[ -n $appNewVersion && $appversion == $appNewVersion ]]; then
         printlog "Downloaded version of $name is $appNewVersion on versionKey $versionKey, same as installed."
         if [[ $INSTALL != "force" ]]; then
@@ -489,7 +491,8 @@ installAppWithPath() { # $1: path to app to install in $targetDir
     fi
 
     # macOS versioncheck
-    minimumOSversion=$(defaults read $appPath/Contents/Info.plist LSMinimumSystemVersion 2>/dev/null )
+    #minimumOSversion=$(defaults read $appPath/Contents/Info.plist LSMinimumSystemVersion 2>/dev/null )
+    minimumOSversion=$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' $appPath/Contents/Info.plist 2>/dev/null) # "defaults" should only be used for reading preferences domains (documented as a warning in "man defaults").
     if [[ -n $minimumOSversion && $minimumOSversion =~ '[0-9.]*' ]]; then
         printlog "App has LSMinimumSystemVersion: $minimumOSversion"
         if ! is-at-least $minimumOSversion $installedOSversion; then


### PR DESCRIPTION
"defaults" is designed and intended only to operate on preferences domains and it has been stated in "man defaults" for multiple OS versions that its ability to be used for general plist operations on non-preferences plist may eventually be removed.

"PlistBuddy" is being used over "plutil" since raw values can only be outputted by "plutil" using the new "raw" extraction option that was added in macOS 12 Monterey, but Installomator needs to support back to macOS 10.14 Mojave.

From "man defaults":

WARNING: The defaults command will be changed in an upcoming major release to only operate on preferences domains. General plist manipulation utilities will be folded into a different command-line program.