### PR TITLE
Huddly Label

### DIFF
--- a/fragments/labels/huddly.sh
+++ b/fragments/labels/huddly.sh
@@ -1,0 +1,7 @@
+huddly)
+    name="Huddly"
+    type="dmg"
+    downloadURL="https://app.huddly.com/download/latest/osx"
+    appNewVersion="$(curl -fsIL "${downloadURL}" | grep -i '^content-disposition' | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/g')"
+    expectedTeamID="J659R47HZT"
+    ;;


### PR DESCRIPTION
Label for https://www.huddly.com/app/

Output
```
sudo ./assemble.sh huddly DEBUG=0
2023-04-11 15:52:41 : REQ   : huddly : ################## Start Installomator v. 10.4beta, date 2023-04-11
2023-04-11 15:52:41 : INFO  : huddly : ################## Version: 10.4beta
2023-04-11 15:52:41 : INFO  : huddly : ################## Date: 2023-04-11
2023-04-11 15:52:41 : INFO  : huddly : ################## huddly
2023-04-11 15:52:41 : INFO  : huddly : SwiftDialog is not installed, clear cmd file var
2023-04-11 15:52:41 : INFO  : huddly : BLOCKING_PROCESS_ACTION=tell_user
2023-04-11 15:52:41 : INFO  : huddly : NOTIFY=success
2023-04-11 15:52:41 : INFO  : huddly : LOGGING=DEBUG
2023-04-11 15:52:41 : INFO  : huddly : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-11 15:52:41 : INFO  : huddly : Label type: dmg
2023-04-11 15:52:41 : INFO  : huddly : archiveName: Huddly.dmg
2023-04-11 15:52:41 : INFO  : huddly : no blocking processes defined, using Huddly as default
2023-04-11 15:52:41 : INFO  : huddly : App(s) found: /Applications/Huddly.app
2023-04-11 15:52:41 : INFO  : huddly : found app at /Applications/Huddly.app, version 3.3.6, on versionKey CFBundleShortVersionString
2023-04-11 15:52:42 : INFO  : huddly : appversion: 3.3.6
2023-04-11 15:52:42 : INFO  : huddly : Latest version of Huddly is 3.3.6
2023-04-11 15:52:42 : WARN  : huddly : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-04-11 15:52:42 : REQ   : huddly : Downloading https://app.huddly.com/download/latest/osx to Huddly.dmg
2023-04-11 15:53:09 : REQ   : huddly : Installing Huddly
2023-04-11 15:53:09 : INFO  : huddly : Mounting /Users/<user>/dev/installomator/Installomator/build/Huddly.dmg
2023-04-11 15:53:13 : INFO  : huddly : Mounted: /Volumes/Huddly 3.3.6 1
2023-04-11 15:53:13 : INFO  : huddly : Verifying: /Volumes/Huddly 3.3.6 1/Huddly.app
2023-04-11 15:53:15 : INFO  : huddly : Team ID matching: J659R47HZT (expected: J659R47HZT )
2023-04-11 15:53:15 : INFO  : huddly : Downloaded version of Huddly is 3.3.6 on versionKey CFBundleShortVersionString, same as installed.
2023-04-11 15:53:15 : REG   : huddly : No new version to install
2023-04-11 15:53:15 : REQ   : huddly : ################## End Installomator, exit code 0
```