### PR TITLE
Updated Labels: Nudge and NudgeSuite

### DIFF
--- a/fragments/labels/nudge.sh
+++ b/fragments/labels/nudge.sh
@@ -1,8 +1,8 @@
 nudge)
     name="Nudge"
     type="pkg"
+    archiveName="Nudge-[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
-    archiveName="Nudge-$appNewVersion.pkg"
     expectedTeamID="T4SK8ZXCXG"
     ;;

--- a/fragments/labels/nudgesuite.sh
+++ b/fragments/labels/nudgesuite.sh
@@ -2,8 +2,8 @@ nudgesuite)
     name="Nudge Suite"
     appName="Nudge.app"
     type="pkg"
+    archiveName="Nudge_Suite-[0-9.]*.pkg"
     appNewVersion=$(versionFromGit macadmins Nudge )
-    archiveName="Nudge_Suite-$appNewVersion.pkg"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( "Nudge" )


### PR DESCRIPTION
The `nudgesuite` label was downloading the wrong PKG due to an order of operations issue with the variables making up the label.

I changed the `archiveName` variable and location in the label to correct the problem.

```
2023-05-24 22:31:52 : REQ   : nudgesuite : ################## Start Installomator v. 10.4beta, date 2023-05-24
2023-05-24 22:31:52 : INFO  : nudgesuite : ################## Version: 10.4beta
2023-05-24 22:31:52 : INFO  : nudgesuite : ################## Date: 2023-05-24
2023-05-24 22:31:52 : INFO  : nudgesuite : ################## nudgesuite
2023-05-24 22:31:52 : DEBUG : nudgesuite : DEBUG mode 1 enabled.
2023-05-24 22:31:54 : DEBUG : nudgesuite : name=Nudge Suite
2023-05-24 22:31:54 : DEBUG : nudgesuite : appName=Nudge.app
2023-05-24 22:31:54 : DEBUG : nudgesuite : type=pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : archiveName=Nudge_Suite-[0-9.]*.pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : downloadURL=https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge_Suite-1.1.11.81465.pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : curlOptions=
2023-05-24 22:31:54 : DEBUG : nudgesuite : appNewVersion=1.1.11.81465
2023-05-24 22:31:54 : DEBUG : nudgesuite : appCustomVersion function: Not defined
2023-05-24 22:31:54 : DEBUG : nudgesuite : versionKey=CFBundleShortVersionString
2023-05-24 22:31:54 : DEBUG : nudgesuite : packageID=
2023-05-24 22:31:54 : DEBUG : nudgesuite : pkgName=
2023-05-24 22:31:54 : DEBUG : nudgesuite : choiceChangesXML=
2023-05-24 22:31:54 : DEBUG : nudgesuite : expectedTeamID=T4SK8ZXCXG
2023-05-24 22:31:54 : DEBUG : nudgesuite : blockingProcesses=Nudge
2023-05-24 22:31:54 : DEBUG : nudgesuite : installerTool=
2023-05-24 22:31:54 : DEBUG : nudgesuite : CLIInstaller=
2023-05-24 22:31:54 : DEBUG : nudgesuite : CLIArguments=
2023-05-24 22:31:54 : DEBUG : nudgesuite : updateTool=
2023-05-24 22:31:54 : DEBUG : nudgesuite : updateToolArguments=
2023-05-24 22:31:54 : DEBUG : nudgesuite : updateToolRunAsCurrentUser=
2023-05-24 22:31:54 : INFO  : nudgesuite : BLOCKING_PROCESS_ACTION=tell_user
2023-05-24 22:31:54 : INFO  : nudgesuite : NOTIFY=success
2023-05-24 22:31:54 : INFO  : nudgesuite : LOGGING=DEBUG
2023-05-24 22:31:54 : INFO  : nudgesuite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-24 22:31:54 : INFO  : nudgesuite : Label type: pkg
2023-05-24 22:31:54 : INFO  : nudgesuite : archiveName: Nudge_Suite-[0-9.]*.pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : Changing directory to /Users/Shared/_GithubRepos/Installomator-NudgeFix/build
2023-05-24 22:31:54 : INFO  : nudgesuite : App(s) found: /Applications/Utilities/Nudge.app
2023-05-24 22:31:54 : INFO  : nudgesuite : found app at /Applications/Utilities/Nudge.app, version 1.1.11.81465, on versionKey CFBundleShortVersionString
2023-05-24 22:31:54 : INFO  : nudgesuite : appversion: 1.1.11.81465
2023-05-24 22:31:54 : INFO  : nudgesuite : Latest version of Nudge Suite is 1.1.11.81465
2023-05-24 22:31:54 : WARN  : nudgesuite : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-05-24 22:31:54 : INFO  : nudgesuite : Nudge_Suite-[0-9.]*.pkg exists and DEBUG mode 1 enabled, skipping download
2023-05-24 22:31:54 : DEBUG : nudgesuite : DEBUG mode 1, not checking for blocking processes
2023-05-24 22:31:54 : REQ   : nudgesuite : Installing Nudge Suite
2023-05-24 22:31:54 : INFO  : nudgesuite : Verifying: Nudge_Suite-[0-9.]*.pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : File list: -rw-r--r--  1 root  staff   1.6M May 24 22:21 Nudge_Suite-[0-9.]*.pkg
2023-05-24 22:31:54 : DEBUG : nudgesuite : File type: Nudge_Suite-[0-9.]*.pkg: xar archive compressed TOC: 4695, SHA-1 checksum
2023-05-24 22:31:55 : DEBUG : nudgesuite : spctlOut is Nudge_Suite-[0-9.]*.pkg: accepted
2023-05-24 22:31:55 : DEBUG : nudgesuite : source=Notarized Developer ID
2023-05-24 22:31:55 : DEBUG : nudgesuite : origin=Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
2023-05-24 22:31:55 : INFO  : nudgesuite : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2023-05-24 22:31:55 : DEBUG : nudgesuite : DEBUG enabled, skipping installation
2023-05-24 22:31:55 : INFO  : nudgesuite : Finishing...
2023-05-24 22:31:58 : INFO  : nudgesuite : App(s) found: /Applications/Utilities/Nudge.app
2023-05-24 22:31:58 : INFO  : nudgesuite : found app at /Applications/Utilities/Nudge.app, version 1.1.11.81465, on versionKey CFBundleShortVersionString
2023-05-24 22:31:58 : REQ   : nudgesuite : Installed Nudge Suite, version 1.1.11.81465
2023-05-24 22:31:58 : INFO  : nudgesuite : notifying
2023-05-24 22:31:58 : DEBUG : nudgesuite : DEBUG mode 1, not reopening anything
2023-05-24 22:31:58 : REQ   : nudgesuite : All done!
2023-05-24 22:31:58 : REQ   : nudgesuite : ################## End Installomator, exit code 0 
```

