### PR TITLE
New Label: displaylinkmanagergraphicsconnectivity

### DIFF
--- a/fragments/labels/displaylinkmanagergraphicsconnectivity.sh
+++ b/fragments/labels/displaylinkmanagergraphicsconnectivity.sh
@@ -1,0 +1,8 @@
+displaylinkmanagergraphicsconnectivity)
+    name="DisplayLink Manager Graphics Connectivity"
+    type="pkg"
+    packageID="com.displaylink.displaylinkmanagerapp"
+    downloadURL=https://www.synaptics.com$(curl -fLs "https://www.synaptics.com$(curl -fLs https://www.synaptics.com/products/displaylink-graphics/downloads/macos | xmllint --html --format - 2>/dev/null | grep -oE '"/node/.+?"' | head -n1 | tr -d '"')" | xmllint --html --format - 2>/dev/null | grep -oE "/.+\.pkg")
+    appNewVersion=$(echo "${downloadURL}" | grep -Eo '[0-9]\.[0-9]+(\.[0-9])?')
+    expectedTeamID="73YQY62QM3"
+    ;;


### PR DESCRIPTION
https://www.synaptics.com/products/displaylink-graphics/downloads/macos

Related to #291

```sh
$ utils/assemble.sh displaylinkmanagergraphicsconnectivity DEBUG=1
2023-05-02 13:40:09 : INFO  : displaylinkmanagergraphicsconnectivity : setting variable from argument DEBUG=1
2023-05-02 13:40:09 : REQ   : displaylinkmanagergraphicsconnectivity : ################## Start Installomator v. 10.4beta, date 2023-05-02
2023-05-02 13:40:09 : INFO  : displaylinkmanagergraphicsconnectivity : ################## Version: 10.4beta
2023-05-02 13:40:09 : INFO  : displaylinkmanagergraphicsconnectivity : ################## Date: 2023-05-02
2023-05-02 13:40:09 : INFO  : displaylinkmanagergraphicsconnectivity : ################## displaylinkmanagergraphicsconnectivity
2023-05-02 13:40:09 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1 enabled.
2023-05-02 13:40:09 : INFO  : displaylinkmanagergraphicsconnectivity : SwiftDialog is not installed, clear cmd file var
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : name=DisplayLink Manager Graphics Connectivity
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : appName=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : type=pkg
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : archiveName=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : downloadURL=https://www.synaptics.com/sites/default/files/exe_files/2023-03/DisplayLink%20Manager%20Graphics%20Connectivity1.8.1-EXE.pkg
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : curlOptions=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : appNewVersion=1.8.1
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : appCustomVersion function: Not defined
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : versionKey=CFBundleShortVersionString
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : packageID=com.displaylink.displaylinkmanagerapp
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : pkgName=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : choiceChangesXML=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : expectedTeamID=73YQY62QM3
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : blockingProcesses=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : installerTool=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : CLIInstaller=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : CLIArguments=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : updateTool=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : updateToolArguments=
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : updateToolRunAsCurrentUser=
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : BLOCKING_PROCESS_ACTION=tell_user
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : NOTIFY=success
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : LOGGING=DEBUG
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : Label type: pkg
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : archiveName: DisplayLink Manager Graphics Connectivity.pkg
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : no blocking processes defined, using DisplayLink Manager Graphics Connectivity as default
2023-05-02 13:40:12 : DEBUG : displaylinkmanagergraphicsconnectivity : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : No version found using packageID com.displaylink.displaylinkmanagerapp
2023-05-02 13:40:12 : INFO  : displaylinkmanagergraphicsconnectivity : name: DisplayLink Manager Graphics Connectivity, appName: DisplayLink Manager Graphics Connectivity.app
2023-05-02 13:40:13 : WARN  : displaylinkmanagergraphicsconnectivity : No previous app found
2023-05-02 13:40:13 : WARN  : displaylinkmanagergraphicsconnectivity : could not find DisplayLink Manager Graphics Connectivity.app
2023-05-02 13:40:13 : INFO  : displaylinkmanagergraphicsconnectivity : appversion:
2023-05-02 13:40:13 : INFO  : displaylinkmanagergraphicsconnectivity : Latest version of DisplayLink Manager Graphics Connectivity is 1.8.1
2023-05-02 13:40:13 : REQ   : displaylinkmanagergraphicsconnectivity : Downloading https://www.synaptics.com/sites/default/files/exe_files/2023-03/DisplayLink%20Manager%20Graphics%20Connectivity1.8.1-EXE.pkg to DisplayLink Manager Graphics Connectivity.pkg
2023-05-02 13:40:13 : DEBUG : displaylinkmanagergraphicsconnectivity : No Dialog connection, just download
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : File list: -rw-r--r--  1 kenchan0130  staff   8.3M  5  2 13:40 DisplayLink Manager Graphics Connectivity.pkg
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : File type: DisplayLink Manager Graphics Connectivity.pkg: xar archive compressed TOC: 4995, SHA-1 checksum
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : curl output was:
*   Trying 54.245.106.105:443...
* Connected to www.synaptics.com (54.245.106.105) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3095 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Synaptics Inc.; CN=www.synaptics.com
*  start date: Apr 29 00:00:00 2022 GMT
*  expire date: May 30 23:59:59 2023 GMT
*  subjectAltName: host "www.synaptics.com" matched cert's "www.synaptics.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /sites/default/files/exe_files/2023-03/DisplayLink%20Manager%20Graphics%20Connectivity1.8.1-EXE.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.synaptics.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15b00a800)
> GET /sites/default/files/exe_files/2023-03/DisplayLink%20Manager%20Graphics%20Connectivity1.8.1-EXE.pkg HTTP/2
> Host: www.synaptics.com
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< server: nginx
< date: Tue, 02 May 2023 04:40:14 GMT
< content-length: 8716434
< x-content-type-options: nosniff
< last-modified: Thu, 16 Mar 2023 18:38:17 GMT
< accept-ranges: bytes
< cache-control: max-age=1209600
< expires: Tue, 16 May 2023 04:40:14 GMT
< x-request-id: v-6df579ac-e8a3-11ed-b31c-5fa354d4598e
< x-ah-environment: prod
< vary: Host
< age: 0
< via: varnish
< x-cache: MISS
<
{ [16093 bytes data]
* Connection #0 to host www.synaptics.com left intact

2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1, not checking for blocking processes
2023-05-02 13:40:15 : REQ   : displaylinkmanagergraphicsconnectivity : Installing DisplayLink Manager Graphics Connectivity
2023-05-02 13:40:15 : INFO  : displaylinkmanagergraphicsconnectivity : Verifying: DisplayLink Manager Graphics Connectivity.pkg
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : File list: -rw-r--r--  1 kenchan0130  staff   8.3M  5  2 13:40 DisplayLink Manager Graphics Connectivity.pkg
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : File type: DisplayLink Manager Graphics Connectivity.pkg: xar archive compressed TOC: 4995, SHA-1 checksum
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : spctlOut is DisplayLink Manager Graphics Connectivity.pkg: accepted
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : source=Notarized Developer ID
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : origin=Developer ID Installer: DisplayLink Corp (73YQY62QM3)
2023-05-02 13:40:15 : INFO  : displaylinkmanagergraphicsconnectivity : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2023-05-02 13:40:15 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG enabled, skipping installation
2023-05-02 13:40:15 : INFO  : displaylinkmanagergraphicsconnectivity : Finishing...
2023-05-02 13:40:18 : INFO  : displaylinkmanagergraphicsconnectivity : No version found using packageID com.displaylink.displaylinkmanagerapp
2023-05-02 13:40:18 : INFO  : displaylinkmanagergraphicsconnectivity : name: DisplayLink Manager Graphics Connectivity, appName: DisplayLink Manager Graphics Connectivity.app
2023-05-02 13:40:19 : WARN  : displaylinkmanagergraphicsconnectivity : No previous app found
2023-05-02 13:40:19 : WARN  : displaylinkmanagergraphicsconnectivity : could not find DisplayLink Manager Graphics Connectivity.app
2023-05-02 13:40:19 : REQ   : displaylinkmanagergraphicsconnectivity : Installed DisplayLink Manager Graphics Connectivity
2023-05-02 13:40:19 : INFO  : displaylinkmanagergraphicsconnectivity : notifying
2023-05-02 13:40:19 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1, not reopening anything
2023-05-02 13:40:19 : REQ   : displaylinkmanagergraphicsconnectivity : All done!
2023-05-02 13:40:19 : REQ   : displaylinkmanagergraphicsconnectivity : ################## End Installomator, exit code 0
```