### PR TITLE
Label update: Remote Desktop Free/Enterprise - URL / Curl fix

### DIFF
--- a/fragments/labels/remotedesktopmanagerenterprise.sh
+++ b/fragments/labels/remotedesktopmanagerenterprise.sh
@@ -1,7 +1,7 @@
 remotedesktopmanagerenterprise)
     name="Remote Desktop Manager"
     type="dmg"
-    downloadURL=$(curl -fs https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacbin | grep -oe "http.*\.dmg" | head -1)
+    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacbin/ | grep -oe "http.*\.dmg" | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
     expectedTeamID="N592S9ASDB"
     blockingProcesses=( "$name" )

--- a/fragments/labels/remotedesktopmanagerfree.sh
+++ b/fragments/labels/remotedesktopmanagerfree.sh
@@ -1,7 +1,7 @@
 remotedesktopmanagerfree)
     name="Remote Desktop Manager"
     type="dmg"
-    downloadURL=$(curl -fs https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacfreebin | grep -oe "http.*\.dmg" | head -1)
+    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacfreebin/ | grep -oe "http.*\.dmg" | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
     expectedTeamID="N592S9ASDB"
     ;;


### PR DESCRIPTION
Submitting for issue #1114 , and as a proper version of #1111 . Making the change for two labels in one PR due to same company and issue between the labels.

Current curl gives error for URL:
<h1>Object Moved</h1>This document may be found <a HREF="https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacfreebin/">here

Changing curl options to include -L follows the redirect automatically and fixes it, but I'm also editing the URL to just include the change too.

Output: (same result for 'enterprise' vesion)

