### PR TITLE
New label: Print by WeWork

### DIFF
--- a/fragments/labels/weprint.sh
+++ b/fragments/labels/weprint.sh
@@ -1,0 +1,8 @@
+weprint)
+    name="Print"
+    type="appInDmgInZip"
+    downloadURL="https://it-assets.s3.amazonaws.com/print-by-we/Print-By-We-Mac-Installer.zip"
+    appNewVersion=""
+    expectedTeamID="2D42ACMA8R"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Add the Print app, used for the better print functionality at WeWork campuses.

Test output:

2023-07-26 15:43:30 : REQ   : weprint : ################## Start Installomator v. 10.5beta, date 2023-07-26
2023-07-26 15:43:30 : INFO  : weprint : ################## Version: 10.5beta
2023-07-26 15:43:30 : INFO  : weprint : ################## Date: 2023-07-26
2023-07-26 15:43:30 : INFO  : weprint : ################## weprint
2023-07-26 15:43:30 : DEBUG : weprint : DEBUG mode 1 enabled.
2023-07-26 15:43:30 : DEBUG : weprint : name=Print
2023-07-26 15:43:30 : DEBUG : weprint : appName=
2023-07-26 15:43:30 : DEBUG : weprint : type=appInDmgInZip
2023-07-26 15:43:30 : DEBUG : weprint : archiveName=
2023-07-26 15:43:30 : DEBUG : weprint : downloadURL=https://it-assets.s3.amazonaws.com/print-by-we/Print-By-We-Mac-Installer.zip
2023-07-26 15:43:30 : DEBUG : weprint : curlOptions=
2023-07-26 15:43:30 : DEBUG : weprint : appNewVersion=
2023-07-26 15:43:30 : DEBUG : weprint : appCustomVersion function: Not defined
2023-07-26 15:43:30 : DEBUG : weprint : versionKey=CFBundleVersion
2023-07-26 15:43:30 : DEBUG : weprint : packageID=
2023-07-26 15:43:30 : DEBUG : weprint : pkgName=
2023-07-26 15:43:30 : DEBUG : weprint : choiceChangesXML=
2023-07-26 15:43:30 : DEBUG : weprint : expectedTeamID=2D42ACMA8R
2023-07-26 15:43:30 : DEBUG : weprint : blockingProcesses=
2023-07-26 15:43:30 : DEBUG : weprint : installerTool=
2023-07-26 15:43:30 : DEBUG : weprint : CLIInstaller=
2023-07-26 15:43:30 : DEBUG : weprint : CLIArguments=
2023-07-26 15:43:30 : DEBUG : weprint : updateTool=
2023-07-26 15:43:30 : DEBUG : weprint : updateToolArguments=
2023-07-26 15:43:30 : DEBUG : weprint : updateToolRunAsCurrentUser=
2023-07-26 15:43:30 : INFO  : weprint : BLOCKING_PROCESS_ACTION=tell_user
2023-07-26 15:43:30 : INFO  : weprint : NOTIFY=success
2023-07-26 15:43:30 : INFO  : weprint : LOGGING=DEBUG
2023-07-26 15:43:30 : INFO  : weprint : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-26 15:43:30 : INFO  : weprint : Label type: appInDmgInZip
2023-07-26 15:43:30 : INFO  : weprint : archiveName: Print.zip
2023-07-26 15:43:30 : INFO  : weprint : no blocking processes defined, using Print as default
2023-07-26 15:43:30 : DEBUG : weprint : Changing directory to /Users/mark/Dev/Jamf/Installomator/build
2023-07-26 15:43:30 : INFO  : weprint : App(s) found: /Applications/Print.app
2023-07-26 15:43:31 : INFO  : weprint : found app at /Applications/Print.app, version 3, on versionKey CFBundleVersion
2023-07-26 15:43:31 : INFO  : weprint : appversion: 3
2023-07-26 15:43:31 : INFO  : weprint : Latest version not specified.
2023-07-26 15:43:31 : INFO  : weprint : Print.zip exists and DEBUG mode 1 enabled, skipping download
2023-07-26 15:43:31 : DEBUG : weprint : DEBUG mode 1, not checking for blocking processes
2023-07-26 15:43:31 : REQ   : weprint : Installing Print
2023-07-26 15:43:31 : INFO  : weprint : Unzipping Print.zip
2023-07-26 15:43:31 : INFO  : weprint : found dmg: /Users/mark/Dev/Jamf/Installomator/build/WeWork+Print+Installer.dmg
2023-07-26 15:43:31 : INFO  : weprint : Mounting /Users/mark/Dev/Jamf/Installomator/build/WeWork+Print+Installer.dmg
2023-07-26 15:43:33 : DEBUG : weprint : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $F99897FB
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $542A869C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $8000D633
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $DF52D0E9
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $8000D633
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $E76BFB42
verified CRC32 $88E0A33F
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/WeWork+Print+Installer 2

2023-07-26 15:43:33 : INFO  : weprint : Mounted: /Volumes/WeWork+Print+Installer 2
2023-07-26 15:43:33 : INFO  : weprint : Verifying: /Volumes/WeWork+Print+Installer 2/Print.app
2023-07-26 15:43:33 : DEBUG : weprint : App size:  17M	/Volumes/WeWork+Print+Installer 2/Print.app
2023-07-26 15:43:34 : DEBUG : weprint : Debugging enabled, App Verification output was:
/Volumes/WeWork+Print+Installer 2/Print.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: WeWork Companies, Inc. (2D42ACMA8R)

2023-07-26 15:43:34 : INFO  : weprint : Team ID matching: 2D42ACMA8R (expected: 2D42ACMA8R )
2023-07-26 15:43:35 : INFO  : weprint : Downloaded version of Print is 3 on versionKey CFBundleVersion, same as installed.
2023-07-26 15:43:35 : DEBUG : weprint : Unmounting /Volumes/WeWork+Print+Installer 2
2023-07-26 15:43:35 : DEBUG : weprint : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-07-26 15:43:35 : DEBUG : weprint : DEBUG mode 1, not reopening anything
2023-07-26 15:43:35 : REG   : weprint : No new version to install
2023-07-26 15:43:35 : REQ   : weprint : ################## End Installomator, exit code 0 

This was after I'd run the new label "live" hence reporting app as same version as installed.