### PR TITLE
New label: mdm-watchdog

### DIFF
--- a/fragments/labels/mdm-watchdog.sh
+++ b/fragments/labels/mdm-watchdog.sh
@@ -1,0 +1,8 @@
+mdm-watchdog)
+    name="mdm-watchdog"
+    type="pkg"
+    packageID="com.addigy.mdm-watchdog"
+    downloadURL="https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg"
+    appNewVersion=""
+    expectedTeamID="R5LEJ8Y242"
+    ;;


### PR DESCRIPTION
Create label for [Addigy MDM-Watchdog](https://addigy.com/mdm-watchdog/)

label=mdm-watchdog

Download URL and package name appear to be static as of an update to the Addigy site this morning. Previously it was displaying a version 5 specific URL on the download page but it has since updated to a generic/no version included URL.

Addigy removed the version info from the download page and does not appear to have MDM-Watchdog current version listed anywhere else on their site in a location that can be checked for latest version.

## buildLabel.sh Output:
```

utils % ./buildLabel.sh https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg
Changing directory to /Users/gknackstedt/GitHub/Installomator/utils/2023-06-13-14-21-28
Working dir: /Users/gknackstedt/GitHub/Installomator/utils/2023-06-13-14-21-28
Downloading https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg
mdm-watchdog.pkg
Redirecting to (maybe this can help us with version):
HTTP/1.1 302 Found
Content-Length: 0
Connection: keep-alive
Server: CloudFront
Date: Tue, 13 Jun 2023 18:21:30 GMT
Location: https://agents.addigy.com/tools/mdm-watchdog/6/mdm-watchdog.pkg
X-Cache: LambdaGeneratedResponse from cloudfront
Via: 1.1 4076c139caa3b19374b9d2d1784ca5e0.cloudfront.net (CloudFront)
X-Amz-Cf-Pop: ORD56-P4
X-Amz-Cf-Id: SnK5q8OQHKVchqBH68Tifw9QVyP1nPif5asCsdl9xzC9Ep9-TKUaOw==

HTTP/1.1 200 OK
Content-Type: application/octet-stream
Content-Length: 2381802
Connection: keep-alive
Date: Tue, 13 Jun 2023 16:16:20 GMT
Last-Modified: Tue, 13 Jun 2023 15:51:20 GMT
ETag: "0ef52f897eced5cda84a5521e8657076"
x-amz-server-side-encryption: AES256
x-amz-version-id: uw0BiqlRSubTWThSgzgU1g2JAJeUGIs1
Accept-Ranges: bytes
Server: AmazonS3
X-Cache: Hit from cloudfront
Via: 1.1 4076c139caa3b19374b9d2d1784ca5e0.cloudfront.net (CloudFront)
X-Amz-Cf-Pop: ORD56-P4
X-Amz-Cf-Id: hjFUTqAr77i3XcGVL9Ydo8CAGvJpYQh9QyMcpsv5j_7WICkLMrjNNw==
Age: 7511

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2325k  100 2325k    0     0  3029k      0 --:--:-- --:--:-- --:--:-- 34.5M
archiveTempName: mdm-watchdog.pkg
archivePath: https://agents.addigy.com/tools/mdm-watchdog/6/mdm-watchdog.pkg
Calculated archiveName: mdm-watchdog.pkg
name: mdm-watchdog
archiveExt: pkg
PKG found: mdm-watchdog.pkg
Package investigation.
Team ID found for PKG: R5LEJ8Y242
For PKGs it's advised to find packageID for version checking, so extracting those
<pkg-ref id="com.addigy.mdm-watchdog" version="6" onConclusion="none" installKBytes="0">#addigy-component.pkg</pkg-ref>
com.addigy.mdm-watchdog
Above is the possible packageIDs that can be used, and the correct one is probably one of those with a version number. More investigation might be needed to figure out correct packageID if several are displayed.
identifier: mdmwatchdog

**********

Labels should be named in small caps, numbers 0-9, “-”, and “_”. No other characters allowed.

appNewVersion is often difficult to find. Can sometimes be found in the filename, sometimes as part of the download redirects, but also on a web page. See redirect and archivePath above if link contains information about this. That is a good place to start

mdmwatchdog)
    name="mdm-watchdog"
    type="pkg"
    packageID="com.addigy.mdm-watchdog"
    downloadURL="https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg"
    appNewVersion=""
    expectedTeamID="R5LEJ8Y242"
    ;;

Above should be saved in a file with exact same name as label, and given extension “.sh”.
Put this file in folder “fragments/labels”.
```


## Create mdm-watchdog.sh fragment:
Changed the app label from mdmwatchdog outputted by buildLabel.sh to mdm-watchdog so as to match everything else when creating the fragment.

## assemble.sh Output:

```
utils % sudo ./assemble.sh mdm-watchdog DEBUG=0
Password:
2023-06-13 15:53:42 : REQ   : mdm-watchdog : ################## Start Installomator v. 10.5beta, date 2023-06-13
2023-06-13 15:53:42 : INFO  : mdm-watchdog : ################## Version: 10.5beta
2023-06-13 15:53:42 : INFO  : mdm-watchdog : ################## Date: 2023-06-13
2023-06-13 15:53:42 : INFO  : mdm-watchdog : ################## mdm-watchdog
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : DEBUG mode 1 enabled.
2023-06-13 15:53:42 : INFO  : mdm-watchdog : setting variable from argument DEBUG=0
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : name=mdm-watchdog
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : appName=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : type=pkg
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : archiveName=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : downloadURL=https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : curlOptions=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : appNewVersion=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : appCustomVersion function: Not defined
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : versionKey=CFBundleShortVersionString
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : packageID=com.addigy.mdm-watchdog
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : pkgName=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : choiceChangesXML=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : expectedTeamID=R5LEJ8Y242
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : blockingProcesses=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : installerTool=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : CLIInstaller=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : CLIArguments=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : updateTool=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : updateToolArguments=
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : updateToolRunAsCurrentUser=
2023-06-13 15:53:42 : INFO  : mdm-watchdog : BLOCKING_PROCESS_ACTION=tell_user
2023-06-13 15:53:42 : INFO  : mdm-watchdog : NOTIFY=success
2023-06-13 15:53:42 : INFO  : mdm-watchdog : LOGGING=DEBUG
2023-06-13 15:53:42 : INFO  : mdm-watchdog : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-13 15:53:42 : INFO  : mdm-watchdog : Label type: pkg
2023-06-13 15:53:42 : INFO  : mdm-watchdog : archiveName: mdm-watchdog.pkg
2023-06-13 15:53:42 : INFO  : mdm-watchdog : no blocking processes defined, using mdm-watchdog as default
2023-06-13 15:53:42 : DEBUG : mdm-watchdog : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.W7rsUcPG
2023-06-13 15:53:42 : INFO  : mdm-watchdog : found packageID com.addigy.mdm-watchdog installed, version 7
2023-06-13 15:53:43 : INFO  : mdm-watchdog : appversion: 7
2023-06-13 15:53:43 : INFO  : mdm-watchdog : Latest version not specified.
2023-06-13 15:53:43 : REQ   : mdm-watchdog : Downloading https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg to mdm-watchdog.pkg
2023-06-13 15:53:43 : DEBUG : mdm-watchdog : No Dialog connection, just download
2023-06-13 15:53:44 : DEBUG : mdm-watchdog : File list: -rw-r--r--  1 root  wheel   2.3M Jun 13 15:53 mdm-watchdog.pkg
2023-06-13 15:53:44 : DEBUG : mdm-watchdog : File type: mdm-watchdog.pkg: xar archive compressed TOC: 4532, SHA-1 checksum
2023-06-13 15:53:44 : DEBUG : mdm-watchdog : curl output was:
*   Trying 108.159.227.25:443...
* Connected to agents.addigy.com (108.159.227.25) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [5035 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.addigy.com
*  start date: Mar 20 14:32:31 2023 GMT
*  expire date: Apr 19 14:32:31 2024 GMT
*  subjectAltName: host "agents.addigy.com" matched cert's "*.addigy.com"
*  issuer: C=US; ST=Texas; L=Houston; O=SSL Corporation; CN=SSL.com RSA SSL subCA
*  SSL certificate verify ok.
> GET /tools/mdm-watchdog/latest/mdm-watchdog.pkg HTTP/1.1
> Host: agents.addigy.com
> User-Agent: curl/7.87.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Content-Length: 0
< Connection: keep-alive
< Server: CloudFront
< Date: Tue, 13 Jun 2023 19:53:44 GMT
< Location: https://agents.addigy.com/tools/mdm-watchdog/7/mdm-watchdog.pkg
< X-Cache: LambdaGeneratedResponse from cloudfront
< Via: 1.1 ddf37d12ac6373c1561a67b71dfb8816.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD56-P4
< X-Amz-Cf-Id: 33ASI-sVYXIfL5daNihaqiMcVjNxWSvo8MpKQkeEDpJq-874YDc_tg==
< 
* Connection #0 to host agents.addigy.com left intact
* Issue another request to this URL: 'https://agents.addigy.com/tools/mdm-watchdog/7/mdm-watchdog.pkg'
* Found bundle for host: 0x6000026189c0 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection #0 with host agents.addigy.com
> GET /tools/mdm-watchdog/7/mdm-watchdog.pkg HTTP/1.1
> Host: agents.addigy.com
> User-Agent: curl/7.87.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/octet-stream
< Content-Length: 2382516
< Connection: keep-alive
< Date: Tue, 13 Jun 2023 19:28:41 GMT
< Last-Modified: Tue, 13 Jun 2023 19:10:24 GMT
< ETag: "7aeeb1d57ee0842c5c31098b93d649b9"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: cq_V9gARiraphrzrzkm1klahZpJA8g4c
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 ddf37d12ac6373c1561a67b71dfb8816.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD56-P4
< X-Amz-Cf-Id: 7vOAHbl81ewCLQDo-wA3P5HdH2hTGTAewhuD_vhMH3hKcQULhWYaZQ==
< Age: 1504
< 
{ [16384 bytes data]
* Connection #0 to host agents.addigy.com left intact

2023-06-13 15:53:44 : REQ   : mdm-watchdog : no more blocking processes, continue with update
2023-06-13 15:53:44 : REQ   : mdm-watchdog : Installing mdm-watchdog
2023-06-13 15:53:44 : INFO  : mdm-watchdog : Verifying: mdm-watchdog.pkg
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : File list: -rw-r--r--  1 root  wheel   2.3M Jun 13 15:53 mdm-watchdog.pkg
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : File type: mdm-watchdog.pkg: xar archive compressed TOC: 4532, SHA-1 checksum
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : spctlOut is mdm-watchdog.pkg: accepted
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : source=Notarized Developer ID
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : origin=Developer ID Installer: Addigy, Inc (R5LEJ8Y242)
2023-06-13 15:53:45 : INFO  : mdm-watchdog : Team ID: R5LEJ8Y242 (expected: R5LEJ8Y242 )
2023-06-13 15:53:45 : INFO  : mdm-watchdog : Checking package version.
2023-06-13 15:53:45 : INFO  : mdm-watchdog : Downloaded package com.addigy.mdm-watchdog version 7
2023-06-13 15:53:45 : INFO  : mdm-watchdog : Downloaded version of mdm-watchdog is the same as installed.
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.W7rsUcPG
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.W7rsUcPG/mdm-watchdog.pkg
2023-06-13 15:53:45 : DEBUG : mdm-watchdog : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.W7rsUcPG
2023-06-13 15:53:45 : INFO  : mdm-watchdog : App not closed, so no reopen.
2023-06-13 15:53:45 : REQ   : mdm-watchdog : No new version to install
2023-06-13 15:53:45 : REQ   : mdm-watchdog : ################## End Installomator, exit code 0 
```
  