### PR TITLE
create label - miniconda

### DIFF
--- a/fragments/labels/miniconda.sh
+++ b/fragments/labels/miniconda.sh
@@ -1,0 +1,12 @@
+miniconda)
+    type="pkg"
+	packageID="io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate"
+    if [[ $(arch) == arm64 ]]; then
+		name="Miniconda3-latest-MacOSX-arm64"
+		downloadURL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg"
+	elif [[ $(arch) == i386 ]]; then
+		name="Miniconda3-latest-MacOSX-x86_64"
+		downloadURL="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg"
+	fi
+    expectedTeamID="Z5788K4JT7"
+    ;;


### PR DESCRIPTION
create label - miniconda

Installs latest version of miniconda
https://github.com/conda/conda-docs/blob/main/docs/source/miniconda.rst

downloads from https://repo.anaconda.com/miniconda/

## Output >>>> 

Installomator % ./assemble.sh miniconda
2023-04-10 14:41:33 : REQ   : miniconda : ################## Start Installomator v. 10.4beta, date 2023-04-10
2023-04-10 14:41:33 : INFO  : miniconda : ################## Version: 10.4beta
2023-04-10 14:41:33 : INFO  : miniconda : ################## Date: 2023-04-10
2023-04-10 14:41:33 : INFO  : miniconda : ################## miniconda
2023-04-10 14:41:33 : DEBUG : miniconda : DEBUG mode 1 enabled.
2023-04-10 14:41:33 : DEBUG : miniconda : name=Miniconda3-latest-MacOSX-arm64
2023-04-10 14:41:33 : DEBUG : miniconda : appName=
2023-04-10 14:41:33 : DEBUG : miniconda : type=pkg
2023-04-10 14:41:33 : DEBUG : miniconda : archiveName=
2023-04-10 14:41:33 : DEBUG : miniconda : downloadURL=https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:34 : DEBUG : miniconda : curlOptions=
2023-04-10 14:41:34 : DEBUG : miniconda : appNewVersion=
2023-04-10 14:41:34 : DEBUG : miniconda : appCustomVersion function: Not defined
2023-04-10 14:41:34 : DEBUG : miniconda : versionKey=CFBundleShortVersionString
2023-04-10 14:41:34 : DEBUG : miniconda : packageID=io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate
2023-04-10 14:41:34 : DEBUG : miniconda : pkgName=
2023-04-10 14:41:34 : DEBUG : miniconda : choiceChangesXML=
2023-04-10 14:41:34 : DEBUG : miniconda : expectedTeamID=Z5788K4JT7
2023-04-10 14:41:34 : DEBUG : miniconda : blockingProcesses=
2023-04-10 14:41:34 : DEBUG : miniconda : installerTool=
2023-04-10 14:41:34 : DEBUG : miniconda : CLIInstaller=
2023-04-10 14:41:34 : DEBUG : miniconda : CLIArguments=
2023-04-10 14:41:34 : DEBUG : miniconda : updateTool=
2023-04-10 14:41:34 : DEBUG : miniconda : updateToolArguments=
2023-04-10 14:41:34 : DEBUG : miniconda : updateToolRunAsCurrentUser=
2023-04-10 14:41:34 : INFO  : miniconda : BLOCKING_PROCESS_ACTION=tell_user
2023-04-10 14:41:34 : INFO  : miniconda : NOTIFY=success
2023-04-10 14:41:34 : INFO  : miniconda : LOGGING=DEBUG
2023-04-10 14:41:34 : INFO  : miniconda : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-10 14:41:34 : INFO  : miniconda : Label type: pkg
2023-04-10 14:41:34 : INFO  : miniconda : archiveName: Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:34 : INFO  : miniconda : no blocking processes defined, using Miniconda3-latest-MacOSX-arm64 as default
2023-04-10 14:41:34 : DEBUG : miniconda : Changing directory to /Users/gknackstedt/GitHub/Installomator/build
2023-04-10 14:41:34 : INFO  : miniconda : No version found using packageID io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate
2023-04-10 14:41:34 : INFO  : miniconda : name: Miniconda3-latest-MacOSX-arm64, appName: Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:41:34.388 mdfind[43048:295064] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-04-10 14:41:34.388 mdfind[43048:295064] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-04-10 14:41:34.439 mdfind[43048:295064] Couldn't determine the mapping between prefab keywords and predicates.
2023-04-10 14:41:34 : WARN  : miniconda : No previous app found
2023-04-10 14:41:34 : WARN  : miniconda : could not find Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:41:34 : INFO  : miniconda : appversion:
2023-04-10 14:41:34 : INFO  : miniconda : Latest version not specified.
2023-04-10 14:41:34 : REQ   : miniconda : Downloading https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg to Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:34 : DEBUG : miniconda : No Dialog connection, just download
2023-04-10 14:41:35 : DEBUG : miniconda : File list: -rw-r--r--  1 gknackstedt  staff    41M Apr 10 14:41 Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:35 : DEBUG : miniconda : File type: Miniconda3-latest-MacOSX-arm64.pkg: xar archive compressed TOC: 5640, SHA-1 checksum
2023-04-10 14:41:35 : DEBUG : miniconda : curl output was:
*   Trying 104.16.131.3:443...
* Connected to repo.anaconda.com (104.16.131.3) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [2334 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Jun 12 00:00:00 2022 GMT
*  expire date: Jun 12 23:59:59 2023 GMT
*  subjectAltName: host "repo.anaconda.com" matched cert's "*.anaconda.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /miniconda/Miniconda3-latest-MacOSX-arm64.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: repo.anaconda.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x122013400)
> GET /miniconda/Miniconda3-latest-MacOSX-arm64.pkg HTTP/2
> Host: repo.anaconda.com
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 256)! < HTTP/2 200
< date: Mon, 10 Apr 2023 18:41:34 GMT
< content-type: application/vnd.apple.installer+xml < content-length: 43440573
< x-amz-id-2: m5XkeSqn2LP/nxl6upcYRuCK+zqiWBswEuHUce6WWGPs4o9ikdAJuLz+pKAvZggPKvcMXLAgP50= < x-amz-request-id: P69PAPGM6TE2XDZT
< last-modified: Wed, 08 Feb 2023 03:48:18 GMT
< x-amz-version-id: XP.VxTh944T0dWF2mEuiFVr72Mmsw8Oc < etag: "4263b0d2dad6b103b421a953b4f3ef3d-6"
< cf-cache-status: HIT
< age: 90868
< expires: Mon, 10 Apr 2023 18:42:04 GMT
< cache-control: public, max-age=30
< accept-ranges: bytes
< set-cookie: __cf_bm=nhRbMYjkfjPCa4exJ5YpSArxGbD9mfwNAu91PFrJsO0-1681152094-0-AX5hUVoGgNJrAUzVzIFWugZNqK1VTKEfjsO0FCuzFcKwvZszrwYib18QV1Fk66Z4VnniufR5DeqwHi4/NzsUiO4=; path=/; expires=Mon, 10-Apr-23 19:11:34 GMT; domain=.anaconda.com; HttpOnly; Secure; SameSite=None < server: cloudflare
< cf-ray: 7b5d1ff13a5d13cd-ORD
<
{ [796 bytes data]
* Connection #0 to host repo.anaconda.com left intact

2023-04-10 14:41:35 : DEBUG : miniconda : DEBUG mode 1, not checking for blocking processes
2023-04-10 14:41:35 : REQ   : miniconda : Installing Miniconda3-latest-MacOSX-arm64
2023-04-10 14:41:35 : INFO  : miniconda : Verifying: Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:35 : DEBUG : miniconda : File list: -rw-r--r--  1 gknackstedt  staff    41M Apr 10 14:41 Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:41:35 : DEBUG : miniconda : File type: Miniconda3-latest-MacOSX-arm64.pkg: xar archive compressed TOC: 5640, SHA-1 checksum
2023-04-10 14:41:36 : DEBUG : miniconda : spctlOut is Miniconda3-latest-MacOSX-arm64.pkg: accepted
2023-04-10 14:41:36 : DEBUG : miniconda : source=Notarized Developer ID
2023-04-10 14:41:36 : DEBUG : miniconda : origin=Developer ID Installer: Anaconda, Inc (Z5788K4JT7)
2023-04-10 14:41:36 : INFO  : miniconda : Team ID: Z5788K4JT7 (expected: Z5788K4JT7 )
2023-04-10 14:41:36 : DEBUG : miniconda : DEBUG enabled, skipping installation
2023-04-10 14:41:36 : INFO  : miniconda : Finishing...
2023-04-10 14:41:39 : INFO  : miniconda : No version found using packageID io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate
2023-04-10 14:41:39 : INFO  : miniconda : name: Miniconda3-latest-MacOSX-arm64, appName: Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:41:39.367 mdfind[43118:295259] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-04-10 14:41:39.368 mdfind[43118:295259] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-04-10 14:41:39.422 mdfind[43118:295259] Couldn't determine the mapping between prefab keywords and predicates.
2023-04-10 14:41:39 : WARN  : miniconda : No previous app found
2023-04-10 14:41:39 : WARN  : miniconda : could not find Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:41:39 : REQ   : miniconda : Installed Miniconda3-latest-MacOSX-arm64
2023-04-10 14:41:39 : INFO  : miniconda : notifying
2023-04-10 14:41:39 : DEBUG : miniconda : DEBUG mode 1, not reopening anything
2023-04-10 14:41:39 : REQ   : miniconda : All done!
2023-04-10 14:41:39 : REQ   : miniconda : ################## End Installomator, exit code 0

## Output from DEBUG=0 >>>>>

sudo ./assemble.sh miniconda DEBUG=0
2023-04-10 14:48:07 : INFO  : miniconda : setting variable from argument DEBUG=0
2023-04-10 14:48:07 : REQ   : miniconda : ################## Start Installomator v. 10.4beta, date 2023-04-10
2023-04-10 14:48:07 : INFO  : miniconda : ################## Version: 10.4beta
2023-04-10 14:48:07 : INFO  : miniconda : ################## Date: 2023-04-10
2023-04-10 14:48:07 : INFO  : miniconda : ################## miniconda
2023-04-10 14:48:07 : INFO  : miniconda : BLOCKING_PROCESS_ACTION=tell_user
2023-04-10 14:48:07 : INFO  : miniconda : NOTIFY=success
2023-04-10 14:48:07 : INFO  : miniconda : LOGGING=INFO
2023-04-10 14:48:07 : INFO  : miniconda : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-10 14:48:07 : INFO  : miniconda : Label type: pkg
2023-04-10 14:48:07 : INFO  : miniconda : archiveName: Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:48:07 : INFO  : miniconda : no blocking processes defined, using Miniconda3-latest-MacOSX-arm64 as default
2023-04-10 14:48:07 : INFO  : miniconda : No version found using packageID io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate
2023-04-10 14:48:07 : INFO  : miniconda : name: Miniconda3-latest-MacOSX-arm64, appName: Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:48:07.661 mdfind[46656:307939] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-04-10 14:48:07.661 mdfind[46656:307939] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-04-10 14:48:07.712 mdfind[46656:307939] Couldn't determine the mapping between prefab keywords and predicates.
2023-04-10 14:48:07 : WARN  : miniconda : No previous app found
2023-04-10 14:48:07 : WARN  : miniconda : could not find Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:48:07 : INFO  : miniconda : appversion:
2023-04-10 14:48:07 : INFO  : miniconda : Latest version not specified.
2023-04-10 14:48:07 : REQ   : miniconda : Downloading https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg to Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:48:08 : REQ   : miniconda : no more blocking processes, continue with update
2023-04-10 14:48:08 : REQ   : miniconda : Installing Miniconda3-latest-MacOSX-arm64
2023-04-10 14:48:08 : INFO  : miniconda : Verifying: Miniconda3-latest-MacOSX-arm64.pkg
2023-04-10 14:48:09 : INFO  : miniconda : Team ID: Z5788K4JT7 (expected: Z5788K4JT7 )
2023-04-10 14:48:09 : INFO  : miniconda : Installing Miniconda3-latest-MacOSX-arm64.pkg to /
2023-04-10 14:48:11 : INFO  : miniconda : Finishing...
2023-04-10 14:48:14 : INFO  : miniconda : No version found using packageID io.continuum.pkg.prepare_installation io.continuum.pkg.run_installation io.continuum.pkg.pathupdate
2023-04-10 14:48:14 : INFO  : miniconda : name: Miniconda3-latest-MacOSX-arm64, appName: Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:48:14.998 mdfind[46753:308276] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-04-10 14:48:14.999 mdfind[46753:308276] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-04-10 14:48:15.057 mdfind[46753:308276] Couldn't determine the mapping between prefab keywords and predicates.
2023-04-10 14:48:15 : WARN  : miniconda : No previous app found
2023-04-10 14:48:15 : WARN  : miniconda : could not find Miniconda3-latest-MacOSX-arm64.app
2023-04-10 14:48:15 : REQ   : miniconda : Installed Miniconda3-latest-MacOSX-arm64
2023-04-10 14:48:15 : INFO  : miniconda : notifying
2023-04-10 14:48:15 : INFO  : miniconda : App not closed, so no reopen.
2023-04-10 14:48:15 : REQ   : miniconda : All done!
2023-04-10 14:48:15 : REQ   : miniconda : ################## End Installomator, exit code 0