### PR TITLE
Create label for panopto

### DIFF
--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -1,0 +1,11 @@
+panopto)
+    name="Panopto"
+    type="pkg"
+    if [[ -z $panoptoServer ]]; then
+        cleanupAndExit 89 "This label requires more parameters: panoptoServer=hostname, this will ensure the downloaded version is both current and supports your server." ERROR
+    fi
+    downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
+    # while there is version information in the URL, it rarely directly matches the client that gets downloaded.
+    # need to create a service account createAccount -username panopto_upload -realname panopto_upload -home /var/panopto -shell /sbin/nologin -hiddenUser
+    expectedTeamID="G7FR783UED"
+    ;;

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -12,7 +12,7 @@ panopto)
         dscl . create /Users/panopto_upload dsAttrTypeNative:IsHidden 1
     fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
-    packageID="com.panopto.mac"
+    # not setting packageID as the version will never match (i.e. 13.0.0.12345), while appNewVersion matches CFBundleShortVersionString (i.e. 13.0.0)
     appNewVersion=$(curl -s "$downloadURL" | grep "Object moved to" | sed -e 's/.*Version\=\mac\%2f\(.*\)\&amp\;server.*/\1/')
     expectedTeamID="G7FR783UED"
     ;;

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -12,6 +12,7 @@ panopto)
         dscl . create /Users/panopto_upload dsAttrTypeNative:IsHidden 1
     fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
-    # While there is version information in the URL, it rarely directly matches the client that gets downloaded (major version only).
+    packageID="com.panopto.mac"
+    appNewVersion=$(curl -s "$downloadURL" | grep "Object moved to" | sed -e 's/.*Version\=\mac\%2f\(.*\)\&amp\;server.*/\1/')
     expectedTeamID="G7FR783UED"
     ;;

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -4,31 +4,6 @@ panopto)
     if [ -z $panoptoServer ]; then
         cleanupAndExit 89 "This label requires more parameters: panoptoServer=host.name.panopto.com, this will ensure the downloaded version is both current and supports your server." ERROR
     fi
-    # The installer pkg will try to create this account and fail when it attempts to update the
-    #   NFSHomeDirectory and home settings (or it triggers a request for permission from the user).
-    # However, the installer pkg will detect if the account has already been created, and use it,
-    #   so manually creating it stops the installer from bothering the user or failing.
-    # The following is based on what the package does, but should handle it better.
-    panoptoUser="/Users/panopto_upload" # Including /Users/ path
-    if [ "$(dscl . read $panoptoUser 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]; then
-        for ((panoptoUID = 401; panoptoUID < 500; panoptoUID++)); do
-            if [ "$(dscl . -search /Users UniqueID $panoptoUID | wc -l)" -eq 0 ]; then
-                break  
-            fi
-        done 
-        dscl . -create $panoptoUser UniqueID $panoptoUID
-        dscl . -append $panoptoUser AuthenticationAuthority ';DisabledTags;SecureToken'
-        dscl . -create $panoptoUser PrimaryGroupID 1
-        dscl . -create $panoptoUser NFSHomeDirectory /private/var/panopto
-        dscl . -create $panoptoUser UserShell /sbin/nologin
-        dscl . -passwd $panoptoUser this_password_is_disabled
-        dscl . -create $panoptoUser dsAttrTypeNative:IsHidden 1
-    # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
-    #   the account already exists. Installomator may still require Full Disk Access, but should
-    #   inherit that permission from the calling process, which doesn't happen for mk_hidden_user.sh.
-    # mk_hidden_user.sh will fail (or request permission) if the NFSHomeDirectory setting is missing,
-    #   because it will attempt to remove the account first.
-    fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
     # not setting packageID as the version will never match (i.e. 13.0.0.12345), while appNewVersion matches CFBundleShortVersionString (i.e. 13.0.0)
     appNewVersion=$(curl -s "$downloadURL" | grep "Object moved to" | sed -e 's/.*Version\=\mac\%2f\(.*\)\&amp\;server.*/\1/')

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -11,20 +11,19 @@ panopto)
     # However, the installer pkg will detect if the account has already been created, and use it,
     #   so manually creating it stops the installer from bothering the user or failing.
     # The following is based on what the package does, but should handle it better.
