### PR TITLE
New label: CodeMeter

### DIFF
--- a/fragments/labels/codemeter.sh
+++ b/fragments/labels/codemeter.sh
@@ -1,0 +1,11 @@
+codemeter)
+    name="CodeMeter"
+    type="pkgInDmg"
+    archiveName="CmInstall.pkg"
+    html_page_source="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware.html"
+    macos_value=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo '10.15"> <option value=".*?"' | cut -d '"' -f3)
+    downloadHTML="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/$macos_value.html"
+    downloadURL="https://www.wibu.com"$(curl -fs $downloadHTML | xmllint --html --format - 2>/dev/null | grep -Eo 'rel="nofollow" href=".*?"' | cut -d '"' -f4)
+    appNewVersion=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo "option value=\"$macos_value\" style=\"\">Version .*?\"" | sed -E 's/.*Version (.*) \| 2.*/\1/g')
+    expectedTeamID="2SE7W37452"
+    ;;


### PR DESCRIPTION
CodeMeter is the universal technology for software publishers and intelligent device manufacturers, upon which all solutions from Wibu-Systems are built.

sudo ./assemble.sh -l /Desktop/Mosyle/Resources/InstallomatorLabels codemeter NOTIFY=silent DEBUG=0
2023-06-04 12:19:50 : REQ   : codemeter : ################## Start Installomator v. 10.5beta, date 2023-06-04
2023-06-04 12:19:50 : INFO  : codemeter : ################## Version: 10.5beta
2023-06-04 12:19:50 : INFO  : codemeter : ################## Date: 2023-06-04
2023-06-04 12:19:50 : INFO  : codemeter : ################## codemeter
2023-06-04 12:19:50 : DEBUG : codemeter : DEBUG mode 1 enabled.
2023-06-04 12:19:55 : INFO  : codemeter : setting variable from argument NOTIFY=silent
2023-06-04 12:19:55 : INFO  : codemeter : setting variable from argument DEBUG=0
2023-06-04 12:19:55 : DEBUG : codemeter : name=CodeMeter
2023-06-04 12:19:55 : DEBUG : codemeter : appName=
2023-06-04 12:19:55 : DEBUG : codemeter : type=pkgInDmg
2023-06-04 12:19:55 : DEBUG : codemeter : archiveName=CmInstall.pkg
2023-06-04 12:19:55 : DEBUG : codemeter : downloadURL=https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/11358.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd
2023-06-04 12:19:55 : DEBUG : codemeter : curlOptions=
2023-06-04 12:19:55 : DEBUG : codemeter : appNewVersion=7.60a
2023-06-04 12:19:55 : DEBUG : codemeter : appCustomVersion function: Not defined
2023-06-04 12:19:55 : DEBUG : codemeter : versionKey=CFBundleShortVersionString
2023-06-04 12:19:55 : DEBUG : codemeter : packageID=
2023-06-04 12:19:55 : DEBUG : codemeter : pkgName=
2023-06-04 12:19:55 : DEBUG : codemeter : choiceChangesXML=
2023-06-04 12:19:55 : DEBUG : codemeter : expectedTeamID=2SE7W37452
2023-06-04 12:19:55 : DEBUG : codemeter : blockingProcesses=
2023-06-04 12:19:55 : DEBUG : codemeter : installerTool=
2023-06-04 12:19:55 : DEBUG : codemeter : CLIInstaller=
2023-06-04 12:19:55 : DEBUG : codemeter : CLIArguments=
2023-06-04 12:19:55 : DEBUG : codemeter : updateTool=
2023-06-04 12:19:55 : DEBUG : codemeter : updateToolArguments=
2023-06-04 12:19:55 : DEBUG : codemeter : updateToolRunAsCurrentUser=
2023-06-04 12:19:55 : INFO  : codemeter : BLOCKING_PROCESS_ACTION=tell_user
2023-06-04 12:19:55 : INFO  : codemeter : NOTIFY=silent
2023-06-04 12:19:55 : INFO  : codemeter : LOGGING=DEBUG
2023-06-04 12:19:55 : INFO  : codemeter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-04 12:19:55 : INFO  : codemeter : Label type: pkgInDmg
2023-06-04 12:19:55 : INFO  : codemeter : archiveName: CmInstall.pkg
2023-06-04 12:19:55 : INFO  : codemeter : no blocking processes defined, using CodeMeter as default
2023-06-04 12:19:55 : DEBUG : codemeter : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lcc8bqeq
2023-06-04 12:19:55 : INFO  : codemeter : name: CodeMeter, appName: CodeMeter.app
2023-06-04 12:19:55.710 mdfind[40567:2022039] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-06-04 12:19:55.710 mdfind[40567:2022039] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-06-04 12:19:55.749 mdfind[40567:2022039] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-04 12:19:55 : WARN  : codemeter : No previous app found
2023-06-04 12:19:55 : WARN  : codemeter : could not find CodeMeter.app
2023-06-04 12:19:55 : INFO  : codemeter : appversion:
2023-06-04 12:19:55 : INFO  : codemeter : Latest version of CodeMeter is 7.60a
2023-06-04 12:19:55 : REQ   : codemeter : Downloading https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/11358.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd to CmInstall.pkg
2023-06-04 12:19:55 : DEBUG : codemeter : No Dialog connection, just download
2023-06-04 12:20:07 : DEBUG : codemeter : File list: -rw-r--r--  1 root  wheel    88M  4 Jun 12:20 CmInstall.pkg
2023-06-04 12:20:07 : DEBUG : codemeter : File type: CmInstall.pkg: zlib compressed data
2023-06-04 12:20:07 : DEBUG : codemeter : curl output was:
*   Trying 91.184.33.136:443...
* Connected to www.wibu.com (91.184.33.136) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2844 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=DE; ST=Baden-Wuerttemberg; L=Karlsruhe; O=WIBU-SYSTEMS AG; CN=wibu.com
*  start date: Sep  6 13:41:02 2022 GMT
*  expire date: Oct  8 13:41:01 2023 GMT
*  subjectAltName: host "www.wibu.com" matched cert's "www.wibu.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign RSA OV SSL CA 2018
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /de/support/anwendersoftware/anwendersoftware/file/download/11358.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.wibu.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x143011400)
> GET /de/support/anwendersoftware/anwendersoftware/file/download/11358.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd HTTP/2
> Host: www.wibu.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 302
< date: Sun, 04 Jun 2023 10:19:56 GMT
< server: Apache
< location: https://d1fa9c7844vy1r.cloudfront.net//wibu_downloads/codemeter/user/7.60a/mac/CmRuntimeUser_7.60.5609.501.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_7.60.5609.501.dmg&response-content-type=application%2Fforce-download&Expires=1685874296&Signature=WU5wGFDvgj8rXPWLKcwal8QO8mG0cR9V0Exzy4eRP-60m2AwVw0RazOlovykyApP8z0SIhh1eri~K3myx9sYZa53VpvA8gcJCYPcXkIgf2Gc6lP09AJW4vVHlqI3Wm3qyiyYBNfILl3YxhAg~OFPl3igCf7JWwfG4PRbysvLEYKdtwtEeoxkiXKAFeuWH9ug9W1c5kScvnf2AsExYOMJQlIkdI50-ybXDxvGsaLPJEJNnf-Y8GZtK7ZyIIk7Z~rPgJRgIL5FzVm98aW1GZy3jaZGE0KLVoMwEMM-tDLiiQL4i21wFPaRsiTiJW-E5v1mU8eS2trfeXBbCI29UQ5miQ__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ < cache-control: max-age=0
< expires: Sun, 04 Jun 2023 10:19:56 GMT
< x-ua-compatible: IE=edge
< x-content-type-options: nosniff
< content-length: 0
< content-type: text/html; charset=UTF-8
<
{ [0 bytes data]
* Connection #0 to host www.wibu.com left intact
* Issue another request to this URL: 'https://d1fa9c7844vy1r.cloudfront.net//wibu_downloads/codemeter/user/7.60a/mac/CmRuntimeUser_7.60.5609.501.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_7.60.5609.501.dmg&response-content-type=application%2Fforce-download&Expires=1685874296&Signature=WU5wGFDvgj8rXPWLKcwal8QO8mG0cR9V0Exzy4eRP-60m2AwVw0RazOlovykyApP8z0SIhh1eri~K3myx9sYZa53VpvA8gcJCYPcXkIgf2Gc6lP09AJW4vVHlqI3Wm3qyiyYBNfILl3YxhAg~OFPl3igCf7JWwfG4PRbysvLEYKdtwtEeoxkiXKAFeuWH9ug9W1c5kScvnf2AsExYOMJQlIkdI50-ybXDxvGsaLPJEJNnf-Y8GZtK7ZyIIk7Z~rPgJRgIL5FzVm98aW1GZy3jaZGE0KLVoMwEMM-tDLiiQL4i21wFPaRsiTiJW-E5v1mU8eS2trfeXBbCI29UQ5miQ__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ'
*   Trying 108.138.34.46:443...
* Connected to d1fa9c7844vy1r.cloudfront.net (108.138.34.46) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4972 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Dec  8 00:00:00 2022 GMT
*  expire date: Dec  7 23:59:59 2023 GMT
*  subjectAltName: host "d1fa9c7844vy1r.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: //wibu_downloads/codemeter/user/7.60a/mac/CmRuntimeUser_7.60.5609.501.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_7.60.5609.501.dmg&response-content-type=application%2Fforce-download&Expires=1685874296&Signature=WU5wGFDvgj8rXPWLKcwal8QO8mG0cR9V0Exzy4eRP-60m2AwVw0RazOlovykyApP8z0SIhh1eri~K3myx9sYZa53VpvA8gcJCYPcXkIgf2Gc6lP09AJW4vVHlqI3Wm3qyiyYBNfILl3YxhAg~OFPl3igCf7JWwfG4PRbysvLEYKdtwtEeoxkiXKAFeuWH9ug9W1c5kScvnf2AsExYOMJQlIkdI50-ybXDxvGsaLPJEJNnf-Y8GZtK7ZyIIk7Z~rPgJRgIL5FzVm98aW1GZy3jaZGE0KLVoMwEMM-tDLiiQL4i21wFPaRsiTiJW-E5v1mU8eS2trfeXBbCI29UQ5miQ__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ]
* h2h3 [:scheme: https]
* h2h3 [:authority: d1fa9c7844vy1r.cloudfront.net]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x143011400)
> GET //wibu_downloads/codemeter/user/7.60a/mac/CmRuntimeUser_7.60.5609.501.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_7.60.5609.501.dmg&response-content-type=application%2Fforce-download&Expires=1685874296&Signature=WU5wGFDvgj8rXPWLKcwal8QO8mG0cR9V0Exzy4eRP-60m2AwVw0RazOlovykyApP8z0SIhh1eri~K3myx9sYZa53VpvA8gcJCYPcXkIgf2Gc6lP09AJW4vVHlqI3Wm3qyiyYBNfILl3YxhAg~OFPl3igCf7JWwfG4PRbysvLEYKdtwtEeoxkiXKAFeuWH9ug9W1c5kScvnf2AsExYOMJQlIkdI50-ybXDxvGsaLPJEJNnf-Y8GZtK7ZyIIk7Z~rPgJRgIL5FzVm98aW1GZy3jaZGE0KLVoMwEMM-tDLiiQL4i21wFPaRsiTiJW-E5v1mU8eS2trfeXBbCI29UQ5miQ__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ HTTP/2
> Host: d1fa9c7844vy1r.cloudfront.net
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/force-download
< content-length: 91858908
< date: Sun, 04 Jun 2023 10:07:32 GMT
< last-modified: Wed, 03 May 2023 08:32:10 GMT
< etag: "c06ea0538eee1c566ba5af4c663fe564"
< x-amz-storage-class: REDUCED_REDUNDANCY
< x-amz-server-side-encryption: AES256
< content-disposition: attachment; filename=CmRuntimeUser_7.60.5609.501.dmg < accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 e33c4b19512a86c5972c18d1c60d21f8.cloudfront.net (CloudFront) < x-amz-cf-pop: MUC50-P2
< x-amz-cf-id: DPv8i_py2Q-kzcXnFHZ2gvcZDfY891uEOrwz2kR81vACymirG2AUFQ== < age: 745
<
{ [15930 bytes data]
* Connection #1 to host d1fa9c7844vy1r.cloudfront.net left intact

2023-06-04 12:20:07 : REQ   : codemeter : no more blocking processes, continue with update
2023-06-04 12:20:07 : REQ   : codemeter : Installing CodeMeter
2023-06-04 12:20:07 : INFO  : codemeter : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lcc8bqeq/CmInstall.pkg
2023-06-04 12:20:07 : DEBUG : codemeter : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $2DFD3808
Die überprüfte CRC32-Prüfsumme ist $D7447CB5
/dev/disk8          	                               	/Volumes/CM-Install

2023-06-04 12:20:07 : INFO  : codemeter : Mounted: /Volumes/CM-Install 2023-06-04 12:20:07 : DEBUG : codemeter : Found pkg(s): /Volumes/CM-Install/CmInstall.pkg
2023-06-04 12:20:07 : INFO  : codemeter : found pkg: /Volumes/CM-Install/CmInstall.pkg 2023-06-04 12:20:07 : INFO  : codemeter : Verifying: /Volumes/CM-Install/CmInstall.pkg
2023-06-04 12:20:07 : DEBUG : codemeter : File list: -rw-r--r--  1 cadmin  staff    87M 20 Apr 22:13 /Volumes/CM-Install/CmInstall.pkg
2023-06-04 12:20:07 : DEBUG : codemeter : File type: /Volumes/CM-Install/CmInstall.pkg: xar archive compressed TOC: 5261, SHA-1 checksum
2023-06-04 12:20:08 : DEBUG : codemeter : spctlOut is /Volumes/CM-Install/CmInstall.pkg: accepted
2023-06-04 12:20:08 : DEBUG : codemeter : source=Notarized Developer ID
2023-06-04 12:20:08 : DEBUG : codemeter : override=security disabled
2023-06-04 12:20:08 : DEBUG : codemeter : origin=Developer ID Installer: WIBU-SYSTEMS AG (2SE7W37452)
2023-06-04 12:20:08 : INFO  : codemeter : Team ID: 2SE7W37452 (expected: 2SE7W37452 )
2023-06-04 12:20:08 : INFO  : codemeter : Installing /Volumes/CM-Install/CmInstall.pkg to /
2023-06-04 12:20:19 : DEBUG : codemeter : Debugging enabled, installer output was:
Jun  4 12:20:08  installer[40719] <Info>: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
Jun  4 12:20:08  installer[40719] <Warning>: Architecture Translation: Process is about to get executed as Intel.
Jun  4 12:20:09  installer[40719] <Debug>: Product archive /Volumes/CM-Install/CmInstall.pkg trustLevel=350
Jun  4 12:20:09  installer[40719] <Debug>: External component packages (2) trustLevel=350
Jun  4 12:20:09  installer[40719] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Jun  4 12:20:09  installer[40719] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg
Jun  4 12:20:09  installer[40719] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg
Jun  4 12:20:09  installer[40719] <Info>: Set authorization level to root for session
Jun  4 12:20:09  installer[40719] <Info>: Authorization is being checked, waiting until authorization arrives.
Jun  4 12:20:09  installer[40719] <Info>: Administrator authorization granted.
Jun  4 12:20:09  installer[40719] <Info>: Packages have been authorized for installation.
Jun  4 12:20:09  installer[40719] <Debug>: Will use PK session
Jun  4 12:20:09  installer[40719] <Debug>: Using authorization level of root for IFPKInstallElement
Jun  4 12:20:09  installer[40719] <Info>: Install request is requesting Rosetta translation.
Jun  4 12:20:09  installer[40719] <Info>: Starting installation:
Jun  4 12:20:09  installer[40719] <Notice>: Configuring volume "Macintosh HD"
Jun  4 12:20:09  installer[40719] <Info>: Preparing disk for local booted install.
Jun  4 12:20:09  installer[40719] <Notice>: Free space on "Macintosh HD": 297,91 GB (297907916800 bytes).
Jun  4 12:20:09  installer[40719] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.40719fyfVwp"
Jun  4 12:20:09  installer[40719] <Notice>: IFPKInstallElement (2 packages)
Jun  4 12:20:09  installer[40719] <Info>: Current Path: /usr/sbin/installer
Jun  4 12:20:09  installer[40719] <Info>: Current Path: /bin/zsh
Jun  4 12:20:09  installer[40719] <Info>: Current Path: /usr/bin/sudo
Jun  4 12:20:09  installer[40719] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is CodeMeter Runtime Kit
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „CodeMeter Runtime Kit“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
Last Log repeated 5 times
#Jun  4 12:20:16  installer[40719] <Info>: PackageKit: Registered bundle file:///Applications/CodeMeter.app/ for uid 0

installer: Paketquittungen sichern ….....
installer: Pakete überprüfen ….....
#Jun  4 12:20:17  installer[40719] <Notice>: Running install actions Jun  4 12:20:17  installer[40719] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.40719fyfVwp" Jun  4 12:20:17  installer[40719] <Notice>: Finalize disk "Macintosh HD" Jun  4 12:20:17  installer[40719] <Notice>: Notifying system of updated components Jun  4 12:20:17  installer[40719] <Notice>:
Jun  4 12:20:17  installer[40719] <Notice>: **** Summary Information ****
Jun  4 12:20:17  installer[40719] <Notice>:   Operation      Elapsed time
Jun  4 12:20:17  installer[40719] <Notice>: -----------------------------
Jun  4 12:20:17  installer[40719] <Notice>:        disk      0.02 seconds
Jun  4 12:20:17  installer[40719] <Notice>:      script      0.00 seconds
Jun  4 12:20:17  installer[40719] <Notice>:        zero      0.00 seconds
Jun  4 12:20:17  installer[40719] <Notice>:     install      8.11 seconds
Jun  4 12:20:17  installer[40719] <Notice>:     -total-      8.14 seconds
Jun  4 12:20:17  installer[40719] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert...... installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-06-04 12:20:08+02 savvas-LF0Y25WVCX installer[40719]: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel. 2023-06-04 12:20:08+02 savvas-LF0Y25WVCX installer[40719]: Architecture Translation: Process is about to get executed as Intel. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Product archive /Volumes/CM-Install/CmInstall.pkg trustLevel=350 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: External component packages (2) trustLevel=350 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Set authorization level to root for session 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Authorization is being checked, waiting until authorization arrives. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Administrator authorization granted. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Packages have been authorized for installation. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Will use PK session 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Using authorization level of root for IFPKInstallElement 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Install request is requesting Rosetta translation. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Starting installation: 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Configuring volume "Macintosh HD" 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Preparing disk for local booted install. 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Free space on "Macintosh HD": 297,91 GB (297907916800 bytes). 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.40719fyfVwp" 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: IFPKInstallElement (2 packages) 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Current Path: /usr/sbin/installer 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Current Path: /bin/zsh 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: Current Path: /usr/bin/sudo 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Adding client PKInstallDaemonClient pid=40719, uid=0 (/usr/sbin/installer) 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installer[40719]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Set reponsibility for install to 38671 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Hosted team responsibility for install set to team:(2SE7W37452) 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: ----- Begin install -----
2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: packages=( 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/32AA90C2-8717-4CE4-A0D6-A1313380B657.activeSandbox 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/0BD34AEF-D776-4E4A-9B3C-52CA7C5F5977.activeSandbox 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/45C2D2B7-FFF5-45A6-82F3-AC326DD0CA1F.activeSandbox 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Will do receipt-based obsoleting for package identifier com.wibu.axprotector (prefix path=/) 2023-06-04 12:20:09+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Extracting file:///Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/62FE291F-46D6-4591-B5A1-DA851FBAD52E.activeSandbox/Root, uid=0) 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Extracting file:///Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/62FE291F-46D6-4591-B5A1-DA851FBAD52E.activeSandbox/Root, uid=0) 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: prevent user idle system sleep 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: suspending backupd 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Set responsibility to pid: 38671, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Hosted team responsibility for script set to team:(2SE7W37452) 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/preinstall' 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX install_monitor[40722]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./preinstall: Starting preinstall 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./preinstall: No matching processes were found Last Log repeated 2 times
2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./preinstall: Finished preinstall 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Hosted team responsible for script has been cleared. 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Responsibility set back to self. 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/62FE291F-46D6-4591-B5A1-DA851FBAD52E.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/62FE291F-46D6-4591-B5A1-DA851FBAD52E.activeSandbox 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/62FE291F-46D6-4591-B5A1-DA851FBAD52E.activeSandbox/Root (3 items) to / 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX installd[1521]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Set responsibility to pid: 38671, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Hosted team responsibility for script set to team:(2SE7W37452) 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall' 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:3> echo Starting postinstall 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: Starting postinstall 2023-06-04 12:20:11+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:6> /bin/mkdir -p /Library/Logs/CodeMeter/ 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:7> /bin/chmod a+rwx /Library/Logs/CodeMeter 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:10> [ -L '/Library/Application Support/CodeMeter' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:13> /bin/mkdir -p '/Library/Application Support/CodeMeter' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:14> [ -d /Applications/CodeMeter.app/Backup ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:17> [ -d /Users/savvas/CmRemover/Backup ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:21> [ -d /Applications/CodeMeter.app/CmAct ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:28> /bin/mkdir -p '/Library/Application Support/CodeMeter/CmAct' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:29> /bin/mkdir -p '/Library/Application Support/CodeMeter/CmCloud' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:30> /bin/mkdir -p '/Library/Application Support/CodeMeter/Backup' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:31> /bin/mkdir -p '/Library/Application Support/CodeMeter/WebAdmin' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:32> /bin/mkdir -p '/Library/Application Support/CodeMeter/NamedUser' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:35> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/Backup' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:36> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/CmAct' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:37> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/CmCloud' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:38> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/WebAdmin' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:39> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/NamedUser' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:42> [ -f /Library/Preferences/com.wibu.CodeMeter.Server.ini_save ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:45> cat /Library/Preferences/com.wibu.CodeMeter.Server.ini 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:45> sed 's//Applications/CodeMeter.app/Backup//Library/Application Support/CodeMeter/Backup//' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:46> mv /tmp/cminstaller /Library/Preferences/com.wibu.CodeMeter.Server.ini 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:47> /bin/chmod a+rw /Library/Preferences/com.wibu.CodeMeter.Server.ini 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:50> [ -f /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:51> /usr/bin/chgrp wheel /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:52> /usr/sbin/chown root /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:53> /bin/chmod 0644 /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:55> [ -f /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:56> /usr/bin/chgrp wheel /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:57> /usr/sbin/chown root /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:58> /bin/chmod 0644 /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:61> echo 'setup CmAct permissions' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: setup CmAct permissions 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:62> [ -d '/Library/Application Support/CodeMeter/CmAct' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:63> echo 'setup CmAct permissions - 42' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: setup CmAct permissions - 42 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:64: no matches found: /Library/Application Support/CodeMeter/CmAct/*.wbb 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:65: no matches found: /Library/Application Support/CodeMeter/CmAct/*.wbb 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:68> echo 'setup CmCloud permissions' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: setup CmCloud permissions 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:69> [ -d '/Library/Application Support/CodeMeter/CmCloud' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:70> echo 'setup CmCloud permissions - 42' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: setup CmCloud permissions - 42 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:71: no matches found: /Library/Application Support/CodeMeter/CmCloud/*.wbc 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: /tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:72: no matches found: /Library/Application Support/CodeMeter/CmCloud/*.wbc 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:76> [ -f /usr/bin/ranlib ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:77> [ -f '/Applications/WIBU-SYSTEMS Devkit/CodeMeter/lib/libwibucmmac.a' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:82> [ -f '/Library/Application Support/CodeMeter/CmFirm.wbc_save' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:86> [ -f '/Library/Application Support/CodeMeter/CmFirm.wbc' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:91> [ -d /Library/Extensions/CmUSBMassStorage.kext ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:101> [ -f '/Applications/WIBU-SYSTEMS Devkit/CodeMeter/Java/WibuCmTrigger.jar' ']' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:106> su root -c '/Applications/CodeMeter.app/Contents/MacOS/CodeMeterCC &' 2023-06-04 12:20:12+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:108> sleep 1 2023-06-04 12:20:13+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:109> /Applications/CodeMeter.app/Contents/MacOS/CodeMeterMacX -x 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:112> /bin/launchctl load /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:113> /bin/launchctl start com.wibu.CodeMeter.Server 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:115> /bin/launchctl load /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:116> /bin/launchctl start com.wibu.CodeMeter.WebAdmin 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:118> echo Finished postinstall 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: Finished postinstall 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: ./postinstall: +/tmp/PKInstallSandbox.UtZUM2/Scripts/com.wibu.cmdriver.bCwVN3/postinstall:119> exit 0 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: PackageKit: Hosted team responsible for script has been cleared. 2023-06-04 12:20:15+02 savvas-LF0Y25WVCX package_script_service[8483]: Responsibility set back to self. 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Writing receipt for com.wibu.cmdriver to / 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Writing receipt for com.wibu.axprotector to / 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: oahd translated /Library/PreferencePanes/CodeMeter.prefPane/Contents/MacOS/CodeMeter 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Translated 1 binaries. 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Touched bundle /Applications/CodeMeter.app 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: Installed "CodeMeter Runtime Kit" (7.60.5609.501) 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX install_monitor[40722]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: releasing backupd 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: allow user idle system sleep 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: ----- End install ----- 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: 7.1s elapsed install time 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Cleared responsibility for install from 40719. 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Hosted team responsible for install has been cleared. 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Running idle tasks 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Done with sandbox removals 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installer[40719]: PackageKit: Registered bundle file:///Applications/CodeMeter.app/ for uid 0 2023-06-04 12:20:16+02 savvas-LF0Y25WVCX installd[1521]: PackageKit: Removing client PKInstallDaemonClient pid=40719, uid=0 (/usr/sbin/installer) 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: Running install actions 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.40719fyfVwp" 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: Finalize disk "Macintosh HD" 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: Notifying system of updated components 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: 2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: **** Summary Information ****
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:   Operation      Elapsed time
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]: -----------------------------
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:        disk      0.02 seconds
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:      script      0.00 seconds
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:        zero      0.00 seconds
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:     install      8.11 seconds
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:     -total-      8.14 seconds
2023-06-04 12:20:17+02 savvas-LF0Y25WVCX installer[40719]:

2023-06-04 12:20:19 : INFO  : codemeter : Finishing... 2023-06-04 12:20:22 : INFO  : codemeter : App(s) found: /Applications/CodeMeter.app 2023-06-04 12:20:23 : INFO  : codemeter : found app at /Applications/CodeMeter.app, version 7.60.5609, on versionKey CFBundleShortVersionString
2023-06-04 12:20:23 : REQ   : codemeter : Installed CodeMeter, version 7.60a
2023-06-04 12:20:23 : DEBUG : codemeter : Unmounting /Volumes/CM-Install
2023-06-04 12:20:23 : DEBUG : codemeter : Debugging enabled, Unmounting output was:
"disk8" ejected.
2023-06-04 12:20:23 : DEBUG : codemeter : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lcc8bqeq
2023-06-04 12:20:23 : DEBUG : codemeter : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lcc8bqeq/CmInstall.pkg
2023-06-04 12:20:23 : DEBUG : codemeter : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Lcc8bqeq
2023-06-04 12:20:23 : INFO  : codemeter : App not closed, so no reopen.
2023-06-04 12:20:23 : REQ   : codemeter : All done!
2023-06-04 12:20:23 : REQ   : codemeter : ################## End Installomator, exit code 0