### PR TITLE
New Label: starface73x

### DIFF
--- a/fragments/labels/starface73x.sh
+++ b/fragments/labels/starface73x.sh
@@ -1,0 +1,9 @@
+starface73x)
+    name="STARFACE"
+    # Downloads the latest 7.3.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="dmg"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "7.3" | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure url=' | grep -m 1 "7.3" | cut -d '"' -f 2 | cut -d '-' -f 4 | sed 's/\(.*\).dmg/\1/')
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Downloads the latest 7.3.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation

"The STARFACE app for Windows and macOS serves as the desktop user interface for your VoIP phone system. Make calls using your choice of desk or DECT telephone. Besides a powerful call manager, the STARFACE app integrates an SIP client for use of an appropriate headset"

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels starface73x NOTIFY=silent DEBUG=0 Password:
2023-07-08 17:33:31 : REQ   : starface73x : ################## Start Installomator v. 10.5beta, date 2023-07-08
2023-07-08 17:33:31 : INFO  : starface73x : ################## Version: 10.5beta
2023-07-08 17:33:31 : INFO  : starface73x : ################## Date: 2023-07-08
2023-07-08 17:33:31 : INFO  : starface73x : ################## starface73x
2023-07-08 17:33:31 : DEBUG : starface73x : DEBUG mode 1 enabled.
2023-07-08 17:33:32 : INFO  : starface73x : setting variable from argument NOTIFY=silent
2023-07-08 17:33:32 : INFO  : starface73x : setting variable from argument DEBUG=0
2023-07-08 17:33:32 : DEBUG : starface73x : name=STARFACE
2023-07-08 17:33:32 : DEBUG : starface73x : appName=
2023-07-08 17:33:32 : DEBUG : starface73x : type=dmg
2023-07-08 17:33:32 : DEBUG : starface73x : archiveName=
2023-07-08 17:33:32 : DEBUG : starface73x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE-7.3.1.0-484.dmg
2023-07-08 17:33:32 : DEBUG : starface73x : curlOptions=
2023-07-08 17:33:32 : DEBUG : starface73x : appNewVersion=484
2023-07-08 17:33:32 : DEBUG : starface73x : appCustomVersion function: Not defined
2023-07-08 17:33:32 : DEBUG : starface73x : versionKey=CFBundleVersion
2023-07-08 17:33:32 : DEBUG : starface73x : packageID=
2023-07-08 17:33:32 : DEBUG : starface73x : pkgName=
2023-07-08 17:33:32 : DEBUG : starface73x : choiceChangesXML=
2023-07-08 17:33:32 : DEBUG : starface73x : expectedTeamID=Q965D3UXEW
2023-07-08 17:33:32 : DEBUG : starface73x : blockingProcesses=
2023-07-08 17:33:32 : DEBUG : starface73x : installerTool=
2023-07-08 17:33:32 : DEBUG : starface73x : CLIInstaller=
2023-07-08 17:33:32 : DEBUG : starface73x : CLIArguments=
2023-07-08 17:33:32 : DEBUG : starface73x : updateTool=
2023-07-08 17:33:32 : DEBUG : starface73x : updateToolArguments=
2023-07-08 17:33:32 : DEBUG : starface73x : updateToolRunAsCurrentUser=
2023-07-08 17:33:32 : INFO  : starface73x : BLOCKING_PROCESS_ACTION=tell_user
2023-07-08 17:33:32 : INFO  : starface73x : NOTIFY=silent
2023-07-08 17:33:32 : INFO  : starface73x : LOGGING=DEBUG
2023-07-08 17:33:32 : INFO  : starface73x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-08 17:33:32 : INFO  : starface73x : Label type: dmg
2023-07-08 17:33:32 : INFO  : starface73x : archiveName: STARFACE.dmg
2023-07-08 17:33:32 : INFO  : starface73x : no blocking processes defined, using STARFACE as default
2023-07-08 17:33:32 : DEBUG : starface73x : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UdyUcUVT
2023-07-08 17:33:32 : INFO  : starface73x : App(s) found: /Applications/STARFACE.app
2023-07-08 17:33:32 : INFO  : starface73x : found app at /Applications/STARFACE.app, version 457, on versionKey CFBundleVersion
2023-07-08 17:33:32 : INFO  : starface73x : appversion: 457
2023-07-08 17:33:32 : INFO  : starface73x : Latest version of STARFACE is 484
2023-07-08 17:33:32 : REQ   : starface73x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE-7.3.1.0-484.dmg to STARFACE.dmg
2023-07-08 17:33:32 : DEBUG : starface73x : No Dialog connection, just download
2023-07-08 17:33:51 : DEBUG : starface73x : File list: -rw-r--r--  1 root  wheel   183M  8 Jul 17:33 STARFACE.dmg
2023-07-08 17:33:51 : DEBUG : starface73x : File type: STARFACE.dmg: zlib compressed data
2023-07-08 17:33:51 : DEBUG : starface73x : curl output was:
*   Trying 217.160.0.241:443...
* Connected to www.starface-cdn.de (217.160.0.241) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2756 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Sep 30 00:00:00 2022 GMT
*  expire date: Oct 15 23:59:59 2023 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Encryption Everywhere DV TLS CA - G1
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /starface/clients/mac/STARFACE-7.3.1.0-484.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.starface-cdn.de]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14b00b800)
> GET /starface/clients/mac/STARFACE-7.3.1.0-484.dmg HTTP/2
> Host: www.starface-cdn.de
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 192236233
< date: Sat, 08 Jul 2023 15:33:32 GMT
< server: Apache
< last-modified: Wed, 19 Apr 2023 08:58:19 GMT
< etag: "b754ac9-5f9aca023eb34"
< accept-ranges: bytes
<
{ [16207 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2023-07-08 17:33:51 : REQ   : starface73x : no more blocking processes, continue with update
2023-07-08 17:33:51 : REQ   : starface73x : Installing STARFACE
2023-07-08 17:33:51 : INFO  : starface73x : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UdyUcUVT/STARFACE.dmg
2023-07-08 17:33:54 : DEBUG : starface73x : Debugging enabled, dmgmount output was:
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $CD0C7044
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $8982CDFE
Prüfsumme für DiscRecording 9.0.3d5 (Apple_HFS : 2) berechnen …
DiscRecording 9.0.3d5 (Apple_HFS : 2: Die überprüfte CRC32-Prüfsumme ist $3162CB45
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Die überprüfte CRC32-Prüfsumme ist $FA3880C9
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/STARFACE Installer

2023-07-08 17:33:54 : INFO  : starface73x : Mounted: /Volumes/STARFACE Installer 2023-07-08 17:33:54 : INFO  : starface73x : Verifying: /Volumes/STARFACE Installer/STARFACE.app 2023-07-08 17:33:54 : DEBUG : starface73x : App size: 433M	/Volumes/STARFACE Installer/STARFACE.app 2023-07-08 17:33:58 : DEBUG : starface73x : Debugging enabled, App Verification output was: /Volumes/STARFACE Installer/STARFACE.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2023-07-08 17:33:58 : INFO  : starface73x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW ) 2023-07-08 17:33:58 : INFO  : starface73x : Downloaded version of STARFACE is 484 on versionKey CFBundleVersion (replacing version 457). 2023-07-08 17:33:58 : INFO  : starface73x : App has LSMinimumSystemVersion: 10.15 2023-07-08 17:33:59 : WARN  : starface73x : Removing existing /Applications/STARFACE.app 2023-07-08 17:33:59 : DEBUG : starface73x : Debugging enabled, App removing output was: /Applications/STARFACE.app/Contents/
Last Log repeated 1196 times
/Applications/STARFACE.app/Contents
/Applications/STARFACE.app

2023-07-08 17:33:59 : INFO  : starface73x : Copy /Volumes/STARFACE Installer/STARFACE.app to /Applications 2023-07-08 17:33:59 : DEBUG : starface73x : Debugging enabled, App copy output was: Copying /Volumes/STARFACE Installer/STARFACE.app

2023-07-08 17:33:59 : WARN  : starface73x : Changing owner to savvas 2023-07-08 17:33:59 : INFO  : starface73x : Finishing... 2023-07-08 17:34:02 : INFO  : starface73x : App(s) found: /Applications/STARFACE.app 2023-07-08 17:34:03 : INFO  : starface73x : found app at /Applications/STARFACE.app, version 484, on versionKey CFBundleVersion
2023-07-08 17:34:03 : REQ   : starface73x : Installed STARFACE, version 484
2023-07-08 17:34:03 : DEBUG : starface73x : Unmounting /Volumes/STARFACE Installer
2023-07-08 17:34:03 : DEBUG : starface73x : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-08 17:34:03 : DEBUG : starface73x : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UdyUcUVT
2023-07-08 17:34:03 : DEBUG : starface73x : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UdyUcUVT/STARFACE.dmg
2023-07-08 17:34:03 : DEBUG : starface73x : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UdyUcUVT
2023-07-08 17:34:03 : INFO  : starface73x : App not closed, so no reopen.
2023-07-08 17:34:03 : REQ   : starface73x : All done!
2023-07-08 17:34:03 : REQ   : starface73x : ################## End Installomator, exit code 0