### PR TITLE
New Label: Xmind

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -565,6 +565,7 @@ xeroxphaser7800
 xeroxworkcentre7800
 xink
 xmenu
+xmind
 xquartz
 yed
 yubicoauthenticator

--- a/fragments/labels/xmind.sh
+++ b/fragments/labels/xmind.sh
@@ -1,0 +1,7 @@
+xmind)
+    name="Xmind"
+    type="dmg"
+    downloadURL=https://www.xmind.net/zen/download/mac/
+    appNewVersion=$(echo $downloadURL | grep -oe "http.*\.dmg" | sed -e 's/.*\/Xmind-for-macOS-.*\-\([0-9.]*\)\.dmg/\1/g')
+    expectedTeamID="4WV38P2X5K"
+    ;;


### PR DESCRIPTION
```
# sudo ./Installomator.sh xmind DEBUG=1 NOTIFY=success                                                                                                                
2023-04-21 12:32:53 : INFO  : xmind : setting variable from argument DEBUG=1
2023-04-21 12:32:53 : INFO  : xmind : setting variable from argument NOTIFY=success
2023-04-21 12:32:53 : REQ   : xmind : ################## Start Installomator v. 10.4beta, date 2023-04-12
2023-04-21 12:32:53 : INFO  : xmind : ################## Version: 10.4beta
2023-04-21 12:32:53 : INFO  : xmind : ################## Date: 2023-04-12
2023-04-21 12:32:53 : INFO  : xmind : ################## xmind
2023-04-21 12:32:53 : DEBUG : xmind : DEBUG mode 1 enabled.

2023-04-21 12:32:53 : DEBUG : xmind : name=Xmind
2023-04-21 12:32:53 : DEBUG : xmind : appName=
2023-04-21 12:32:53 : DEBUG : xmind : type=dmg
2023-04-21 12:32:53 : DEBUG : xmind : archiveName=
2023-04-21 12:32:53 : DEBUG : xmind : downloadURL=https://www.xmind.net/zen/download/mac/
2023-04-21 12:32:53 : DEBUG : xmind : curlOptions=
2023-04-21 12:32:53 : DEBUG : xmind : appNewVersion=
2023-04-21 12:32:53 : DEBUG : xmind : appCustomVersion function: Not defined
2023-04-21 12:32:53 : DEBUG : xmind : versionKey=CFBundleShortVersionString
2023-04-21 12:32:53 : DEBUG : xmind : packageID=
2023-04-21 12:32:53 : DEBUG : xmind : pkgName=
2023-04-21 12:32:53 : DEBUG : xmind : choiceChangesXML=
2023-04-21 12:32:53 : DEBUG : xmind : expectedTeamID=4WV38P2X5K
2023-04-21 12:32:53 : DEBUG : xmind : blockingProcesses=
2023-04-21 12:32:53 : DEBUG : xmind : installerTool=
2023-04-21 12:32:53 : DEBUG : xmind : CLIInstaller=
2023-04-21 12:32:53 : DEBUG : xmind : CLIArguments=
2023-04-21 12:32:53 : DEBUG : xmind : updateTool=
2023-04-21 12:32:53 : DEBUG : xmind : updateToolArguments=
2023-04-21 12:32:53 : DEBUG : xmind : updateToolRunAsCurrentUser=
2023-04-21 12:32:53 : INFO  : xmind : BLOCKING_PROCESS_ACTION=tell_user
2023-04-21 12:32:53 : INFO  : xmind : NOTIFY=success
2023-04-21 12:32:53 : INFO  : xmind : LOGGING=DEBUG
2023-04-21 12:32:53 : INFO  : xmind : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-21 12:32:54 : INFO  : xmind : Label type: dmg
2023-04-21 12:32:54 : INFO  : xmind : archiveName: Xmind.dmg
2023-04-21 12:32:54 : INFO  : xmind : no blocking processes defined, using Xmind as default
2023-04-21 12:32:54 : DEBUG : xmind : Changing directory to .
2023-04-21 12:32:54 : INFO  : xmind : App(s) found: /Applications/Xmind.app
2023-04-21 12:32:54 : INFO  : xmind : found app at /Applications/Xmind.app, version 22.11.3656, on versionKey CFBundleShortVersionString
2023-04-21 12:32:54 : INFO  : xmind : appversion: 22.11.3656
2023-04-21 12:32:54 : INFO  : xmind : Latest version not specified.
2023-04-21 12:32:54 : REQ   : xmind : Downloading https://www.xmind.net/zen/download/mac/ to Xmind.dmg
2023-04-21 12:32:54 : DEBUG : xmind : No Dialog connection, just download
2023-04-21 12:34:50 : DEBUG : xmind : File list: -rw-r--r--  1 root  staff   207M 21 Apr 12:34 Xmind.dmg
2023-04-21 12:34:50 : DEBUG : xmind : File type: Xmind.dmg: bzip2 compressed data, block size = 100k
2023-04-21 12:34:50 : DEBUG : xmind : curl output was:
*   Trying 34.231.246.88:443...
* Connected to www.xmind.net (34.231.246.88) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4949 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.xmind.net
*  start date: Feb 22 00:00:00 2023 GMT
*  expire date: Jul 19 23:59:59 2023 GMT
*  subjectAltName: host "www.xmind.net" matched cert's "*.xmind.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /zen/download/mac/]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.xmind.net]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13380c600)
> GET /zen/download/mac/ HTTP/2
> Host: www.xmind.net
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 302
< date: Fri, 21 Apr 2023 10:32:54 GMT
< content-type: text/html; charset=utf-8
< content-length: 107
< location: http://www.xmind.app/zen/download/mac/
<
* Ignoring the response-body
{ [107 bytes data]
* Connection #0 to host www.xmind.net left intact
* Clear auth, redirects to port from 443 to 80
* Issue another request to this URL: 'http://www.xmind.app/zen/download/mac/'
*   Trying 52.44.0.73:80...
* Connected to www.xmind.app (52.44.0.73) port 80 (#1)
> GET /zen/download/mac/ HTTP/1.1
> Host: www.xmind.app
> User-Agent: curl/7.87.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Date: Fri, 21 Apr 2023 10:32:54 GMT
< Content-Length: 0
< Connection: keep-alive
< Location: https://www.xmind.app/zen/download/mac/
<
* Connection #1 to host www.xmind.app left intact
* Clear auth, redirects to port from 80 to 443
* Issue another request to this URL: 'https://www.xmind.app/zen/download/mac/'
*   Trying 52.44.0.73:443...
* Connected to www.xmind.app (52.44.0.73) port 443 (#2)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-2-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
* [CONN-2-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4948 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-2-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=xmind.app
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Nov  1 23:59:59 2023 GMT
*  subjectAltName: host "www.xmind.app" matched cert's "www.xmind.app"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /zen/download/mac/]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.xmind.app]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13380c600)
> GET /zen/download/mac/ HTTP/2
> Host: www.xmind.app
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 302
< date: Fri, 21 Apr 2023 10:32:55 GMT
< content-type: text/html; charset=utf-8
< content-length: 135
< location: https://dl3.xmind.net/Xmind-for-macOS-22.11.3656.dmg
<
* Ignoring the response-body
{ [135 bytes data]
* Connection #2 to host www.xmind.app left intact
* Issue another request to this URL: 'https://dl3.xmind.net/Xmind-for-macOS-22.11.3656.dmg'
*   Trying 18.66.218.17:443...
* Connected to dl3.xmind.net (18.66.218.17) port 443 (#3)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-3-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
* [CONN-3-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-3-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* [CONN-3-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [4958 bytes data]
* [CONN-3-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-3-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-3-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.xmind.net
*  start date: Feb 22 00:00:00 2023 GMT
*  expire date: Jul 19 23:59:59 2023 GMT
*  subjectAltName: host "dl3.xmind.net" matched cert's "*.xmind.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
> GET /Xmind-for-macOS-22.11.3656.dmg HTTP/1.1
> Host: dl3.xmind.net
> User-Agent: curl/7.87.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 217023515
< Connection: keep-alive
< Date: Fri, 21 Apr 2023 08:42:13 GMT
< Last-Modified: Wed, 11 Jan 2023 05:39:59 GMT
< ETag: "7c1bc88f17b1336a49854381d5579d1c-13"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: w0knnxowQihzm9qmn_TSYkgAsc6x34CZ
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 ea387b850914681ced817b614bc2da7c.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: MXP63-P2
< X-Amz-Cf-Id: 2-qdhwOfWB3ehTWJVE6_FIoukGeBl0-a_LZkPCVyS7CNr2g7LGApFA==
< Age: 6643
<
{ [16384 bytes data]
* Connection #3 to host dl3.xmind.net left intact

2023-04-21 12:34:50 : DEBUG : xmind : DEBUG mode 1, not checking for blocking processes
2023-04-21 12:34:50 : REQ   : xmind : Installing Xmind
2023-04-21 12:34:50 : INFO  : xmind : Mounting ./Xmind.dmg
2023-04-21 12:35:07 : DEBUG : xmind : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $CECCCC95
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $B99F22CC
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $328EC66B
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $8CDA08AA
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $328EC66B
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $70C7E895
Die überprüfte CRC32-Prüfsumme ist $53994BD6
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/Xmind

2023-04-21 12:35:07 : INFO  : xmind : Mounted: /Volumes/Xmind
2023-04-21 12:35:07 : INFO  : xmind : Verifying: /Volumes/Xmind/Xmind.app
2023-04-21 12:35:07 : DEBUG : xmind : App size: 515M	/Volumes/Xmind/Xmind.app
2023-04-21 12:35:27 : DEBUG : xmind : Debugging enabled, App Verification output was:
/Volumes/Xmind/Xmind.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: XMind Ltd. (4WV38P2X5K)

2023-04-21 12:35:27 : INFO  : xmind : Team ID matching: 4WV38P2X5K (expected: 4WV38P2X5K )
2023-04-21 12:35:27 : INFO  : xmind : Downloaded version of Xmind is 22.11.3656 on versionKey CFBundleShortVersionString, same as installed.
2023-04-21 12:35:27 : DEBUG : xmind : Unmounting /Volumes/Xmind
2023-04-21 12:35:27 : DEBUG : xmind : Debugging enabled, Unmounting output was:
"disk7" ejected.
2023-04-21 12:35:27 : DEBUG : xmind : DEBUG mode 1, not reopening anything
2023-04-21 12:35:27 : REG   : xmind : No new version to install
2023-04-21 12:35:27 : REQ   : xmind : ################## End Installomator, exit code 0
```