### PR TITLE
New Laber: starface72x

### DIFF
--- a/fragments/labels/starface72x.sh
+++ b/fragments/labels/starface72x.sh
@@ -1,0 +1,9 @@
+starface72x)
+    name="STARFACE"
+    # Downloads the latest 7.2.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="zip"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "7.2" | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "7.2" | cut -d '"' -f 2 | cut -d '-' -f 4 | sed 's/\(.*\).zip/\1/')
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Downloads the latest 7.2.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation

"The STARFACE app for Windows and macOS serves as the desktop user interface for your VoIP phone system. Make calls using your choice of desk or DECT telephone. Besides a powerful call manager, the STARFACE app integrates an SIP client for use of an appropriate headset"

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels starface72x NOTIFY=silent DEBUG=0 Password:
2023-07-08 17:27:57 : REQ   : starface72x : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 17:27:57 : INFO  : starface72x : ################## Version: 10.5beta
2023-07-08 17:27:57 : INFO  : starface72x : ################## Date: 2023-07-08
2023-07-08 17:27:57 : INFO  : starface72x : ################## starface72x
2023-07-08 17:27:57 : DEBUG : starface72x : DEBUG mode 1 enabled.
2023-07-08 17:27:57 : INFO  : starface72x : setting variable from argument NOTIFY=silent
2023-07-08 17:27:57 : INFO  : starface72x : setting variable from argument DEBUG=0
2023-07-08 17:27:57 : DEBUG : starface72x : name=STARFACE
2023-07-08 17:27:57 : DEBUG : starface72x : appName=
2023-07-08 17:27:57 : DEBUG : starface72x : type=zip
2023-07-08 17:27:57 : DEBUG : starface72x : archiveName=
2023-07-08 17:27:57 : DEBUG : starface72x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE-7.2.0.0-457-x64_64-hotfix.zip
2023-07-08 17:27:57 : DEBUG : starface72x : curlOptions=
2023-07-08 17:27:57 : DEBUG : starface72x : appNewVersion=457
2023-07-08 17:27:57 : DEBUG : starface72x : appCustomVersion function: Not defined
2023-07-08 17:27:57 : DEBUG : starface72x : versionKey=CFBundleVersion
2023-07-08 17:27:57 : DEBUG : starface72x : packageID=
2023-07-08 17:27:57 : DEBUG : starface72x : pkgName=
2023-07-08 17:27:57 : DEBUG : starface72x : choiceChangesXML=
2023-07-08 17:27:57 : DEBUG : starface72x : expectedTeamID=Q965D3UXEW
2023-07-08 17:27:57 : DEBUG : starface72x : blockingProcesses=
2023-07-08 17:27:57 : DEBUG : starface72x : installerTool=
2023-07-08 17:27:58 : DEBUG : starface72x : CLIInstaller=
2023-07-08 17:27:58 : DEBUG : starface72x : CLIArguments=
2023-07-08 17:27:58 : DEBUG : starface72x : updateTool=
2023-07-08 17:27:58 : DEBUG : starface72x : updateToolArguments=
2023-07-08 17:27:58 : DEBUG : starface72x : updateToolRunAsCurrentUser=
2023-07-08 17:27:58 : INFO  : starface72x : BLOCKING_PROCESS_ACTION=tell_user
2023-07-08 17:27:58 : INFO  : starface72x : NOTIFY=silent
2023-07-08 17:27:58 : INFO  : starface72x : LOGGING=DEBUG
2023-07-08 17:27:58 : INFO  : starface72x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 17:27:58 : INFO  : starface72x : Label type: zip
2023-07-08 17:27:58 : INFO  : starface72x : archiveName: STARFACE.zip
2023-07-08 17:27:58 : INFO  : starface72x : no blocking processes defined, using STARFACE as default
2023-07-08 17:27:58 : DEBUG : starface72x : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk
2023-07-08 17:27:58 : INFO  : starface72x : name: STARFACE, appName: STARFACE.app
2023-07-08 17:27:58.151 mdfind[64628:7132952] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-08 17:27:58.151 mdfind[64628:7132952] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-08 17:27:58.193 mdfind[64628:7132952] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-08 17:27:58 : WARN  : starface72x : No previous app found
2023-07-08 17:27:58 : WARN  : starface72x : could not find STARFACE.app
2023-07-08 17:27:58 : INFO  : starface72x : appversion:
2023-07-08 17:27:58 : INFO  : starface72x : Latest version of STARFACE is 457
2023-07-08 17:27:58 : REQ   : starface72x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE-7.2.0.0-457-x64_64-hotfix.zip to STARFACE.zip
2023-07-08 17:27:58 : DEBUG : starface72x : No Dialog connection, just download
2023-07-08 17:28:07 : DEBUG : starface72x : File list: -rw-r--r--  1 root  wheel    98M  8 Jul 17:28 STARFACE.zip
2023-07-08 17:28:07 : DEBUG : starface72x : File type: STARFACE.zip: Zip archive data, at least v2.0 to extract, compression method=store
2023-07-08 17:28:07 : DEBUG : starface72x : curl output was:
*   Trying 217.160.0.241:443...
* Connected to www.starface-cdn.de (217.160.0.241) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2756 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Sep 30 00:00:00 2022 GMT
*  expire date: Oct 15 23:59:59 2023 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Encryption Everywhere DV TLS CA - G1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /starface/clients/mac/STARFACE-7.2.0.0-457-x64_64-hotfix.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.starface-cdn.de]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x137012400)
> GET /starface/clients/mac/STARFACE-7.2.0.0-457-x64_64-hotfix.zip HTTP/2
> Host: www.starface-cdn.de
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/zip
< content-length: 102877428
< date: Sat, 08 Jul 2023 15:27:58 GMT
< server: Apache
< last-modified: Mon, 22 Aug 2022 09:43:42 GMT
< etag: "621c8f4-5e6d148790f80"
< accept-ranges: bytes
<
{ [16217 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2023-07-08 17:28:07 : REQ   : starface72x : no more blocking processes, continue with update
2023-07-08 17:28:07 : REQ   : starface72x : Installing STARFACE
2023-07-08 17:28:07 : INFO  : starface72x : Unzipping STARFACE.zip
2023-07-08 17:28:09 : INFO  : starface72x : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.app
2023-07-08 17:28:09 : DEBUG : starface72x : App size: 229M	/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.app
2023-07-08 17:28:09 : DEBUG : starface72x : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2023-07-08 17:28:09 : INFO  : starface72x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW ) 2023-07-08 17:28:10 : INFO  : starface72x : Installing STARFACE version 457 on versionKey CFBundleVersion. 2023-07-08 17:28:10 : INFO  : starface72x : App has LSMinimumSystemVersion: 10.15 2023-07-08 17:28:10 : INFO  : starface72x : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.app to /Applications 2023-07-08 17:28:10 : DEBUG : starface72x : Debugging enabled, App copy output was: Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.app

2023-07-08 17:28:10 : WARN  : starface72x : Changing owner to savvas 2023-07-08 17:28:10 : INFO  : starface72x : Finishing... 2023-07-08 17:28:13 : INFO  : starface72x : App(s) found: /Applications/STARFACE.app 2023-07-08 17:28:13 : INFO  : starface72x : found app at /Applications/STARFACE.app, version 457, on versionKey CFBundleVersion
2023-07-08 17:28:13 : REQ   : starface72x : Installed STARFACE, version 457
2023-07-08 17:28:13 : DEBUG : starface72x : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk
2023-07-08 17:28:13 : DEBUG : starface72x : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk/STARFACE.zip
.
.
.
2023-07-08 17:28:13 : DEBUG : starface72x : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4lIGhaCk
2023-07-08 17:28:19 : INFO  : starface72x : App not closed, so no reopen.
2023-07-08 17:28:19 : REQ   : starface72x : All done!
2023-07-08 17:28:19 : REQ   : starface72x : ################## End Installomator, exit code 0