### PR TITLE
New Label: mdmwatchdog by Addigy

### DIFF
--- a/fragments/labels/mdmwatchdog.sh
+++ b/fragments/labels/mdmwatchdog.sh
@@ -1,0 +1,9 @@
+mdmwatchdog)
+    name="Addigy MDM Watchdog"
+    type="pkg"
+    packageID="com.addigy.mdm-watchdog"
+    downloadURL="https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg"
+    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i location | cut -d '/' -f 6)"
+    expectedTeamID="R5LEJ8Y242"
+    blockingProcesses=( "NONE" )
+    ;;


### PR DESCRIPTION
2023-06-13 13:45:04 : REQ   : mdmwatchdog : ################## Start Installomator v. 10.5beta, date 2023-06-13
2023-06-13 13:45:04 : INFO  : mdmwatchdog : ################## Version: 10.5beta
2023-06-13 13:45:04 : INFO  : mdmwatchdog : ################## Date: 2023-06-13
2023-06-13 13:45:04 : INFO  : mdmwatchdog : ################## mdmwatchdog
2023-06-13 13:45:04 : DEBUG : mdmwatchdog : DEBUG mode 1 enabled.
2023-06-13 13:45:06 : INFO  : mdmwatchdog : setting variable from argument DEBUG=0
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : name=Addigy MDM Watchdog
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : appName=
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : type=pkg
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : archiveName=
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : downloadURL=https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg
2023-06-13 13:45:06 : DEBUG : mdmwatchdog : curlOptions=
2023-06-13 13:45:07 : DEBUG : mdmwatchdog : appNewVersion=7
2023-06-13 13:45:07 : DEBUG : mdmwatchdog : appCustomVersion function: Not defined
2023-06-13 13:45:07 : DEBUG : mdmwatchdog : versionKey=CFBundleShortVersionString
2023-06-13 13:45:07 : DEBUG : mdmwatchdog : packageID=com.addigy.mdm-watchdog
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : pkgName=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : choiceChangesXML=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : expectedTeamID=R5LEJ8Y242
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : blockingProcesses=NONE
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : installerTool=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : CLIInstaller=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : CLIArguments=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : updateTool=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : updateToolArguments=
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : updateToolRunAsCurrentUser=
2023-06-13 13:45:08 : INFO  : mdmwatchdog : BLOCKING_PROCESS_ACTION=tell_user
2023-06-13 13:45:08 : INFO  : mdmwatchdog : NOTIFY=success
2023-06-13 13:45:08 : INFO  : mdmwatchdog : LOGGING=DEBUG
2023-06-13 13:45:08 : INFO  : mdmwatchdog : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-13 13:45:08 : INFO  : mdmwatchdog : Label type: pkg
2023-06-13 13:45:08 : INFO  : mdmwatchdog : archiveName: Addigy MDM Watchdog.pkg
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy
2023-06-13 13:45:08 : INFO  : mdmwatchdog : No version found using packageID com.addigy.mdm-watchdog
2023-06-13 13:45:08 : INFO  : mdmwatchdog : name: Addigy MDM Watchdog, appName: Addigy MDM Watchdog.app
2023-06-13 13:45:08.616 mdfind[18137:245514] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-06-13 13:45:08.617 mdfind[18137:245514] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-06-13 13:45:08.657 mdfind[18137:245514] Couldn't determine the mapping between prefab keywords and predicates.
2023-06-13 13:45:08 : WARN  : mdmwatchdog : No previous app found
2023-06-13 13:45:08 : WARN  : mdmwatchdog : could not find Addigy MDM Watchdog.app
2023-06-13 13:45:08 : INFO  : mdmwatchdog : appversion:
2023-06-13 13:45:08 : INFO  : mdmwatchdog : Latest version of Addigy MDM Watchdog is 7
2023-06-13 13:45:08 : REQ   : mdmwatchdog : Downloading https://agents.addigy.com/tools/mdm-watchdog/latest/mdm-watchdog.pkg to Addigy MDM Watchdog.pkg
2023-06-13 13:45:08 : DEBUG : mdmwatchdog : No Dialog connection, just download
2023-06-13 13:45:09 : DEBUG : mdmwatchdog : File list: -rw-r--r--  1 root  wheel   2.3M Jun 13 13:45 Addigy MDM Watchdog.pkg
2023-06-13 13:45:09 : DEBUG : mdmwatchdog : File type: Addigy MDM Watchdog.pkg: xar archive compressed TOC: 4532, SHA-1 checksum
2023-06-13 13:45:10 : DEBUG : mdmwatchdog : curl output was:
*   Trying 54.230.21.58:443...
* Connected to agents.addigy.com (54.230.21.58) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5035 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.addigy.com
*  start date: Mar 20 14:32:31 2023 GMT
*  expire date: Apr 19 14:32:31 2024 GMT
*  subjectAltName: host "agents.addigy.com" matched cert's "*.addigy.com"
*  issuer: C=US; ST=Texas; L=Houston; O=SSL Corporation; CN=SSL.com RSA SSL subCA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /tools/mdm-watchdog/latest/mdm-watchdog.pkg HTTP/1.1
> Host: agents.addigy.com
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 302 Found
< Content-Length: 0
< Connection: keep-alive
< Server: CloudFront
< Date: Tue, 13 Jun 2023 20:45:09 GMT
< Location: https://agents.addigy.com/tools/mdm-watchdog/7/mdm-watchdog.pkg < X-Cache: LambdaGeneratedResponse from cloudfront < Via: 1.1 c64e12c2a3b915048a2b1de9bf337b0a.cloudfront.net (CloudFront) < X-Amz-Cf-Pop: LAX50-C4
< X-Amz-Cf-Id: XRN3GISj92oMfcxv__KmHiB84UJHtf5KrpnUjcW5bIn0tdzS3Y7jPw== <
* Connection #0 to host agents.addigy.com left intact
* Issue another request to this URL: 'https://agents.addigy.com/tools/mdm-watchdog/7/mdm-watchdog.pkg'
* Found bundle for host: 0x6000030000f0 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection #0 with host agents.addigy.com
> GET /tools/mdm-watchdog/7/mdm-watchdog.pkg HTTP/1.1
> Host: agents.addigy.com
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/octet-stream
< Content-Length: 2382516
< Connection: keep-alive
< Date: Tue, 13 Jun 2023 20:18:18 GMT
< Last-Modified: Tue, 13 Jun 2023 19:10:24 GMT
< ETag: "7aeeb1d57ee0842c5c31098b93d649b9"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: cq_V9gARiraphrzrzkm1klahZpJA8g4c < Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 c64e12c2a3b915048a2b1de9bf337b0a.cloudfront.net (CloudFront) < X-Amz-Cf-Pop: LAX50-C4
< X-Amz-Cf-Id: gBRB1LQU5yyhXSSMo83nDSvmolQP0i4gtAHCv5o7Bsg3Jn_1U7ckgQ== < Age: 1612
<
{ [15814 bytes data]
* Connection #0 to host agents.addigy.com left intact

2023-06-13 13:45:10 : REQ   : mdmwatchdog : Installing Addigy MDM Watchdog
2023-06-13 13:45:10 : INFO  : mdmwatchdog : Verifying: Addigy MDM Watchdog.pkg
2023-06-13 13:45:10 : DEBUG : mdmwatchdog : File list: -rw-r--r--  1 root  wheel   2.3M Jun 13 13:45 Addigy MDM Watchdog.pkg
2023-06-13 13:45:10 : DEBUG : mdmwatchdog : File type: Addigy MDM Watchdog.pkg: xar archive compressed TOC: 4532, SHA-1 checksum
2023-06-13 13:45:11 : DEBUG : mdmwatchdog : spctlOut is Addigy MDM Watchdog.pkg: accepted
2023-06-13 13:45:11 : DEBUG : mdmwatchdog : source=Notarized Developer ID
2023-06-13 13:45:11 : DEBUG : mdmwatchdog : origin=Developer ID Installer: Addigy, Inc (R5LEJ8Y242)
2023-06-13 13:45:11 : INFO  : mdmwatchdog : Team ID: R5LEJ8Y242 (expected: R5LEJ8Y242 )
2023-06-13 13:45:11 : INFO  : mdmwatchdog : Installing Addigy MDM Watchdog.pkg to /
2023-06-13 13:45:15 : DEBUG : mdmwatchdog : Debugging enabled, installer output was:
Jun 13 13:45:11  installer[18227] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy MDM Watchdog.pkg trustLevel=350
Jun 13 13:45:11  installer[18227] <Debug>: External component packages (1) trustLevel=350
Jun 13 13:45:11  installer[18227] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Jun 13 13:45:11  installer[18227] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy%20MDM%20Watchdog.pkg#mdm-watchdog-component.pkg
Jun 13 13:45:11  installer[18227] <Info>: Set authorization level to root for session
Jun 13 13:45:11  installer[18227] <Info>: Authorization is being checked, waiting until authorization arrives.
Jun 13 13:45:11  installer[18227] <Info>: Administrator authorization granted.
Jun 13 13:45:11  installer[18227] <Info>: Packages have been authorized for installation.
Jun 13 13:45:11  installer[18227] <Debug>: Will use PK session
Jun 13 13:45:11  installer[18227] <Debug>: Using authorization level of root for IFPKInstallElement
Jun 13 13:45:11  installer[18227] <Info>: Starting installation:
Jun 13 13:45:11  installer[18227] <Notice>: Configuring volume "Macintosh HD"
Jun 13 13:45:11  installer[18227] <Info>: Preparing disk for local booted install.
Jun 13 13:45:11  installer[18227] <Notice>: Free space on "Macintosh HD": 136.77 GB (136771702784 bytes).
Jun 13 13:45:11  installer[18227] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.18227dlkhdH"
Jun 13 13:45:11  installer[18227] <Notice>: IFPKInstallElement (1 packages)
Jun 13 13:45:12  installer[18227] <Info>: Current Path: /usr/sbin/installer
Jun 13 13:45:12  installer[18227] <Info>: Current Path: /bin/zsh
Last Log repeated 2 times
Jun 13 13:45:12  installer[18227] <Info>: Current Path: /usr/bin/sudo
Jun 13 13:45:12  installer[18227] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing ….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Removing old files….....
installer: Validating packages….....
#Jun 13 13:45:14  installer[18227] <Notice>: Running install actions
Jun 13 13:45:14  installer[18227] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.18227dlkhdH"
Jun 13 13:45:14  installer[18227] <Notice>: Finalize disk "Macintosh HD"
Jun 13 13:45:14  installer[18227] <Notice>: Notifying system of updated components
Jun 13 13:45:14  installer[18227] <Notice>:
Jun 13 13:45:14  installer[18227] <Notice>: **** Summary Information ****
Jun 13 13:45:14  installer[18227] <Notice>:   Operation      Elapsed time
Jun 13 13:45:14  installer[18227] <Notice>: -----------------------------
Jun 13 13:45:14  installer[18227] <Notice>:        disk      0.02 seconds
Jun 13 13:45:14  installer[18227] <Notice>:      script      0.00 seconds
Jun 13 13:45:14  installer[18227] <Notice>:        zero      0.00 seconds
Jun 13 13:45:14  installer[18227] <Notice>:     install      2.06 seconds
Jun 13 13:45:14  installer[18227] <Notice>:     -total-      2.09 seconds
Jun 13 13:45:14  installer[18227] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed...... installer: The install was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy MDM Watchdog.pkg trustLevel=350 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: External component packages (1) trustLevel=350 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy%20MDM%20Watchdog.pkg#mdm-watchdog-component.pkg 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Set authorization level to root for session 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Authorization is being checked, waiting until authorization arrives. 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Administrator authorization granted. 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Packages have been authorized for installation. 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Will use PK session 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Using authorization level of root for IFPKInstallElement 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Starting installation: 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Configuring volume "Macintosh HD" 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Preparing disk for local booted install. 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Free space on "Macintosh HD": 136.77 GB (136771702784 bytes). 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.18227dlkhdH" 2023-06-13 13:45:11-07 SSC-Q9KWWF6DV7 installer[18227]: IFPKInstallElement (1 packages) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installer[18227]: Current Path: /usr/sbin/installer 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installer[18227]: Current Path: /bin/zsh Last Log repeated 2 times
2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installer[18227]: Current Path: /usr/bin/sudo 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Adding client PKInstallDaemonClient pid=18227, uid=0 (/usr/sbin/installer) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installer[18227]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Set reponsibility for install to 12643 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Hosted team responsibility for install set to team:(R5LEJ8Y242) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: ----- Begin install -----
2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: packages=( 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy%20MDM%20Watchdog.pkg#mdm-watchdog-component.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/CE78FA6C-97EF-42F1-BA61-D8DD762A1143.activeSandbox/Root, uid=0) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: prevent user idle system sleep 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: suspending backupd 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.xju08B/Scripts/com.addigy.mdm-watchdog.7HdjwO 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.xju08B/Scripts/com.addigy.mdm-watchdog.7HdjwO 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: Set responsibility to pid: 12643, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: Hosted team responsibility for script set to team:(R5LEJ8Y242) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.xju08B/Scripts/com.addigy.mdm-watchdog.7HdjwO 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 install_monitor[18228]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: PackageKit: Hosted team responsible for script has been cleared. 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 package_script_service[2261]: Responsibility set back to self. 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/CE78FA6C-97EF-42F1-BA61-D8DD762A1143.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/CE78FA6C-97EF-42F1-BA61-D8DD762A1143.activeSandbox 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/CE78FA6C-97EF-42F1-BA61-D8DD762A1143.activeSandbox/Root (0 items) to / 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Writing receipt for com.addigy.mdm-watchdog to / 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: No Intel binaries to translate. 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: Installed "" (7) 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 installd[876]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist 2023-06-13 13:45:12-07 SSC-Q9KWWF6DV7 install_monitor[18228]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: releasing backupd 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: allow user idle system sleep 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: ----- End install ----- 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: 1.1s elapsed install time 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Cleared responsibility for install from 18227. 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Hosted team responsible for install has been cleared. 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Removing client PKInstallDaemonClient pid=18227, uid=0 (/usr/sbin/installer) 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Running idle tasks 2023-06-13 13:45:13-07 SSC-Q9KWWF6DV7 installd[876]: PackageKit: Done with sandbox removals 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: Running install actions 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.18227dlkhdH" 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: Finalize disk "Macintosh HD" 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: Notifying system of updated components 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: 2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: **** Summary Information ****
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:   Operation      Elapsed time
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]: -----------------------------
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:        disk      0.02 seconds
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:      script      0.00 seconds
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:        zero      0.00 seconds
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:     install      2.06 seconds
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:     -total-      2.09 seconds
2023-06-13 13:45:14-07 SSC-Q9KWWF6DV7 installer[18227]:

2023-06-13 13:45:15 : INFO  : mdmwatchdog : Finishing... 2023-06-13 13:45:18 : INFO  : mdmwatchdog : found packageID com.addigy.mdm-watchdog installed, version 7
2023-06-13 13:45:18 : REQ   : mdmwatchdog : Installed Addigy MDM Watchdog, version 7
2023-06-13 13:45:18 : INFO  : mdmwatchdog : notifying
2023-06-13 13:45:19 : DEBUG : mdmwatchdog : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy
2023-06-13 13:45:19 : DEBUG : mdmwatchdog : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy/Addigy MDM Watchdog.pkg
2023-06-13 13:45:19 : DEBUG : mdmwatchdog : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zs6ck1Xy
2023-06-13 13:45:19 : INFO  : mdmwatchdog : App not closed, so no reopen.
2023-06-13 13:45:19 : REQ   : mdmwatchdog : All done!
2023-06-13 13:45:19 : REQ   : mdmwatchdog : ################## End Installomator, exit code 0