### PR TITLE
Updated Label: NVivo

### DIFF
--- a/fragments/labels/nvivo.sh
+++ b/fragments/labels/nvivo.sh
@@ -1,8 +1,8 @@
 nvivo)
     name="NVivo"
     type="dmg"
-    downloadURL="https://download.qsrinternational.com/Software/NVivoforMac/NVivo.dmg"
-    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | tr '/' '\n' | grep "[0-9]" | cut -d "." -f1-3 )
+    downloadURL="https://download.qsrinternational.com/Software/NVivo14forMac/NVivo.dmg"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | awk -F'/' '{ print $6 }' | cut -d "." -f1-3 )
     expectedTeamID="A66L57342X"
     blockingProcesses=( NVivo NVivoHelper )
     ;;

--- a/fragments/labels/nvivo13.sh
+++ b/fragments/labels/nvivo13.sh
@@ -1,0 +1,8 @@
+nvivo13)
+    name="NVivo"
+    type="dmg"
+    downloadURL="https://download.qsrinternational.com/Software/NVivoforMac/NVivo.dmg"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | tr '/' '\n' | grep "[0-9]" | cut -d "." -f1-3 )
+    expectedTeamID="A66L57342X"
+    blockingProcesses=( NVivo NVivoHelper )
+    ;;

--- a/fragments/labels/nvivo14.sh
+++ b/fragments/labels/nvivo14.sh
@@ -1,4 +1,4 @@
-nvivo)
+nvivo14)
     name="NVivo"
     type="dmg"
     downloadURL="https://download.qsrinternational.com/Software/NVivo14forMac/NVivo.dmg"


### PR DESCRIPTION
New download URL and appNewVersion variable due to change of version naming by the developer: https://support.qsrinternational.com/nvivo/s/article/NVivo-Software-Version-Naming-Background

