### PR TITLE
Label update: Audacity - appCustomVersion for precision

### DIFF
--- a/fragments/labels/audacity.sh
+++ b/fragments/labels/audacity.sh
@@ -4,5 +4,6 @@ audacity)
     archiveName="audacity-macOS-[0-9.]*-universal.dmg"
     downloadURL=$(downloadURLFromGit audacity audacity)
     appNewVersion=$(versionFromGit audacity audacity)
+    appCustomVersion(){ defaults read "/Applications/Audacity.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-3 }
     expectedTeamID="AWEYX923UX"
     ;;


### PR DESCRIPTION
Response to #1075

The releases of Audacity don't seem to actually use the 4th set in the versions in info.plist (currently 3.3.2.0), nor do any of the alternative version keys. But on Github they release only 3 sets (i.e 3.3.2). This leads to Installomator downloading & installing when the software is already installed. To avoid, we can use appCustomVersion.

The cut command here will not affect the version number when the 3rd set is a zero (so 3.4.0.0 will be 3.4.0). If they ever switch to only using 3 sets in info.plist to match what GitHub release versions are, the versioning will still be unaffected.

Two different outputs included below.

Output, Already installed, DEBUG=1:
./assemble.sh audacity
2023-06-06 14:42:23 : REQ   : audacity : ################## Start Installomator v. 10.5beta, date 2023-06-06
2023-06-06 14:42:23 : INFO  : audacity : ################## Version: 10.5beta
2023-06-06 14:42:23 : INFO  : audacity : ################## Date: 2023-06-06
2023-06-06 14:42:23 : INFO  : audacity : ################## audacity
2023-06-06 14:42:23 : DEBUG : audacity : DEBUG mode 1 enabled.
2023-06-06 14:42:24 : DEBUG : audacity : name=Audacity
2023-06-06 14:42:24 : DEBUG : audacity : appName=
2023-06-06 14:42:24 : DEBUG : audacity : type=dmg
2023-06-06 14:42:24 : DEBUG : audacity : archiveName=audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:42:24 : DEBUG : audacity : downloadURL=https://github.com/audacity/audacity/releases/download/Audacity-3.3.2/audacity-macOS-3.3.2-universal.dmg
2023-06-06 14:42:24 : DEBUG : audacity : curlOptions=
2023-06-06 14:42:24 : DEBUG : audacity : appNewVersion=3.3.2
2023-06-06 14:42:24 : DEBUG : audacity : appCustomVersion function: Defined.
2023-06-06 14:42:24 : DEBUG : audacity : versionKey=CFBundleShortVersionString
2023-06-06 14:42:24 : DEBUG : audacity : packageID=
2023-06-06 14:42:24 : DEBUG : audacity : pkgName=
2023-06-06 14:42:24 : DEBUG : audacity : choiceChangesXML=
2023-06-06 14:42:24 : DEBUG : audacity : expectedTeamID=AWEYX923UX
2023-06-06 14:42:24 : DEBUG : audacity : blockingProcesses=
2023-06-06 14:42:24 : DEBUG : audacity : installerTool=
2023-06-06 14:42:24 : DEBUG : audacity : CLIInstaller=
2023-06-06 14:42:24 : DEBUG : audacity : CLIArguments=
2023-06-06 14:42:24 : DEBUG : audacity : updateTool=
2023-06-06 14:42:24 : DEBUG : audacity : updateToolArguments=
2023-06-06 14:42:24 : DEBUG : audacity : updateToolRunAsCurrentUser=
2023-06-06 14:42:24 : INFO  : audacity : BLOCKING_PROCESS_ACTION=tell_user
2023-06-06 14:42:24 : INFO  : audacity : NOTIFY=success
2023-06-06 14:42:24 : INFO  : audacity : LOGGING=DEBUG
2023-06-06 14:42:24 : INFO  : audacity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-06 14:42:24 : INFO  : audacity : Label type: dmg
2023-06-06 14:42:24 : INFO  : audacity : archiveName: audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:42:24 : INFO  : audacity : no blocking processes defined, using Audacity as default
2023-06-06 14:42:24 : DEBUG : audacity : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-06-06 14:42:24 : INFO  : audacity : Custom App Version detection is used, found 3.3.2
2023-06-06 14:42:24 : INFO  : audacity : appversion: 3.3.2
2023-06-06 14:42:24 : INFO  : audacity : Latest version of Audacity is 3.3.2
2023-06-06 14:42:24 : WARN  : audacity : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-06-06 14:42:24 : INFO  : audacity : audacity-macOS-[0-9.]*-universal.dmg exists and DEBUG mode 1 enabled, skipping download
2023-06-06 14:42:24 : DEBUG : audacity : DEBUG mode 1, not checking for blocking processes
2023-06-06 14:42:24 : REQ   : audacity : Installing Audacity
2023-06-06 14:42:24 : INFO  : audacity : Mounting /Users/admin/Documents/GitHub/Installomator/build/audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:42:24 : DEBUG : audacity : Debugging enabled, dmgmount output was:
expected   CRC32 $58D807B1
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Audacity

2023-06-06 14:42:24 : INFO  : audacity : Mounted: /Volumes/Audacity 2023-06-06 14:42:24 : INFO  : audacity : Verifying: /Volumes/Audacity/Audacity.app 2023-06-06 14:42:24 : DEBUG : audacity : App size: 162M	/Volumes/Audacity/Audacity.app 2023-06-06 14:42:27 : DEBUG : audacity : Debugging enabled, App Verification output was: /Volumes/Audacity/Audacity.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Dmitri Vedenko (AWEYX923UX)

2023-06-06 14:42:27 : INFO  : audacity : Team ID matching: AWEYX923UX (expected: AWEYX923UX ) 2023-06-06 14:42:27 : INFO  : audacity : Downloaded version of Audacity is 3.3.2.0 on versionKey CFBundleShortVersionString (replacing version 3.3.2). 2023-06-06 14:42:27 : INFO  : audacity : App has LSMinimumSystemVersion: 10.13 2023-06-06 14:42:27 : DEBUG : audacity : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-06-06 14:42:27 : INFO  : audacity : Finishing... 2023-06-06 14:42:30 : INFO  : audacity : Custom App Version detection is used, found 3.3.2
2023-06-06 14:42:30 : REQ   : audacity : Installed Audacity, version 3.3.2.0
2023-06-06 14:42:30 : INFO  : audacity : notifying
2023-06-06 14:42:31 : DEBUG : audacity : Unmounting /Volumes/Audacity
2023-06-06 14:42:31 : DEBUG : audacity : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-06-06 14:42:31 : DEBUG : audacity : DEBUG mode 1, not reopening anything
2023-06-06 14:42:31 : REQ   : audacity : All done!
2023-06-06 14:42:31 : REQ   : audacity : ################## End Installomator, exit code 0




Output, not previously installed, DEBUG=0

./assemble.sh audacity DEBUG=0
2023-06-06 14:44:14 : REQ   : audacity : ################## Start Installomator v. 10.5beta, date 2023-06-06
2023-06-06 14:44:14 : INFO  : audacity : ################## Version: 10.5beta
2023-06-06 14:44:14 : INFO  : audacity : ################## Date: 2023-06-06
2023-06-06 14:44:14 : INFO  : audacity : ################## audacity
2023-06-06 14:44:14 : DEBUG : audacity : DEBUG mode 1 enabled.
2023-06-06 14:44:15 : INFO  : audacity : setting variable from argument DEBUG=0
2023-06-06 14:44:15 : DEBUG : audacity : name=Audacity
2023-06-06 14:44:15 : DEBUG : audacity : appName=
2023-06-06 14:44:15 : DEBUG : audacity : type=dmg
2023-06-06 14:44:15 : DEBUG : audacity : archiveName=audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:15 : DEBUG : audacity : downloadURL=https://github.com/audacity/audacity/releases/download/Audacity-3.3.2/audacity-macOS-3.3.2-universal.dmg
2023-06-06 14:44:15 : DEBUG : audacity : curlOptions=
2023-06-06 14:44:15 : DEBUG : audacity : appNewVersion=3.3.2
2023-06-06 14:44:15 : DEBUG : audacity : appCustomVersion function: Defined.
2023-06-06 14:44:15 : DEBUG : audacity : versionKey=CFBundleShortVersionString
2023-06-06 14:44:15 : DEBUG : audacity : packageID=
2023-06-06 14:44:15 : DEBUG : audacity : pkgName=
2023-06-06 14:44:15 : DEBUG : audacity : choiceChangesXML=
2023-06-06 14:44:15 : DEBUG : audacity : expectedTeamID=AWEYX923UX
2023-06-06 14:44:15 : DEBUG : audacity : blockingProcesses=
2023-06-06 14:44:15 : DEBUG : audacity : installerTool=
2023-06-06 14:44:15 : DEBUG : audacity : CLIInstaller=
2023-06-06 14:44:15 : DEBUG : audacity : CLIArguments=
2023-06-06 14:44:15 : DEBUG : audacity : updateTool=
2023-06-06 14:44:15 : DEBUG : audacity : updateToolArguments=
2023-06-06 14:44:15 : DEBUG : audacity : updateToolRunAsCurrentUser=
2023-06-06 14:44:15 : INFO  : audacity : BLOCKING_PROCESS_ACTION=tell_user
2023-06-06 14:44:15 : INFO  : audacity : NOTIFY=success
2023-06-06 14:44:15 : INFO  : audacity : LOGGING=DEBUG
2023-06-06 14:44:15 : INFO  : audacity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-06 14:44:15 : INFO  : audacity : Label type: dmg
2023-06-06 14:44:15 : INFO  : audacity : archiveName: audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:15 : INFO  : audacity : no blocking processes defined, using Audacity as default
2023-06-06 14:44:15 : DEBUG : audacity : Changing directory to /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.YoTyavTZ
2023-06-06 14:44:15.281 defaults[27714:456649]
The domain/default pair of (/Applications/Audacity.app/Contents/Info.plist, CFBundleVersion) does not exist
2023-06-06 14:44:15 : INFO  : audacity : Custom App Version detection is used, found
2023-06-06 14:44:15 : INFO  : audacity : appversion:
2023-06-06 14:44:15 : INFO  : audacity : Latest version of Audacity is 3.3.2
2023-06-06 14:44:15 : REQ   : audacity : Downloading https://github.com/audacity/audacity/releases/download/Audacity-3.3.2/audacity-macOS-3.3.2-universal.dmg to audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:15 : DEBUG : audacity : No Dialog connection, just download
2023-06-06 14:44:18 : DEBUG : audacity : File list: -rw-r--r--  1 admin  2103187081    48M Jun  6 14:44 audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:18 : DEBUG : audacity : File type: audacity-macOS-[0-9.]*-universal.dmg: zlib compressed data
2023-06-06 14:44:18 : DEBUG : audacity : curl output was:
*   Trying 192.30.255.112:443...
* Connected to github.com (192.30.255.112) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /audacity/audacity/releases/download/Audacity-3.3.2/audacity-macOS-3.3.2-universal.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: github.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x155813400)
> GET /audacity/audacity/releases/download/Audacity-3.3.2/audacity-macOS-3.3.2-universal.dmg HTTP/2
> Host: github.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Tue, 06 Jun 2023 21:44:02 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/32921736/97678405-4591-4e9a-a73c-b16379d1b294?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230606T214402Z&X-Amz-Expires=300&X-Amz-Signature=d526c730b1fa3952037574d04006b4b77331f8d685536ceeef5bff4f77d1edb4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32921736&response-content-disposition=attachment%3B%20filename%3Daudacity-macOS-3.3.2-universal.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: 71DD:65F7:4FFE8B:52E04D:647FA8AF <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/32921736/97678405-4591-4e9a-a73c-b16379d1b294?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230606T214402Z&X-Amz-Expires=300&X-Amz-Signature=d526c730b1fa3952037574d04006b4b77331f8d685536ceeef5bff4f77d1edb4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32921736&response-content-disposition=attachment%3B%20filename%3Daudacity-macOS-3.3.2-universal.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /github-production-release-asset-2e65be/32921736/97678405-4591-4e9a-a73c-b16379d1b294?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230606T214402Z&X-Amz-Expires=300&X-Amz-Signature=d526c730b1fa3952037574d04006b4b77331f8d685536ceeef5bff4f77d1edb4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32921736&response-content-disposition=attachment%3B%20filename%3Daudacity-macOS-3.3.2-universal.dmg&response-content-type=application%2Foctet-stream]
* h2h3 [:scheme: https]
* h2h3 [:authority: objects.githubusercontent.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x155813400)
> GET /github-production-release-asset-2e65be/32921736/97678405-4591-4e9a-a73c-b16379d1b294?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230606%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230606T214402Z&X-Amz-Expires=300&X-Amz-Signature=d526c730b1fa3952037574d04006b4b77331f8d685536ceeef5bff4f77d1edb4&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=32921736&response-content-disposition=attachment%3B%20filename%3Daudacity-macOS-3.3.2-universal.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: gvNemgfUriqWiE8z/10yOw==
< last-modified: Fri, 05 May 2023 20:36:28 GMT
< etag: "0x8DB4DA8673A5A06"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: fe9dd5da-601e-005e-02be-980ab5000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Fri, 05 May 2023 20:36:28 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=audacity-macOS-3.3.2-universal.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Tue, 06 Jun 2023 21:44:15 GMT
< x-served-by: cache-iad-kjyo7100176-IAD, cache-pdx12332-PDX < x-cache: HIT, MISS
< x-cache-hits: 29, 0
< x-timer: S1686087855.375682,VS0,VE162
< content-length: 50332228
<
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-06-06 14:44:18 : REQ   : audacity : no more blocking processes, continue with update
2023-06-06 14:44:18 : REQ   : audacity : Installing Audacity
2023-06-06 14:44:18 : INFO  : audacity : Mounting /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.YoTyavTZ/audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:21 : DEBUG : audacity : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8BDB0B27
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F373BBEC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $FF402480
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $9BE9F631
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $FF402480
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FA3F0478
verified   CRC32 $58D807B1
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Audacity

