### PR TITLE
Updated Label: Cytoscape

### DIFF
--- a/fragments/labels/cytoscape.sh
+++ b/fragments/labels/cytoscape.sh
@@ -2,6 +2,12 @@ cytoscape)
     name="Cytoscape"
     #appName="Cytoscape Installer.app"
     type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="Cytoscape_[0-9._]*_macos_aarch64.dmg"
+
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="Cytoscape_[0-9._]*_macos_x64.dmg"
+    fi
     downloadURL="$(downloadURLFromGit cytoscape cytoscape)"
     appNewVersion="$(versionFromGit cytoscape cytoscape)"
     installerTool="Cytoscape Installer.app"


### PR DESCRIPTION
Fixes a problem that causes the Apple Silicon version of Cytoscape to be downloaded to Intel devices with installation failure as result.