### PR TITLE
Updated Label: boxdrive

### DIFF
--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -1,6 +1,6 @@
 boxdrive)
     name="Box"
     type="pkg"
-    downloadURL="https://e3.boxcdn.net/box-installers/desktop/releases/mac/Box.pkg"
+    downloadURL="https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg"
     expectedTeamID="M683GB7CPW"
     ;;


### PR DESCRIPTION
Output:

/Installomator/utils/assemble.sh boxdrive DEBUG=0
2023-06-12 15:09:02 : INFO  : boxdrive : Finishing... 2023-06-12 15:09:05 : INFO  : boxdrive : App(s) found: /Applications/Box.app 2023-06-12 15:09:05 : INFO  : boxdrive : found app at /Applications/Box.app, version 2.32.112, on versionKey CFBundleShortVersionString
2023-06-12 15:09:05 : REQ   : boxdrive : Installed Box
2023-06-12 15:09:05 : INFO  : boxdrive : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-06-12 15:09:05 : DEBUG : boxdrive : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vfqD07rF
2023-06-12 15:09:05 : DEBUG : boxdrive : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vfqD07rF/Box.pkg
2023-06-12 15:09:05 : DEBUG : boxdrive : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vfqD07rF
2023-06-12 15:09:05 : INFO  : boxdrive : App not closed, so no reopen.
2023-06-12 15:09:05 : REQ   : boxdrive : All done!
2023-06-12 15:09:05 : REQ   : boxdrive : ################## End Installomator, exit code 0