### PR TITLE
Add native Apple Silicon downloadURL for Dialpad

### DIFF
--- a/fragments/labels/dialpad.sh
+++ b/fragments/labels/dialpad.sh
@@ -2,6 +2,10 @@ dialpad)
     # credit: @ehosaka
     name="Dialpad"
     type="dmg"
-    downloadURL="https://storage.googleapis.com/dialpad_native/osx/Dialpad.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://storage.googleapis.com/dialpad_native/osx/arm64/Dialpad.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://storage.googleapis.com/dialpad_native/osx/x64/Dialpad.dmg"
+    fi
     expectedTeamID="9V29MQSZ9M"
     ;;


### PR DESCRIPTION
% utils/assemble.sh dialpad
2023-05-19 14:12:34 : REQ   : dialpad : ################## Start Installomator v. 10.4beta, date 2023-05-19
2023-05-19 14:12:35 : INFO  : dialpad : ################## Version: 10.4beta
2023-05-19 14:12:35 : INFO  : dialpad : ################## Date: 2023-05-19
2023-05-19 14:12:35 : INFO  : dialpad : ################## dialpad
2023-05-19 14:12:35 : DEBUG : dialpad : DEBUG mode 1 enabled.
2023-05-19 14:12:35 : INFO  : dialpad : SwiftDialog is not installed, clear cmd file var
2023-05-19 14:12:35 : DEBUG : dialpad : name=Dialpad
2023-05-19 14:12:35 : DEBUG : dialpad : appName=
2023-05-19 14:12:35 : DEBUG : dialpad : type=dmg
2023-05-19 14:12:35 : DEBUG : dialpad : archiveName=
2023-05-19 14:12:35 : DEBUG : dialpad : downloadURL=https://storage.googleapis.com/dialpad_native/osx/arm64/Dialpad.dmg
2023-05-19 14:12:35 : DEBUG : dialpad : curlOptions=
2023-05-19 14:12:35 : DEBUG : dialpad : appNewVersion=
2023-05-19 14:12:35 : DEBUG : dialpad : appCustomVersion function: Not defined
2023-05-19 14:12:35 : DEBUG : dialpad : versionKey=CFBundleShortVersionString
2023-05-19 14:12:35 : DEBUG : dialpad : packageID=
2023-05-19 14:12:35 : DEBUG : dialpad : pkgName=
2023-05-19 14:12:35 : DEBUG : dialpad : choiceChangesXML=
2023-05-19 14:12:35 : DEBUG : dialpad : expectedTeamID=9V29MQSZ9M
2023-05-19 14:12:35 : DEBUG : dialpad : blockingProcesses=
2023-05-19 14:12:35 : DEBUG : dialpad : installerTool=
2023-05-19 14:12:35 : DEBUG : dialpad : CLIInstaller=
2023-05-19 14:12:35 : DEBUG : dialpad : CLIArguments=
2023-05-19 14:12:35 : DEBUG : dialpad : updateTool=
2023-05-19 14:12:35 : DEBUG : dialpad : updateToolArguments=
2023-05-19 14:12:35 : DEBUG : dialpad : updateToolRunAsCurrentUser=
2023-05-19 14:12:35 : INFO  : dialpad : BLOCKING_PROCESS_ACTION=tell_user
2023-05-19 14:12:35 : INFO  : dialpad : NOTIFY=success
2023-05-19 14:12:35 : INFO  : dialpad : LOGGING=DEBUG
2023-05-19 14:12:35 : INFO  : dialpad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-19 14:12:35 : INFO  : dialpad : Label type: dmg
2023-05-19 14:12:35 : INFO  : dialpad : archiveName: Dialpad.dmg
2023-05-19 14:12:35 : INFO  : dialpad : no blocking processes defined, using Dialpad as default
2023-05-19 14:12:35 : DEBUG : dialpad : Changing directory to /Users/hessf/Git/Installomator/build
2023-05-19 14:12:35 : INFO  : dialpad : App(s) found: /Applications/Dialpad.app
2023-05-19 14:12:35 : INFO  : dialpad : found app at /Applications/Dialpad.app, version 2304.1.2, on versionKey CFBundleShortVersionString
2023-05-19 14:12:35 : INFO  : dialpad : appversion: 2304.1.2
2023-05-19 14:12:35 : INFO  : dialpad : Latest version not specified.
2023-05-19 14:12:35 : INFO  : dialpad : Dialpad.dmg exists and DEBUG mode 1 enabled, skipping download
2023-05-19 14:12:35 : DEBUG : dialpad : DEBUG mode 1, not checking for blocking processes
2023-05-19 14:12:35 : REQ   : dialpad : Installing Dialpad
2023-05-19 14:12:35 : INFO  : dialpad : Mounting /Users/hessf/Git/Installomator/build/Dialpad.dmg
2023-05-19 14:12:39 : DEBUG : dialpad : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F23ABF42
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7B34CEFC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $8DA4F5F3
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E6FBB6A3
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $8DA4F5F3
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $370F60F1
verified   CRC32 $4852B23D
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Dialpad

2023-05-19 14:12:39 : INFO  : dialpad : Mounted: /Volumes/Dialpad 2023-05-19 14:12:39 : INFO  : dialpad : Verifying: /Volumes/Dialpad/Dialpad.app 2023-05-19 14:12:39 : DEBUG : dialpad : App size: 242M	/Volumes/Dialpad/Dialpad.app 2023-05-19 14:12:41 : DEBUG : dialpad : Debugging enabled, App Verification output was: /Volumes/Dialpad/Dialpad.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Dialpad, Inc. (9V29MQSZ9M)

2023-05-19 14:12:41 : INFO  : dialpad : Team ID matching: 9V29MQSZ9M (expected: 9V29MQSZ9M ) 2023-05-19 14:12:41 : INFO  : dialpad : Downloaded version of Dialpad is 22.0.1 on versionKey CFBundleShortVersionString (replacing version 2304.1.2). 2023-05-19 14:12:41 : INFO  : dialpad : App has LSMinimumSystemVersion: 10.13 2023-05-19 14:12:41 : DEBUG : dialpad : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-05-19 14:12:41 : INFO  : dialpad : Finishing... 2023-05-19 14:12:44 : INFO  : dialpad : App(s) found: /Applications/Dialpad.app 2023-05-19 14:12:44 : INFO  : dialpad : found app at /Applications/Dialpad.app, version 2304.1.2, on versionKey CFBundleShortVersionString
2023-05-19 14:12:44 : REQ   : dialpad : Installed Dialpad, version 2304.1.2
2023-05-19 14:12:44 : INFO  : dialpad : notifying
2023-05-19 14:12:45 : DEBUG : dialpad : Unmounting /Volumes/Dialpad
2023-05-19 14:12:45 : DEBUG : dialpad : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-05-19 14:12:45 : DEBUG : dialpad : DEBUG mode 1, not reopening anything
2023-05-19 14:12:45 : REQ   : dialpad : All done!
2023-05-19 14:12:45 : REQ   : dialpad : ################## End Installomator, exit code 0