./assemble.sh remotedesktopmanagerfree
2023-07-03 08:17:20 : REQ   : remotedesktopmanagerfree : ################## Start Installomator v. 10.5beta, date 2023-07-03
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : ################## Version: 10.5beta
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : ################## Date: 2023-07-03
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : ################## remotedesktopmanagerfree
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : DEBUG mode 1 enabled.
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : name=Remote Desktop Manager
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : appName=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : type=dmg
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : archiveName=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : downloadURL=https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2023.2.5.1.dmg
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : curlOptions=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : appNewVersion=2023.2.5.1
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : appCustomVersion function: Not defined
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : versionKey=CFBundleShortVersionString
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : packageID=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : pkgName=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : choiceChangesXML=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : expectedTeamID=N592S9ASDB
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : blockingProcesses=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : installerTool=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : CLIInstaller=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : CLIArguments=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : updateTool=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : updateToolArguments=
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : updateToolRunAsCurrentUser=
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : BLOCKING_PROCESS_ACTION=tell_user
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : NOTIFY=success
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : LOGGING=DEBUG
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : Label type: dmg
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : archiveName: Remote Desktop Manager.dmg
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : no blocking processes defined, using Remote Desktop Manager as default
2023-07-03 08:17:20 : DEBUG : remotedesktopmanagerfree : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-07-03 08:17:20 : INFO  : remotedesktopmanagerfree : name: Remote Desktop Manager, appName: Remote Desktop Manager.app
2023-07-03 08:17:20.916 mdfind[42483:1104291] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-07-03 08:17:20.916 mdfind[42483:1104291] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-07-03 08:17:20.968 mdfind[42483:1104291] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-03 08:17:21 : WARN  : remotedesktopmanagerfree : No previous app found
2023-07-03 08:17:21 : WARN  : remotedesktopmanagerfree : could not find Remote Desktop Manager.app
2023-07-03 08:17:21 : INFO  : remotedesktopmanagerfree : appversion:
2023-07-03 08:17:21 : INFO  : remotedesktopmanagerfree : Latest version of Remote Desktop Manager is 2023.2.5.1
2023-07-03 08:17:21 : REQ   : remotedesktopmanagerfree : Downloading https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2023.2.5.1.dmg to Remote Desktop Manager.dmg
2023-07-03 08:17:21 : DEBUG : remotedesktopmanagerfree : No Dialog connection, just download
2023-07-03 08:17:35 : DEBUG : remotedesktopmanagerfree : File list: -rw-r--r--  1 admin  2103187081   307M Jul  3 08:17 Remote Desktop Manager.dmg
2023-07-03 08:17:35 : DEBUG : remotedesktopmanagerfree : File type: Remote Desktop Manager.dmg: zlib compressed data
2023-07-03 08:17:35 : DEBUG : remotedesktopmanagerfree : curl output was:
*   Trying 152.195.19.97:443...
* Connected to cdn.devolutions.net (152.195.19.97) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [357 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [155 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3051 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Los Angeles; O=Edgecast Inc.; CN=sni10e5gl.wpc.edgecastcdn.net
*  start date: May 10 00:00:00 2023 GMT
*  expire date: Jun  9 23:59:59 2024 GMT
*  subjectAltName: host "cdn.devolutions.net" matched cert's "cdn.devolutions.net"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /download/Mac/Devolutions.RemoteDesktopManager.Mac.2023.2.5.1.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: cdn.devolutions.net]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14c811400)
> GET /download/Mac/Devolutions.RemoteDesktopManager.Mac.2023.2.5.1.dmg HTTP/2
> Host: cdn.devolutions.net
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< accept-ranges: bytes
< age: 1120642
< cache-control: max-age=2592000
< content-type: application/x-apple-diskimage
< date: Mon, 03 Jul 2023 15:17:21 GMT
< etag: 0x8DB71A3B3ED99A7
< expires: Wed, 02 Aug 2023 15:17:21 GMT
< last-modified: Tue, 20 Jun 2023 15:33:31 GMT
< server: ECAcc (sec/96D4)
< x-cache: HIT
< x-ms-blob-type: BlockBlob
< x-ms-lease-status: unlocked
< x-ms-request-id: 543991ae-901e-0068-2290-a3f94e000000 < x-ms-version: 2009-09-19
< content-length: 321637408
<
{ [16383 bytes data]
* Connection #0 to host cdn.devolutions.net left intact

2023-07-03 08:17:35 : DEBUG : remotedesktopmanagerfree : DEBUG mode 1, not checking for blocking processes
2023-07-03 08:17:35 : REQ   : remotedesktopmanagerfree : Installing Remote Desktop Manager
2023-07-03 08:17:35 : INFO  : remotedesktopmanagerfree : Mounting /Users/admin/Documents/GitHub/Installomator/build/Remote Desktop Manager.dmg
2023-07-03 08:17:41 : DEBUG : remotedesktopmanagerfree : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D39DF90B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $AA06BC15
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $32E43C70
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $6FF6CB95
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $32E43C70
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FEDF1921
verified   CRC32 $6B298468
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Remote Desktop Manager.app Installer

2023-07-03 08:17:41 : INFO  : remotedesktopmanagerfree : Mounted: /Volumes/Remote Desktop Manager.app Installer 2023-07-03 08:17:41 : INFO  : remotedesktopmanagerfree : Verifying: /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app 2023-07-03 08:17:41 : DEBUG : remotedesktopmanagerfree : App size: 1.3G	/Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app 2023-07-03 08:17:49 : DEBUG : remotedesktopmanagerfree : Debugging enabled, App Verification output was: /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Devolutions inc. (N592S9ASDB)

2023-07-03 08:17:49 : INFO  : remotedesktopmanagerfree : Team ID matching: N592S9ASDB (expected: N592S9ASDB ) 2023-07-03 08:17:49 : INFO  : remotedesktopmanagerfree : Installing Remote Desktop Manager version 2023.2.5.1 on versionKey CFBundleShortVersionString. 2023-07-03 08:17:49 : INFO  : remotedesktopmanagerfree : App has LSMinimumSystemVersion: 10.15 2023-07-03 08:17:49 : DEBUG : remotedesktopmanagerfree : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-07-03 08:17:49 : INFO  : remotedesktopmanagerfree : Finishing... 2023-07-03 08:17:52 : INFO  : remotedesktopmanagerfree : name: Remote Desktop Manager, appName: Remote Desktop Manager.app 2023-07-03 08:17:52.688 mdfind[42570:1104812] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-07-03 08:17:52.689 mdfind[42570:1104812] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-07-03 08:17:52.755 mdfind[42570:1104812] Couldn't determine the mapping between prefab keywords and predicates. 2023-07-03 08:17:52 : WARN  : remotedesktopmanagerfree : No previous app found 2023-07-03 08:17:52 : WARN  : remotedesktopmanagerfree : could not find Remote Desktop Manager.app
2023-07-03 08:17:52 : REQ   : remotedesktopmanagerfree : Installed Remote Desktop Manager, version 2023.2.5.1
2023-07-03 08:17:52 : INFO  : remotedesktopmanagerfree : notifying
2023-07-03 08:17:53 : DEBUG : remotedesktopmanagerfree : Unmounting /Volumes/Remote Desktop Manager.app Installer
2023-07-03 08:17:53 : DEBUG : remotedesktopmanagerfree : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-03 08:17:53 : DEBUG : remotedesktopmanagerfree : DEBUG mode 1, not reopening anything
2023-07-03 08:17:53 : REQ   : remotedesktopmanagerfree : All done!
2023-07-03 08:17:53 : REQ   : remotedesktopmanagerfree : ################## End Installomator, exit code 0