### PR TITLE
Update label: bitwarden - repo change (and more)

### DIFF
--- a/fragments/labels/bitwarden.sh
+++ b/fragments/labels/bitwarden.sh
@@ -1,7 +1,7 @@
 bitwarden)
     name="Bitwarden"
     type="dmg"
-    downloadURL=$(downloadURLFromGit bitwarden desktop )
-    appNewVersion=$(versionFromGit bitwarden desktop )
+    appNewVersion=$(curl -s "https://github.com/bitwarden/clients/releases?q\=desktop" | xmllint --html --xpath 'substring-after(string(//h2[starts-with(text(),"Desktop v")]), " v")' - 2>/dev/null)
+    downloadURL="https://github.com/bitwarden/clients/releases/download/desktop-v${appNewVersion}/Bitwarden-${appNewVersion}-universal.dmg"
     expectedTeamID="LTZ2PFU5D6"
     ;;


### PR DESCRIPTION
Label is going to an archived repository (as of June 22 2022). Updating to reflect new label. However, they have multiple releases for different platforms, so using the versionFromGit and DownloadURLFromGit don't get the right info for MacOS releases. So things are done a little more manually here. Please let me know if there might be a better way to do this.

Partial fix for issue #1062 

Output:
admin in ~/Documents/GitHub/Installomator on labelFix-Bitwarden-updatedRepo ● ● : ./build/Installomator.sh bitwarden DEBUG=0
2023-05-26 10:55:13 : REQ   : bitwarden : ################## Start Installomator v. 10.4beta, date 2023-05-26
2023-05-26 10:55:13 : INFO  : bitwarden : ################## Version: 10.4beta
2023-05-26 10:55:13 : INFO  : bitwarden : ################## Date: 2023-05-26
2023-05-26 10:55:13 : INFO  : bitwarden : ################## bitwarden
2023-05-26 10:55:13 : DEBUG : bitwarden : DEBUG mode 1 enabled.
2023-05-26 10:55:14 : INFO  : bitwarden : setting variable from argument DEBUG=0
2023-05-26 10:55:14 : DEBUG : bitwarden : name=Bitwarden
2023-05-26 10:55:14 : DEBUG : bitwarden : appName=
2023-05-26 10:55:14 : DEBUG : bitwarden : type=dmg
2023-05-26 10:55:14 : DEBUG : bitwarden : archiveName=
2023-05-26 10:55:14 : DEBUG : bitwarden : downloadURL=https://github.com/bitwarden/clients/releases/download/desktop-v2023.4.0/Bitwarden-2023.4.0-universal.dmg
2023-05-26 10:55:14 : DEBUG : bitwarden : curlOptions=
2023-05-26 10:55:14 : DEBUG : bitwarden : appNewVersion=2023.4.0
2023-05-26 10:55:14 : DEBUG : bitwarden : appCustomVersion function: Not defined
2023-05-26 10:55:14 : DEBUG : bitwarden : versionKey=CFBundleShortVersionString
2023-05-26 10:55:14 : DEBUG : bitwarden : packageID=
2023-05-26 10:55:14 : DEBUG : bitwarden : pkgName=
2023-05-26 10:55:14 : DEBUG : bitwarden : choiceChangesXML=
2023-05-26 10:55:14 : DEBUG : bitwarden : expectedTeamID=LTZ2PFU5D6
2023-05-26 10:55:14 : DEBUG : bitwarden : blockingProcesses=
2023-05-26 10:55:14 : DEBUG : bitwarden : installerTool=
2023-05-26 10:55:14 : DEBUG : bitwarden : CLIInstaller=
2023-05-26 10:55:14 : DEBUG : bitwarden : CLIArguments=
2023-05-26 10:55:14 : DEBUG : bitwarden : updateTool=
2023-05-26 10:55:14 : DEBUG : bitwarden : updateToolArguments=
2023-05-26 10:55:14 : DEBUG : bitwarden : updateToolRunAsCurrentUser=
2023-05-26 10:55:14 : INFO  : bitwarden : BLOCKING_PROCESS_ACTION=tell_user
2023-05-26 10:55:14 : INFO  : bitwarden : NOTIFY=success
2023-05-26 10:55:14 : INFO  : bitwarden : LOGGING=DEBUG
2023-05-26 10:55:14 : INFO  : bitwarden : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-26 10:55:14 : INFO  : bitwarden : Label type: dmg
2023-05-26 10:55:14 : INFO  : bitwarden : archiveName: Bitwarden.dmg
2023-05-26 10:55:14 : INFO  : bitwarden : no blocking processes defined, using Bitwarden as default
2023-05-26 10:55:14 : DEBUG : bitwarden : Changing directory to /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.qyFB59q4
2023-05-26 10:55:14 : INFO  : bitwarden : name: Bitwarden, appName: Bitwarden.app
2023-05-26 10:55:14.741 mdfind[35268:276621] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-26 10:55:14.741 mdfind[35268:276621] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-26 10:55:14.788 mdfind[35268:276621] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-26 10:55:14 : WARN  : bitwarden : No previous app found
2023-05-26 10:55:14 : WARN  : bitwarden : could not find Bitwarden.app
2023-05-26 10:55:14 : INFO  : bitwarden : appversion:
2023-05-26 10:55:14 : INFO  : bitwarden : Latest version of Bitwarden is 2023.4.0
2023-05-26 10:55:14 : REQ   : bitwarden : Downloading https://github.com/bitwarden/clients/releases/download/desktop-v2023.4.0/Bitwarden-2023.4.0-universal.dmg to Bitwarden.dmg
2023-05-26 10:55:14 : DEBUG : bitwarden : No Dialog connection, just download
2023-05-26 10:55:21 : DEBUG : bitwarden : File list: -rw-r--r--  1 admin  2103187081   168M May 26 10:55 Bitwarden.dmg
2023-05-26 10:55:21 : DEBUG : bitwarden : File type: Bitwarden.dmg: zlib compressed data
2023-05-26 10:55:21 : DEBUG : bitwarden : curl output was:
*   Trying 192.30.255.112:443...
* Connected to github.com (192.30.255.112) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /bitwarden/clients/releases/download/desktop-v2023.4.0/Bitwarden-2023.4.0-universal.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14b813400)
> GET /bitwarden/clients/releases/download/desktop-v2023.4.0/Bitwarden-2023.4.0-universal.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Fri, 26 May 2023 17:54:22 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/53538899/01020beb-74c2-48db-85b8-a9c9664b0953?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230526T175422Z&X-Amz-Expires=300&X-Amz-Signature=ea2950e1904b71f507c47bf5b7357820456ff413d8f3d8528096cfba65b32054&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=53538899&response-content-disposition=attachment%3B%20filename%3DBitwarden-2023.4.0-universal.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache < strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny < x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0 < x-github-request-id: 8F52:9835:5D47FA:61916A:6470F282 < { [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/53538899/01020beb-74c2-48db-85b8-a9c9664b0953?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230526T175422Z&X-Amz-Expires=300&X-Amz-Signature=ea2950e1904b71f507c47bf5b7357820456ff413d8f3d8528096cfba65b32054&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=53538899&response-content-disposition=attachment%3B%20filename%3DBitwarden-2023.4.0-universal.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/53538899/01020beb-74c2-48db-85b8-a9c9664b0953?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230526T175422Z&X-Amz-Expires=300&X-Amz-Signature=ea2950e1904b71f507c47bf5b7357820456ff413d8f3d8528096cfba65b32054&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=53538899&response-content-disposition=attachment%3B%20filename%3DBitwarden-2023.4.0-universal.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14b813400)
> GET /github-production-release-asset-2e65be/53538899/01020beb-74c2-48db-85b8-a9c9664b0953?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230526T175422Z&X-Amz-Expires=300&X-Amz-Signature=ea2950e1904b71f507c47bf5b7357820456ff413d8f3d8528096cfba65b32054&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=53538899&response-content-disposition=attachment%3B%20filename%3DBitwarden-2023.4.0-universal.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: o0Ris+J5Baas3qQvH/ImEA==
< last-modified: Wed, 26 Apr 2023 13:34:43 GMT
< etag: "0x8DB465AFEAB79E8"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 467b79c6-201e-0012-37fa-8f9a85000000 < x-ms-version: 2020-04-08 < x-ms-creation-time: Wed, 26 Apr 2023 13:34:43 GMT < x-ms-lease-status: unlocked < x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Bitwarden-2023.4.0-universal.dmg < x-ms-server-encrypted: true < via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 281
< date: Fri, 26 May 2023 17:55:15 GMT
< x-served-by: cache-iad-kjyo7100122-IAD, cache-pdx12330-PDX < x-cache: MISS, HIT < x-cache-hits: 0, 0
< x-timer: S1685123715.922678,VS0,VE98
< content-length: 176031725
<
{ [16375 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-05-26 10:55:21 : REQ   : bitwarden : no more blocking processes, continue with update
2023-05-26 10:55:21 : REQ   : bitwarden : Installing Bitwarden
2023-05-26 10:55:21 : INFO  : bitwarden : Mounting /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.qyFB59q4/Bitwarden.dmg
2023-05-26 10:55:26 : DEBUG : bitwarden : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $6BCEC1D9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E433846B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $482740A0
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $B2776514
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $482740A0
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E70E786B
verified   CRC32 $92EA515F
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Bitwarden 2023.4.0-universal

2023-05-26 10:55:26 : INFO  : bitwarden : Mounted: /Volumes/Bitwarden 2023.4.0-universal 2023-05-26 10:55:26 : INFO  : bitwarden : Verifying: /Volumes/Bitwarden 2023.4.0-universal/Bitwarden.app 2023-05-26 10:55:26 : DEBUG : bitwarden : App size: 415M	/Volumes/Bitwarden 2023.4.0-universal/Bitwarden.app 2023-05-26 10:55:29 : DEBUG : bitwarden : Debugging enabled, App Verification output was: /Volumes/Bitwarden 2023.4.0-universal/Bitwarden.app: accepted source=Notarized Developer ID
origin=Developer ID Application: 8bit Solutions LLC (LTZ2PFU5D6)

2023-05-26 10:55:29 : INFO  : bitwarden : Team ID matching: LTZ2PFU5D6 (expected: LTZ2PFU5D6 ) 2023-05-26 10:55:29 : INFO  : bitwarden : Installing Bitwarden version 2023.4.0 on versionKey CFBundleShortVersionString. 2023-05-26 10:55:29 : INFO  : bitwarden : App has LSMinimumSystemVersion: 10.13 2023-05-26 10:55:29 : INFO  : bitwarden : Copy /Volumes/Bitwarden 2023.4.0-universal/Bitwarden.app to /Applications 2023-05-26 10:55:30 : DEBUG : bitwarden : Debugging enabled, App copy output was: Copying /Volumes/Bitwarden 2023.4.0-universal/Bitwarden.app

2023-05-26 10:55:30 : WARN  : bitwarden : Changing owner to admin 2023-05-26 10:55:30 : INFO  : bitwarden : Finishing... 2023-05-26 10:55:33 : INFO  : bitwarden : App(s) found: /Applications/Bitwarden.app 2023-05-26 10:55:33 : INFO  : bitwarden : found app at /Applications/Bitwarden.app, version 2023.4.0, on versionKey CFBundleShortVersionString
2023-05-26 10:55:33 : REQ   : bitwarden : Installed Bitwarden, version 2023.4.0
2023-05-26 10:55:33 : INFO  : bitwarden : notifying
2023-05-26 10:55:33 : DEBUG : bitwarden : Unmounting /Volumes/Bitwarden 2023.4.0-universal
2023-05-26 10:55:34 : DEBUG : bitwarden : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-05-26 10:55:34 : DEBUG : bitwarden : Deleting /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.qyFB59q4
2023-05-26 10:55:34 : DEBUG : bitwarden : Debugging enabled, Deleting tmpDir output was:
/var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.qyFB59q4/Bitwarden.dmg
2023-05-26 10:55:34 : DEBUG : bitwarden : /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.qyFB59q4
2023-05-26 10:55:34 : INFO  : bitwarden : App not closed, so no reopen.
2023-05-26 10:55:34 : REQ   : bitwarden : All done!
2023-05-26 10:55:34 : REQ   : bitwarden : ################## End Installomator, exit code 0