### PR TITLE
LabelUpdate: Thunderbird - appNewVersion added

### DIFF
--- a/fragments/labels/thunderbird.sh
+++ b/fragments/labels/thunderbird.sh
@@ -2,6 +2,6 @@ thunderbird)
     name="Thunderbird"
     type="dmg"
     downloadURL="https://download.mozilla.org/?product=thunderbird-latest&os=osx&lang=en-US"
+    appNewVersion=$(curl -fsL "https://www.thunderbird.net/en-US/thunderbird/releases/" | xmllint --html --xpath 'string(//aside/a[last()]/text())' - 2> /dev/null)
     expectedTeamID="43AQ936H96"
-    blockingProcesses=( thunderbird )
     ;;


### PR DESCRIPTION
Added appNewVersion, and it is targeting the last entry of the first table on Mozilla's "All Releases" page: https://www.thunderbird.net/en-US/thunderbird/releases/

I've removed the blockingProcesses line, as it is redundant to default Installmator behavior since the name entered and the label name are the same.

Output:

./assemble.sh thunderbird
2023-07-10 14:39:23 : REQ   : thunderbird : ################## Start Installomator v. 10.5beta, date 2023-07-10
2023-07-10 14:39:23 : INFO  : thunderbird : ################## Version: 10.5beta
2023-07-10 14:39:23 : INFO  : thunderbird : ################## Date: 2023-07-10
2023-07-10 14:39:23 : INFO  : thunderbird : ################## thunderbird
2023-07-10 14:39:23 : DEBUG : thunderbird : DEBUG mode 1 enabled.
2023-07-10 14:39:24 : DEBUG : thunderbird : name=Thunderbird
2023-07-10 14:39:24 : DEBUG : thunderbird : appName=
2023-07-10 14:39:24 : DEBUG : thunderbird : type=dmg
2023-07-10 14:39:24 : DEBUG : thunderbird : archiveName=
2023-07-10 14:39:24 : DEBUG : thunderbird : downloadURL=https://download.mozilla.org/?product=thunderbird-latest&os=osx&lang=en-US
2023-07-10 14:39:24 : DEBUG : thunderbird : curlOptions=
2023-07-10 14:39:24 : DEBUG : thunderbird : appNewVersion=102.13.0
2023-07-10 14:39:24 : DEBUG : thunderbird : appCustomVersion function: Not defined
2023-07-10 14:39:24 : DEBUG : thunderbird : versionKey=CFBundleShortVersionString
2023-07-10 14:39:24 : DEBUG : thunderbird : packageID=
2023-07-10 14:39:24 : DEBUG : thunderbird : pkgName=
2023-07-10 14:39:24 : DEBUG : thunderbird : choiceChangesXML=
2023-07-10 14:39:24 : DEBUG : thunderbird : expectedTeamID=43AQ936H96
2023-07-10 14:39:24 : DEBUG : thunderbird : blockingProcesses=
2023-07-10 14:39:24 : DEBUG : thunderbird : installerTool=
2023-07-10 14:39:24 : DEBUG : thunderbird : CLIInstaller=
2023-07-10 14:39:24 : DEBUG : thunderbird : CLIArguments=
2023-07-10 14:39:24 : DEBUG : thunderbird : updateTool=
2023-07-10 14:39:24 : DEBUG : thunderbird : updateToolArguments=
2023-07-10 14:39:24 : DEBUG : thunderbird : updateToolRunAsCurrentUser=
2023-07-10 14:39:24 : INFO  : thunderbird : BLOCKING_PROCESS_ACTION=tell_user
2023-07-10 14:39:24 : INFO  : thunderbird : NOTIFY=success
2023-07-10 14:39:24 : INFO  : thunderbird : LOGGING=DEBUG
2023-07-10 14:39:24 : INFO  : thunderbird : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-10 14:39:24 : INFO  : thunderbird : Label type: dmg
2023-07-10 14:39:24 : INFO  : thunderbird : archiveName: Thunderbird.dmg
2023-07-10 14:39:24 : INFO  : thunderbird : no blocking processes defined, using Thunderbird as default
2023-07-10 14:39:24 : DEBUG : thunderbird : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-07-10 14:39:24 : INFO  : thunderbird : name: Thunderbird, appName: Thunderbird.app
2023-07-10 14:39:24.201 mdfind[14473:192439] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-07-10 14:39:24.201 mdfind[14473:192439] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-07-10 14:39:24.248 mdfind[14473:192439] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-10 14:39:24 : WARN  : thunderbird : No previous app found
2023-07-10 14:39:24 : WARN  : thunderbird : could not find Thunderbird.app
2023-07-10 14:39:24 : INFO  : thunderbird : appversion:
2023-07-10 14:39:24 : INFO  : thunderbird : Latest version of Thunderbird is 102.13.0
2023-07-10 14:39:24 : REQ   : thunderbird : Downloading https://download.mozilla.org/?product=thunderbird-latest&os=osx&lang=en-US to Thunderbird.dmg
2023-07-10 14:39:24 : DEBUG : thunderbird : No Dialog connection, just download
2023-07-10 14:39:29 : DEBUG : thunderbird : File list: -rw-r--r--  1 admin  2103187081   119M Jul 10 14:39 Thunderbird.dmg
2023-07-10 14:39:29 : DEBUG : thunderbird : File type: Thunderbird.dmg: bzip2 compressed data, block size = 900k
2023-07-10 14:39:29 : DEBUG : thunderbird : curl output was:
*   Trying 52.24.85.17:443...
* Connected to download.mozilla.org (52.24.85.17) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3006 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Mozilla Corporation; CN=download.mozilla.org
*  start date: Feb 27 00:00:00 2023 GMT
*  expire date: Mar  8 23:59:59 2024 GMT
*  subjectAltName: host "download.mozilla.org" matched cert's "download.mozilla.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /?product=thunderbird-latest&os=osx&lang=en-US HTTP/1.1
> Host: download.mozilla.org
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 302 Found
< Cache-Control: max-age=60
< Content-Type: text/html; charset=utf-8
< Date: Mon, 10 Jul 2023 21:39:24 GMT
< Location: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.13.0/mac/en-US/Thunderbird%20102.13.0.dmg < Content-Length: 136
< Connection: keep-alive
<
* Ignoring the response-body { [136 bytes data]
* Connection #0 to host download.mozilla.org left intact
* Issue another request to this URL: 'https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.13.0/mac/en-US/Thunderbird%20102.13.0.dmg'
*   Trying 34.117.35.28:443...
* Connected to download-installer.cdn.mozilla.net (34.117.35.28) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [339 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4008 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download-installer.cdn.mozilla.net
*  start date: Jul 10 11:51:59 2023 GMT
*  expire date: Oct  8 11:51:58 2023 GMT
*  subjectAltName: host "download-installer.cdn.mozilla.net" matched cert's "download-installer.cdn.mozilla.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /pub/thunderbird/releases/102.13.0/mac/en-US/Thunderbird%20102.13.0.dmg]
* h2h3 [:scheme: https]
* h2h3 [:authority: download-installer.cdn.mozilla.net]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x132013400)
> GET /pub/thunderbird/releases/102.13.0/mac/en-US/Thunderbird%20102.13.0.dmg HTTP/2
> Host: download-installer.cdn.mozilla.net
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< server: nginx
< x-guploader-uploadid: ADPycdt9P-yW7W3AEko0aKBYVAl4QapRk9SKD0yeG3LsVoMxqNjz1bVEfhBGbAjhz2oe9IfOXJB0CcwMVrTIkolf7ES29ysm0aXP < x-goog-generation: 1688752426232743
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 124623698
< x-goog-hash: crc32c=GwOhpg==
< x-goog-hash: md5=uxRK6xBbsl7T4CqtEEvWRQ==
< x-goog-storage-class: STANDARD
< accept-ranges: bytes
< strict-transport-security: max-age=31536000
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000 < alt-svc: clear
< via: 1.1 google, 1.1 google
< date: Fri, 07 Jul 2023 18:28:18 GMT
< expires: Wed, 12 Jul 2023 18:28:18 GMT
< cache-control: max-age=432000
< last-modified: Fri, 07 Jul 2023 17:53:46 GMT
< etag: "bb144aeb105bb25ed3e02aad104bd645"
< content-type: application/x-iso9660-image
< vary: Origin
< content-length: 124623698
< age: 270666
<
{ [1207 bytes data]
* Connection #1 to host download-installer.cdn.mozilla.net left intact

2023-07-10 14:39:29 : DEBUG : thunderbird : DEBUG mode 1, not checking for blocking processes
2023-07-10 14:39:29 : REQ   : thunderbird : Installing Thunderbird
2023-07-10 14:39:29 : INFO  : thunderbird : Mounting /Users/admin/Documents/GitHub/Installomator/build/Thunderbird.dmg
2023-07-10 14:39:37 : DEBUG : thunderbird : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $34912769
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $CED7AC08
Checksumming Macintosh (Apple_Driver_ATAPI : 2)…
Macintosh (Apple_Driver_ATAPI : 2): verified   CRC32 $C71C0011
Checksumming Mac_OS_X (Apple_HFSX : 3)…
Mac_OS_X (Apple_HFSX : 3): verified   CRC32 $772FB4F8
Checksumming  (Apple_Free : 4)…
(Apple_Free : 4): verified   CRC32 $00000000
verified   CRC32 $21630091
/dev/disk5          	Apple_partition_scheme
/dev/disk5s1        	Apple_partition_map
/dev/disk5s2        	Apple_Driver_ATAPI
/dev/disk5s3        	Apple_HFSX                     	/Volumes/Thunderbird

2023-07-10 14:39:37 : INFO  : thunderbird : Mounted: /Volumes/Thunderbird 2023-07-10 14:39:37 : INFO  : thunderbird : Verifying: /Volumes/Thunderbird/Thunderbird.app 2023-07-10 14:39:37 : DEBUG : thunderbird : App size: 346M	/Volumes/Thunderbird/Thunderbird.app 2023-07-10 14:39:45 : DEBUG : thunderbird : Debugging enabled, App Verification output was: /Volumes/Thunderbird/Thunderbird.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mozilla Corporation (43AQ936H96)

2023-07-10 14:39:45 : INFO  : thunderbird : Team ID matching: 43AQ936H96 (expected: 43AQ936H96 ) 2023-07-10 14:39:45 : INFO  : thunderbird : Installing Thunderbird version 102.13.0 on versionKey CFBundleShortVersionString. 2023-07-10 14:39:45 : INFO  : thunderbird : App has LSMinimumSystemVersion: 10.12.0 2023-07-10 14:39:45 : DEBUG : thunderbird : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-07-10 14:39:45 : INFO  : thunderbird : Finishing... 2023-07-10 14:39:48 : INFO  : thunderbird : name: Thunderbird, appName: Thunderbird.app 2023-07-10 14:39:48.856 mdfind[14567:192987] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-07-10 14:39:48.856 mdfind[14567:192987] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-07-10 14:39:48.913 mdfind[14567:192987] Couldn't determine the mapping between prefab keywords and predicates. 2023-07-10 14:39:49 : WARN  : thunderbird : No previous app found 2023-07-10 14:39:49 : WARN  : thunderbird : could not find Thunderbird.app
2023-07-10 14:39:49 : REQ   : thunderbird : Installed Thunderbird, version 102.13.0
2023-07-10 14:39:49 : INFO  : thunderbird : notifying
2023-07-10 14:39:49 : DEBUG : thunderbird : Unmounting /Volumes/Thunderbird
2023-07-10 14:39:49 : DEBUG : thunderbird : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-07-10 14:39:49 : DEBUG : thunderbird : DEBUG mode 1, not reopening anything
2023-07-10 14:39:49 : REQ   : thunderbird : All done!
2023-07-10 14:39:49 : REQ   : thunderbird : ################## End Installomator, exit code 0