### PR TITLE
New Label: morisawadesktopmanager

### DIFF
--- a/fragments/labels/morisawadesktopmanager.sh
+++ b/fragments/labels/morisawadesktopmanager.sh
@@ -1,0 +1,9 @@
+morisawadesktopmanager)
+    name="Morisawa Desktop Manager"
+    type="pkgInDmg"
+    packageID="jp.co.morisawa.MorisawaDesktopManager.Installer"
+    morisawadesktopmanagerVersions=$(curl -fsL https://morisawafonts.com/resources/dm/mf_updates.mac.json)
+    downloadURL=$(getJSONValue "${morisawadesktopmanagerVersions}" "latest_url")
+    appNewVersion=$(getJSONValue "${morisawadesktopmanagerVersions}" "latest_version")
+    expectedTeamID="662PVPVA3N"
+    ;;


### PR DESCRIPTION
The Morisawa Font is a well-known font company in Japan providing Japanese fonts.
Morisawa Desktop Manager is software to install its fonts on mac devices.

https://support.morisawafonts.com/hc/ja/articles/10826594615449-Desktop-Manager%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6

```sh
$ utils/assemble.sh morisawadesktopmanager DEBUG=1
2023-07-14 19:31:22 : REQ   : morisawadesktopmanager : ################## Start Installomator v. 10.5beta, date 2023-07-14
2023-07-14 19:31:22 : INFO  : morisawadesktopmanager : ################## Version: 10.5beta
2023-07-14 19:31:22 : INFO  : morisawadesktopmanager : ################## Date: 2023-07-14
2023-07-14 19:31:22 : INFO  : morisawadesktopmanager : ################## morisawadesktopmanager
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : DEBUG mode 1 enabled.
2023-07-14 19:31:22 : INFO  : morisawadesktopmanager : setting variable from argument DEBUG=1
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : name=Morisawa Desktop Manager
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : appName=
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : type=pkgInDmg
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : archiveName=
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : downloadURL=https://morisawafonts.com/resources/dm/1.4.0/mac/site/MorisawaDesktopManager_1.4.0.dmg
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : curlOptions=
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : appNewVersion=1.4.0
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : appCustomVersion function: Not defined
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : versionKey=CFBundleShortVersionString
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : packageID=jp.co.morisawa.MorisawaDesktopManager.Installer
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : pkgName=
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : choiceChangesXML=
2023-07-14 19:31:22 : DEBUG : morisawadesktopmanager : expectedTeamID=662PVPVA3N
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : blockingProcesses=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : installerTool=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : CLIInstaller=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : CLIArguments=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : updateTool=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : updateToolArguments=
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : updateToolRunAsCurrentUser=
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : BLOCKING_PROCESS_ACTION=tell_user
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : NOTIFY=success
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : LOGGING=DEBUG
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Label type: pkgInDmg
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : archiveName: Morisawa Desktop Manager.dmg
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : no blocking processes defined, using Morisawa Desktop Manager as default
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : found packageID jp.co.morisawa.MorisawaDesktopManager.Installer installed, version 1.3.0
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : appversion: 1.3.0
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Latest version of Morisawa Desktop Manager is 1.4.0
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Morisawa Desktop Manager.dmg exists and DEBUG mode 1 enabled, skipping download
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : DEBUG mode 1, not checking for blocking processes
2023-07-14 19:31:23 : REQ   : morisawadesktopmanager : Installing Morisawa Desktop Manager
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Mounting /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build/Morisawa Desktop Manager.dmg
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : Debugging enabled, dmgmount output was:
期待される結果 CRC32 $63A86478
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Morisawa Desktop Manager

2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Mounted: /Volumes/Morisawa Desktop Manager
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : Found pkg(s):
/Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : found pkg: /Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg
2023-07-14 19:31:23 : INFO  : morisawadesktopmanager : Verifying: /Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg
2023-07-14 19:31:23 : DEBUG : morisawadesktopmanager : File list: -rw-r--r--  1 kenchan0130  staff   138M  5  8 18:32 /Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg
2023-07-14 19:31:24 : DEBUG : morisawadesktopmanager : File type: /Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg: xar archive compressed TOC: 5428, SHA-1 checksum
2023-07-14 19:31:24 : DEBUG : morisawadesktopmanager : spctlOut is /Volumes/Morisawa Desktop Manager/Morisawa Desktop Manager.pkg: accepted
2023-07-14 19:31:24 : DEBUG : morisawadesktopmanager : source=Notarized Developer ID
2023-07-14 19:31:24 : DEBUG : morisawadesktopmanager : origin=Developer ID Installer: Morisawa Inc. (662PVPVA3N)
2023-07-14 19:31:24 : INFO  : morisawadesktopmanager : Team ID: 662PVPVA3N (expected: 662PVPVA3N )
2023-07-14 19:31:24 : INFO  : morisawadesktopmanager : Checking package version.
2023-07-14 19:31:25 : INFO  : morisawadesktopmanager : Downloaded package jp.co.morisawa.MorisawaDesktopManager.Installer version 1.4.0
2023-07-14 19:31:25 : DEBUG : morisawadesktopmanager : DEBUG enabled, skipping installation
2023-07-14 19:31:26 : INFO  : morisawadesktopmanager : Finishing...
2023-07-14 19:31:29 : INFO  : morisawadesktopmanager : found packageID jp.co.morisawa.MorisawaDesktopManager.Installer installed, version 1.3.0
2023-07-14 19:31:29 : REQ   : morisawadesktopmanager : Installed Morisawa Desktop Manager, version 1.4.0
2023-07-14 19:31:29 : INFO  : morisawadesktopmanager : notifying
2023-07-14 19:31:29 : DEBUG : morisawadesktopmanager : Unmounting /Volumes/Morisawa Desktop Manager
2023-07-14 19:31:29 : DEBUG : morisawadesktopmanager : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-14 19:31:29 : DEBUG : morisawadesktopmanager : DEBUG mode 1, not reopening anything
2023-07-14 19:31:29 : REQ   : morisawadesktopmanager : All done!
2023-07-14 19:31:29 : REQ   : morisawadesktopmanager : ################## End Installomator, exit code 0
```