### PR TITLE
Remove any possible control chars from "appNewVersion"

### DIFF
--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -15,6 +15,8 @@ fi
 
 # MARK: application download and installation starts here
 
+appNewVersion=$(echo $appNewVersion | tr -d '[:cntrl:]') # Remove any possible control chars (such as "\r") that may have unintentionally gotten included in "appNewVersion" from some "curl" output.
+
 # Debug output of all variables in a label
 printlog "name=${name}" DEBUG
 printlog "appName=${appName}" DEBUG


### PR DESCRIPTION
As discussed in https://github.com/Installomator/Installomator/issues/772 it is possible for "appNewVersion" values set by "curl" output in labels to contain control chars such as "\r" which could mess up conditions like "if [[ $appversion == $appNewVersion ]]; then".

Removing any and all possible control characters after the label has been processed and before "appNewVersion" is used throughout the rest of Installomator will resolve any possible issues of invisible control chars existing in some "curl" output without this complexity needing to be handled in every current or future label.

Credit to [@macbofh](https://github.com/macbofh) for discovering and documenting this issue.