```
2023-05-24 22:32:45 : REQ   : nudge : ################## Start Installomator v. 10.4beta, date 2023-05-24
2023-05-24 22:32:45 : INFO  : nudge : ################## Version: 10.4beta
2023-05-24 22:32:45 : INFO  : nudge : ################## Date: 2023-05-24
2023-05-24 22:32:45 : INFO  : nudge : ################## nudge
2023-05-24 22:32:45 : DEBUG : nudge : DEBUG mode 1 enabled.
2023-05-24 22:32:46 : DEBUG : nudge : name=Nudge
2023-05-24 22:32:46 : DEBUG : nudge : appName=
2023-05-24 22:32:46 : DEBUG : nudge : type=pkg
2023-05-24 22:32:46 : DEBUG : nudge : archiveName=Nudge-[0-9.]*.pkg
2023-05-24 22:32:47 : DEBUG : nudge : downloadURL=https://github.com/macadmins/nudge/releases/download/v1.1.11.81465/Nudge-1.1.11.81465.pkg
2023-05-24 22:32:47 : DEBUG : nudge : curlOptions=
2023-05-24 22:32:47 : DEBUG : nudge : appNewVersion=1.1.11.81465
2023-05-24 22:32:47 : DEBUG : nudge : appCustomVersion function: Not defined
2023-05-24 22:32:47 : DEBUG : nudge : versionKey=CFBundleShortVersionString
2023-05-24 22:32:47 : DEBUG : nudge : packageID=
2023-05-24 22:32:47 : DEBUG : nudge : pkgName=
2023-05-24 22:32:47 : DEBUG : nudge : choiceChangesXML=
2023-05-24 22:32:47 : DEBUG : nudge : expectedTeamID=T4SK8ZXCXG
2023-05-24 22:32:47 : DEBUG : nudge : blockingProcesses=
2023-05-24 22:32:47 : DEBUG : nudge : installerTool=
2023-05-24 22:32:47 : DEBUG : nudge : CLIInstaller=
2023-05-24 22:32:47 : DEBUG : nudge : CLIArguments=
2023-05-24 22:32:47 : DEBUG : nudge : updateTool=
2023-05-24 22:32:47 : DEBUG : nudge : updateToolArguments=
2023-05-24 22:32:47 : DEBUG : nudge : updateToolRunAsCurrentUser=
2023-05-24 22:32:47 : INFO  : nudge : BLOCKING_PROCESS_ACTION=tell_user
2023-05-24 22:32:47 : INFO  : nudge : NOTIFY=success
2023-05-24 22:32:47 : INFO  : nudge : LOGGING=DEBUG
2023-05-24 22:32:47 : INFO  : nudge : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-24 22:32:48 : INFO  : nudge : Label type: pkg
2023-05-24 22:32:48 : INFO  : nudge : archiveName: Nudge-[0-9.]*.pkg
2023-05-24 22:32:48 : INFO  : nudge : no blocking processes defined, using Nudge as default
2023-05-24 22:32:48 : DEBUG : nudge : Changing directory to /Users/Shared/_GithubRepos/Installomator-NudgeFix/build
2023-05-24 22:32:48 : INFO  : nudge : App(s) found: /Applications/Utilities/Nudge.app
2023-05-24 22:32:48 : INFO  : nudge : found app at /Applications/Utilities/Nudge.app, version 1.1.11.81465, on versionKey CFBundleShortVersionString
2023-05-24 22:32:48 : INFO  : nudge : appversion: 1.1.11.81465
2023-05-24 22:32:48 : INFO  : nudge : Latest version of Nudge is 1.1.11.81465
2023-05-24 22:32:48 : WARN  : nudge : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-05-24 22:32:48 : INFO  : nudge : Nudge-[0-9.]*.pkg exists and DEBUG mode 1 enabled, skipping download
2023-05-24 22:32:48 : DEBUG : nudge : DEBUG mode 1, not checking for blocking processes
2023-05-24 22:32:48 : REQ   : nudge : Installing Nudge
2023-05-24 22:32:48 : INFO  : nudge : Verifying: Nudge-[0-9.]*.pkg
2023-05-24 22:32:48 : DEBUG : nudge : File list: -rw-r--r--  1 root  staff   1.6M May 24 22:21 Nudge-[0-9.]*.pkg
2023-05-24 22:32:48 : DEBUG : nudge : File type: Nudge-[0-9.]*.pkg: xar archive compressed TOC: 4688, SHA-1 checksum
2023-05-24 22:32:48 : DEBUG : nudge : spctlOut is Nudge-[0-9.]*.pkg: accepted
2023-05-24 22:32:48 : DEBUG : nudge : source=Notarized Developer ID
2023-05-24 22:32:48 : DEBUG : nudge : origin=Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
2023-05-24 22:32:48 : INFO  : nudge : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2023-05-24 22:32:48 : DEBUG : nudge : DEBUG enabled, skipping installation
2023-05-24 22:32:48 : INFO  : nudge : Finishing...
2023-05-24 22:32:51 : INFO  : nudge : App(s) found: /Applications/Utilities/Nudge.app
2023-05-24 22:32:52 : INFO  : nudge : found app at /Applications/Utilities/Nudge.app, version 1.1.11.81465, on versionKey CFBundleShortVersionString
2023-05-24 22:32:52 : REQ   : nudge : Installed Nudge, version 1.1.11.81465
2023-05-24 22:32:52 : INFO  : nudge : notifying
2023-05-24 22:32:52 : DEBUG : nudge : DEBUG mode 1, not reopening anything
2023-05-24 22:32:52 : REQ   : nudge : All done!
2023-05-24 22:32:52 : REQ   : nudge : ################## End Installomator, exit code 0 
```