### PR TITLE
Label fix: Python - TeamID change

### DIFF
--- a/fragments/labels/python.sh
+++ b/fragments/labels/python.sh
@@ -6,7 +6,7 @@ python)
     downloadURL="https://www.python.org/ftp/python/$appNewVersion/$archiveName"
     shortVersion=$( cut -d '.' -f1,2 <<< $appNewVersion )
     packageID="org.python.Python.PythonFramework-$shortVersion"
-    expectedTeamID="DJ3H93M7VJ"
+    expectedTeamID="BMM5U3QVKW"
     blockingProcesses=( "IDLE" "Python Launcher" )
     versionKey="CFBundleVersion"
     appCustomVersion() {


### PR DESCRIPTION
I couldn't find any reference to a changed TeamID in the python/cpython repository, or other places on github- except for AutoPKG recipe's and other secondary places (ex: https://github.com/autopkg/scriptingosx-recipes/issues/83). I thought I'd submit it to be official now after a few days.

Fix for #1116

Output:

./assemble.sh python
2023-07-10 14:52:45 : REQ   : python : ################## Start Installomator v. 10.5beta, date 2023-07-10
2023-07-10 14:52:45 : INFO  : python : ################## Version: 10.5beta
2023-07-10 14:52:45 : INFO  : python : ################## Date: 2023-07-10
2023-07-10 14:52:45 : INFO  : python : ################## python
2023-07-10 14:52:45 : DEBUG : python : DEBUG mode 1 enabled.
2023-07-10 14:52:45 : DEBUG : python : name=Python
2023-07-10 14:52:45 : DEBUG : python : appName=
2023-07-10 14:52:45 : DEBUG : python : type=pkg
2023-07-10 14:52:45 : DEBUG : python : archiveName=python-3.11.4-macos11.pkg
2023-07-10 14:52:45 : DEBUG : python : downloadURL=https://www.python.org/ftp/python/3.11.4/python-3.11.4-macos11.pkg
2023-07-10 14:52:45 : DEBUG : python : curlOptions=
2023-07-10 14:52:45 : DEBUG : python : appNewVersion=3.11.4
2023-07-10 14:52:45 : DEBUG : python : appCustomVersion function: Defined.
2023-07-10 14:52:45 : DEBUG : python : versionKey=CFBundleVersion
2023-07-10 14:52:45 : DEBUG : python : packageID=org.python.Python.PythonFramework-3.11
2023-07-10 14:52:45 : DEBUG : python : pkgName=
2023-07-10 14:52:45 : DEBUG : python : choiceChangesXML=
2023-07-10 14:52:45 : DEBUG : python : expectedTeamID=BMM5U3QVKW
2023-07-10 14:52:45 : DEBUG : python : blockingProcesses=IDLE Python Launcher
2023-07-10 14:52:45 : DEBUG : python : installerTool=
2023-07-10 14:52:45 : DEBUG : python : CLIInstaller=
2023-07-10 14:52:45 : DEBUG : python : CLIArguments=
2023-07-10 14:52:45 : DEBUG : python : updateTool=
2023-07-10 14:52:45 : DEBUG : python : updateToolArguments=
2023-07-10 14:52:45 : DEBUG : python : updateToolRunAsCurrentUser=
2023-07-10 14:52:45 : INFO  : python : BLOCKING_PROCESS_ACTION=tell_user
2023-07-10 14:52:45 : INFO  : python : NOTIFY=success
2023-07-10 14:52:45 : INFO  : python : LOGGING=DEBUG
2023-07-10 14:52:45 : INFO  : python : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-10 14:52:45 : INFO  : python : Label type: pkg
2023-07-10 14:52:45 : INFO  : python : archiveName: python-3.11.4-macos11.pkg
2023-07-10 14:52:45 : DEBUG : python : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2023-07-10 14:52:45 : INFO  : python : Custom App Version detection is used, found
2023-07-10 14:52:45 : INFO  : python : appversion:
2023-07-10 14:52:45 : INFO  : python : Latest version of Python is 3.11.4
2023-07-10 14:52:45 : REQ   : python : Downloading https://www.python.org/ftp/python/3.11.4/python-3.11.4-macos11.pkg to python-3.11.4-macos11.pkg
2023-07-10 14:52:45 : DEBUG : python : No Dialog connection, just download
2023-07-10 14:52:47 : DEBUG : python : File list: -rw-r--r--  1 admin  2103187081    41M Jul 10 14:52 python-3.11.4-macos11.pkg
2023-07-10 14:52:47 : DEBUG : python : File type: python-3.11.4-macos11.pkg: xar archive compressed TOC: 6289, SHA-1 checksum, contains
2023-07-10 14:52:47 : DEBUG : python : - OpenPGP Public Key
2023-07-10 14:52:47 : DEBUG : python : curl output was:
*   Trying 199.232.144.223:443...
* Connected to www.python.org (199.232.144.223) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2906 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.python.org
*  start date: Jun 29 16:48:43 2023 GMT
*  expire date: Jul 30 16:48:42 2024 GMT
*  subjectAltName: host "www.python.org" matched cert's "www.python.org"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2023 Q2
*  SSL certificate verify ok.
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /ftp/python/3.11.4/python-3.11.4-macos11.pkg]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.python.org]
* h2h3 [user-agent: curl/7.88.1]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x122013400)
> GET /ftp/python/3.11.4/python-3.11.4-macos11.pkg HTTP/2
> Host: www.python.org
> user-agent: curl/7.88.1
> accept: */*
>
< HTTP/2 200
< server: nginx
< content-type: application/octet-stream
< last-modified: Tue, 06 Jun 2023 23:32:41 GMT
< etag: "647fc219-291f956"
< x-clacks-overhead: GNU Terry Pratchett
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 1777660
< date: Mon, 10 Jul 2023 21:52:45 GMT
< x-served-by: cache-lga21974-LGA, cache-pdx12327-PDX < x-cache: HIT, HIT
< x-cache-hits: 2867, 0
< x-timer: S1689025966.953953,VS0,VE1
< strict-transport-security: max-age=63072000; includeSubDomains; preload < content-length: 43120982
<
{ [1359 bytes data]
* Connection #0 to host www.python.org left intact

2023-07-10 14:52:47 : DEBUG : python : DEBUG mode 1, not checking for blocking processes
2023-07-10 14:52:47 : REQ   : python : Installing Python
2023-07-10 14:52:47 : INFO  : python : Verifying: python-3.11.4-macos11.pkg
2023-07-10 14:52:47 : DEBUG : python : File list: -rw-r--r--  1 admin  2103187081    41M Jul 10 14:52 python-3.11.4-macos11.pkg
2023-07-10 14:52:47 : DEBUG : python : File type: python-3.11.4-macos11.pkg: xar archive compressed TOC: 6289, SHA-1 checksum, contains
2023-07-10 14:52:47 : DEBUG : python : - OpenPGP Public Key
2023-07-10 14:52:47 : DEBUG : python : spctlOut is python-3.11.4-macos11.pkg: accepted
2023-07-10 14:52:47 : DEBUG : python : source=Notarized Developer ID
2023-07-10 14:52:47 : DEBUG : python : origin=Developer ID Installer: Python Software Foundation (BMM5U3QVKW)
2023-07-10 14:52:47 : INFO  : python : Team ID: BMM5U3QVKW (expected: BMM5U3QVKW )
2023-07-10 14:52:47 : DEBUG : python : DEBUG enabled, skipping installation
2023-07-10 14:52:47 : INFO  : python : Finishing...
2023-07-10 14:52:50 : INFO  : python : Custom App Version detection is used, found
2023-07-10 14:52:50 : REQ   : python : Installed Python, version 3.11.4
2023-07-10 14:52:50 : INFO  : python : notifying
2023-07-10 14:52:50 : DEBUG : python : DEBUG mode 1, not reopening anything
2023-07-10 14:52:50 : REQ   : python : All done!
2023-07-10 14:52:50 : REQ   : python : ################## End Installomator, exit code 0