### PR TITLE
add hubstaff label

### DIFF
--- a/fragments/labels/hubstaff.sh
+++ b/fragments/labels/hubstaff.sh
@@ -1,0 +1,7 @@
+hubstaff)
+    name="Hubstaff"
+    type="dmg"
+    downloadURL="https://app.hubstaff.com/download/osx"
+    appNewVersion=""
+    expectedTeamID="24BCJT3JW2"
+    ;;


### PR DESCRIPTION
 ✘  ~/Documents/Dev/Installomator/build   label-hubstaff  sudo ./Installomator.sh hubstaff DEBUG=0
2023-03-02 12:06:28 : INFO  : hubstaff : setting variable from argument DEBUG=0
2023-03-02 12:06:28 : REQ   : hubstaff : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 12:06:28 : INFO  : hubstaff : ################## Version: 10.4beta
2023-03-02 12:06:28 : INFO  : hubstaff : ################## Date: 2023-03-02
2023-03-02 12:06:28 : INFO  : hubstaff : ################## hubstaff
2023-03-02 12:06:28 : INFO  : hubstaff : SwiftDialog is not installed, clear cmd file var
2023-03-02 12:06:28 : INFO  : hubstaff : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 12:06:28 : INFO  : hubstaff : NOTIFY=success
2023-03-02 12:06:28 : INFO  : hubstaff : LOGGING=INFO
2023-03-02 12:06:28 : INFO  : hubstaff : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 12:06:28 : INFO  : hubstaff : Label type: dmg
2023-03-02 12:06:28 : INFO  : hubstaff : archiveName: Hubstaff.dmg
2023-03-02 12:06:28 : INFO  : hubstaff : no blocking processes defined, using Hubstaff as default
2023-03-02 12:06:28 : INFO  : hubstaff : name: Hubstaff, appName: Hubstaff.app
2023-03-02 12:06:28.971 mdfind[62148:5089771] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-03-02 12:06:28.971 mdfind[62148:5089771] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-03-02 12:06:29.082 mdfind[62148:5089771] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-02 12:06:29 : WARN  : hubstaff : No previous app found
2023-03-02 12:06:29 : WARN  : hubstaff : could not find Hubstaff.app
2023-03-02 12:06:29 : INFO  : hubstaff : appversion:
2023-03-02 12:06:29 : INFO  : hubstaff : Latest version not specified.
2023-03-02 12:06:29 : REQ   : hubstaff : Downloading https://app.hubstaff.com/download/osx to Hubstaff.dmg
2023-03-02 12:06:30 : REQ   : hubstaff : no more blocking processes, continue with update
2023-03-02 12:06:30 : REQ   : hubstaff : Installing Hubstaff
2023-03-02 12:06:30 : INFO  : hubstaff : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dru51Dxr/Hubstaff.dmg
2023-03-02 12:06:33 : INFO  : hubstaff : Mounted: /Volumes/Hubstaff-1.6.12-da9418f3
2023-03-02 12:06:33 : INFO  : hubstaff : Verifying: /Volumes/Hubstaff-1.6.12-da9418f3/Hubstaff.app
2023-03-02 12:06:34 : INFO  : hubstaff : Team ID matching: 24BCJT3JW2 (expected: 24BCJT3JW2 )
2023-03-02 12:06:34 : INFO  : hubstaff : Installing Hubstaff version 1.6.12-da9418f3 on versionKey CFBundleShortVersionString.
2023-03-02 12:06:34 : INFO  : hubstaff : App has LSMinimumSystemVersion: 10.9
2023-03-02 12:06:34 : INFO  : hubstaff : Copy /Volumes/Hubstaff-1.6.12-da9418f3/Hubstaff.app to /Applications
2023-03-02 12:06:36 : WARN  : hubstaff : Changing owner to jakenichols
2023-03-02 12:06:36 : INFO  : hubstaff : Finishing...
2023-03-02 12:06:39 : INFO  : hubstaff : App(s) found: /Applications/Hubstaff.app
2023-03-02 12:06:39 : INFO  : hubstaff : found app at /Applications/Hubstaff.app, version 1.6.12-da9418f3, on versionKey CFBundleShortVersionString
2023-03-02 12:06:39 : REQ   : hubstaff : Installed Hubstaff, version 1.6.12-da9418f3
2023-03-02 12:06:39 : INFO  : hubstaff : notifying
2023-03-02 12:06:40 : INFO  : hubstaff : App not closed, so no reopen.
2023-03-02 12:06:40 : REQ   : hubstaff : All done!
2023-03-02 12:06:40 : REQ   : hubstaff : ################## End Installomator, exit code 0