### PR TITLE
Remove printlog from downloadURLFromGit function

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -164,14 +164,12 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     if [ -n "$archiveName" ]; then
         downloadURL=$(curl -sfL "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
         if [[ "$(echo $downloadURL | grep -ioE "https.*$archiveName")" == "" ]]; then
-            printlog "GitHub API not returning URL, trying https://github.com/$gitusername/$gitreponame/releases/latest."
             #downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*$archiveName" | head -1)
             downloadURL="https://github.com$(curl -sfL "$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "expanded_assets" | head -1)" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*$archiveName" | head -1)"
         fi
     else
         downloadURL=$(curl -sfL "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }")
         if [[ "$(echo $downloadURL | grep -ioE "https.*.$filetype")" == "" ]]; then
-            printlog "GitHub API not returning URL, trying https://github.com/$gitusername/$gitreponame/releases/latest."
             #downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)
             downloadURL="https://github.com$(curl -sfL "$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "expanded_assets" | head -1)" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)"
         fi


### PR DESCRIPTION
The printlog function uses echo which causes unexpected output from the function "downloadURLFromGit".

Example:
In function "downloadURLFromGit", if the downloadURL cannot be read from Github API (which it can't very often because of the Github API ratelimit being set to 60 requests per 60 minutes from the same IP) the "printlog" function used will use an echo to write message to console. However this echo:d  message will also be the final output of the function "downloadURLFromGit" since the variable "$downloadURL" is not empty. When running Installomator in DEBUG mode and trying to download dockutil and the x-ratelimit-limit is reached for the IP I request from the function "downloadURLFromGit" will output the following to the variable $downloadURL: "2023-04-05 14:58:22 : INFO  : dockutil : GitHub API not returning URL, trying https://github.com/kcrawford/dockutil/releases/latest."

This can also be seen in the console DEBUG output for the $downloadURL variable: 2023-04-05 14:58:23 : DEBUG : dockutil : downloadURL=2023-04-05 14:58:22 : INFO  : dockutil : GitHub API not returning URL, trying https://github.com/kcrawford/dockutil/releases/latest.

Source:
https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting