### PR TITLE
Label fix: VMWareHorizonClient- install type changed

### DIFF
--- a/fragments/labels/vmwarehorizonclient.sh
+++ b/fragments/labels/vmwarehorizonclient.sh
@@ -1,6 +1,6 @@
 vmwarehorizonclient)
     name="VMware Horizon Client"
-    type="dmg"
+    type="pkgInDmg"
     downloadGroup=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY" | grep -o '[^"]*_MAC_[^"]*')
     fileName=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&dlgType=PRODUCT_BINARY&downloadGroup=${downloadGroup}" | grep -o '"fileName":"[^"]*"' | cut -d: -f2 | sed 's/"//g')
     downloadURL="https://download3.vmware.com/software/$downloadGroup/${fileName}"


### PR DESCRIPTION
Fix for #1117 

Changed type Dmg to pkgInDmg. Tested with a fresh, full install and it worked; though logs below are only for the assemble.

Output:
./assemble.sh vmwarehorizonclient
2023-07-10 14:21:43 : REQ   : vmwarehorizonclient : ################## Start Installomator v. 10.5beta, date 2023-07-10
2023-07-10 14:21:43 : INFO  : vmwarehorizonclient : ################## Version: 10.5beta
2023-07-10 14:21:43 : INFO  : vmwarehorizonclient : ################## Date: 2023-07-10
2023-07-10 14:21:43 : INFO  : vmwarehorizonclient : ################## vmwarehorizonclient
2023-07-10 14:21:43 : DEBUG : vmwarehorizonclient : DEBUG mode 1 enabled.
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : name=VMware Horizon Client
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : appName=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : type=pkgInDmg
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : archiveName=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : downloadURL=https://download3.vmware.com/software/CART24FQ2_MAC_2306/VMware-Horizon-Client-2306-8.10.0-21964677.dmg
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : curlOptions=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : appNewVersion=8.10.0
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : appCustomVersion function: Not defined
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : versionKey=CFBundleShortVersionString
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : packageID=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : pkgName=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : choiceChangesXML=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : expectedTeamID=EG7KH642X6
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : blockingProcesses=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : installerTool=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : CLIInstaller=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : CLIArguments=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : updateTool=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : updateToolArguments=
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : updateToolRunAsCurrentUser=
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : BLOCKING_PROCESS_ACTION=tell_user
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : NOTIFY=success
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : LOGGING=DEBUG
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : Label type: pkgInDmg
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : archiveName: VMware Horizon Client.dmg
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : no blocking processes defined, using VMware Horizon Client as default
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : Changing directory to /Users/å/Documents/GitHub/Installomator/build
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : name: VMware Horizon Client, appName: VMware Horizon Client.app
2023-07-10 14:21:46.336 mdfind[13262:180619] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-07-10 14:21:46.336 mdfind[13262:180619] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-07-10 14:21:46.385 mdfind[13262:180619] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-10 14:21:46 : WARN  : vmwarehorizonclient : No previous app found
2023-07-10 14:21:46 : WARN  : vmwarehorizonclient : could not find VMware Horizon Client.app
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : appversion:
2023-07-10 14:21:46 : INFO  : vmwarehorizonclient : Latest version of VMware Horizon Client is 8.10.0
2023-07-10 14:21:46 : REQ   : vmwarehorizonclient : Downloading https://download3.vmware.com/software/CART24FQ2_MAC_2306/VMware-Horizon-Client-2306-8.10.0-21964677.dmg to VMware Horizon Client.dmg
2023-07-10 14:21:46 : DEBUG : vmwarehorizonclient : No Dialog connection, just download
2023-07-10 14:21:53 : DEBUG : vmwarehorizonclient : File list: -rw-r--r--  1 admin  2103187081   158M Jul 10 14:21 VMware Horizon Client.dmg
2023-07-10 14:21:53 : DEBUG : vmwarehorizonclient : File type: VMware Horizon Client.dmg: zlib compressed data
2023-07-10 14:21:53 : DEBUG : vmwarehorizonclient : curl output was:
*   Trying 184.30.152.26:443...
* Connected to download3.vmware.com (184.30.152.26) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2959 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Palo Alto; O=VMware, Inc.; CN=*.vmware.com
*  start date: Mar 25 00:00:00 2023 GMT
*  expire date: Mar 27 23:59:59 2024 GMT
*  subjectAltName: host "download3.vmware.com" matched cert's "*.vmware.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /software/CART24FQ2_MAC_2306/VMware-Horizon-Client-2306-8.10.0-21964677.dmg HTTP/1.1
> Host: download3.vmware.com
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Server: AkamaiNetStorage
< Last-Modified: Mon, 26 Jun 2023 19:54:05 GMT
< ETag: "f26c18c07a73cfcd2d664d35ac7007f8:1687809232.171974" < Content-MD5: 8mwYwHpzz80tZk01rHAH+A==
< Content-Length: 165590903
< Date: Mon, 10 Jul 2023 21:21:47 GMT
< Connection: keep-alive
< content-disposition: attachment; filename="VMware-Horizon-Client-2306-8.10.0-21964677.dmg" < Content-Type: application/x-octet-stream
<
{ [15950 bytes data]
* Connection #0 to host download3.vmware.com left intact

2023-07-10 14:21:53 : DEBUG : vmwarehorizonclient : DEBUG mode 1, not checking for blocking processes
2023-07-10 14:21:53 : REQ   : vmwarehorizonclient : Installing VMware Horizon Client
2023-07-10 14:21:53 : INFO  : vmwarehorizonclient : Mounting /Users/admin/Documents/GitHub/Installomator/build/VMware Horizon Client.dmg
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1A985437
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $6B75C3EA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $06F4B2BD
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $089C0DA5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $06F4B2BD
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $0AE47B0B
verified   CRC32 $4BE80260
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/VMware Horizon Client 1

2023-07-10 14:21:57 : INFO  : vmwarehorizonclient : Mounted: /Volumes/VMware Horizon Client 1 2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : Found pkg(s): /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg 2023-07-10 14:21:57 : INFO  : vmwarehorizonclient : found pkg: /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg 2023-07-10 14:21:57 : INFO  : vmwarehorizonclient : Verifying: /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : File list: -rw-r--r--@ 1 admin  2103187081   157M Jun 21 18:26 /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : File type: /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg: xar archive compressed TOC: 5090, SHA-1 checksum
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : spctlOut is /Volumes/VMware Horizon Client 1/VMware Horizon Client.pkg: accepted
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : source=Notarized Developer ID
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : origin=Developer ID Installer: VMware, Inc. (EG7KH642X6)
2023-07-10 14:21:57 : INFO  : vmwarehorizonclient : Team ID: EG7KH642X6 (expected: EG7KH642X6 )
2023-07-10 14:21:57 : DEBUG : vmwarehorizonclient : DEBUG enabled, skipping installation
2023-07-10 14:21:57 : INFO  : vmwarehorizonclient : Finishing...
2023-07-10 14:22:00 : INFO  : vmwarehorizonclient : name: VMware Horizon Client, appName: VMware Horizon Client.app
2023-07-10 14:22:00.515 mdfind[13350:181000] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-07-10 14:22:00.515 mdfind[13350:181000] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-07-10 14:22:00.577 mdfind[13350:181000] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-10 14:22:00 : WARN  : vmwarehorizonclient : No previous app found
2023-07-10 14:22:00 : WARN  : vmwarehorizonclient : could not find VMware Horizon Client.app
2023-07-10 14:22:00 : REQ   : vmwarehorizonclient : Installed VMware Horizon Client, version 8.10.0
2023-07-10 14:22:00 : INFO  : vmwarehorizonclient : notifying
2023-07-10 14:22:00 : DEBUG : vmwarehorizonclient : Unmounting /Volumes/VMware Horizon Client 1
2023-07-10 14:22:00 : DEBUG : vmwarehorizonclient : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-07-10 14:22:00 : DEBUG : vmwarehorizonclient : DEBUG mode 1, not reopening anything
2023-07-10 14:22:00 : REQ   : vmwarehorizonclient : All done!
2023-07-10 14:22:00 : REQ   : vmwarehorizonclient : ################## End Installomator, exit code 0