### PR TITLE
Retrieve installed package version using "PlistBuddy"

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -237,7 +237,8 @@ getAppVersion() {
 
     # pkgs contains a version number, then we don't have to search for an app
     if [[ $packageID != "" ]]; then
-        appversion="$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null | grep -A 1 pkg-version | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g')"
+        #appversion="$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null | grep -A 1 pkg-version | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g')"
+        /usr/libexec/PlistBuddy -c 'Print :pkg-version' /dev/stdin <<< "$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null)" 2>/dev/null # Retrive "pkg-version" using "PlistBuddy" for simplicity and to properly retrieve versions that don't only contain numbers and dots.
         if [[ $appversion != "" ]]; then
             printlog "found packageID $packageID installed, version $appversion"
             updateDetected="YES"

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -238,7 +238,7 @@ getAppVersion() {
     # pkgs contains a version number, then we don't have to search for an app
     if [[ $packageID != "" ]]; then
         #appversion="$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null | grep -A 1 pkg-version | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g')"
-        /usr/libexec/PlistBuddy -c 'Print :pkg-version' /dev/stdin <<< "$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null)" 2>/dev/null # Retrive "pkg-version" using "PlistBuddy" for simplicity and to properly retrieve versions that don't only contain numbers and dots.
+        appversion=$(/usr/libexec/PlistBuddy -c 'Print :pkg-version' /dev/stdin <<< "$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null)" 2>/dev/null) # Retrive "pkg-version" using "PlistBuddy" for simplicity and to properly retrieve versions that don't only contain numbers and dots.
         if [[ $appversion != "" ]]; then
             printlog "found packageID $packageID installed, version $appversion"
             updateDetected="YES"


### PR DESCRIPTION
As described in https://github.com/Installomator/Installomator/pull/907#issuecomment-1443073632 if a package version does not only contains numbers and dots, the current installed package version extraction technique will fail and return the entire plist line containing the opening and closing `<string>` tags.

Using "PlistBuddy" to extract from the plist output of "pkgutil --pkg-info-plist" is simpler an more reliable than using "grep | tail | sed" and these version strings should never be filtered to only contain a certain set of characters the same as version strings from an apps "Info.plist" are not filtered.

For example:
```
% packageID=org.freegeek.pkg.mkuser
```

```
% pkgutil --pkg-info-plist ${packageID} 2>/dev/null | grep -A 1 pkg-version | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g'
	<string>2022.9.30-1</string>
```

```
% /usr/libexec/PlistBuddy -c 'Print :pkg-version' /dev/stdin <<< "$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null)" 2>/dev/null
2022.9.30-1
```