### PR TITLE
update type to pkgInDMG

### DIFF
--- a/fragments/labels/vmwarehorizonclient.sh
+++ b/fragments/labels/vmwarehorizonclient.sh
@@ -1,6 +1,6 @@
 vmwarehorizonclient)
     name="VMware Horizon Client"
-    type="dmg"
+    type="pkgInDmg"
     downloadGroup=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY" | grep -o '[^"]*_MAC_[^"]*')
     fileName=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&dlgType=PRODUCT_BINARY&downloadGroup=${downloadGroup}" | grep -o '"fileName":"[^"]*"' | cut -d: -f2 | sed 's/"//g')
     downloadURL="https://download3.vmware.com/software/$downloadGroup/${fileName}"


### PR DESCRIPTION
Noticed today that the label for this was successfully pulling down the dmg, but was looking for "**VMware Horizon Client.app**" instead of the PKG installer.
Updated the type and confirmed locally. 