### PR TITLE
add brosix label

### DIFF
--- a/fragments/labels/brosix.sh
+++ b/fragments/labels/brosix.sh
@@ -1,0 +1,7 @@
+brosix)
+    name="Brosix"
+    type="pkg"
+    downloadURL="https://www.brosix.com/downloads/builds/official/Brosix.pkg"
+    appNewVersion=""
+    expectedTeamID="TA6P23NW8H"
+    ;;


### PR DESCRIPTION
 ~/Documents/Dev/Installomator/build   label-brosix  sudo ./Installomator.sh brosix DEBUG=0
2023-03-02 11:58:14 : INFO  : brosix : setting variable from argument DEBUG=0
2023-03-02 11:58:14 : REQ   : brosix : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 11:58:14 : INFO  : brosix : ################## Version: 10.4beta
2023-03-02 11:58:14 : INFO  : brosix : ################## Date: 2023-03-02
2023-03-02 11:58:14 : INFO  : brosix : ################## brosix
2023-03-02 11:58:14 : INFO  : brosix : SwiftDialog is not installed, clear cmd file var
2023-03-02 11:58:14 : INFO  : brosix : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 11:58:14 : INFO  : brosix : NOTIFY=success
2023-03-02 11:58:14 : INFO  : brosix : LOGGING=INFO
2023-03-02 11:58:14 : INFO  : brosix : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 11:58:14 : INFO  : brosix : Label type: pkg
2023-03-02 11:58:14 : INFO  : brosix : archiveName: Brosix.pkg
2023-03-02 11:58:14 : INFO  : brosix : no blocking processes defined, using Brosix as default
2023-03-02 11:58:14 : INFO  : brosix : name: Brosix, appName: Brosix.app
2023-03-02 11:58:14.713 mdfind[59954:5074292] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-03-02 11:58:14.714 mdfind[59954:5074292] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-03-02 11:58:14.835 mdfind[59954:5074292] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-02 11:58:14 : WARN  : brosix : No previous app found
2023-03-02 11:58:14 : WARN  : brosix : could not find Brosix.app
2023-03-02 11:58:14 : INFO  : brosix : appversion:
2023-03-02 11:58:14 : INFO  : brosix : Latest version not specified.
2023-03-02 11:58:14 : REQ   : brosix : Downloading https://www.brosix.com/downloads/builds/official/Brosix.pkg to Brosix.pkg
2023-03-02 11:58:18 : REQ   : brosix : no more blocking processes, continue with update
2023-03-02 11:58:18 : REQ   : brosix : Installing Brosix
2023-03-02 11:58:18 : INFO  : brosix : Verifying: Brosix.pkg
2023-03-02 11:58:18 : INFO  : brosix : Team ID: TA6P23NW8H (expected: TA6P23NW8H )
2023-03-02 11:58:18 : INFO  : brosix : Installing Brosix.pkg to /
2023-03-02 11:58:53 : INFO  : brosix : Finishing...
2023-03-02 11:58:56 : INFO  : brosix : App(s) found: /Applications/Brosix.app
2023-03-02 11:58:56 : INFO  : brosix : found app at /Applications/Brosix.app, version 4.7.3, on versionKey CFBundleShortVersionString
2023-03-02 11:58:56 : REQ   : brosix : Installed Brosix, version 4.7.3
2023-03-02 11:58:56 : INFO  : brosix : notifying
2023-03-02 11:58:57 : INFO  : brosix : App not closed, so no reopen.
2023-03-02 11:58:57 : REQ   : brosix : All done!
2023-03-02 11:58:57 : REQ   : brosix : ################## End Installomator, exit code 0