### PR TITLE
New Label: starfaceuccclient

### DIFF
--- a/fragments/labels/starfaceuccclient.sh
+++ b/fragments/labels/starfaceuccclient.sh
@@ -1,0 +1,9 @@
+starfaceuccclient)
+    name="STARFACE UCC Client"
+    # Downloads the latest 6.7.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="zip"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "STARFACE_UCC_Client_6.7" | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "STARFACE_UCC_Client_6.7" | cut -d '"' -f 2 | sed -e 's/.*-\(.*\).zip*/\1/')
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Downloads the latest 6.7.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation

"The STARFACE app for Windows and macOS serves as the desktop user interface for your VoIP phone system. Make calls using your choice of desk or DECT telephone. Besides a powerful call manager, the STARFACE app integrates an SIP client for use of an appropriate headset"

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels starfaceuccclient NOTIFY=silent DEBUG=0 Password:
2023-07-08 17:14:36 : REQ   : starfaceuccclient : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 17:14:36 : INFO  : starfaceuccclient : ################## Version: 10.5beta
2023-07-08 17:14:36 : INFO  : starfaceuccclient : ################## Date: 2023-07-08
2023-07-08 17:14:36 : INFO  : starfaceuccclient : ################## starfaceuccclient
2023-07-08 17:14:36 : DEBUG : starfaceuccclient : DEBUG mode 1 enabled.
2023-07-08 17:14:37 : INFO  : starfaceuccclient : setting variable from argument NOTIFY=silent
2023-07-08 17:14:37 : INFO  : starfaceuccclient : setting variable from argument DEBUG=0
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : name=STARFACE UCC Client
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : appName=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : type=zip
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : archiveName=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_UCC_Client_6.7.3.0-316.zip
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : curlOptions=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : appNewVersion=316
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : appCustomVersion function: Not defined
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : versionKey=CFBundleVersion
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : packageID=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : pkgName=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : choiceChangesXML=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : expectedTeamID=Q965D3UXEW
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : blockingProcesses=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : installerTool=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : CLIInstaller=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : CLIArguments=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : updateTool=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : updateToolArguments=
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : updateToolRunAsCurrentUser=
2023-07-08 17:14:37 : INFO  : starfaceuccclient : BLOCKING_PROCESS_ACTION=tell_user
2023-07-08 17:14:37 : INFO  : starfaceuccclient : NOTIFY=silent
2023-07-08 17:14:37 : INFO  : starfaceuccclient : LOGGING=DEBUG
2023-07-08 17:14:37 : INFO  : starfaceuccclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 17:14:37 : INFO  : starfaceuccclient : Label type: zip
2023-07-08 17:14:37 : INFO  : starfaceuccclient : archiveName: STARFACE UCC Client.zip
2023-07-08 17:14:37 : INFO  : starfaceuccclient : no blocking processes defined, using STARFACE UCC Client as default
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf
2023-07-08 17:14:37 : INFO  : starfaceuccclient : name: STARFACE UCC Client, appName: STARFACE UCC Client.app
2023-07-08 17:14:37.687 mdfind[58318:7114420] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-08 17:14:37.688 mdfind[58318:7114420] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-08 17:14:37.728 mdfind[58318:7114420] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-08 17:14:37 : WARN  : starfaceuccclient : No previous app found
2023-07-08 17:14:37 : WARN  : starfaceuccclient : could not find STARFACE UCC Client.app
2023-07-08 17:14:37 : INFO  : starfaceuccclient : appversion:
2023-07-08 17:14:37 : INFO  : starfaceuccclient : Latest version of STARFACE UCC Client is 316
2023-07-08 17:14:37 : REQ   : starfaceuccclient : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE_UCC_Client_6.7.3.0-316.zip to STARFACE UCC Client.zip
2023-07-08 17:14:37 : DEBUG : starfaceuccclient : No Dialog connection, just download
2023-07-08 17:14:47 : DEBUG : starfaceuccclient : File list: -rw-r--r--  1 root  wheel    99M  8 Jul 17:14 STARFACE UCC Client.zip
2023-07-08 17:14:47 : DEBUG : starfaceuccclient : File type: STARFACE UCC Client.zip: Zip archive data, at least v2.0 to extract, compression method=store
2023-07-08 17:14:47 : DEBUG : starfaceuccclient : curl output was:
*   Trying 217.160.0.241:443...
* Connected to www.starface-cdn.de (217.160.0.241) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2756 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Sep 30 00:00:00 2022 GMT
*  expire date: Oct 15 23:59:59 2023 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Encryption Everywhere DV TLS CA - G1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /starface/clients/mac/STARFACE_UCC_Client_6.7.3.0-316.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.starface-cdn.de]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14e812400)
> GET /starface/clients/mac/STARFACE_UCC_Client_6.7.3.0-316.zip HTTP/2
> Host: www.starface-cdn.de
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/zip
< content-length: 103424362
< date: Sat, 08 Jul 2023 15:14:38 GMT
< server: Apache
< last-modified: Fri, 15 Jan 2021 13:22:17 GMT
< etag: "62a216a-5b8f042dd1440"
< accept-ranges: bytes
<
{ [16217 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2023-07-08 17:14:47 : REQ   : starfaceuccclient : no more blocking processes, continue with update
2023-07-08 17:14:47 : REQ   : starfaceuccclient : Installing STARFACE UCC Client
2023-07-08 17:14:47 : INFO  : starfaceuccclient : Unzipping STARFACE UCC Client.zip
2023-07-08 17:14:48 : INFO  : starfaceuccclient : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.app
2023-07-08 17:14:48 : DEBUG : starfaceuccclient : App size: 229M	/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.app
2023-07-08 17:14:50 : DEBUG : starfaceuccclient : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2023-07-08 17:14:50 : INFO  : starfaceuccclient : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW ) 2023-07-08 17:14:50 : INFO  : starfaceuccclient : Installing STARFACE UCC Client version 316 on versionKey CFBundleVersion. 2023-07-08 17:14:50 : INFO  : starfaceuccclient : App has LSMinimumSystemVersion: 10.13 2023-07-08 17:14:50 : INFO  : starfaceuccclient : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.app to /Applications 2023-07-08 17:14:50 : DEBUG : starfaceuccclient : Debugging enabled, App copy output was: Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.app

2023-07-08 17:14:50 : WARN  : starfaceuccclient : Changing owner to savvas 2023-07-08 17:14:51 : INFO  : starfaceuccclient : Finishing... 2023-07-08 17:14:54 : INFO  : starfaceuccclient : App(s) found: /Applications/STARFACE UCC Client.app 2023-07-08 17:14:54 : INFO  : starfaceuccclient : found app at /Applications/STARFACE UCC Client.app, version 316, on versionKey CFBundleVersion
2023-07-08 17:14:54 : REQ   : starfaceuccclient : Installed STARFACE UCC Client, version 316
2023-07-08 17:14:54 : DEBUG : starfaceuccclient : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf
2023-07-08 17:14:54 : DEBUG : starfaceuccclient : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf/STARFACE UCC Client.zip
.
.
.
2023-07-08 17:14:54 : DEBUG : starfaceuccclient : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UwRZdiWf
2023-07-08 17:15:04 : INFO  : starfaceuccclient : App not closed, so no reopen.
2023-07-08 17:15:04 : REQ   : starfaceuccclient : All done!
2023-07-08 17:15:04 : REQ   : starfaceuccclient : ################## End Installomator, exit code 0 
