### PR TITLE
Update nextcloud Label

### DIFF
--- a/fragments/labels/nextcloud.sh
+++ b/fragments/labels/nextcloud.sh
@@ -2,8 +2,8 @@ nextcloud)
     name="nextcloud"
     type="pkg"
     #packageID="com.nextcloud.desktopclient"
-    downloadURL=$(downloadURLFromGit nextcloud desktop)
-    appNewVersion=$(versionFromGit nextcloud desktop)
+    downloadURL=$(downloadURLFromGit nextcloud-releases desktop)
+    appNewVersion=$(versionFromGit nextcloud-releases desktop)
     # The version of the app is not equal to the version listed on GitHub.
     # App version something like "3.1.3git (build 4850)" but web page lists as "3.1.3"
     # Also it does not math packageID version "3.1.34850"


### PR DESCRIPTION
It looks like starting version 3.9 nextcloud is not publishing the releases packages on their main nextcloud desktop repo anymore but have a separate one for releases only, but this one is not in the nextcloud organisation on github. but i have checked the package, signature and developer ID / notarization and the github releases are signed by a valid and nextcloud org commit able person.