### PR TITLE
Whatroute: fix appNewVersion

### DIFF
--- a/fragments/labels/whatroute.sh
+++ b/fragments/labels/whatroute.sh
@@ -1,0 +1,7 @@
+whatroute)
+    name="WhatRoute"
+    type="zip"
+    downloadURL="$(curl -fs https://www.whatroute.net/whatroute2appcast.xml | xpath '(//rss/channel/item/enclosure/@url)' 2>/dev/null | cut -d '"' -f 2)"
+    appNewVersion="$(curl -fs "https://www.whatroute.net/whatroute2appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)' 2>/dev/null | cut -d '"' -f 2)"
+    expectedTeamID="H5879E8LML"
+    ;;

--- a/fragments/labels/whatroute.sh
+++ b/fragments/labels/whatroute.sh
@@ -2,6 +2,6 @@ whatroute)
     name="WhatRoute"
     type="zip"
     downloadURL="$(curl -fs https://www.whatroute.net/whatroute2appcast.xml | xpath '(//rss/channel/item/enclosure/@url)' 2>/dev/null | cut -d '"' -f 2)"
-    appNewVersion="$(curl -fs "https://www.whatroute.net/whatroute2appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)' 2>/dev/null | cut -d '"' -f 2)"
+    appNewVersion="$(curl -fs "https://www.whatroute.net/whatroute2appcast.xml" | xpath '(//rss/channel/item/sparkle:shortVersionString)' 2>/dev/null | cut -d ">" -f2 | cut -d "<" -f1)"
     expectedTeamID="H5879E8LML"
     ;;


### PR DESCRIPTION
2023-05-14 11:02:27 : INFO  : whatroute : setting variable from argument NOTIFY=silent
2023-05-14 11:02:27 : INFO  : whatroute : setting variable from argument DEBUG=0
2023-05-14 11:02:28 : REQ   : whatroute : ################## Start Installomator v. 10.3, date 2023-05-14
2023-05-14 11:02:28 : INFO  : whatroute : ################## Version: 10.3
2023-05-14 11:02:28 : INFO  : whatroute : ################## Date: 2023-05-14
2023-05-14 11:02:28 : INFO  : whatroute : ################## whatroute
2023-05-14 11:02:32 : INFO  : whatroute : BLOCKING_PROCESS_ACTION=tell_user
2023-05-14 11:02:32 : INFO  : whatroute : NOTIFY=silent
2023-05-14 11:02:32 : INFO  : whatroute : LOGGING=INFO
2023-05-14 11:02:32 : INFO  : whatroute : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-14 11:02:32 : INFO  : whatroute : Label type: zip
2023-05-14 11:02:32 : INFO  : whatroute : archiveName: WhatRoute.zip
2023-05-14 11:02:32 : INFO  : whatroute : no blocking processes defined, using WhatRoute as default
2023-05-14 11:02:32 : INFO  : whatroute : App(s) found: /Applications/WhatRoute.app
2023-05-14 11:02:32 : INFO  : whatroute : found app at /Applications/WhatRoute.app, version 2.6.3, on versionKey CFBundleShortVersionString
2023-05-14 11:02:32 : INFO  : whatroute : appversion: 2.6.3
2023-05-14 11:02:32 : INFO  : whatroute : Latest version of WhatRoute is 2.6.3
2023-05-14 11:02:32 : INFO  : whatroute : There is no newer version available.
2023-05-14 11:02:32 : INFO  : whatroute : App not closed, so no reopen.
2023-05-14 11:02:32 : REQ   : whatroute : No newer version.
2023-05-14 11:02:32 : REQ   : whatroute : ################## End Installomator, exit code 0 
