### PR TITLE
Create jdk20.sh

### DIFF
--- a/fragments/labels/jdk20.sh
+++ b/fragments/labels/jdk20.sh
@@ -1,0 +1,12 @@
+jdk20)
+    name="Java SE Development Kit 20"
+    type="pkgInDmg"
+    versionKey="CFBundleShortVersionString"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.oracle.com/java/20/latest/jdk-20_macos-aarch64_bin.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.oracle.com/java/20/latest/jdk-20_macos-x64_bin.dmg"
+    fi
+    appCustomVersion(){ java --version | grep java | awk '{print $NF}' }
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
Created a new label, "jdk20" for Oracle Java SE Development Kit 20

```
2023-04-13 16:35:44 : INFO  : jdk20 : setting variable from argument DEBUG=0
2023-04-13 16:35:44 : REQ   : jdk20 : ################## Start Installomator v. 10.4beta, date 2023-04-13
2023-04-13 16:35:44 : INFO  : jdk20 : ################## Version: 10.4beta
2023-04-13 16:35:44 : INFO  : jdk20 : ################## Date: 2023-04-13
2023-04-13 16:35:44 : INFO  : jdk20 : ################## jdk20
2023-04-13 16:35:44 : INFO  : jdk20 : SwiftDialog is not installed, clear cmd file var
2023-04-13 16:35:44 : INFO  : jdk20 : BLOCKING_PROCESS_ACTION=tell_user
2023-04-13 16:35:44 : INFO  : jdk20 : NOTIFY=success
2023-04-13 16:35:44 : INFO  : jdk20 : LOGGING=INFO
2023-04-13 16:35:44 : INFO  : jdk20 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-13 16:35:44 : INFO  : jdk20 : Label type: pkgInDmg
2023-04-13 16:35:44 : INFO  : jdk20 : archiveName: Java SE Development Kit 20.dmg
2023-04-13 16:35:44 : INFO  : jdk20 : no blocking processes defined, using Java SE Development Kit 20 as default
2023-04-13 16:35:44 : INFO  : jdk20 : Custom App Version detection is used, found 
2023-04-13 16:35:44 : INFO  : jdk20 : appversion: 
2023-04-13 16:35:44 : INFO  : jdk20 : Latest version not specified.
2023-04-13 16:35:44 : REQ   : jdk20 : Downloading https://download.oracle.com/java/20/latest/jdk-20_macos-aarch64_bin.dmg to Java SE Development Kit 20.dmg
2023-04-13 16:36:19 : REQ   : jdk20 : no more blocking processes, continue with update
2023-04-13 16:36:19 : REQ   : jdk20 : Installing Java SE Development Kit 20
2023-04-13 16:36:19 : INFO  : jdk20 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.w86dZI41/Java SE Development Kit 20.dmg
2023-04-13 16:36:24 : INFO  : jdk20 : Mounted: /Volumes/JDK 20
2023-04-13 16:36:24 : INFO  : jdk20 : found pkg: /Volumes/JDK 20/JDK 20.pkg
2023-04-13 16:36:24 : INFO  : jdk20 : Verifying: /Volumes/JDK 20/JDK 20.pkg
2023-04-13 16:36:24 : INFO  : jdk20 : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2023-04-13 16:36:24 : INFO  : jdk20 : Installing /Volumes/JDK 20/JDK 20.pkg to /
2023-04-13 16:36:29 : INFO  : jdk20 : Finishing...
2023-04-13 16:36:33 : INFO  : jdk20 : Custom App Version detection is used, found 2023-03-21
2023-04-13 16:36:33 : REQ   : jdk20 : Installed Java SE Development Kit 20, version 2023-03-21
2023-04-13 16:36:33 : INFO  : jdk20 : notifying
2023-04-13 16:36:33 : INFO  : jdk20 : App not closed, so no reopen.
2023-04-13 16:36:33 : REQ   : jdk20 : All done!
2023-04-13 16:36:33 : REQ   : jdk20 : ################## End Installomator, exit code 0 
```