### PR TITLE
Updated Label: Inkscape

### DIFF
--- a/fragments/labels/inkscape.sh
+++ b/fragments/labels/inkscape.sh
@@ -2,8 +2,12 @@ inkscape)
     # credit: Søren Theilgaard (@theilgaard)
     name="Inkscape"
     type="dmg"
-    downloadURL="https://inkscape.org$(curl -fs https://inkscape.org$(curl -fsJL https://inkscape.org/release/  | grep "/release/" | grep en | head -n 1 | cut -d '"' -f 6)mac-os-x/dmg/dl/ | grep "click here" | cut -d '"' -f 2)"
     appCustomVersion() { /Applications/Inkscape.app/Contents/MacOS/inkscape --version | cut -d " " -f2 }
     appNewVersion=$(curl -fsJL https://inkscape.org/release/  | grep "<title>" | grep -o -e "[0-9.]*")
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-"$appNewVersion"_arm64.dmg
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-"$appNewVersion"_x86_64.dmg
+    fi
     expectedTeamID="SW3D6BB6A6"
     ;;


### PR DESCRIPTION
The download URL based on arch in #1011 does not work. This change fixes that problem.

**Apple Silicon**
2023-05-04 09:45:00 : INFO  : Inkscape : setting variable from argument DEBUG=0
2023-05-04 09:45:00 : REQ   : inkscape : ################## Start Installomator v. 10.4beta, date 2023-05-04
2023-05-04 09:45:00 : INFO  : inkscape : ################## Version: 10.4beta
2023-05-04 09:45:00 : INFO  : inkscape : ################## Date: 2023-05-04
2023-05-04 09:45:00 : INFO  : inkscape : ################## inkscape
2023-05-04 09:45:00 : INFO  : inkscape : SwiftDialog is not installed, clear cmd file var
2023-05-04 09:45:02 : INFO  : inkscape : BLOCKING_PROCESS_ACTION=tell_user
2023-05-04 09:45:02 : INFO  : inkscape : NOTIFY=success
2023-05-04 09:45:02 : INFO  : inkscape : LOGGING=INFO
2023-05-04 09:45:02 : INFO  : inkscape : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-04 09:45:02 : INFO  : inkscape : Label type: dmg
2023-05-04 09:45:02 : INFO  : inkscape : archiveName: Inkscape.dmg
2023-05-04 09:45:02 : INFO  : inkscape : no blocking processes defined, using Inkscape as default
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2023-05-04 09:45:02 : INFO  : inkscape : Custom App Version detection is used, found 
2023-05-04 09:45:02 : INFO  : inkscape : appversion: 
2023-05-04 09:45:02 : INFO  : inkscape : Latest version of Inkscape is 1.2.2
2023-05-04 09:45:02 : REQ   : inkscape : Downloading https://media.inkscape.org/dl/resources/file/Inkscape-1.2.2_arm64.dmg to Inkscape.dmg
2023-05-04 09:45:09 : REQ   : inkscape : no more blocking processes, continue with update
2023-05-04 09:45:09 : REQ   : inkscape : Installing Inkscape
2023-05-04 09:45:09 : INFO  : inkscape : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MgDTsQpY/Inkscape.dmg
2023-05-04 09:45:21 : INFO  : inkscape : Mounted: /Volumes/Inkscape
2023-05-04 09:45:21 : INFO  : inkscape : Verifying: /Volumes/Inkscape/Inkscape.app
2023-05-04 09:45:33 : INFO  : inkscape : Team ID matching: SW3D6BB6A6 (expected: SW3D6BB6A6 )
2023-05-04 09:45:33 : INFO  : inkscape : Installing Inkscape version 1.2.2 on versionKey CFBundleShortVersionString.
2023-05-04 09:45:33 : INFO  : inkscape : App has LSMinimumSystemVersion: 11.3
2023-05-04 09:45:33 : INFO  : inkscape : Copy /Volumes/Inkscape/Inkscape.app to /Applications
2023-05-04 09:45:36 : WARN  : inkscape : Changing owner to kryptonit
2023-05-04 09:45:37 : INFO  : inkscape : Finishing...
2023-05-04 09:45:44 : INFO  : inkscape : Custom App Version detection is used, found 1.2.2
2023-05-04 09:45:44 : REQ   : inkscape : Installed Inkscape, version 1.2.2
2023-05-04 09:45:44 : INFO  : inkscape : notifying
2023-05-04 09:45:45 : INFO  : inkscape : App not closed, so no reopen.
2023-05-04 09:45:45 : REQ   : inkscape : All done!
2023-05-04 09:45:45 : REQ   : inkscape : ################## End Installomator, exit code 0

**Intel**
2023-05-04 09:43:51 : INFO  : Inkscape : setting variable from argument DEBUG=0
2023-05-04 09:43:51 : REQ   : inkscape : ################## Start Installomator v. 10.4beta, date 2023-05-04
2023-05-04 09:43:51 : INFO  : inkscape : ################## Version: 10.4beta
2023-05-04 09:43:51 : INFO  : inkscape : ################## Date: 2023-05-04
2023-05-04 09:43:51 : INFO  : inkscape : ################## inkscape
2023-05-04 09:43:51 : INFO  : inkscape : SwiftDialog is not installed, clear cmd file var
2023-05-04 09:43:53 : INFO  : inkscape : BLOCKING_PROCESS_ACTION=tell_user
2023-05-04 09:43:53 : INFO  : inkscape : NOTIFY=success
2023-05-04 09:43:53 : INFO  : inkscape : LOGGING=INFO
2023-05-04 09:43:53 : INFO  : inkscape : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-04 09:43:53 : INFO  : inkscape : Label type: dmg
2023-05-04 09:43:53 : INFO  : inkscape : archiveName: Inkscape.dmg
2023-05-04 09:43:53 : INFO  : inkscape : no blocking processes defined, using Inkscape as default
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2023-05-04 09:43:53 : INFO  : inkscape : Custom App Version detection is used, found 
2023-05-04 09:43:53 : INFO  : inkscape : appversion: 
2023-05-04 09:43:53 : INFO  : inkscape : Latest version of Inkscape is 1.2.2
2023-05-04 09:43:53 : REQ   : inkscape : Downloading https://media.inkscape.org/dl/resources/file/Inkscape-1.2.2_x86_64.dmg to Inkscape.dmg
2023-05-04 09:44:00 : REQ   : inkscape : no more blocking processes, continue with update
2023-05-04 09:44:00 : REQ   : inkscape : Installing Inkscape
2023-05-04 09:44:00 : INFO  : inkscape : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ecX0NSnI/Inkscape.dmg
2023-05-04 09:44:11 : INFO  : inkscape : Mounted: /Volumes/Inkscape
2023-05-04 09:44:11 : INFO  : inkscape : Verifying: /Volumes/Inkscape/Inkscape.app
2023-05-04 09:44:23 : INFO  : inkscape : Team ID matching: SW3D6BB6A6 (expected: SW3D6BB6A6 )
2023-05-04 09:44:23 : INFO  : inkscape : Installing Inkscape version 1.2.2 on versionKey CFBundleShortVersionString.
2023-05-04 09:44:23 : INFO  : inkscape : App has LSMinimumSystemVersion: 10.13
2023-05-04 09:44:23 : INFO  : inkscape : Copy /Volumes/Inkscape/Inkscape.app to /Applications
2023-05-04 09:44:27 : WARN  : inkscape : Changing owner to kryptonit
2023-05-04 09:44:27 : INFO  : inkscape : Finishing...
2023-05-04 09:44:38 : INFO  : inkscape : Custom App Version detection is used, found 1.2.2
2023-05-04 09:44:38 : REQ   : inkscape : Installed Inkscape, version 1.2.2
2023-05-04 09:44:38 : INFO  : inkscape : notifying
2023-05-04 09:44:39 : INFO  : inkscape : App not closed, so no reopen.
2023-05-04 09:44:39 : REQ   : inkscape : All done!
2023-05-04 09:44:39 : REQ   : inkscape : ################## End Installomator, exit code 0