### PR TITLE
Enhance Label Inkscape

### DIFF
--- a/fragments/labels/inkscape.sh
+++ b/fragments/labels/inkscape.sh
@@ -2,8 +2,8 @@ inkscape)
     # credit: Søren Theilgaard (@theilgaard)
     name="Inkscape"
     type="dmg"
-    downloadURL="https://inkscape.org$(curl -fs https://inkscape.org$(curl -fsJL https://inkscape.org/release/  | grep "/release/" | grep en | head -n 1 | cut -d '"' -f 6)mac-os-x/dmg/dl/ | grep "click here" | cut -d '"' -f 2)"
     appCustomVersion() { /Applications/Inkscape.app/Contents/MacOS/inkscape --version | cut -d " " -f2 }
     appNewVersion=$(curl -fsJL https://inkscape.org/release/  | grep "<title>" | grep -o -e "[0-9.]*")
+    downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-"$appNewVersion"_"$(arch)".dmg
     expectedTeamID="SW3D6BB6A6"
     ;;


### PR DESCRIPTION
changed the downloadURL to incorporate arch based downloads

```
# sudo ./Installomator.sh inkscape DEBUG=1 NOTIFY=success

2023-04-24 11:27:20 : INFO  : inkscape : setting variable from argument DEBUG=1
2023-04-24 11:27:20 : INFO  : inkscape : setting variable from argument NOTIFY=success
2023-04-24 11:27:20 : REQ   : inkscape : ################## Start Installomator v. 10.4beta, date 2023-04-12
2023-04-24 11:27:20 : INFO  : inkscape : ################## Version: 10.4beta
2023-04-24 11:27:20 : INFO  : inkscape : ################## Date: 2023-04-12
2023-04-24 11:27:20 : INFO  : inkscape : ################## inkscape
2023-04-24 11:27:20 : DEBUG : inkscape : DEBUG mode 1 enabled.
2023-04-24 11:27:21 : DEBUG : inkscape : name=Inkscape
2023-04-24 11:27:21 : DEBUG : inkscape : appName=
2023-04-24 11:27:21 : DEBUG : inkscape : type=dmg
2023-04-24 11:27:22 : DEBUG : inkscape : archiveName=
2023-04-24 11:27:22 : DEBUG : inkscape : downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-1.2.2_arm64.dmg
2023-04-24 11:27:22 : DEBUG : inkscape : curlOptions=
2023-04-24 11:27:22 : DEBUG : inkscape : appNewVersion=1.2.2
2023-04-24 11:27:22 : DEBUG : inkscape : appCustomVersion function: Defined. 
2023-04-24 11:27:22 : DEBUG : inkscape : versionKey=CFBundleShortVersionString
2023-04-24 11:27:22 : DEBUG : inkscape : packageID=
2023-04-24 11:27:22 : DEBUG : inkscape : pkgName=
2023-04-24 11:27:22 : DEBUG : inkscape : choiceChangesXML=
2023-04-24 11:27:22 : DEBUG : inkscape : expectedTeamID=SW3D6BB6A6
2023-04-24 11:27:22 : DEBUG : inkscape : blockingProcesses=
2023-04-24 11:27:22 : DEBUG : inkscape : installerTool=
2023-04-24 11:27:22 : DEBUG : inkscape : CLIInstaller=
2023-04-24 11:27:22 : DEBUG : inkscape : CLIArguments=
2023-04-24 11:27:22 : DEBUG : inkscape : updateTool=
2023-04-24 11:27:22 : DEBUG : inkscape : updateToolArguments=
2023-04-24 11:27:22 : DEBUG : inkscape : updateToolRunAsCurrentUser=
2023-04-24 11:27:22 : INFO  : inkscape : BLOCKING_PROCESS_ACTION=tell_user
2023-04-24 11:27:22 : INFO  : inkscape : NOTIFY=success
2023-04-24 11:27:22 : INFO  : inkscape : LOGGING=DEBUG
2023-04-24 11:27:22 : INFO  : inkscape : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-24 11:27:22 : INFO  : inkscape : Label type: dmg
2023-04-24 11:27:22 : INFO  : inkscape : archiveName: Inkscape.dmg
2023-04-24 11:27:22 : INFO  : inkscape : no blocking processes defined, using Inkscape as default
2023-04-24 11:27:22 : DEBUG : inkscape : Changing directory to .
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2023-04-24 11:27:22 : INFO  : inkscape : Custom App Version detection is used, found 
2023-04-24 11:27:22 : INFO  : inkscape : appversion: 
2023-04-24 11:27:22 : INFO  : inkscape : Latest version of Inkscape is 1.2.2
2023-04-24 11:27:22 : REQ   : inkscape : Downloading https://media.inkscape.org/dl/resources/file/Inkscape-1.2.2_arm64.dmg to Inkscape.dmg
2023-04-24 11:27:22 : DEBUG : inkscape : No Dialog connection, just download
2023-04-24 11:27:36 : DEBUG : inkscape : File list: -rw-r--r--  1 root  staff   142M 24 Apr 11:27 Inkscape.dmg
2023-04-24 11:27:36 : DEBUG : inkscape : File type: Inkscape.dmg: bzip2 compressed data, block size = 100k
2023-04-24 11:27:36 : DEBUG : inkscape : curl output was:
*   Trying 146.75.122.217:443...
* Connected to media.inkscape.org (146.75.122.217) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2818 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.inkscape.org
*  start date: Sep  9 00:40:58 2022 GMT
*  expire date: Oct 11 00:40:57 2023 GMT
*  subjectAltName: host "media.inkscape.org" matched cert's "*.inkscape.org"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2022 Q3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /dl/resources/file/Inkscape-1.2.2_arm64.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: media.inkscape.org]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12b00cc00)
> GET /dl/resources/file/Inkscape-1.2.2_arm64.dmg HTTP/2
> Host: media.inkscape.org
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 200 
< server: nginx/1.20.1
< content-type: application/octet-stream
< last-modified: Sat, 03 Dec 2022 00:58:26 GMT
< etag: "638a9f32-8e357e0"
< expires: Sat, 07 Jan 2023 05:51:50 GMT
< cache-control: max-age=2592000
< content-disposition: attachment; filename="Inkscape-1.2.2_arm64.dmg"
< accept-ranges: bytes
< date: Mon, 24 Apr 2023 09:27:23 GMT
< via: 1.1 varnish
< age: 1142138
< x-served-by: cache-hhn-etou8220052-HHN
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1682328443.112360,VS0,VE2
< content-length: 149116896
< 
{ [1162 bytes data]
* Connection #0 to host media.inkscape.org left intact

2023-04-24 11:27:36 : DEBUG : inkscape : DEBUG mode 1, not checking for blocking processes
2023-04-24 11:27:36 : REQ   : inkscape : Installing Inkscape
2023-04-24 11:27:36 : INFO  : inkscape : Mounting ./Inkscape.dmg
2023-04-24 11:27:47 : DEBUG : inkscape : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $BB9AF0A6
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $3BB75CB9
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $090F35E2
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $37990336
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $090F35E2
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $1DBBC9DE
Die überprüfte CRC32-Prüfsumme ist $89D06C82
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/Inkscape

2023-04-24 11:27:47 : INFO  : inkscape : Mounted: /Volumes/Inkscape
2023-04-24 11:27:47 : INFO  : inkscape : Verifying: /Volumes/Inkscape/Inkscape.app
2023-04-24 11:27:47 : DEBUG : inkscape : App size: 620M /Volumes/Inkscape/Inkscape.app
2023-04-24 11:27:59 : DEBUG : inkscape : Debugging enabled, App Verification output was:
/Volumes/Inkscape/Inkscape.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Rene de Hesselle (SW3D6BB6A6)

2023-04-24 11:27:59 : INFO  : inkscape : Team ID matching: SW3D6BB6A6 (expected: SW3D6BB6A6 )
2023-04-24 11:27:59 : INFO  : inkscape : Installing Inkscape version 1.2.2 on versionKey CFBundleShortVersionString.
2023-04-24 11:27:59 : INFO  : inkscape : App has LSMinimumSystemVersion: 11.3
2023-04-24 11:27:59 : DEBUG : inkscape : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-04-24 11:27:59 : INFO  : inkscape : Finishing...
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2023-04-24 11:28:02 : INFO  : inkscape : Custom App Version detection is used, found 
2023-04-24 11:28:02 : REQ   : inkscape : Installed Inkscape
2023-04-24 11:28:02 : INFO  : inkscape : notifying
2023-04-24 11:28:02 : DEBUG : inkscape : Unmounting /Volumes/Inkscape
2023-04-24 11:28:03 : DEBUG : inkscape : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-04-24 11:28:03 : DEBUG : inkscape : DEBUG mode 1, not reopening anything
2023-04-24 11:28:03 : REQ   : inkscape : All done!
2023-04-24 11:28:03 : REQ   : inkscape : ################## End Installomator, exit code 0 
```