### PR TITLE
Add label CrashplanSMB 

### DIFF
--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -3,6 +3,7 @@ crashplansmb)
     type="pkgInDmg"
     pkgName="Install Crashplan.pkg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"
+    appNewVersion=$( curl https://download.crashplan.com/installs/agent/latest-smb-mac.dmg  -s -L -I -o /dev/null -w '%{url_effective}' | cut -d "/" -f7 )
     expectedTeamID="UGHXR79U6M"
     blockingProcesses=( NONE )
     ;;

--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -1,0 +1,7 @@
+crashplansmb)
+    name="Crashplan"
+    type="pkgInDmg"
+    pkgName="Install Crashplan for SMall Business.pkg"
+    downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"
+    expectedTeamID="9YV9435DHD"
+    ;;

--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -1,7 +1,7 @@
 crashplansmb)
     name="Code42"
     type="pkgInDmg"
-    pkgName="Install Crashplan for SMall Business.pkg"
+    pkgName="Install Crashplan for Small Business.pkg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"
     expectedTeamID="9YV9435DHD"
     ;;

--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -1,5 +1,5 @@
 crashplansmb)
-    name="Crashplan"
+    name="Code42"
     type="pkgInDmg"
     pkgName="Install Crashplan for SMall Business.pkg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"

--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -1,7 +1,8 @@
 crashplansmb)
-    name="Code42"
+    name="CrashPlan"
     type="pkgInDmg"
-    pkgName="Install Crashplan for Small Business.pkg"
+    pkgName="Install Crashplan.pkg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"
-    expectedTeamID="9YV9435DHD"
+    expectedTeamID="UGHXR79U6M"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
 ~/Documents/Dev/Installomator/build   label-crashplan  sudo ./Installomator.sh crashplansmb DEBUG=0
2023-03-02 11:53:50 : INFO  : crashplansmb : setting variable from argument DEBUG=0
2023-03-02 11:53:50 : REQ   : crashplansmb : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 11:53:50 : INFO  : crashplansmb : ################## Version: 10.4beta
2023-03-02 11:53:50 : INFO  : crashplansmb : ################## Date: 2023-03-02
2023-03-02 11:53:50 : INFO  : crashplansmb : ################## crashplansmb
2023-03-02 11:53:50 : INFO  : crashplansmb : SwiftDialog is not installed, clear cmd file var
2023-03-02 11:53:50 : INFO  : crashplansmb : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 11:53:50 : INFO  : crashplansmb : NOTIFY=success
2023-03-02 11:53:50 : INFO  : crashplansmb : LOGGING=INFO
2023-03-02 11:53:50 : INFO  : crashplansmb : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 11:53:50 : INFO  : crashplansmb : Label type: pkgInDmg
2023-03-02 11:53:50 : INFO  : crashplansmb : archiveName: Code42.dmg
2023-03-02 11:53:50 : INFO  : crashplansmb : no blocking processes defined, using Code42 as default
2023-03-02 11:53:50 : INFO  : crashplansmb : name: Code42, appName: Code42.app
2023-03-02 11:53:50.711 mdfind[54972:5058620] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-03-02 11:53:50.711 mdfind[54972:5058620] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-03-02 11:53:50.830 mdfind[54972:5058620] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-02 11:53:50 : WARN  : crashplansmb : No previous app found
2023-03-02 11:53:50 : WARN  : crashplansmb : could not find Code42.app
2023-03-02 11:53:50 : INFO  : crashplansmb : appversion:
2023-03-02 11:53:50 : INFO  : crashplansmb : Latest version not specified.
2023-03-02 11:53:50 : REQ   : crashplansmb : Downloading https://download.crashplan.com/installs/agent/latest-smb-mac.dmg to Code42.dmg
2023-03-02 11:53:57 : REQ   : crashplansmb : no more blocking processes, continue with update
2023-03-02 11:53:57 : REQ   : crashplansmb : Installing Code42
2023-03-02 11:53:57 : INFO  : crashplansmb : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PRfE5S9k/Code42.dmg
2023-03-02 11:54:00 : INFO  : crashplansmb : Mounted: /Volumes/CrashPlanSmb 1
2023-03-02 11:54:00 : INFO  : crashplansmb : found pkg: /Volumes/CrashPlanSmb 1/Install Crashplan for SMall Business.pkg
2023-03-02 11:54:00 : INFO  : crashplansmb : Verifying: /Volumes/CrashPlanSmb 1/Install Crashplan for SMall Business.pkg
2023-03-02 11:54:00 : INFO  : crashplansmb : Team ID: 9YV9435DHD (expected: 9YV9435DHD )
2023-03-02 11:54:00 : INFO  : crashplansmb : Installing /Volumes/CrashPlanSmb 1/Install Crashplan for SMall Business.pkg to /
2023-03-02 11:54:32 : INFO  : crashplansmb : Finishing...
2023-03-02 11:54:35 : INFO  : crashplansmb : App(s) found: /Applications/Code42.app
2023-03-02 11:54:36 : INFO  : crashplansmb : found app at /Applications/Code42.app, version 10.4.1, on versionKey CFBundleShortVersionString
2023-03-02 11:54:36 : REQ   : crashplansmb : Installed Code42, version 10.4.1
2023-03-02 11:54:36 : INFO  : crashplansmb : notifying
2023-03-02 11:54:37 : INFO  : crashplansmb : App not closed, so no reopen.
2023-03-02 11:54:37 : REQ   : crashplansmb : All done!
2023-03-02 11:54:37 : REQ   : crashplansmb : ################## End Installomator, exit code 0