### PR TITLE
Create zulip.sh

### DIFF
--- a/fragments/labels/zulip.sh
+++ b/fragments/labels/zulip.sh
@@ -1,0 +1,11 @@
+zulip)
+    name="Zulip"
+    type="dmg"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL="https://zulip.com/apps/download/mac"
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL="https://zulip.com/apps/download/mac-arm64"
+    fi
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i ^location | sed 's/.*\/v\(.*\)\/Zulip-.*/\1/')
+    expectedTeamID="66KHCWMEYB"
+    ;;


### PR DESCRIPTION
Output:

./assemble.sh zulip DEBUG=0
2023-08-03 09:35:34 : REQ   : zulip : ################## Start Installomator v. 10.5beta, date 2023-08-03
2023-08-03 09:35:34 : INFO  : zulip : ################## Version: 10.5beta
2023-08-03 09:35:34 : INFO  : zulip : ################## Date: 2023-08-03
2023-08-03 09:35:34 : INFO  : zulip : ################## zulip
2023-08-03 09:35:34 : DEBUG : zulip : DEBUG mode 1 enabled.
2023-08-03 09:35:35 : INFO  : zulip : setting variable from argument DEBUG=0
2023-08-03 09:35:35 : DEBUG : zulip : name=Zulip
2023-08-03 09:35:35 : DEBUG : zulip : appName=
2023-08-03 09:35:35 : DEBUG : zulip : type=dmg
2023-08-03 09:35:35 : DEBUG : zulip : archiveName=
2023-08-03 09:35:35 : DEBUG : zulip : downloadURL=https://zulip.com/apps/download/mac-arm64
2023-08-03 09:35:35 : DEBUG : zulip : curlOptions=
2023-08-03 09:35:35 : DEBUG : zulip : appNewVersion=5.10.0
2023-08-03 09:35:35 : DEBUG : zulip : appCustomVersion function: Not defined
2023-08-03 09:35:35 : DEBUG : zulip : versionKey=CFBundleShortVersionString
2023-08-03 09:35:35 : DEBUG : zulip : packageID=
2023-08-03 09:35:35 : DEBUG : zulip : pkgName=
2023-08-03 09:35:35 : DEBUG : zulip : choiceChangesXML=
2023-08-03 09:35:35 : DEBUG : zulip : expectedTeamID=66KHCWMEYB
2023-08-03 09:35:35 : DEBUG : zulip : blockingProcesses=
2023-08-03 09:35:35 : DEBUG : zulip : installerTool=
2023-08-03 09:35:35 : DEBUG : zulip : CLIInstaller=
2023-08-03 09:35:35 : DEBUG : zulip : CLIArguments=
2023-08-03 09:35:35 : DEBUG : zulip : updateTool=
2023-08-03 09:35:35 : DEBUG : zulip : updateToolArguments=
2023-08-03 09:35:35 : DEBUG : zulip : updateToolRunAsCurrentUser=
2023-08-03 09:35:35 : INFO  : zulip : BLOCKING_PROCESS_ACTION=tell_user
2023-08-03 09:35:35 : INFO  : zulip : NOTIFY=success
2023-08-03 09:35:35 : INFO  : zulip : LOGGING=DEBUG
2023-08-03 09:35:35 : INFO  : zulip : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-03 09:35:35 : INFO  : zulip : Label type: dmg
2023-08-03 09:35:35 : INFO  : zulip : archiveName: Zulip.dmg
2023-08-03 09:35:35 : INFO  : zulip : no blocking processes defined, using Zulip as default
2023-08-03 09:35:35 : DEBUG : zulip : Changing directory to /var/folders/s4/tthl4zzj4739wrqmvmc9ltb40000gp/T/tmp.QaUIIlwl
2023-08-03 09:35:35 : INFO  : zulip : name: Zulip, appName: Zulip.app
2023-08-03 09:35:35.807 mdfind[19103:2038179] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-08-03 09:35:35.808 mdfind[19103:2038179] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-08-03 09:35:35.873 mdfind[19103:2038179] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-03 09:35:36 : INFO  : zulip : App(s) found: /Library/Application Support/JAMF/Composer/Sources/Zulip 5.10/ROOT/Applications/Zulip.app
2023-08-03 09:35:36 : WARN  : zulip : could not determine location of Zulip.app
2023-08-03 09:35:36 : INFO  : zulip : appversion:
2023-08-03 09:35:36 : INFO  : zulip : Latest version of Zulip is 5.10.0
2023-08-03 09:35:36 : REQ   : zulip : Downloading https://zulip.com/apps/download/mac-arm64 to Zulip.dmg
2023-08-03 09:35:36 : DEBUG : zulip : No Dialog connection, just download
2023-08-03 09:35:45 : DEBUG : zulip : File list: -rw-r--r--@ 1 naschenbrenner  staff    86M Aug  3 09:35 Zulip.dmg
2023-08-03 09:35:45 : DEBUG : zulip : File type: Zulip.dmg: zlib compressed data
2023-08-03 09:35:45 : DEBUG : zulip : curl output was:
*   Trying 3.221.188.241:443...
* Connected to zulip.com (3.221.188.241) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [314 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3953 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [147 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-ECDSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=zulip.com
*  start date: May  5 00:00:00 2023 GMT
*  expire date: Jun  2 23:59:59 2024 GMT
*  subjectAltName: host "zulip.com" matched cert's "zulip.com"
*  issuer: C=US; O=Amazon; CN=Amazon ECDSA 256 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: zulip.com]
* h2 [:path: /apps/download/mac-arm64]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13f00a800)
> GET /apps/download/mac-arm64 HTTP/2
> Host: zulip.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< date: Thu, 03 Aug 2023 14:35:36 GMT
< content-type: text/html; charset=utf-8
< content-length: 0
< location: https://desktop-download.zulip.com/v5.10.0/Zulip-5.10.0-arm64.dmg < server: nginx/1.18.0 (Ubuntu)
< vary: Accept-Language, Cookie
< content-language: en
< strict-transport-security: max-age=15768000
< x-frame-options: DENY
< x-content-type-options: nosniff
<
{ [0 bytes data]
* Connection #0 to host zulip.com left intact
* Issue another request to this URL: 'https://desktop-download.zulip.com/v5.10.0/Zulip-5.10.0-arm64.dmg'
*   Trying 23.200.156.82:443...
* Connected to desktop-download.zulip.com (23.200.156.82) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3996 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=desktop-download.zulip.com
*  start date: Jun 27 07:22:24 2023 GMT
*  expire date: Sep 25 07:22:23 2023 GMT
*  subjectAltName: host "desktop-download.zulip.com" matched cert's "desktop-download.zulip.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: desktop-download.zulip.com]
* h2 [:path: /v5.10.0/Zulip-5.10.0-arm64.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13f00a800)
> GET /v5.10.0/Zulip-5.10.0-arm64.dmg HTTP/2
> Host: desktop-download.zulip.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 293d8965-701e-0020-2516-c69af2000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Sat, 06 May 2023 00:17:53 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Zulip-5.10.0-arm64.dmg < x-ms-server-encrypted: true
< fastly-restarts: 1
< accept-ranges: bytes
< x-served-by: cache-iad-kcgs7200072-IAD, cache-chi-klot8100057-CHI < x-cache-hits: 0, 0
< x-timer: S1691072661.422866,VS0,VE90
< last-modified: Sat, 06 May 2023 00:17:53 GMT
< etag: "0x8DB4DC755F27686"
< content-md5: EekYXU9CdQMSldCZvcp6UA==
< content-length: 90058372
< cache-control: max-age=604115
< date: Thu, 03 Aug 2023 14:35:36 GMT
< strict-transport-security: max-age=86400
<
{ [16384 bytes data]
* Connection #1 to host desktop-download.zulip.com left intact

2023-08-03 09:35:45 : REQ   : zulip : no more blocking processes, continue with update
2023-08-03 09:35:45 : REQ   : zulip : Installing Zulip
2023-08-03 09:35:45 : INFO  : zulip : Mounting /var/folders/s4/tthl4zzj4739wrqmvmc9ltb40000gp/T/tmp.QaUIIlwl/Zulip.dmg
2023-08-03 09:35:49 : DEBUG : zulip : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0AECA876
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $DD07817E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F19004B8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $47D4E1BE
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F19004B8
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $306F948F
verified   CRC32 $0E136657
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_APFS
/dev/disk9          	EF57347C-0000-11AA-AA11-0030654
/dev/disk9s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Zulip 5.10.0-arm64

2023-08-03 09:35:49 : INFO  : zulip : Mounted: /Volumes/Zulip 5.10.0-arm64 2023-08-03 09:35:49 : INFO  : zulip : Verifying: /Volumes/Zulip 5.10.0-arm64/Zulip.app 2023-08-03 09:35:49 : DEBUG : zulip : App size: 211M	/Volumes/Zulip 5.10.0-arm64/Zulip.app 2023-08-03 09:35:51 : DEBUG : zulip : Debugging enabled, App Verification output was: /Volumes/Zulip 5.10.0-arm64/Zulip.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Kandra Labs, Inc. (66KHCWMEYB)

2023-08-03 09:35:51 : INFO  : zulip : Team ID matching: 66KHCWMEYB (expected: 66KHCWMEYB ) 2023-08-03 09:35:51 : INFO  : zulip : Installing Zulip version 5.10.0 on versionKey CFBundleShortVersionString. 2023-08-03 09:35:51 : INFO  : zulip : App has LSMinimumSystemVersion: 10.13 2023-08-03 09:35:51 : INFO  : zulip : Copy /Volumes/Zulip 5.10.0-arm64/Zulip.app to /Applications 2023-08-03 09:35:52 : DEBUG : zulip : Debugging enabled, App copy output was: Copying /Volumes/Zulip 5.10.0-arm64/Zulip.app

2023-08-03 09:35:52 : WARN  : zulip : Changing owner to naschenbrenner 2023-08-03 09:35:52 : INFO  : zulip : Finishing... 2023-08-03 09:35:55 : INFO  : zulip : App(s) found: /Applications/Zulip.app 2023-08-03 09:35:56 : INFO  : zulip : found app at /Applications/Zulip.app, version 5.10.0, on versionKey CFBundleShortVersionString
2023-08-03 09:35:56 : REQ   : zulip : Installed Zulip, version 5.10.0
2023-08-03 09:35:56 : INFO  : zulip : notifying
2023-08-03 09:35:56 : DEBUG : zulip : Unmounting /Volumes/Zulip 5.10.0-arm64
2023-08-03 09:35:57 : DEBUG : zulip : Debugging enabled, Unmounting output was:
"disk8" ejected.
2023-08-03 09:35:57 : DEBUG : zulip : Deleting /var/folders/s4/tthl4zzj4739wrqmvmc9ltb40000gp/T/tmp.QaUIIlwl
2023-08-03 09:35:57 : DEBUG : zulip : Debugging enabled, Deleting tmpDir output was:
/var/folders/s4/tthl4zzj4739wrqmvmc9ltb40000gp/T/tmp.QaUIIlwl/Zulip.dmg
2023-08-03 09:35:57 : DEBUG : zulip : /var/folders/s4/tthl4zzj4739wrqmvmc9ltb40000gp/T/tmp.QaUIIlwl
2023-08-03 09:35:57 : INFO  : zulip : App not closed, so no reopen.
2023-08-03 09:35:57 : REQ   : zulip : All done!
2023-08-03 09:35:57 : REQ   : zulip : ################## End Installomator, exit code 0