### PR TITLE
Add label: espanso

### DIFF
--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -1,0 +1,13 @@
+espanso)
+    name="Espanso"
+    type="zip"
+    if [[ "$(arch)" == "arm64" ]]; then
+        archiveName="Espanso-Mac-M1.zip"
+    else
+        archiveName="Espanso-Mac-Intel.zip"
+    fi
+    downloadURL="$(downloadURLFromGit espanso espanso)"
+    appNewVersion="$(versionFromGit espanso espanso)"
+    blockingProcesses=( "Espanso" "espanso" )
+    expectedTeamID="K839T4T5BY"
+    ;;


### PR DESCRIPTION
# Add Installomator label for [Espanso](https://github.com/espanso/espanso)

Downloads latest version from GitHub, pulling correct .zip archive for ARM or Intel.

## assemble.sh DEBUG=0 output >>>

2023-05-31 16:33:28 : REQ   : espanso : ################## Start Installomator v. 10.4beta, date 2023-05-31
2023-05-31 16:33:28 : INFO  : espanso : ################## Version: 10.4beta
2023-05-31 16:33:28 : INFO  : espanso : ################## Date: 2023-05-31
2023-05-31 16:33:28 : INFO  : espanso : ################## espanso
2023-05-31 16:33:28 : DEBUG : espanso : DEBUG mode 1 enabled.
2023-05-31 16:33:29 : INFO  : espanso : setting variable from argument DEBUG=0
2023-05-31 16:33:29 : DEBUG : espanso : name=Espanso
2023-05-31 16:33:29 : DEBUG : espanso : appName=
2023-05-31 16:33:29 : DEBUG : espanso : type=zip
2023-05-31 16:33:29 : DEBUG : espanso : archiveName=Espanso-Mac-M1.zip
2023-05-31 16:33:30 : DEBUG : espanso : downloadURL=https://github.com/espanso/espanso/releases/download/v2.1.8/Espanso-Mac-M1.zip
2023-05-31 16:33:30 : DEBUG : espanso : curlOptions=
2023-05-31 16:33:30 : DEBUG : espanso : appNewVersion=2.1.8
2023-05-31 16:33:30 : DEBUG : espanso : appCustomVersion function: Not defined
2023-05-31 16:33:30 : DEBUG : espanso : versionKey=CFBundleShortVersionString
2023-05-31 16:33:30 : DEBUG : espanso : packageID=
2023-05-31 16:33:30 : DEBUG : espanso : pkgName=
2023-05-31 16:33:30 : DEBUG : espanso : choiceChangesXML=
2023-05-31 16:33:30 : DEBUG : espanso : expectedTeamID=K839T4T5BY
2023-05-31 16:33:30 : DEBUG : espanso : blockingProcesses=Espanso espanso
2023-05-31 16:33:30 : DEBUG : espanso : installerTool=
2023-05-31 16:33:30 : DEBUG : espanso : CLIInstaller=
2023-05-31 16:33:30 : DEBUG : espanso : CLIArguments=
2023-05-31 16:33:30 : DEBUG : espanso : updateTool=
2023-05-31 16:33:30 : DEBUG : espanso : updateToolArguments=
2023-05-31 16:33:30 : DEBUG : espanso : updateToolRunAsCurrentUser=
2023-05-31 16:33:30 : INFO  : espanso : BLOCKING_PROCESS_ACTION=tell_user
2023-05-31 16:33:30 : INFO  : espanso : NOTIFY=success
2023-05-31 16:33:30 : INFO  : espanso : LOGGING=DEBUG
2023-05-31 16:33:30 : INFO  : espanso : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-05-31 16:33:30 : INFO  : espanso : Label type: zip
2023-05-31 16:33:30 : INFO  : espanso : archiveName: Espanso-Mac-M1.zip
2023-05-31 16:33:30 : DEBUG : espanso : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU
2023-05-31 16:33:30 : INFO  : espanso : name: Espanso, appName: Espanso.app
2023-05-31 16:33:30 : INFO  : espanso : App(s) found: /Users/gknackstedt/GitHub/Installomator/2023-05-31-15-51-23/Espanso.app/Users/gknackstedt/GitHub/Installomator/2023-05-31-15-52-20/Espanso.app/Users/gknackstedt/GitHub/Installomator/2023-05-31-15-52-33/Espanso.app/Users/gknackstedt/GitHub/Installomator/2023-05-31-15-53-37/Espanso.app/Users/gknackstedt/GitHub/Installomator/utils/2023-05-02-15-41-38/Espanso.app/Users/gknackstedt/GitHub/Installomator/utils/2023-05-02-15-42-15/Espanso.app/Users/gknackstedt/GitHub/Installomator/utils/2023-05-02-15-42-28/Espanso.app/Users/gknackstedt/GitHub/Installomator/utils/2023-05-02-15-43-31/Espanso.app/Users/gknackstedt/GitHub/Installomator/utils/2023-05-02-15-43-54/Espanso.app
2023-05-31 16:33:30 : WARN  : espanso : could not determine location of Espanso.app
2023-05-31 16:33:30 : INFO  : espanso : appversion: 
2023-05-31 16:33:30 : INFO  : espanso : Latest version of Espanso is 2.1.8
2023-05-31 16:33:30 : REQ   : espanso : Downloading https://github.com/espanso/espanso/releases/download/v2.1.8/Espanso-Mac-M1.zip to Espanso-Mac-M1.zip
2023-05-31 16:33:30 : DEBUG : espanso : No Dialog connection, just download
2023-05-31 16:33:31 : DEBUG : espanso : File list: -rw-r--r--  1 root  wheel   6.7M May 31 16:33 Espanso-Mac-M1.zip
2023-05-31 16:33:31 : DEBUG : espanso : File type: Espanso-Mac-M1.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-05-31 16:33:32 : DEBUG : espanso : curl output was:
*   Trying 140.82.114.4:443...
* Connected to github.com (140.82.114.4) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /espanso/espanso/releases/download/v2.1.8/Espanso-Mac-M1.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13c80c600)
> GET /espanso/espanso/releases/download/v2.1.8/Espanso-Mac-M1.zip HTTP/2
> Host: github.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Wed, 31 May 2023 20:33:31 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/205326947/ce892ac7-01ea-4ad7-9f9a-4510e850cdfa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230531%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230531T203331Z&X-Amz-Expires=300&X-Amz-Signature=c0be3addcfc90cc5d7c6eb402fca3cc7d381598ab223e64901261ea970385d34&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=205326947&response-content-disposition=attachment%3B%20filename%3DEspanso-Mac-M1.zip&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: 1292:66E2:AB53486:F607365:6477AF1B < 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/205326947/ce892ac7-01ea-4ad7-9f9a-4510e850cdfa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230531%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230531T203331Z&X-Amz-Expires=300&X-Amz-Signature=c0be3addcfc90cc5d7c6eb402fca3cc7d381598ab223e64901261ea970385d34&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=205326947&response-content-disposition=attachment%3B%20filename%3DEspanso-Mac-M1.zip&response-content-type=application%2Foctet-stream'
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/205326947/ce892ac7-01ea-4ad7-9f9a-4510e850cdfa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230531%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230531T203331Z&X-Amz-Expires=300&X-Amz-Signature=c0be3addcfc90cc5d7c6eb402fca3cc7d381598ab223e64901261ea970385d34&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=205326947&response-content-disposition=attachment%3B%20filename%3DEspanso-Mac-M1.zip&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13c80c600)
> GET /github-production-release-asset-2e65be/205326947/ce892ac7-01ea-4ad7-9f9a-4510e850cdfa?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230531%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230531T203331Z&X-Amz-Expires=300&X-Amz-Signature=c0be3addcfc90cc5d7c6eb402fca3cc7d381598ab223e64901261ea970385d34&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=205326947&response-content-disposition=attachment%3B%20filename%3DEspanso-Mac-M1.zip&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: Q8dwHILoizF2dogXbiEsyw==
< last-modified: Tue, 01 Nov 2022 11:17:49 GMT
< etag: "0x8DABBFAB5B87CF9"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 12b1ebb4-801e-000b-09ff-931a3e000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Tue, 01 Nov 2022 11:17:49 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Espanso-Mac-M1.zip < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Wed, 31 May 2023 20:33:31 GMT
< x-served-by: cache-iad-kcgs7200152-IAD, cache-chi-kigq8000058-CHI < x-cache: MISS, MISS
< x-cache-hits: 0, 0
< x-timer: S1685565211.442719,VS0,VE109
< content-length: 7035814
< 
{ [1413 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-05-31 16:33:32 : REQ   : espanso : no more blocking processes, continue with update
2023-05-31 16:33:32 : REQ   : espanso : Installing Espanso
2023-05-31 16:33:32 : INFO  : espanso : Unzipping Espanso-Mac-M1.zip
2023-05-31 16:33:32 : INFO  : espanso : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app
2023-05-31 16:33:32 : DEBUG : espanso : App size:  17M	/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app
2023-05-31 16:33:32 : DEBUG : espanso : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Federico Terzi (K839T4T5BY)

2023-05-31 16:33:32 : INFO  : espanso : Team ID matching: K839T4T5BY (expected: K839T4T5BY ) 2023-05-31 16:33:32 : INFO  : espanso : Installing Espanso version 2.1.8 on versionKey CFBundleShortVersionString. 2023-05-31 16:33:32 : INFO  : espanso : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app to /Applications 2023-05-31 16:33:32 : DEBUG : espanso : Debugging enabled, App copy output was: Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app

2023-05-31 16:33:32 : WARN  : espanso : Changing owner to gknackstedt 2023-05-31 16:33:32 : INFO  : espanso : Finishing... 2023-05-31 16:33:35 : INFO  : espanso : App(s) found: /Applications/Espanso.app 2023-05-31 16:33:35 : INFO  : espanso : found app at /Applications/Espanso.app, version 2.1.8, on versionKey CFBundleShortVersionString
2023-05-31 16:33:35 : REQ   : espanso : Installed Espanso, version 2.1.8
2023-05-31 16:33:35 : INFO  : espanso : notifying
2023-05-31 16:33:36 : DEBUG : espanso : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU
2023-05-31 16:33:36 : DEBUG : espanso : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso-Mac-M1.zip
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/CodeResources
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/_CodeSignature/CodeResources
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/_CodeSignature
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/MacOS/espanso
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/MacOS
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/Resources/icon.icns
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/Resources
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/Info.plist
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents/PkgInfo
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app/Contents
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU/Espanso.app
2023-05-31 16:33:36 : DEBUG : espanso : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.umphQFoU
2023-05-31 16:33:36 : INFO  : espanso : App not closed, so no reopen.
2023-05-31 16:33:36 : REQ   : espanso : All done!
2023-05-31 16:33:36 : REQ   : espanso : ################## End Installomator, exit code 0