### PR TITLE
New Label: Adobe Digital Editions

### DIFF
--- a/fragments/labels/adobedigitaleditions.sh
+++ b/fragments/labels/adobedigitaleditions.sh
@@ -1,0 +1,7 @@
+adobedigitaleditions)
+    name="Adobe Digital Editions"
+    type="pkgInDmg"
+    downloadURL=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep dmg | sed -n 's/.*href="\([^"]*\)".*/\1/p')
+    appNewVersion=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep -o 'Adobe Digital Editions.*Installers' | awk -F' ' '{ print $4 }')
+    expectedTeamID="JQ525L2MZD"
+    ;;


### PR DESCRIPTION
2023-07-18 09:23:37 : REQ   : adobedigitaleditions : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : ################## Version: 10.4
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : ################## Date: 2023-06-02
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : ################## adobedigitaleditions
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : SwiftDialog is not installed, clear cmd file var
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : BLOCKING_PROCESS_ACTION=tell_user
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : NOTIFY=success
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : LOGGING=INFO
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : Label type: pkgInDmg
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : archiveName: Adobe Digital Editions.dmg
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : no blocking processes defined, using Adobe Digital Editions as default
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : name: Adobe Digital Editions, appName: Adobe Digital Editions.app
2023-07-18 09:23:37.711 mdfind[13493:217561] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-07-18 09:23:37.711 mdfind[13493:217561] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-07-18 09:23:37.751 mdfind[13493:217561] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-18 09:23:37 : WARN  : adobedigitaleditions : No previous app found
2023-07-18 09:23:37 : WARN  : adobedigitaleditions : could not find Adobe Digital Editions.app
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : appversion:
2023-07-18 09:23:37 : INFO  : adobedigitaleditions : Latest version of Adobe Digital Editions is 4.5.12
2023-07-18 09:23:37 : REQ   : adobedigitaleditions : Downloading https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.dmg to Adobe Digital Editions.dmg
2023-07-18 09:23:38 : REQ   : adobedigitaleditions : no more blocking processes, continue with update
2023-07-18 09:23:38 : REQ   : adobedigitaleditions : Installing Adobe Digital Editions
2023-07-18 09:23:38 : INFO  : adobedigitaleditions : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OzieMzsZ/Adobe Digital Editions.dmg
2023-07-18 09:23:43 : INFO  : adobedigitaleditions : Mounted: /Volumes/ADE 4.5 1
2023-07-18 09:23:43 : INFO  : adobedigitaleditions : found pkg: /Volumes/ADE 4.5 1/Digital Editions 4.5 Installer.pkg
2023-07-18 09:23:43 : INFO  : adobedigitaleditions : Verifying: /Volumes/ADE 4.5 1/Digital Editions 4.5 Installer.pkg
2023-07-18 09:23:43 : INFO  : adobedigitaleditions : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2023-07-18 09:23:43 : INFO  : adobedigitaleditions : Installing /Volumes/ADE 4.5 1/Digital Editions 4.5 Installer.pkg to /
2023-07-18 09:23:58 : INFO  : adobedigitaleditions : Finishing...
2023-07-18 09:24:01 : INFO  : adobedigitaleditions : App(s) found: /Applications/Adobe Digital Editions.app
2023-07-18 09:24:01 : INFO  : adobedigitaleditions : found app at /Applications/Adobe Digital Editions.app, version 4.5.12, on versionKey CFBundleShortVersionString
2023-07-18 09:24:01 : REQ   : adobedigitaleditions : Installed Adobe Digital Editions, version 4.5.12
2023-07-18 09:24:01 : INFO  : adobedigitaleditions : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-07-18 09:24:01 : INFO  : adobedigitaleditions : App not closed, so no reopen.
2023-07-18 09:24:01 : REQ   : adobedigitaleditions : All done!
2023-07-18 09:24:01 : REQ   : adobedigitaleditions : ################## End Installomator, exit code 0