### PR TITLE
Updated Label: Inkscape

### DIFF
--- a/fragments/labels/inkscape.sh
+++ b/fragments/labels/inkscape.sh
@@ -1,13 +1,12 @@
 inkscape)
-    # credit: Søren Theilgaard (@theilgaard)
     name="Inkscape"
     type="dmg"
     appCustomVersion() { /Applications/Inkscape.app/Contents/MacOS/inkscape --version | cut -d " " -f2 }
-    appNewVersion=$(curl -fsJL https://inkscape.org/release/  | grep "<title>" | grep -o -e "[0-9.]*")
+    appNewVersion=$(curl -fsL https://inkscape.org/release/  | grep "<title>" | grep -o -e "[0-9.]*")
     if [[ $(arch) == arm64 ]]; then
-        downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-"$appNewVersion"_arm64.dmg
+        downloadURL="https://media.inkscape.org/dl/resources/file/$(curl -fsL https://inkscape.org/release/inkscape-{$appNewVersion}/mac-os-x/dmg-arm64/dl/ | grep -o -m1 "Inkscape-.*.dmg")"
     elif [[ $(arch) == i386 ]]; then
-        downloadURL=https://media.inkscape.org/dl/resources/file/Inkscape-"$appNewVersion"_x86_64.dmg
+        downloadURL="https://media.inkscape.org/dl/resources/file/$(curl -fsL https://inkscape.org/release/inkscape-{$appNewVersion}/mac-os-x/dmg/dl/ | grep -o -m1 "Inkscape-.*.dmg")"
     fi
     expectedTeamID="SW3D6BB6A6"
     ;;


### PR DESCRIPTION
The current version on the Inkscape website is mentioned as version "1.3" while the filename of the dmg contains version "1.3.0". The current label is trying to download Inkscape-1.3_arm64.dmg instead of Inkscape-1.3.0_arm64.dmg so the download URL does currently not work. This updated label fixes this problem.

2023-07-24 12:04:09 : REQ   : inkscape : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-24 12:04:09 : INFO  : inkscape : ################## Version: 10.4
2023-07-24 12:04:09 : INFO  : inkscape : ################## Date: 2023-06-02
2023-07-24 12:04:09 : INFO  : inkscape : ################## inkscape
2023-07-24 12:04:09 : INFO  : inkscape : SwiftDialog is not installed, clear cmd file var
2023-07-24 12:04:11 : INFO  : inkscape : BLOCKING_PROCESS_ACTION=tell_user
2023-07-24 12:04:11 : INFO  : inkscape : NOTIFY=success
2023-07-24 12:04:11 : INFO  : inkscape : LOGGING=INFO
2023-07-24 12:04:11 : INFO  : inkscape : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-24 12:04:11 : INFO  : inkscape : Label type: dmg
2023-07-24 12:04:11 : INFO  : inkscape : archiveName: Inkscape.dmg
2023-07-24 12:04:11 : INFO  : inkscape : no blocking processes defined, using Inkscape as default
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2023-07-24 12:04:11 : INFO  : inkscape : Custom App Version detection is used, found 
2023-07-24 12:04:11 : INFO  : inkscape : appversion: 
2023-07-24 12:04:12 : INFO  : inkscape : Latest version of Inkscape is 1.3
2023-07-24 12:04:12 : REQ   : inkscape : Downloading https://media.inkscape.org/dl/resources/file/Inkscape-1.3.0_arm64.dmg to Inkscape.dmg
2023-07-24 12:04:13 : REQ   : inkscape : no more blocking processes, continue with update
2023-07-24 12:04:13 : REQ   : inkscape : Installing Inkscape
2023-07-24 12:04:13 : INFO  : inkscape : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WhbWMT7I/Inkscape.dmg
2023-07-24 12:04:25 : INFO  : inkscape : Mounted: /Volumes/Inkscape 1
2023-07-24 12:04:25 : INFO  : inkscape : Verifying: /Volumes/Inkscape 1/Inkscape.app
2023-07-24 12:04:38 : INFO  : inkscape : Team ID matching: SW3D6BB6A6 (expected: SW3D6BB6A6 )
2023-07-24 12:04:38 : INFO  : inkscape : Installing Inkscape version 1.3.0 on versionKey CFBundleShortVersionString.
2023-07-24 12:04:39 : INFO  : inkscape : App has LSMinimumSystemVersion: 11.3
2023-07-24 12:04:39 : INFO  : inkscape : Copy /Volumes/Inkscape 1/Inkscape.app to /Applications
2023-07-24 12:05:07 : WARN  : inkscape : Changing owner to kryptonit
2023-07-24 12:05:08 : INFO  : inkscape : Finishing...
2023-07-24 12:05:16 : INFO  : inkscape : Custom App Version detection is used, found 1.3
2023-07-24 12:05:16 : REQ   : inkscape : Installed Inkscape, version 1.3.0
2023-07-24 12:05:16 : INFO  : inkscape : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-07-24 12:05:16 : INFO  : inkscape : App not closed, so no reopen.
2023-07-24 12:05:16 : REQ   : inkscape : All done!
2023-07-24 12:05:16 : REQ   : inkscape : ################## End Installomator, exit code 0 