### PR TITLE
Add label: ClearTouchCollage

### DIFF
--- a/fragments/labels/cleartouchcollage.sh
+++ b/fragments/labels/cleartouchcollage.sh
@@ -2,7 +2,6 @@ cleartouchcollage)
     name="Collage"
     type="pkgInZip"
     packageID="com.cvte.cleartouch.mac"
-    downloadURL="https://www.getcleartouch.com/download/collage-for-mac/?wpdmdl=412"
-    appNewVersion=$(curl -fsIL https://www.getcleartouch.com/download/collage-for-mac/\?wpdmdl\=412 | grep -i ^content-disposition | sed -E 's/.*V([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    downloadURL=$(curl -fs https://www.getcleartouch.com/download/collage-for-mac/ | xmllint --html --xpath 'string(//*[@id="wpdm-filelist-412"]/tbody/tr[1]/td[2]/a/@href)' - 2> /dev/null | sed 's/ /%20/g')
     expectedTeamID="P76M9BE8DQ"
     ;;

--- a/fragments/labels/cleartouchcollage.sh
+++ b/fragments/labels/cleartouchcollage.sh
@@ -1,0 +1,8 @@
+cleartouchcollage)
+    name="Collage"
+    type="pkgInZip"
+    packageID="com.cvte.cleartouch.mac"
+    downloadURL="https://www.getcleartouch.com/download/collage-for-mac/?wpdmdl=412"
+    appNewVersion=$(curl -fsIL https://www.getcleartouch.com/download/collage-for-mac/\?wpdmdl\=412 | grep -i ^content-disposition | sed -E 's/.*V([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    expectedTeamID="P76M9BE8DQ"
+    ;;


### PR DESCRIPTION
Result:
admin in ~/Documents/GitHub/Installomator/build on cleartouch-label λ sudo ./Installomator.sh cleartouchcollage DEBUG=0
2023-05-01 15:41:10 : INFO  : cleartouchcollage : setting variable from argument DEBUG=0
2023-05-01 15:41:10 : REQ   : cleartouchcollage : ################## Start Installomator v. 10.4beta, date 2023-05-01
2023-05-01 15:41:10 : INFO  : cleartouchcollage : ################## Version: 10.4beta
2023-05-01 15:41:10 : INFO  : cleartouchcollage : ################## Date: 2023-05-01
2023-05-01 15:41:10 : INFO  : cleartouchcollage : ################## cleartouchcollage
2023-05-01 15:41:16 : INFO  : cleartouchcollage : BLOCKING_PROCESS_ACTION=tell_user
2023-05-01 15:41:16 : INFO  : cleartouchcollage : NOTIFY=success
2023-05-01 15:41:16 : INFO  : cleartouchcollage : LOGGING=INFO
2023-05-01 15:41:16 : INFO  : cleartouchcollage : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-01 15:41:16 : INFO  : cleartouchcollage : Label type: pkgInZip
2023-05-01 15:41:16 : INFO  : cleartouchcollage : archiveName: Collage.zip
2023-05-01 15:41:16 : INFO  : cleartouchcollage : no blocking processes defined, using Collage as default
2023-05-01 15:41:16 : INFO  : cleartouchcollage : No version found using packageID com.cvte.cleartouch.mac
2023-05-01 15:41:16 : INFO  : cleartouchcollage : name: Collage, appName: Collage.app
2023-05-01 15:41:16.456 mdfind[69946:2560716] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-01 15:41:16.456 mdfind[69946:2560716] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-01 15:41:16.490 mdfind[69946:2560716] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-01 15:41:16 : WARN  : cleartouchcollage : No previous app found
2023-05-01 15:41:16 : WARN  : cleartouchcollage : could not find Collage.app
2023-05-01 15:41:16 : INFO  : cleartouchcollage : appversion: 
2023-05-01 15:41:16 : INFO  : cleartouchcollage : Latest version of Collage is 5.5.0.3459
2023-05-01 15:41:16 : REQ   : cleartouchcollage : Downloading https://www.getcleartouch.com/download/collage-for-mac/?wpdmdl=412 to Collage.zip
2023-05-01 15:41:22 : REQ   : cleartouchcollage : no more blocking processes, continue with update
2023-05-01 15:41:22 : REQ   : cleartouchcollage : Installing Collage
2023-05-01 15:41:22 : INFO  : cleartouchcollage : Unzipping Collage.zip
2023-05-01 15:41:22 : INFO  : cleartouchcollage : found pkg: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YtTdWQAu/Collage_V5.5.0.3459 2/Collage.5.5.0.6803.pkg
2023-05-01 15:41:22 : INFO  : cleartouchcollage : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YtTdWQAu/Collage_V5.5.0.3459 2/Collage.5.5.0.6803.pkg
2023-05-01 15:41:22 : INFO  : cleartouchcollage : Team ID: P76M9BE8DQ (expected: P76M9BE8DQ )
2023-05-01 15:41:22 : INFO  : cleartouchcollage : Installing /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YtTdWQAu/Collage_V5.5.0.3459 2/Collage.5.5.0.6803.pkg to /
2023-05-01 15:41:26 : INFO  : cleartouchcollage : Finishing...
2023-05-01 15:41:29 : INFO  : cleartouchcollage : found packageID com.cvte.cleartouch.mac installed, version 5.5.0.6803
2023-05-01 15:41:29 : REQ   : cleartouchcollage : Installed Collage, version 5.5.0.6803
2023-05-01 15:41:29 : INFO  : cleartouchcollage : notifying
2023-05-01 15:41:30 : INFO  : cleartouchcollage : App not closed, so no reopen.
2023-05-01 15:41:30 : REQ   : cleartouchcollage : All done!
2023-05-01 15:41:30 : REQ   : cleartouchcollage : ################## End Installomator, exit code 0