### PR TITLE
moved Xcreds download back to twocanoes website

### DIFF
--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -1,14 +1,14 @@
 xcreds)
     name="XCreds"
     # Downloading from twocanoes homepage
-    #type="pkgInDmg"
-    #packageID="com.twocanoes.pkg.secureremoteaccess"
-    #downloadURL=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -ioE "https://.*\.zip" | head -1)
-    #appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/" | grep -io "Current Version:.*" | sed -E 's/.*XCreds *([0-9.]*)<.*/\1/g')
-    # GitHub download
     type="pkg"
-    downloadURL="$(downloadURLFromGit twocanoes xcreds)"
-    #appNewVersion="$(versionFromGit twocanoes xcreds)" # GitHub tag contain “_” and not “.” so our function fails to get the right version
-    appNewVersion=$(echo "$downloadURL" | sed -E 's/.*XCreds_.*-([0-9.]*)\.pkg/\1/')
+    #packageID="com.twocanoes.pkg.secureremoteaccess"
+    downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg"
+    appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build.*/\1/p')
+    # GitHub download
+    # type="pkg"
+    # downloadURL="$(downloadURLFromGit twocanoes xcreds)"
+    # appNewVersion="$(versionFromGit twocanoes xcreds)" # GitHub tag contain “_” and not “.” so our function fails to get the right version
+    # appNewVersion=$(echo "$downloadURL" | sed -E 's/.*XCreds_.*-([0-9.]*)\.pkg/\1/')
     expectedTeamID="UXP6YEHSPW"
     ;;


### PR DESCRIPTION
fix #1074 
package indeed removed from github release
Updated downloadURL & appNewVersion to match twocanoes website

