### PR TITLE
Update dropbox.sh label

### DIFF
--- a/fragments/labels/dropbox.sh
+++ b/fragments/labels/dropbox.sh
@@ -1,7 +1,12 @@
 dropbox)
     name="Dropbox"
     type="dmg"
-    downloadURL="https://www.dropbox.com/download?plat=mac&full=1"
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^location" | sed -E 's/.*%20([0-9.]*)\.dmg/\1/g')
+    if [[ $(arch) == "arm64" ]]; then
+       downloadURL="https://www.dropbox.com/download?plat=mac&type=full&arch=arm64"
+       appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^location" | sed -E 's/.*%20([0-9.]*).\arm64\.dmg/\1/g')
+    elif [[ $(arch) == "x86_64" ]]; then
+       downloadURL="https://www.dropbox.com/download?plat=mac&type=full&arch=intel"
+       appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^location" | sed -E 's/.*%20([0-9.]*)\.dmg/\1/g')
+    fi
     expectedTeamID="G7HH3F8CAK"
     ;;


### PR DESCRIPTION
Adds support for Apple Silicon installer that can be downloaded with a ?arch={arm64|intel}, depending on the device.

I specified x86_64 versus i386, if this is incorrect do let me know. 

