### PR TITLE
Updated Label: GraphPad Prism 9

### DIFF
--- a/fragments/labels/prism9.sh
+++ b/fragments/labels/prism9.sh
@@ -2,6 +2,6 @@ prism9)
     name="Prism 9"
     type="dmg"
     downloadURL="https://cdn.graphpad.com/downloads/prism/9/InstallPrism9.dmg"
-    appNewVersion=$(curl -fs "https://www.graphpad.com/updates" | grep -Eio 'The latest Prism version is.*' | cut -d "(" -f 1 | awk -F '<!-- --> <!-- -->' '{print $2}' | cut -d "<" -f 1)
+    appNewVersion="9.5.1"
     expectedTeamID="YQ2D36NS9M"
     ;;


### PR DESCRIPTION
GraphPad Prism 10 has been released (https://www.graphpad.com/updates/prism-1000-release-notes) and this has caused the current appNewVersion variable for the GraphPad Prism 9 label to show version 10.0.0 as the latest version, which is a new major version. It's unlikely that Prism 9 will receive any more updates so I've changed the appNewVersion label to statically be the last released version of Prism 9 (9.5.1) and also created a PR for a Prism 10 label (#1140).