### PR TITLE
Update mattermost.sh to get rid of blocking processes

### DIFF
--- a/fragments/labels/mattermost.sh
+++ b/fragments/labels/mattermost.sh
@@ -5,5 +5,4 @@ mattermost)
     downloadURL=$(downloadURLFromGit mattermost desktop)
     appNewVersion=$(versionFromGit mattermost desktop)
     expectedTeamID="UQ8HT4Q2XM"
-    blockingProcesses=( "Mattermost Helper.app" "Mattermost Helper (Renderer).app" "Mattermost Helper (GPU).app" "Mattermost Helper (Plugin).app" )
     ;;


### PR DESCRIPTION
The blocking process list did not include Mattermost, which is the process of this app. Removing the blocking processes line defaults the blocking process to `Mattermost` which is what it should be.

```
sudo ./assemble.sh mattermost BLOCKING_PROCESS_ACTION=prompt_user DEBUG=0 INSTALL=force
2023-04-14 07:19:36 : INFO  : mattermost : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user
2023-04-14 07:19:36 : INFO  : mattermost : setting variable from argument DEBUG=0
2023-04-14 07:19:36 : INFO  : mattermost : setting variable from argument INSTALL=force
2023-04-14 07:19:36 : REQ   : mattermost : ################## Start Installomator v. 10.4beta, date 2023-04-14
2023-04-14 07:19:36 : INFO  : mattermost : ################## Version: 10.4beta
2023-04-14 07:19:36 : INFO  : mattermost : ################## Date: 2023-04-14
2023-04-14 07:19:36 : INFO  : mattermost : ################## mattermost
2023-04-14 07:19:37 : INFO  : mattermost : BLOCKING_PROCESS_ACTION=prompt_user
2023-04-14 07:19:37 : INFO  : mattermost : NOTIFY=success
2023-04-14 07:19:37 : INFO  : mattermost : LOGGING=INFO
2023-04-14 07:19:37 : INFO  : mattermost : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-14 07:19:37 : INFO  : mattermost : Label type: dmg
2023-04-14 07:19:37 : INFO  : mattermost : archiveName: mac-universal.dmg
2023-04-14 07:19:37 : INFO  : mattermost : no blocking processes defined, using Mattermost as default
2023-04-14 07:19:37 : INFO  : mattermost : App(s) found: /Applications/Mattermost.app
2023-04-14 07:19:37 : INFO  : mattermost : found app at /Applications/Mattermost.app, version 5.3.1, on versionKey CFBundleShortVersionString
2023-04-14 07:19:37 : INFO  : mattermost : appversion: 5.3.1
2023-04-14 07:19:37 : INFO  : mattermost : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-04-14 07:19:37 : INFO  : mattermost : Latest version of Mattermost is 5.3.1
2023-04-14 07:19:37 : INFO  : mattermost : There is no newer version available.
2023-04-14 07:19:37 : REQ   : mattermost : Downloading https://github.com/mattermost/desktop/releases/download/v5.3.1/mattermost-desktop-5.3.1-mac-universal.dmg to mac-universal.dmg
2023-04-14 07:19:40 : INFO  : mattermost : found blocking process Mattermost
2023-04-14 07:19:42 : INFO  : mattermost : telling app Mattermost to quit
2023-04-14 07:19:42 : INFO  : mattermost : waiting 30 seconds for processes to quit
2023-04-14 07:20:12 : REQ   : mattermost : no more blocking processes, continue with update
2023-04-14 07:20:12 : REQ   : mattermost : Installing Mattermost
2023-04-14 07:20:12 : INFO  : mattermost : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.FYsF7WUs/mac-universal.dmg
2023-04-14 07:20:16 : INFO  : mattermost : Mounted: /Volumes/Mattermost 5.3.1-universal
2023-04-14 07:20:16 : INFO  : mattermost : Verifying: /Volumes/Mattermost 5.3.1-universal/Mattermost.app
2023-04-14 07:20:19 : INFO  : mattermost : Team ID matching: UQ8HT4Q2XM (expected: UQ8HT4Q2XM )
2023-04-14 07:20:19 : INFO  : mattermost : Downloaded version of Mattermost is 5.3.1 on versionKey CFBundleShortVersionString, same as installed.
2023-04-14 07:20:19 : INFO  : mattermost : Using force to install anyway.
2023-04-14 07:20:19 : INFO  : mattermost : App has LSMinimumSystemVersion: 10.13
2023-04-14 07:20:19 : WARN  : mattermost : Removing existing /Applications/Mattermost.app
2023-04-14 07:20:19 : INFO  : mattermost : Copy /Volumes/Mattermost 5.3.1-universal/Mattermost.app to /Applications
2023-04-14 07:20:20 : WARN  : mattermost : Changing owner to dnikles
2023-04-14 07:20:20 : INFO  : mattermost : Finishing...
2023-04-14 07:20:23 : INFO  : mattermost : App(s) found: /Applications/Mattermost.app
2023-04-14 07:20:23 : INFO  : mattermost : found app at /Applications/Mattermost.app, version 5.3.1, on versionKey CFBundleShortVersionString
2023-04-14 07:20:23 : REQ   : mattermost : Installed Mattermost, version 5.3.1
2023-04-14 07:20:23 : INFO  : mattermost : notifying
2023-04-14 07:20:24 : INFO  : mattermost : Telling app Mattermost.app to open
2023-04-14 07:20:24 : INFO  : mattermost : Reopened Mattermost.app as dnikles
2023-04-14 07:20:24 : REQ   : mattermost : All done!
2023-04-14 07:20:24 : REQ   : mattermost : ################## End Installomator, exit code 0
```