### PR TITLE
TickTick app label

### DIFF
--- a/fragments/labels/ticktick.sh
+++ b/fragments/labels/ticktick.sh
@@ -1,0 +1,8 @@
+ticktick)
+    # TickTick is a x-platform ToDo-app for groups/teams, see https://ticktick.com
+    name="TickTick"
+    type="dmg"
+    downloadURL="https://ticktick.com/down/getApp/download?type=mac"
+    appNewVersion="$(curl -fsIL "$downloadURL" | grep -Ei "^location" | cut -d "_" -f2)"
+    expectedTeamID="75TY9UT8AY"
+    ;;


### PR DESCRIPTION
TickTick is a x-platform ToDo-app for groups/teams.

```
% sudo /Users/st/Documents/GitHub/Installomator-Theile/utils/assemble.sh ticktick DEBUG=0 INSTALL=force
2023-04-12 14:56:41 : INFO  : ticktick : setting variable from argument DEBUG=0
2023-04-12 14:56:41 : INFO  : ticktick : setting variable from argument INSTALL=force
2023-04-12 14:56:41 : REQ   : ticktick : ################## Start Installomator v. 10.4beta, date 2023-04-12
2023-04-12 14:56:41 : INFO  : ticktick : ################## Version: 10.4beta
2023-04-12 14:56:41 : INFO  : ticktick : ################## Date: 2023-04-12
2023-04-12 14:56:41 : INFO  : ticktick : ################## ticktick
2023-04-12 14:56:43 : INFO  : ticktick : BLOCKING_PROCESS_ACTION=tell_user
2023-04-12 14:56:43 : INFO  : ticktick : NOTIFY=success
2023-04-12 14:56:43 : INFO  : ticktick : LOGGING=INFO
2023-04-12 14:56:43 : INFO  : ticktick : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-12 14:56:43 : INFO  : ticktick : Label type: dmg
2023-04-12 14:56:43 : INFO  : ticktick : archiveName: TickTick.dmg
2023-04-12 14:56:43 : INFO  : ticktick : no blocking processes defined, using TickTick as default
2023-04-12 14:56:43 : INFO  : ticktick : App(s) found: /Applications/TickTick.app
2023-04-12 14:56:43 : INFO  : ticktick : found app at /Applications/TickTick.app, version 4.4.40, on versionKey CFBundleShortVersionString
2023-04-12 14:56:43 : INFO  : ticktick : appversion: 4.4.40
2023-04-12 14:56:43 : INFO  : ticktick : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-04-12 14:56:43 : INFO  : ticktick : Latest version of TickTick is 4.4.40
2023-04-12 14:56:43 : INFO  : ticktick : There is no newer version available.
2023-04-12 14:56:43 : REQ   : ticktick : Downloading https://ticktick.com/down/getApp/download?type=mac to TickTick.dmg
2023-04-12 14:57:11 : REQ   : ticktick : no more blocking processes, continue with update
2023-04-12 14:57:11 : REQ   : ticktick : Installing TickTick
2023-04-12 14:57:11 : INFO  : ticktick : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vHUbRCWu/TickTick.dmg
2023-04-12 14:57:16 : INFO  : ticktick : Mounted: /Volumes/TickTick 1
2023-04-12 14:57:16 : INFO  : ticktick : Verifying: /Volumes/TickTick 1/TickTick.app
2023-04-12 14:57:30 : INFO  : ticktick : Team ID matching: 75TY9UT8AY (expected: 75TY9UT8AY )
2023-04-12 14:57:30 : INFO  : ticktick : Downloaded version of TickTick is 4.4.40 on versionKey CFBundleShortVersionString, same as installed.
2023-04-12 14:57:30 : INFO  : ticktick : Using force to install anyway.
2023-04-12 14:57:30 : INFO  : ticktick : App has LSMinimumSystemVersion: 10.13
2023-04-12 14:57:30 : WARN  : ticktick : Removing existing /Applications/TickTick.app
2023-04-12 14:57:30 : INFO  : ticktick : Copy /Volumes/TickTick 1/TickTick.app to /Applications
2023-04-12 14:57:39 : WARN  : ticktick : Changing owner to st
2023-04-12 14:57:39 : INFO  : ticktick : Finishing...
2023-04-12 14:57:42 : INFO  : ticktick : App(s) found: /Applications/TickTick.app
2023-04-12 14:57:42 : INFO  : ticktick : found app at /Applications/TickTick.app, version 4.4.40, on versionKey CFBundleShortVersionString
2023-04-12 14:57:42 : REQ   : ticktick : Installed TickTick, version 4.4.40
2023-04-12 14:57:42 : INFO  : ticktick : notifying
2023-04-12 14:57:43 : INFO  : ticktick : App not closed, so no reopen.
2023-04-12 14:57:43 : REQ   : ticktick : All done!
2023-04-12 14:57:43 : REQ   : ticktick : ################## End Installomator, exit code 0
```