### PR TITLE
Add support for Apple Silicon builds of Azure Storage Explorer

### DIFF
--- a/fragments/labels/microsoftazurestorageexplorer.sh
+++ b/fragments/labels/microsoftazurestorageexplorer.sh
@@ -1,8 +1,12 @@
 microsoftazurestorageexplorer)
     name="Microsoft Azure Storage Explorer"
     type="zip"
+    if [[ $(arch) == arm64 ]]; then
+        archiveName="StorageExplorer-darwin-arm64.zip"
+    elif [[ $(arch) == i386 ]]; then
+        archiveName="StorageExplorer-darwin-x64.zip" 
+    fi
     downloadURL=$(downloadURLFromGit microsoft AzureStorageExplorer )
     appNewVersion=$(versionFromGit microsoft AzureStorageExplorer )
     expectedTeamID="UBF8T346G9"
-    archiveName="Mac_StorageExplorer.zip"
     ;;


### PR DESCRIPTION
```
$ ./assemble.sh microsoftazurestorageexplorer
2023-08-17 11:20:35 : REQ   : microsoftazurestorageexplorer : ################## Start Installomator v. 10.5beta, date 2023-08-17
2023-08-17 11:20:35 : INFO  : microsoftazurestorageexplorer : ################## Version: 10.5beta
2023-08-17 11:20:35 : INFO  : microsoftazurestorageexplorer : ################## Date: 2023-08-17
2023-08-17 11:20:35 : INFO  : microsoftazurestorageexplorer : ################## microsoftazurestorageexplorer
2023-08-17 11:20:35 : DEBUG : microsoftazurestorageexplorer : DEBUG mode 1 enabled.
2023-08-17 11:20:35 : INFO  : microsoftazurestorageexplorer : SwiftDialog is not installed, clear cmd file var
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : name=Microsoft Azure Storage Explorer
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : appName=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : type=zip
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : archiveName=StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : downloadURL=https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.31.0/StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : curlOptions=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : appNewVersion=1.31.0
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : appCustomVersion function: Not defined
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : versionKey=CFBundleShortVersionString
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : packageID=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : pkgName=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : choiceChangesXML=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : expectedTeamID=UBF8T346G9
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : blockingProcesses=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : installerTool=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : CLIInstaller=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : CLIArguments=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : updateTool=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : updateToolArguments=
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : updateToolRunAsCurrentUser=
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : BLOCKING_PROCESS_ACTION=tell_user
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : NOTIFY=success
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : LOGGING=DEBUG
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : Label type: zip
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : archiveName: StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : no blocking processes defined, using Microsoft Azure Storage Explorer as default
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : Changing directory to /Users/cpressland/dev/Installomator/build
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : App(s) found: /Applications/Microsoft Azure Storage Explorer.app
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : found app at /Applications/Microsoft Azure Storage Explorer.app, version 1.28.1, on versionKey CFBundleShortVersionString
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : appversion: 1.28.1
2023-08-17 11:20:36 : INFO  : microsoftazurestorageexplorer : Latest version of Microsoft Azure Storage Explorer is 1.31.0
2023-08-17 11:20:36 : REQ   : microsoftazurestorageexplorer : Downloading https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.31.0/StorageExplorer-darwin-arm64.zip to StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:36 : DEBUG : microsoftazurestorageexplorer : No Dialog connection, just download
2023-08-17 11:20:44 : DEBUG : microsoftazurestorageexplorer : File list: -rw-r--r--@ 1 cpressland  staff   198M 17 Aug 11:20 StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:44 : DEBUG : microsoftazurestorageexplorer : File type: StorageExplorer-darwin-arm64.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-08-17 11:20:44 : DEBUG : microsoftazurestorageexplorer : curl output was:
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /microsoft/AzureStorageExplorer/releases/download/v1.31.0/StorageExplorer-darwin-arm64.zip]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15700a800)
> GET /microsoft/AzureStorageExplorer/releases/download/v1.31.0/StorageExplorer-darwin-arm64.zip HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 17 Aug 2023 10:20:37 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/124597291/3894a309-a9f8-4c02-809d-f18d2d76d6f6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230817%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230817T102037Z&X-Amz-Expires=300&X-Amz-Signature=a9f2883dfbbae6631cfac18660d5052033d2827b33553e94fcc7234fc26fc781&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=124597291&response-content-disposition=attachment%3B%20filename%3DStorageExplorer-darwin-arm64.zip&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com objects-origin.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: E86C:5B6A:355F51:35EA26:64DDF474
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/124597291/3894a309-a9f8-4c02-809d-f18d2d76d6f6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230817%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230817T102037Z&X-Amz-Expires=300&X-Amz-Signature=a9f2883dfbbae6631cfac18660d5052033d2827b33553e94fcc7234fc26fc781&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=124597291&response-content-disposition=attachment%3B%20filename%3DStorageExplorer-darwin-arm64.zip&response-content-type=application%2Foctet-stream'
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/124597291/3894a309-a9f8-4c02-809d-f18d2d76d6f6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230817%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230817T102037Z&X-Amz-Expires=300&X-Amz-Signature=a9f2883dfbbae6631cfac18660d5052033d2827b33553e94fcc7234fc26fc781&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=124597291&response-content-disposition=attachment%3B%20filename%3DStorageExplorer-darwin-arm64.zip&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15700a800)
> GET /github-production-release-asset-2e65be/124597291/3894a309-a9f8-4c02-809d-f18d2d76d6f6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230817%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230817T102037Z&X-Amz-Expires=300&X-Amz-Signature=a9f2883dfbbae6631cfac18660d5052033d2827b33553e94fcc7234fc26fc781&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=124597291&response-content-disposition=attachment%3B%20filename%3DStorageExplorer-darwin-arm64.zip&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: umILsnVJdPOji1rmhKG97w==
< last-modified: Fri, 11 Aug 2023 20:34:15 GMT
< etag: "0x8DB9AAA5452CC47"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 0dcf724b-101e-0026-31f4-d0a94d000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Fri, 11 Aug 2023 20:34:15 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=StorageExplorer-darwin-arm64.zip
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< date: Thu, 17 Aug 2023 10:20:37 GMT
< age: 0
< x-served-by: cache-iad-kjyo7100170-IAD, cache-lhr7357-LHR
< x-cache: MISS, MISS
< x-cache-hits: 0, 0
< x-timer: S1692267637.121778,VS0,VE194
< content-length: 207714118
< 
{ [6881 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-08-17 11:20:44 : DEBUG : microsoftazurestorageexplorer : DEBUG mode 1, not checking for blocking processes
2023-08-17 11:20:44 : REQ   : microsoftazurestorageexplorer : Installing Microsoft Azure Storage Explorer
2023-08-17 11:20:44 : INFO  : microsoftazurestorageexplorer : Unzipping StorageExplorer-darwin-arm64.zip
2023-08-17 11:20:48 : INFO  : microsoftazurestorageexplorer : Verifying: /Users/cpressland/dev/Installomator/build/Microsoft Azure Storage Explorer.app
2023-08-17 11:20:48 : DEBUG : microsoftazurestorageexplorer : App size: 540M    /Users/cpressland/dev/Installomator/build/Microsoft Azure Storage Explorer.app
2023-08-17 11:20:49 : DEBUG : microsoftazurestorageexplorer : Debugging enabled, App Verification output was:
/Users/cpressland/dev/Installomator/build/Microsoft Azure Storage Explorer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Microsoft Corporation (UBF8T346G9)

2023-08-17 11:20:49 : INFO  : microsoftazurestorageexplorer : Team ID matching: UBF8T346G9 (expected: UBF8T346G9 )
2023-08-17 11:20:49 : INFO  : microsoftazurestorageexplorer : Downloaded version of Microsoft Azure Storage Explorer is 1.31.0 on versionKey CFBundleShortVersionString (replacing version 1.28.1).
2023-08-17 11:20:49 : INFO  : microsoftazurestorageexplorer : App has LSMinimumSystemVersion: 10.13
2023-08-17 11:20:49 : DEBUG : microsoftazurestorageexplorer : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-08-17 11:20:49 : INFO  : microsoftazurestorageexplorer : Finishing...
2023-08-17 11:20:52 : INFO  : microsoftazurestorageexplorer : App(s) found: /Applications/Microsoft Azure Storage Explorer.app
2023-08-17 11:20:52 : INFO  : microsoftazurestorageexplorer : found app at /Applications/Microsoft Azure Storage Explorer.app, version 1.28.1, on versionKey CFBundleShortVersionString
2023-08-17 11:20:52 : REQ   : microsoftazurestorageexplorer : Installed Microsoft Azure Storage Explorer, version 1.31.0
2023-08-17 11:20:52 : INFO  : microsoftazurestorageexplorer : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2023-08-17 11:20:52 : DEBUG : microsoftazurestorageexplorer : DEBUG mode 1, not reopening anything
2023-08-17 11:20:52 : REQ   : microsoftazurestorageexplorer : All done!
2023-08-17 11:20:52 : REQ   : microsoftazurestorageexplorer : ################## End Installomator, exit code 0 
```