### PR TITLE
New Label: Sassafras KeyAccess client for AllSight (formerly KeyServer)

### DIFF
--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -6,8 +6,9 @@ keyaccess)
     appNewVersion="$(echo "$downloadStore" | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
     expectedTeamID="7Z2KSDFMVY"
     BLOCKING_PROCESS_ACTION=ignore
+    blockingProcesses=( NONE )
     # Application is not installed in /Applications
-    targetDir="/Library/KeyAccess"
+    appName="Library/KeyAccess/KeyAccess.app"
     # Allowing for setting host as it is the only setting required for a fresh install.
     if [[ -n $keyaccessHost ]]; then
         defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,2 +1,11 @@
 keyaccess)
-  
+    name="KeyAccess"
+    type="pkg"
+    downloadPAGE="http://www.sassafras.com/client-download/"
+    downloadURL="$(curl -s "$downloadPAGE" | tr '>' '\n' | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
+    appNewVersion="$(curl -s "$downloadPAGE" | tr '>' '\n' | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
+    expectedTeamID="7Z2KSDFMVY"
+    blockingProcesses=( NONE )
+    # Application is not installed in /Applications
+    targetDir="/Library/KeyAccess"
+    ;;

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -8,4 +8,8 @@ keyaccess)
     blockingProcesses=( NONE )
     # Application is not installed in /Applications
     targetDir="/Library/KeyAccess"
+    # Allowing for setting host as it is the only setting required for a fresh install.
+    if [[ -n $keyaccessHost ]]; then
+        defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"
+    fi
     ;;

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,0 +1,2 @@
+keyaccess)
+  

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -5,7 +5,7 @@ keyaccess)
     downloadURL="$(echo "$downloadStore" | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
     appNewVersion="$(echo "$downloadStore" | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
     expectedTeamID="7Z2KSDFMVY"
-    blockingProcesses=( NONE )
+    BLOCKING_PROCESS_ACTION=ignore
     # Application is not installed in /Applications
     targetDir="/Library/KeyAccess"
     # Allowing for setting host as it is the only setting required for a fresh install.

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,9 +1,9 @@
 keyaccess)
     name="KeyAccess"
     type="pkg"
-    downloadPAGE="http://www.sassafras.com/client-download/"
-    downloadURL="$(curl -s "$downloadPAGE" | tr '>' '\n' | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
-    appNewVersion="$(curl -s "$downloadPAGE" | tr '>' '\n' | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
+    downloadStore="$(curl -s "http://www.sassafras.com/client-download/" | tr '>' '\n')"
+    downloadURL="$(echo "$downloadStore" | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
+    appNewVersion="$(echo "$downloadStore" | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
     expectedTeamID="7Z2KSDFMVY"
     blockingProcesses=( NONE )
     # Application is not installed in /Applications


### PR DESCRIPTION
Adding a label for the KeyAccess client, as they now have a cloud hosted option (and we are in the process of moving ours from hosted to cloud).

(Sorry for the repost, removed the , from the branch name without realising it would close the pull request.)