### PR TITLE
Added Docker Desktop to blocking processes for Docker

### DIFF
--- a/fragments/labels/docker.sh
+++ b/fragments/labels/docker.sh
@@ -9,4 +9,5 @@ docker)
      appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
     fi
     expectedTeamID="9BNSXJN65R"
+    blockingProcesses=( "Docker Desktop" "Docker" )
     ;;


### PR DESCRIPTION
WIthout this Docker does not quit for updates
```
% utils/assemble.sh docker
2023-05-11 16:51:23 : REQ   : docker : ################## Start Installomator v. 10.4beta, date 2023-05-11
2023-05-11 16:51:23 : INFO  : docker : ################## Version: 10.4beta
2023-05-11 16:51:23 : INFO  : docker : ################## Date: 2023-05-11
2023-05-11 16:51:23 : INFO  : docker : ################## docker
2023-05-11 16:51:23 : DEBUG : docker : DEBUG mode 1 enabled.
2023-05-11 16:51:23 : INFO  : docker : SwiftDialog is not installed, clear cmd file var
2023-05-11 16:51:23 : DEBUG : docker : name=Docker
2023-05-11 16:51:23 : DEBUG : docker : appName=
2023-05-11 16:51:23 : DEBUG : docker : type=dmg
2023-05-11 16:51:23 : DEBUG : docker : archiveName=
2023-05-11 16:51:23 : DEBUG : docker : downloadURL=https://desktop.docker.com/mac/stable/arm64/Docker.dmg
2023-05-11 16:51:23 : DEBUG : docker : curlOptions=
2023-05-11 16:51:23 : DEBUG : docker : appNewVersion=4.19.0
2023-05-11 16:51:23 : DEBUG : docker : appCustomVersion function: Not defined
2023-05-11 16:51:23 : DEBUG : docker : versionKey=CFBundleShortVersionString
2023-05-11 16:51:23 : DEBUG : docker : packageID=
2023-05-11 16:51:23 : DEBUG : docker : pkgName=
2023-05-11 16:51:23 : DEBUG : docker : choiceChangesXML=
2023-05-11 16:51:23 : DEBUG : docker : expectedTeamID=9BNSXJN65R
2023-05-11 16:51:23 : DEBUG : docker : blockingProcesses=Docker Desktop Docker
2023-05-11 16:51:23 : DEBUG : docker : installerTool=
2023-05-11 16:51:23 : DEBUG : docker : CLIInstaller=
2023-05-11 16:51:23 : DEBUG : docker : CLIArguments=
2023-05-11 16:51:23 : DEBUG : docker : updateTool=
2023-05-11 16:51:23 : DEBUG : docker : updateToolArguments=
2023-05-11 16:51:23 : DEBUG : docker : updateToolRunAsCurrentUser=
2023-05-11 16:51:23 : INFO  : docker : BLOCKING_PROCESS_ACTION=tell_user
2023-05-11 16:51:23 : INFO  : docker : NOTIFY=success
2023-05-11 16:51:23 : INFO  : docker : LOGGING=DEBUG
2023-05-11 16:51:23 : INFO  : docker : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-11 16:51:23 : INFO  : docker : Label type: dmg
2023-05-11 16:51:23 : INFO  : docker : archiveName: Docker.dmg
2023-05-11 16:51:23 : DEBUG : docker : Changing directory to /Users/hessf/Git/Installomator/build
2023-05-11 16:51:23 : INFO  : docker : name: Docker, appName: Docker.app
2023-05-11 16:51:23.863 mdfind[36643:273593] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-11 16:51:23.864 mdfind[36643:273593] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-11 16:51:23.920 mdfind[36643:273593] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-11 16:51:24 : WARN  : docker : No previous app found
2023-05-11 16:51:24 : WARN  : docker : could not find Docker.app
2023-05-11 16:51:24 : INFO  : docker : appversion:
2023-05-11 16:51:24 : INFO  : docker : Latest version of Docker is 4.19.0
2023-05-11 16:51:24 : REQ   : docker : Downloading https://desktop.docker.com/mac/stable/arm64/Docker.dmg to Docker.dmg
2023-05-11 16:51:24 : DEBUG : docker : No Dialog connection, just download
2023-05-11 16:51:40 : DEBUG : docker : File list: -rw-r--r--@ 1 hessf  staff   590M May 11 16:51 Docker.dmg
2023-05-11 16:51:40 : DEBUG : docker : File type: Docker.dmg: XZ compressed data, checksum NONE
2023-05-11 16:51:40 : DEBUG : docker : curl output was:
*   Trying 18.160.143.46:443...
* Connected to desktop.docker.com (18.160.143.46) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5101 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.docker.com
*  start date: Feb 22 00:00:00 2023 GMT
*  expire date: Nov 30 23:59:59 2023 GMT
*  subjectAltName: host "desktop.docker.com" matched cert's "*.docker.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /mac/stable/arm64/Docker.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: desktop.docker.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14c013400)
> GET /mac/stable/arm64/Docker.dmg HTTP/2
> Host: desktop.docker.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 301
< content-length: 0
< location: https://desktop.docker.com/mac/main/arm64/Docker.dmg
< date: Thu, 11 May 2023 06:43:24 GMT
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 422414d66021e4e123bcb2b5087f7042.cloudfront.net (CloudFront)
< x-amz-cf-pop: DEN52-P2
< x-amz-cf-id: N5o7iy8C8nK6eJYrUFzaTl2ICBzdOKVctslzFZrPcBKsuZyenYDuHQ==
< age: 58081
<
{ [0 bytes data]
* Connection #0 to host desktop.docker.com left intact
* Issue another request to this URL: 'https://desktop.docker.com/mac/main/arm64/Docker.dmg'
* Found bundle for host: 0x600002974f90 [can multiplex]
* Re-using existing connection #0 with host desktop.docker.com
* h2h3 [:method: GET]
* h2h3 [:path: /mac/main/arm64/Docker.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: desktop.docker.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 3 (easy handle 0x14c013400)
> GET /mac/main/arm64/Docker.dmg HTTP/2
> Host: desktop.docker.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-length: 619179401
< last-modified: Thu, 27 Apr 2023 15:01:42 GMT
< x-amz-version-id: mIF3RlR6kzyIBTKRs7r7Q8zUvELbGtWB
< server: AmazonS3
< date: Thu, 11 May 2023 11:11:41 GMT
< etag: "99ebcb2c04f0ba8bb8736782a767db7f"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 422414d66021e4e123bcb2b5087f7042.cloudfront.net (CloudFront)
< x-amz-cf-pop: DEN52-P2
< x-amz-cf-id: wFwbDU_Q7tdpAVT7wziUOWKmL8ro47kQX6_NJN6ec-5wRFrwOg-x7A==
< age: 41984
<
{ [16018 bytes data]
* Connection #0 to host desktop.docker.com left intact

2023-05-11 16:51:40 : DEBUG : docker : DEBUG mode 1, not checking for blocking processes
2023-05-11 16:51:40 : REQ   : docker : Installing Docker
2023-05-11 16:51:40 : INFO  : docker : Mounting /Users/hessf/Git/Installomator/build/Docker.dmg
2023-05-11 16:52:04 : DEBUG : docker : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $2A86718E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $88B3EAB1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $98B396E6
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $28595568
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $98B396E6
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $99A7BD34
verified   CRC32 $00BDEC6C
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Docker

2023-05-11 16:52:04 : INFO  : docker : Mounted: /Volumes/Docker
2023-05-11 16:52:04 : INFO  : docker : Verifying: /Volumes/Docker/Docker.app
2023-05-11 16:52:04 : DEBUG : docker : App size: 1.9G	/Volumes/Docker/Docker.app
2023-05-11 16:52:31 : DEBUG : docker : Debugging enabled, App Verification output was:
/Volumes/Docker/Docker.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Docker Inc (9BNSXJN65R)

2023-05-11 16:52:31 : INFO  : docker : Team ID matching: 9BNSXJN65R (expected: 9BNSXJN65R )
2023-05-11 16:52:32 : INFO  : docker : Installing Docker version 4.19.0 on versionKey CFBundleShortVersionString.
2023-05-11 16:52:32 : INFO  : docker : App has LSMinimumSystemVersion: 11.0
2023-05-11 16:52:32 : DEBUG : docker : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-05-11 16:52:32 : INFO  : docker : Finishing...
2023-05-11 16:52:35 : INFO  : docker : name: Docker, appName: Docker.app
2023-05-11 16:52:35.252 mdfind[36886:275235] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-11 16:52:35.252 mdfind[36886:275235] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-11 16:52:35.316 mdfind[36886:275235] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-11 16:52:35 : WARN  : docker : No previous app found
2023-05-11 16:52:35 : WARN  : docker : could not find Docker.app
2023-05-11 16:52:35 : REQ   : docker : Installed Docker
2023-05-11 16:52:35 : INFO  : docker : notifying
2023-05-11 16:52:36 : DEBUG : docker : Unmounting /Volumes/Docker
2023-05-11 16:52:36 : DEBUG : docker : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-05-11 16:52:36 : DEBUG : docker : DEBUG mode 1, not reopening anything
2023-05-11 16:52:36 : REQ   : docker : All done!
2023-05-11 16:52:36 : REQ   : docker : ################## End Installomator, exit code 0```