### PR TITLE
Red Canary Mac Monitor

### DIFF
--- a/fragments/labels/redcanarymacmonitor.sh
+++ b/fragments/labels/redcanarymacmonitor.sh
@@ -1,0 +1,9 @@
+redcanarymacmonitor)
+    name="Red Canary Mac Monitor"
+    # Red Canary Mac Monitor is an advanced, stand-alone system monitoring tool tailor-made for macOS security research, malware triage, and system troubleshooting
+    type="pkg"
+    packageID="com.redcanary.agent"
+    downloadURL="$(downloadURLFromGit redcanaryco mac-monitor)"
+    appNewVersion="$(versionFromGit redcanaryco mac-monitor)"
+    expectedTeamID="UA6JCQGF3F"
+    ;;


### PR DESCRIPTION
Interesting GitHub project:
```
% sudo utils/assemble.sh redcanarymacmonitor DEBUG=0
Password:
2023-04-28 13:40:50 : INFO  : redcanarymacmonitor : setting variable from argument DEBUG=0
2023-04-28 13:40:50 : REQ   : redcanarymacmonitor : ################## Start Installomator v. 10.4beta, date 2023-04-28
2023-04-28 13:40:50 : INFO  : redcanarymacmonitor : ################## Version: 10.4beta
2023-04-28 13:40:50 : INFO  : redcanarymacmonitor : ################## Date: 2023-04-28
2023-04-28 13:40:50 : INFO  : redcanarymacmonitor : ################## redcanarymacmonitor
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : BLOCKING_PROCESS_ACTION=tell_user
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : NOTIFY=success
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : LOGGING=INFO
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : Label type: pkg
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : archiveName: Red Canary Mac Monitor.pkg
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : no blocking processes defined, using Red Canary Mac Monitor as default
2023-04-28 13:40:51 : INFO  : redcanarymacmonitor : No version found using packageID com.redcanary.agent
2023-04-28 13:40:52 : INFO  : redcanarymacmonitor : name: Red Canary Mac Monitor, appName: Red Canary Mac Monitor.app
2023-04-28 13:40:52 : WARN  : redcanarymacmonitor : No previous app found
2023-04-28 13:40:52 : WARN  : redcanarymacmonitor : could not find Red Canary Mac Monitor.app
2023-04-28 13:40:52 : INFO  : redcanarymacmonitor : appversion:
2023-04-28 13:40:52 : INFO  : redcanarymacmonitor : Latest version of Red Canary Mac Monitor is 1.0.3
2023-04-28 13:40:52 : REQ   : redcanarymacmonitor : Downloading https://github.com/redcanaryco/mac-monitor/releases/download/v1.0.3/Red-Canary-Mac-Monitor-GoldCardinal-1-0-3.pkg to Red Canary Mac Monitor.pkg
2023-04-28 13:40:54 : REQ   : redcanarymacmonitor : no more blocking processes, continue with update
2023-04-28 13:40:54 : REQ   : redcanarymacmonitor : Installing Red Canary Mac Monitor
2023-04-28 13:40:54 : INFO  : redcanarymacmonitor : Verifying: Red Canary Mac Monitor.pkg
2023-04-28 13:40:54 : INFO  : redcanarymacmonitor : Team ID: UA6JCQGF3F (expected: UA6JCQGF3F )
2023-04-28 13:40:54 : INFO  : redcanarymacmonitor : Installing Red Canary Mac Monitor.pkg to /
2023-04-28 13:40:57 : INFO  : redcanarymacmonitor : Finishing...
2023-04-28 13:41:00 : INFO  : redcanarymacmonitor : found packageID com.redcanary.agent installed, version 0
2023-04-28 13:41:00 : REQ   : redcanarymacmonitor : Installed Red Canary Mac Monitor, version 0
2023-04-28 13:41:00 : INFO  : redcanarymacmonitor : notifying
2023-04-28 13:41:00 : INFO  : redcanarymacmonitor : App not closed, so no reopen.
2023-04-28 13:41:00 : REQ   : redcanarymacmonitor : All done!
2023-04-28 13:41:00 : REQ   : redcanarymacmonitor : ################## End Installomator, exit code 0
```