### PR TITLE
Figma update appNewVersion

### DIFF
--- a/fragments/labels/figma.sh
+++ b/fragments/labels/figma.sh
@@ -6,6 +6,6 @@ figma)
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://desktop.figma.com/mac/Figma.zip"
     fi
-    appNewVersion="$(curl -fsL https://desktop.figma.com/mac/RELEASE.json | awk -F '"' '{ print $8 }')"
+    appNewVersion="$(curl -fsL https://desktop.figma.com/mac/RELEASE.json | grep -m 1 -oE "\d+\.\d+\.*\d*" | head -)"
     expectedTeamID="T8RA8NE3B7"
     ;;

--- a/fragments/labels/figma.sh
+++ b/fragments/labels/figma.sh
@@ -6,6 +6,6 @@ figma)
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://desktop.figma.com/mac/Figma.zip"
     fi
-    appNewVersion="$(curl -fsL https://desktop.figma.com/mac/RELEASE.json | grep -m 1 -oE "\d+\.\d+\.*\d*" | head -)"
+    appNewVersion="$(getJSONValue "$(curl -fs https://desktop.figma.com/mac/RELEASE.json)" "version")"
     expectedTeamID="T8RA8NE3B7"
     ;;


### PR DESCRIPTION
Version check on label `figma` fails as it a splits fields on `"` and Figma has changed which field has the version number.
As Figma version is in a JSON file, I changed it to use the `getJSONValue` function.

```
2023-08-11 10:16:21 : REQ   : figma : ################## Start Installomator v. 10.5beta, date 2023-08-11
2023-08-11 10:16:21 : INFO  : figma : ################## Version: 10.5beta
2023-08-11 10:16:21 : INFO  : figma : ################## Date: 2023-08-11
2023-08-11 10:16:21 : INFO  : figma : ################## figma
2023-08-11 10:16:21 : DEBUG : figma : DEBUG mode 1 enabled.
2023-08-11 10:16:21 : DEBUG : figma : name=Figma
2023-08-11 10:16:21 : DEBUG : figma : appName=
2023-08-11 10:16:21 : DEBUG : figma : type=zip
2023-08-11 10:16:21 : DEBUG : figma : archiveName=
2023-08-11 10:16:21 : DEBUG : figma : downloadURL=https://desktop.figma.com/mac/Figma.zip
2023-08-11 10:16:21 : DEBUG : figma : curlOptions=
2023-08-11 10:16:21 : DEBUG : figma : appNewVersion=116.11.1
2023-08-11 10:16:21 : DEBUG : figma : appCustomVersion function: Not defined
2023-08-11 10:16:21 : DEBUG : figma : versionKey=CFBundleShortVersionString
2023-08-11 10:16:21 : DEBUG : figma : packageID=
2023-08-11 10:16:21 : DEBUG : figma : pkgName=
2023-08-11 10:16:21 : DEBUG : figma : choiceChangesXML=
2023-08-11 10:16:21 : DEBUG : figma : expectedTeamID=T8RA8NE3B7
2023-08-11 10:16:21 : DEBUG : figma : blockingProcesses=
2023-08-11 10:16:22 : DEBUG : figma : installerTool=
2023-08-11 10:16:22 : DEBUG : figma : CLIInstaller=
2023-08-11 10:16:22 : DEBUG : figma : CLIArguments=
2023-08-11 10:16:22 : DEBUG : figma : updateTool=
2023-08-11 10:16:22 : DEBUG : figma : updateToolArguments=
2023-08-11 10:16:22 : DEBUG : figma : updateToolRunAsCurrentUser=
2023-08-11 10:16:22 : INFO  : figma : BLOCKING_PROCESS_ACTION=tell_user
2023-08-11 10:16:22 : INFO  : figma : NOTIFY=success
2023-08-11 10:16:22 : INFO  : figma : LOGGING=DEBUG
2023-08-11 10:16:22 : INFO  : figma : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-11 10:16:22 : INFO  : figma : Label type: zip
2023-08-11 10:16:22 : INFO  : figma : archiveName: Figma.zip
2023-08-11 10:16:22 : INFO  : figma : no blocking processes defined, using Figma as default
2023-08-11 10:16:22 : DEBUG : figma : Changing directory to /Users/erse001/Library/CloudStorage/OneDrive-Kristiania/Github/Installomator/build
2023-08-11 10:16:22 : INFO  : figma : name: Figma, appName: Figma.app
2023-08-11 10:16:22.373 mdfind[31529:10816159] [UserQueryParser] Loading keywords and predicates for locale "nb_NO"
2023-08-11 10:16:22.374 mdfind[31529:10816159] [UserQueryParser] Loading keywords and predicates for locale "nb"
2023-08-11 10:16:22.374 mdfind[31529:10816159] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-08-11 10:16:22.585 mdfind[31529:10816159] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-11 10:16:22 : INFO  : figma : App(s) found: /Users/erse001/Library/CloudStorage/OneDrive-Deltebiblioteker–HøyskolenKristiania/IT Klientdrift - General/Script/Installomator-10beta2/utils/2022-09-29-15-42-28/Figma.app/Users/erse001/Downloads/Figma.app
2023-08-11 10:16:22 : WARN  : figma : could not determine location of Figma.app
2023-08-11 10:16:22 : INFO  : figma : appversion: 
2023-08-11 10:16:22 : INFO  : figma : Latest version of Figma is 116.11.1
2023-08-11 10:16:22 : REQ   : figma : Downloading https://desktop.figma.com/mac/Figma.zip to Figma.zip
2023-08-11 10:16:22 : DEBUG : figma : No Dialog connection, just download
2023-08-11 10:16:23 : DEBUG : figma : File list: -rw-r--r--  1 erse001  staff    94M Aug 11 10:16 Figma.zip
2023-08-11 10:16:23 : DEBUG : figma : File type: Figma.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-08-11 10:16:23 : DEBUG : figma : curl output was:
*   Trying 143.204.55.25:443...
* Connected to desktop.figma.com (143.204.55.25) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4960 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.figma.com
*  start date: Jun  6 00:00:00 2023 GMT
*  expire date: Jul  3 23:59:59 2024 GMT
*  subjectAltName: host "desktop.figma.com" matched cert's "*.figma.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /mac/Figma.zip]
* h2h3 [:scheme: https]
* h2h3 [:authority: desktop.figma.com]
* h2h3 [user-agent: curl/7.86.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fce09010a00)
> GET /mac/Figma.zip HTTP/2
> Host: desktop.figma.com
> user-agent: curl/7.86.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 98417214
< last-modified: Wed, 09 Aug 2023 21:18:00 GMT
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< date: Fri, 11 Aug 2023 08:15:31 GMT
< cache-control: max-age=120
< etag: "014bb7e95949c7e4ab9b22eb4054fda6-12"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 410f51195842d9b592b15d6588c36654.cloudfront.net (CloudFront)
< x-amz-cf-pop: OSL50-C1
< x-amz-cf-id: Kt0dgHdn26ZSBXykCpinXIAy3fvDSbRpSpoA-woBaQkxaXVAPSmIzg==
< age: 52
< 
{ [15978 bytes data]
* Connection #0 to host desktop.figma.com left intact

2023-08-11 10:16:23 : DEBUG : figma : DEBUG mode 1, not checking for blocking processes
2023-08-11 10:16:23 : REQ   : figma : Installing Figma
2023-08-11 10:16:23 : INFO  : figma : Unzipping Figma.zip
2023-08-11 10:16:25 : INFO  : figma : Verifying: /Users/erse001/Library/CloudStorage/OneDrive-Kristiania/Github/Installomator/build/Figma.app
2023-08-11 10:16:25 : DEBUG : figma : App size: 221M	/Users/erse001/Library/CloudStorage/OneDrive-Kristiania/Github/Installomator/build/Figma.app
2023-08-11 10:16:28 : DEBUG : figma : Debugging enabled, App Verification output was:
/Users/erse001/Library/CloudStorage/OneDrive-Kristiania/Github/Installomator/build/Figma.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Figma, Inc. (T8RA8NE3B7)

2023-08-11 10:16:28 : INFO  : figma : Team ID matching: T8RA8NE3B7 (expected: T8RA8NE3B7 )
2023-08-11 10:16:30 : INFO  : figma : Installing Figma version 116.12.2 on versionKey CFBundleShortVersionString.
2023-08-11 10:16:30 : INFO  : figma : App has LSMinimumSystemVersion: 10.12.0
2023-08-11 10:16:30 : DEBUG : figma : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-08-11 10:16:30 : INFO  : figma : Finishing...
2023-08-11 10:16:33 : INFO  : figma : name: Figma, appName: Figma.app
2023-08-11 10:16:33.895 mdfind[31616:10816836] [UserQueryParser] Loading keywords and predicates for locale "nb_NO"
2023-08-11 10:16:33.895 mdfind[31616:10816836] [UserQueryParser] Loading keywords and predicates for locale "nb"
2023-08-11 10:16:33.895 mdfind[31616:10816836] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-08-11 10:16:33.962 mdfind[31616:10816836] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-11 10:16:34 : INFO  : figma : App(s) found: /Users/erse001/Library/CloudStorage/OneDrive-Kristiania/Github/Installomator/build/Figma.app/Users/erse001/Library/CloudStorage/OneDrive-Deltebiblioteker–HøyskolenKristiania/IT Klientdrift - General/Script/Installomator-10beta2/utils/2022-09-29-15-42-28/Figma.app/Users/erse001/Downloads/Figma.app
2023-08-11 10:16:34 : WARN  : figma : could not determine location of Figma.app
2023-08-11 10:16:34 : REQ   : figma : Installed Figma, version 116.12.2
2023-08-11 10:16:34 : INFO  : figma : notifying
2023-08-11 10:16:34 : DEBUG : figma : DEBUG mode 1, not reopening anything
2023-08-11 10:16:34 : REQ   : figma : All done!
2023-08-11 10:16:34 : REQ   : figma : ################## End Installomator, exit code 0 
```