### PR TITLE
'qlab' added to labels

### DIFF
--- a/fragments/labels/qlab.sh
+++ b/fragments/labels/qlab.sh
@@ -1,0 +1,7 @@
+qlab)
+    name="QLab"
+    type="dmg"
+    downloadURL="https://qlab.app/downloads/QLab.dmg"
+    appNewVersion=""
+    expectedTeamID="7672N4CCJM"
+    ;;


### PR DESCRIPTION
Output:

Installomator/utils/assemble.sh qlab
2023-06-21 10:11:26 : REQ   : qlab : ################## Start Installomator v. 10.5beta, date 2023-06-21
2023-06-21 10:11:26 : INFO  : qlab : ################## Version: 10.5beta
2023-06-21 10:11:26 : INFO  : qlab : ################## Date: 2023-06-21
2023-06-21 10:11:26 : INFO  : qlab : ################## qlab
2023-06-21 10:11:26 : DEBUG : qlab : DEBUG mode 1 enabled.
2023-06-21 10:11:26 : INFO  : qlab : SwiftDialog is not installed, clear cmd file var
2023-06-21 10:11:27 : DEBUG : qlab : name=QLab
2023-06-21 10:11:27 : DEBUG : qlab : appName=
2023-06-21 10:11:27 : DEBUG : qlab : type=dmg
2023-06-21 10:11:27 : DEBUG : qlab : archiveName=
2023-06-21 10:11:27 : DEBUG : qlab : downloadURL=https://qlab.app/downloads/QLab.dmg
2023-06-21 10:11:27 : DEBUG : qlab : curlOptions=
2023-06-21 10:11:27 : DEBUG : qlab : appNewVersion=
2023-06-21 10:11:27 : DEBUG : qlab : appCustomVersion function: Not defined
2023-06-21 10:11:27 : DEBUG : qlab : versionKey=CFBundleShortVersionString
2023-06-21 10:11:27 : DEBUG : qlab : packageID=
2023-06-21 10:11:27 : DEBUG : qlab : pkgName=
2023-06-21 10:11:27 : DEBUG : qlab : choiceChangesXML=
2023-06-21 10:11:27 : DEBUG : qlab : expectedTeamID=7672N4CCJM
2023-06-21 10:11:27 : DEBUG : qlab : blockingProcesses=
2023-06-21 10:11:27 : DEBUG : qlab : installerTool=
2023-06-21 10:11:27 : DEBUG : qlab : CLIInstaller=
2023-06-21 10:11:27 : DEBUG : qlab : CLIArguments=
2023-06-21 10:11:27 : DEBUG : qlab : updateTool=
2023-06-21 10:11:27 : DEBUG : qlab : updateToolArguments=
2023-06-21 10:11:27 : DEBUG : qlab : updateToolRunAsCurrentUser=
2023-06-21 10:11:27 : INFO  : qlab : BLOCKING_PROCESS_ACTION=tell_user
2023-06-21 10:11:27 : INFO  : qlab : NOTIFY=success
2023-06-21 10:11:27 : INFO  : qlab : LOGGING=DEBUG
2023-06-21 10:11:27 : INFO  : qlab : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-06-21 10:11:27 : INFO  : qlab : Label type: dmg
2023-06-21 10:11:27 : INFO  : qlab : archiveName: QLab.dmg
2023-06-21 10:11:27 : INFO  : qlab : no blocking processes defined, using QLab as default
2023-06-21 10:11:27 : DEBUG : qlab : Changing directory to /Users/brian/Documents/GitHub/Installomator/build
2023-06-21 10:11:27 : INFO  : qlab : App(s) found: /Applications/QLab.app
2023-06-21 10:11:28 : INFO  : qlab : found app at /Applications/QLab.app, version 5.1.2, on versionKey CFBundleShortVersionString
2023-06-21 10:11:28 : INFO  : qlab : appversion: 5.1.2
2023-06-21 10:11:28 : INFO  : qlab : Latest version not specified.
2023-06-21 10:11:28 : REQ   : qlab : Downloading https://qlab.app/downloads/QLab.dmg to QLab.dmg
2023-06-21 10:11:28 : DEBUG : qlab : No Dialog connection, just download
2023-06-21 10:11:35 : DEBUG : qlab : File list: -rw-r--r--@ 1 brian  staff    34M Jun 21 10:11 QLab.dmg
2023-06-21 10:11:35 : DEBUG : qlab : File type: QLab.dmg: bzip2 compressed data, block size = 100k
2023-06-21 10:11:35 : DEBUG : qlab : curl output was:
*   Trying 68.183.48.113:443...
* Connected to qlab.app (68.183.48.113) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [313 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5635 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=qlab.app
*  start date: Nov  6 00:00:00 2022 GMT
*  expire date: Dec  7 23:59:59 2023 GMT
*  subjectAltName: host "qlab.app" matched cert's "qlab.app"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /downloads/QLab.dmg HTTP/1.1
> Host: qlab.app
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.21.4
< Date: Wed, 21 Jun 2023 14:11:29 GMT
< Content-Type: application/octet-stream
< Content-Length: 35191541
< Last-Modified: Tue, 20 Jun 2023 17:14:11 GMT
< Connection: keep-alive
< ETag: "6491de63-218faf5"
< Cache-Control: public, max-age=0, must-revalidate < Accept-Ranges: bytes
<
{ [16071 bytes data]
* Connection #0 to host qlab.app left intact

2023-06-21 10:11:35 : DEBUG : qlab : DEBUG mode 1, not checking for blocking processes
2023-06-21 10:11:35 : REQ   : qlab : Installing QLab
2023-06-21 10:11:35 : INFO  : qlab : Mounting /Users/brian/Documents/GitHub/Installomator/build/QLab.dmg
2023-06-21 10:11:41 : DEBUG : qlab : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A610C7C2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D0DCAC95
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5A6FA770
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $EB2873F5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5A6FA770
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $91C68C11
verified   CRC32 $A273BD86
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/QLab 5.2

2023-06-21 10:11:41 : INFO  : qlab : Mounted: /Volumes/QLab 5.2 2023-06-21 10:11:41 : INFO  : qlab : Verifying: /Volumes/QLab 5.2/QLab.app 2023-06-21 10:11:41 : DEBUG : qlab : App size: 121M	/Volumes/QLab 5.2/QLab.app 2023-06-21 10:12:57 : DEBUG : qlab : Debugging enabled, App Verification output was: /Volumes/QLab 5.2/QLab.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Figure 53, LLC (7672N4CCJM)

2023-06-21 10:12:57 : INFO  : qlab : Team ID matching: 7672N4CCJM (expected: 7672N4CCJM ) 2023-06-21 10:12:57 : INFO  : qlab : Downloaded version of QLab is 5.2 on versionKey CFBundleShortVersionString (replacing version 5.1.2). 2023-06-21 10:12:57 : INFO  : qlab : App has LSMinimumSystemVersion: 11.0 2023-06-21 10:12:57 : DEBUG : qlab : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-06-21 10:12:57 : INFO  : qlab : Finishing...
2023-06-21 10:13:00 : INFO  : qlab : App(s) found: /Applications/QLab.app 2023-06-21 10:13:01 : INFO  : qlab : found app at /Applications/QLab.app, version 5.1.2, on versionKey CFBundleShortVersionString
2023-06-21 10:13:01 : REQ   : qlab : Installed QLab, version 5.2
2023-06-21 10:13:01 : INFO  : qlab : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-06-21 10:13:01 : DEBUG : qlab : Unmounting /Volumes/QLab 5.2
2023-06-21 10:13:01 : DEBUG : qlab : Debugging enabled, Unmounting output was:
"disk2" ejected.
2023-06-21 10:13:01 : DEBUG : qlab : DEBUG mode 1, not reopening anything
2023-06-21 10:13:01 : REQ   : qlab : All done!
2023-06-21 10:13:01 : REQ   : qlab : ################## End Installomator, exit code 0