### PR TITLE
New Label: xbar

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -563,6 +563,7 @@ wwdc
 xcreds
 xeroxphaser7800
 xeroxworkcentre7800
+xbar
 xink
 xmenu
 xquartz

--- a/fragments/labels/xbar.sh
+++ b/fragments/labels/xbar.sh
@@ -1,0 +1,7 @@
+xbar)
+    name="xbar"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit matryer xbar)
+    appNewVersion=$(versionFromGit matryer xbar)
+    expectedTeamID="N3H5B92L5N"
+    ;;


### PR DESCRIPTION
```
# sudo ./Installomator.sh xbar DEBUG=1 NOTIFY=success    

2023-04-24 11:33:59 : INFO  : xbar : setting variable from argument DEBUG=1
2023-04-24 11:33:59 : INFO  : xbar : setting variable from argument NOTIFY=success
2023-04-24 11:33:59 : REQ   : xbar : ################## Start Installomator v. 10.4beta, date 2023-04-12
2023-04-24 11:33:59 : INFO  : xbar : ################## Version: 10.4beta
2023-04-24 11:33:59 : INFO  : xbar : ################## Date: 2023-04-12
2023-04-24 11:33:59 : INFO  : xbar : ################## xbar
2023-04-24 11:33:59 : DEBUG : xbar : DEBUG mode 1 enabled.
2023-04-24 11:34:01 : DEBUG : xbar : name=xbar
2023-04-24 11:34:01 : DEBUG : xbar : appName=
2023-04-24 11:34:01 : DEBUG : xbar : type=dmg
2023-04-24 11:34:01 : DEBUG : xbar : archiveName=
2023-04-24 11:34:01 : DEBUG : xbar : downloadURL=https://github.com/matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg
2023-04-24 11:34:01 : DEBUG : xbar : curlOptions=
2023-04-24 11:34:01 : DEBUG : xbar : appNewVersion=2.1.7
2023-04-24 11:34:01 : DEBUG : xbar : appCustomVersion function: Not defined
2023-04-24 11:34:01 : DEBUG : xbar : versionKey=CFBundleShortVersionString
2023-04-24 11:34:01 : DEBUG : xbar : packageID=
2023-04-24 11:34:01 : DEBUG : xbar : pkgName=
2023-04-24 11:34:01 : DEBUG : xbar : choiceChangesXML=
2023-04-24 11:34:01 : DEBUG : xbar : expectedTeamID=N3H5B92L5N
2023-04-24 11:34:01 : DEBUG : xbar : blockingProcesses=
2023-04-24 11:34:01 : DEBUG : xbar : installerTool=
2023-04-24 11:34:01 : DEBUG : xbar : CLIInstaller=
2023-04-24 11:34:01 : DEBUG : xbar : CLIArguments=
2023-04-24 11:34:01 : DEBUG : xbar : updateTool=
2023-04-24 11:34:01 : DEBUG : xbar : updateToolArguments=
2023-04-24 11:34:01 : DEBUG : xbar : updateToolRunAsCurrentUser=
2023-04-24 11:34:01 : INFO  : xbar : BLOCKING_PROCESS_ACTION=tell_user
2023-04-24 11:34:01 : INFO  : xbar : NOTIFY=success
2023-04-24 11:34:01 : INFO  : xbar : LOGGING=DEBUG
2023-04-24 11:34:01 : INFO  : xbar : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-24 11:34:01 : INFO  : xbar : Label type: dmg
2023-04-24 11:34:01 : INFO  : xbar : archiveName: xbar.dmg
2023-04-24 11:34:01 : INFO  : xbar : no blocking processes defined, using xbar as default
2023-04-24 11:34:01 : DEBUG : xbar : Changing directory to .
2023-04-24 11:34:01 : INFO  : xbar : App(s) found: /Applications/xbar.app
2023-04-24 11:34:01 : INFO  : xbar : found app at /Applications/xbar.app, version v2.1.7-beta, on versionKey CFBundleShortVersionString
2023-04-24 11:34:01 : INFO  : xbar : appversion: v2.1.7-beta
2023-04-24 11:34:01 : INFO  : xbar : Latest version of xbar is 2.1.7
2023-04-24 11:34:01 : REQ   : xbar : Downloading https://github.com/matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg to xbar.dmg
2023-04-24 11:34:01 : DEBUG : xbar : No Dialog connection, just download
2023-04-24 11:34:03 : DEBUG : xbar : File list: -rw-r--r--  1 root  staff   8,1M 24 Apr 11:34 xbar.dmg
2023-04-24 11:34:03 : DEBUG : xbar : File type: xbar.dmg: lzfse encoded, lzvn compressed
2023-04-24 11:34:03 : DEBUG : xbar : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x120812400)
> GET /matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Mon, 24 Apr 2023 09:34:02 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/14376285/8ee7f0f7-4238-49ec-a0f3-7869d477fc9a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230424%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230424T093402Z&X-Amz-Expires=300&X-Amz-Signature=3c5d376b4a58abf5262622e5d75b149480f83fcc395fb999b33000ecd1b2b19d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=14376285&response-content-disposition=attachment%3B%20filename%3Dxbar.v2.1.7-beta.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: C5A0:2811:9B61BE2:9E741D5:64464D0A
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/14376285/8ee7f0f7-4238-49ec-a0f3-7869d477fc9a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230424%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230424T093402Z&X-Amz-Expires=300&X-Amz-Signature=3c5d376b4a58abf5262622e5d75b149480f83fcc395fb999b33000ecd1b2b19d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=14376285&response-content-disposition=attachment%3B%20filename%3Dxbar.v2.1.7-beta.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/14376285/8ee7f0f7-4238-49ec-a0f3-7869d477fc9a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230424%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230424T093402Z&X-Amz-Expires=300&X-Amz-Signature=3c5d376b4a58abf5262622e5d75b149480f83fcc395fb999b33000ecd1b2b19d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=14376285&response-content-disposition=attachment%3B%20filename%3Dxbar.v2.1.7-beta.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x120812400)
> GET /github-production-release-asset-2e65be/14376285/8ee7f0f7-4238-49ec-a0f3-7869d477fc9a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230424%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230424T093402Z&X-Amz-Expires=300&X-Amz-Signature=3c5d376b4a58abf5262622e5d75b149480f83fcc395fb999b33000ecd1b2b19d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=14376285&response-content-disposition=attachment%3B%20filename%3Dxbar.v2.1.7-beta.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Mon, 06 Dec 2021 23:40:55 GMT
< etag: "0x8D9B911D8CB8262"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: d952b31a-c01e-0025-798f-764829000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Mon, 06 Dec 2021 23:40:55 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=xbar.v2.1.7-beta.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Mon, 24 Apr 2023 09:34:02 GMT
< x-served-by: cache-iad-kiad7000048-IAD, cache-ams21080-AMS
< x-cache: HIT, MISS
< x-cache-hits: 1, 0
< x-timer: S1682328843.623503,VS0,VE170
< content-length: 8484887
< 
{ [1161 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-04-24 11:34:03 : DEBUG : xbar : DEBUG mode 1, not checking for blocking processes
2023-04-24 11:34:03 : REQ   : xbar : Installing xbar
2023-04-24 11:34:03 : INFO  : xbar : Mounting ./xbar.dmg
2023-04-24 11:34:06 : DEBUG : xbar : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $926B0229
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $6D23AA2E
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $27E5E0B7
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $F264BEFA
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $27E5E0B7
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $2E04118C
Die überprüfte CRC32-Prüfsumme ist $D6FA5F64
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/Install xbar

2023-04-24 11:34:06 : INFO  : xbar : Mounted: /Volumes/Install xbar
2023-04-24 11:34:06 : INFO  : xbar : Verifying: /Volumes/Install xbar/xbar.app
2023-04-24 11:34:06 : DEBUG : xbar : App size:  24M     /Volumes/Install xbar/xbar.app
2023-04-24 11:34:06 : DEBUG : xbar : Debugging enabled, App Verification output was:
/Volumes/Install xbar/xbar.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mat Ryer (N3H5B92L5N)

2023-04-24 11:34:06 : INFO  : xbar : Team ID matching: N3H5B92L5N (expected: N3H5B92L5N )
2023-04-24 11:34:06 : INFO  : xbar : Downloaded version of xbar is v2.1.7-beta on versionKey CFBundleShortVersionString, same as installed.
2023-04-24 11:34:06 : DEBUG : xbar : Unmounting /Volumes/Install xbar
2023-04-24 11:34:06 : DEBUG : xbar : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-04-24 11:34:06 : DEBUG : xbar : DEBUG mode 1, not reopening anything
2023-04-24 11:34:06 : REG   : xbar : No new version to install
2023-04-24 11:34:06 : REQ   : xbar : ################## End Installomator, exit code 0 
```