### PR TITLE
New Label: TeamViewer QuickSupport (custom)

### DIFF
--- a/fragments/labels/teamviewerqscustom.sh
+++ b/fragments/labels/teamviewerqscustom.sh
@@ -1,0 +1,11 @@
+teamviewerqscustom)
+    name="TeamViewerQS"
+    type="zip"
+    teamviewerCustomDownloadURL="" # https://get.teamviewer.com/your_custom_name_here
+    teamviewerConfigID=$(curl -fs ${teamviewerCustomDownloadURL} -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' | grep -o 'var configId = ".*"' | awk -F'"' '{ print $2 }')
+    teamviewerVersion=$(curl -fs ${teamviewerCustomDownloadURL} -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' | grep -o 'var version = ".*"' | awk -F'"' '{ print $2 }')
+    downloadURL=$(curl -fs -X POST --url "https://get.teamviewer.com/api/CustomDesign" --header 'Content-Type: application/json; charset=utf-8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' --data '{ "ConfigId": "'"$teamviewerConfigID"'", "Version": "'"$teamviewerVersion"'", "IsCustomModule": true, "Subdomain": "1", "ConnectionId": "" }' | tr -d '"')
+    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/mac-os/" | grep "Current version" | cut -d " " -f3 | cut -d "<" -f1)
+    appName="TeamViewerQS.app"
+    expectedTeamID="H7UGFBUGV6"
+    ;;

--- a/fragments/labels/teamviewerqscustom.sh
+++ b/fragments/labels/teamviewerqscustom.sh
@@ -5,7 +5,7 @@ teamviewerqscustom)
     teamviewerConfigID=$(curl -fs ${teamviewerCustomDownloadURL} -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' | grep -o 'var configId = ".*"' | awk -F'"' '{ print $2 }')
     teamviewerVersion=$(curl -fs ${teamviewerCustomDownloadURL} -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' | grep -o 'var version = ".*"' | awk -F'"' '{ print $2 }')
     downloadURL=$(curl -fs -X POST --url "https://get.teamviewer.com/api/CustomDesign" --header 'Content-Type: application/json; charset=utf-8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36' --data '{ "ConfigId": "'"$teamviewerConfigID"'", "Version": "'"$teamviewerVersion"'", "IsCustomModule": true, "Subdomain": "1", "ConnectionId": "" }' | tr -d '"')
-    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/mac-os/" | grep "Current version" | cut -d " " -f3 | cut -d "<" -f1)
+    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/macos/" | grep "Current version" | cut -d " " -f3 | cut -d "<" -f1)
     appName="TeamViewerQS.app"
     expectedTeamID="H7UGFBUGV6"
     ;;


### PR DESCRIPTION
This label can be used for customized versions of TeamViewer QuickSupport. The **teamviewerCustomDownloadURL** variable value needs to be configured to the custom TeamViewer download URL (https://get.teamviewer.com/your_custom_name_here) in order for the label to work.

```
2023-05-08 12:53:41 : REQ   : teamviewerqscustom : ################## Start Installomator v. 10.3, date 2023-02-10
2023-05-08 12:53:41 : INFO  : teamviewerqscustom : ################## Version: 10.3
2023-05-08 12:53:41 : INFO  : teamviewerqscustom : ################## Date: 2023-02-10
2023-05-08 12:53:41 : INFO  : teamviewerqscustom : ################## teamviewerqscustom
2023-05-08 12:53:41 : INFO  : teamviewerqscustom : SwiftDialog is not installed, clear cmd file var
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : BLOCKING_PROCESS_ACTION=tell_user
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : NOTIFY=silent
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : LOGGING=INFO
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : Label type: zip
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : archiveName: TeamViewerQS.zip
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : no blocking processes defined, using TeamViewerQS as default
2023-05-08 12:53:43 : INFO  : teamviewerqscustom : name: TeamViewerQS, appName: TeamViewerQS.app
2023-05-08 12:53:44 : WARN  : teamviewerqscustom : No previous app found
2023-05-08 12:53:44 : WARN  : teamviewerqscustom : could not find TeamViewerQS.app
2023-05-08 12:53:44 : INFO  : teamviewerqscustom : appversion: 
2023-05-08 12:53:44 : INFO  : teamviewerqscustom : Latest version of TeamViewerQS is 15.41.9
2023-05-08 12:53:44 : REQ   : teamviewerqscustom : Downloading https://customdesignservice.teamviewer.com/download/mac/v15/xxx/TeamViewerQS.zip?sv=2020-04-08&se=2023-05-09T10%3A53%3A43Z&sr=b&sp=r&sig=2grtGZdz9qG2gKpobjwz31FYNAmDOceqgfCTXVpcYh6%3D to TeamViewerQS.zip
2023-05-08 12:53:50 : REQ   : teamviewerqscustom : no more blocking processes, continue with update
2023-05-08 12:53:50 : REQ   : teamviewerqscustom : Installing TeamViewerQS
2023-05-08 12:53:50 : INFO  : teamviewerqscustom : Unzipping TeamViewerQS.zip
2023-05-08 12:53:51 : INFO  : teamviewerqscustom : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.v004pNEE/TeamViewerQS.app
2023-05-08 12:53:53 : INFO  : teamviewerqscustom : Team ID matching: H7UGFBUGV6 (expected: H7UGFBUGV6 )
2023-05-08 12:53:53 : INFO  : teamviewerqscustom : Installing TeamViewerQS version 15.41.9 on versionKey CFBundleShortVersionString.
2023-05-08 12:53:53 : INFO  : teamviewerqscustom : App has LSMinimumSystemVersion: 10.14.6
2023-05-08 12:53:53 : INFO  : teamviewerqscustom : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.v004pNEE/TeamViewerQS.app to /Applications
2023-05-08 12:53:54 : WARN  : teamviewerqscustom : Changing owner to kryptonit
2023-05-08 12:53:54 : INFO  : teamviewerqscustom : Finishing...
2023-05-08 12:53:57 : INFO  : teamviewerqscustom : App(s) found: /Applications/TeamViewerQS.app
2023-05-08 12:53:57 : INFO  : teamviewerqscustom : found app at /Applications/TeamViewerQS.app, version 15.41.9, on versionKey CFBundleShortVersionString
2023-05-08 12:53:57 : REQ   : teamviewerqscustom : Installed TeamViewerQS, version 15.41.9
2023-05-08 12:53:57 : INFO  : teamviewerqscustom : App not closed, so no reopen.
2023-05-08 12:53:57 : REQ   : teamviewerqscustom : All done!
2023-05-08 12:53:57 : REQ   : teamviewerqscustom : ################## End Installomator, exit code 0 
```