### PR TITLE
Add label: keeperpasswordmanager

### DIFF
--- a/fragments/labels/keeperpasswordmanager.sh
+++ b/fragments/labels/keeperpasswordmanager.sh
@@ -1,0 +1,8 @@
+keeperpasswordmanager)
+    name="Keeper Password Manager"
+    type="dmg"
+    downloadURL="https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg"
+    appNewVersion=""
+    expectedTeamID="234QNB7GCA"
+    blockingProcess=( "Keeper Password Manager" )
+    ;;


### PR DESCRIPTION
# Installomator label for [Keeper Password Manager ](https://www.keepersecurity.com/)


# buildlabel.sh results >>>>> 

(base) gknackstedt@serial utils % ./buildLabel.sh https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg Changing directory to /Users/gknackstedt/Installomator-main/utils/2023-05-30-13-07-30 Working dir: /Users/gknackstedt/Installomator-main/utils/2023-05-30-13-07-30 Downloading https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg KeeperSetup.dmg
Redirecting to (maybe this can help us with version): HTTP/2 400 
date: Tue, 30 May 2023 17:07:31 GMT
content-type: text/html
content-length: 150
server: nginx
content-security-policy: default-src 'self';

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    468      0 --:--:-- --:--:-- --:--:--   482
100  275M  100  275M    0     0  53.3M      0  0:00:05  0:00:05 --:--:-- 57.4M
archiveTempName: KeeperSetup.dmg
archivePath: https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
Calculated archiveName: KeeperSetup.dmg
name: KeeperSetup
archiveExt: dmg
Diskimage found
DMG investigation.
Mounting KeeperSetup.dmg
Mounted: /Volumes/Keeper Password Manager
App found: /Volumes/Keeper Password Manager/Keeper Password Manager.app
Application investigation.
Team ID found for app: 234QNB7GCA
"disk4" ejected.
identifier: keeperpasswordmanager

**********

Labels should be named in small caps, numbers 0-9, “-”, and “_”. No other characters allowed.

appNewVersion is often difficult to find. Can sometimes be found in the filename, sometimes as part of the download redirects, but also on a web page. See redirect and archivePath above if link contains information about this. That is a good place to start

keeperpasswordmanager)
    name="Keeper Password Manager"
    type="dmg"
    downloadURL="https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg"
    appNewVersion=""
    expectedTeamID="234QNB7GCA"
    ;;

Above should be saved in a file with exact same name as label, and given extension “.sh”. Put this file in folder “fragments/labels”.

## NOTE: Unable to parse current version from Keeper's webpage because it seems to be hidden behind some browser user agent trickery:
### Per ChatGPT:

