### PR TITLE
add label zipwhip

### DIFF
--- a/fragments/labels/zipwhip.sh
+++ b/fragments/labels/zipwhip.sh
@@ -1,0 +1,7 @@
+zipwhip)
+    name="Zipwhip"
+    type="dmg"
+    downloadURL="https://s3-us-west-2.amazonaws.com/zw-app-upload/mac/master/Zipwhip-latest.dmg"
+    appNewVersion=""
+    expectedTeamID="96NL5642U7"
+    ;;


### PR DESCRIPTION
 ~/Documents/Dev/Installomator/build   label-zipwhip  sudo ./Installomator.sh zipwhip DEBUG=0
2023-03-02 12:59:23 : INFO  : zipwhip : setting variable from argument DEBUG=0
2023-03-02 12:59:23 : REQ   : zipwhip : ################## Start Installomator v. 10.4beta, date 2023-03-02
2023-03-02 12:59:23 : INFO  : zipwhip : ################## Version: 10.4beta
2023-03-02 12:59:23 : INFO  : zipwhip : ################## Date: 2023-03-02
2023-03-02 12:59:23 : INFO  : zipwhip : ################## zipwhip
2023-03-02 12:59:23 : INFO  : zipwhip : SwiftDialog is not installed, clear cmd file var
2023-03-02 12:59:23 : INFO  : zipwhip : BLOCKING_PROCESS_ACTION=tell_user
2023-03-02 12:59:23 : INFO  : zipwhip : NOTIFY=success
2023-03-02 12:59:23 : INFO  : zipwhip : LOGGING=INFO
2023-03-02 12:59:23 : INFO  : zipwhip : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-02 12:59:23 : INFO  : zipwhip : Label type: dmg
2023-03-02 12:59:23 : INFO  : zipwhip : archiveName: Zipwhip.dmg
2023-03-02 12:59:23 : INFO  : zipwhip : no blocking processes defined, using Zipwhip as default
2023-03-02 12:59:24 : INFO  : zipwhip : name: Zipwhip, appName: Zipwhip.app
2023-03-02 12:59:24.063 mdfind[70836:5163931] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-03-02 12:59:24.064 mdfind[70836:5163931] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-03-02 12:59:24.190 mdfind[70836:5163931] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-02 12:59:24 : WARN  : zipwhip : No previous app found
2023-03-02 12:59:24 : WARN  : zipwhip : could not find Zipwhip.app
2023-03-02 12:59:24 : INFO  : zipwhip : appversion:
2023-03-02 12:59:24 : INFO  : zipwhip : Latest version not specified.
2023-03-02 12:59:24 : REQ   : zipwhip : Downloading https://s3-us-west-2.amazonaws.com/zw-app-upload/mac/master/Zipwhip-latest.dmg to Zipwhip.dmg
2023-03-02 12:59:28 : REQ   : zipwhip : no more blocking processes, continue with update
2023-03-02 12:59:28 : REQ   : zipwhip : Installing Zipwhip
2023-03-02 12:59:28 : INFO  : zipwhip : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nqTCbfbL/Zipwhip.dmg
2023-03-02 12:59:32 : INFO  : zipwhip : Mounted: /Volumes/Zipwhip
2023-03-02 12:59:32 : INFO  : zipwhip : Verifying: /Volumes/Zipwhip/Zipwhip.app
2023-03-02 12:59:36 : INFO  : zipwhip : Team ID matching: 96NL5642U7 (expected: 96NL5642U7 )
2023-03-02 12:59:36 : INFO  : zipwhip : Installing Zipwhip version 3.15.1 on versionKey CFBundleShortVersionString.
2023-03-02 12:59:36 : INFO  : zipwhip : App has LSMinimumSystemVersion: 10.11.0
2023-03-02 12:59:36 : INFO  : zipwhip : Copy /Volumes/Zipwhip/Zipwhip.app to /Applications
2023-03-02 12:59:38 : WARN  : zipwhip : Changing owner to jakenichols
2023-03-02 12:59:38 : INFO  : zipwhip : Finishing...
2023-03-02 12:59:41 : INFO  : zipwhip : App(s) found: /Applications/Zipwhip.app
2023-03-02 12:59:41 : INFO  : zipwhip : found app at /Applications/Zipwhip.app, version 3.15.1, on versionKey CFBundleShortVersionString
2023-03-02 12:59:41 : REQ   : zipwhip : Installed Zipwhip, version 3.15.1
2023-03-02 12:59:41 : INFO  : zipwhip : notifying
2023-03-02 12:59:42 : INFO  : zipwhip : App not closed, so no reopen.
2023-03-02 12:59:42 : REQ   : zipwhip : All done!
2023-03-02 12:59:42 : REQ   : zipwhip : ################## End Installomator, exit code 0