### PR TITLE
Update Label: Wireshark, Fixed newversion

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,7 +1,7 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    appNewVersion=$(curl -fs https://www.wireshark.org/download.html | grep -i "href.*_stable" | sed -E 's/.*\(([0-9.]*)\).*/\1/g')
+    appNewVersion=$(curl -fs https://www.wireshark.org/download.html | grep -io "<p>The current stable release of Wireshark is *[0-9.]* It supersedes all previous releases.</p>" | sed -e 's/.*The current stable release of Wireshark is \(.*\). It supersedes all previous releases.*/\1/')
     if [[ $(arch) == i386 ]]; then
       downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20$appNewVersion%20Intel%2064.dmg"
     elif [[ $(arch) == arm64 ]]; then


### PR DESCRIPTION
```
2023-03-22 13:44:10 : INFO  : wireshark : setting variable from argument DEBUG=0
2023-03-22 13:44:10 : INFO  : wireshark : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2023-03-22 13:44:10 : INFO  : wireshark : setting variable from argument INSTALL=force
2023-03-22 13:44:10 : REQ   : wireshark : ################## Start Installomator v. 10.4beta, date 2023-03-22
2023-03-22 13:44:10 : INFO  : wireshark : ################## Version: 10.4beta
2023-03-22 13:44:10 : INFO  : wireshark : ################## Date: 2023-03-22
2023-03-22 13:44:10 : INFO  : wireshark : ################## wireshark
2023-03-22 13:44:10 : INFO  : wireshark : SwiftDialog is not installed, clear cmd file var
2023-03-22 13:44:10 : INFO  : wireshark : BLOCKING_PROCESS_ACTION=kill
2023-03-22 13:44:10 : INFO  : wireshark : NOTIFY=success
2023-03-22 13:44:10 : INFO  : wireshark : LOGGING=INFO
2023-03-22 13:44:10 : INFO  : wireshark : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-22 13:44:10 : INFO  : wireshark : Label type: dmg
2023-03-22 13:44:10 : INFO  : wireshark : archiveName: Wireshark.dmg
2023-03-22 13:44:10 : INFO  : wireshark : no blocking processes defined, using Wireshark as default
2023-03-22 13:44:10 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2023-03-22 13:44:10 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 4.0.3, on versionKey CFBundleShortVersionString
2023-03-22 13:44:10 : INFO  : wireshark : appversion: 4.0.3
2023-03-22 13:44:10 : INFO  : wireshark : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-03-22 13:44:10 : INFO  : wireshark : Latest version of Wireshark is 4.0.4
2023-03-22 13:44:10 : REQ   : wireshark : Downloading https://1.as.dl.wireshark.org/osx/Wireshark%204.0.4%20Intel%2064.dmg to Wireshark.dmg
2023-03-22 13:44:24 : REQ   : wireshark : no more blocking processes, continue with update
2023-03-22 13:44:24 : REQ   : wireshark : Installing Wireshark
2023-03-22 13:44:24 : INFO  : wireshark : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1jsRMXAN/Wireshark.dmg
2023-03-22 13:44:27 : INFO  : wireshark : Mounted: /Volumes/Wireshark 4.0.4
2023-03-22 13:44:27 : INFO  : wireshark : Verifying: /Volumes/Wireshark 4.0.4/Wireshark.app
2023-03-22 13:44:36 : INFO  : wireshark : Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2023-03-22 13:44:36 : INFO  : wireshark : Downloaded version of Wireshark is 4.0.4 on versionKey CFBundleShortVersionString (replacing version 4.0.3).
2023-03-22 13:44:36 : INFO  : wireshark : App has LSMinimumSystemVersion: 10.14
2023-03-22 13:44:36 : WARN  : wireshark : Removing existing /Applications/Wireshark.app
2023-03-22 13:44:36 : INFO  : wireshark : Copy /Volumes/Wireshark 4.0.4/Wireshark.app to /Applications
2023-03-22 13:44:39 : WARN  : wireshark : Changing owner to user
2023-03-22 13:44:39 : INFO  : wireshark : Finishing...
2023-03-22 13:44:42 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2023-03-22 13:44:42 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 4.0.4, on versionKey CFBundleShortVersionString
2023-03-22 13:44:42 : REQ   : wireshark : Installed Wireshark, version 4.0.4
2023-03-22 13:44:42 : INFO  : wireshark : notifying
2023-03-22 13:44:42 : INFO  : wireshark : App not closed, so no reopen.
2023-03-22 13:44:42 : REQ   : wireshark : All done!
2023-03-22 13:44:42 : REQ   : wireshark : ################## End Installomator, exit code 0 
```