-    panoptoUser="panopto_upload"
-    panoptoPath="/Users/$panoptoUser"
-    if [ "$(dscl . read $panoptoPath 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]; then
+    panoptoUser="/Users/panopto_upload" # Including /Users/ path
+    if [ "$(dscl . read $panoptoUser 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]; then
         for ((panoptoUID = 401; panoptoUID < 500; panoptoUID++)); do
             if [ "$(dscl . -search /Users UniqueID $panoptoUID | wc -l)" -eq 0 ]; then
                 break  
             fi
         done 
-        dscl . -create $panoptoPath UniqueID $panoptoUID
-        dscl . -append $panoptoPath PrimaryGroupID 1
-        dscl . -append $panoptoPath NFSHomeDirectory /private/var/panopto
-        dscl . -append $panoptoPath UserShell /sbin/nologin
-        dscl . -passwd $panoptoPath this_password_is_disabled
-        dscl . -append $panoptoPath dsAttrTypeNative:IsHidden 1
+        dscl . -create $panoptoUser UniqueID $panoptoUID
+        dscl . -append $panoptoUser PrimaryGroupID 1
+        dscl . -append $panoptoUser NFSHomeDirectory /private/var/panopto
+        dscl . -append $panoptoUser UserShell /sbin/nologin
+        dscl . -passwd $panoptoUser this_password_is_disabled
+        dscl . -append $panoptoUser dsAttrTypeNative:IsHidden 1
     # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
     #   the account already exists. Installomator may still require Full Disk Access, but should
     #   inherit that permission from the calling process, which doesn't happen for mk_hidden_user.sh.

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -1,15 +1,33 @@
 panopto)
     name="Panopto"
     type="pkg"
-    if [[ -z $panoptoServer ]]; then
+    if [ "$(who | grep console | cut -d ' ' -f 1)" = "_mbsetupuser" ] || [ -z "$(fdesetup list)" ]; then
+        cleanupAndExit 89 "This label cannot be installed when there are no user attached Secure Tokens, such as during a DEP/ASM/ABM enrolment into an MDM, as the package requires adding an account that could in-advertantly steal the first Token." ERROR
+    elif [ -z $panoptoServer ]; then
         cleanupAndExit 89 "This label requires more parameters: panoptoServer=host.name.panopto.com, this will ensure the downloaded version is both current and supports your server." ERROR
-    elif [[ "$(dscl . read /Users/panopto_upload 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]]; then
-    # The installer pkg will try to create this account without permission and fail, or ask the user to create it.
+    fi
+    # The installer pkg will try to create this account and fail when it attempts to update the
+    #   NFSHomeDirectory (or it triggers a request for permission from the user).
     # However, the installer pkg will detect if the account has already been created, and use it,
-    #    so manually creating it stops the installer from bothering the user or failing.
-        sysadminctl -addUser panopto_upload -fullName panopto_upload -home /private/var/panopto -shell /sbin/nologin
-        sleep 1
-        dscl . create /Users/panopto_upload dsAttrTypeNative:IsHidden 1
+    #   so manually creating it stops the installer from bothering the user or failing.
+    # The following is based on what the package does, but should handle it with the permission required.
+    panoptoUser="panopto_upload"
+    panoptoPath="/Users/$panoptoUser"
+    if [ "$(dscl . -read $panoptoPath NFSHomeDirectory 2>&1 | grep -c "No such key")" -gt 0 ]; then
+        sysadminctl -deleteUser $panoptoUser
+    fi
+    if [ "$(dscl . read $panoptoPath 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]; then
+        for ((new_uid = 401; new_uid < 500; new_uid++)); do
+            if [ "$(dscl . -search /Users UniqueID $new_uid | wc -l)" -eq 0 ]; then
+                break  
+            fi
+        done
+        sysadminctl -addUser $panoptoUser -fullName $panoptoUser -home /private/var/panopto -shell /sbin/nologin -UID $new_uid -GID 1
+        dscl . create $panoptoPath this_password_is_disabled
+        dscl . create $panoptoPath dsAttrTypeNative:IsHidden 1
+    # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
+    #   the account already exists. Installomator may still require Full Disk Access, but should
+    #   inherit that permission from the calling process, which doesn't happen for mk_hidden_user.sh.
     fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
     # not setting packageID as the version will never match (i.e. 13.0.0.12345), while appNewVersion matches CFBundleShortVersionString (i.e. 13.0.0)

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -20,10 +20,10 @@ panopto)
             fi
         done 
         dscl . -create $panoptoPath UniqueID $panoptoUID
-        dscl . -append /Users/$username PrimaryGroupID 1
-        dscl . -append /Users/$username NFSHomeDirectory /private/var/panopto
-        dscl . -append /Users/$username UserShell /sbin/nologin
-        dscl . -passwd /Users/$username this_password_is_disabled
+        dscl . -append $panoptoPath PrimaryGroupID 1
+        dscl . -append $panoptoPath NFSHomeDirectory /private/var/panopto
+        dscl . -append $panoptoPath UserShell /sbin/nologin
+        dscl . -passwd $panoptoPath this_password_is_disabled
         dscl . -append $panoptoPath dsAttrTypeNative:IsHidden 1
     # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
     #   the account already exists. Installomator may still require Full Disk Access, but should

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -19,11 +19,11 @@ panopto)
             fi
         done 
         dscl . -create $panoptoUser UniqueID $panoptoUID
-        dscl . -append $panoptoUser PrimaryGroupID 1
-        dscl . -append $panoptoUser NFSHomeDirectory /private/var/panopto
-        dscl . -append $panoptoUser UserShell /sbin/nologin
+        dscl . -create $panoptoUser PrimaryGroupID 1
+        dscl . -create $panoptoUser NFSHomeDirectory /private/var/panopto
+        dscl . -create $panoptoUser UserShell /sbin/nologin
         dscl . -passwd $panoptoUser this_password_is_disabled
-        dscl . -append $panoptoUser dsAttrTypeNative:IsHidden 1
+        dscl . -create $panoptoUser dsAttrTypeNative:IsHidden 1
     # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
     #   the account already exists. Installomator may still require Full Disk Access, but should
     #   inherit that permission from the calling process, which doesn't happen for mk_hidden_user.sh.

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -2,10 +2,16 @@ panopto)
     name="Panopto"
     type="pkg"
     if [[ -z $panoptoServer ]]; then
-        cleanupAndExit 89 "This label requires more parameters: panoptoServer=hostname, this will ensure the downloaded version is both current and supports your server." ERROR
+        cleanupAndExit 89 "This label requires more parameters: panoptoServer=host.name.panopto.com, this will ensure the downloaded version is both current and supports your server." ERROR
+    elif [[ "$(dscl . read /Users/panopto_upload 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]]; then
+    # The installer pkg will try to create this account without permission and fail, or ask the user to create it.
+    # However, the installer pkg will detect if the account has already been created, and use it,
+    #    so manually creating it stops the installer from bothering the user or failing.
+        sysadminctl -addUser panopto_upload -fullName panopto_upload -home /private/var/panopto -shell /sbin/nologin
+        sleep 1
+        dscl . create /Users/panopto_upload dsAttrTypeNative:IsHidden 1
     fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
-    # while there is version information in the URL, it rarely directly matches the client that gets downloaded.
-    # need to create a service account createAccount -username panopto_upload -realname panopto_upload -home /var/panopto -shell /sbin/nologin -hiddenUser
+    # While there is version information in the URL, it rarely directly matches the client that gets downloaded (major version only).
     expectedTeamID="G7FR783UED"
     ;;

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -1,9 +1,7 @@
 panopto)
     name="Panopto"
     type="pkg"
-    if [ "$(who | grep console | cut -d ' ' -f 1)" = "_mbsetupuser" ] || [ -z "$(fdesetup list)" ]; then
-        cleanupAndExit 89 "This label cannot be installed when there are no user attached Secure Tokens, such as during a DEP/ASM/ABM enrolment into an MDM, as the package requires adding an account that could in-advertantly steal the first Token." ERROR
-    elif [ -z $panoptoServer ]; then
+    if [ -z $panoptoServer ]; then
         cleanupAndExit 89 "This label requires more parameters: panoptoServer=host.name.panopto.com, this will ensure the downloaded version is both current and supports your server." ERROR
     fi
     # The installer pkg will try to create this account and fail when it attempts to update the
@@ -19,6 +17,7 @@ panopto)
             fi
         done 
         dscl . -create $panoptoUser UniqueID $panoptoUID
+        dscl . -append $panoptoUser AuthenticationAuthority ';DisabledTags;SecureToken'
         dscl . -create $panoptoUser PrimaryGroupID 1
         dscl . -create $panoptoUser NFSHomeDirectory /private/var/panopto
         dscl . -create $panoptoUser UserShell /sbin/nologin

--- a/fragments/labels/panopto.sh
+++ b/fragments/labels/panopto.sh
@@ -7,27 +7,29 @@ panopto)
         cleanupAndExit 89 "This label requires more parameters: panoptoServer=host.name.panopto.com, this will ensure the downloaded version is both current and supports your server." ERROR
     fi
     # The installer pkg will try to create this account and fail when it attempts to update the
