### PR TITLE
Update label: cryptomator - intel package name

### DIFF
--- a/fragments/labels/cryptomator.sh
+++ b/fragments/labels/cryptomator.sh
@@ -5,7 +5,7 @@ cryptomator)
         archiveName="Cryptomator-[0-9.]*-arm64.dmg"
 
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="Cryptomator-[0-9.]*.dmg"
+        archiveName="Cryptomator-[0-9.]*-x64.dmg"
     fi
     downloadURL=$(downloadURLFromGit cryptomator cryptomator)
     appNewVersion=$(versionFromGit cryptomator cryptomator)


### PR DESCRIPTION
Fixing Intel's package name from Github.

New results:

2023-05-16 08:39:48 : INFO  : cryptomator : setting variable from argument DEBUG=1
2023-05-16 08:39:48 : REQ   : cryptomator : ################## Start Installomator v. 10.3, date 2023-02-10
2023-05-16 08:39:48 : INFO  : cryptomator : ################## Version: 10.3
2023-05-16 08:39:48 : INFO  : cryptomator : ################## Date: 2023-02-10
2023-05-16 08:39:48 : INFO  : cryptomator : ################## cryptomator
2023-05-16 08:39:48 : DEBUG : cryptomator : DEBUG mode 1 enabled.
2023-05-16 08:39:49 : DEBUG : cryptomator : name=Cryptomator
2023-05-16 08:39:49 : DEBUG : cryptomator : appName=
2023-05-16 08:39:49 : DEBUG : cryptomator : type=dmg
2023-05-16 08:39:49 : DEBUG : cryptomator : archiveName=Cryptomator-[0-9.]*-x64.dmg
2023-05-16 08:39:49 : DEBUG : cryptomator : downloadURL=https://github.com/cryptomator/cryptomator/releases/download/1.8.0/Cryptomator-1.8.0-x64.dmg
2023-05-16 08:39:49 : DEBUG : cryptomator : curlOptions=
2023-05-16 08:39:49 : DEBUG : cryptomator : appNewVersion=1.8.0
2023-05-16 08:39:49 : DEBUG : cryptomator : appCustomVersion function: Not defined
2023-05-16 08:39:49 : DEBUG : cryptomator : versionKey=CFBundleShortVersionString
2023-05-16 08:39:49 : DEBUG : cryptomator : packageID=
2023-05-16 08:39:49 : DEBUG : cryptomator : pkgName=
2023-05-16 08:39:49 : DEBUG : cryptomator : choiceChangesXML=
2023-05-16 08:39:49 : DEBUG : cryptomator : expectedTeamID=YZQJQUHA3L
2023-05-16 08:39:49 : DEBUG : cryptomator : blockingProcesses=
2023-05-16 08:39:49 : DEBUG : cryptomator : installerTool=
2023-05-16 08:39:49 : DEBUG : cryptomator : CLIInstaller=
2023-05-16 08:39:50 : DEBUG : cryptomator : CLIArguments=
2023-05-16 08:39:50 : DEBUG : cryptomator : updateTool=
2023-05-16 08:39:50 : DEBUG : cryptomator : updateToolArguments=
2023-05-16 08:39:50 : DEBUG : cryptomator : updateToolRunAsCurrentUser=
2023-05-16 08:39:50 : INFO  : cryptomator : BLOCKING_PROCESS_ACTION=tell_user
2023-05-16 08:39:50 : INFO  : cryptomator : NOTIFY=success
2023-05-16 08:39:50 : INFO  : cryptomator : LOGGING=DEBUG
2023-05-16 08:39:50 : INFO  : cryptomator : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-16 08:39:50 : INFO  : cryptomator : Label type: dmg
2023-05-16 08:39:50 : INFO  : cryptomator : archiveName: Cryptomator-[0-9.]*-x64.dmg
2023-05-16 08:39:50 : INFO  : cryptomator : no blocking processes defined, using Cryptomator as default
2023-05-16 08:39:50 : DEBUG : cryptomator : Changing directory to .
2023-05-16 08:39:50 : INFO  : cryptomator : name: Cryptomator, appName: Cryptomator.app
2023-05-16 08:39:50 : WARN  : cryptomator : No previous app found
2023-05-16 08:39:50 : WARN  : cryptomator : could not find Cryptomator.app
2023-05-16 08:39:50 : INFO  : cryptomator : appversion: 
2023-05-16 08:39:50 : INFO  : cryptomator : Latest version of Cryptomator is 1.8.0
2023-05-16 08:39:50 : REQ   : cryptomator : Downloading https://github.com/cryptomator/cryptomator/releases/download/1.8.0/Cryptomator-1.8.0-x64.dmg to Cryptomator-[0-9.]*-x64.dmg
2023-05-16 08:39:50 : DEBUG : cryptomator : No Dialog connection, just download
2023-05-16 08:39:54 : DEBUG : cryptomator : File list: -rw-r--r--  1 admin  staff    47M May 16 08:39 Cryptomator-[0-9.]*-x64.dmg
2023-05-16 08:39:55 : DEBUG : cryptomator : File type: Cryptomator-[0-9.]*-x64.dmg: zlib compressed data
2023-05-16 08:39:55 : DEBUG : cryptomator : curl output was:
*   Trying 192.30.255.112:443...
* Connected to github.com (192.30.255.112) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /cryptomator/cryptomator/releases/download/1.8.0/Cryptomator-1.8.0-x64.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f9dfd811400)
> GET /cryptomator/cryptomator/releases/download/1.8.0/Cryptomator-1.8.0-x64.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Tue, 16 May 2023 15:39:50 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/16446099/aa820a5a-881c-4171-a0ed-bc3bf890194c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T153950Z&X-Amz-Expires=300&X-Amz-Signature=ba4bd2e2ff1ac614188536d26d8dab2440dfc97a3bcc2f8482c975458971cd89&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=16446099&response-content-disposition=attachment%3B%20filename%3DCryptomator-1.8.0-x64.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: 6560:2683:580BF23:5CA421F:6463A3C6
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/16446099/aa820a5a-881c-4171-a0ed-bc3bf890194c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T153950Z&X-Amz-Expires=300&X-Amz-Signature=ba4bd2e2ff1ac614188536d26d8dab2440dfc97a3bcc2f8482c975458971cd89&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=16446099&response-content-disposition=attachment%3B%20filename%3DCryptomator-1.8.0-x64.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/16446099/aa820a5a-881c-4171-a0ed-bc3bf890194c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T153950Z&X-Amz-Expires=300&X-Amz-Signature=ba4bd2e2ff1ac614188536d26d8dab2440dfc97a3bcc2f8482c975458971cd89&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=16446099&response-content-disposition=attachment%3B%20filename%3DCryptomator-1.8.0-x64.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f9dfd811400)
> GET /github-production-release-asset-2e65be/16446099/aa820a5a-881c-4171-a0ed-bc3bf890194c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T153950Z&X-Amz-Expires=300&X-Amz-Signature=ba4bd2e2ff1ac614188536d26d8dab2440dfc97a3bcc2f8482c975458971cd89&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=16446099&response-content-disposition=attachment%3B%20filename%3DCryptomator-1.8.0-x64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: H2ryfvP+skgK4Bf5rp60oQ==
< last-modified: Tue, 25 Apr 2023 09:27:30 GMT
< etag: "0x8DB456F4B46401E"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: b5907f86-d01e-0039-670c-881a49000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Tue, 25 Apr 2023 09:27:30 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Cryptomator-1.8.0-x64.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Tue, 16 May 2023 15:39:51 GMT
< x-served-by: cache-iad-kiad7000154-IAD, cache-pdx12327-PDX
< x-cache: MISS, MISS
< x-cache-hits: 0, 0
< x-timer: S1684251591.076849,VS0,VE206
< content-length: 49212360
< 
{ [1207 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-05-16 08:39:55 : DEBUG : cryptomator : DEBUG mode 1, not checking for blocking processes
2023-05-16 08:39:55 : REQ   : cryptomator : Installing Cryptomator
2023-05-16 08:39:55 : INFO  : cryptomator : Mounting ./Cryptomator-[0-9.]*-x64.dmg
2023-05-16 08:39:58 : DEBUG : cryptomator : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A38AABF9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $15068FF6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $77AA5150
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $621A258E
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $77AA5150
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $F51B936C
verified   CRC32 $06F65F7D
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Cryptomator

2023-05-16 08:39:58 : INFO  : cryptomator : Mounted: /Volumes/Cryptomator
2023-05-16 08:39:58 : INFO  : cryptomator : Verifying: /Volumes/Cryptomator/Cryptomator.app
2023-05-16 08:39:58 : DEBUG : cryptomator : App size:  90M	/Volumes/Cryptomator/Cryptomator.app
2023-05-16 08:39:59 : DEBUG : cryptomator : Debugging enabled, App Verification output was:
/Volumes/Cryptomator/Cryptomator.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Skymatic GmbH (YZQJQUHA3L)

2023-05-16 08:39:59 : INFO  : cryptomator : Team ID matching: YZQJQUHA3L (expected: YZQJQUHA3L )
2023-05-16 08:39:59 : INFO  : cryptomator : Installing Cryptomator version 1.8.0 on versionKey CFBundleShortVersionString.
2023-05-16 08:39:59 : INFO  : cryptomator : App has LSMinimumSystemVersion: 10.13.0
2023-05-16 08:39:59 : DEBUG : cryptomator : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-05-16 08:40:00 : INFO  : cryptomator : Finishing...
2023-05-16 08:40:03 : INFO  : cryptomator : name: Cryptomator, appName: Cryptomator.app
2023-05-16 08:40:03 : WARN  : cryptomator : No previous app found
2023-05-16 08:40:03 : WARN  : cryptomator : could not find Cryptomator.app
2023-05-16 08:40:03 : REQ   : cryptomator : Installed Cryptomator
2023-05-16 08:40:03 : INFO  : cryptomator : notifying
2023-05-16 08:40:03 : DEBUG : cryptomator : Unmounting /Volumes/Cryptomator
2023-05-16 08:40:03 : DEBUG : cryptomator : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-05-16 08:40:03 : DEBUG : cryptomator : DEBUG mode 1, not reopening anything
2023-05-16 08:40:03 : REQ   : cryptomator : All done!
2023-05-16 08:40:03 : REQ   : cryptomator : ################## End Installomator, exit code 0 

Old results (snipped):

2023-05-15 15:23:00 : DEBUG : cryptomator : archiveName=Cryptomator-[0-9.]*.dmg
2023-05-15 15:23:00 : DEBUG : cryptomator : downloadURL=2023-05-15 15:22:59 : INFO  : cryptomator : GitHub API not returning URL, trying https://github.com/cryptomator/cryptomator/releases/latest.
2023-05-15 15:23:00 : DEBUG : cryptomator : https://github.com