### PR TITLE
Label update lansweeper agent options for server and agentkey can be used at the same time

### DIFF
--- a/fragments/labels/lsagent.sh
+++ b/fragments/labels/lsagent.sh
@@ -48,13 +48,14 @@ lsagent)
     if [[ -z $lsagentServer && -z $lsagentKey ]]; then
         cleanupAndExit 89 "This label requires more parameters: lsagentServer OR lsagentCloudKey, and maybe also lsagentPort, lsagentMode, and lsagentLanguage\nSee /Volumes/LsAgent/LsAgent-osx.app/Contents/MacOS/installbuilder.sh --help" ERROR
     fi
-    #CLIArguments=(--server $lsagentServer --port $lsagentPort --agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
-    if [[ -n $lsagentServer && -n $lsagentKey ]]; then
-        CLIArguments=(--server $lsagentServer --port $lsagentPort --agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
+    CLIArguments=( --mode $lsagentMode --installer-language $lsagentLanguage )
+
     if [[ -n $lsagentServer ]]; then
-        CLIArguments=(--server $lsagentServer --port $lsagentPort --mode $lsagentMode --installer-language $lsagentLanguage)
-    elif [[ -n $lsagentKey ]]; then
-        CLIArguments=(--agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
+        CLIArguments+=( --server $lsagentServer --port $lsagentPort )
+    fi
+
+    if [[ -n $lsagentKey ]]; then
+        CLIArguments+=( --agentkey $lsagentKey )
     fi
     expectedTeamID="65LX6K7CBA"
     ;;

--- a/fragments/labels/lsagent.sh
+++ b/fragments/labels/lsagent.sh
@@ -49,9 +49,11 @@ lsagent)
         cleanupAndExit 89 "This label requires more parameters: lsagentServer OR lsagentCloudKey, and maybe also lsagentPort, lsagentMode, and lsagentLanguage\nSee /Volumes/LsAgent/LsAgent-osx.app/Contents/MacOS/installbuilder.sh --help" ERROR
     fi
     #CLIArguments=(--server $lsagentServer --port $lsagentPort --agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
+    if [[ -n $lsagentServer && -n $lsagentKey ]]; then
+        CLIArguments=(--server $lsagentServer --port $lsagentPort --agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
     if [[ -n $lsagentServer ]]; then
         CLIArguments=(--server $lsagentServer --port $lsagentPort --mode $lsagentMode --installer-language $lsagentLanguage)
-    else
+    elif [[ -n $lsagentKey ]]; then
         CLIArguments=(--agentkey $lsagentKey --mode $lsagentMode --installer-language $lsagentLanguage)
     fi
     expectedTeamID="65LX6K7CBA"

--- a/fragments/labels/lsagent.sh
+++ b/fragments/labels/lsagent.sh
@@ -3,34 +3,33 @@ lsagent)
     #Description: Lansweeper is an IT Asset Management solution. This label installs the latest version. 
     #Download: https://www.lansweeper.com/download/lsagent/
     #Icon: https://www.lansweeper.com/wp-content/uploads/2018/08/LsAgent-Scanning-Agent.png
-    # Not tested with "agentkey", but expecting server and port to be not needed if used.
-#Usage:
-#  --help                                      Display the list of valid options
-#  --version                                   Display product information
-#  --unattendedmodeui <unattendedmodeui>       Unattended Mode UI
-#                                              Default: none
-#                                              Allowed: none minimal minimalWithDialogs
-#  --optionfile <optionfile>                   Installation option file
-#                                              Default: 
-#  --debuglevel <debuglevel>                   Debug information level of verbosity
-#                                              Default: 2
-#                                              Allowed: 0 1 2 3 4
-#  --mode <mode>                               Installation mode
-#                                              Default: osx
-#                                              Allowed: osx text unattended
-#  --debugtrace <debugtrace>                   Debug filename
-#                                              Default: 
-#  --installer-language <installer-language>   Language selection
-#                                              Default: en
-#                                              Allowed: sq ar es_AR az eu pt_BR bg ca hr cs da nl en et fi fr de el he hu id it ja kk ko lv lt no fa pl pt ro ru sr zh_CN sk sl es sv th zh_TW tr tk uk va vi cy
-#  --prefix <prefix>                           Installation Directory
-#                                              Default: /Applications/LansweeperAgent
-#  --server <server>                           FQDN, NetBios or IP of the Scanning Server
-#                                              Default: 
-#  --port <port>                               Listening Port on the Scanning Server
-#                                              Default: 9524
-#  --agentkey <agentkey>                       Cloud Relay Authentication Key (Optional)
-#                                              Default: 
+    #Usage:
+    #  --help                                      Display the list of valid options
+    #  --version                                   Display product information
+    #  --unattendedmodeui <unattendedmodeui>       Unattended Mode UI
+    #                                              Default: none
+    #                                              Allowed: none minimal minimalWithDialogs
+    #  --optionfile <optionfile>                   Installation option file
+    #                                              Default: 
+    #  --debuglevel <debuglevel>                   Debug information level of verbosity
+    #                                              Default: 2
+    #                                              Allowed: 0 1 2 3 4
+    #  --mode <mode>                               Installation mode
+    #                                              Default: osx
+    #                                              Allowed: osx text unattended
+    #  --debugtrace <debugtrace>                   Debug filename
+    #                                              Default: 
+    #  --installer-language <installer-language>   Language selection
+    #                                              Default: en
+    #                                              Allowed: sq ar es_AR az eu pt_BR bg ca hr cs da nl en et fi fr de el he hu id it ja kk ko lv lt no fa pl pt ro ru sr zh_CN sk sl es sv th zh_TW tr tk uk va vi cy
+    #  --prefix <prefix>                           Installation Directory
+    #                                              Default: /Applications/LansweeperAgent
+    #  --server <server>                           FQDN, NetBios or IP of the Scanning Server
+    #                                              Default: 
+    #  --port <port>                               Listening Port on the Scanning Server
+    #                                              Default: 9524
+    #  --agentkey <agentkey>                       Cloud Relay Authentication Key (Optional)
+    #                                              Default: 
     type="dmg"
     downloadURL="https://content.lansweeper.com/lsagent-mac/"
     appNewVersion="$(curl -fsIL "$downloadURL" | grep -i "location" | cut -w -f2 | cut -d "/" -f5-6 | tr "/" ".")"
@@ -49,11 +48,9 @@ lsagent)
         cleanupAndExit 89 "This label requires more parameters: lsagentServer OR lsagentCloudKey, and maybe also lsagentPort, lsagentMode, and lsagentLanguage\nSee /Volumes/LsAgent/LsAgent-osx.app/Contents/MacOS/installbuilder.sh --help" ERROR
     fi
     CLIArguments=( --mode $lsagentMode --installer-language $lsagentLanguage )
-
     if [[ -n $lsagentServer ]]; then
         CLIArguments+=( --server $lsagentServer --port $lsagentPort )
     fi
-
     if [[ -n $lsagentKey ]]; then
         CLIArguments+=( --agentkey $lsagentKey )
     fi


### PR DESCRIPTION
Lansweeper agent options for server and agentkey can be used at the same time, and cleaned up some of the formatting.

Also thanks @PicoMitchell (sorry referenced the wrong Pico in the actual commit), for cleaning up the building of CLIArguments. Using brackets to define a string like that is still new to me, so I had initially followed the format of the original label.