### PR TITLE
New Label: KIMplus Clientmodul

### DIFF
--- a/fragments/labels/kimplusclientmodul.sh
+++ b/fragments/labels/kimplusclientmodul.sh
@@ -1,0 +1,13 @@
+kimplusclientmodul)
+    name="KIMplus Clientmodul"
+    # appName="KIMplus Clientmodul.app"
+    type="dmg"
+    downloadName=$(curl -fs "https://cm.kimplus.de/download/current/updates.xml" | grep -i 'targetMediaFileId="mac"' | sed "s|.*fileName=\(.*\)newVersion.*|\\1|" | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://cm.kimplus.de/download/current/updates.xml" | grep -i 'targetMediaFileId="mac"' | sed "s|.*newVersion=\(.*\)newMedia.*|\\1|" | cut -d '"' -f 2)
+    downloadURL=https://cm.kimplus.de/download/current/$downloadName
+    installerTool="KIMplus Clientmodul Installationsprogramm.app"
+    CLIInstaller="KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub"
+    CLIArguments=(-q -overwrite)
+    expectedTeamID="7QZS8E98SZ"
+    blockingProcesses=( "JavaApplicationStub" )
+    ;;


### PR DESCRIPTION
sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels kimplusclientmodul NOTIFY=silent DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user_then_kill Password:
2023-07-08 16:29:24 : REQ   : kimplusclientmodul : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : ################## Version: 10.5beta
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : ################## Date: 2023-07-08
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : ################## kimplusclientmodul
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : DEBUG mode 1 enabled.
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : setting variable from argument NOTIFY=silent
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : setting variable from argument DEBUG=0
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : name=KIMplus Clientmodul
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : appName=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : type=dmg
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : archiveName=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : downloadURL=https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_0_PU_macos.dmg
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : curlOptions=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : appNewVersion=1.4.7.0.PU
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : appCustomVersion function: Not defined
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : versionKey=CFBundleShortVersionString
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : packageID=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : pkgName=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : choiceChangesXML=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : expectedTeamID=7QZS8E98SZ
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : blockingProcesses=JavaApplicationStub
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : installerTool=KIMplus Clientmodul Installationsprogramm.app
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : CLIInstaller=KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : CLIArguments=-q -overwrite
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : updateTool=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : updateToolArguments=
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : updateToolRunAsCurrentUser=
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : NOTIFY=silent
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : LOGGING=DEBUG
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : Label type: dmg
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : archiveName: KIMplus Clientmodul.dmg
2023-07-08 16:29:24 : DEBUG : kimplusclientmodul : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5YPs4r0M
2023-07-08 16:29:24 : INFO  : kimplusclientmodul : name: KIMplus Clientmodul, appName: KIMplus Clientmodul.app
2023-07-08 16:29:24.979 mdfind[52136:7076261] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-08 16:29:24.980 mdfind[52136:7076261] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-08 16:29:25.021 mdfind[52136:7076261] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-08 16:29:25 : WARN  : kimplusclientmodul : No previous app found
2023-07-08 16:29:25 : WARN  : kimplusclientmodul : could not find KIMplus Clientmodul.app
2023-07-08 16:29:25 : INFO  : kimplusclientmodul : appversion:
2023-07-08 16:29:25 : INFO  : kimplusclientmodul : Latest version of KIMplus Clientmodul is 1.4.7.0.PU
2023-07-08 16:29:25 : REQ   : kimplusclientmodul : Downloading https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_0_PU_macos.dmg to KIMplus Clientmodul.dmg
2023-07-08 16:29:25 : DEBUG : kimplusclientmodul : No Dialog connection, just download
2023-07-08 16:30:16 : DEBUG : kimplusclientmodul : File list: -rw-r--r--  1 root  wheel   241M  8 Jul 16:30 KIMplus Clientmodul.dmg
2023-07-08 16:30:16 : DEBUG : kimplusclientmodul : File type: KIMplus Clientmodul.dmg: Apple Driver Map, blocksize 512, blockcount 492536, devtype 0, devid 0, driver count 0, contains[@0x200]: Apple Partition Map, map block count 2, start block 1, block count 63, name Apple, type Apple_partition_map, valid, allocated, contains[@0x400]: Apple Partition Map, map block count 2, start block 64, block count 492472, name disk image, type Apple_HFS, valid, allocated, readable, writable
2023-07-08 16:30:16 : DEBUG : kimplusclientmodul : curl output was:
*   Trying 146.185.115.98:443...
* Connected to cm.kimplus.de (146.185.115.98) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [383 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [187 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3796 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=DE; L=Leipzig; O=Arvato Systems Digital GmbH; CN=am.kimplus.de
*  start date: Feb  6 00:00:00 2023 GMT
*  expire date: Mar  4 23:59:59 2024 GMT
*  subjectAltName: host "cm.kimplus.de" matched cert's "cm.kimplus.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=GeoTrust RSA CA 2018
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /download/current/kimplus-clientmodul_1_4_7_0_PU_macos.dmg HTTP/1.1
> Host: cm.kimplus.de
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sat, 08 Jul 2023 14:29:25 GMT
< Server: Apache
< Last-Modified: Mon, 03 Apr 2023 08:08:26 GMT
< ETag: "f083459-5f86a103f3343"
< Accept-Ranges: bytes
< Content-Length: 252195929
< Vary: User-Agent
< Content-Type: application/x-apple-diskimage
<
{ [7931 bytes data]
* Connection #0 to host cm.kimplus.de left intact

2023-07-08 16:30:16 : REQ   : kimplusclientmodul : no more blocking processes, continue with update
2023-07-08 16:30:16 : REQ   : kimplusclientmodul : Installing KIMplus Clientmodul
2023-07-08 16:30:16 : REQ   : kimplusclientmodul : installerTool used: KIMplus Clientmodul Installationsprogramm.app
2023-07-08 16:30:16 : INFO  : kimplusclientmodul : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5YPs4r0M/KIMplus Clientmodul.dmg
2023-07-08 16:30:16 : DEBUG : kimplusclientmodul : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $25EA1917
Die überprüfte CRC32-Prüfsumme ist $0A0EF9B9
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/kimplus-clientmodul

2023-07-08 16:30:16 : INFO  : kimplusclientmodul : Mounted: /Volumes/kimplus-clientmodul 2023-07-08 16:30:16 : INFO  : kimplusclientmodul : Verifying: /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app 2023-07-08 16:30:16 : DEBUG : kimplusclientmodul : App size: 240M	/Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app 2023-07-08 16:30:17 : DEBUG : kimplusclientmodul : Debugging enabled, App Verification output was: /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: arvato Systems GmbH (7QZS8E98SZ)

2023-07-08 16:30:17 : INFO  : kimplusclientmodul : Team ID matching: 7QZS8E98SZ (expected: 7QZS8E98SZ ) 2023-07-08 16:30:17 : INFO  : kimplusclientmodul : Installing KIMplus Clientmodul version 1.4.7.0.PU on versionKey CFBundleShortVersionString. 2023-07-08 16:30:17 : INFO  : kimplusclientmodul : App has LSMinimumSystemVersion: 10.11 2023-07-08 16:30:17 : INFO  : kimplusclientmodul : CLIInstaller exists, running installer command /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub -q -overwrite 2023-07-08 16:30:27 : INFO  : kimplusclientmodul : Succesfully ran /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub -q -overwrite 2023-07-08 16:30:27 : DEBUG : kimplusclientmodul : Debugging enabled, update tool output was: Warning: the fonts "Times" and "Times" are not available for the Java logical font "Serif", which may have unexpected appearance or behavior. Re-enable the "Times" font to remove this warning. Das Installationsverzeichnis wurde auf /Applications gesetzt. Dateien werden ausgepackt ...
Installation wird beendet ...

2023-07-08 16:30:27 : INFO  : kimplusclientmodul : Finishing... 2023-07-08 16:30:30 : INFO  : kimplusclientmodul : name: KIMplus Clientmodul, appName: KIMplus Clientmodul Installationsprogramm.app 2023-07-08 16:30:30.252 mdfind[52378:7077889] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2023-07-08 16:30:30.253 mdfind[52378:7077889] [UserQueryParser] Loading keywords and predicates for locale "de" 2023-07-08 16:30:30.296 mdfind[52378:7077889] Couldn't determine the mapping between prefab keywords and predicates. 2023-07-08 16:30:30 : WARN  : kimplusclientmodul : No previous app found 2023-07-08 16:30:30 : WARN  : kimplusclientmodul : could not find KIMplus Clientmodul Installationsprogramm.app
2023-07-08 16:30:30 : REQ   : kimplusclientmodul : Installed KIMplus Clientmodul, version 1.4.7.0.PU
2023-07-08 16:30:30 : DEBUG : kimplusclientmodul : Unmounting /Volumes/kimplus-clientmodul
2023-07-08 16:30:30 : DEBUG : kimplusclientmodul : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-08 16:30:30 : DEBUG : kimplusclientmodul : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5YPs4r0M
2023-07-08 16:30:30 : DEBUG : kimplusclientmodul : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5YPs4r0M/KIMplus Clientmodul.dmg
2023-07-08 16:30:30 : DEBUG : kimplusclientmodul : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5YPs4r0M
2023-07-08 16:30:30 : INFO  : kimplusclientmodul : App not closed, so no reopen.
2023-07-08 16:30:30 : REQ   : kimplusclientmodul : All done!
2023-07-08 16:30:30 : REQ   : kimplusclientmodul : ################## End Installomator, exit code 0

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels kimplusclientmodul NOTIFY=silent DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:30:48 : REQ   : kimplusclientmodul : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 16:30:48 : INFO  : kimplusclientmodul : ################## Version: 10.5beta
2023-07-08 16:30:48 : INFO  : kimplusclientmodul : ################## Date: 2023-07-08
2023-07-08 16:30:48 : INFO  : kimplusclientmodul : ################## kimplusclientmodul
2023-07-08 16:30:48 : DEBUG : kimplusclientmodul : DEBUG mode 1 enabled.
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : setting variable from argument NOTIFY=silent
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : setting variable from argument DEBUG=0
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : name=KIMplus Clientmodul
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : appName=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : type=dmg
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : archiveName=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : downloadURL=https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_0_PU_macos.dmg
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : curlOptions=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : appNewVersion=1.4.7.0.PU
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : appCustomVersion function: Not defined
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : versionKey=CFBundleShortVersionString
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : packageID=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : pkgName=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : choiceChangesXML=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : expectedTeamID=7QZS8E98SZ
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : blockingProcesses=JavaApplicationStub
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : installerTool=KIMplus Clientmodul Installationsprogramm.app
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : CLIInstaller=KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : CLIArguments=-q -overwrite
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : updateTool=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : updateToolArguments=
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : updateToolRunAsCurrentUser=
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : NOTIFY=silent
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : LOGGING=DEBUG
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : Label type: dmg
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : archiveName: KIMplus Clientmodul.dmg
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XtlFp8S8
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : App(s) found: /Applications/KIMplus Clientmodul.app
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : found app at /Applications/KIMplus Clientmodul.app, version 1.4.7.0.PU, on versionKey CFBundleShortVersionString
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : appversion: 1.4.7.0.PU
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : Latest version of KIMplus Clientmodul is 1.4.7.0.PU
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : There is no newer version available.
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XtlFp8S8
2023-07-08 16:30:49 : DEBUG : kimplusclientmodul : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XtlFp8S8
2023-07-08 16:30:49 : INFO  : kimplusclientmodul : App not closed, so no reopen.
2023-07-08 16:30:49 : REQ   : kimplusclientmodul : No newer version.
2023-07-08 16:30:49 : REQ   : kimplusclientmodul : ################## End Installomator, exit code 0