### PR TITLE
Add Label: Burp Suite Professional and Community Edition

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -89,6 +89,7 @@ bracketsio
 brave
 brosix
 bugdom
+burpsuiteprofessional
 caffeine
 cakebrew
 calcservice

--- a/Labels.txt
+++ b/Labels.txt
@@ -90,6 +90,7 @@ brave
 brosix
 bugdom
 burpsuiteprofessional
+burpsuitecommunityedition
 caffeine
 cakebrew
 calcservice

--- a/fragments/labels/burpsuitecommunityedition.sh
+++ b/fragments/labels/burpsuitecommunityedition.sh
@@ -4,10 +4,8 @@ burpsuitecommunityedition)
     appNewVersion=$(curl -s https://portswigger.net/burp/releases | grep 'releases/professional-community' | head -n 1 | sed 's/.*href="//' | sed 's/".*//' | cut -d '/' -f4 | cut -d '-' -f3-6 | sed -r 's/-/./g')
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://portswigger.net/burp/releases/startdownload/?product=community&version&="$appNewVersion"&type=macosarm64"
-        echo $downloadURL
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://portswigger.net/burp/releases/startdownload/?product=community&version&="$appNewVersion"&type=macosx"
-        echo $downloadURL
     fi
     expectedTeamID="N82YM748DZ"
     ;;

--- a/fragments/labels/burpsuitecommunityedition.sh
+++ b/fragments/labels/burpsuitecommunityedition.sh
@@ -1,0 +1,13 @@
+burpsuitecommunityedition)
+    name="Burp Suite Community Edition"
+    type="dmg"
+    appNewVersion=$(curl -s https://portswigger.net/burp/releases | grep 'releases/professional-community' | head -n 1 | sed 's/.*href="//' | sed 's/".*//' | cut -d '/' -f4 | cut -d '-' -f3-6 | sed -r 's/-/./g')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://portswigger.net/burp/releases/startdownload/?product=community&version&="$appNewVersion"&type=macosarm64"
+        echo $downloadURL
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://portswigger.net/burp/releases/startdownload/?product=community&version&="$appNewVersion"&type=macosx"
+        echo $downloadURL
+    fi
+    expectedTeamID="N82YM748DZ"
+    ;;

--- a/fragments/labels/burpsuiteprofessional.sh
+++ b/fragments/labels/burpsuiteprofessional.sh
@@ -4,10 +4,8 @@ burpsuiteprofessional)
     appNewVersion=$(curl -s https://portswigger.net/burp/releases | grep 'releases/professional-community' | head -n 1 | sed 's/.*href="//' | sed 's/".*//' | cut -d '/' -f4 | cut -d '-' -f3-6 | sed -r 's/-/./g')
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://portswigger.net/burp/releases/startdownload/?product=pro&version&="$appNewVersion"&type=macosarm64"
-        echo $downloadURL
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://portswigger.net/burp/releases/startdownload/?product=pro&version&="$appNewVersion"&type=macosx"
-        echo $downloadURL
     fi
     expectedTeamID="N82YM748DZ"
     ;;

--- a/fragments/labels/burpsuiteprofessional.sh
+++ b/fragments/labels/burpsuiteprofessional.sh
@@ -1,0 +1,13 @@
+burpsuiteprofessional)
+    name="Burp Suite Professional"
+    type="dmg"
+    appNewVersion=$(curl -s https://portswigger.net/burp/releases | grep 'releases/professional-community' | head -n 1 | sed 's/.*href="//' | sed 's/".*//' | cut -d '/' -f4 | cut -d '-' -f3-6 | sed -r 's/-/./g')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://portswigger.net/burp/releases/startdownload/?product=pro&version&="$appNewVersion"&type=macosarm64"
+        echo $downloadURL
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://portswigger.net/burp/releases/startdownload/?product=pro&version&="$appNewVersion"&type=macosx"
+        echo $downloadURL
+    fi
+    expectedTeamID="N82YM748DZ"
+    ;;


### PR DESCRIPTION
Basically both labels are the same, just the download argument is different.

```
# sudo ./Installomator.sh burpsuiteprofessional DEBUG=0 NOTIFY=success

2023-07-26 15:54:06 : REQ   : burpsuiteprofessional : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : ################## Version: 10.4
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : ################## Date: 2023-06-02
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : ################## burpsuiteprofessional
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : DEBUG mode 1 enabled.
https://portswigger.net/burp/releases/startdownload/?product=pro&version&=2023.7.1&type=macosarm64
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : setting variable from argument DEBUG=0
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : setting variable from argument NOTIFY=success
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : name=Burp Suite Professional
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : appName=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : type=dmg
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : archiveName=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : downloadURL=https://portswigger.net/burp/releases/startdownload/?product=pro&version&=2023.7.1&type=macosarm64
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : curlOptions=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : appNewVersion=2023.7.1
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : appCustomVersion function: Not defined
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : versionKey=CFBundleShortVersionString
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : packageID=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : pkgName=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : choiceChangesXML=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : expectedTeamID=N82YM748DZ
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : blockingProcesses=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : installerTool=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : CLIInstaller=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : CLIArguments=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : updateTool=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : updateToolArguments=
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : updateToolRunAsCurrentUser=
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : BLOCKING_PROCESS_ACTION=tell_user
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : NOTIFY=success
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : LOGGING=DEBUG
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : Label type: dmg
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : archiveName: Burp Suite Professional.dmg
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : no blocking processes defined, using Burp Suite Professional as default
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tW3K0OZn
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : name: Burp Suite Professional, appName: Burp Suite Professional.app
2023-07-26 15:54:06.849 mdfind[66439:709260] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-26 15:54:06.850 mdfind[66439:709260] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-26 15:54:06.915 mdfind[66439:709260] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-26 15:54:06 : WARN  : burpsuiteprofessional : No previous app found
2023-07-26 15:54:06 : WARN  : burpsuiteprofessional : could not find Burp Suite Professional.app
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : appversion: 
2023-07-26 15:54:06 : INFO  : burpsuiteprofessional : Latest version of Burp Suite Professional is 2023.7.1
2023-07-26 15:54:06 : REQ   : burpsuiteprofessional : Downloading https://portswigger.net/burp/releases/startdownload/?product=pro&version&=2023.7.1&type=macosarm64 to Burp Suite Professional.dmg
2023-07-26 15:54:06 : DEBUG : burpsuiteprofessional : No Dialog connection, just download
2023-07-26 15:54:32 : DEBUG : burpsuiteprofessional : File list: -rw-r--r--  1 root  wheel   231M 26 Jul 15:54 Burp Suite Professional.dmg
2023-07-26 15:54:32 : DEBUG : burpsuiteprofessional : File type: Burp Suite Professional.dmg: zlib compressed data
2023-07-26 15:54:32 : DEBUG : burpsuiteprofessional : curl output was:
*   Trying 34.249.63.188:443...
* Connected to portswigger.net (34.249.63.188) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4946 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=portswigger.net
*  start date: Feb 13 00:00:00 2023 GMT
*  expire date: Oct 11 23:59:59 2023 GMT
*  subjectAltName: host "portswigger.net" matched cert's "portswigger.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger.net]
* h2 [:path: /burp/releases/startdownload/?product=pro&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15b812400)
> GET /burp/releases/startdownload/?product=pro&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 301 
< date: Wed, 26 Jul 2023 13:54:07 GMT
< server: Kestrel
< cache-control: no-store, no-cache, s-maxage=0, private
< location: https://portswigger.net/burp/releases/startdownload?product=pro&version&=2023.7.1&type=macosarm64
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< set-cookie: AWSALBAPP-0=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-1=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-2=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-3=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< 
{ [0 bytes data]
* Connection #0 to host portswigger.net left intact
* Issue another request to this URL: 'https://portswigger.net/burp/releases/startdownload?product=pro&version&=2023.7.1&type=macosarm64'
* Found bundle for host: 0x600003a40f90 [can multiplex]
* Re-using existing connection #0 with host portswigger.net
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger.net]
* h2 [:path: /burp/releases/startdownload?product=pro&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 3 (easy handle 0x15b812400)
> GET /burp/releases/startdownload?product=pro&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 302 
< date: Wed, 26 Jul 2023 13:54:07 GMT
< content-length: 0
< server: Kestrel
< cache-control: no-store, no-cache, s-maxage=0, private
< location: https://portswigger-cdn.net/burp/releases/download?product=pro&version&=2023.7.1&type=macosarm64
< set-cookie: SessionId=CfDJ8Irs0%2FGU6%2B1JiUpiJ2O2KqOsVvPEFqE%2Fft695PyxPXyAzuC%2BiRhWNyR31pcmSp8MKVMf5Hn3q46E7%2F%2FXZRC5bDlLIk0Mmu%2FcFx0gIWT1itZ6BIivYTOGHUaPFIF9hzWlamrxOz%2BDmu7JF%2F0EPDSLz3R%2FV1Gt15ASfUkDyXXsBy2B; max-age=43200; domain=.portswigger.net; path=/; secure; samesite=lax; httponly
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< content-security-policy: default-src 'none';base-uri 'none';child-src 'self' https://www.youtube.com/embed/;connect-src 'self' https://ps.containers.piwik.pro https://ps.piwik.pro https://www.google.com/recaptcha/;font-src 'self';frame-src 'self' https://www.youtube.com/embed/ https://www.google.com/recaptcha/;img-src 'self' data:;media-src 'self' https://d21v5rjx8s17cr.cloudfront.net/ https://d2gl1b374o3yzk.cloudfront.net/;script-src 'self' https://ps.containers.piwik.pro/ppms.js https://ps.piwik.pro/ppms.js 'nonce-jtcwLByMS0O6ICEe3ghBBV0JXMvAvTMy' 'strict-dynamic';style-src 'self';
< cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin
< set-cookie: AWSALBAPP-0=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-1=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-2=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< set-cookie: AWSALBAPP-3=_remove_; Expires=Wed, 02 Aug 2023 13:54:07 GMT; Path=/
< 
{ [0 bytes data]
* Connection #0 to host portswigger.net left intact
* Issue another request to this URL: 'https://portswigger-cdn.net/burp/releases/download?product=pro&version&=2023.7.1&type=macosarm64'
*   Trying 108.138.17.16:443...
* Connected to portswigger-cdn.net (108.138.17.16) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4988 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=portswigger-cdn.net
*  start date: Feb 23 00:00:00 2023 GMT
*  expire date: Dec  3 23:59:59 2023 GMT
*  subjectAltName: host "portswigger-cdn.net" matched cert's "portswigger-cdn.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger-cdn.net]
* h2 [:path: /burp/releases/download?product=pro&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15b812400)
> GET /burp/releases/download?product=pro&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger-cdn.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 242059998
< date: Wed, 26 Jul 2023 09:23:56 GMT
< server: Kestrel
< accept-ranges: bytes
< cache-control: max-age=31536000, no-cache="Set-Cookie"
< last-modified: Tue, 25 Jul 2023 11:44:39 GMT
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< content-security-policy: default-src 'none';base-uri 'none';child-src 'self' https://www.youtube.com/embed/;connect-src 'self' https://ps.containers.piwik.pro https://ps.piwik.pro https://www.google.com/recaptcha/;font-src 'self';frame-src 'self' https://www.youtube.com/embed/ https://www.google.com/recaptcha/;img-src 'self' data:;media-src 'self' https://d21v5rjx8s17cr.cloudfront.net/ https://d2gl1b374o3yzk.cloudfront.net/;script-src 'self' https://ps.containers.piwik.pro/ppms.js https://ps.piwik.pro/ppms.js 'nonce-jQc+uMsw2OP9x10N7nF4NYHAZNt2AyGq' 'strict-dynamic';style-src 'self';
< cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin
< x-ua-compatible: IE=EmulateIE7
< content-disposition: attachment; filename=burpsuite_pro_macos_arm64_v2023_7_1.dmg; filename*=UTF-8''burpsuite_pro_macos_arm64_v2023_7_1.dmg
< x-cache: Hit from cloudfront
< via: 1.1 6e5ec1ef7875ec0751cb61200df7f212.cloudfront.net (CloudFront)
< x-amz-cf-pop: FRA56-P7
< x-amz-cf-id: lxqgPn9ZEC80WJWyLckSQrLskIjcNW4RRZ7QHEWeIPzCnL4afSgUjg==
< age: 16211
< 
{ [15294 bytes data]
* Connection #1 to host portswigger-cdn.net left intact

2023-07-26 15:54:32 : REQ   : burpsuiteprofessional : no more blocking processes, continue with update
2023-07-26 15:54:32 : REQ   : burpsuiteprofessional : Installing Burp Suite Professional
2023-07-26 15:54:32 : INFO  : burpsuiteprofessional : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tW3K0OZn/Burp Suite Professional.dmg
2023-07-26 15:54:33 : DEBUG : burpsuiteprofessional : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $34301F01
Die überprüfte CRC32-Prüfsumme ist $C03B6B72
/dev/disk4              Apple_partition_scheme
/dev/disk4s1            Apple_partition_map
/dev/disk4s2            Apple_HFS                       /Volumes/BurpSuitePro

2023-07-26 15:54:33 : INFO  : burpsuiteprofessional : Mounted: /Volumes/BurpSuitePro
2023-07-26 15:54:33 : INFO  : burpsuiteprofessional : Verifying: /Volumes/BurpSuitePro/Burp Suite Professional.app
2023-07-26 15:54:33 : DEBUG : burpsuiteprofessional : App size: 435M    /Volumes/BurpSuitePro/Burp Suite Professional.app
2023-07-26 15:54:35 : DEBUG : burpsuiteprofessional : Debugging enabled, App Verification output was:
/Volumes/BurpSuitePro/Burp Suite Professional.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: PortSwigger Ltd (N82YM748DZ)

2023-07-26 15:54:35 : INFO  : burpsuiteprofessional : Team ID matching: N82YM748DZ (expected: N82YM748DZ )
2023-07-26 15:54:35 : INFO  : burpsuiteprofessional : Installing Burp Suite Professional version 2023.7.1 on versionKey CFBundleShortVersionString.
2023-07-26 15:54:35 : INFO  : burpsuiteprofessional : App has LSMinimumSystemVersion: 10.11
2023-07-26 15:54:35 : INFO  : burpsuiteprofessional : Copy /Volumes/BurpSuitePro/Burp Suite Professional.app to /Applications
2023-07-26 15:54:35 : DEBUG : burpsuiteprofessional : Debugging enabled, App copy output was:
Copying /Volumes/BurpSuitePro/Burp Suite Professional.app

2023-07-26 15:54:36 : WARN  : burpsuiteprofessional : Changing owner to stefan
2023-07-26 15:54:36 : INFO  : burpsuiteprofessional : Finishing...
2023-07-26 15:54:39 : INFO  : burpsuiteprofessional : App(s) found: /Applications/Burp Suite Professional.app
2023-07-26 15:54:39 : INFO  : burpsuiteprofessional : found app at /Applications/Burp Suite Professional.app, version 2023.7.1, on versionKey CFBundleShortVersionString
2023-07-26 15:54:39 : REQ   : burpsuiteprofessional : Installed Burp Suite Professional, version 2023.7.1
2023-07-26 15:54:39 : INFO  : burpsuiteprofessional : notifying
2023-07-26 15:54:39 : DEBUG : burpsuiteprofessional : Unmounting /Volumes/BurpSuitePro
2023-07-26 15:54:39 : DEBUG : burpsuiteprofessional : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-26 15:54:39 : DEBUG : burpsuiteprofessional : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tW3K0OZn
2023-07-26 15:54:39 : DEBUG : burpsuiteprofessional : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tW3K0OZn/Burp Suite Professional.dmg
2023-07-26 15:54:39 : DEBUG : burpsuiteprofessional : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tW3K0OZn
2023-07-26 15:54:39 : INFO  : burpsuiteprofessional : App not closed, so no reopen.
2023-07-26 15:54:39 : REQ   : burpsuiteprofessional : All done!
2023-07-26 15:54:39 : REQ   : burpsuiteprofessional : ################## End Installomator, exit code 0 
```

```
# sudo ./Installomator.sh burpsuitecommunityedition  DEBUG=0 NOTIFY=success

2023-07-26 15:25:12 : REQ   : burpsuitecommunityedition : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-26 15:25:12 : INFO  : burpsuitecommunityedition : ################## Version: 10.4
2023-07-26 15:25:12 : INFO  : burpsuitecommunityedition : ################## Date: 2023-06-02
2023-07-26 15:25:12 : INFO  : burpsuitecommunityedition : ################## burpsuitecommunityedition
2023-07-26 15:25:12 : DEBUG : burpsuitecommunityedition : DEBUG mode 1 enabled.
https://portswigger.net/burp/releases/startdownload/?product=community&version&=2023.7.1&type=macosarm64
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : setting variable from argument DEBUG=0
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : setting variable from argument NOTIFY=success
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : name=Burp Suite Community Edition
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : appName=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : type=dmg
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : archiveName=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : downloadURL=https://portswigger.net/burp/releases/startdownload/?product=community&version&=2023.7.1&type=macosarm64
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : curlOptions=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : appNewVersion=2023.7.1
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : appCustomVersion function: Not defined
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : versionKey=CFBundleShortVersionString
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : packageID=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : pkgName=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : choiceChangesXML=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : expectedTeamID=N82YM748DZ
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : blockingProcesses=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : installerTool=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : CLIInstaller=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : CLIArguments=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : updateTool=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : updateToolArguments=
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : updateToolRunAsCurrentUser=
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : BLOCKING_PROCESS_ACTION=tell_user
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : NOTIFY=success
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : LOGGING=DEBUG
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : Label type: dmg
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : archiveName: Burp Suite Community Edition.dmg
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : no blocking processes defined, using Burp Suite Community Edition as default
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2R6pZ7vq
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : name: Burp Suite Community Edition, appName: Burp Suite Community Edition.app
2023-07-26 15:25:13.477 mdfind[65280:695999] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-07-26 15:25:13.477 mdfind[65280:695999] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-07-26 15:25:13.547 mdfind[65280:695999] Couldn't determine the mapping between prefab keywords and predicates.
2023-07-26 15:25:13 : WARN  : burpsuitecommunityedition : No previous app found
2023-07-26 15:25:13 : WARN  : burpsuitecommunityedition : could not find Burp Suite Community Edition.app
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : appversion: 
2023-07-26 15:25:13 : INFO  : burpsuitecommunityedition : Latest version of Burp Suite Community Edition is 2023.7.1
2023-07-26 15:25:13 : REQ   : burpsuitecommunityedition : Downloading https://portswigger.net/burp/releases/startdownload/?product=community&version&=2023.7.1&type=macosarm64 to Burp Suite Community Edition.dmg
2023-07-26 15:25:13 : DEBUG : burpsuitecommunityedition : No Dialog connection, just download
2023-07-26 15:25:38 : DEBUG : burpsuitecommunityedition : File list: -rw-r--r--  1 root  wheel   227M 26 Jul 15:25 Burp Suite Community Edition.dmg
2023-07-26 15:25:38 : DEBUG : burpsuitecommunityedition : File type: Burp Suite Community Edition.dmg: zlib compressed data
2023-07-26 15:25:38 : DEBUG : burpsuitecommunityedition : curl output was:
*   Trying 34.249.63.188:443...
* Connected to portswigger.net (34.249.63.188) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4946 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=portswigger.net
*  start date: Feb 13 00:00:00 2023 GMT
*  expire date: Oct 11 23:59:59 2023 GMT
*  subjectAltName: host "portswigger.net" matched cert's "portswigger.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger.net]
* h2 [:path: /burp/releases/startdownload/?product=community&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13a012400)
> GET /burp/releases/startdownload/?product=community&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 301 
< date: Wed, 26 Jul 2023 13:25:13 GMT
< server: Kestrel
< cache-control: no-store, no-cache, s-maxage=0, private
< location: https://portswigger.net/burp/releases/startdownload?product=community&version&=2023.7.1&type=macosarm64
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< set-cookie: AWSALBAPP-0=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-1=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-2=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-3=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< 
{ [0 bytes data]
* Connection #0 to host portswigger.net left intact
* Issue another request to this URL: 'https://portswigger.net/burp/releases/startdownload?product=community&version&=2023.7.1&type=macosarm64'
* Found bundle for host: 0x600002c9cf30 [can multiplex]
* Re-using existing connection #0 with host portswigger.net
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger.net]
* h2 [:path: /burp/releases/startdownload?product=community&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 3 (easy handle 0x13a012400)
> GET /burp/releases/startdownload?product=community&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 302 
< date: Wed, 26 Jul 2023 13:25:13 GMT
< content-length: 0
< server: Kestrel
< cache-control: no-store, no-cache, s-maxage=0, private
< location: https://portswigger-cdn.net/burp/releases/download?product=community&version&=2023.7.1&type=macosarm64
< set-cookie: SessionId=CfDJ8Irs0%2FGU6%2B1JiUpiJ2O2KqP4pz2qL%2BOLKVQ33kQdpPh7jvQqowZkL2BJSOy6jqFEBPzeoqX7yn7nZ%2BnnYEJ7jv8B7QrG8X9CD2Za5FIDA9P%2Fmy97GqbIsfuhFCOslh2n1MLa4AYTJl2DOSrdQWCOxSc4mMSDRrsix7V7I441ronx; max-age=43200; domain=.portswigger.net; path=/; secure; samesite=lax; httponly
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< content-security-policy: default-src 'none';base-uri 'none';child-src 'self' https://www.youtube.com/embed/;connect-src 'self' https://ps.containers.piwik.pro https://ps.piwik.pro https://www.google.com/recaptcha/;font-src 'self';frame-src 'self' https://www.youtube.com/embed/ https://www.google.com/recaptcha/;img-src 'self' data:;media-src 'self' https://d21v5rjx8s17cr.cloudfront.net/ https://d2gl1b374o3yzk.cloudfront.net/;script-src 'self' https://ps.containers.piwik.pro/ppms.js https://ps.piwik.pro/ppms.js 'nonce-eTvUneOLaZQy2b+k0LvKrjSP8F9W3SCX' 'strict-dynamic';style-src 'self';
< cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin
< set-cookie: AWSALBAPP-0=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-1=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-2=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< set-cookie: AWSALBAPP-3=_remove_; Expires=Wed, 02 Aug 2023 13:25:13 GMT; Path=/
< 
{ [0 bytes data]
* Connection #0 to host portswigger.net left intact
* Issue another request to this URL: 'https://portswigger-cdn.net/burp/releases/download?product=community&version&=2023.7.1&type=macosarm64'
*   Trying 108.138.17.50:443...
* Connected to portswigger-cdn.net (108.138.17.50) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4988 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=portswigger-cdn.net
*  start date: Feb 23 00:00:00 2023 GMT
*  expire date: Dec  3 23:59:59 2023 GMT
*  subjectAltName: host "portswigger-cdn.net" matched cert's "portswigger-cdn.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: portswigger-cdn.net]
* h2 [:path: /burp/releases/download?product=community&version&=2023.7.1&type=macosarm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13a012400)
> GET /burp/releases/download?product=community&version&=2023.7.1&type=macosarm64 HTTP/2
> Host: portswigger-cdn.net
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 237953132
< date: Wed, 26 Jul 2023 13:22:52 GMT
< server: Kestrel
< accept-ranges: bytes
< cache-control: max-age=31536000, no-cache="Set-Cookie"
< last-modified: Tue, 25 Jul 2023 11:32:01 GMT
< strict-transport-security: max-age=31536000; preload
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< content-security-policy: default-src 'none';base-uri 'none';child-src 'self' https://www.youtube.com/embed/;connect-src 'self' https://ps.containers.piwik.pro https://ps.piwik.pro https://www.google.com/recaptcha/;font-src 'self';frame-src 'self' https://www.youtube.com/embed/ https://www.google.com/recaptcha/;img-src 'self' data:;media-src 'self' https://d21v5rjx8s17cr.cloudfront.net/ https://d2gl1b374o3yzk.cloudfront.net/;script-src 'self' https://ps.containers.piwik.pro/ppms.js https://ps.piwik.pro/ppms.js 'nonce-2+iMtIqkEy5ORlbs6Ro3De40DzKDW4AL' 'strict-dynamic';style-src 'self';
< cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin
< x-ua-compatible: IE=EmulateIE7
< content-disposition: attachment; filename=burpsuite_community_macos_arm64_v2023_7_1.dmg; filename*=UTF-8''burpsuite_community_macos_arm64_v2023_7_1.dmg
< x-cache: Hit from cloudfront
< via: 1.1 6f32a39163a1e36ace7a71a85e2d2884.cloudfront.net (CloudFront)
< x-amz-cf-pop: FRA56-P7
< x-amz-cf-id: 5UO4YDtemoi2JFNBJ7dwlnNADa8dy3d5D6f5Z6dwNYYJ7IWR_Or0iA==
< age: 142
< 
{ [15288 bytes data]
* Connection #1 to host portswigger-cdn.net left intact

2023-07-26 15:25:38 : REQ   : burpsuitecommunityedition : no more blocking processes, continue with update
2023-07-26 15:25:38 : REQ   : burpsuitecommunityedition : Installing Burp Suite Community Edition
2023-07-26 15:25:38 : INFO  : burpsuitecommunityedition : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2R6pZ7vq/Burp Suite Community Edition.dmg
2023-07-26 15:25:39 : DEBUG : burpsuitecommunityedition : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $8FCBABAB
Die überprüfte CRC32-Prüfsumme ist $05731F92
/dev/disk4              Apple_partition_scheme
/dev/disk4s1            Apple_partition_map
/dev/disk4s2            Apple_HFS                       /Volumes/BurpSuiteCommunity

2023-07-26 15:25:39 : INFO  : burpsuitecommunityedition : Mounted: /Volumes/BurpSuiteCommunity
2023-07-26 15:25:39 : INFO  : burpsuitecommunityedition : Verifying: /Volumes/BurpSuiteCommunity/Burp Suite Community Edition.app
2023-07-26 15:25:39 : DEBUG : burpsuitecommunityedition : App size: 431M        /Volumes/BurpSuiteCommunity/Burp Suite Community Edition.app
2023-07-26 15:25:41 : DEBUG : burpsuitecommunityedition : Debugging enabled, App Verification output was:
/Volumes/BurpSuiteCommunity/Burp Suite Community Edition.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: PortSwigger Ltd (N82YM748DZ)

2023-07-26 15:25:41 : INFO  : burpsuitecommunityedition : Team ID matching: N82YM748DZ (expected: N82YM748DZ )
2023-07-26 15:25:41 : INFO  : burpsuitecommunityedition : Installing Burp Suite Community Edition version 2023.7.1 on versionKey CFBundleShortVersionString.
2023-07-26 15:25:41 : INFO  : burpsuitecommunityedition : App has LSMinimumSystemVersion: 10.11
2023-07-26 15:25:41 : INFO  : burpsuitecommunityedition : Copy /Volumes/BurpSuiteCommunity/Burp Suite Community Edition.app to /Applications
2023-07-26 15:25:42 : DEBUG : burpsuitecommunityedition : Debugging enabled, App copy output was:
Copying /Volumes/BurpSuiteCommunity/Burp Suite Community Edition.app

2023-07-26 15:25:42 : WARN  : burpsuitecommunityedition : Changing owner to stefan
2023-07-26 15:25:42 : INFO  : burpsuitecommunityedition : Finishing...
2023-07-26 15:25:45 : INFO  : burpsuitecommunityedition : App(s) found: /Applications/Burp Suite Community Edition.app
2023-07-26 15:25:45 : INFO  : burpsuitecommunityedition : found app at /Applications/Burp Suite Community Edition.app, version 2023.7.1, on versionKey CFBundleShortVersionString
2023-07-26 15:25:45 : REQ   : burpsuitecommunityedition : Installed Burp Suite Community Edition, version 2023.7.1
2023-07-26 15:25:45 : INFO  : burpsuitecommunityedition : notifying
2023-07-26 15:25:45 : DEBUG : burpsuitecommunityedition : Unmounting /Volumes/BurpSuiteCommunity
2023-07-26 15:25:46 : DEBUG : burpsuitecommunityedition : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-07-26 15:25:46 : DEBUG : burpsuitecommunityedition : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2R6pZ7vq
2023-07-26 15:25:46 : DEBUG : burpsuitecommunityedition : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2R6pZ7vq/Burp Suite Community Edition.dmg
2023-07-26 15:25:46 : DEBUG : burpsuitecommunityedition : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2R6pZ7vq
2023-07-26 15:25:46 : INFO  : burpsuitecommunityedition : App not closed, so no reopen.
2023-07-26 15:25:46 : REQ   : burpsuitecommunityedition : All done!
2023-07-26 15:25:46 : REQ   : burpsuitecommunityedition : ################## End Installomator, exit code 0 
```