### PR TITLE
New label magicbullet

### DIFF
--- a/fragments/labels/magicbullet.sh
+++ b/fragments/labels/magicbullet.sh
@@ -1,0 +1,13 @@
+magicbullet)
+    name="Magic Bullet Suite"
+    type="zip"
+    appCustomVersion(){
+    	ls "/Users/Shared/Red Giant/uninstall" | grep bullet | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
+    }
+    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405444242-Magic-Bullet-Suite" | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | sort -gru | head -n 1)"
+    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/$appNewVersion/MagicBulletSuite-${appNewVersion}_Mac.zip"
+    installerTool="Magic Bullet Suite Installer.app"
+    CLIInstaller="Magic Bullet Suite Installer.app/Contents/Scripts/install.sh"
+    CLIArguments=()
+    expectedTeamID="4ZY22YGXQG"
+    ;;


### PR DESCRIPTION
```
./assemble.sh magicbullet
2023-05-26 13:50:00 : REQ   : magicbullet : ################## Start Installomator v. 10.4beta, date 2023-05-26
2023-05-26 13:50:01 : INFO  : magicbullet : ################## Version: 10.4beta
2023-05-26 13:50:01 : INFO  : magicbullet : ################## Date: 2023-05-26
2023-05-26 13:50:01 : INFO  : magicbullet : ################## magicbullet
2023-05-26 13:50:01 : DEBUG : magicbullet : DEBUG mode 1 enabled.
2023-05-26 13:50:01 : DEBUG : magicbullet : name=Magic Bullet Suite
2023-05-26 13:50:01 : DEBUG : magicbullet : appName=
2023-05-26 13:50:01 : DEBUG : magicbullet : type=zip
2023-05-26 13:50:01 : DEBUG : magicbullet : archiveName=
2023-05-26 13:50:01 : DEBUG : magicbullet : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/2023.2.1/MagicBulletSuite-2023.2.1_Mac.zip
2023-05-26 13:50:01 : DEBUG : magicbullet : curlOptions=
2023-05-26 13:50:01 : DEBUG : magicbullet : appNewVersion=2023.2.1
2023-05-26 13:50:01 : DEBUG : magicbullet : appCustomVersion function: Defined. 
2023-05-26 13:50:01 : DEBUG : magicbullet : versionKey=CFBundleShortVersionString
2023-05-26 13:50:02 : DEBUG : magicbullet : packageID=
2023-05-26 13:50:02 : DEBUG : magicbullet : pkgName=
2023-05-26 13:50:02 : DEBUG : magicbullet : choiceChangesXML=
2023-05-26 13:50:02 : DEBUG : magicbullet : expectedTeamID=4ZY22YGXQG
2023-05-26 13:50:02 : DEBUG : magicbullet : blockingProcesses=
2023-05-26 13:50:02 : DEBUG : magicbullet : installerTool=Magic Bullet Suite Installer.app
2023-05-26 13:50:02 : DEBUG : magicbullet : CLIInstaller=Magic Bullet Suite Installer.app/Contents/Scripts/install.sh
2023-05-26 13:50:02 : DEBUG : magicbullet : CLIArguments=
2023-05-26 13:50:02 : DEBUG : magicbullet : updateTool=
2023-05-26 13:50:02 : DEBUG : magicbullet : updateToolArguments=
2023-05-26 13:50:02 : DEBUG : magicbullet : updateToolRunAsCurrentUser=
2023-05-26 13:50:02 : INFO  : magicbullet : BLOCKING_PROCESS_ACTION=tell_user
2023-05-26 13:50:02 : INFO  : magicbullet : NOTIFY=success
2023-05-26 13:50:02 : INFO  : magicbullet : LOGGING=DEBUG
2023-05-26 13:50:02 : INFO  : magicbullet : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-26 13:50:02 : INFO  : magicbullet : Label type: zip
2023-05-26 13:50:02 : INFO  : magicbullet : archiveName: Magic Bullet Suite.zip
2023-05-26 13:50:02 : INFO  : magicbullet : no blocking processes defined, using Magic Bullet Suite as default
2023-05-26 13:50:02 : DEBUG : magicbullet : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
ls: /Users/Shared/Red Giant/uninstall: No such file or directory
2023-05-26 13:50:02 : INFO  : magicbullet : Custom App Version detection is used, found 
2023-05-26 13:50:02 : INFO  : magicbullet : appversion: 
2023-05-26 13:50:02 : INFO  : magicbullet : Latest version of Magic Bullet Suite is 2023.2.1
2023-05-26 13:50:02 : REQ   : magicbullet : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/2023.2.1/MagicBulletSuite-2023.2.1_Mac.zip to Magic Bullet Suite.zip
2023-05-26 13:50:02 : DEBUG : magicbullet : No Dialog connection, just download
2023-05-26 13:50:31 : DEBUG : magicbullet : File list: -rw-r--r--@ 1 root  staff   340M 26 Mai 13:50 Magic Bullet Suite.zip
2023-05-26 13:50:31 : DEBUG : magicbullet : File type: Magic Bullet Suite.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-05-26 13:50:31 : DEBUG : magicbullet : curl output was:
*   Trying [2606:4700::6812:1032]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700::6812:1032) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /mx-package-production/installer/macos/redgiant/magicbullet/releases/2023.2.1/MagicBulletSuite-2023.2.1_Mac.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: mx-app-blob-prod.maxon.net]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x11f00b800)
> GET /mx-package-production/installer/macos/redgiant/magicbullet/releases/2023.2.1/MagicBulletSuite-2023.2.1_Mac.zip HTTP/2
> Host: mx-app-blob-prod.maxon.net
> user-agent: curl/7.88.1
> accept: */*
> 
< HTTP/2 200 
< date: Fri, 26 May 2023 11:50:02 GMT
< content-type: application/octet-stream
< content-length: 356931025
< content-md5: VjnIhnQ61YZT/FlO/83iUA==
< last-modified: Wed, 03 May 2023 13:00:00 GMT
< etag: 0x8DB4BD64DCE9C17
< x-ms-request-id: 128cfd95-e01e-0045-7ac8-8f8cae000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: MISS
< expires: Sat, 25 May 2024 11:50:02 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 7cd5cc58dae291e3-FRA
< 
{ [875 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2023-05-26 13:50:31 : DEBUG : magicbullet : DEBUG mode 1, not checking for blocking processes
2023-05-26 13:50:31 : REQ   : magicbullet : Installing Magic Bullet Suite
2023-05-26 13:50:31 : REQ   : magicbullet : installerTool used: Magic Bullet Suite Installer.app
2023-05-26 13:50:31 : INFO  : magicbullet : Unzipping Magic Bullet Suite.zip
2023-05-26 13:50:31 : INFO  : magicbullet : Verifying: /Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app
2023-05-26 13:50:32 : DEBUG : magicbullet : App size: 351M	/Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app
2023-05-26 13:50:32 : DEBUG : magicbullet : Debugging enabled, App Verification output was:
/Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2023-05-26 13:50:32 : INFO  : magicbullet : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2023-05-26 13:50:32 : INFO  : magicbullet : Installing Magic Bullet Suite version 2023.2.1 on versionKey CFBundleShortVersionString.
2023-05-26 13:50:32 : INFO  : magicbullet : App has LSMinimumSystemVersion: 10.11
2023-05-26 13:50:32 : DEBUG : magicbullet : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-05-26 13:50:32 : INFO  : magicbullet : Finishing...
ls: /Users/Shared/Red Giant/uninstall: No such file or directory
2023-05-26 13:50:35 : INFO  : magicbullet : Custom App Version detection is used, found 
2023-05-26 13:50:35 : REQ   : magicbullet : Installed Magic Bullet Suite
2023-05-26 13:50:35 : INFO  : magicbullet : notifying
2023-05-26 13:50:36 : DEBUG : magicbullet : DEBUG mode 1, not reopening anything
2023-05-26 13:50:36 : REQ   : magicbullet : All done!
2023-05-26 13:50:36 : REQ   : magicbullet : ################## End Installomator, exit code 0
```