### PR TITLE
Change appName for adobecreativeclouddesktop

### DIFF
--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -1,6 +1,6 @@
 adobecreativeclouddesktop)
     name="Adobe Creative Cloud"
-    appName="Install.app"
+    appName="Creative Cloud.app"
     type="dmg"
     if pgrep -q "Adobe Installer"; then
         printlog "Adobe Installer is running, not a good time to update." WARN


### PR DESCRIPTION
The appname of "Install.app" is forcing installs of Creative Cloud Desktop when the current version is already installed. The version checking function is getting the version of the installer, not the Creative Cloud app itself.

Tested:
```% sudo /usr/local/Installomator/Installomator.sh adobecreativeclouddesktop
2023-03-28 12:04:09 : REQ   : adobecreativeclouddesktop : ################## Start Installomator v. 10.3, date 2023-02-10
2023-03-28 12:04:09 : INFO  : adobecreativeclouddesktop : ################## Version: 10.3
2023-03-28 12:04:09 : INFO  : adobecreativeclouddesktop : ################## Date: 2023-02-10
2023-03-28 12:04:09 : INFO  : adobecreativeclouddesktop : ################## adobecreativeclouddesktop
2023-03-28 12:04:09 : INFO  : adobecreativeclouddesktop : SwiftDialog is not installed, clear cmd file var
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : BLOCKING_PROCESS_ACTION=tell_user
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : NOTIFY=success
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : LOGGING=INFO
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : Label type: dmg
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : archiveName: Adobe Creative Cloud.dmg
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : App(s) found: /Applications/Utilities/Adobe Creative Cloud/ACC//Creative Cloud.app
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : found app at /Applications/Utilities/Adobe Creative Cloud/ACC//Creative Cloud.app, version 5.9.0.373, on versionKey CFBundleShortVersionString
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : appversion: 5.9.0.373
2023-03-28 12:04:10 : INFO  : adobecreativeclouddesktop : Latest version of Adobe Creative Cloud is 5.10.0.573
2023-03-28 12:04:10 : REQ   : adobecreativeclouddesktop : Downloading https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_10_0/osx10/ACCCx5_10_0_573.dmg to Adobe Creative Cloud.dmg
```