### PR TITLE
New label: VMware Fusion

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -600,6 +600,7 @@ visualstudiocode
 vivaldi
 vlc
 vmwarehorizonclient
+vmwarefusion
 vonagebusiness
 vpntracker365
 vscodium

--- a/fragments/labels/vmwarefusion.sh
+++ b/fragments/labels/vmwarefusion.sh
@@ -1,0 +1,8 @@
+vmwarefusion)
+    name="VMware Fusion"
+    type="dmg"
+    downloadURL="https://www.vmware.com/go/getfusion"
+    curlOptions=(-H "Accept: */*" -H "Accept-Encoding: gzip, deflate" -H "Connection: keep-alive" -H "Host: www.vmware.com" -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15")
+    appNewVersion=$(curl -fsIL ${curlOptions} "https://www.vmware.com/go/getfusion" | grep -i "^location" | awk '{print $2}' | sed 's/.*-\(.*\)-.*/\1/')
+    expectedTeamID="EG7KH642X6"
+    ;;


### PR DESCRIPTION
Add the universal build of VMware Fusion

```
# sudo ./Installomator.sh vmwarefusion DEBUG=1 NOTIFY=success                                                                                                                          

2023-07-25 15:39:47 : REQ   : vmwarefusion : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-25 15:39:47 : INFO  : vmwarefusion : ################## Version: 10.4
2023-07-25 15:39:47 : INFO  : vmwarefusion : ################## Date: 2023-06-02
2023-07-25 15:39:47 : INFO  : vmwarefusion : ################## vmwarefusion
2023-07-25 15:39:47 : DEBUG : vmwarefusion : DEBUG mode 1 enabled.
2023-07-25 15:39:48 : INFO  : vmwarefusion : setting variable from argument DEBUG=1
2023-07-25 15:39:48 : INFO  : vmwarefusion : setting variable from argument NOTIFY=success
2023-07-25 15:39:48 : DEBUG : vmwarefusion : name=VMware Fusion
2023-07-25 15:39:48 : DEBUG : vmwarefusion : appName=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : type=dmg
2023-07-25 15:39:48 : DEBUG : vmwarefusion : archiveName=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : downloadURL=https://www.vmware.com/go/getfusion
2023-07-25 15:39:48 : DEBUG : vmwarefusion : curlOptions=-H Accept: */* -H Accept-Encoding: gzip, deflate -H Connection: keep-alive -H Host: www.vmware.com -H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
2023-07-25 15:39:48 : DEBUG : vmwarefusion : appNewVersion=13.0.2
2023-07-25 15:39:48 : DEBUG : vmwarefusion : appCustomVersion function: Not defined
2023-07-25 15:39:48 : DEBUG : vmwarefusion : versionKey=CFBundleShortVersionString
2023-07-25 15:39:48 : DEBUG : vmwarefusion : packageID=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : pkgName=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : choiceChangesXML=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : expectedTeamID=EG7KH642X6
2023-07-25 15:39:48 : DEBUG : vmwarefusion : blockingProcesses=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : installerTool=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : CLIInstaller=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : CLIArguments=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : updateTool=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : updateToolArguments=
2023-07-25 15:39:48 : DEBUG : vmwarefusion : updateToolRunAsCurrentUser=
2023-07-25 15:39:48 : INFO  : vmwarefusion : BLOCKING_PROCESS_ACTION=tell_user
2023-07-25 15:39:48 : INFO  : vmwarefusion : NOTIFY=success
2023-07-25 15:39:48 : INFO  : vmwarefusion : LOGGING=DEBUG
2023-07-25 15:39:48 : INFO  : vmwarefusion : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-25 15:39:48 : INFO  : vmwarefusion : Label type: dmg
2023-07-25 15:39:48 : INFO  : vmwarefusion : archiveName: VMware Fusion.dmg
2023-07-25 15:39:48 : INFO  : vmwarefusion : no blocking processes defined, using VMware Fusion as default
2023-07-25 15:39:48 : DEBUG : vmwarefusion : Changing directory to .
2023-07-25 15:39:48 : INFO  : vmwarefusion : name: VMware Fusion, appName: VMware Fusion.app
2023-07-25 15:39:48.421 mdfind[26190:350980] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-25 15:39:48.421 mdfind[26190:350980] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-25 15:39:48.489 mdfind[26190:350980] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-25 15:39:48 : WARN  : vmwarefusion : No previous app found
2023-07-25 15:39:48 : WARN  : vmwarefusion : could not find VMware Fusion.app
2023-07-25 15:39:48 : INFO  : vmwarefusion : appversion: 
2023-07-25 15:39:48 : INFO  : vmwarefusion : Latest version of VMware Fusion is 13.0.2
2023-07-25 15:39:48 : REQ   : vmwarefusion : Downloading https://www.vmware.com/go/getfusion to VMware Fusion.dmg
2023-07-25 15:39:48 : DEBUG : vmwarefusion : No Dialog connection, just download
2023-07-25 15:41:02 : DEBUG : vmwarefusion : File list: -rw-r--r--  1 root  staff   672M 25 Jul 15:41 VMware Fusion.dmg
2023-07-25 15:41:02 : DEBUG : vmwarefusion : File type: VMware Fusion.dmg: zlib compressed data
2023-07-25 15:41:02 : DEBUG : vmwarefusion : curl output was:
*   Trying 23.215.120.25:443...
* Connected to www.vmware.com (23.215.120.25) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2959 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Palo Alto; O=VMware, Inc.; CN=*.vmware.com
*  start date: Mar 25 00:00:00 2023 GMT
*  expire date: Mar 27 23:59:59 2024 GMT
*  subjectAltName: host "www.vmware.com" matched cert's "*.vmware.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: www.vmware.com]
* h2 [:path: /go/getfusion]
* h2 [accept: */*]
* h2 [accept-encoding: gzip, deflate]
* h2 [user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15]
* Using Stream ID: 1 (easy handle 0x14d811400)
> GET /go/getfusion HTTP/2
> Host: www.vmware.com
> Accept: */*
> Accept-Encoding: gzip, deflate
> Connection: keep-alive
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
> 
< HTTP/2 302 
< content-type: text/html; charset=UTF-8
< content-length: 0
< server: Apache
< dc-pool-id: p3tx622k
< x-powered-by: PHP/7.3.26
< location: https://download3.vmware.com/software/FUS-1302/VMware-Fusion-13.0.2-21581413_universal.dmg
< date: Tue, 25 Jul 2023 13:39:48 GMT
< set-cookie: AVI_COOKIE=02ff22dd16-71ca-41fQ9eLd_EQiScxWP7-VOFAkeXF1slco5FhiLpu_dTsWzzvhkBNavKEWMNAYQnnzhh5Q8; path=/; Secure
< set-cookie: myvmware-www=02d02dc99a-4b61-4b3Zs-W4NrMX2SYjsaDsvQrXkolY1AIPaX1rnxumGtcvQEmNhOWQSjE9Wtcu9ouVpbCEk; path=/; SameSite=None; Secure
< server-timing: cdn-cache; desc=MISS
< server-timing: edge; dur=149
< server-timing: origin; dur=137
< content-security-policy: frame-ancestors 'self' https://*.vmware.com;
< x-frame-options: DENY
< set-cookie: _abck=4C4313E149FAFFA4777D570AC95F8E73~-1~YAAQRFATAm67VXmJAQAAQwRHjQrOPqIK231xDbSxTkSzIOXF4rgy0zZ8RtRvABTAnPU9VAgKJWgB7dAck8DO3Oo9/FYrgTCpHvgUElirWEhCstDDR2tZuG/0SaG4wUw5im55avO+5JQNuinc+K7nxtPhIQiFu9L52UsFuOXy69CkjsiX4A4g81NHWobBgsFn7LD8l93N5gdRovIdcPOrWt8BRZKVOFl1W5Lg4kBFqb8xKF9PzIIlVZyJ+fZ5gc6F8vpnjbpX7a3PYO0RXwVKTECMKAcLLTiwTzkyrsA2v9GWLd5wc/3/IOtMMJ/def7pJgGHkm+BdekyKJdyEj97NQiZcVkYjdiNqgfHwltXovbmjskLuktdssZn2TpQ~-1~-1~-1; Domain=.vmware.com; Path=/; Expires=Wed, 24 Jul 2024 13:39:48 GMT; Max-Age=31536000; Secure
< set-cookie: ak_bmsc=3E66F0D8B188F93E8566E6A03D4C0417~000000000000000000000000000000~YAAQRFATAm+7VXmJAQAAQwRHjRQQTFWkIV8xTxv0W+LjvzHSIuE4MtlMEiWgLBt5mrzV4C2DfF9mleOFF3Qn5pDHdqyg0Cv1J3Qv8YNPL13efjiPrd18l4w1U+0zqQAfRFS4SrG2Hh+Dut00JB4KiYMu/U7qXTFBiAHGPigp6j1+YV158gOSOwX+imy95xBLDeVfSKfA10b6WvLncs5OR8tXKMh5LpctKmVmB1/1/MzAAQljbOYQg3TriT4s2qBZnrnsdYDIlZ4BJIMpDmABmE1r4bjll9GNEPz0i9FN56kKJau9EkYRg0jpeRb3g6YMLcLPQ9vphsn3zxFV1mRRv5F5DqAYjPPDH97rzXZX7ktlaApA7skx8aMX+gsMg9kLOjeqSR/opsNxTEE=; Domain=.vmware.com; Path=/; Expires=Tue, 25 Jul 2023 15:39:48 GMT; Max-Age=7200; HttpOnly
< set-cookie: bm_sz=2B153ED6582D1EA3F30542814ECBFA22~YAAQRFATAnC7VXmJAQAAQwRHjRSykhIe6HaAdefI/3aUWu1Xpa2ZahHI3G7NoM+jdc1SUZEFeM75WAgwQsasiKNp9AHd1lgCNl0WZ0wxRurTHsuX6yToSz8G2rA8gg8mmhnL39mQ4DX8R4rGO+ac2Pd9J9KIjdCVxqbJF0It4llk7b6LRmzLwfmcCwCFVUH48FRe9sr3pCAQX8HDaw45VJKIZ7AfA1Xo1916Gd1587nA5je7bzZtBFGKZeaSUJ2Bcz5bjcrehY6bifdaX3QKeE+XbkfB05ZcMKs2C8Rye1+Oaxg=~3360070~4605238; Domain=.vmware.com; Path=/; Expires=Tue, 25 Jul 2023 17:39:48 GMT; Max-Age=14400
< server-timing: ak_p; desc="469525_34820164_161655225_28542_7959_16_0_15";dur=1
< 
{ [0 bytes data]
* Connection #0 to host www.vmware.com left intact
* Issue another request to this URL: 'https://download3.vmware.com/software/FUS-1302/VMware-Fusion-13.0.2-21581413_universal.dmg'
*   Trying 23.35.236.25:443...
* Connected to download3.vmware.com (23.35.236.25) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2959 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Palo Alto; O=VMware, Inc.; CN=*.vmware.com
*  start date: Mar 25 00:00:00 2023 GMT
*  expire date: Mar 27 23:59:59 2024 GMT
*  subjectAltName: host "download3.vmware.com" matched cert's "*.vmware.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /software/FUS-1302/VMware-Fusion-13.0.2-21581413_universal.dmg HTTP/1.1
> Host: download3.vmware.com
> Accept: */*
> Accept-Encoding: gzip, deflate
> Connection: keep-alive
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
> 
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Server: AkamaiNetStorage
< X-EdgeConnect-Cache-Status: 1
< Last-Modified: Mon, 17 Apr 2023 18:18:16 GMT
< ETag: "09ad98ba511caeede47e9aae37b9bdf2:1681755447.123955"
< Content-MD5: Ca2YulEcru3kfpquN7m98g==
< Content-Length: 704732960
< Date: Tue, 25 Jul 2023 13:39:49 GMT
< Connection: keep-alive
< content-disposition: attachment; filename="VMware-Fusion-13.0.2-21581413_universal.dmg"
< Content-Type: application/x-octet-stream
< 
{ [1300 bytes data]
* Connection #1 to host download3.vmware.com left intact

2023-07-25 15:41:03 : DEBUG : vmwarefusion : DEBUG mode 1, not checking for blocking processes
2023-07-25 15:41:03 : REQ   : vmwarefusion : Installing VMware Fusion
2023-07-25 15:41:03 : INFO  : vmwarefusion : Mounting ./VMware Fusion.dmg
2023-07-25 15:41:09 : DEBUG : vmwarefusion : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $9DD229C7
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $6E3071F9
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $6D14FEFC
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $64149514
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $6D14FEFC
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $A0C5C454
Die überprüfte CRC32-Prüfsumme ist $D786281F
/dev/disk6              GUID_partition_scheme
/dev/disk6s1            Apple_HFS                       /Volumes/VMware Fusion

2023-07-25 15:41:09 : INFO  : vmwarefusion : Mounted: /Volumes/VMware Fusion
2023-07-25 15:41:09 : INFO  : vmwarefusion : Verifying: /Volumes/VMware Fusion/VMware Fusion.app
2023-07-25 15:41:09 : DEBUG : vmwarefusion : App size: 1,3G     /Volumes/VMware Fusion/VMware Fusion.app
2023-07-25 15:41:14 : DEBUG : vmwarefusion : Debugging enabled, App Verification output was:
/Volumes/VMware Fusion/VMware Fusion.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: VMware, Inc. (EG7KH642X6)

2023-07-25 15:41:14 : INFO  : vmwarefusion : Team ID matching: EG7KH642X6 (expected: EG7KH642X6 )
2023-07-25 15:41:14 : INFO  : vmwarefusion : Installing VMware Fusion version 13.0.2 on versionKey CFBundleShortVersionString.
2023-07-25 15:41:14 : INFO  : vmwarefusion : App has LSMinimumSystemVersion: 11.00.0
2023-07-25 15:41:14 : DEBUG : vmwarefusion : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-07-25 15:41:14 : INFO  : vmwarefusion : Finishing...
2023-07-25 15:41:17 : INFO  : vmwarefusion : name: VMware Fusion, appName: VMware Fusion.app
2023-07-25 15:41:17.737 mdfind[26340:352103] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-25 15:41:17.738 mdfind[26340:352103] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-25 15:41:17.811 mdfind[26340:352103] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-25 15:41:17 : WARN  : vmwarefusion : No previous app found
2023-07-25 15:41:17 : WARN  : vmwarefusion : could not find VMware Fusion.app
2023-07-25 15:41:17 : REQ   : vmwarefusion : Installed VMware Fusion, version 13.0.2
2023-07-25 15:41:17 : INFO  : vmwarefusion : notifying
2023-07-25 15:41:17 : DEBUG : vmwarefusion : Unmounting /Volumes/VMware Fusion
2023-07-25 15:41:18 : DEBUG : vmwarefusion : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-07-25 15:41:18 : DEBUG : vmwarefusion : DEBUG mode 1, not reopening anything
2023-07-25 15:41:18 : REQ   : vmwarefusion : All done!
2023-07-25 15:41:18 : REQ   : vmwarefusion : ################## End Installomator, exit code 0 
```