### PR TITLE
add label crashplan 

### DIFF
--- a/fragments/labels/crashplan.sh
+++ b/fragments/labels/crashplan.sh
@@ -1,0 +1,8 @@
+crashplan)
+    name="CrashPlan"
+    type="pkgInDmg"
+    pkgName="Install CrashPlan.pkg"
+    downloadURL="https://download.crashplan.com/installs/agent/latest-mac.dmg"
+    expectedTeamID="UGHXR79U6M"
+    blockingProcesses=( NONE )
+    ;;

--- a/fragments/labels/crashplan.sh
+++ b/fragments/labels/crashplan.sh
@@ -3,6 +3,7 @@ crashplan)
     type="pkgInDmg"
     pkgName="Install CrashPlan.pkg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-mac.dmg"
+    appNewVersion=$( curl https://download.crashplan.com/installs/agent/latest-mac.dmg  -s -L -I -o /dev/null -w '%{url_effective}' | cut -d "/" -f7 )
     expectedTeamID="UGHXR79U6M"
     blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
Adding crashplan label based on this comment: https://github.com/Installomator/Installomator/pull/931#issuecomment-1483063906

> ❯ sudo ./Installomator.sh crashplan DEBUG=0
> 2023-03-24 13:04:13 : INFO  : crashplan : setting variable from argument DEBUG=0
> 2023-03-24 13:04:13 : REQ   : crashplan : ################## Start Installomator v. 10.4beta, date 2023-03-24
> 2023-03-24 13:04:13 : INFO  : crashplan : ################## Version: 10.4beta
> 2023-03-24 13:04:13 : INFO  : crashplan : ################## Date: 2023-03-24
> 2023-03-24 13:04:13 : INFO  : crashplan : ################## crashplan
> 2023-03-24 13:04:13 : INFO  : crashplan : SwiftDialog is not installed, clear cmd file var
> 2023-03-24 13:04:13 : INFO  : crashplan : BLOCKING_PROCESS_ACTION=tell_user
> 2023-03-24 13:04:13 : INFO  : crashplan : NOTIFY=success
> 2023-03-24 13:04:13 : INFO  : crashplan : LOGGING=INFO
> 2023-03-24 13:04:13 : INFO  : crashplan : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
> 2023-03-24 13:04:13 : INFO  : crashplan : Label type: pkgInDmg
> 2023-03-24 13:04:13 : INFO  : crashplan : archiveName: CrashPlan.dmg
> 2023-03-24 13:04:14 : INFO  : crashplan : name: CrashPlan, appName: CrashPlan.app
> 2023-03-24 13:04:14.033 mdfind[61365:678736] [UserQueryParser] Loading keywords and predicates for locale "en_US"
> 2023-03-24 13:04:14.033 mdfind[61365:678736] [UserQueryParser] Loading keywords and predicates for locale "en"
> 2023-03-24 13:04:14.168 mdfind[61365:678736] Couldn't determine the mapping between prefab keywords and predicates.
> 2023-03-24 13:04:14 : WARN  : crashplan : No previous app found
> 2023-03-24 13:04:14 : WARN  : crashplan : could not find CrashPlan.app
> 2023-03-24 13:04:14 : INFO  : crashplan : appversion:
> 2023-03-24 13:04:14 : INFO  : crashplan : Latest version not specified.
> 2023-03-24 13:04:14 : REQ   : crashplan : Downloading https://download.crashplan.com/installs/agent/latest-mac.dmg to CrashPlan.dmg
> 2023-03-24 13:04:21 : REQ   : crashplan : Installing CrashPlan
> 2023-03-24 13:04:21 : INFO  : crashplan : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.0xQYsH1Y/CrashPlan.dmg
> 2023-03-24 13:04:23 : INFO  : crashplan : Mounted: /Volumes/CrashPlan
> 2023-03-24 13:04:23 : INFO  : crashplan : found pkg: /Volumes/CrashPlan/Install CrashPlan.pkg
> 2023-03-24 13:04:23 : INFO  : crashplan : Verifying: /Volumes/CrashPlan/Install CrashPlan.pkg
> 2023-03-24 13:04:23 : INFO  : crashplan : Team ID: UGHXR79U6M (expected: UGHXR79U6M )
> 2023-03-24 13:04:23 : INFO  : crashplan : Installing /Volumes/CrashPlan/Install CrashPlan.pkg to /
> 2023-03-24 13:04:55 : INFO  : crashplan : Finishing...
> 2023-03-24 13:04:58 : INFO  : crashplan : App(s) found: /Applications/CrashPlan.app
> 2023-03-24 13:04:58 : INFO  : crashplan : found app at /Applications/CrashPlan.app, version 11.0.1, on versionKey CFBundleShortVersionString
> 2023-03-24 13:04:58 : REQ   : crashplan : Installed CrashPlan, version 11.0.1
> 2023-03-24 13:04:58 : INFO  : crashplan : notifying
> 2023-03-24 13:04:59 : INFO  : crashplan : App not closed, so no reopen.
> 2023-03-24 13:04:59 : REQ   : crashplan : All done!
> 2023-03-24 13:04:59 : REQ   : crashplan : ################## End Installomator, exit code 0