### PR TITLE
Label update: pgadmin4 - fix download URL

### DIFF
--- a/fragments/labels/pgadmin4.sh
+++ b/fragments/labels/pgadmin4.sh
@@ -3,6 +3,6 @@ pgadmin4)
     type="dmg"
     downloadParent="https://www.postgresql.org/ftp/pgadmin/pgadmin4/"
     appNewVersion=$(curl -fs "${downloadParent}" | grep -oE 'v[0-9]+.[0-9]+' | sort -V | tail -n 1 | sed 's/v//g')
-    downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion.dmg"
+    downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion-x86_64.dmg"
     expectedTeamID="26QKX55P9K"
     ;;


### PR DESCRIPTION
Fix for issue #1080

For the last 2 versions now, the filename download has included the "-x86_64" suffix to the name. Since its been two in a row, that may be the start of a new pattern so submitting this PR to match.

Output:
./assemble.sh pgadmin4
2023-06-06 13:30:10 : REQ   : pgadmin4 : ################## Start Installomator v. 10.5beta, date 2023-06-06
2023-06-06 13:30:10 : INFO  : pgadmin4 : ################## Version: 10.5beta
2023-06-06 13:30:10 : INFO  : pgadmin4 : ################## Date: 2023-06-06
2023-06-06 13:30:10 : INFO  : pgadmin4 : ################## pgadmin4
2023-06-06 13:30:10 : DEBUG : pgadmin4 : DEBUG mode 1 enabled.
2023-06-06 13:30:11 : DEBUG : pgadmin4 : name=pgAdmin 4
2023-06-06 13:30:11 : DEBUG : pgadmin4 : appName=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : type=dmg
2023-06-06 13:30:11 : DEBUG : pgadmin4 : archiveName=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : downloadURL=https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v7.3/macos/pgadmin4-7.3-x86_64.dmg
2023-06-06 13:30:11 : DEBUG : pgadmin4 : curlOptions=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : appNewVersion=7.3
2023-06-06 13:30:11 : DEBUG : pgadmin4 : appCustomVersion function: Not defined
2023-06-06 13:30:11 : DEBUG : pgadmin4 : versionKey=CFBundleShortVersionString
2023-06-06 13:30:11 : DEBUG : pgadmin4 : packageID=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : pkgName=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : choiceChangesXML=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : expectedTeamID=26QKX55P9K
2023-06-06 13:30:11 : DEBUG : pgadmin4 : blockingProcesses=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : installerTool=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : CLIInstaller=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : CLIArguments=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : updateTool=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : updateToolArguments=
2023-06-06 13:30:11 : DEBUG : pgadmin4 : updateToolRunAsCurrentUser=
2023-06-06 13:30:11 : INFO  : pgadmin4 : BLOCKING_PROCESS_ACTION=tell_user
2023-06-06 13:30:11 : INFO  : pgadmin4 : NOTIFY=success
2023-06-06 13:30:11 : INFO  : pgadmin4 : LOGGING=DEBUG
2023-06-06 13:30:11 : INFO  : pgadmin4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-06 13:30:11 : INFO  : pgadmin4 : Label type: dmg
2023-06-06 13:30:11 : INFO  : pgadmin4 : archiveName: pgAdmin 4.dmg
2023-06-06 13:30:11 : INFO  : pgadmin4 : no blocking processes defined, using pgAdmin 4 as default
2023-06-06 13:30:11 : DEBUG : pgadmin4 : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-06-06 13:30:11 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app
2023-06-06 13:30:11.123 mdfind[23685:397453] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-06-06 13:30:11.123 mdfind[23685:397453] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-06-06 13:30:11.172 mdfind[23685:397453] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-06 13:30:11 : WARN  : pgadmin4 : No previous app found
2023-06-06 13:30:11 : WARN  : pgadmin4 : could not find pgAdmin 4.app
2023-06-06 13:30:11 : INFO  : pgadmin4 : appversion:
2023-06-06 13:30:11 : INFO  : pgadmin4 : Latest version of pgAdmin 4 is 7.3
2023-06-06 13:30:11 : REQ   : pgadmin4 : Downloading https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v7.3/macos/pgadmin4-7.3-x86_64.dmg to pgAdmin 4.dmg
2023-06-06 13:30:11 : DEBUG : pgadmin4 : No Dialog connection, just download
2023-06-06 13:31:04 : DEBUG : pgadmin4 : File list: -rw-r--r--  1 admin  2103187081   204M Jun  6 13:31 pgAdmin 4.dmg
2023-06-06 13:31:04 : DEBUG : pgadmin4 : File type: pgAdmin 4.dmg: bzip2 compressed data, block size = 900k
2023-06-06 13:31:04 : DEBUG : pgadmin4 : curl output was:
*   Trying 72.32.157.246:443...
* Connected to ftp.postgresql.org (72.32.157.246) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [388 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [187 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4359 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=ftp.postgresql.org
*  start date: May 31 05:08:21 2023 GMT
*  expire date: Aug 29 05:08:20 2023 GMT
*  subjectAltName: host "ftp.postgresql.org" matched cert's "ftp.postgresql.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /pub/pgadmin/pgadmin4/v7.3/macos/pgadmin4-7.3-x86_64.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: ftp.postgresql.org]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15d011400)
> GET /pub/pgadmin/pgadmin4/v7.3/macos/pgadmin4-7.3-x86_64.dmg HTTP/2
> Host: ftp.postgresql.org
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< server: nginx
< date: Tue, 06 Jun 2023 20:30:11 GMT
< content-type: application/octet-stream
< content-length: 214263901
< last-modified: Tue, 06 Jun 2023 12:11:03 GMT
< etag: "647f2257-cc5685d"
< strict-transport-security: max-age=31536000
< accept-ranges: bytes
<
{ [16366 bytes data]
* Connection #0 to host ftp.postgresql.org left intact

2023-06-06 13:31:04 : DEBUG : pgadmin4 : DEBUG mode 1, not checking for blocking processes
2023-06-06 13:31:04 : REQ   : pgadmin4 : Installing pgAdmin 4
2023-06-06 13:31:04 : INFO  : pgadmin4 : Mounting /Users/admin/Documents/GitHub/Installomator/build/pgAdmin 4.dmg
2023-06-06 13:31:18 : DEBUG : pgadmin4 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $52B8A382
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D51C40D4
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $1782259B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A78AB87E
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $1782259B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FFFB5A69
verified   CRC32 $528AAB6F
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/pgAdmin 4

2023-06-06 13:31:18 : INFO  : pgadmin4 : Mounted: /Volumes/pgAdmin 4 2023-06-06 13:31:18 : INFO  : pgadmin4 : Verifying: /Volumes/pgAdmin 4/pgAdmin 4.app 2023-06-06 13:31:18 : DEBUG : pgadmin4 : App size: 756M	/Volumes/pgAdmin 4/pgAdmin 4.app 2023-06-06 13:32:17 : DEBUG : pgadmin4 : Debugging enabled, App Verification output was: /Volumes/pgAdmin 4/pgAdmin 4.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: EnterpriseDB Corporation (26QKX55P9K)

2023-06-06 13:32:17 : INFO  : pgadmin4 : Team ID matching: 26QKX55P9K (expected: 26QKX55P9K ) 2023-06-06 13:32:17 : INFO  : pgadmin4 : Installing pgAdmin 4 version 7.3 on versionKey CFBundleShortVersionString. 2023-06-06 13:32:23 : INFO  : pgadmin4 : App has LSMinimumSystemVersion: 10.10.0 2023-06-06 13:32:23 : DEBUG : pgadmin4 : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-06-06 13:32:23 : INFO  : pgadmin4 : Finishing... 2023-06-06 13:32:26 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app 2023-06-06 13:32:26.097 mdfind[23784:398846] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-06-06 13:32:26.098 mdfind[23784:398846] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-06-06 13:32:26.167 mdfind[23784:398846] Couldn't determine the mapping between prefab keywords and predicates. 2023-06-06 13:32:26 : WARN  : pgadmin4 : No previous app found 2023-06-06 13:32:26 : WARN  : pgadmin4 : could not find pgAdmin 4.app
2023-06-06 13:32:26 : REQ   : pgadmin4 : Installed pgAdmin 4, version 7.3
2023-06-06 13:32:26 : INFO  : pgadmin4 : notifying
2023-06-06 13:32:26 : DEBUG : pgadmin4 : Unmounting /Volumes/pgAdmin 4
2023-06-06 13:32:26 : DEBUG : pgadmin4 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-06-06 13:32:26 : DEBUG : pgadmin4 : DEBUG mode 1, not reopening anything
2023-06-06 13:32:26 : REQ   : pgadmin4 : All done!
2023-06-06 13:32:26 : REQ   : pgadmin4 : ################## End Installomator, exit code 0