### PR TITLE
New Label: Aspera Connect

### DIFF
--- a/fragments/labels/asperaconnect.sh
+++ b/fragments/labels/asperaconnect.sh
@@ -1,0 +1,7 @@
+asperaconnect)
+    name="$(curl -fS 'https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm~Other%20software&product=ibm/Other+software/IBM+Aspera+Connect' --data-raw 'showStatus=false' | egrep -o "ibm-aspera-connect_[0-9.]+_macOS_x86_64" | head -n1)"
+    type="pkg"
+    downloadURL="https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/${name}.pkg"
+    appNewVersion=$(echo "${name}" | sed -E 's/.*_([0-9.]*)_mac.*/\1/')
+    expectedTeamID="RJ747GSBCT"
+    ;;


### PR DESCRIPTION
New label for IBM Aspera Connect:

```
# ./assemble.sh asperaconnect

2023-07-27 23:14:13 : REQ   : asperaconnect : ################## Start Installomator v. 10.4, date 2023-07-27
2023-07-27 23:14:13 : INFO  : asperaconnect : ################## Version: 10.4
2023-07-27 23:14:13 : INFO  : asperaconnect : ################## Date: 2023-07-27
2023-07-27 23:14:13 : INFO  : asperaconnect : ################## asperaconnect
2023-07-27 23:14:13 : DEBUG : asperaconnect : DEBUG mode 2 enabled.
2023-07-27 23:14:16 : DEBUG : asperaconnect : name=ibm-aspera-connect_4.2.6.393_macOS_x86_64
2023-07-27 23:14:16 : DEBUG : asperaconnect : appName=
2023-07-27 23:14:16 : DEBUG : asperaconnect : type=pkg
2023-07-27 23:14:16 : DEBUG : asperaconnect : archiveName=
2023-07-27 23:14:16 : DEBUG : asperaconnect : downloadURL=https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:16 : DEBUG : asperaconnect : curlOptions=
2023-07-27 23:14:16 : DEBUG : asperaconnect : appNewVersion=4.2.6.393
2023-07-27 23:14:16 : DEBUG : asperaconnect : appCustomVersion function: Not defined
2023-07-27 23:14:16 : DEBUG : asperaconnect : versionKey=CFBundleShortVersionString
2023-07-27 23:14:16 : DEBUG : asperaconnect : packageID=
2023-07-27 23:14:16 : DEBUG : asperaconnect : pkgName=
2023-07-27 23:14:16 : DEBUG : asperaconnect : choiceChangesXML=
2023-07-27 23:14:16 : DEBUG : asperaconnect : expectedTeamID=RJ747GSBCT
2023-07-27 23:14:16 : DEBUG : asperaconnect : blockingProcesses=
2023-07-27 23:14:16 : DEBUG : asperaconnect : installerTool=
2023-07-27 23:14:16 : DEBUG : asperaconnect : CLIInstaller=
2023-07-27 23:14:16 : DEBUG : asperaconnect : CLIArguments=
2023-07-27 23:14:16 : DEBUG : asperaconnect : updateTool=
2023-07-27 23:14:16 : DEBUG : asperaconnect : updateToolArguments=
2023-07-27 23:14:16 : DEBUG : asperaconnect : updateToolRunAsCurrentUser=
2023-07-27 23:14:16 : INFO  : asperaconnect : BLOCKING_PROCESS_ACTION=tell_user
2023-07-27 23:14:16 : INFO  : asperaconnect : NOTIFY=success
2023-07-27 23:14:16 : INFO  : asperaconnect : LOGGING=DEBUG
2023-07-27 23:14:16 : INFO  : asperaconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-27 23:14:16 : INFO  : asperaconnect : Label type: pkg
2023-07-27 23:14:16 : INFO  : asperaconnect : archiveName: ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:16 : INFO  : asperaconnect : no blocking processes defined, using ibm-aspera-connect_4.2.6.393_macOS_x86_64 as default
2023-07-27 23:14:16 : DEBUG : asperaconnect : Changing directory to /var/folders/xh/hbxgdmz54c52s3hgdk27rj_m0000gn/T/tmp.NWRnh3L8
2023-07-27 23:14:16 : INFO  : asperaconnect : name: ibm-aspera-connect_4.2.6.393_macOS_x86_64, appName: ibm-aspera-connect_4.2.6.393_macOS_x86_64.app
2023-07-27 23:14:16 : WARN  : asperaconnect : No previous app found
2023-07-27 23:14:16 : WARN  : asperaconnect : could not find ibm-aspera-connect_4.2.6.393_macOS_x86_64.app
2023-07-27 23:14:16 : INFO  : asperaconnect : appversion: 
2023-07-27 23:14:16 : INFO  : asperaconnect : Latest version of ibm-aspera-connect_4.2.6.393_macOS_x86_64 is 4.2.6.393
2023-07-27 23:14:16 : REQ   : asperaconnect : Downloading https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg to ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:16 : DEBUG : asperaconnect : No Dialog connection, just download
2023-07-27 23:14:17 : DEBUG : asperaconnect : File list: -rw-r--r--  1 seanm  staff    77M Jul 27 23:14 ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:17 : DEBUG : asperaconnect : File type: ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg: xar archive compressed TOC: 5471, SHA-1 checksum
2023-07-27 23:14:17 : DEBUG : asperaconnect : curl output was:
*   Trying 18.239.176.69:443...
* Connected to d3gcli72yxqn2z.cloudfront.net (18.239.176.69) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
{ [4972 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Dec  8 00:00:00 2022 GMT
*  expire date: Dec  7 23:59:59 2023 GMT
*  subjectAltName: host "d3gcli72yxqn2z.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
> GET /downloads/connect/latest/bin/ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg HTTP/1.1
> Host: d3gcli72yxqn2z.cloudfront.net
> User-Agent: curl/7.87.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: binary/octet-stream
< Content-Length: 80510802
< Connection: keep-alive
< Date: Fri, 28 Jul 2023 02:47:52 GMT
< Last-Modified: Tue, 30 May 2023 17:35:53 GMT
< ETag: "00a2e8f1a1c9b7c8ad8242481a15d86e-10"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 e1f917b36e487366392dda44fb2783ee.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: BOS50-P4
< X-Amz-Cf-Id: D27QTMut_TjZeg7lyzDzid5SjfFT07VTQ-RLpn18qAZl6nfy2nbpCw==
< Age: 1585
< 
{ [16384 bytes data]
* Connection #0 to host d3gcli72yxqn2z.cloudfront.net left intact

2023-07-27 23:14:18 : REQ   : asperaconnect : no more blocking processes, continue with update
2023-07-27 23:14:18 : REQ   : asperaconnect : Installing ibm-aspera-connect_4.2.6.393_macOS_x86_64
2023-07-27 23:14:18 : INFO  : asperaconnect : Verifying: ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:18 : DEBUG : asperaconnect : File list: -rw-r--r--  1 seanm  staff    77M Jul 27 23:14 ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:18 : DEBUG : asperaconnect : File type: ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg: xar archive compressed TOC: 5471, SHA-1 checksum
2023-07-27 23:14:18 : DEBUG : asperaconnect : spctlOut is ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg: accepted
2023-07-27 23:14:18 : DEBUG : asperaconnect : source=Notarized Developer ID
2023-07-27 23:14:18 : DEBUG : asperaconnect : origin=Developer ID Installer: Aspera, Inc. (RJ747GSBCT)
2023-07-27 23:14:18 : INFO  : asperaconnect : Team ID: RJ747GSBCT (expected: RJ747GSBCT )
2023-07-27 23:14:18 : DEBUG : asperaconnect : Deleting /var/folders/xh/hbxgdmz54c52s3hgdk27rj_m0000gn/T/tmp.NWRnh3L8
2023-07-27 23:14:18 : DEBUG : asperaconnect : Debugging enabled, Deleting tmpDir output was:
/var/folders/xh/hbxgdmz54c52s3hgdk27rj_m0000gn/T/tmp.NWRnh3L8/ibm-aspera-connect_4.2.6.393_macOS_x86_64.pkg
2023-07-27 23:14:18 : DEBUG : asperaconnect : /var/folders/xh/hbxgdmz54c52s3hgdk27rj_m0000gn/T/tmp.NWRnh3L8
2023-07-27 23:14:18 : INFO  : asperaconnect : App not closed, so no reopen.
2023-07-27 23:14:18 : DEBUG : asperaconnect : DEBUG mode 2 enabled, exiting
2023-07-27 23:14:18 : REQ   : asperaconnect : ################## End Installomator, exit code 0 


```