### PR TITLE
New Label: shotcut

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -498,6 +498,7 @@ selfcontrol
 sequelpro
 sfsymbols
 shield
+shotcut
 shottr
 sidekick
 signal

--- a/fragments/labels/shotcut.sh
+++ b/fragments/labels/shotcut.sh
@@ -1,0 +1,9 @@
+shotcut)
+    name="shotcut"
+    type="dmg"
+    appNewVersion=$(curl -fsL https://www.shotcut.org/download/releasenotes | grep 'release-' | head -n 1 | cut -d '"' -f 2 | cut -d '-' -f 2)
+    appCustomVersion() { echo "$(/usr/bin/defaults read "/Applications/shotcut.app/Contents/Info.plist" "CFBundleVersion" | sed -r 's/[.]//g')" }
+    archiveName="shotcut-macos-$appNewVersion.dmg"
+    downloadURL=$(downloadURLFromGit mltframework shotcut)
+    expectedTeamID="Y6RX44QG2G"
+    ;;


### PR DESCRIPTION
```
2023-07-31 16:57:50 : REQ   : shotcut : ################## Start Installomator v. 10.4, date 2023-06-02
2023-07-31 16:57:50 : INFO  : shotcut : ################## Version: 10.4
2023-07-31 16:57:50 : INFO  : shotcut : ################## Date: 2023-06-02
2023-07-31 16:57:50 : INFO  : shotcut : ################## shotcut
2023-07-31 16:57:50 : DEBUG : shotcut : DEBUG mode 1 enabled.
2023-07-31 16:57:51 : INFO  : shotcut : setting variable from argument DEBUG=0
2023-07-31 16:57:51 : INFO  : shotcut : setting variable from argument NOTIFY=success
2023-07-31 16:57:51 : DEBUG : shotcut : name=shotcut
2023-07-31 16:57:51 : DEBUG : shotcut : appName=
2023-07-31 16:57:51 : DEBUG : shotcut : type=dmg
2023-07-31 16:57:51 : DEBUG : shotcut : archiveName=shotcut-macos-230729.dmg
2023-07-31 16:57:51 : DEBUG : shotcut : downloadURL=https://github.com/mltframework/shotcut/releases/download/v23.07.29/shotcut-macos-230729.dmg
2023-07-31 16:57:51 : DEBUG : shotcut : curlOptions=
2023-07-31 16:57:51 : DEBUG : shotcut : appNewVersion=230729
2023-07-31 16:57:51 : DEBUG : shotcut : appCustomVersion function: Defined.
2023-07-31 16:57:51 : DEBUG : shotcut : versionKey=CFBundleShortVersionString
2023-07-31 16:57:51 : DEBUG : shotcut : packageID=
2023-07-31 16:57:51 : DEBUG : shotcut : pkgName=
2023-07-31 16:57:51 : DEBUG : shotcut : choiceChangesXML=
2023-07-31 16:57:51 : DEBUG : shotcut : expectedTeamID=Y6RX44QG2G
2023-07-31 16:57:51 : DEBUG : shotcut : blockingProcesses=
2023-07-31 16:57:51 : DEBUG : shotcut : installerTool=
2023-07-31 16:57:51 : DEBUG : shotcut : CLIInstaller=
2023-07-31 16:57:51 : DEBUG : shotcut : CLIArguments=
2023-07-31 16:57:51 : DEBUG : shotcut : updateTool=
2023-07-31 16:57:51 : DEBUG : shotcut : updateToolArguments=
2023-07-31 16:57:51 : DEBUG : shotcut : updateToolRunAsCurrentUser=
2023-07-31 16:57:51 : INFO  : shotcut : BLOCKING_PROCESS_ACTION=tell_user
2023-07-31 16:57:51 : INFO  : shotcut : NOTIFY=success
2023-07-31 16:57:51 : INFO  : shotcut : LOGGING=DEBUG
2023-07-31 16:57:51 : INFO  : shotcut : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-07-31 16:57:51 : INFO  : shotcut : Label type: dmg
2023-07-31 16:57:51 : INFO  : shotcut : archiveName: shotcut-macos-230729.dmg
2023-07-31 16:57:51 : INFO  : shotcut : no blocking processes defined, using shotcut as default
2023-07-31 16:57:51 : DEBUG : shotcut : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wkFxWZgG
2023-07-31 16:57:51.954 defaults[15572:286509]
The domain/default pair of (/Applications/shotcut.app/Contents/Info.plist, CFBundleVersion) does not exist
2023-07-31 16:57:51 : INFO  : shotcut : Custom App Version detection is used, found
2023-07-31 16:57:51 : INFO  : shotcut : appversion:
2023-07-31 16:57:51 : INFO  : shotcut : Latest version of shotcut is 230729
2023-07-31 16:57:51 : REQ   : shotcut : Downloading https://github.com/mltframework/shotcut/releases/download/v23.07.29/shotcut-macos-230729.dmg to shotcut-macos-230729.dmg
2023-07-31 16:57:51 : DEBUG : shotcut : No Dialog connection, just download
2023-07-31 16:58:16 : DEBUG : shotcut : File list: -rw-r--r--  1 root  wheel   238M Jul 31 16:58 shotcut-macos-230729.dmg
2023-07-31 16:58:16 : DEBUG : shotcut : File type: shotcut-macos-230729.dmg: bzip2 compressed data, block size = 100k
2023-07-31 16:58:16 : DEBUG : shotcut : curl output was:
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /mltframework/shotcut/releases/download/v23.07.29/shotcut-macos-230729.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x155811a00)
> GET /mltframework/shotcut/releases/download/v23.07.29/shotcut-macos-230729.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Mon, 31 Jul 2023 14:57:52 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/4118776/72366a50-51d0-41ea-92f5-ba05cb04691f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230731T145752Z&X-Amz-Expires=300&X-Amz-Signature=20a06fed3123c835897695101fcc16d0e981f94fe5dda68721f6346d97b76f66&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=4118776&response-content-disposition=attachment%3B%20filename%3Dshotcut-macos-230729.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: D850:FA07:201E290:206CF86:64C7CBF0
<
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/4118776/72366a50-51d0-41ea-92f5-ba05cb04691f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230731T145752Z&X-Amz-Expires=300&X-Amz-Signature=20a06fed3123c835897695101fcc16d0e981f94fe5dda68721f6346d97b76f66&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=4118776&response-content-disposition=attachment%3B%20filename%3Dshotcut-macos-230729.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/4118776/72366a50-51d0-41ea-92f5-ba05cb04691f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230731T145752Z&X-Amz-Expires=300&X-Amz-Signature=20a06fed3123c835897695101fcc16d0e981f94fe5dda68721f6346d97b76f66&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=4118776&response-content-disposition=attachment%3B%20filename%3Dshotcut-macos-230729.dmg&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x155811a00)
> GET /github-production-release-asset-2e65be/4118776/72366a50-51d0-41ea-92f5-ba05cb04691f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230731T145752Z&X-Amz-Expires=300&X-Amz-Signature=20a06fed3123c835897695101fcc16d0e981f94fe5dda68721f6346d97b76f66&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=4118776&response-content-disposition=attachment%3B%20filename%3Dshotcut-macos-230729.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: iF/FBUTosUdch4hRcb1Atw==
< last-modified: Sat, 29 Jul 2023 19:49:34 GMT
< etag: "0x8DB906CEF29C94B"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: f232b16e-c01e-0057-37be-c34f66000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Sat, 29 Jul 2023 19:49:34 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=shotcut-macos-230729.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 0
< date: Mon, 31 Jul 2023 14:57:52 GMT
< x-served-by: cache-iad-kjyo7100169-IAD, cache-fra-eddf8230046-FRA
< x-cache: HIT, MISS
< x-cache-hits: 6, 0
< x-timer: S1690815472.404742,VS0,VE188
< content-length: 250013170
<
{ [11015 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-07-31 16:58:16 : REQ   : shotcut : no more blocking processes, continue with update
2023-07-31 16:58:16 : REQ   : shotcut : Installing shotcut
2023-07-31 16:58:16 : INFO  : shotcut : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wkFxWZgG/shotcut-macos-230729.dmg
2023-07-31 16:58:31 : DEBUG : shotcut : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $FD137690
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $AE69F8D6
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $67FA940B
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_APFS : 4) berechnen …
disk image (Apple_APFS : 4): Die überprüfte CRC32-Prüfsumme ist $59A04983
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $67FA940B
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $1B65A1AC
Die überprüfte CRC32-Prüfsumme ist $47DF8468
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Shotcut

2023-07-31 16:58:31 : INFO  : shotcut : Mounted: /Volumes/Shotcut
2023-07-31 16:58:31 : INFO  : shotcut : Verifying: /Volumes/Shotcut/shotcut.app
2023-07-31 16:58:32 : DEBUG : shotcut : App size: 659M	/Volumes/Shotcut/shotcut.app
2023-07-31 16:59:01 : DEBUG : shotcut : Debugging enabled, App Verification output was:
/Volumes/Shotcut/shotcut.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Meltytech, LLC (Y6RX44QG2G)

2023-07-31 16:59:01 : INFO  : shotcut : Team ID matching: Y6RX44QG2G (expected: Y6RX44QG2G )
2023-07-31 16:59:01 : INFO  : shotcut : Installing shotcut version 23.07 on versionKey CFBundleShortVersionString.
2023-07-31 16:59:01 : INFO  : shotcut : App has LSMinimumSystemVersion: 10.14.0
2023-07-31 16:59:01 : INFO  : shotcut : Copy /Volumes/Shotcut/shotcut.app to /Applications
2023-07-31 16:59:34 : DEBUG : shotcut : Debugging enabled, App copy output was:
Copying /Volumes/Shotcut 1/shotcut.app

2023-07-31 16:59:34 : WARN  : shotcut : Changing owner to yyyy
2023-07-31 16:59:34 : INFO  : shotcut : Finishing...
2023-07-31 16:59:37 : INFO  : shotcut : Custom App Version detection is used, found 230729
2023-07-31 16:59:37 : REQ   : shotcut : Installed shotcut, version 23.07
2023-07-31 16:59:37 : INFO  : shotcut : notifying
2023-07-31 16:59:38 : DEBUG : shotcut : Unmounting /Volumes/Shotcut
2023-07-31 16:59:38 : DEBUG : shotcut : Debugging enabled, Unmounting output was:
"disk6" ejected.
2023-07-31 16:59:38 : DEBUG : shotcut : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wkFxWZgG
2023-07-31 16:59:38 : DEBUG : shotcut : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wkFxWZgG/shotcut-macos-230729.dmg
2023-07-31 16:59:38 : DEBUG : shotcut : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wkFxWZgG
2023-07-31 16:59:38 : INFO  : shotcut : App not closed, so no reopen.
2023-07-31 16:59:38 : REQ   : shotcut : All done!
2023-07-31 16:59:38 : REQ   : shotcut : ################## End Installomator, exit code 0
```

and if installed the `appCustomVersion` is also working

```
2023-07-31 16:43:23 : INFO  : shotcut : archiveName: shotcut-macos-230729.dmg
2023-07-31 16:43:23 : INFO  : shotcut : no blocking processes defined, using shotcut as default
2023-07-31 16:43:23 : DEBUG : shotcut : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.UXOAlA6R
2023-07-31 16:43:23 : INFO  : shotcut : Custom App Version detection is used, found 230729
2023-07-31 16:43:23 : INFO  : shotcut : appversion: 230729
2023-07-31 16:43:23 : INFO  : shotcut : Latest version of shotcut is 230729
```