### PR TITLE
New Label: LibreOffice Language Pack (intl)

### DIFF
--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -11,7 +11,7 @@ libreofficelanguagepack_intl)
     packageID="org.libreoffice.script.langpack"
     userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | head -2 | tail -1 | tr -dc "[:alnum:]\-")
     if [[ "$userLanguage" == "en-US" ]]; then
-        cleanupAndExit 88 "No installation of a language pack is necessary for the US-English language." ERROR
+        cleanupAndExit 0 "No installation of a language pack is necessary for the US-English language."
     fi
     appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"

--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -1,9 +1,13 @@
 libreofficelanguagepack_intl)
     name="LibreOffice Language Pack"
     # appName="LibreOffice.app"
+    # Installs the Language Pack for the latest LibreOffice STABLE Version
+    # Use in combination and after installing Libre Office (STABLE Version)
+    # This label requires user interaction to complete the installation
+    #
     type="dmg"
     packageID="org.libreoffice.script.langpack"
-    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | tr -dc "[:alnum:]\-")
+    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | head -2 | tail -1 | tr -dc "[:alnum:]\-")
     appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
     until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do

--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -1,0 +1,32 @@
+libreofficelanguagepack_intl)
+    name="LibreOffice Language Pack"
+    # appName="LibreOffice.app"
+    type="dmg"
+    packageID="org.libreoffice.script.langpack"
+    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | tr -dc "[:alnum:]\-")
+    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
+    until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do
+        if [ ${#userLanguage} -eq 2 ]; then
+            break
+        fi
+        printlog "No locale matching '$userLanguage', trying '${userLanguage:0:2}'"
+        userLanguage=${userLanguage:0:2}
+    done
+    printlog "Using language '$userLanguage' for download."
+    # downloadURL="https://downloadarchive.documentfoundation.org/libreoffice/old/latest/mac/aarch64/"
+    # if ! curl -sfL --output /dev/null -r 0-0 $downloadURL; then
+    #     printlog "Download not found for '$userLanguage', exiting."
+    #     exit
+    # fi
+    # appNewVersion=$(curl -sf $releaseURL | grep -m 1 "_langpack_$userLanguage.dmg" | sed "s|.*LibreOffice_\(.*\)_MacOS.*|\\1|")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/LibreOffice_"$appNewVersion"_MacOS_aarch64_langpack_"$userLanguage".dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/x86_64/LibreOffice_"$appNewVersion"_MacOS_x86-64_langpack_"$userLanguage".dmg"
+    fi
+    installerTool="LibreOffice Language Pack.app"
+    CLIInstaller="LibreOffice Language Pack.app/Contents/LibreOffice Language Pack"
+    expectedTeamID="7P5S3ZLCN7"
+    # blockingProcesses=( soffice )
+    ;;

--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -1,13 +1,18 @@
 libreofficelanguagepack_intl)
     name="LibreOffice Language Pack"
     # appName="LibreOffice.app"
-    # Installs the Language Pack for the latest LibreOffice STABLE Version
+    #
+    # Reads the primary language of the system and installs the appropriate language pack for the latest LibreOffice STABLE version
+    # There is no language pack for the US English language and no installation is required other than the LibreOffice software itself.
     # Use in combination and after installing Libre Office (STABLE Version)
     # This label requires user interaction to complete the installation
     #
     type="dmg"
     packageID="org.libreoffice.script.langpack"
     userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | head -2 | tail -1 | tr -dc "[:alnum:]\-")
+    if [[ "$userLanguage" == "en-US" ]]; then
+        cleanupAndExit 88 "No installation of a language pack is necessary for the US-English language." ERROR
+    fi
     appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
     until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do


### PR DESCRIPTION
Localized Language Pack for LibreOffice (latest stable version)

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels libreofficelanguagepack_intl NOTIFY=silent DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user_then_kill

