### PR TITLE
Pass variables as args to all "osascript" commands

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -53,14 +53,14 @@ displaydialog() { # $1: message $2: title
     title=${2:-"Installomator"}
     #runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Not Now\", \"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\")"
     runAsUser osascript -e '
-on run argv
+on run {dialogMessage, dialogTitle, dialogIconPath, dialogTimeoutSeconds as integer}
     try
-        return (button returned of (display dialog (text item 1 of argv) with title (text item 2 of argv) buttons {"Not Now", "Quit and Update"} cancel button 1 default button 2 with icon (POSIX file (text item 3 of argv))))
+        return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Not Now", "Quit and Update"} cancel button 1 default button 2 with icon (POSIX file dialogIconPath) giving up after dialogTimeoutSeconds))
     on error
         return "Not Now"
     end try
 end run
-' -- "$message" "$title" "$LOGO" # Pass all variables to "osascript" as args so that they are not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variables to break execution of the entire the AppleScript command.
+' -- "$message" "$title" "$LOGO" "$PROMPT_TIMEOUT" # Pass all variables to "osascript" as args so that they are not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variables to break execution of the entire the AppleScript command.
     # NOTE: The "Not Now" button is set to the "cancel button" so that the escape key can be properly used to dismiss the alert. When an AppleScript alert is canceled, it throws an error which is caught in the "try" block and in the "on error" block the "Not Now" string is manually returned the same as if they had clicked the button.
 }
 
@@ -69,8 +69,8 @@ displaydialogContinue() { # $1: message $2: title
     title=${2:-"Installomator"}
     #runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\")"
     runAsUser osascript -e '
-on run argv
-    return (button returned of (display dialog (text item 1 of argv) with title (text item 2 of argv) buttons {"Quit and Update"} default button 1 with icon (POSIX file (text item 3 of argv))))
+on run {dialogMessage, dialogTitle, dialogIconPath}
+    return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Quit and Update"} default button 1 with icon (POSIX file dialogIconPath)))
 end run
 ' -- "$message" "$title" "$LOGO" # Pass all variables to "osascript" as args so that they are not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variables to break execution of the entire the AppleScript command.
 }
@@ -87,14 +87,14 @@ displaynotification() { # $1: message $2: title
          "$hubcli" notify -t "$title" -i "$message" -c "Dismiss"
     else
         #runAsUser osascript -e "display notification \"$message\" with title \"$title\""
-        runAsUser osascript -e 'on run argv' -e 'display notification (text item 1 of argv) with title (text item 2 of argv)' -e 'end run' -- "$message" "$title"
+        runAsUser osascript -e 'on run {notificationMessage, notificationTitle}' -e 'display notification notificationMessage with title notificationTitle' -e 'end run' -- "$message" "$title"
     # Pass all variables to "osascript" as args so that they are not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variables to break execution of the entire the AppleScript command.
     fi
 }
 
 quitApp() { # $1: app name
     if [[ -n "$1" ]]; then
-        runAsUser osascript -e 'on run argv' -e 'quit application (text item 1 of argv)' -e 'end run' -- "$1"
+        runAsUser osascript -e 'on run {appName}' -e 'quit application appName' -e 'end run' -- "$1"
         # Pass app name variables to "osascript" as arg so that it is not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variable to break execution of the entire the AppleScript command.
     fi
 }

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -53,9 +53,9 @@ displaydialog() { # $1: message $2: title
     title=${2:-"Installomator"}
     #runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Not Now\", \"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\")"
     runAsUser osascript -e '
-on run {dialogMessage, dialogTitle, dialogIconPath, dialogTimeoutSeconds as integer}
+on run {dialogMessage, dialogTitle, dialogIconFile as POSIX file, dialogTimeoutSeconds as integer}
     try
-        return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Not Now", "Quit and Update"} cancel button 1 default button 2 with icon (POSIX file dialogIconPath) giving up after dialogTimeoutSeconds))
+        return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Not Now", "Quit and Update"} cancel button 1 default button 2 with icon dialogIconFile giving up after dialogTimeoutSeconds))
     on error
         return "Not Now"
     end try
@@ -69,8 +69,8 @@ displaydialogContinue() { # $1: message $2: title
     title=${2:-"Installomator"}
     #runAsUser osascript -e "button returned of (display dialog \"$message\" with  title \"$title\" buttons {\"Quit and Update\"} default button \"Quit and Update\" with icon POSIX file \"$LOGO\")"
     runAsUser osascript -e '
-on run {dialogMessage, dialogTitle, dialogIconPath}
-    return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Quit and Update"} default button 1 with icon (POSIX file dialogIconPath)))
+on run {dialogMessage, dialogTitle, dialogIconFile as POSIX file}
+    return (button returned of (display dialog dialogMessage with title dialogTitle buttons {"Quit and Update"} default button 1 with icon dialogIconFile))
 end run
 ' -- "$message" "$title" "$LOGO" # Pass all variables to "osascript" as args so that they are not expanded by the shell and interpreted as AppleScript code which could cause double quotes or other special characters within the variables to break execution of the entire the AppleScript command.
 }


### PR DESCRIPTION
Instead of placing variables directly in AppleScript code passed to  "osascript", pass the variables as arguments to be retrieved from within the AppleScript code instead.

To be able to retrieve arguments passed to "osascript" within the AppleScript code, the AppleScript code must be within an "run" function/handler, which is shown and described near the top of the "DESCRIPTION" section in "man osascript".

When a variable is placed directly in AppleScript code, its value is expanded by the shell before being passed to "osascript" and is therefore being interpreted as raw AppleScript code. This means that any special characters such as double quotes (") would need to be manually escaped within the variables contents to not break the quoted AppleScript string that the variable is being placed within.

But, when the values are passed to "osascript" as arguments and then retrieved within the AppleScript code from the arguments array, they are always static string values that are never interpreted as AppleScript code. This means that any literal quotes within a variable are properly displayed without needing to be escaped and without ever breaking the AppleScript code.

Double quotes are just one example, but in general passing variables as arguments prevents any possible arbitrary AppleScript code execution. While that is not really likely with how these function are used in Installomator, passing arguments to other environments that interpret code instead of placing variables directly in that code is a safe practice in general and helps avoids any possible mistakes or bugs in the future.

Also, I have slightly adjusted the behavior of "displaydialog" function to set the "Not Now" button as the dialogs "cancel button" which means the Escape key can now be used to dismiss the alert as is normal and expected in standard macOS dialogs. The adjustments needed for this behavior to not require other changes throughout the code is documented in the "NOTE" comment at the end of the "displaydialog" function.

Finally, I added a new "quitApp" function instead of repeating the same "osascript" command 4 times to quit apps in different case statements within the "checkRunningProcesses" function.

These may be a lot of changes in a single PR, but they were all pretty interconnected. If any part of all these changes is not desired, I can make changes as needed.