### PR TITLE
Updated label: FlowJo

### DIFF
--- a/fragments/labels/flowjo.sh
+++ b/fragments/labels/flowjo.sh
@@ -1,8 +1,7 @@
 flowjo)
-    name="FlowJo-OSX64-10.8.0"
+    name="FlowJo"
     type="dmg"
     downloadURL="$(curl -fs "https://www.flowjo.com/solutions/flowjo/downloads" | grep -i -o -E "https.*\.dmg")"
     appNewVersion=$(echo "${downloadURL}" | tr "-" "\n" | grep dmg | sed -E 's/([0-9.]*)\.dmg/\1/g')
     expectedTeamID="C79HU5AD9V"
-    appName="FlowJo.app"
     ;;


### PR DESCRIPTION
The name variable should be the name of the installed application. Not a static dmg name containing a specific version of the application.