### PR TITLE
Add "xpathFromHTML" for convenient usage in labels

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -148,6 +148,11 @@ deduplicatelogs() {
     done <<< "$loginput"
 }
 
+xpathFromHTML() { # $1 XPath expression to extract from HTML passed via STDIN.
+    xmllint --html --xpath "$1" - 2> /dev/null
+    # NOTE: It's important to always redirect stderr to /dev/null because it's common for irrelevant "HTML parser" errors/warnings to be outputted on stderr.
+}
+
 # will get the latest release download from a github repo
 downloadURLFromGit() { # $1 git user name, $2 git repo name
     gitusername=${1?:"no git user name"}


### PR DESCRIPTION
When looking through the Installomator source, I see lots of labels that use a pipeline of `grep`, `awk`, `head`, `tail`, `sed`, etc to extract values from HTML source code.

Many of these extractions could be made to be more precise and reliable by using XPath on the HTML source instead (in some cases the resulting code is simpler, but in other cases there is complexity around understanding and taking full advantage of the the XPath capabilities, but that's not much different than the complexity of understanding how `grep`, `awk`, `sed` etc work).

The `xpath` command cannot parse HTML (as far as I know), but `xmllint` can when used with the `xmllint --html --xpath` options, so that is why a new function would be necessary instead of being able to use the existing `xpath` function.

This `xpathFromHTML` function could also be encouraged to be used by maybe including a little tutorial of basic XPath abilities, and with more labels using XPath there would be more examples for people to work from and base new labels on.

If this would be a welcome change, I would be willing to work through some labels on my free time to update them to use just a single XPath expression instead of a pipelines of multiple commands.

Here are a few random examples of how things could be changed using this new `xpathFromHTML` function:

Current "lucifer" label `appNewVersion`:
`appNewVersion=$( curl -fs "https://www.hexedbits.com/lucifer/" | grep "Latest version" | sed -E 's/.*Latest version ([0-9.]*),.*/\1/g')`
(NOTE: This one is actually currently BROKEN because the word "version" now has a capitol "V" and it is wrapped in a bold tag which it seems like it wasn't before.)

New possible "lucifer" label `appNewVersion` using only XPath:
`appNewVersion=$(curl -fs "https://www.hexedbits.com/lucifer/" | xpathFromHTML 'normalize-space(//b[text()="Latest Version:"]/../text())')`

Current "merlinproject" label `appNewVersion`:
`appNewVersion="$(curl -fs "https://www.projectwizards.net/de/support/release-notes"  | grep Version | head -n 6 | tail -n 1 | sed 's/[^0-9.]*//g')"`

New possible "merlinproject" label `appNewVersion` using only XPath:
`appNewVersion=$(curl -fs "https://www.projectwizards.net/de/support/release-notes" | xpathFromHTML 'translate(string(//span[starts-with(text(),"Version ")]), "Version ", "")')`
Or a more general way to remove any first word: `appNewVersion=$(curl -fs "https://www.projectwizards.net/de/support/release-notes" | xpathFromHTML 'substring-after(string(//span[starts-with(text(),"Version ")]), " ")')`

Current "jabradirect" label `appNewVersion`:
`appNewVersion=$(curl -fs https://www.jabra.com/Support/release-notes/release-note-jabra-direct | grep -oe "Release version:.*[0-9.]*<" | head -1 | cut -d ">" -f2 | cut -d "<" -f1 | sed 's/ //g')`

New possible "jabradirect" label `appNewVersion` using only XPath:
`appNewVersion=$(curl -fs https://www.jabra.com/Support/release-notes/release-note-jabra-direct | xpathFromHTML 'normalize-space(string(//strong[text()="Release version:"]/../text()))')`

While the XPath expressions can get complex, there is a lot a built-in capability that can be taken advantage of once the language is understood. In the "lucifer" example, I am using `normalize-space()` function to trim a leading space from the final `text()` value without having to pipe to `tr` or `sed` etc to get rid of that. In the second example, I'm taking advantage of the `string()` functions behavior to only return the string value of the 1st element when an array (node set) is passed to it since the `//span[starts-with(text(),"Version ")` expression alone is actually matching 55 nodes of different version listings. Then, I am using the `translate()` or `substring-after()` function to remove the "Version " portion of the output value without having to pipe to `sed` or `awk` etc to extract only the version string. And final "merlinproject" example uses the `string()` and `normalize-space()` functions for the same reasons as the prior examples. While this can be complex and confusing at first, I don't think the learning curve is much more than figuring out how to do extractions with `grep`, `awk`, `sed`, etc.

It is worth noting that using XPath makes the extraction very reliant on the current state of the page source, and could break if the page source is changed. But, as can be seen by how the current "lucifer" label is broken because of page source changes, I don't think that limitation is any different that using `grep`, `awk`, `sed`, etc. Label parsing/extracting from HTML done in any way are always going to be prone to breakage when page source changes.

Of course, I don't think using `xpathFromHTML` should be a requirement, but does this seem like something that would be a desirable direction for current and future Installomator labels to be encouraged to go in?