2023-07-08 16:17:22 : REQ   : libreofficelanguagepack_intl : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 16:17:22 : INFO  : libreofficelanguagepack_intl : ################## Version: 10.5beta
2023-07-08 16:17:22 : INFO  : libreofficelanguagepack_intl : ################## Date: 2023-07-08
2023-07-08 16:17:22 : INFO  : libreofficelanguagepack_intl : ################## libreofficelanguagepack_intl
2023-07-08 16:17:22 : DEBUG : libreofficelanguagepack_intl : DEBUG mode 1 enabled.
2023-07-08 16:17:24 : INFO  : libreofficelanguagepack_intl : No locale matching 'de-DE', trying 'de'
2023-07-08 16:17:24 : INFO  : libreofficelanguagepack_intl : Using language 'de' for download.
2023-07-08 16:17:24 : INFO  : libreofficelanguagepack_intl : setting variable from argument NOTIFY=silent
2023-07-08 16:17:24 : INFO  : libreofficelanguagepack_intl : setting variable from argument DEBUG=0
2023-07-08 16:17:24 : INFO  : libreofficelanguagepack_intl : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : name=LibreOffice Language Pack
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : appName=
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : type=dmg
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : archiveName=
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : downloadURL=https://download.documentfoundation.org/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : curlOptions=
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : appNewVersion=7.5.4
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : appCustomVersion function: Not defined
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : versionKey=CFBundleShortVersionString
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : packageID=org.libreoffice.script.langpack
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : pkgName=
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : choiceChangesXML=
2023-07-08 16:17:24 : DEBUG : libreofficelanguagepack_intl : expectedTeamID=7P5S3ZLCN7
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : blockingProcesses=
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : installerTool=LibreOffice Language Pack.app
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : CLIInstaller=LibreOffice Language Pack.app/Contents/LibreOffice Language Pack
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : CLIArguments=
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : updateTool=
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : updateToolArguments=
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : updateToolRunAsCurrentUser=
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : NOTIFY=silent
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : LOGGING=DEBUG
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : Label type: dmg
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : archiveName: LibreOffice Language Pack.dmg
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : no blocking processes defined, using LibreOffice Language Pack as default
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.etyOlShx
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : No version found using packageID org.libreoffice.script.langpack
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : name: LibreOffice Language Pack, appName: LibreOffice Language Pack.app
2023-07-08 16:17:25.361 mdfind[51241:7065099] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-08 16:17:25.361 mdfind[51241:7065099] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-08 16:17:25.407 mdfind[51241:7065099] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-08 16:17:25 : WARN  : libreofficelanguagepack_intl : No previous app found
2023-07-08 16:17:25 : WARN  : libreofficelanguagepack_intl : could not find LibreOffice Language Pack.app
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : appversion:
2023-07-08 16:17:25 : INFO  : libreofficelanguagepack_intl : Latest version of LibreOffice Language Pack is 7.5.4
2023-07-08 16:17:25 : REQ   : libreofficelanguagepack_intl : Downloading https://download.documentfoundation.org/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg to LibreOffice Language Pack.dmg
2023-07-08 16:17:25 : DEBUG : libreofficelanguagepack_intl : No Dialog connection, just download
2023-07-08 16:17:30 : DEBUG : libreofficelanguagepack_intl : File list: -rw-r--r--  1 root  wheel    22M  8 Jul 16:17 LibreOffice Language Pack.dmg
2023-07-08 16:17:31 : DEBUG : libreofficelanguagepack_intl : File type: LibreOffice Language Pack.dmg: lzfse encoded, lzvn compressed
2023-07-08 16:17:31 : DEBUG : libreofficelanguagepack_intl : curl output was:
*   Trying 89.238.68.185:443...
* Connected to download.documentfoundation.org (89.238.68.185) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [336 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [98 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4312 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [556 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.documentfoundation.org
*  start date: Jun  8 02:07:15 2023 GMT
*  expire date: Sep  6 02:07:14 2023 GMT
*  subjectAltName: host "download.documentfoundation.org" matched cert's "download.documentfoundation.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download.documentfoundation.org]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x11f012400)
> GET /libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg HTTP/2
> Host: download.documentfoundation.org
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 302
< date: Sat, 08 Jul 2023 14:17:25 GMT
< content-type: text/html; charset=iso-8859-1
< content-length: 437
< server: Apache
< x-prefix: 87.128.0.0/10
< x-as: 3320
< x-mirrorbrain-mirror: mirror.netcologne.de
< x-mirrorbrain-realm: country
< link: <http://download.documentfoundation.org/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg.meta4>; rel=describedby; type="application/metalink4+xml" < link: <http://download.documentfoundation.org/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg.asc>; rel=describedby; type="application/pgp-signature" < link: <http://download.documentfoundation.org/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg.torrent>; rel=describedby; type="application/x-bittorrent" < link: <https://mirror.netcologne.de/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg>; rel=duplicate; pri=1; geo=de < link: <https://ftp.halifax.rwth-aachen.de/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg>; rel=duplicate; pri=2; geo=de < link: <https://ftp.gwdg.de/pub/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg>; rel=duplicate; pri=3; geo=de < link: <https://mirror.unlogisch.ch/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg>; rel=duplicate; pri=4; geo=de < link: <https://mirror.faigner.de/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg>; rel=duplicate; pri=5; geo=de < digest: MD5=md3ksSJK34GnOsJ6rs1fvQ==
< digest: SHA=1hRfZW+15fQRjmGooxj/wlxjaU0=
< digest: SHA-256=6MQs0ajjuEkmzFQdxYW11D7oCA12VxVz1axSqK99BY4= < location: https://mirror.netcologne.de/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg <
* Ignoring the response-body { [437 bytes data]
* Connection #0 to host download.documentfoundation.org left intact
* Issue another request to this URL: 'https://mirror.netcologne.de/tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg'
*   Trying 194.8.197.22:443...
* Connected to mirror.netcologne.de (194.8.197.22) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4335 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [556 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=mirror.netcologne.de
*  start date: Jun  6 20:14:17 2023 GMT
*  expire date: Sep  4 20:14:16 2023 GMT
*  subjectAltName: host "mirror.netcologne.de" matched cert's "mirror.netcologne.de"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: mirror.netcologne.de]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x11f012400)
> GET /tdf/libreoffice/stable/7.5.4/mac/aarch64/LibreOffice_7.5.4_MacOS_aarch64_langpack_de.dmg HTTP/2
> Host: mirror.netcologne.de
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< server: nginx/1.21.1
< date: Sat, 08 Jul 2023 14:17:25 GMT
< content-type: application/octet-stream
< content-length: 23304426
< last-modified: Fri, 02 Jun 2023 13:36:23 GMT
< etag: "6479f057-16398ea"
< accept-ranges: bytes
<
{ [16233 bytes data]
* Connection #1 to host mirror.netcologne.de left intact

2023-07-08 16:17:31 : REQ   : libreofficelanguagepack_intl : no more blocking processes, continue with update
2023-07-08 16:17:31 : REQ   : libreofficelanguagepack_intl : Installing LibreOffice Language Pack
2023-07-08 16:17:31 : REQ   : libreofficelanguagepack_intl : installerTool used: LibreOffice Language Pack.app
2023-07-08 16:17:31 : INFO  : libreofficelanguagepack_intl : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.etyOlShx/LibreOffice Language Pack.dmg
2023-07-08 16:17:33 : DEBUG : libreofficelanguagepack_intl : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $F7A82429
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $D51F5D85
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $E1E039D8
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $3F45ABD9
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $E1E039D8
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $9BB4530D
Die überprüfte CRC32-Prüfsumme ist $9B371543
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/LibreOffice de Language Pack

2023-07-08 16:17:33 : INFO  : libreofficelanguagepack_intl : Mounted: /Volumes/LibreOffice de Language Pack 2023-07-08 16:17:33 : INFO  : libreofficelanguagepack_intl : Verifying: /Volumes/LibreOffice de Language Pack/LibreOffice Language Pack.app 2023-07-08 16:17:33 : DEBUG : libreofficelanguagepack_intl : App size:  21M	/Volumes/LibreOffice de Language Pack/LibreOffice Language Pack.app 2023-07-08 16:17:33 : DEBUG : libreofficelanguagepack_intl : Debugging enabled, App Verification output was: /Volumes/LibreOffice de Language Pack/LibreOffice Language Pack.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: The Document Foundation (7P5S3ZLCN7)

2023-07-08 16:17:33 : INFO  : libreofficelanguagepack_intl : Team ID matching: 7P5S3ZLCN7 (expected: 7P5S3ZLCN7 ) 2023-07-08 16:17:33 : INFO  : libreofficelanguagepack_intl : Installing LibreOffice Language Pack version 9 on versionKey CFBundleShortVersionString. 2023-07-08 16:17:33 : INFO  : libreofficelanguagepack_intl : CLIInstaller exists, running installer command /Volumes/LibreOffice de Language Pack/LibreOffice Language Pack.app/Contents/LibreOffice Language Pack 2023-07-08 16:17:45 : INFO  : libreofficelanguagepack_intl : Succesfully ran /Volumes/LibreOffice de Language Pack/LibreOffice Language Pack.app/Contents/LibreOffice Language Pack 2023-07-08 16:17:45 : DEBUG : libreofficelanguagepack_intl : Debugging enabled, update tool output was: button returned:OK

2023-07-08 16:17:45 : INFO  : libreofficelanguagepack_intl : Finishing... 2023-07-08 16:17:48 : INFO  : libreofficelanguagepack_intl : No version found using packageID org.libreoffice.script.langpack 2023-07-08 16:17:48 : INFO  : libreofficelanguagepack_intl : name: LibreOffice Language Pack, appName: LibreOffice Language Pack.app 2023-07-08 16:17:48.829 mdfind[51423:7065915] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2023-07-08 16:17:48.830 mdfind[51423:7065915] [UserQueryParser] Loading keywords and predicates for locale "de" 2023-07-08 16:17:48.874 mdfind[51423:7065915] Couldn't determine the mapping between prefab keywords and predicates. 2023-07-08 16:17:48 : WARN  : libreofficelanguagepack_intl : No previous app found 2023-07-08 16:17:48 : WARN  : libreofficelanguagepack_intl : could not find LibreOffice Language Pack.app
2023-07-08 16:17:48 : REQ   : libreofficelanguagepack_intl : Installed LibreOffice Language Pack, version 9
2023-07-08 16:17:48 : DEBUG : libreofficelanguagepack_intl : Unmounting /Volumes/LibreOffice de Language Pack
2023-07-08 16:17:49 : DEBUG : libreofficelanguagepack_intl : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-08 16:17:49 : DEBUG : libreofficelanguagepack_intl : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.etyOlShx
2023-07-08 16:17:49 : DEBUG : libreofficelanguagepack_intl : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.etyOlShx/LibreOffice Language Pack.dmg
2023-07-08 16:17:49 : DEBUG : libreofficelanguagepack_intl : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.etyOlShx
2023-07-08 16:17:49 : INFO  : libreofficelanguagepack_intl : App not closed, so no reopen.
2023-07-08 16:17:49 : REQ   : libreofficelanguagepack_intl : All done!
2023-07-08 16:17:49 : REQ   : libreofficelanguagepack_intl : ################## End Installomator, exit code 0