### PR TITLE
Dymoconnectdesktop label

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2784,7 +2784,8 @@ dymoconnectdesktop)
     appNewVersion=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | awk -F/ '{print $NF}' | sed 's/DCDMac\([0-9\.]*\)\.pkg/\1.pkg/' | cut -d"." -f1-4 | sort -rV | head -n 1)
     expectedTeamID="N3S6676K3E"
     blockingProcesses="DYMO Connect"
-    ;;dynalist)
+    ;;
+dynalist)
     name="Dynalist"
     type="dmg"
     downloadURL="https://dynalist.io/standalone/download?file=Dynalist.dmg"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -323,7 +323,7 @@ if [[ $(/usr/bin/arch) == "arm64" ]]; then
     fi
 fi
 VERSION="10.4beta"
-VERSIONDATE="2023-02-24"
+VERSIONDATE="2023-03-16"
 
 # MARK: Functions
 
@@ -2776,7 +2776,15 @@ duodevicehealth)
     appName="Duo Device Health.app"
     expectedTeamID="FNN8Z5JMFP"
     ;;
-dynalist)
+dymoconnectdesktop)
+    name="DYMO Connect"
+    type="pkg"
+    packageID="com.dymo.dymo-connect"
+    downloadURL=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | sort -rV | head -n 1| sort -rV | head -n 1)
+    appNewVersion=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | awk -F/ '{print $NF}' | sed 's/DCDMac\([0-9\.]*\)\.pkg/\1.pkg/' | cut -d"." -f1-4 | sort -rV | head -n 1)
+    expectedTeamID="N3S6676K3E"
+    blockingProcesses="DYMO Connect"
+    ;;dynalist)
     name="Dynalist"
     type="dmg"
     downloadURL="https://dynalist.io/standalone/download?file=Dynalist.dmg"

--- a/Labels.txt
+++ b/Labels.txt
@@ -143,7 +143,7 @@ dropbox
 druvainsync
 duckduckgo
 duodevicehealth
-dynalist
+dymoconnectdesktop
 easeusdatarecoverywizard
 easyfind
 egnyte

--- a/Labels.txt
+++ b/Labels.txt
@@ -143,6 +143,7 @@ dropbox
 druvainsync
 duckduckgo
 duodevicehealth
+dynalist
 dymoconnectdesktop
 easeusdatarecoverywizard
 easyfind

--- a/fragments/labels/dymoconnectdesktop.sh
+++ b/fragments/labels/dymoconnectdesktop.sh
@@ -1,0 +1,8 @@
+dymoconnectdesktop)
+    name="DYMO Connect"
+    type="pkg"
+    downloadURL=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | sort -rV | head -n 1| sort -rV | head -n 1)
+    appNewVersion=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | awk -F/ '{print $NF}' | sed 's/DCDMac\([0-9\.]*\)\.pkg/\1.pkg/' | cut -d"." -f1-4 | sort -rV | head -n 1)
+    expectedTeamID="N3S6676K3E"
+    blockingProcesses="DYMO Connect"
+    ;;


### PR DESCRIPTION
Added Dymo Connect label, downloadURL uses the Dymo Compatibility chart webpage (https://www.dymo.com/compatibility-chart.html ) and looks for all the pkg links and arranges the latest. App New Version looks for the same links and cuts the version number.