### PR TITLE
create label - jupyterlab

### DIFF
--- a/fragments/labels/jupyterlab.sh
+++ b/fragments/labels/jupyterlab.sh
@@ -1,0 +1,14 @@
+jupyterlab)
+    name="JupyterLab"
+    type="dmg"
+    if [[ $(arch) == arm64 ]]; then
+        archiveName="JupyterLab-Setup-macOS-arm64.dmg"
+		downloadURL="$(downloadURLFromGit jupyterlab jupyterlab-desktop)"
+		appNewVersion="$(versionFromGit jupyterlab jupyterlab-desktop)"
+	elif [[ $(arch) == i386 ]]; then
+		archiveName="JupyterLab-Setup-macOS-x64.dmg"
+		downloadURL="$(downloadURLFromGit jupyterlab jupyterlab-desktop)"
+		appNewVersion="$(versionFromGit jupyterlab jupyterlab-desktop)"
+ 	fi
+    expectedTeamID="2YJ64GUAVW"
+    ;;


### PR DESCRIPTION
create label - jupyterlab

https://github.com/jupyterlab/jupyterlab-desktop

## Output >>>>

Installomator % ./assemble.sh jupyterlab
2023-04-10 14:33:02 : REQ   : jupyterlab : ################## Start Installomator v. 10.4beta, date 2023-04-10
2023-04-10 14:33:02 : INFO  : jupyterlab : ################## Version: 10.4beta
2023-04-10 14:33:02 : INFO  : jupyterlab : ################## Date: 2023-04-10
2023-04-10 14:33:02 : INFO  : jupyterlab : ################## jupyterlab
2023-04-10 14:33:02 : DEBUG : jupyterlab : DEBUG mode 1 enabled.
2023-04-10 14:33:03 : DEBUG : jupyterlab : name=JupyterLab
2023-04-10 14:33:03 : DEBUG : jupyterlab : appName=
2023-04-10 14:33:03 : DEBUG : jupyterlab : type=dmg
2023-04-10 14:33:03 : DEBUG : jupyterlab : archiveName=JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:03 : DEBUG : jupyterlab : downloadURL=https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:03 : DEBUG : jupyterlab : curlOptions=
2023-04-10 14:33:04 : DEBUG : jupyterlab : appNewVersion=3.6.21
2023-04-10 14:33:04 : DEBUG : jupyterlab : appCustomVersion function: Not defined
2023-04-10 14:33:04 : DEBUG : jupyterlab : versionKey=CFBundleShortVersionString
2023-04-10 14:33:04 : DEBUG : jupyterlab : packageID=
2023-04-10 14:33:04 : DEBUG : jupyterlab : pkgName=
2023-04-10 14:33:04 : DEBUG : jupyterlab : choiceChangesXML=
2023-04-10 14:33:04 : DEBUG : jupyterlab : expectedTeamID=2YJ64GUAVW
2023-04-10 14:33:04 : DEBUG : jupyterlab : blockingProcesses=
2023-04-10 14:33:04 : DEBUG : jupyterlab : installerTool=
2023-04-10 14:33:04 : DEBUG : jupyterlab : CLIInstaller=
2023-04-10 14:33:04 : DEBUG : jupyterlab : CLIArguments=
2023-04-10 14:33:04 : DEBUG : jupyterlab : updateTool=
2023-04-10 14:33:04 : DEBUG : jupyterlab : updateToolArguments=
2023-04-10 14:33:04 : DEBUG : jupyterlab : updateToolRunAsCurrentUser=
2023-04-10 14:33:04 : INFO  : jupyterlab : BLOCKING_PROCESS_ACTION=tell_user
2023-04-10 14:33:04 : INFO  : jupyterlab : NOTIFY=success
2023-04-10 14:33:04 : INFO  : jupyterlab : LOGGING=DEBUG
2023-04-10 14:33:04 : INFO  : jupyterlab : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-10 14:33:04 : INFO  : jupyterlab : Label type: dmg
2023-04-10 14:33:04 : INFO  : jupyterlab : archiveName: JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:04 : INFO  : jupyterlab : no blocking processes defined, using JupyterLab as default
2023-04-10 14:33:04 : DEBUG : jupyterlab : Changing directory to /Users/gknackstedt/GitHub/Installomator/build
2023-04-10 14:33:04 : INFO  : jupyterlab : App(s) found: /Applications/JupyterLab.app
2023-04-10 14:33:05 : INFO  : jupyterlab : found app at /Applications/JupyterLab.app, version 3.6.2-1, on versionKey CFBundleShortVersionString
2023-04-10 14:33:05 : INFO  : jupyterlab : appversion: 3.6.2-1
2023-04-10 14:33:05 : INFO  : jupyterlab : Latest version of JupyterLab is 3.6.21
2023-04-10 14:33:05 : REQ   : jupyterlab : Downloading https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-macOS-arm64.dmg to JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:05 : DEBUG : jupyterlab : No Dialog connection, just download
2023-04-10 14:33:10 : DEBUG : jupyterlab : File list: -rw-r--r--  1 gknackstedt  staff   317M Apr 10 14:33 JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:10 : DEBUG : jupyterlab : File type: JupyterLab-Setup-macOS-arm64.dmg: zlib compressed data
2023-04-10 14:33:10 : DEBUG : jupyterlab : curl output was:
*   Trying 140.82.113.3:443...
* Connected to github.com (140.82.113.3) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-macOS-arm64.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x131813400)
> GET /jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-macOS-arm64.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.87.0
> accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Mon, 10 Apr 2023 18:33:05 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/90307576/767f8fc8-8873-40f2-904d-87ec3b4c8753?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230410%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230410T183305Z&X-Amz-Expires=300&X-Amz-Signature=a4627a2225e6a67e044685a04dd188ba0d09954b635f789fc6e69d5820ba747c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=90307576&response-content-disposition=attachment%3B%20filename%3DJupyterLab-Setup-macOS-arm64.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com online.visualstudio.com/api/v1/locations github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: 1EE0:1AB6:822E7:C484D:64345661 <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/90307576/767f8fc8-8873-40f2-904d-87ec3b4c8753?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230410%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230410T183305Z&X-Amz-Expires=300&X-Amz-Signature=a4627a2225e6a67e044685a04dd188ba0d09954b635f789fc6e69d5820ba747c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=90307576&response-content-disposition=attachment%3B%20filename%3DJupyterLab-Setup-macOS-arm64.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/90307576/767f8fc8-8873-40f2-904d-87ec3b4c8753?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230410%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230410T183305Z&X-Amz-Expires=300&X-Amz-Signature=a4627a2225e6a67e044685a04dd188ba0d09954b635f789fc6e69d5820ba747c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=90307576&response-content-disposition=attachment%3B%20filename%3DJupyterLab-Setup-macOS-arm64.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x131813400)
> GET /github-production-release-asset-2e65be/90307576/767f8fc8-8873-40f2-904d-87ec3b4c8753?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230410%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230410T183305Z&X-Amz-Expires=300&X-Amz-Signature=a4627a2225e6a67e044685a04dd188ba0d09954b635f789fc6e69d5820ba747c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=90307576&response-content-disposition=attachment%3B%20filename%3DJupyterLab-Setup-macOS-arm64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.87.0
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: YI8bAaKTkREtuVkaGV6rWw==
< last-modified: Thu, 23 Mar 2023 04:45:12 GMT
< etag: "0x8DB2B5963783F45"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 186435ee-801e-0058-7ada-6bfa3a000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Thu, 23 Mar 2023 04:45:12 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=JupyterLab-Setup-macOS-arm64.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Mon, 10 Apr 2023 18:33:05 GMT
< x-served-by: cache-iad-kcgs7200162-IAD, cache-cmh1290049-CMH < x-cache: MISS, MISS
< x-cache-hits: 0, 0
< x-timer: S1681151586.803426,VS0,VE90
< content-length: 332888337
<
{ [1349 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-04-10 14:33:10 : DEBUG : jupyterlab : DEBUG mode 1, not checking for blocking processes
2023-04-10 14:33:10 : REQ   : jupyterlab : Installing JupyterLab
2023-04-10 14:33:10 : INFO  : jupyterlab : Mounting /Users/gknackstedt/GitHub/Installomator/build/JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:33:14 : DEBUG : jupyterlab : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D524C3F0
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $98FBE0C7
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $55AA8606
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $B1674C15
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $55AA8606
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $122E7695
verified   CRC32 $11C4DA7E
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/JupyterLab 3.6.2-1-arm64

2023-04-10 14:33:14 : INFO  : jupyterlab : Mounted: /Volumes/JupyterLab 3.6.2-1-arm64 2023-04-10 14:33:14 : INFO  : jupyterlab : Verifying: /Volumes/JupyterLab 3.6.2-1-arm64/JupyterLab.app 2023-04-10 14:33:14 : DEBUG : jupyterlab : App size: 571M	/Volumes/JupyterLab 3.6.2-1-arm64/JupyterLab.app 2023-04-10 14:33:16 : DEBUG : jupyterlab : Debugging enabled, App Verification output was: /Volumes/JupyterLab 3.6.2-1-arm64/JupyterLab.app: accepted source=Notarized Developer ID
origin=Developer ID Application: NumFOCUS, Inc. (2YJ64GUAVW)

2023-04-10 14:33:16 : INFO  : jupyterlab : Team ID matching: 2YJ64GUAVW (expected: 2YJ64GUAVW ) 2023-04-10 14:33:17 : INFO  : jupyterlab : Downloaded version of JupyterLab is 3.6.2-1 on versionKey CFBundleShortVersionString, same as installed. 2023-04-10 14:33:17 : DEBUG : jupyterlab : Unmounting /Volumes/JupyterLab 3.6.2-1-arm64 2023-04-10 14:33:17 : DEBUG : jupyterlab : Debugging enabled, Unmounting output was: "disk4" ejected.
2023-04-10 14:33:17 : DEBUG : jupyterlab : DEBUG mode 1, not reopening anything
2023-04-10 14:33:17 : REG   : jupyterlab : No new version to install
2023-04-10 14:33:17 : REQ   : jupyterlab : ################## End Installomator, exit code 0

## Output from DEBUG=0 >>>>>

 sudo ./assemble.sh jupyterlab DEBUG=0
Password:
2023-04-10 14:45:27 : INFO  : jupyterlab : setting variable from argument DEBUG=0
2023-04-10 14:45:27 : REQ   : jupyterlab : ################## Start Installomator v. 10.4beta, date 2023-04-10
2023-04-10 14:45:28 : INFO  : jupyterlab : ################## Version: 10.4beta
2023-04-10 14:45:28 : INFO  : jupyterlab : ################## Date: 2023-04-10
2023-04-10 14:45:28 : INFO  : jupyterlab : ################## jupyterlab
2023-04-10 14:45:29 : INFO  : jupyterlab : BLOCKING_PROCESS_ACTION=tell_user
2023-04-10 14:45:29 : INFO  : jupyterlab : NOTIFY=success
2023-04-10 14:45:29 : INFO  : jupyterlab : LOGGING=INFO
2023-04-10 14:45:29 : INFO  : jupyterlab : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-10 14:45:29 : INFO  : jupyterlab : Label type: dmg
2023-04-10 14:45:29 : INFO  : jupyterlab : archiveName: JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:45:29 : INFO  : jupyterlab : no blocking processes defined, using JupyterLab as default
2023-04-10 14:45:29 : INFO  : jupyterlab : App(s) found: /Applications/JupyterLab.app
2023-04-10 14:45:29 : INFO  : jupyterlab : found app at /Applications/JupyterLab.app, version 3.6.2-1, on versionKey CFBundleShortVersionString
2023-04-10 14:45:29 : INFO  : jupyterlab : appversion: 3.6.2-1
2023-04-10 14:45:29 : INFO  : jupyterlab : Latest version of JupyterLab is 3.6.21
2023-04-10 14:45:29 : REQ   : jupyterlab : Downloading https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.6.2-1/JupyterLab-Setup-macOS-arm64.dmg to JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:45:35 : REQ   : jupyterlab : no more blocking processes, continue with update
2023-04-10 14:45:35 : REQ   : jupyterlab : Installing JupyterLab
2023-04-10 14:45:35 : INFO  : jupyterlab : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.CePFllA1/JupyterLab-Setup-macOS-arm64.dmg
2023-04-10 14:45:38 : INFO  : jupyterlab : Mounted: /Volumes/JupyterLab 3.6.2-1-arm64
2023-04-10 14:45:38 : INFO  : jupyterlab : Verifying: /Volumes/JupyterLab 3.6.2-1-arm64/JupyterLab.app
2023-04-10 14:45:40 : INFO  : jupyterlab : Team ID matching: 2YJ64GUAVW (expected: 2YJ64GUAVW )
2023-04-10 14:45:40 : INFO  : jupyterlab : Downloaded version of JupyterLab is 3.6.2-1 on versionKey CFBundleShortVersionString, same as installed.
2023-04-10 14:45:41 : INFO  : jupyterlab : App not closed, so no reopen.
2023-04-10 14:45:41 : REQ   : jupyterlab : ################## End Installomator, exit code 0