### PR TITLE
Update adobeacrobatprodc

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -261,11 +261,8 @@ getAppVersion() {
 #            targetDir="/Applications/Utilities"
 #        fi
     else
-    #    applist=$(mdfind "kind:application $appName" -0 )
-        printlog "name: $name, appName: $appName"
-        applist=$(mdfind "kind:application AND name:$name" -0 )
-#        printlog "App(s) found: ${applist}" DEBUG
-#        applist=$(mdfind "kind:application AND name:$appName" -0 )
+        applist=$(mdfind -onlyin /Applications/ "kMDItemKind == 'Application' && kMDItemFSName == '$appName'" -0 )
+        printlog "App(s) found: ${applist}" DEBUG
     fi
     if [[ -z $applist ]]; then
         printlog "No previous app found" WARN
@@ -633,7 +630,7 @@ installFromPKG() {
         baseArchiveName=$(basename $archiveName)
         expandedPkg="$tmpDir/${baseArchiveName}_pkg"
         pkgutil --expand "$archiveName" "$expandedPkg"
-        appNewVersion=$(cat "$expandedPkg"/Distribution | xpath 'string(//installer-gui-script/pkg-ref[@id][@version]/@version)' 2>/dev/null )
+        appNewVersion=$(cat "$expandedPkg"/Distribution | xpath "string(//installer-gui-script//pkg-ref[@id='$packageID'][@version]/@version)" 2>/dev/null )
         rm -r "$expandedPkg"
         printlog "Downloaded package $packageID version $appNewVersion"
         if [[ $appversion == $appNewVersion ]]; then

--- a/fragments/labels/adobeacrobatprodc.sh
+++ b/fragments/labels/adobeacrobatprodc.sh
@@ -1,7 +1,9 @@
 adobeacrobatprodc)
     name="Adobe Acrobat Pro DC"
+    appName="Acrobat Distiller.app"
     type="pkgInDmg"
     pkgName="Acrobat/Acrobat DC Installer.pkg"
+    packageID="com.adobe.acrobat.DC.viewer.app.pkg.MUI"
     downloadURL="https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg"
     expectedTeamID="JQ525L2MZD"
     blockingProcesses=( "Acrobat Pro DC" )


### PR DESCRIPTION
Update for the Adobe Acrobat package.

The Adobe application is stored in a sub-directory in /Applications. Without the mdfind patch an installed Acrobat application is never detected.

The xpath patch is required to identify the new version number in the Distribution file of the downloaded packages to be installed.

Without both patches to functions.sh version detection will not work for the Adobe Acrobat package and the package will be reinstalled on every run.


Install:
```
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : setting variable from argument DEBUG=0
2023-03-02 08:57:32 : REQ   : adobeacrobatprodc : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : ################## Version: 10.4beta
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : ################## Date: 2023-03-02
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : ################## adobeacrobatprodc
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : SwiftDialog is not installed, clear cmd file var
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : NOTIFY=success
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : LOGGING=INFO
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : Label type: pkgInDmg
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : archiveName: Adobe Acrobat Pro DC.dmg
2023-03-02 08:57:32 : INFO  : adobeacrobatprodc : No version found using packageID com.adobe.acrobat.DC.viewer.app.pkg.MUI
2023-03-02 08:57:33 : WARN  : adobeacrobatprodc : No previous app found
2023-03-02 08:57:33 : WARN  : adobeacrobatprodc : could not find Acrobat Distiller.app
2023-03-02 08:57:33 : INFO  : adobeacrobatprodc : appversion: 
2023-03-02 08:57:33 : INFO  : adobeacrobatprodc : Latest version not specified.
2023-03-02 08:57:33 : REQ   : adobeacrobatprodc : Downloading https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg to Adobe Acrobat Pro DC.dmg
2023-03-02 08:57:57 : REQ   : adobeacrobatprodc : no more blocking processes, continue with update
2023-03-02 08:57:57 : REQ   : adobeacrobatprodc : Installing Adobe Acrobat Pro DC
2023-03-02 08:57:57 : INFO  : adobeacrobatprodc : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gaz1Gtfj/Adobe Acrobat Pro DC.dmg
2023-03-02 08:57:58 : INFO  : adobeacrobatprodc : Mounted: /Volumes/Acrobat 1
2023-03-02 08:57:58 : INFO  : adobeacrobatprodc : found pkg: /Volumes/Acrobat 1/Acrobat/Acrobat DC Installer.pkg
2023-03-02 08:57:58 : INFO  : adobeacrobatprodc : Verifying: /Volumes/Acrobat 1/Acrobat/Acrobat DC Installer.pkg
2023-03-02 08:57:58 : INFO  : adobeacrobatprodc : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2023-03-02 08:57:58 : INFO  : adobeacrobatprodc : Installing /Volumes/Acrobat 1/Acrobat/Acrobat DC Installer.pkg to /
2023-03-02 08:58:42 : INFO  : adobeacrobatprodc : Finishing...
2023-03-02 08:58:45 : INFO  : adobeacrobatprodc : found packageID com.adobe.acrobat.DC.viewer.app.pkg.MUI installed, version 22.003.20310
2023-03-02 08:58:45 : REQ   : adobeacrobatprodc : Installed Adobe Acrobat Pro DC, version 22.003.20310
2023-03-02 08:58:45 : INFO  : adobeacrobatprodc : notifying
2023-03-02 08:58:46 : INFO  : adobeacrobatprodc : App not closed, so no reopen.
2023-03-02 08:58:46 : REQ   : adobeacrobatprodc : All done!
2023-03-02 08:58:46 : REQ   : adobeacrobatprodc : ################## End Installomator, exit code 0 
```


Update:
```
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : setting variable from argument DEBUG=0
2023-03-02 08:54:56 : REQ   : adobeacrobatprodc : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : ################## Version: 10.4beta
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : ################## Date: 2023-03-02
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : ################## adobeacrobatprodc
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : SwiftDialog is not installed, clear cmd file var
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : NOTIFY=success
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : LOGGING=INFO
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : Label type: pkgInDmg
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : archiveName: Adobe Acrobat Pro DC.dmg
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : found packageID com.adobe.acrobat.DC.viewer.app.pkg.MUI installed, version 22.003.20310
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : appversion: 22.003.20310
2023-03-02 08:54:56 : INFO  : adobeacrobatprodc : Latest version not specified.
2023-03-02 08:54:56 : REQ   : adobeacrobatprodc : Downloading https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg to Adobe Acrobat Pro DC.dmg
2023-03-02 08:55:20 : REQ   : adobeacrobatprodc : no more blocking processes, continue with update
2023-03-02 08:55:20 : REQ   : adobeacrobatprodc : Installing Adobe Acrobat Pro DC
2023-03-02 08:55:20 : INFO  : adobeacrobatprodc : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QyzS5Vg1/Adobe Acrobat Pro DC.dmg
2023-03-02 08:55:22 : INFO  : adobeacrobatprodc : Mounted: /Volumes/Acrobat 1
2023-03-02 08:55:22 : INFO  : adobeacrobatprodc : found pkg: /Volumes/Acrobat 1/Acrobat/Acrobat DC Installer.pkg
2023-03-02 08:55:22 : INFO  : adobeacrobatprodc : Verifying: /Volumes/Acrobat 1/Acrobat/Acrobat DC Installer.pkg
2023-03-02 08:55:22 : INFO  : adobeacrobatprodc : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2023-03-02 08:55:22 : INFO  : adobeacrobatprodc : Checking package version.
2023-03-02 08:55:24 : INFO  : adobeacrobatprodc : Downloaded package com.adobe.acrobat.DC.viewer.app.pkg.MUI version 22.003.20310
2023-03-02 08:55:24 : INFO  : adobeacrobatprodc : Downloaded version of Adobe Acrobat Pro DC is the same as installed.
2023-03-02 08:55:24 : INFO  : adobeacrobatprodc : App not closed, so no reopen.
2023-03-02 08:55:24 : REQ   : adobeacrobatprodc : No new version to install
2023-03-02 08:55:24 : REQ   : adobeacrobatprodc : ################## End Installomator, exit code 0
```