##### My question to ChatGPT:
```
I located the element which contains the Keeper for macOS version: <h2>Keeper for macOS <span class="version">XXX</span></h2><p>
Supports Touch ID on supported hardware and iCloud Keychain import.</p><div class="actions"><a 
href="/desktop_electron/Darwin/KeeperSetup.dmg" class="btn btn-yellow">
Download</a> 

which appears to reference the following script higher up in the page source: <script>
window.keeper.registerTabs(["d","f","m","e","c"]),jQuery(document).ready(function(o){var e;-1!==(window.navigator&&window.navigator.userAgent||"").indexOf("Edg/")&&o('[href="ms-windows-store://pdp/?productid=9N0MNNSLFZ1T"]').attr("href","https://microsoftedge.microsoft.com/insider-addons/detail/lfochlioelphaglamdcakfjemolpichk"),o(document).on("click","a.desktopPlatform",function(e){e.preventDefault();e=o(this).data("platform");o(".desktopPlatform").removeClass("active"),o(this).addClass("active"),o(".desktopSelectors .platform").removeClass("active"),o(".desktopSelectors .platform."+e).addClass("active"),o(".desktopPlatformImage").removeClass("active"),o(".desktopPlatformImage."+e).addClass("active")}),(o(document).find("body").hasClass("mac")||o(document).find("body").hasClass("ios")||o(document).find("body").hasClass("iPad")||o(document).find("body").hasClass("iPhone"))&&((e=o(document).find('a.desktopPlatform[data-platform="mac"]:not(.active)')).click(),e.addClass("active")),(o(document).find("body").hasClass("win")||o(document).find("body").hasClass("Android"))&&((e=o(document).find('a.desktopPlatform[data-platform="win"]:not(.active)')).click(),e.addClass("active")),o(document).find("body").hasClass("linux")&&((e=o(document).find('a.desktopPlatform[data-platform="linux"]:not(.active)')).click(),e.addClass("active")),o(document).on("click touchend","#showOperaInstructions",function(e){e.preventDefault(),o('[component="lightbox"] #operaInstructions.keeperLightbox').addClass("moduleVisible"),o("#operaInstallInstructions .overlay").addClass("overlayVisible"),o("#operaInstructions").addClass("moduleVisible"),o(".header, .main, .footer").addClass("blurForModal")}),o(document).on("click",".closePopup, .overlay",function(e){o('[component="lightbox"] .keeperLightbox').removeClass("moduleVisible"),o(".overlay").removeClass("overlayVisible"),o(".header, .main, .footer").removeClass("blurForModal")})}),function(){var t={},s=(t.product=window.keeper.getParams().product||"vault",t.os=window.keeper.whatOS(),t.browser=window.keeper.whatBrowser(),t.isMobile=window.matchMedia("(max-width: 768px)").matches,t.extensionVersionIE="",t.extensionVersion="",t.desktopVersion="",t.isMobile&&"m"!==window.keeper.getParams().t&&(window.location="/download.html?t=m"),!t.isMobile||"win"!==t.os&&"WinPhone"!==t.os||(window.location="https://www.keepersecurity.com/vault/#new/lang/en_US"),"iPhone"!==t.os&&"iPad"!==t.os&&"Kindle"!==t.os&&"WinPhone"!==t.os&&"Android"!==t.os||(t.isMobile=!0),t.isMobile?$(".content.container.mobile").show():$(".content.container.mobile").hide(),$(document).on("click",".browser",function(e){i("browser");var o=$(this).data("browser");t.browser=o,s(),"windows"==$(document).find(".platform.active").data("os")?"chrome"==o||"safari"==o||"firefox"==o||"ie"==o||"edge"==o||"chromium-edge"==o||"brave"==o?$(".browser-extension").find(".download.active .setup").show().css("visibility","visible"):$(".browser-extension").find(".download.active .setup").show().css("visibility","hidden"):"chrome"==o||"safari"==o||"firefox"==o||"ie"==o||"edge"==o||"chromium-edge"==o||"opera"==o||"brave"==o?($(".browser-extension").find(".download.active .setup").show().css("visibility","visible"),$(document).find(".desktopSelectors .downloads .download.active span").show()):($(".browser-extension").find(".download.active .setup").hide(),$(document).find(".desktopSelectors .downloads .download.active:not(.windows) span").hide())}),$(document).on("tab_change",function(){$(document).ready(function(){var e;s(),window.matchMedia("(min-width: 769px)").matches&&(e=void 0!==t.os?t.os:"mac",$(".platform."+e).click(),$(".desktopPlatform").removeClass("active"),$('.desktopPlatform[data-platform="'+e+'"]').addClass("active"),$(".appStoresDownload").find("a").removeClass("active").find("a."+e).addClass("active"),$('.desktopPlatform[data-platform="'+e+'"]').click(),$(".browser."+(void 0!==t.browser?t.browser:"chrome")).click()),window.keeper.getDesktopElectronVersion(function(e){$('[data-type="deb"]').length<1||($('[data-type="deb"]').attr("href",$('[data-type="deb"]').attr("href").replace("XXX",e.version)),$('[data-type="rpm"]').attr("href",$('[data-type="rpm"]').attr("href").replace("XXX",e.version)))})})}),function(){"win"===t.os&&(t.os="windows"),$("."+t.os).not("body").addClass("active"),$("."+t.browser).not("body").addClass("active"),window.keeper.getDesktopElectronVersion(function(s){s&&s.version&&(t.desktopVersion=s.version||"",$(".desktopSelectors .version").html("v"+s.version||"").addClass("active"),$(".windows .download .details").length<1||$(".windows .download .details").each(function(e,o){var t=$(o).html().replace("XXX",s.version||"");$(o).html(t)}))}),"safari"===t.browser?window.keeper.getDesktopElectronVersion(function(e){e&&e.version&&(t.extensionVersionIE=e.version||"",$(".browser-extension .version.current").length<1||$(".browser-extension .version.current").html("v"+e.version||"").addClass("active"))}):"ie"==t.browser?window.keeper.getBrowserExtensionVersionIE(function(e){e&&e.version&&(t.extensionVersionIE=e.version||"",$(".browser-extension .version.current").length<1||$(".browser-extension .version.current").html("v"+e.version||"").addClass("active"))}):window.keeper.getBrowserExtensionVersionsStable(function(e){var o=e.current;e.stable;t.extensionVersion=o||"",$(".browser-extension .version.current").length<1||$(".browser-extension .version.current").html("v"+o||"").addClass("active")})}),i=function(e){("browser"===e?$(".browser-extension .active"):"desktop"===e?$(".desktopSelectors .active"):$(".active")).removeClass("active")}}()
</script>
```
##### ChatGPT response:
```
Great! You've located the HTML element that contains the version number. This is very helpful. The script you found does seem to be injecting the version number dynamically, which means it won't be directly visible in the static HTML source. However, it also means that our current approach for extracting the version number using curl and grep will not work because these tools only see the static HTML source and do not execute JavaScript.

One potential workaround could be to use a different method for retrieving the version number. If the version number is not easily accessible from the webpage, you might want to contact Keeper's support to see if they provide a more straightforward way to retrieve the current version number, such as a dedicated API or a simpler webpage that doesn't require JavaScript.

If that's not an option, you could consider using a more powerful tool like a headless browser (e.g., Puppeteer, Selenium, etc.) that can load the page, execute JavaScript, and then extract the version number. However, this would involve a considerable amount of additional complexity and may not be suitable depending on your environment and constraints.
```