```
2023-06-12 09:01:08 : REQ   : nvivo : ################## Start Installomator v. 10.4beta, date 2023-06-12
2023-06-12 09:01:08 : INFO  : nvivo : ################## Version: 10.4beta
2023-06-12 09:01:08 : INFO  : nvivo : ################## Date: 2023-06-12
2023-06-12 09:01:08 : INFO  : nvivo : ################## nvivo
2023-06-12 09:01:08 : DEBUG : nvivo : DEBUG mode 1 enabled.
2023-06-12 09:01:08 : INFO  : nvivo : SwiftDialog is not installed, clear cmd file var
2023-06-12 09:01:08 : INFO  : nvivo : setting variable from argument DEBUG=0
2023-06-12 09:01:08 : DEBUG : nvivo : name=NVivo
2023-06-12 09:01:08 : DEBUG : nvivo : appName=
2023-06-12 09:01:08 : DEBUG : nvivo : type=dmg
2023-06-12 09:01:08 : DEBUG : nvivo : archiveName=
2023-06-12 09:01:08 : DEBUG : nvivo : downloadURL=https://download.qsrinternational.com/Software/NVivo14forMac/NVivo.dmg
2023-06-12 09:01:09 : DEBUG : nvivo : curlOptions=
2023-06-12 09:01:09 : DEBUG : nvivo : appNewVersion=14.23.0
2023-06-12 09:01:09 : DEBUG : nvivo : appCustomVersion function: Not defined
2023-06-12 09:01:09 : DEBUG : nvivo : versionKey=CFBundleShortVersionString
2023-06-12 09:01:09 : DEBUG : nvivo : packageID=
2023-06-12 09:01:09 : DEBUG : nvivo : pkgName=
2023-06-12 09:01:09 : DEBUG : nvivo : choiceChangesXML=
2023-06-12 09:01:09 : DEBUG : nvivo : expectedTeamID=A66L57342X
2023-06-12 09:01:09 : DEBUG : nvivo : blockingProcesses=NVivo NVivoHelper
2023-06-12 09:01:09 : DEBUG : nvivo : installerTool=
2023-06-12 09:01:09 : DEBUG : nvivo : CLIInstaller=
2023-06-12 09:01:09 : DEBUG : nvivo : CLIArguments=
2023-06-12 09:01:09 : DEBUG : nvivo : updateTool=
2023-06-12 09:01:09 : DEBUG : nvivo : updateToolArguments=
2023-06-12 09:01:09 : DEBUG : nvivo : updateToolRunAsCurrentUser=
2023-06-12 09:01:09 : INFO  : nvivo : BLOCKING_PROCESS_ACTION=tell_user
2023-06-12 09:01:09 : INFO  : nvivo : NOTIFY=success
2023-06-12 09:01:09 : INFO  : nvivo : LOGGING=DEBUG
2023-06-12 09:01:09 : INFO  : nvivo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-12 09:01:09 : INFO  : nvivo : Label type: dmg
2023-06-12 09:01:09 : INFO  : nvivo : archiveName: NVivo.dmg
2023-06-12 09:01:09 : DEBUG : nvivo : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swwAB4vR
2023-06-12 09:01:09 : INFO  : nvivo : name: NVivo, appName: NVivo.app
2023-06-12 09:01:09.282 mdfind[78914:7838412] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-06-12 09:01:09.282 mdfind[78914:7838412] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-06-12 09:01:09.335 mdfind[78914:7838412] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-12 09:01:09 : WARN  : nvivo : No previous app found
2023-06-12 09:01:09 : WARN  : nvivo : could not find NVivo.app
2023-06-12 09:01:09 : INFO  : nvivo : appversion: 
2023-06-12 09:01:09 : INFO  : nvivo : Latest version of NVivo is 14.23.0
2023-06-12 09:01:09 : REQ   : nvivo : Downloading https://download.qsrinternational.com/Software/NVivo14forMac/NVivo.dmg to NVivo.dmg
2023-06-12 09:01:09 : DEBUG : nvivo : No Dialog connection, just download
2023-06-12 09:01:15 : DEBUG : nvivo : File list: -rw-r--r--  1 root  wheel   659M Jun 12 09:01 NVivo.dmg
2023-06-12 09:01:15 : DEBUG : nvivo : File type: NVivo.dmg: zlib compressed data
2023-06-12 09:01:15 : DEBUG : nvivo : curl output was:
*   Trying 108.157.214.104:443...
* Connected to download.qsrinternational.com (108.157.214.104) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5834 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=AU; ST=Victoria; O=QSR INTERNATIONAL PTY LTD; CN=*.qsrinternational.com
*  start date: Aug 22 00:00:00 2022 GMT
*  expire date: Sep 20 23:59:59 2023 GMT
*  subjectAltName: host "download.qsrinternational.com" matched cert's "*.qsrinternational.com"
*  issuer: C=US; ST=DE; L=Wilmington; O=Corporation Service Company; CN=Trusted Secure Certificate Authority 5
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /Software/NVivo14forMac/NVivo.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.qsrinternational.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x139811a00)
> GET /Software/NVivo14forMac/NVivo.dmg HTTP/2
> Host: download.qsrinternational.com
> user-agent: curl/7.88.1
> accept: */*
> 
< HTTP/2 302 
< content-length: 0
< location: https://download.qsrinternational.com/Software/NVivo14forMac/14.23.0.13/NVivo14.dmg
< date: Mon, 12 Jun 2023 06:59:37 GMT
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 472198048b2177f6905d44f001875bcc.cloudfront.net (CloudFront)
< x-amz-cf-pop: ARN56-P1
< x-amz-cf-id: zTJBJE9_LZWKRTVlxNaaBt_eKJTrAKVphESDSflRqApwvmmFBbUxnQ==
< age: 93
< 
{ [0 bytes data]
* Connection #0 to host download.qsrinternational.com left intact
* Issue another request to this URL: 'https://download.qsrinternational.com/Software/NVivo14forMac/14.23.0.13/NVivo14.dmg'
* Found bundle for host: 0x60000114ce40 [can multiplex]
* Re-using existing connection #0 with host download.qsrinternational.com
* h2h3 [:method: GET]
* h2h3 [:path: /Software/NVivo14forMac/14.23.0.13/NVivo14.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.qsrinternational.com]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 3 (easy handle 0x139811a00)
> GET /Software/NVivo14forMac/14.23.0.13/NVivo14.dmg HTTP/2
> Host: download.qsrinternational.com
> user-agent: curl/7.88.1
> accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 691351286
< date: Mon, 12 Jun 2023 06:59:37 GMT
< last-modified: Tue, 16 May 2023 14:21:24 GMT
< etag: "3e6e87808d843e8a8eac09ab5d378956-42"
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 472198048b2177f6905d44f001875bcc.cloudfront.net (CloudFront)
< x-amz-cf-pop: ARN56-P1
< x-amz-cf-id: b1SefGy_DWIA6T5iynR2R5Xaik4AeInWhSq6CvWfxqyHxrA8zLM3QQ==
< age: 93
< 
{ [16059 bytes data]
* Connection #0 to host download.qsrinternational.com left intact

2023-06-12 09:01:15 : REQ   : nvivo : no more blocking processes, continue with update
2023-06-12 09:01:15 : REQ   : nvivo : Installing NVivo
2023-06-12 09:01:15 : INFO  : nvivo : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swwAB4vR/NVivo.dmg
2023-06-12 09:01:23 : DEBUG : nvivo : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $047FA7C8
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $871C9EB1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $1F023240
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $BD93A3ED
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $1F023240
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $90A63A48
verified CRC32 $20B763DD
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/NVivo

2023-06-12 09:01:23 : INFO  : nvivo : Mounted: /Volumes/NVivo
2023-06-12 09:01:23 : INFO  : nvivo : Verifying: /Volumes/NVivo/NVivo.app
2023-06-12 09:01:23 : DEBUG : nvivo : App size: 1.5G	/Volumes/NVivo/NVivo.app
2023-06-12 09:01:47 : DEBUG : nvivo : Debugging enabled, App Verification output was:
/Volumes/NVivo/NVivo.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: QSR International Pty Ltd (A66L57342X)

2023-06-12 09:01:47 : INFO  : nvivo : Team ID matching: A66L57342X (expected: A66L57342X )
2023-06-12 09:01:47 : INFO  : nvivo : Installing NVivo version 14.23.0 on versionKey CFBundleShortVersionString.
2023-06-12 09:01:47 : INFO  : nvivo : App has LSMinimumSystemVersion: 10.13
2023-06-12 09:01:47 : INFO  : nvivo : Copy /Volumes/NVivo/NVivo.app to /Applications
2023-06-12 09:02:16 : DEBUG : nvivo : Debugging enabled, App copy output was:
Copying /Volumes/NVivo/NVivo.app

2023-06-12 09:02:16 : WARN  : nvivo : Changing owner to kryptonit
2023-06-12 09:02:18 : INFO  : nvivo : Finishing...
2023-06-12 09:02:21 : INFO  : nvivo : App(s) found: /Applications/NVivo.app
2023-06-12 09:02:21 : INFO  : nvivo : found app at /Applications/NVivo.app, version 14.23.0, on versionKey CFBundleShortVersionString
2023-06-12 09:02:21 : REQ   : nvivo : Installed NVivo, version 14.23.0
2023-06-12 09:02:21 : INFO  : nvivo : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-06-12 09:02:21 : DEBUG : nvivo : Unmounting /Volumes/NVivo
2023-06-12 09:02:21 : DEBUG : nvivo : Debugging enabled, Unmounting output was:
"disk7" ejected.
2023-06-12 09:02:21 : DEBUG : nvivo : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swwAB4vR
2023-06-12 09:02:21 : DEBUG : nvivo : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swwAB4vR/NVivo.dmg
2023-06-12 09:02:21 : DEBUG : nvivo : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swwAB4vR
2023-06-12 09:02:21 : INFO  : nvivo : App not closed, so no reopen.
2023-06-12 09:02:21 : REQ   : nvivo : All done!
2023-06-12 09:02:21 : REQ   : nvivo : ################## End Installomator, exit code 0
```