### PR TITLE
Updated Label: ScaleFT - TeamID change

### DIFF
--- a/fragments/labels/scaleft.sh
+++ b/fragments/labels/scaleft.sh
@@ -3,6 +3,6 @@ scaleft)
     type="pkg"
     downloadURL="https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg"
     appNewVersion=$(curl -sf "https://dist.scaleft.com/client-tools/mac/" | awk '/dir/{i++}i==2' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
-    expectedTeamID="HV2G9Z3RP5"
+    expectedTeamID="B7F62B65BN"
     blockingProcesses=( ScaleFT )
     ;;


### PR DESCRIPTION
Responding to help wanted for issue #918 . Verified current version was not matching with TeamID.

New output:
./assemble.sh scaleft
2023-05-26 15:23:50 : REQ   : scaleft : ################## Start Installomator v. 10.4beta, date 2023-05-26
2023-05-26 15:23:50 : INFO  : scaleft : ################## Version: 10.4beta
2023-05-26 15:23:50 : INFO  : scaleft : ################## Date: 2023-05-26
2023-05-26 15:23:50 : INFO  : scaleft : ################## scaleft
2023-05-26 15:23:50 : DEBUG : scaleft : DEBUG mode 1 enabled.
2023-05-26 15:23:50 : DEBUG : scaleft : name=ScaleFT
2023-05-26 15:23:50 : DEBUG : scaleft : appName=
2023-05-26 15:23:50 : DEBUG : scaleft : type=pkg
2023-05-26 15:23:50 : DEBUG : scaleft : archiveName=
2023-05-26 15:23:50 : DEBUG : scaleft : downloadURL=https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg
2023-05-26 15:23:50 : DEBUG : scaleft : curlOptions=
2023-05-26 15:23:50 : DEBUG : scaleft : appNewVersion=1.67.4
2023-05-26 15:23:50 : DEBUG : scaleft : appCustomVersion function: Not defined
2023-05-26 15:23:50 : DEBUG : scaleft : versionKey=CFBundleShortVersionString
2023-05-26 15:23:50 : DEBUG : scaleft : packageID=
2023-05-26 15:23:50 : DEBUG : scaleft : pkgName=
2023-05-26 15:23:50 : DEBUG : scaleft : choiceChangesXML=
2023-05-26 15:23:50 : DEBUG : scaleft : expectedTeamID=B7F62B65BN
2023-05-26 15:23:50 : DEBUG : scaleft : blockingProcesses=ScaleFT
2023-05-26 15:23:50 : DEBUG : scaleft : installerTool=
2023-05-26 15:23:50 : DEBUG : scaleft : CLIInstaller=
2023-05-26 15:23:50 : DEBUG : scaleft : CLIArguments=
2023-05-26 15:23:50 : DEBUG : scaleft : updateTool=
2023-05-26 15:23:50 : DEBUG : scaleft : updateToolArguments=
2023-05-26 15:23:50 : DEBUG : scaleft : updateToolRunAsCurrentUser=
2023-05-26 15:23:50 : INFO  : scaleft : BLOCKING_PROCESS_ACTION=tell_user
2023-05-26 15:23:50 : INFO  : scaleft : NOTIFY=success
2023-05-26 15:23:50 : INFO  : scaleft : LOGGING=DEBUG
2023-05-26 15:23:50 : INFO  : scaleft : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-26 15:23:50 : INFO  : scaleft : Label type: pkg
2023-05-26 15:23:50 : INFO  : scaleft : archiveName: ScaleFT.pkg
2023-05-26 15:23:50 : DEBUG : scaleft : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-05-26 15:23:50 : INFO  : scaleft : name: ScaleFT, appName: ScaleFT.app
2023-05-26 15:23:50.480 mdfind[41934:384498] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-26 15:23:50.480 mdfind[41934:384498] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-26 15:23:50.529 mdfind[41934:384498] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-26 15:23:50 : WARN  : scaleft : No previous app found
2023-05-26 15:23:50 : WARN  : scaleft : could not find ScaleFT.app
2023-05-26 15:23:50 : INFO  : scaleft : appversion:
2023-05-26 15:23:50 : INFO  : scaleft : Latest version of ScaleFT is 1.67.4
2023-05-26 15:23:50 : REQ   : scaleft : Downloading https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg to ScaleFT.pkg
2023-05-26 15:23:50 : DEBUG : scaleft : No Dialog connection, just download
2023-05-26 15:23:51 : DEBUG : scaleft : File list: -rw-r--r--  1 admin  2103187081    23M May 26 15:23 ScaleFT.pkg
2023-05-26 15:23:51 : DEBUG : scaleft : File type: ScaleFT.pkg: xar archive compressed TOC: 4962, SHA-1 checksum
2023-05-26 15:23:51 : DEBUG : scaleft : curl output was:
*   Trying 99.84.66.123:443...
* Connected to dist.scaleft.com (99.84.66.123) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4958 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=dist.scaleft.com
*  start date: May 22 00:00:00 2023 GMT
*  expire date: Jun 19 23:59:59 2024 GMT
*  subjectAltName: host "dist.scaleft.com" matched cert's "dist.scaleft.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /client-tools/mac/latest/ScaleFT.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: dist.scaleft.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14e011400)
> GET /client-tools/mac/latest/ScaleFT.pkg HTTP/2
> Host: dist.scaleft.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 301
< content-length: 0
< location: https://dist.scaleft.com/client-tools/mac/v1.67.4/ScaleFT-1.67.4.pkg < date: Fri, 26 May 2023 22:19:53 GMT
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 f13aef0c4b52f6f681401f232d03eb68.cloudfront.net (CloudFront) < x-amz-cf-pop: HIO50-C1
< x-amz-cf-id: 1TUOyuOyTJR2yiUyOQaOldkjs_9TufxuzAinUZUXDe9Uq70IlgD0ZA== < age: 238
<
{ [0 bytes data]
* Connection #0 to host dist.scaleft.com left intact
* Issue another request to this URL: 'https://dist.scaleft.com/client-tools/mac/v1.67.4/ScaleFT-1.67.4.pkg'
* Found bundle for host: 0x600001004870 [can multiplex]
* Re-using existing connection #0 with host dist.scaleft.com
* h2h3 [:method: GET]
* h2h3 [:path: /client-tools/mac/v1.67.4/ScaleFT-1.67.4.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: dist.scaleft.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 3 (easy handle 0x14e011400)
> GET /client-tools/mac/v1.67.4/ScaleFT-1.67.4.pkg HTTP/2
> Host: dist.scaleft.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 24178363
< x-amz-meta-hash-sha512: 064a5f29f0ab4d9c8956ae4fa7cc0938b3d1d73c8bfcafb26ef6b73767e0a3e102f54550f3becc0ffaaaeac4c812472263dfcade8265ef35d7671619104714aa < last-modified: Thu, 23 Feb 2023 16:52:02 GMT
< server: AmazonS3
< date: Fri, 26 May 2023 22:19:54 GMT
< cache-control: max-age=300,public
< etag: "42c8f3eb105a2073b5117f589634e3d7-5"
< x-cache: Hit from cloudfront
< via: 1.1 f13aef0c4b52f6f681401f232d03eb68.cloudfront.net (CloudFront) < x-amz-cf-pop: HIO50-C1
< x-amz-cf-id: Gp2lSmOsKT8TgRw6CHu5DXEgBPiNEcekmtidhVY0sgIT4yD42-55xQ== < age: 237
<
{ [15926 bytes data]
* Connection #0 to host dist.scaleft.com left intact

2023-05-26 15:23:51 : DEBUG : scaleft : DEBUG mode 1, not checking for blocking processes
2023-05-26 15:23:51 : REQ   : scaleft : Installing ScaleFT
2023-05-26 15:23:51 : INFO  : scaleft : Verifying: ScaleFT.pkg
2023-05-26 15:23:51 : DEBUG : scaleft : File list: -rw-r--r--  1 admin  2103187081    23M May 26 15:23 ScaleFT.pkg
2023-05-26 15:23:51 : DEBUG : scaleft : File type: ScaleFT.pkg: xar archive compressed TOC: 4962, SHA-1 checksum
2023-05-26 15:23:51 : DEBUG : scaleft : spctlOut is ScaleFT.pkg: accepted
2023-05-26 15:23:51 : DEBUG : scaleft : source=Notarized Developer ID
2023-05-26 15:23:51 : DEBUG : scaleft : origin=Developer ID Installer: Okta, Inc. (B7F62B65BN)
2023-05-26 15:23:51 : INFO  : scaleft : Team ID: B7F62B65BN (expected: B7F62B65BN )
2023-05-26 15:23:51 : DEBUG : scaleft : DEBUG enabled, skipping installation
2023-05-26 15:23:51 : INFO  : scaleft : Finishing...
2023-05-26 15:23:54 : INFO  : scaleft : name: ScaleFT, appName: ScaleFT.app
2023-05-26 15:23:54.821 mdfind[41990:384682] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-05-26 15:23:54.822 mdfind[41990:384682] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-05-26 15:23:54.881 mdfind[41990:384682] Couldn't determine the mapping between prefab keywords and predicates.
2023-05-26 15:23:54 : WARN  : scaleft : No previous app found
2023-05-26 15:23:54 : WARN  : scaleft : could not find ScaleFT.app
2023-05-26 15:23:54 : REQ   : scaleft : Installed ScaleFT, version 1.67.4
2023-05-26 15:23:54 : INFO  : scaleft : notifying
2023-05-26 15:23:55 : DEBUG : scaleft : DEBUG mode 1, not reopening anything
2023-05-26 15:23:55 : REQ   : scaleft : All done!
2023-05-26 15:23:55 : REQ   : scaleft : ################## End Installomator, exit code 0