### PR TITLE
GPG Suite: Update domain

### DIFF
--- a/fragments/labels/gpgsuite.sh
+++ b/fragments/labels/gpgsuite.sh
@@ -3,7 +3,7 @@ gpgsuite)
     name="GPG Suite"
     type="pkgInDmg"
     pkgName="Install.pkg"
-    downloadURL=$(curl -s https://gpgtools.org/ | grep https://releases.gpgtools.org/GPG_Suite- | grep Download | cut -d'"' -f4)
+    downloadURL=$(curl -s https://gpgtools.com/ | grep https://releases.gpgtools.com/GPG_Suite- | grep Download | cut -d'"' -f4)
     appNewVersion=$(echo $downloadURL | cut -d "-" -f 2 | cut -d "." -f 1-2)
     expectedTeamID="PKV8ZPD836"
     blockingProcesses=( "GPG Keychain" )


### PR DESCRIPTION
switch from gpgtools.org to gpgtools.com
The install file is no longer hosted on gpgtools.org