### PR TITLE
Update shottr.sh

### DIFF
--- a/fragments/labels/shottr.sh
+++ b/fragments/labels/shottr.sh
@@ -1,7 +1,7 @@
 shottr)
     name="Shottr"
     type="dmg"
-    downloadURL="https://shottr.cc/dl/Shottr-1.5.3.dmg"
-    appNewVersion=$( echo ${downloadURL} | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' )
+    appNewVersion=$(curl -s https://shottr.cc/newversion.html | grep "Shottr v" | head -1 | sed 's/.*v\([0-9.]*\).*/\1/')
+    downloadURL="https://shottr.cc/dl/Shottr-${appNewVersion}.dmg"
     expectedTeamID="2Y683PRQWN"
     ;;


### PR DESCRIPTION
Changed to get the version from the website changelog, then use that in the download link. Currently download version is static and counter to Installomator's use case.

Fix for issue #997

Result:

admin in ~/Documents/GitHub/Installomator on Shottr-labelFix ● : sudo ./build/Installomator.sh shottr DEBUG=0                          
Password:
2023-05-02 15:49:21 : INFO  : shottr : setting variable from argument DEBUG=0
2023-05-02 15:49:21 : REQ   : shottr : ################## Start Installomator v. 10.4beta, date 2023-05-02
2023-05-02 15:49:21 : INFO  : shottr : ################## Version: 10.4beta
2023-05-02 15:49:21 : INFO  : shottr : ################## Date: 2023-05-02
2023-05-02 15:49:21 : INFO  : shottr : ################## shottr
2023-05-02 15:49:22 : INFO  : shottr : BLOCKING_PROCESS_ACTION=tell_user
2023-05-02 15:49:22 : INFO  : shottr : NOTIFY=success
2023-05-02 15:49:22 : INFO  : shottr : LOGGING=INFO
2023-05-02 15:49:22 : INFO  : shottr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-02 15:49:22 : INFO  : shottr : Label type: dmg
2023-05-02 15:49:22 : INFO  : shottr : archiveName: Shottr.dmg
2023-05-02 15:49:22 : INFO  : shottr : no blocking processes defined, using Shottr as default
2023-05-02 15:49:22 : INFO  : shottr : name: Shottr, appName: Shottr.app
2023-05-02 15:49:22.122 mdfind[25523:620883] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-02 15:49:22.122 mdfind[25523:620883] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-02 15:49:22.159 mdfind[25523:620883] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-02 15:49:22 : WARN  : shottr : No previous app found
2023-05-02 15:49:22 : WARN  : shottr : could not find Shottr.app
2023-05-02 15:49:22 : INFO  : shottr : appversion: 
2023-05-02 15:49:22 : INFO  : shottr : Latest version of Shottr is 1.6.2
2023-05-02 15:49:22 : REQ   : shottr : Downloading https://shottr.cc/dl/Shottr-1.6.2.dmg to Shottr.dmg
2023-05-02 15:49:22 : REQ   : shottr : no more blocking processes, continue with update
2023-05-02 15:49:22 : REQ   : shottr : Installing Shottr
2023-05-02 15:49:22 : INFO  : shottr : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hT3aN8Xu/Shottr.dmg
2023-05-02 15:49:23 : INFO  : shottr : Mounted: /Volumes/Shottr
2023-05-02 15:49:23 : INFO  : shottr : Verifying: /Volumes/Shottr/Shottr.app
2023-05-02 15:49:23 : INFO  : shottr : Team ID matching: 2Y683PRQWN (expected: 2Y683PRQWN )
2023-05-02 15:49:23 : INFO  : shottr : Installing Shottr version 1.6.2 on versionKey CFBundleShortVersionString.
2023-05-02 15:49:23 : INFO  : shottr : App has LSMinimumSystemVersion: 10.15
2023-05-02 15:49:23 : INFO  : shottr : Copy /Volumes/Shottr/Shottr.app to /Applications
2023-05-02 15:49:23 : WARN  : shottr : Changing owner to admin
2023-05-02 15:49:23 : INFO  : shottr : Finishing...
2023-05-02 15:49:26 : INFO  : shottr : App(s) found: /Applications/Shottr.app
2023-05-02 15:49:26 : INFO  : shottr : found app at /Applications/Shottr.app, version 1.6.2, on versionKey CFBundleShortVersionString
2023-05-02 15:49:26 : REQ   : shottr : Installed Shottr, version 1.6.2
2023-05-02 15:49:26 : INFO  : shottr : notifying
2023-05-02 15:49:27 : INFO  : shottr : App not closed, so no reopen.
2023-05-02 15:49:27 : REQ   : shottr : All done!
2023-05-02 15:49:27 : REQ   : shottr : ################## End Installomator, exit code 0