### PR TITLE
Label update: shottr - fix versioning

### DIFF
--- a/fragments/labels/shottr.sh
+++ b/fragments/labels/shottr.sh
@@ -1,7 +1,7 @@
 shottr)
     name="Shottr"
     type="dmg"
-    appNewVersion=$(curl -s https://shottr.cc/newversion.html | grep "Shottr v" | head -1 | sed 's/.*v\([0-9.]*\).*/\1/')
+    appNewVersion=$(curl -fs "https://shottr.cc/newversion.html" | xmllint --html --xpath 'substring-before(substring-after(string(//a[@id="downloadButton"]/small), "v"), ",")' - 2> /dev/null)
     downloadURL="https://shottr.cc/dl/Shottr-${appNewVersion}.dmg"
     expectedTeamID="2Y683PRQWN"
     ;;


### PR DESCRIPTION
Previously scoped only to the announcement, but apparently they cut off 'extra' version numbers, in this case the ".0" of "1.7.0". However, the download button includes the full, real version number.

For clarity and ease of use, at least for me, I've also switched to xmllint to get the version number now.

Output:
./assemble.sh shottr
2023-06-06 13:18:06 : REQ   : shottr : ################## Start Installomator v. 10.5beta, date 2023-06-06
2023-06-06 13:18:06 : INFO  : shottr : ################## Version: 10.5beta
2023-06-06 13:18:06 : INFO  : shottr : ################## Date: 2023-06-06
2023-06-06 13:18:06 : INFO  : shottr : ################## shottr
2023-06-06 13:18:06 : DEBUG : shottr : DEBUG mode 1 enabled.
2023-06-06 13:18:11 : DEBUG : shottr : name=Shottr
2023-06-06 13:18:11 : DEBUG : shottr : appName=
2023-06-06 13:18:11 : DEBUG : shottr : type=dmg
2023-06-06 13:18:11 : DEBUG : shottr : archiveName=
2023-06-06 13:18:11 : DEBUG : shottr : downloadURL=https://shottr.cc/dl/Shottr-1.7.0.dmg
2023-06-06 13:18:11 : DEBUG : shottr : curlOptions=
2023-06-06 13:18:11 : DEBUG : shottr : appNewVersion=1.7.0
2023-06-06 13:18:11 : DEBUG : shottr : appCustomVersion function: Not defined
2023-06-06 13:18:11 : DEBUG : shottr : versionKey=CFBundleShortVersionString
2023-06-06 13:18:11 : DEBUG : shottr : packageID=
2023-06-06 13:18:11 : DEBUG : shottr : pkgName=
2023-06-06 13:18:11 : DEBUG : shottr : choiceChangesXML=
2023-06-06 13:18:11 : DEBUG : shottr : expectedTeamID=2Y683PRQWN
2023-06-06 13:18:11 : DEBUG : shottr : blockingProcesses=
2023-06-06 13:18:11 : DEBUG : shottr : installerTool=
2023-06-06 13:18:11 : DEBUG : shottr : CLIInstaller=
2023-06-06 13:18:11 : DEBUG : shottr : CLIArguments=
2023-06-06 13:18:11 : DEBUG : shottr : updateTool=
2023-06-06 13:18:11 : DEBUG : shottr : updateToolArguments=
2023-06-06 13:18:11 : DEBUG : shottr : updateToolRunAsCurrentUser=
2023-06-06 13:18:11 : INFO  : shottr : BLOCKING_PROCESS_ACTION=tell_user
2023-06-06 13:18:11 : INFO  : shottr : NOTIFY=success
2023-06-06 13:18:11 : INFO  : shottr : LOGGING=DEBUG
2023-06-06 13:18:11 : INFO  : shottr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-06 13:18:11 : INFO  : shottr : Label type: dmg
2023-06-06 13:18:11 : INFO  : shottr : archiveName: Shottr.dmg
2023-06-06 13:18:11 : INFO  : shottr : no blocking processes defined, using Shottr as default
2023-06-06 13:18:11 : DEBUG : shottr : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-06-06 13:18:11 : INFO  : shottr : name: Shottr, appName: Shottr.app
2023-06-06 13:18:11.315 mdfind[22811:389855] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-06-06 13:18:11.316 mdfind[22811:389855] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-06-06 13:18:11.362 mdfind[22811:389855] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-06 13:18:11 : WARN  : shottr : No previous app found
2023-06-06 13:18:11 : WARN  : shottr : could not find Shottr.app
2023-06-06 13:18:11 : INFO  : shottr : appversion:
2023-06-06 13:18:11 : INFO  : shottr : Latest version of Shottr is 1.7.0
2023-06-06 13:18:11 : REQ   : shottr : Downloading https://shottr.cc/dl/Shottr-1.7.0.dmg to Shottr.dmg
2023-06-06 13:18:11 : DEBUG : shottr : No Dialog connection, just download
2023-06-06 13:18:12 : DEBUG : shottr : File list: -rw-r--r--  1 admin  2103187081   1.5M Jun  6 13:18 Shottr.dmg
2023-06-06 13:18:12 : DEBUG : shottr : File type: Shottr.dmg: XZ compressed data, checksum NONE
2023-06-06 13:18:12 : DEBUG : shottr : curl output was:
*   Trying 172.67.220.8:443...
* Connected to shottr.cc (172.67.220.8) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [314 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4211 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=shottr.cc
*  start date: Jun  2 17:28:57 2023 GMT
*  expire date: Aug 31 17:28:56 2023 GMT
*  subjectAltName: host "shottr.cc" matched cert's "shottr.cc"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1P5
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /dl/Shottr-1.7.0.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: shottr.cc]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15a013400)
> GET /dl/Shottr-1.7.0.dmg HTTP/2
> Host: shottr.cc
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< date: Tue, 06 Jun 2023 20:18:11 GMT
< content-type: application/x-apple-diskimage
< content-length: 1577116
< last-modified: Wed, 31 May 2023 15:48:52 GMT
< etag: "18109c-5fcff41a8e100"
< cache-control: max-age=14400
< cf-cache-status: REVALIDATED
< accept-ranges: bytes
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v3?s=0pXqJrm%2FifDgtb7%2BB32HfbvXJD140cVcV2YrhVtyROJ5TOO6FbDmVcCZcy8I9iv6TOYRfC97vXJv5%2BGkJKSlrvunEB%2F3%2BrZ2anz8HEysIw4EYQoZ5VOiWTMBsco%3D"}],"group":"cf-nel","max_age":604800} < nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800} < server: cloudflare
< cf-ray: 7d3357d5ea2bef53-PDX
< alt-svc: h3=":443"; ma=86400
<
{ [886 bytes data]
* Connection #0 to host shottr.cc left intact

2023-06-06 13:18:12 : DEBUG : shottr : DEBUG mode 1, not checking for blocking processes
2023-06-06 13:18:12 : REQ   : shottr : Installing Shottr
2023-06-06 13:18:12 : INFO  : shottr : Mounting /Users/admin/Documents/GitHub/Installomator/build/Shottr.dmg
2023-06-06 13:18:13 : DEBUG : shottr : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F49A65DF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D9664E43
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DC190A04
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $14866060
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DC190A04
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $A4670AA6
verified   CRC32 $AB8CE4A7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Shottr

2023-06-06 13:18:13 : INFO  : shottr : Mounted: /Volumes/Shottr 2023-06-06 13:18:13 : INFO  : shottr : Verifying: /Volumes/Shottr/Shottr.app 2023-06-06 13:18:13 : DEBUG : shottr : App size: 4.4M	/Volumes/Shottr/Shottr.app 2023-06-06 13:18:13 : DEBUG : shottr : Debugging enabled, App Verification output was: /Volumes/Shottr/Shottr.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Max Kovalenko (2Y683PRQWN)

2023-06-06 13:18:13 : INFO  : shottr : Team ID matching: 2Y683PRQWN (expected: 2Y683PRQWN ) 2023-06-06 13:18:13 : INFO  : shottr : Installing Shottr version 1.7.0 on versionKey CFBundleShortVersionString. 2023-06-06 13:18:13 : INFO  : shottr : App has LSMinimumSystemVersion: 10.15 2023-06-06 13:18:13 : DEBUG : shottr : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-06-06 13:18:13 : INFO  : shottr : Finishing... 2023-06-06 13:18:16 : INFO  : shottr : name: Shottr, appName: Shottr.app 2023-06-06 13:18:16.986 mdfind[22894:390157] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-06-06 13:18:16.986 mdfind[22894:390157] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-06-06 13:18:17.046 mdfind[22894:390157] Couldn't determine the mapping between prefab keywords and predicates. 2023-06-06 13:18:17 : WARN  : shottr : No previous app found 2023-06-06 13:18:17 : WARN  : shottr : could not find Shottr.app
2023-06-06 13:18:17 : REQ   : shottr : Installed Shottr, version 1.7.0
2023-06-06 13:18:17 : INFO  : shottr : notifying
2023-06-06 13:18:17 : DEBUG : shottr : Unmounting /Volumes/Shottr
2023-06-06 13:18:17 : DEBUG : shottr : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-06-06 13:18:17 : DEBUG : shottr : DEBUG mode 1, not reopening anything
2023-06-06 13:18:17 : REQ   : shottr : All done!
2023-06-06 13:18:17 : REQ   : shottr : ################## End Installomator, exit code 0