### PR TITLE
Wireshark: fix appNewVersion & download URL

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,11 +1,12 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    appNewVersion=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:version)[1]' 2>/dev/null | head -1 | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xmllint --xpath '/rss/channel/item/enclosure/@url' - | head -1 | cut -d '"' -f 2)
+    urlToParse=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xmllint --xpath '/rss/channel/item/enclosure/@url' - | head -1 | cut -d ':' -f 2 | cut -d '%' -f 1)
     if [[ $(arch) == i386 ]]; then
-      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Intel%2064.dmg"
+      downloadURL="https:$urlToParse%20Latest%20Intel%2064.dmg"
     elif [[ $(arch) == arm64 ]]; then
-      downloadURL="https://1.as.dl.wireshark.org/osx/Wireshark%20Latest%20Arm%2064.dmg"
+      downloadURL="https:$urlToParse%20Latest%20Arm%2064.dmg"
     fi
     expectedTeamID="7Z6EMTD2C6"
     ;;


### PR DESCRIPTION
dmg archives are not downloading due to wrong download URL, update appNewVersion too
#1008 


```
2023-05-08 18:05:46 : REQ   : wireshark : ################## Start Installomator v. 10.4beta, date 2023-05-08
2023-05-08 18:05:46 : INFO  : wireshark : ################## Version: 10.4beta
2023-05-08 18:05:46 : INFO  : wireshark : ################## Date: 2023-05-08
2023-05-08 18:05:46 : INFO  : wireshark : ################## wireshark
2023-05-08 18:05:46 : DEBUG : wireshark : DEBUG mode 1 enabled.
2023-05-08 18:05:49 : DEBUG : wireshark : name=Wireshark
2023-05-08 18:05:49 : DEBUG : wireshark : appName=
2023-05-08 18:05:49 : DEBUG : wireshark : type=dmg
2023-05-08 18:05:49 : DEBUG : wireshark : archiveName=
2023-05-08 18:05:49 : DEBUG : wireshark : downloadURL=https://2.na.dl.wireshark.org/osx/Wireshark%20Latest%20Intel%2064.dmg
2023-05-08 18:05:49 : DEBUG : wireshark : curlOptions=
2023-05-08 18:05:49 : DEBUG : wireshark : appNewVersion=https://2.na.dl.wireshark.org/osx/Wireshark%204.0.5%20Intel%2064.dmg
2023-05-08 18:05:49 : DEBUG : wireshark : appCustomVersion function: Not defined
2023-05-08 18:05:49 : DEBUG : wireshark : versionKey=CFBundleShortVersionString
2023-05-08 18:05:49 : DEBUG : wireshark : packageID=
2023-05-08 18:05:49 : DEBUG : wireshark : pkgName=
2023-05-08 18:05:49 : DEBUG : wireshark : choiceChangesXML=
2023-05-08 18:05:49 : DEBUG : wireshark : expectedTeamID=7Z6EMTD2C6
2023-05-08 18:05:49 : DEBUG : wireshark : blockingProcesses=
2023-05-08 18:05:49 : DEBUG : wireshark : installerTool=
2023-05-08 18:05:49 : DEBUG : wireshark : CLIInstaller=
2023-05-08 18:05:49 : DEBUG : wireshark : CLIArguments=
2023-05-08 18:05:49 : DEBUG : wireshark : updateTool=
2023-05-08 18:05:49 : DEBUG : wireshark : updateToolArguments=
2023-05-08 18:05:49 : DEBUG : wireshark : updateToolRunAsCurrentUser=
2023-05-08 18:05:49 : INFO  : wireshark : BLOCKING_PROCESS_ACTION=tell_user
2023-05-08 18:05:49 : INFO  : wireshark : NOTIFY=success
2023-05-08 18:05:49 : INFO  : wireshark : LOGGING=DEBUG
2023-05-08 18:05:49 : INFO  : wireshark : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-08 18:05:49 : INFO  : wireshark : Label type: dmg
2023-05-08 18:05:49 : INFO  : wireshark : archiveName: Wireshark.dmg
2023-05-08 18:05:49 : INFO  : wireshark : no blocking processes defined, using Wireshark as default
2023-05-08 18:05:49 : DEBUG : wireshark : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-05-08 18:05:49 : INFO  : wireshark : name: Wireshark, appName: Wireshark.app
2023-05-08 18:05:49.909 mdfind[39898:351048] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-05-08 18:05:50.074 mdfind[39898:351048] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-08 18:05:50 : INFO  : wireshark : App(s) found: /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.Wireshark-pkg-upload/Wireshark/Applications/Wireshark.app
2023-05-08 18:05:50 : WARN  : wireshark : could not determine location of Wireshark.app
2023-05-08 18:05:50 : INFO  : wireshark : appversion: 
2023-05-08 18:05:50 : INFO  : wireshark : Latest version of Wireshark is https://2.na.dl.wireshark.org/osx/Wireshark%204.0.5%20Intel%2064.dmg
2023-05-08 18:05:50 : INFO  : wireshark : Wireshark.dmg exists and DEBUG mode 1 enabled, skipping download
2023-05-08 18:05:50 : DEBUG : wireshark : DEBUG mode 1, not checking for blocking processes
2023-05-08 18:05:50 : REQ   : wireshark : Installing Wireshark
2023-05-08 18:05:50 : INFO  : wireshark : Mounting /Users/asri/Documents/dev/Installomator/build/Wireshark.dmg
2023-05-08 18:05:51 : DEBUG : wireshark : Debugging enabled, dmgmount output was:
expected CRC32 $BCE746F3
/dev/disk2              GUID_partition_scheme
/dev/disk2s1            Apple_HFS                       /Volumes/Wireshark 4.0.5

2023-05-08 18:05:51 : INFO  : wireshark : Mounted: /Volumes/Wireshark 4.0.5
2023-05-08 18:05:51 : INFO  : wireshark : Verifying: /Volumes/Wireshark 4.0.5/Wireshark.app
2023-05-08 18:05:51 : DEBUG : wireshark : App size: 227M        /Volumes/Wireshark 4.0.5/Wireshark.app
2023-05-08 18:05:58 : DEBUG : wireshark : Debugging enabled, App Verification output was:
/Volumes/Wireshark 4.0.5/Wireshark.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Wireshark Foundation, Inc. (7Z6EMTD2C6)

2023-05-08 18:05:58 : INFO  : wireshark : Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2023-05-08 18:05:59 : INFO  : wireshark : Installing Wireshark version 4.0.5 on versionKey CFBundleShortVersionString.
2023-05-08 18:05:59 : INFO  : wireshark : App has LSMinimumSystemVersion: 10.14
2023-05-08 18:05:59 : DEBUG : wireshark : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-05-08 18:05:59 : INFO  : wireshark : Finishing...
2023-05-08 18:06:02 : INFO  : wireshark : name: Wireshark, appName: Wireshark.app
2023-05-08 18:06:02.587 mdfind[39993:351553] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-05-08 18:06:02.740 mdfind[39993:351553] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-08 18:06:02 : INFO  : wireshark : App(s) found: /Users/asri/Library/AutoPkg/Cache/com.github.autopkg.grahampugh-recipes.jamf.Wireshark-pkg-upload/Wireshark/Applications/Wireshark.app
2023-05-08 18:06:02 : WARN  : wireshark : could not determine location of Wireshark.app
2023-05-08 18:06:03 : REQ   : wireshark : Installed Wireshark
2023-05-08 18:06:03 : INFO  : wireshark : notifying
2023-05-08 18:06:03 : DEBUG : wireshark : Unmounting /Volumes/Wireshark 4.0.5
2023-05-08 18:06:03 : DEBUG : wireshark : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-05-08 18:06:03 : DEBUG : wireshark : DEBUG mode 1, not reopening anything
2023-05-08 18:06:03 : REQ   : wireshark : All done!
2023-05-08 18:06:03 : REQ   : wireshark : ################## End Installomator, exit code 0
```