# assemble.sh DEBUG=0 testing results >>>>>

2023-05-31 15:26:54 : REQ   : keeperpasswordmanager : ################## Start Installomator v. 10.4beta, date 2023-05-31
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : ################## Version: 10.4beta
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : ################## Date: 2023-05-31
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : ################## keeperpasswordmanager
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : DEBUG mode 1 enabled.
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : setting variable from argument DEBUG=0
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : name=Keeper Password Manager
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : appName=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : type=dmg
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : archiveName=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : downloadURL=https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : curlOptions=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : appNewVersion=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : appCustomVersion function: Not defined
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : versionKey=CFBundleShortVersionString
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : packageID=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : pkgName=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : choiceChangesXML=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : expectedTeamID=234QNB7GCA
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : blockingProcesses=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : installerTool=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : CLIInstaller=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : CLIArguments=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : updateTool=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : updateToolArguments=
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : updateToolRunAsCurrentUser=
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : BLOCKING_PROCESS_ACTION=tell_user
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : NOTIFY=success
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : LOGGING=DEBUG
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : Label type: dmg
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : archiveName: Keeper Password Manager.dmg
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : no blocking processes defined, using Keeper Password Manager as default
2023-05-31 15:26:54 : DEBUG : keeperpasswordmanager : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mK7rmkH3
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : App(s) found: /Applications/Keeper Password Manager.app
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : found app at /Applications/Keeper Password Manager.app, version 16.10.2, on versionKey CFBundleShortVersionString
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : appversion: 16.10.2
2023-05-31 15:26:54 : INFO  : keeperpasswordmanager : Latest version not specified.
2023-05-31 15:26:54 : REQ   : keeperpasswordmanager : Downloading https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg to Keeper Password Manager.dmg
2023-05-31 15:26:55 : DEBUG : keeperpasswordmanager : No Dialog connection, just download
2023-05-31 15:27:14 : DEBUG : keeperpasswordmanager : File list: -rw-r--r--  1 root  wheel   276M May 31 15:27 Keeper Password Manager.dmg
2023-05-31 15:27:14 : DEBUG : keeperpasswordmanager : File type: Keeper Password Manager.dmg: zlib compressed data
2023-05-31 15:27:14 : DEBUG : keeperpasswordmanager : curl output was:
*   Trying 100.25.27.45:443...
* Connected to www.keepersecurity.com (100.25.27.45) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4976 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=keepersecurity.com
*  start date: Feb 23 00:00:00 2023 GMT
*  expire date: Sep 21 23:59:59 2023 GMT
*  subjectAltName: host "www.keepersecurity.com" matched cert's "www.keepersecurity.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /desktop_electron/Darwin/KeeperSetup.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.keepersecurity.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15480b800)
> GET /desktop_electron/Darwin/KeeperSetup.dmg HTTP/2
> Host: www.keepersecurity.com
> user-agent: curl/7.87.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)! < HTTP/2 301 
< date: Wed, 31 May 2023 19:26:55 GMT
< content-type: text/html
< content-length: 162
< location: https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg < server: nginx
< content-security-policy: default-src 'self';
< x-frame-options: DENY
< strict-transport-security: max-age=31536000; includeSubDomains; preload < x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< expect-ct: max-age=10, report-uri="https://keepersecurity.report-uri.com/r/t/ct/reportOnly" < 
* Ignoring the response-body { [162 bytes data]
* Connection #0 to host www.keepersecurity.com left intact
* Issue another request to this URL: 'https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg'
*   Trying 100.25.27.45:443...
* Connected to keepersecurity.com (100.25.27.45) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4976 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* [CONN-1-0][CF-SSL] TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=keepersecurity.com
*  start date: Feb 23 00:00:00 2023 GMT
*  expire date: Sep 21 23:59:59 2023 GMT
*  subjectAltName: host "keepersecurity.com" matched cert's "keepersecurity.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /desktop_electron/Darwin/KeeperSetup.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: keepersecurity.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15480b800)
> GET /desktop_electron/Darwin/KeeperSetup.dmg HTTP/2
> Host: keepersecurity.com
> user-agent: curl/7.87.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)! < HTTP/2 200 
< date: Wed, 31 May 2023 19:26:56 GMT
< content-type: application/x-apple-diskimage
< content-length: 289182542
< server: nginx
< last-modified: Mon, 22 May 2023 18:34:49 GMT
< etag: "0ff7a499124ea8f302ae3eefff8a00f9-35"
< content-security-policy: default-src 'self';
< x-frame-options: DENY
< strict-transport-security: max-age=31536000; includeSubDomains; preload < x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< expect-ct: max-age=10, report-uri="https://keepersecurity.report-uri.com/r/t/ct/reportOnly" < accept-ranges: bytes
< 
{ [15803 bytes data]
* Connection #1 to host keepersecurity.com left intact

2023-05-31 15:27:14 : INFO  : keeperpasswordmanager : found blocking process Keeper Password Manager 2023-05-31 15:27:16 : INFO  : keeperpasswordmanager : telling app Keeper Password Manager to quit 2023-05-31 15:27:16 : INFO  : keeperpasswordmanager : waiting 30 seconds for processes to quit
2023-05-31 15:27:46 : REQ   : keeperpasswordmanager : no more blocking processes, continue with update
2023-05-31 15:27:46 : REQ   : keeperpasswordmanager : Installing Keeper Password Manager
2023-05-31 15:27:46 : INFO  : keeperpasswordmanager : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mK7rmkH3/Keeper Password Manager.dmg
2023-05-31 15:27:51 : DEBUG : keeperpasswordmanager : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $AC57014D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3C49C88F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $702D2B6A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $8B396138
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $702D2B6A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $09BF809A
verified   CRC32 $A658E801
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Keeper Password Manager

2023-05-31 15:27:51 : INFO  : keeperpasswordmanager : Mounted: /Volumes/Keeper Password Manager 2023-05-31 15:27:51 : INFO  : keeperpasswordmanager : Verifying: /Volumes/Keeper Password Manager/Keeper Password Manager.app 2023-05-31 15:27:51 : DEBUG : keeperpasswordmanager : App size: 652M	/Volumes/Keeper Password Manager/Keeper Password Manager.app 2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : Debugging enabled, App Verification output was: /Volumes/Keeper Password Manager/Keeper Password Manager.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Callpod Inc. (234QNB7GCA)

2023-05-31 15:27:57 : INFO  : keeperpasswordmanager : Team ID matching: 234QNB7GCA (expected: 234QNB7GCA ) 2023-05-31 15:27:57 : INFO  : keeperpasswordmanager : Downloaded version of Keeper Password Manager is 16.10.2 on versionKey CFBundleShortVersionString, same as installed. 2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : Unmounting /Volumes/Keeper Password Manager 2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : Debugging enabled, Unmounting output was: "disk4" ejected.
2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mK7rmkH3 2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : Debugging enabled, Deleting tmpDir output was: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mK7rmkH3/Keeper Password Manager.dmg 2023-05-31 15:27:57 : DEBUG : keeperpasswordmanager : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mK7rmkH3 2023-05-31 15:27:57 : INFO  : keeperpasswordmanager : Telling app Keeper Password Manager.app to open 2023-05-31 15:27:58 : INFO  : keeperpasswordmanager : Reopened Keeper Password Manager.app as gknackstedt
2023-05-31 15:27:58 : REG   : keeperpasswordmanager : No new version to install
2023-05-31 15:27:58 : REQ   : keeperpasswordmanager : ################## End Installomator, exit code 0