### PR TITLE
Cricut Design Space - fix appNewVersion with new urls

### DIFF
--- a/fragments/labels/cricutdesignspace.sh
+++ b/fragments/labels/cricutdesignspace.sh
@@ -1,7 +1,10 @@
 cricutdesignspace)
     name="Cricut Design Space"
     type="dmg"
-    appNewVersion=$(getJSONValue "$(curl -fsL https://s3-us-west-2.amazonaws.com/staticcontent.cricut.com/a/software/osx-native/latest.json)" "rolloutVersion")
+    cricutVersionURL=$(getJSONValue $(curl -fsL "https://apis.cricut.com/desktopdownload/UpdateJson?operatingSystem=osxnative&shard=a") "result")
+    cricutVersionJSON=$(curl -fs "$cricutVersionURL")
+    appNewVersion=$(getJSONValue "$cricutVersionJSON" "rolloutVersion")
     downloadURL=$(getJSONValue $(curl  -fsL "https://apis.cricut.com/desktopdownload/InstallerFile?shard=a&operatingSystem=osxnative&fileName=CricutDesignSpace-Install-v${appNewVersion}.dmg") "result")
     expectedTeamID="25627ZFVT7"
     ;;
+


### PR DESCRIPTION
Had to do some hopscotch to get the URLs right here. I tried putting it into one big embedded line but kept failing, so I broke it out into separate variables

```
Installomator % sudo ./assemble.sh cricutdesignspace DEBUG=0 
2023-04-11 15:11:56 : INFO  : cricutdesignspace : setting variable from argument DEBUG=0
2023-04-11 15:11:56 : REQ   : cricutdesignspace : ################## Start Installomator v. 10.4beta, date 2023-04-11
2023-04-11 15:11:56 : INFO  : cricutdesignspace : ################## Version: 10.4beta
2023-04-11 15:11:56 : INFO  : cricutdesignspace : ################## Date: 2023-04-11
2023-04-11 15:11:56 : INFO  : cricutdesignspace : ################## cricutdesignspace
2023-04-11 15:11:57 : INFO  : cricutdesignspace : BLOCKING_PROCESS_ACTION=tell_user
2023-04-11 15:11:57 : INFO  : cricutdesignspace : NOTIFY=success
2023-04-11 15:11:58 : INFO  : cricutdesignspace : LOGGING=INFO
2023-04-11 15:11:58 : INFO  : cricutdesignspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-11 15:11:58 : INFO  : cricutdesignspace : Label type: dmg
2023-04-11 15:11:58 : INFO  : cricutdesignspace : archiveName: Cricut Design Space.dmg
2023-04-11 15:11:58 : INFO  : cricutdesignspace : no blocking processes defined, using Cricut Design Space as default
2023-04-11 15:11:58 : INFO  : cricutdesignspace : App(s) found: /Applications/Cricut Design Space.app
2023-04-11 15:11:58 : INFO  : cricutdesignspace : found app at /Applications/Cricut Design Space.app, version 7.30.128, on versionKey CFBundleShortVersionString
2023-04-11 15:11:58 : INFO  : cricutdesignspace : appversion: 7.30.128
2023-04-11 15:11:58 : INFO  : cricutdesignspace : Latest version of Cricut Design Space is 7.31.167
2023-04-11 15:11:58 : REQ   : cricutdesignspace : Downloading https://staticcontent.cricut.com/a/software/osx-native/CricutDesignSpace-Install-v7.31.167.dmg?Expires=1681240917&Signature=pFyVA7v4CQoLm1MsR2x9eWXC1aPWybq5-znUY8XeHlPGZK0IZurmsPkBaKpWXn-fBiF3GHA0dQrzZk9Kb1hEWUBjQEZy08CN6cicHJGGL48dqSjFgd2LKII7OAlaDmlzVjO-NPk9KjXA4vzVnrqfn8IRgX5O5xTQVzRm0WBWGxpNf1BuwD1sJstXzLCZxKt9z3Fe2-qT9vszKdvA5M-txaR6ng6pptk1TLh4PbO4vvW3eY2B9vJG6DSo6nwB1PEh5JZ6g0SOUccfX2UDvNnyIOqUpuU-c34EHByhUX7hMuS1XrRp5Rt~DKiGxqTkTu64zfQZW53GwJtkBCmFMqnaDQ__&Key-Pair-Id=K2W1AJ47IQWIOI to Cricut Design Space.dmg
2023-04-11 15:12:01 : REQ   : cricutdesignspace : no more blocking processes, continue with update
2023-04-11 15:12:01 : REQ   : cricutdesignspace : Installing Cricut Design Space
2023-04-11 15:12:01 : INFO  : cricutdesignspace : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.GdczfhLW/Cricut Design Space.dmg
2023-04-11 15:12:03 : INFO  : cricutdesignspace : Mounted: /Volumes/Cricut Design Space Install
2023-04-11 15:12:03 : INFO  : cricutdesignspace : Verifying: /Volumes/Cricut Design Space Install/Cricut Design Space.app
2023-04-11 15:12:04 : INFO  : cricutdesignspace : Team ID matching: 25627ZFVT7 (expected: 25627ZFVT7 )
2023-04-11 15:12:04 : INFO  : cricutdesignspace : Downloaded version of Cricut Design Space is 7.31.167 on versionKey CFBundleShortVersionString (replacing version 7.30.128).
2023-04-11 15:12:04 : INFO  : cricutdesignspace : App has LSMinimumSystemVersion: 10.13
2023-04-11 15:12:04 : WARN  : cricutdesignspace : Removing existing /Applications/Cricut Design Space.app
2023-04-11 15:12:04 : INFO  : cricutdesignspace : Copy /Volumes/Cricut Design Space Install/Cricut Design Space.app to /Applications
2023-04-11 15:12:05 : WARN  : cricutdesignspace : Changing owner to dnikles
2023-04-11 15:12:05 : INFO  : cricutdesignspace : Finishing...
2023-04-11 15:12:08 : INFO  : cricutdesignspace : App(s) found: /Applications/Cricut Design Space.app
2023-04-11 15:12:08 : INFO  : cricutdesignspace : found app at /Applications/Cricut Design Space.app, version 7.31.167, on versionKey CFBundleShortVersionString
2023-04-11 15:12:08 : REQ   : cricutdesignspace : Installed Cricut Design Space, version 7.31.167
2023-04-11 15:12:08 : INFO  : cricutdesignspace : notifying
2023-04-11 15:12:08 : INFO  : cricutdesignspace : App not closed, so no reopen.
2023-04-11 15:12:09 : REQ   : cricutdesignspace : All done!
2023-04-11 15:12:09 : REQ   : cricutdesignspace : ################## End Installomator, exit code 0 
```