```
2023-06-12 11:54:39 : REQ   : xcreds : ################## Start Installomator v. 10.5beta, date 2023-06-12
2023-06-12 11:54:39 : INFO  : xcreds : ################## Version: 10.5beta
2023-06-12 11:54:39 : INFO  : xcreds : ################## Date: 2023-06-12
2023-06-12 11:54:39 : INFO  : xcreds : ################## xcreds
2023-06-12 11:54:39 : DEBUG : xcreds : DEBUG mode 1 enabled.
2023-06-12 11:54:40 : DEBUG : xcreds : name=XCreds
2023-06-12 11:54:40 : DEBUG : xcreds : appName=
2023-06-12 11:54:40 : DEBUG : xcreds : type=pkg
2023-06-12 11:54:40 : DEBUG : xcreds : archiveName=
2023-06-12 11:54:40 : DEBUG : xcreds : downloadURL=https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg
2023-06-12 11:54:40 : DEBUG : xcreds : curlOptions=
2023-06-12 11:54:40 : DEBUG : xcreds : appNewVersion=3.0
2023-06-12 11:54:40 : DEBUG : xcreds : appCustomVersion function: Not defined
2023-06-12 11:54:40 : DEBUG : xcreds : versionKey=CFBundleShortVersionString
2023-06-12 11:54:40 : DEBUG : xcreds : packageID=
2023-06-12 11:54:40 : DEBUG : xcreds : pkgName=
2023-06-12 11:54:40 : DEBUG : xcreds : choiceChangesXML=
2023-06-12 11:54:40 : DEBUG : xcreds : expectedTeamID=UXP6YEHSPW
2023-06-12 11:54:40 : DEBUG : xcreds : blockingProcesses=
2023-06-12 11:54:40 : DEBUG : xcreds : installerTool=
2023-06-12 11:54:40 : DEBUG : xcreds : CLIInstaller=
2023-06-12 11:54:40 : DEBUG : xcreds : CLIArguments=
2023-06-12 11:54:40 : DEBUG : xcreds : updateTool=
2023-06-12 11:54:40 : DEBUG : xcreds : updateToolArguments=
2023-06-12 11:54:40 : DEBUG : xcreds : updateToolRunAsCurrentUser=
2023-06-12 11:54:40 : INFO  : xcreds : BLOCKING_PROCESS_ACTION=tell_user
2023-06-12 11:54:40 : INFO  : xcreds : NOTIFY=success
2023-06-12 11:54:40 : INFO  : xcreds : LOGGING=DEBUG
2023-06-12 11:54:40 : INFO  : xcreds : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-12 11:54:40 : INFO  : xcreds : Label type: pkg
2023-06-12 11:54:40 : INFO  : xcreds : archiveName: XCreds.pkg
2023-06-12 11:54:41 : INFO  : xcreds : no blocking processes defined, using XCreds as default
2023-06-12 11:54:41 : DEBUG : xcreds : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-06-12 11:54:41 : INFO  : xcreds : name: XCreds, appName: XCreds.app
2023-06-12 11:54:41.086 mdfind[14245:104213] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-06-12 11:54:41.216 mdfind[14245:104213] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-12 11:54:41 : WARN  : xcreds : No previous app found
2023-06-12 11:54:41 : WARN  : xcreds : could not find XCreds.app
2023-06-12 11:54:41 : INFO  : xcreds : appversion: 
2023-06-12 11:54:41 : INFO  : xcreds : Latest version of XCreds is 3.0
2023-06-12 11:54:41 : REQ   : xcreds : Downloading https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg to XCreds.pkg
2023-06-12 11:54:41 : DEBUG : xcreds : No Dialog connection, just download
2023-06-12 11:54:50 : DEBUG : xcreds : File list: -rw-r--r--@ 2 asri  staff    19M Jun 12 11:54 XCreds.pkg
2023-06-12 11:54:51 : DEBUG : xcreds : File type: XCreds.pkg: xar archive compressed TOC: 5804, SHA-1 checksum
2023-06-12 11:54:51 : DEBUG : xcreds : curl output was:
*   Trying 52.217.113.153:443...
* Connected to twocanoes-software-updates.s3.amazonaws.com (52.217.113.153) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [348 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [106 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4970 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Mar 21 00:00:00 2023 GMT
*  expire date: Dec 19 23:59:59 2023 GMT
*  subjectAltName: host "twocanoes-software-updates.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /XCreds.pkg HTTP/1.1
> Host: twocanoes-software-updates.s3.amazonaws.com
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< x-amz-id-2: pWEmDW2h1r4Ywu51goLlicoLNWe7qYjwcr1Va6l7mIAKd6gxM2Ie4K7SNd906YpiDrsG1snKeTY=
< x-amz-request-id: P8QCXW77CFXQGXT6
< Date: Mon, 12 Jun 2023 03:54:43 GMT
< Last-Modified: Wed, 19 Apr 2023 14:51:54 GMT
< ETag: "7ee103c0f6d9b1e62dcff03643f75df0"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AmazonS3
< Content-Length: 19828622
< 
{ [1525 bytes data]
* Connection #0 to host twocanoes-software-updates.s3.amazonaws.com left intact

2023-06-12 11:54:51 : DEBUG : xcreds : DEBUG mode 1, not checking for blocking processes
2023-06-12 11:54:51 : REQ   : xcreds : Installing XCreds
2023-06-12 11:54:51 : INFO  : xcreds : Verifying: XCreds.pkg
2023-06-12 11:54:51 : DEBUG : xcreds : File list: -rw-r--r--@ 2 asri  staff    19M Jun 12 11:54 XCreds.pkg
2023-06-12 11:54:51 : DEBUG : xcreds : File type: XCreds.pkg: xar archive compressed TOC: 5804, SHA-1 checksum
2023-06-12 11:54:51 : DEBUG : xcreds : spctlOut is XCreds.pkg: accepted
2023-06-12 11:54:51 : DEBUG : xcreds : source=Notarized Developer ID
2023-06-12 11:54:51 : DEBUG : xcreds : origin=Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)
2023-06-12 11:54:51 : INFO  : xcreds : Team ID: UXP6YEHSPW (expected: UXP6YEHSPW )
2023-06-12 11:54:51 : DEBUG : xcreds : DEBUG enabled, skipping installation
2023-06-12 11:54:51 : INFO  : xcreds : Finishing...
2023-06-12 11:54:54 : INFO  : xcreds : name: XCreds, appName: XCreds.app
2023-06-12 11:54:54.404 mdfind[14330:104547] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2023-06-12 11:54:54.520 mdfind[14330:104547] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-12 11:54:54 : WARN  : xcreds : No previous app found
2023-06-12 11:54:54 : WARN  : xcreds : could not find XCreds.app
2023-06-12 11:54:54 : REQ   : xcreds : Installed XCreds, version 3.0
2023-06-12 11:54:54 : INFO  : xcreds : notifying
2023-06-12 11:54:54 : DEBUG : xcreds : DEBUG mode 1, not reopening anything
2023-06-12 11:54:54 : REQ   : xcreds : All done!
2023-06-12 11:54:54 : REQ   : xcreds : ################## End Installomator, exit code 0
```