### PR TITLE
Create microsoftoutlook-monthly.sh

### DIFF
--- a/fragments/labels/microsoftoutlook-monthly.sh
+++ b/fragments/labels/microsoftoutlook-monthly.sh
@@ -1,0 +1,16 @@
+microsoftoutlook-monthly)
+    name="Microsoft Outlook"
+    # As macadmin.software has provided a link to a monthly edition of Outlook, I have created this label.
+    # Not sure about the requirements for this label, nor if the call to msupdate should be there or not.
+    type="pkg"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=2228510"
+    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.outlook.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    expectedTeamID="UBF8T346G9"
+    if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
+        printlog "Running msupdate --list"
+        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+    fi
+    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+    updateToolArguments=( --install --apps OPIM2019 )
+    ;;


### PR DESCRIPTION
As [macadmins.software](https://macadmin.software) has provided a link to a monthly edition of Outlook, I have created this label.

Not sure about the requirements for this label, nor if the call to `msupdate` should be there or not.