2023-06-06 14:44:21 : INFO  : audacity : Mounted: /Volumes/Audacity 2023-06-06 14:44:21 : INFO  : audacity : Verifying: /Volumes/Audacity/Audacity.app 2023-06-06 14:44:21 : DEBUG : audacity : App size: 162M	/Volumes/Audacity/Audacity.app 2023-06-06 14:44:23 : DEBUG : audacity : Debugging enabled, App Verification output was: /Volumes/Audacity/Audacity.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Dmitri Vedenko (AWEYX923UX)

2023-06-06 14:44:23 : INFO  : audacity : Team ID matching: AWEYX923UX (expected: AWEYX923UX ) 2023-06-06 14:44:23 : INFO  : audacity : Installing Audacity version 3.3.2.0 on versionKey CFBundleShortVersionString. 2023-06-06 14:44:23 : INFO  : audacity : App has LSMinimumSystemVersion: 10.13 2023-06-06 14:44:23 : INFO  : audacity : Copy /Volumes/Audacity/Audacity.app to /Applications 2023-06-06 14:44:24 : DEBUG : audacity : Debugging enabled, App copy output was: Copying /Volumes/Audacity/Audacity.app

2023-06-06 14:44:24 : WARN  : audacity : Changing owner to admin 2023-06-06 14:44:24 : INFO  : audacity : Finishing... 2023-06-06 14:44:27 : INFO  : audacity : Custom App Version detection is used, found 3.3.2
2023-06-06 14:44:27 : REQ   : audacity : Installed Audacity, version 3.3.2.0
2023-06-06 14:44:27 : INFO  : audacity : notifying
2023-06-06 14:44:27 : DEBUG : audacity : Unmounting /Volumes/Audacity
2023-06-06 14:44:27 : DEBUG : audacity : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-06-06 14:44:27 : DEBUG : audacity : Deleting /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.YoTyavTZ
2023-06-06 14:44:27 : DEBUG : audacity : Debugging enabled, Deleting tmpDir output was:
/var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.YoTyavTZ/audacity-macOS-[0-9.]*-universal.dmg
2023-06-06 14:44:27 : DEBUG : audacity : /var/folders/x6/ktgw5pg168l26d5k4sh49hm9mtb9zh/T/tmp.YoTyavTZ
2023-06-06 14:44:27 : INFO  : audacity : App not closed, so no reopen.
2023-06-06 14:44:27 : REQ   : audacity : All done!
2023-06-06 14:44:27 : REQ   : audacity : ################## End Installomator, exit code 0