### PR TITLE
New Label: catoclient

### DIFF
--- a/fragments/labels/catoclient.sh
+++ b/fragments/labels/catoclient.sh
@@ -1,0 +1,9 @@
+catoclient)
+    name="CatoClient"
+    type="pkg"
+    packageID="com.catonetworks.pkg.CatoClient"
+    downloadURL="https://myvpn.catonetworks.com/public/clients/CatoClient.pkg"
+    appNewVersion=$(curl -Ls -o /dev/null -w %{url_effective} "${downloadURL}" | sed -E 's/.*\/([0-9.]*)\/.*/\1/g' | awk -F '.' '{print $1 "." $2 "." $3}')
+    expectedTeamID="CKGSB8CH43"
+    blockingProcesses=( "CatoClient" "CatoClientExtension" )
+    ;;


### PR DESCRIPTION
https://myvpn.catonetworks.com/downloadMvpnClient

```sh
utils/assemble.sh catoclient DEBUG=1 IGNORE_APP_STORE_APPS=yes
2023-06-07 14:20:03 : REQ   : catoclient : ################## Start Installomator v. 10.5beta, date 2023-06-07
2023-06-07 14:20:03 : INFO  : catoclient : ################## Version: 10.5beta
2023-06-07 14:20:03 : INFO  : catoclient : ################## Date: 2023-06-07
2023-06-07 14:20:03 : INFO  : catoclient : ################## catoclient
2023-06-07 14:20:03 : DEBUG : catoclient : DEBUG mode 1 enabled.
2023-06-07 14:20:03 : INFO  : catoclient : setting variable from argument DEBUG=1
2023-06-07 14:20:03 : INFO  : catoclient : setting variable from argument IGNORE_APP_STORE_APPS=yes
2023-06-07 14:20:03 : DEBUG : catoclient : name=CatoClient
2023-06-07 14:20:03 : DEBUG : catoclient : appName=
2023-06-07 14:20:03 : DEBUG : catoclient : type=pkg
2023-06-07 14:20:03 : DEBUG : catoclient : archiveName=
2023-06-07 14:20:03 : DEBUG : catoclient : downloadURL=https://myvpn.catonetworks.com/public/clients/CatoClient.pkg
2023-06-07 14:20:03 : DEBUG : catoclient : curlOptions=
2023-06-07 14:20:03 : DEBUG : catoclient : appNewVersion=
2023-06-07 14:20:03 : DEBUG : catoclient : appCustomVersion function: Not defined
2023-06-07 14:20:03 : DEBUG : catoclient : versionKey=CFBundleShortVersionString
2023-06-07 14:20:03 : DEBUG : catoclient : packageID=com.catonetworks.pkg.CatoClient
2023-06-07 14:20:03 : DEBUG : catoclient : pkgName=
2023-06-07 14:20:03 : DEBUG : catoclient : choiceChangesXML=
2023-06-07 14:20:03 : DEBUG : catoclient : expectedTeamID=CKGSB8CH43
2023-06-07 14:20:04 : DEBUG : catoclient : blockingProcesses=CatoClient CatoClientExtension
2023-06-07 14:20:04 : DEBUG : catoclient : installerTool=
2023-06-07 14:20:04 : DEBUG : catoclient : CLIInstaller=
2023-06-07 14:20:04 : DEBUG : catoclient : CLIArguments=
2023-06-07 14:20:04 : DEBUG : catoclient : updateTool=
2023-06-07 14:20:04 : DEBUG : catoclient : updateToolArguments=
2023-06-07 14:20:04 : DEBUG : catoclient : updateToolRunAsCurrentUser=
2023-06-07 14:20:04 : INFO  : catoclient : BLOCKING_PROCESS_ACTION=tell_user
2023-06-07 14:20:04 : INFO  : catoclient : NOTIFY=success
2023-06-07 14:20:04 : INFO  : catoclient : LOGGING=DEBUG
2023-06-07 14:20:04 : INFO  : catoclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-07 14:20:04 : INFO  : catoclient : Label type: pkg
2023-06-07 14:20:04 : INFO  : catoclient : archiveName: CatoClient.pkg
2023-06-07 14:20:04 : DEBUG : catoclient : Changing directory to /Users/tonishi/ghq/github.com/Installomator/Installomator/build
2023-06-07 14:20:04 : INFO  : catoclient : No version found using packageID com.catonetworks.pkg.CatoClient
2023-06-07 14:20:04 : INFO  : catoclient : App(s) found: /Applications/CatoClient.app
2023-06-07 14:20:04 : INFO  : catoclient : found app at /Applications/CatoClient.app, version 4.5.2, on versionKey CFBundleShortVersionString
2023-06-07 14:20:04 : INFO  : catoclient : Installed CatoClient.app is from App Store, use “IGNORE_APP_STORE_APPS=yes” to replace.
2023-06-07 14:20:04 : WARN  : catoclient : Replacing App Store apps, no matter the version
2023-06-07 14:20:04 : INFO  : catoclient : appversion: 0
2023-06-07 14:20:04 : INFO  : catoclient : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-06-07 14:20:04 : INFO  : catoclient : Latest version not specified.
2023-06-07 14:20:04 : REQ   : catoclient : Downloading https://myvpn.catonetworks.com/public/clients/CatoClient.pkg to CatoClient.pkg
2023-06-07 14:20:04 : DEBUG : catoclient : No Dialog connection, just download
2023-06-07 14:20:07 : DEBUG : catoclient : File list: -rw-r--r--  1 kenchan0130  staff    57M  6  7 14:20 CatoClient.pkg
2023-06-07 14:20:07 : DEBUG : catoclient : File type: CatoClient.pkg: xar archive compressed TOC: 4886, SHA-1 checksum
2023-06-07 14:20:07 : DEBUG : catoclient : curl output was:
*   Trying 107.154.247.90:443...
* Connected to myvpn.catonetworks.com (107.154.247.90) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [5137 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.catonetworks.com
*  start date: Aug  6 19:27:53 2022 GMT
*  expire date: Sep  7 19:27:53 2023 GMT
*  subjectAltName: host "myvpn.catonetworks.com" matched cert's "*.catonetworks.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /public/clients/CatoClient.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: myvpn.catonetworks.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14d80d800)
> GET /public/clients/CatoClient.pkg HTTP/2
> Host: myvpn.catonetworks.com
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 301
< date: Wed, 07 Jun 2023 05:20:05 GMT
< content-type: application/octet-stream
< content-length: 17
< set-cookie: AWSALB=L8Q2zYnrs/KuHRLHLJM2Ye65o9MwVv49sNIn/QgU2ivr3i0TNjXvLSTmeFn24j1bGlvSJ6y6DhFOCXtY+XBSnFkJeOOAIXV+qs1rPpXcj0OyRvm89YiflTrQDSQL; Expires=Wed, 14 Jun 2023 05:20:05 GMT; Path=/
< set-cookie: AWSALBCORS=L8Q2zYnrs/KuHRLHLJM2Ye65o9MwVv49sNIn/QgU2ivr3i0TNjXvLSTmeFn24j1bGlvSJ6y6DhFOCXtY+XBSnFkJeOOAIXV+qs1rPpXcj0OyRvm89YiflTrQDSQL; Expires=Wed, 14 Jun 2023 05:20:05 GMT; Path=/; SameSite=None; Secure
< location: https://clients.catonetworks.com/macos/5.3.0.230/CatoClient.pkg
< set-cookie: visid_incap_1131178=7IKi2c4TRnWvuy08MKMW94QTgGQAAAAAQUIPAAAAAABYW4fssu3FVC8Kss8WOrG0; expires=Wed, 05 Jun 2024 07:00:20 GMT; HttpOnly; path=/; Domain=.catonetworks.com
< set-cookie: nlbi_1131178=RLNXDCjO2FJAFC26vsxDSAAAAACyC2fDa2/+nSjriJ67qRzJ; path=/; Domain=.catonetworks.com
< set-cookie: incap_ses_1357_1131178=074KFGmijWQJSV1hBwnVEoQTgGQAAAAAp2Y/yqfoKDrBXyNTCyFhiw==; path=/; Domain=.catonetworks.com
< x-cdn: Imperva
< x-iinfo: 11-15489782-15489803 NNNN CT(145 294 0) RT(1686115204258 120) q(0 0 5 0) r(6 6) U11
<
* Ignoring the response-body
{ [17 bytes data]
* Connection #0 to host myvpn.catonetworks.com left intact
* Issue another request to this URL: 'https://clients.catonetworks.com/macos/5.3.0.230/CatoClient.pkg'
*   Trying 143.204.86.16:443...
* Connected to clients.catonetworks.com (143.204.86.16) port 443 (#1)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [4974 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-1-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-1-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=clients.catonetworks.com
*  start date: Feb 22 00:00:00 2023 GMT
*  expire date: Sep  6 23:59:59 2023 GMT
*  subjectAltName: host "clients.catonetworks.com" matched cert's "clients.catonetworks.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /macos/5.3.0.230/CatoClient.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: clients.catonetworks.com]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14d80d800)
> GET /macos/5.3.0.230/CatoClient.pkg HTTP/2
> Host: clients.catonetworks.com
> user-agent: curl/7.87.0
> accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 60050653
< date: Wed, 07 Jun 2023 04:49:59 GMT
< last-modified: Sun, 12 Feb 2023 17:25:21 GMT
< etag: "b2ab4d8f27349cfeafa2a74dad637a7a-8"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 9a2ebfa47ec949f3601703115ee52784.cloudfront.net (CloudFront)
< x-amz-cf-pop: NRT12-C2
< x-amz-cf-id: 91W0mHbXbx62mQz4Bmp95POdBV2UbmFWv_GiJIS-8AfRNNGf_rGH0A==
< age: 1807
<
{ [16018 bytes data]
* Connection #1 to host clients.catonetworks.com left intact

2023-06-07 14:20:07 : DEBUG : catoclient : DEBUG mode 1, not checking for blocking processes
2023-06-07 14:20:07 : REQ   : catoclient : Installing CatoClient
2023-06-07 14:20:07 : INFO  : catoclient : Verifying: CatoClient.pkg
2023-06-07 14:20:07 : DEBUG : catoclient : File list: -rw-r--r--  1 kenchan0130  staff    57M  6  7 14:20 CatoClient.pkg
2023-06-07 14:20:07 : DEBUG : catoclient : File type: CatoClient.pkg: xar archive compressed TOC: 4886, SHA-1 checksum
2023-06-07 14:20:07 : DEBUG : catoclient : spctlOut is CatoClient.pkg: accepted
2023-06-07 14:20:07 : DEBUG : catoclient : source=Notarized Developer ID
2023-06-07 14:20:07 : DEBUG : catoclient : origin=Developer ID Installer: Cato Networks Ltd (CKGSB8CH43)
2023-06-07 14:20:07 : INFO  : catoclient : Team ID: CKGSB8CH43 (expected: CKGSB8CH43 )
2023-06-07 14:20:07 : INFO  : catoclient : Checking package version.
2023-06-07 14:20:08 : INFO  : catoclient : Downloaded package com.catonetworks.pkg.CatoClient version 1.0
2023-06-07 14:20:08 : DEBUG : catoclient : DEBUG enabled, skipping installation
2023-06-07 14:20:08 : INFO  : catoclient : Finishing...
2023-06-07 14:20:11 : INFO  : catoclient : No version found using packageID com.catonetworks.pkg.CatoClient
2023-06-07 14:20:11 : INFO  : catoclient : App(s) found: /Applications/CatoClient.app
2023-06-07 14:20:11 : INFO  : catoclient : found app at /Applications/CatoClient.app, version 4.5.2, on versionKey CFBundleShortVersionString
2023-06-07 14:20:11 : INFO  : catoclient : Installed CatoClient.app is from App Store, use “IGNORE_APP_STORE_APPS=yes” to replace.
2023-06-07 14:20:11 : WARN  : catoclient : Replacing App Store apps, no matter the version
2023-06-07 14:20:11 : REQ   : catoclient : Installed CatoClient, version 1.0
2023-06-07 14:20:11 : INFO  : catoclient : notifying
2023-06-07 14:20:12 : DEBUG : catoclient : DEBUG mode 1, not reopening anything
2023-06-07 14:20:12 : REQ   : catoclient : All done!
2023-06-07 14:20:12 : REQ   : catoclient : ################## End Installomator, exit code 0
```