### PR TITLE
New app name for Remote Desktop Manager Free

### DIFF
--- a/fragments/labels/remotedesktopmanagerfree.sh
+++ b/fragments/labels/remotedesktopmanagerfree.sh
@@ -1,5 +1,5 @@
 remotedesktopmanagerfree)
-    name="Remote Desktop Manager Free"
+    name="Remote Desktop Manager"
     type="dmg"
     downloadURL=$(curl -fs https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacfreebin | grep -oe "http.*\.dmg" | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')


### PR DESCRIPTION
The app name has changed for Devolutions Remote Desktop Manager Free (dropping the "Free" from the end.)

Output:
```
# ./utils/assemble.sh remotedesktopmanagerfree DEBUG=0
2023-04-04 16:04:51 : INFO  : remotedesktopmanagerfree : setting variable from argument DEBUG=0
2023-04-04 16:04:51 : REQ   : remotedesktopmanagerfree : ################## Start Installomator v. 10.4beta, date 2023-04-04
2023-04-04 16:04:51 : INFO  : remotedesktopmanagerfree : ################## Version: 10.4beta
2023-04-04 16:04:51 : INFO  : remotedesktopmanagerfree : ################## Date: 2023-04-04
2023-04-04 16:04:51 : INFO  : remotedesktopmanagerfree : ################## remotedesktopmanagerfree
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : BLOCKING_PROCESS_ACTION=tell_user
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : NOTIFY=success
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : LOGGING=INFO
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : Label type: dmg
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : archiveName: Remote Desktop Manager.dmg
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : no blocking processes defined, using Remote Desktop Manager as default
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : name: Remote Desktop Manager, appName: Remote Desktop Manager.app
2023-04-04 16:04:52.758 mdfind[33401:230094] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-04-04 16:04:52.758 mdfind[33401:230094] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-04-04 16:04:52.806 mdfind[33401:230094] Couldn't determine the mapping between prefab keywords and predicates.
2023-04-04 16:04:52 : WARN  : remotedesktopmanagerfree : No previous app found
2023-04-04 16:04:52 : WARN  : remotedesktopmanagerfree : could not find Remote Desktop Manager.app
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : appversion:
2023-04-04 16:04:52 : INFO  : remotedesktopmanagerfree : Latest version of Remote Desktop Manager is 2023.1.7.1
2023-04-04 16:04:52 : REQ   : remotedesktopmanagerfree : Downloading https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2023.1.7.1.dmg to Remote Desktop Manager.dmg
2023-04-04 16:05:02 : REQ   : remotedesktopmanagerfree : no more blocking processes, continue with update
2023-04-04 16:05:02 : REQ   : remotedesktopmanagerfree : Installing Remote Desktop Manager
2023-04-04 16:05:02 : INFO  : remotedesktopmanagerfree : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dww1oegz/Remote Desktop Manager.dmg
2023-04-04 16:05:05 : INFO  : remotedesktopmanagerfree : Mounted: /Volumes/Remote Desktop Manager.app Installer
2023-04-04 16:05:05 : INFO  : remotedesktopmanagerfree : Verifying: /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app
2023-04-04 16:05:13 : INFO  : remotedesktopmanagerfree : Team ID matching: N592S9ASDB (expected: N592S9ASDB )
2023-04-04 16:05:13 : INFO  : remotedesktopmanagerfree : Installing Remote Desktop Manager version 2023.1.7.1 on versionKey CFBundleShortVersionString.
2023-04-04 16:05:13 : INFO  : remotedesktopmanagerfree : App has LSMinimumSystemVersion: 10.15
2023-04-04 16:05:13 : INFO  : remotedesktopmanagerfree : Copy /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app to /Applications
2023-04-04 16:05:17 : WARN  : remotedesktopmanagerfree : Changing owner to schwartzm
2023-04-04 16:05:17 : INFO  : remotedesktopmanagerfree : Finishing...
2023-04-04 16:05:20 : INFO  : remotedesktopmanagerfree : App(s) found: /Applications/Remote Desktop Manager.app
2023-04-04 16:05:20 : INFO  : remotedesktopmanagerfree : found app at /Applications/Remote Desktop Manager.app, version 2023.1.7.1, on versionKey CFBundleShortVersionString
2023-04-04 16:05:20 : REQ   : remotedesktopmanagerfree : Installed Remote Desktop Manager, version 2023.1.7.1
2023-04-04 16:05:20 : INFO  : remotedesktopmanagerfree : notifying
2023-04-04 16:05:22 : INFO  : remotedesktopmanagerfree : App not closed, so no reopen.
2023-04-04 16:05:22 : REQ   : remotedesktopmanagerfree : All done!
2023-04-04 16:05:22 : REQ   : remotedesktopmanagerfree : ################## End Installomator, exit code 0
```