-    #   NFSHomeDirectory (or it triggers a request for permission from the user).
+    #   NFSHomeDirectory and home settings (or it triggers a request for permission from the user).
     # However, the installer pkg will detect if the account has already been created, and use it,
     #   so manually creating it stops the installer from bothering the user or failing.
-    # The following is based on what the package does, but should handle it with the permission required.
+    # The following is based on what the package does, but should handle it better.
     panoptoUser="panopto_upload"
     panoptoPath="/Users/$panoptoUser"
-    if [ "$(dscl . -read $panoptoPath NFSHomeDirectory 2>&1 | grep -c "No such key")" -gt 0 ]; then
-        sysadminctl -deleteUser $panoptoUser
-    fi
     if [ "$(dscl . read $panoptoPath 2>&1 | grep -c eDSRecordNotFound)" -gt 0 ]; then
-        for ((new_uid = 401; new_uid < 500; new_uid++)); do
-            if [ "$(dscl . -search /Users UniqueID $new_uid | wc -l)" -eq 0 ]; then
+        for ((panoptoUID = 401; panoptoUID < 500; panoptoUID++)); do
+            if [ "$(dscl . -search /Users UniqueID $panoptoUID | wc -l)" -eq 0 ]; then
                 break  
             fi
-        done
-        sysadminctl -addUser $panoptoUser -fullName $panoptoUser -home /private/var/panopto -shell /sbin/nologin -UID $new_uid -GID 1
-        dscl . create $panoptoPath this_password_is_disabled
-        dscl . create $panoptoPath dsAttrTypeNative:IsHidden 1
+        done 
+        dscl . -create $panoptoPath UniqueID $panoptoUID
+        dscl . -append /Users/$username PrimaryGroupID 1
+        dscl . -append /Users/$username NFSHomeDirectory /private/var/panopto
+        dscl . -append /Users/$username UserShell /sbin/nologin
+        dscl . -passwd /Users/$username this_password_is_disabled
+        dscl . -append $panoptoPath dsAttrTypeNative:IsHidden 1
     # The package does do more, however the above covers what is skipped by mk_hidden_user.sh when
     #   the account already exists. Installomator may still require Full Disk Access, but should
     #   inherit that permission from the calling process, which doesn't happen for mk_hidden_user.sh.
+    # mk_hidden_user.sh will fail (or request permission) if the NFSHomeDirectory setting is missing,
+    #   because it will attempt to remove the account first.
     fi
     downloadURL="http://$panoptoServer/$(curl -Ls http://$panoptoServer/ | grep cacheRoot | cut -d "'" -f 2 | awk -F '\\' '{ printf  $4 $5 $6 }' | awk -F 'x2f' '{ printf $2 "/" $3 "/" $4 }')/Software/Panopto%20Recorder.pkg?arch=None&useCustomBinary=True"
     # not setting packageID as the version will never match (i.e. 13.0.0.12345), while appNewVersion matches CFBundleShortVersionString (i.e. 13.0.0)


### PR DESCRIPTION
Panopto works best with a client that appropriately matches the server version, hence the requirement for the server address.

The initial download URL will show the server version, but it actually re-directs to another link with the clients CFBundleShortVersionString.