### PR TITLE
Add "isAppleSilicon" and "isIntel" functions for use in labels, etc

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -34,6 +34,14 @@ cleanupAndExit() { # $1 = exit code, $2 message, $3 level
     exit "$1"
 }
 
+isAppleSilicon() {
+    [[ "$(sysctl -in hw.optional.arm64)" == '1' ]]
+}
+
+isIntel() {
+    ! isAppleSilicon
+}
+
 runAsUser() {
     if [[ $currentUser != "loginwindow" ]]; then
         uid=$(id -u "$currentUser")


### PR DESCRIPTION
I've noticed the `arch` command is used throughout Installomator to check if running on Apple Silicon.

While this works in general, it is not a guaranteed check since it would output "i386" when running on Apple Silicon if the parent process is running under Rosetta (which shouldn't normally happen, but still).

One of the guaranteed and reliable checks to determine if running on Apple Silicon is the to use `sysctl -in hw.optional.arm64` which will output "1" on Apple Silicon (even if the parent process is running under Rosetta) and output nothing on Intel. So, this check can be done in a new `isAppleSilicon` function for convenience for label writers to not need to worry about doing the actual condition properly.

I think also adding an `isIntel` function may be handy in some scenarios, but I think it just be a NOT Apple Silicon check is reliable and effective enough rather than explicitly checking for an Intel processor or something. Or, an `isIntel` function could be left out since it's never really necessary to explicity check for Intel in a `elif` condition like is often done in labels currently, and if for some reason its needed folks could just do `if ! isAppleSilicon; then` without needing a separate function for it. But, it may be best to have an `isIntel` function anyway for clarity.

At least, I think an `isAppleSilicon` function would be nice for use in labels to make the code more consistent and simple for folks to do things the best way without having to worry about what actual condition is being used. And if the condition ever needs to change in the future, it would be simple to update the code in that single function rather than in every label.

Currently I see a lot of labels doing one of the following:
```
if [[ "$(arch)" == "arm64" ]]; then
    ...
else
    ...
fi
```

```
if [[ $(arch) == "arm64" ]]; then
    ...
elif [[ $(arch) == "i386" ]]; then
    ...
fi
```

```
case $(arch) in
    "arm64")
        ...
        ;;
    "i386")
        ...
        ;;
esac
```

I think all of these could be replaced with one of these two conditions:
```
if isAppleSilicon; then
    ...
else
    ...
fi
```

```
if isAppleSilicon; then
    ...
elif isIntel; then
    ...
fi
```

If it were up to me I would just do the former without the explicit `isIntel` check, but the latter may be desirable for clarity.

Making this change across all existing labels would currently require 75 updated labels, but it wouldn't be that hard if it would be alright to just do a single mass PR without having to test each change since I'm sure it can be done with no mistakes by just auditing the code changes thoroughly by a few sets of eyes.

If this idea is accepted, it would also require updates in https://github.com/Installomator/Installomator/blob/main/utils/checkLabels.sh since that makes a list labels that contain `arch` conditions for extra testing, but it would be simple for that to also check for the `isAppleSilicon` and `isIntel` functions being used.

**EDIT: I see the `checkLabels.sh` function does already override `arch` to be able to test both architecture downloads on any Mac, which is great! So this final paragraph can be disregarded since it's not a benefit and it just the same it currently is.** 
_Another benefit of this function is that it could be overridden for testing to be able to easily test either the Intel or Apple Silicon download options without having to actually be testing on an Intel or Apple Silicon Mac directly. Although, Intel downloads could currently be tested on an Apple Silicon Mac by running the test under Rosetta since `arch` would output "i386" under Rosetta, but it's not currently possible to test Apple Silicon downloads on Intel, and being able to override a function is likely simpler and more future-proof than playing tricks with Rosetta._