### PR TITLE
Create Label: GDevelop

### DIFF
--- a/fragments/labels/gdevelop.sh
+++ b/fragments/labels/gdevelop.sh
@@ -1,0 +1,12 @@
+gdevelop)
+    name="GDevelop"
+    type="dmg"
+    if [[ $(arch) == arm64 ]]; then
+        archiveName="GDevelop-5-[0-9.]*-arm64.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        archiveName="GDevelop-5-[0-9.]*.dmg" 
+    fi
+    appNewVersion="$(versionFromGit 4ian GDevelop)"
+    downloadURL="$(downloadURLFromGit 4ian GDevelop)"
+    expectedTeamID="5CG65LEVUK"
+    ;;

--- a/fragments/labels/gdevelop.sh
+++ b/fragments/labels/gdevelop.sh
@@ -1,5 +1,5 @@
 gdevelop)
-    name="GDevelop"
+    name="GDevelop 5"
     type="dmg"
     if [[ $(arch) == arm64 ]]; then
         archiveName="GDevelop-5-[0-9.]*-arm64.dmg"


### PR DESCRIPTION
Results:

```
sudo ./assemble.sh gdevelop
2023-05-16 09:16:37 : REQ   : gdevelop : ################## Start Installomator v. 10.4beta, date 2023-05-16
2023-05-16 09:16:37 : INFO  : gdevelop : ################## Version: 10.4beta
2023-05-16 09:16:37 : INFO  : gdevelop : ################## Date: 2023-05-16
2023-05-16 09:16:37 : INFO  : gdevelop : ################## gdevelop
2023-05-16 09:16:37 : DEBUG : gdevelop : DEBUG mode 1 enabled.
2023-05-16 09:16:38 : DEBUG : gdevelop : name=GDevelop
2023-05-16 09:16:38 : DEBUG : gdevelop : appName=
2023-05-16 09:16:38 : DEBUG : gdevelop : type=dmg
2023-05-16 09:16:38 : DEBUG : gdevelop : archiveName=GDevelop-5-[0-9.]*-arm64.dmg
2023-05-16 09:16:38 : DEBUG : gdevelop : downloadURL=https://github.com/4ian/GDevelop/releases/download/v5.1.160/GDevelop-5-5.1.160-arm64.dmg
2023-05-16 09:16:38 : DEBUG : gdevelop : curlOptions=
2023-05-16 09:16:38 : DEBUG : gdevelop : appNewVersion=5.1.160
2023-05-16 09:16:38 : DEBUG : gdevelop : appCustomVersion function: Not defined
2023-05-16 09:16:38 : DEBUG : gdevelop : versionKey=CFBundleShortVersionString
2023-05-16 09:16:38 : DEBUG : gdevelop : packageID=
2023-05-16 09:16:38 : DEBUG : gdevelop : pkgName=
2023-05-16 09:16:38 : DEBUG : gdevelop : choiceChangesXML=
2023-05-16 09:16:38 : DEBUG : gdevelop : expectedTeamID=5CG65LEVUK
2023-05-16 09:16:38 : DEBUG : gdevelop : blockingProcesses=
2023-05-16 09:16:38 : DEBUG : gdevelop : installerTool=
2023-05-16 09:16:38 : DEBUG : gdevelop : CLIInstaller=
2023-05-16 09:16:38 : DEBUG : gdevelop : CLIArguments=
2023-05-16 09:16:38 : DEBUG : gdevelop : updateTool=
2023-05-16 09:16:38 : DEBUG : gdevelop : updateToolArguments=
2023-05-16 09:16:38 : DEBUG : gdevelop : updateToolRunAsCurrentUser=
2023-05-16 09:16:38 : INFO  : gdevelop : BLOCKING_PROCESS_ACTION=tell_user
2023-05-16 09:16:38 : INFO  : gdevelop : NOTIFY=success
2023-05-16 09:16:38 : INFO  : gdevelop : LOGGING=DEBUG
2023-05-16 09:16:38 : INFO  : gdevelop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-16 09:16:38 : INFO  : gdevelop : Label type: dmg
2023-05-16 09:16:38 : INFO  : gdevelop : archiveName: GDevelop-5-[0-9.]*-arm64.dmg
2023-05-16 09:16:38 : INFO  : gdevelop : no blocking processes defined, using GDevelop as default
2023-05-16 09:16:38 : DEBUG : gdevelop : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-05-16 09:16:38 : INFO  : gdevelop : name: GDevelop, appName: GDevelop.app
2023-05-16 09:16:38.951 mdfind[99898:1486605] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-16 09:16:38.951 mdfind[99898:1486605] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-16 09:16:38.984 mdfind[99898:1486605] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-16 09:16:38 : WARN  : gdevelop : No previous app found
2023-05-16 09:16:38 : WARN  : gdevelop : could not find GDevelop.app
2023-05-16 09:16:38 : INFO  : gdevelop : appversion:
2023-05-16 09:16:39 : INFO  : gdevelop : Latest version of GDevelop is 5.1.160
2023-05-16 09:16:39 : REQ   : gdevelop : Downloading https://github.com/4ian/GDevelop/releases/download/v5.1.160/GDevelop-5-5.1.160-arm64.dmg to GDevelop-5-[0-9.]*-arm64.dmg
2023-05-16 09:16:39 : DEBUG : gdevelop : No Dialog connection, just download
2023-05-16 09:16:45 : DEBUG : gdevelop : File list: -rw-r--r--  1 root  2103187081   128M May 16 09:16 GDevelop-5-[0-9.]*-arm64.dmg
2023-05-16 09:16:45 : DEBUG : gdevelop : File type: GDevelop-5-[0-9.]*-arm64.dmg: zlib compressed data
2023-05-16 09:16:45 : DEBUG : gdevelop : curl output was:
*   Trying 192.30.255.112:443...
* Connected to github.com (192.30.255.112) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /4ian/GDevelop/releases/download/v5.1.160/GDevelop-5-5.1.160-arm64.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x154812400)
> GET /4ian/GDevelop/releases/download/v5.1.160/GDevelop-5-5.1.160-arm64.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Tue, 16 May 2023 16:16:39 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/21331090/3a26034b-a67e-4677-9332-76a47232132e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T161639Z&X-Amz-Expires=300&X-Amz-Signature=e2052ab76e0fcd95665a0921f66c0388484a572ac921b156b352ae088e2b9a28&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=21331090&response-content-disposition=attachment%3B%20filename%3DGDevelop-5-5.1.160-arm64.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: 05A3:2683:58E44A2:5D865C2:6463AC67 <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/21331090/3a26034b-a67e-4677-9332-76a47232132e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T161639Z&X-Amz-Expires=300&X-Amz-Signature=e2052ab76e0fcd95665a0921f66c0388484a572ac921b156b352ae088e2b9a28&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=21331090&response-content-disposition=attachment%3B%20filename%3DGDevelop-5-5.1.160-arm64.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/21331090/3a26034b-a67e-4677-9332-76a47232132e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T161639Z&X-Amz-Expires=300&X-Amz-Signature=e2052ab76e0fcd95665a0921f66c0388484a572ac921b156b352ae088e2b9a28&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=21331090&response-content-disposition=attachment%3B%20filename%3DGDevelop-5-5.1.160-arm64.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x154812400)
> GET /github-production-release-asset-2e65be/21331090/3a26034b-a67e-4677-9332-76a47232132e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230516%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230516T161639Z&X-Amz-Expires=300&X-Amz-Signature=e2052ab76e0fcd95665a0921f66c0388484a572ac921b156b352ae088e2b9a28&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=21331090&response-content-disposition=attachment%3B%20filename%3DGDevelop-5-5.1.160-arm64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: eHVAib+P7fZ14sDqbYEiDw==
< last-modified: Wed, 05 Apr 2023 12:10:00 GMT
< etag: "0x8DB35CEAE0F2055"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: a98eba79-701e-0052-0511-889dbd000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Wed, 05 Apr 2023 12:10:00 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=GDevelop-5-5.1.160-arm64.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Tue, 16 May 2023 16:16:39 GMT
< x-served-by: cache-iad-kcgs7200170-IAD, cache-pdx12323-PDX < x-cache: HIT, MISS
< x-cache-hits: 1, 0
< x-timer: S1684253799.311370,VS0,VE174
< content-length: 134136971
<
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-05-16 09:16:45 : DEBUG : gdevelop : DEBUG mode 1, not checking for blocking processes
2023-05-16 09:16:45 : REQ   : gdevelop : Installing GDevelop
2023-05-16 09:16:45 : INFO  : gdevelop : Mounting /Users/admin/Documents/GitHub/Installomator/build/GDevelop-5-[0-9.]*-arm64.dmg
2023-05-16 09:16:48 : DEBUG : gdevelop : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DE1CC7F6
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B6E56C29
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $1107BF0E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $495477C3
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $1107BF0E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $6B68AC3F
verified   CRC32 $2BE8909A
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/GDevelop 5 5.1.160-arm64

2023-05-16 09:16:48 : INFO  : gdevelop : Mounted: /Volumes/GDevelop 5 5.1.160-arm64 2023-05-16 09:16:48 : DEBUG : gdevelop : Unmounting /Volumes/GDevelop 5 5.1.160-arm64 2023-05-16 09:16:48 : DEBUG : gdevelop : Debugging enabled, Unmounting output was: "disk5" ejected.
2023-05-16 09:16:48 : DEBUG : gdevelop : DEBUG mode 1, not reopening anything 2023-05-16 09:16:48 : ERROR : gdevelop : ERROR: could not find: /Volumes/GDevelop 5 5.1.160-arm64/GDevelop.app
2023-05-16 09:16:48 : REQ   : gdevelop : ################## End Installomator, exit code 8
```