### PR TITLE
New label: JetBrains Gateway

### DIFF
--- a/fragments/labels/jetbrainsgateway.sh
+++ b/fragments/labels/jetbrainsgateway.sh
@@ -1,0 +1,13 @@
+jetbrainsgateway)
+    name="JetBrains Gateway"
+    type="dmg"
+    jetbrainscode="GW"
+    if [[ $(arch) == i386 ]]; then
+        jetbrainsdistribution="mac"
+    elif [[ $(arch) == arm64 ]]; then
+        jetbrainsdistribution="macM1"
+    fi
+    downloadURL="https://download.jetbrains.com/product?code=${jetbrainscode}&latest&distribution=${jetbrainsdistribution}"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "location" | tail -1 | sed -E 's/.*\/[a-zA-Z-]*-([0-9.]*).*[-.].*dmg/\1/g' )
+    expectedTeamID="2ZEFAR8TH3"
+    ;;


### PR DESCRIPTION


```
2023-03-03 10:53:31 : REQ   : jetbrainsgateway : ################## Start Installomator v. 10.4beta, date 2023-03-03
2023-03-03 10:53:32 : INFO  : jetbrainsgateway : ################## Version: 10.4beta
2023-03-03 10:53:32 : INFO  : jetbrainsgateway : ################## Date: 2023-03-03
2023-03-03 10:53:32 : INFO  : jetbrainsgateway : ################## jetbrainsgateway
2023-03-03 10:53:32 : DEBUG : jetbrainsgateway : DEBUG mode 1 enabled.
2023-03-03 10:53:34 : DEBUG : jetbrainsgateway : name=JetBrains Gateway
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : appName=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : type=dmg
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : archiveName=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : downloadURL=https://download.jetbrains.com/product?code=GW&latest&distribution=mac
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : curlOptions=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : appNewVersion=223.8617.56
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : appCustomVersion function: Not defined
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : versionKey=CFBundleShortVersionString
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : packageID=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : pkgName=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : choiceChangesXML=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : expectedTeamID=2ZEFAR8TH3
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : blockingProcesses=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : installerTool=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : CLIInstaller=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : CLIArguments=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : updateTool=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : updateToolArguments=
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : updateToolRunAsCurrentUser=
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : BLOCKING_PROCESS_ACTION=tell_user
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : NOTIFY=success
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : LOGGING=DEBUG
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : Label type: dmg
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : archiveName: JetBrains Gateway.dmg
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : no blocking processes defined, using JetBrains Gateway as default
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : name: JetBrains Gateway, appName: JetBrains Gateway.app
2023-03-03 10:53:35.545 mdfind[4071:41584] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-03-03 10:53:35.692 mdfind[4071:41584] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-03 10:53:35 : WARN  : jetbrainsgateway : No previous app found
2023-03-03 10:53:35 : WARN  : jetbrainsgateway : could not find JetBrains Gateway.app
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : appversion: 
2023-03-03 10:53:35 : INFO  : jetbrainsgateway : Latest version of JetBrains Gateway is 223.8617.56
2023-03-03 10:53:35 : REQ   : jetbrainsgateway : Downloading https://download.jetbrains.com/product?code=GW&latest&distribution=mac to JetBrains Gateway.dmg
2023-03-03 10:53:35 : DEBUG : jetbrainsgateway : No Dialog connection, just download
2023-03-03 10:53:56 : DEBUG : jetbrainsgateway : File list: -rw-r--r--  2 asri  staff   228M Mar  3 10:53 JetBrains Gateway.dmg
2023-03-03 10:53:56 : DEBUG : jetbrainsgateway : File type: JetBrains Gateway.dmg: lzfse encoded, lzvn compressed
2023-03-03 10:53:56 : DEBUG : jetbrainsgateway : curl output was:
*   Trying 54.77.126.11:443...
* Connected to download.jetbrains.com (54.77.126.11) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4960 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.jetbrains.com
*  start date: Feb 10 00:00:00 2023 GMT
*  expire date: Jul 14 23:59:59 2023 GMT
*  subjectAltName: host "download.jetbrains.com" matched cert's "download.jetbrains.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /product?code=GW&latest&distribution=mac]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.jetbrains.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fcd6a010600)
> GET /product?code=GW&latest&distribution=mac HTTP/2
> Host: download.jetbrains.com
> user-agent: curl/7.86.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 302 
< date: Fri, 03 Mar 2023 02:53:37 GMT
< content-length: 0
< location: https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.8617.56.dmg
< server: nginx
< access-control-allow-origin: *
< strict-transport-security: max-age=31536000; includeSubdomains;
< x-frame-options: DENY
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block;
< x-geocountry: Singapore
< x-geocode: SG
< 
{ [0 bytes data]
* Connection #0 to host download.jetbrains.com left intact
* Issue another request to this URL: 'https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.8617.56.dmg'
* Found bundle for host: 0x7fcd69813770 [can multiplex]
* Re-using existing connection #0 with host download.jetbrains.com
* Connected to download.jetbrains.com (54.77.126.11) port 443 (#0)
* h2h3 [:method: GET]
* h2h3 [:path: /idea/gateway/JetBrainsGateway-223.8617.56.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.jetbrains.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 3 (easy handle 0x7fcd6a010600)
> GET /idea/gateway/JetBrainsGateway-223.8617.56.dmg HTTP/2
> Host: download.jetbrains.com
> user-agent: curl/7.86.0
> accept: */*
> 
< HTTP/2 302 
< date: Fri, 03 Mar 2023 02:53:37 GMT
< content-type: text/html
< content-length: 138
< location: https://download-cdn.jetbrains.com/idea/gateway/JetBrainsGateway-223.8617.56.dmg
< server: nginx
< strict-transport-security: max-age=31536000; includeSubdomains;
< x-frame-options: DENY
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block;
< x-geocountry: Singapore
< x-geocode: SG
< 
* Ignoring the response-body
{ [138 bytes data]
* Connection #0 to host download.jetbrains.com left intact
* Issue another request to this URL: 'https://download-cdn.jetbrains.com/idea/gateway/JetBrainsGateway-223.8617.56.dmg'
*   Trying 18.66.171.5:443...
* Connected to download-cdn.jetbrains.com (18.66.171.5) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5003 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download-cdn.jetbrains.com
*  start date: Feb 23 00:00:00 2023 GMT
*  expire date: May 10 23:59:59 2023 GMT
*  subjectAltName: host "download-cdn.jetbrains.com" matched cert's "download-cdn.jetbrains.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /idea/gateway/JetBrainsGateway-223.8617.56.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download-cdn.jetbrains.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fcd6a010600)
> GET /idea/gateway/JetBrainsGateway-223.8617.56.dmg HTTP/2
> Host: download-cdn.jetbrains.com
> user-agent: curl/7.86.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200 
< content-type: binary/octet-stream
< content-length: 238855620
< date: Fri, 03 Mar 2023 02:53:39 GMT
< x-amz-replication-status: COMPLETED
< last-modified: Fri, 27 Jan 2023 08:26:04 GMT
< etag: "6135bef398dc76c43cd484aaa63ed4a5-29"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: ZGo13ddpLUjSpzK_IZmYxJ4e9MMJKY3G
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 6c764dc941201b2dee59f4fdf4cd1602.cloudfront.net (CloudFront)
< x-amz-cf-pop: DUB56-P1
< x-amz-cf-id: 90oX1SnoDFMGJtDtZD2NK6cfMk2wWgCR3GlQ2h1Q-mbapfuUEpCUJA==
< 
{ [7581 bytes data]
* Connection #1 to host download-cdn.jetbrains.com left intact

2023-03-03 10:53:56 : DEBUG : jetbrainsgateway : DEBUG mode 1, not checking for blocking processes
2023-03-03 10:53:56 : REQ   : jetbrainsgateway : Installing JetBrains Gateway
2023-03-03 10:53:56 : INFO  : jetbrainsgateway : Mounting /Users/asri/Documents/dev/Installomator/build/JetBrains Gateway.dmg
2023-03-03 10:54:00 : DEBUG : jetbrainsgateway : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $735830F7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $7D9092F9
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $63D16FBA
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $2C83125C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $63D16FBA
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $D6E43588
verified CRC32 $EE39FE40
/dev/disk2              GUID_partition_scheme
/dev/disk2s1            Apple_HFS                       /Volumes/JetBrains Gateway

2023-03-03 10:54:00 : INFO  : jetbrainsgateway : Mounted: /Volumes/JetBrains Gateway
2023-03-03 10:54:00 : INFO  : jetbrainsgateway : Verifying: /Volumes/JetBrains Gateway/JetBrains Gateway.app
2023-03-03 10:54:00 : DEBUG : jetbrainsgateway : App size: 837M /Volumes/JetBrains Gateway/JetBrains Gateway.app
2023-03-03 10:54:07 : DEBUG : jetbrainsgateway : Debugging enabled, App Verification output was:
/Volumes/JetBrains Gateway/JetBrains Gateway.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: JetBrains s.r.o. (2ZEFAR8TH3)

2023-03-03 10:54:07 : INFO  : jetbrainsgateway : Team ID matching: 2ZEFAR8TH3 (expected: 2ZEFAR8TH3 )
2023-03-03 10:54:08 : INFO  : jetbrainsgateway : Installing JetBrains Gateway version 2022.3.2 on versionKey CFBundleShortVersionString.
2023-03-03 10:54:08 : INFO  : jetbrainsgateway : App has LSMinimumSystemVersion: 10.8
2023-03-03 10:54:08 : DEBUG : jetbrainsgateway : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-03-03 10:54:08 : INFO  : jetbrainsgateway : Finishing...
2023-03-03 10:54:11 : INFO  : jetbrainsgateway : name: JetBrains Gateway, appName: JetBrains Gateway.app
2023-03-03 10:54:11.839 mdfind[4193:42418] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-03-03 10:54:11.965 mdfind[4193:42418] Couldn't determine the mapping between prefab keywords and predicates.
2023-03-03 10:54:12 : WARN  : jetbrainsgateway : No previous app found
2023-03-03 10:54:12 : WARN  : jetbrainsgateway : could not find JetBrains Gateway.app
2023-03-03 10:54:12 : REQ   : jetbrainsgateway : Installed JetBrains Gateway
2023-03-03 10:54:12 : INFO  : jetbrainsgateway : notifying
2023-03-03 10:54:12 : DEBUG : jetbrainsgateway : Unmounting /Volumes/JetBrains Gateway
2023-03-03 10:54:12 : DEBUG : jetbrainsgateway : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-03-03 10:54:12 : DEBUG : jetbrainsgateway : DEBUG mode 1, not reopening anything
2023-03-03 10:54:12 : REQ   : jetbrainsgateway : All done!
2023-03-03 10:54:12 : REQ   : jetbrainsgateway : ################## End Installomator, exit code 0 
```