### PR TITLE
Update label: citrixworkspace (versioning fix)

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -11,8 +11,9 @@ citrixworkspace)
     newVersionString() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
         htmlDocument=$(curl -fs $urlToParse)
-        xmllint --html --xpath 'string(//p[contains(., "Version:")])' 2> /dev/null <(print $htmlDocument)
+        xmllint --html --xpath 'string(//p[contains(., "Version")])' 2> /dev/null <(print $htmlDocument)
     }
-    appNewVersion=$(newVersionString | cut -f 2- -d ' ')
+    appNewVersion=$(newVersionString | cut -f 2- -d ' ' | cut -d ' ' -f 1)
+    versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;

--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -13,7 +13,7 @@ citrixworkspace)
         htmlDocument=$(curl -fs $urlToParse)
         xmllint --html --xpath 'string(//p[contains(., "Version")])' 2> /dev/null <(print $htmlDocument)
     }
-    appNewVersion=$(newVersionString | cut -f 2- -d ' ' | cut -d ' ' -f 1)
+    appNewVersion=$(newVersionString | cut -d ' ' -f2 )
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;


### PR DESCRIPTION
appNewVersion was no longer working. It seems Citrix removed the colon after "Version" at some point.

However, this output gave a result like "23.04.0.36 (2304)", which the ending parenthesis is a shortened version of the first two sets in the version number and was not needed, so edited the cut to only include the useful part.

Added versionKey as well to match that full version number, rather than using the shorter and slightly less precise triple version number.

Results when fully up to date version is already installed:

admin in ~/Documents/GitHub/Installomator on CitrixWorkspace-labelEdit-VersionFix: ./build/Installomator.sh citrixworkspace DEBUG=2
2023-05-03 14:47:17 : INFO  : citrixworkspace : setting variable from argument DEBUG=2
2023-05-03 14:47:17 : REQ   : citrixworkspace : ################## Start Installomator v. 10.4beta, date 2023-05-03
2023-05-03 14:47:17 : INFO  : citrixworkspace : ################## Version: 10.4beta
2023-05-03 14:47:17 : INFO  : citrixworkspace : ################## Date: 2023-05-03
2023-05-03 14:47:17 : INFO  : citrixworkspace : ################## citrixworkspace
2023-05-03 14:47:17 : DEBUG : citrixworkspace : DEBUG mode 2 enabled.
2023-05-03 14:47:19 : DEBUG : citrixworkspace : name=Citrix Workspace
2023-05-03 14:47:19 : DEBUG : citrixworkspace : appName=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : type=pkgInDmg
2023-05-03 14:47:19 : DEBUG : citrixworkspace : archiveName=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : downloadURL=https://downloads.citrix.com/21799/CitrixWorkspaceApp.dmg?__gda__=exp=1683154038~acl=/*~hmac=8fdaebc8be8d4830367171894e011512a20853aa9dd8680d882b832d50225bd3
2023-05-03 14:47:19 : DEBUG : citrixworkspace : curlOptions=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : appNewVersion=23.04.0.36
2023-05-03 14:47:19 : DEBUG : citrixworkspace : appCustomVersion function: Not defined
2023-05-03 14:47:19 : DEBUG : citrixworkspace : versionKey=CitrixVersionString
2023-05-03 14:47:19 : DEBUG : citrixworkspace : packageID=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : pkgName=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : choiceChangesXML=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : expectedTeamID=S272Y5R93J
2023-05-03 14:47:19 : DEBUG : citrixworkspace : blockingProcesses=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : installerTool=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : CLIInstaller=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : CLIArguments=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : updateTool=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : updateToolArguments=
2023-05-03 14:47:19 : DEBUG : citrixworkspace : updateToolRunAsCurrentUser=
2023-05-03 14:47:19 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2023-05-03 14:47:19 : INFO  : citrixworkspace : NOTIFY=success
2023-05-03 14:47:19 : INFO  : citrixworkspace : LOGGING=DEBUG
2023-05-03 14:47:19 : INFO  : citrixworkspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-03 14:47:19 : INFO  : citrixworkspace : Label type: pkgInDmg
2023-05-03 14:47:19 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2023-05-03 14:47:19 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2023-05-03 14:47:19 : DEBUG : citrixworkspace : Changing directory to /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.bhiopgTo
2023-05-03 14:47:19 : INFO  : citrixworkspace : App(s) found: /Applications/Citrix Workspace.app
2023-05-03 14:47:19 : INFO  : citrixworkspace : found app at /Applications/Citrix Workspace.app, version 23.04.0.36, on versionKey CitrixVersionString
2023-05-03 14:47:19 : INFO  : citrixworkspace : appversion: 23.04.0.36
2023-05-03 14:47:19 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 23.04.0.36
2023-05-03 14:47:19 : INFO  : citrixworkspace : There is no newer version available.
2023-05-03 14:47:19 : DEBUG : citrixworkspace : Deleting /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.bhiopgTo
2023-05-03 14:47:19 : DEBUG : citrixworkspace : Debugging enabled, Deleting tmpDir output was:
/var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.bhiopgTo
2023-05-03 14:47:19 : INFO  : citrixworkspace : App not closed, so no reopen.
2023-05-03 14:47:19 : REQ   : citrixworkspace : No newer version.
2023-05-03 14:47:19 : REQ   : citrixworkspace : ################## End Installomator, exit code 0