### PR TITLE
Create surfdrive.sh

### DIFF
--- a/fragments/labels/surfdrive.sh
+++ b/fragments/labels/surfdrive.sh
@@ -1,0 +1,9 @@
+surfdrive)
+    name="SURFdrive"
+    type="pkg"
+    downloadURL="https://surfdrive.surf.nl/downloads/surfdrive-latest-x86_64.pkg"
+    expectedTeamID="4AP2STM4H5"
+    appNewVersion=$(curl -fs https://wiki.surfnet.nl/display/SURFdrive/Downloads+voor+SURFdrive|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg|cut -d- -f2)
+    appName="surfdrive.app"
+    blockingProcesses=( "surfdrive" )
+    ;;


### PR DESCRIPTION
added surfdrive label

Output:
```
./assemble.sh surfdrive DEBUG=0
2023-06-14 13:35:50 : REQ   : surfdrive : ################## Start Installomator v. 10.5beta, date 2023-06-14
2023-06-14 13:35:50 : INFO  : surfdrive : ################## Version: 10.5beta
2023-06-14 13:35:50 : INFO  : surfdrive : ################## Date: 2023-06-14
2023-06-14 13:35:50 : INFO  : surfdrive : ################## surfdrive
2023-06-14 13:35:50 : DEBUG : surfdrive : DEBUG mode 1 enabled.
2023-06-14 13:35:51 : INFO  : surfdrive : setting variable from argument DEBUG=0
2023-06-14 13:35:51 : DEBUG : surfdrive : name=SURFdrive
2023-06-14 13:35:51 : DEBUG : surfdrive : appName=surfdrive.app
2023-06-14 13:35:51 : DEBUG : surfdrive : type=pkg
2023-06-14 13:35:51 : DEBUG : surfdrive : archiveName=
2023-06-14 13:35:51 : DEBUG : surfdrive : downloadURL=https://surfdrive.surf.nl/downloads/surfdrive-latest-x86_64.pkg
2023-06-14 13:35:51 : DEBUG : surfdrive : curlOptions=
2023-06-14 13:35:51 : DEBUG : surfdrive : appNewVersion=3.2.1.10587
2023-06-14 13:35:51 : DEBUG : surfdrive : appCustomVersion function: Not defined
2023-06-14 13:35:51 : DEBUG : surfdrive : versionKey=CFBundleShortVersionString
2023-06-14 13:35:51 : DEBUG : surfdrive : packageID=
2023-06-14 13:35:51 : DEBUG : surfdrive : pkgName=
2023-06-14 13:35:51 : DEBUG : surfdrive : choiceChangesXML=
2023-06-14 13:35:51 : DEBUG : surfdrive : expectedTeamID=4AP2STM4H5
2023-06-14 13:35:51 : DEBUG : surfdrive : blockingProcesses=surfdrive
2023-06-14 13:35:51 : DEBUG : surfdrive : installerTool=
2023-06-14 13:35:51 : DEBUG : surfdrive : CLIInstaller=
2023-06-14 13:35:51 : DEBUG : surfdrive : CLIArguments=
2023-06-14 13:35:51 : DEBUG : surfdrive : updateTool=
2023-06-14 13:35:51 : DEBUG : surfdrive : updateToolArguments=
2023-06-14 13:35:51 : DEBUG : surfdrive : updateToolRunAsCurrentUser=
2023-06-14 13:35:51 : INFO  : surfdrive : BLOCKING_PROCESS_ACTION=tell_user
2023-06-14 13:35:51 : INFO  : surfdrive : NOTIFY=success
2023-06-14 13:35:51 : INFO  : surfdrive : LOGGING=DEBUG
2023-06-14 13:35:51 : INFO  : surfdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-14 13:35:51 : INFO  : surfdrive : Label type: pkg
2023-06-14 13:35:51 : INFO  : surfdrive : archiveName: SURFdrive.pkg
2023-06-14 13:35:51 : DEBUG : surfdrive : Changing directory to /var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.00rvFllU
2023-06-14 13:35:51 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2023-06-14 13:35:51 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 3.2.1.10587, on versionKey CFBundleShortVersionString
2023-06-14 13:35:51 : INFO  : surfdrive : appversion: 3.2.1.10587
2023-06-14 13:35:51 : INFO  : surfdrive : Latest version of SURFdrive is 3.2.1.10587
2023-06-14 13:35:51 : INFO  : surfdrive : There is no newer version available.
2023-06-14 13:35:51 : DEBUG : surfdrive : Deleting /var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.00rvFllU
2023-06-14 13:35:51 : DEBUG : surfdrive : Debugging enabled, Deleting tmpDir output was:
/var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.00rvFllU
2023-06-14 13:35:51 : INFO  : surfdrive : App not closed, so no reopen.
2023-06-14 13:35:51 : REQ   : surfdrive : No newer version.
2023-06-14 13:35:51 : REQ   : surfdrive : ################## End Installomator, exit code 0