### PR TITLE
New Label: Elgato Stream Deck

### DIFF
--- a/fragments/labels/elgatostreamdeck.sh
+++ b/fragments/labels/elgatostreamdeck.sh
@@ -1,0 +1,9 @@
+elgatostreamdeck)
+    name="Elgato Stream Deck"
+    type="pkg"
+    # packageID="com.elgato.StreamDeck"
+    releaseURL="https://help.elgato.com/hc/en-us/sections/5162671529357-Elgato-Stream-Deck-Software-Release-Notes"
+    downloadURL=$(redirect=$(curl -A "Mozilla" $releaseURL | grep -A 2 'class="article-list-item "' | head -3 | tail -1 | sed -r 's/.*href="(.*)" class.*/\1/') && curl -A "Mozilla" "https://help.elgato.com$redirect" | grep -e 'macos.*.pkg' | sed -r 's/.*href="(.*)" target.*/\1/')
+    appNewVersion=$(sed -E 's/.*Stream_Deck_([0-9.]*).pkg/\1/g' <<< $downloadURL | sed 's/\.[^.]*//3')
+    expectedTeamID="Y93VXCB8Q5"
+    ;;

--- a/fragments/labels/elgatostreamdeck.sh
+++ b/fragments/labels/elgatostreamdeck.sh
@@ -5,4 +5,5 @@ elgatostreamdeck)
 	downloadURL="https://gc-updates.elgato.com/mac/sd-update/final/download-website.php"
     appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/sd-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Stream_Deck_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3')
     expectedTeamID="Y93VXCB8Q5"
+    blockingProcesses=( "Stream Deck" )
     ;;

--- a/fragments/labels/elgatostreamdeck.sh
+++ b/fragments/labels/elgatostreamdeck.sh
@@ -2,8 +2,7 @@ elgatostreamdeck)
     name="Elgato Stream Deck"
     type="pkg"
     # packageID="com.elgato.StreamDeck"
-    releaseURL="https://help.elgato.com/hc/en-us/sections/5162671529357-Elgato-Stream-Deck-Software-Release-Notes"
-    downloadURL=$(redirect=$(curl -A "Mozilla" $releaseURL | grep -A 2 'class="article-list-item "' | head -3 | tail -1 | sed -r 's/.*href="(.*)" class.*/\1/') && curl -A "Mozilla" "https://help.elgato.com$redirect" | grep -e 'macos.*.pkg' | sed -r 's/.*href="(.*)" target.*/\1/')
-    appNewVersion=$(sed -E 's/.*Stream_Deck_([0-9.]*).pkg/\1/g' <<< $downloadURL | sed 's/\.[^.]*//3')
+	downloadURL="https://gc-updates.elgato.com/mac/sd-update/final/download-website.php"
+    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/sd-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Stream_Deck_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3')
     expectedTeamID="Y93VXCB8Q5"
     ;;


### PR DESCRIPTION
sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels elgatostreamdeck NOTIFY=silent DEBUG=0
2023-08-19 12:02:47 : REQ   : elgatostreamdeck : ################## Start Installomator v. 10.5beta, date 2023-08-19
2023-08-19 12:02:47 : INFO  : elgatostreamdeck : ################## Version: 10.5beta
2023-08-19 12:02:47 : INFO  : elgatostreamdeck : ################## Date: 2023-08-19
2023-08-19 12:02:47 : INFO  : elgatostreamdeck : ################## elgatostreamdeck
2023-08-19 12:02:47 : DEBUG : elgatostreamdeck : DEBUG mode 1 enabled.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 54863    0 54863    0     0   469k      0 --:--:-- --:--:-- --:--:--  487k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 65932    0 65932    0     0  79706      0 --:--:-- --:--:-- --:--:-- 80111
2023-08-19 12:02:48 : INFO  : elgatostreamdeck : setting variable from argument NOTIFY=silent
2023-08-19 12:02:48 : INFO  : elgatostreamdeck : setting variable from argument DEBUG=0
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : name=Elgato Stream Deck
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : appName=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : type=pkg
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : archiveName=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : downloadURL=https://edge.elgato.com/egc/macos/sd/Stream_Deck_6.3.0.18948.pkg
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : curlOptions=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : appNewVersion=6.3.0
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : appCustomVersion function: Not defined
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : versionKey=CFBundleShortVersionString
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : packageID=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : pkgName=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : choiceChangesXML=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : expectedTeamID=Y93VXCB8Q5
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : blockingProcesses=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : installerTool=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : CLIInstaller=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : CLIArguments=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : updateTool=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : updateToolArguments=
2023-08-19 12:02:48 : DEBUG : elgatostreamdeck : updateToolRunAsCurrentUser=
2023-08-19 12:02:48 : INFO  : elgatostreamdeck : BLOCKING_PROCESS_ACTION=tell_user
2023-08-19 12:02:48 : INFO  : elgatostreamdeck : NOTIFY=silent
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : LOGGING=DEBUG
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : Label type: pkg
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : archiveName: Elgato Stream Deck.pkg
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : no blocking processes defined, using Elgato Stream Deck as default
2023-08-19 12:02:49 : DEBUG : elgatostreamdeck : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : name: Elgato Stream Deck, appName: Elgato Stream Deck.app
2023-08-19 12:02:49.097 mdfind[25662:997226] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-08-19 12:02:49.097 mdfind[25662:997226] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-08-19 12:02:49.142 mdfind[25662:997226] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-19 12:02:49 : WARN  : elgatostreamdeck : No previous app found
2023-08-19 12:02:49 : WARN  : elgatostreamdeck : could not find Elgato Stream Deck.app
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : appversion:
2023-08-19 12:02:49 : INFO  : elgatostreamdeck : Latest version of Elgato Stream Deck is 6.3.0
2023-08-19 12:02:49 : REQ   : elgatostreamdeck : Downloading https://edge.elgato.com/egc/macos/sd/Stream_Deck_6.3.0.18948.pkg to Elgato Stream Deck.pkg
2023-08-19 12:02:49 : DEBUG : elgatostreamdeck : No Dialog connection, just download
2023-08-19 12:02:58 : DEBUG : elgatostreamdeck : File list: -rw-r--r--  1 root  wheel   235M 19 Aug 12:02 Elgato Stream Deck.pkg
2023-08-19 12:02:58 : DEBUG : elgatostreamdeck : File type: Elgato Stream Deck.pkg: xar archive compressed TOC: 5847, SHA-1 checksum
2023-08-19 12:02:58 : DEBUG : elgatostreamdeck : curl output was:
*   Trying 104.102.36.166:443...
* Connected to edge.elgato.com (104.102.36.166) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2760 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Fremont; O=Corsair Memory, Inc.; CN=*.elgato.com
*  start date: Jan  3 00:00:00 2023 GMT
*  expire date: Jan  6 23:59:59 2024 GMT
*  subjectAltName: host "edge.elgato.com" matched cert's "*.elgato.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /egc/macos/sd/Stream_Deck_6.3.0.18948.pkg HTTP/1.1
> Host: edge.elgato.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< x-amz-id-2: oPwsxmzuI0Ry43HNKk9LpDCuoDc2xnzBmzs+JVez/d+dEiuErC5lN2H/ba6sNtZO2DZ22AEJfgU= < x-amz-request-id: W3HHJDTNBGEXVVJD
< x-amz-server-side-encryption: AES256
< x-amz-version-id: OD30AMYhVvgMiZGnyZNK2Eo4dvDUbo_B < Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AmazonS3
< Last-Modified: Tue, 20 Jun 2023 10:03:07 GMT
< ETag: "6cdce30ca0e1378aec73319090a392d7-30"
< Content-Length: 246700699
< Date: Sat, 19 Aug 2023 10:02:49 GMT
< Connection: keep-alive
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET, OPTIONS
< Access-Control-Allow-Origin: https://kc.smm.io
<
{ [15758 bytes data]
* Connection #0 to host edge.elgato.com left intact

2023-08-19 12:02:58 : REQ   : elgatostreamdeck : no more blocking processes, continue with update
2023-08-19 12:02:58 : REQ   : elgatostreamdeck : Installing Elgato Stream Deck
2023-08-19 12:02:58 : INFO  : elgatostreamdeck : Verifying: Elgato Stream Deck.pkg
2023-08-19 12:02:58 : DEBUG : elgatostreamdeck : File list: -rw-r--r--  1 root  wheel   235M 19 Aug 12:02 Elgato Stream Deck.pkg
2023-08-19 12:02:59 : DEBUG : elgatostreamdeck : File type: Elgato Stream Deck.pkg: xar archive compressed TOC: 5847, SHA-1 checksum
2023-08-19 12:02:59 : DEBUG : elgatostreamdeck : spctlOut is Elgato Stream Deck.pkg: accepted
2023-08-19 12:02:59 : DEBUG : elgatostreamdeck : source=Notarized Developer ID
2023-08-19 12:02:59 : DEBUG : elgatostreamdeck : override=security disabled
2023-08-19 12:02:59 : DEBUG : elgatostreamdeck : origin=Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)
2023-08-19 12:02:59 : INFO  : elgatostreamdeck : Team ID: Y93VXCB8Q5 (expected: Y93VXCB8Q5 )
2023-08-19 12:02:59 : INFO  : elgatostreamdeck : Installing Elgato Stream Deck.pkg to /
2023-08-19 12:03:07 : DEBUG : elgatostreamdeck : Debugging enabled, installer output was:
Aug 19 12:02:59  installer[25761] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato Stream Deck.pkg trustLevel=350
Aug 19 12:02:59  installer[25761] <Debug>: External component packages (1) trustLevel=350
Aug 19 12:02:59  installer[25761] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Aug 19 12:02:59  installer[25761] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato%20Stream%20Deck.pkg#Stream_Deck.pkg
Aug 19 12:02:59  installer[25761] <Info>: Set authorization level to root for session
Aug 19 12:02:59  installer[25761] <Info>: Authorization is being checked, waiting until authorization arrives.
Aug 19 12:02:59  installer[25761] <Info>: Administrator authorization granted.
Aug 19 12:02:59  installer[25761] <Info>: Packages have been authorized for installation.
Aug 19 12:02:59  installer[25761] <Debug>: Will use PK session
Aug 19 12:02:59  installer[25761] <Debug>: Using authorization level of root for IFPKInstallElement
Aug 19 12:02:59  installer[25761] <Info>: Starting installation:
Aug 19 12:02:59  installer[25761] <Notice>: Configuring volume "Macintosh HD"
Aug 19 12:02:59  installer[25761] <Info>: Preparing disk for local booted install.
Aug 19 12:02:59  installer[25761] <Notice>: Free space on "Macintosh HD": 413,64 GB (413638852608 bytes).
Aug 19 12:02:59  installer[25761] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.257616in8ez"
Aug 19 12:02:59  installer[25761] <Notice>: IFPKInstallElement (1 packages)
Aug 19 12:02:59  installer[25761] <Info>: Current Path: /usr/sbin/installer
Aug 19 12:02:59  installer[25761] <Info>: Current Path: /bin/zsh
Aug 19 12:02:59  installer[25761] <Info>: Current Path: /usr/bin/sudo
Aug 19 12:02:59  installer[25761] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Stream Deck
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „Stream Deck“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Aug 19 12:03:05  installer[25761] <Info>: Error getting application status info for file:///Applications/Stream%20Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „QtWebEngineProcess.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Stream%20Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app, NSFilePath=/Applications/Stream Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app, NSUnderlyingError=0x600003a663d0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
Aug 19 12:03:05  installer[25761] <Info>: Error getting application status info for file:///Applications/Stream%20Deck.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „Stream Deck.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Stream%20Deck.app, NSFilePath=/Applications/Stream Deck.app, NSUnderlyingError=0x600003a761c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

installer: Paketskripte ausführen ….....
installer: Pakete überprüfen ….....
#Aug 19 12:03:05  installer[25761] <Notice>: Running install actions Aug 19 12:03:05  installer[25761] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.257616in8ez" Aug 19 12:03:05  installer[25761] <Notice>: Finalize disk "Macintosh HD" Aug 19 12:03:05  installer[25761] <Notice>: Notifying system of updated components Aug 19 12:03:05  installer[25761] <Notice>:
Aug 19 12:03:05  installer[25761] <Notice>: **** Summary Information ****
Aug 19 12:03:05  installer[25761] <Notice>:   Operation      Elapsed time
Aug 19 12:03:05  installer[25761] <Notice>: -----------------------------
Aug 19 12:03:05  installer[25761] <Notice>:        disk      0.02 seconds
Aug 19 12:03:05  installer[25761] <Notice>:      script      0.00 seconds
Aug 19 12:03:05  installer[25761] <Notice>:        zero      0.00 seconds
Aug 19 12:03:05  installer[25761] <Notice>:     install      6.08 seconds
Aug 19 12:03:05  installer[25761] <Notice>:     -total-      6.10 seconds
Aug 19 12:03:05  installer[25761] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert...... installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato Stream Deck.pkg trustLevel=350 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: External component packages (1) trustLevel=350 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato%20Stream%20Deck.pkg#Stream_Deck.pkg 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Set authorization level to root for session 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Authorization is being checked, waiting until authorization arrives. 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Administrator authorization granted. 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Packages have been authorized for installation. 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Will use PK session 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Using authorization level of root for IFPKInstallElement 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Starting installation: 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Configuring volume "Macintosh HD" 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Preparing disk for local booted install. 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Free space on "Macintosh HD": 413,64 GB (413638852608 bytes). 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.257616in8ez" 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: IFPKInstallElement (1 packages) 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Current Path: /usr/sbin/installer 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Current Path: /bin/zsh Last Log repeated 2 times
2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: Current Path: /usr/bin/sudo 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Adding client PKInstallDaemonClient pid=25761, uid=0 (/usr/sbin/installer) 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installer[25761]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Set reponsibility for install to 18223 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Hosted team responsibility for install set to team:(Y93VXCB8Q5) 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: ----- Begin install -----
2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: packages=( 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/B74B1466-ADF9-494E-8D4A-9D61E4731092.activeSandbox 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/32AA90C2-8717-4CE4-A0D6-A1313380B657.activeSandbox 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/0BD34AEF-D776-4E4A-9B3C-52CA7C5F5977.activeSandbox 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/45C2D2B7-FFF5-45A6-82F3-AC326DD0CA1F.activeSandbox 2023-08-19 12:02:59+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Will do receipt-based obsoleting for package identifier com.elgato.StreamDeck (prefix path=) 2023-08-19 12:03:00+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato%20Stream%20Deck.pkg#Stream_Deck.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/F7BF1475-A7BE-4C68-8287-4A2DF652AA89.activeSandbox/Root, uid=0) 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: prevent user idle system sleep 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: suspending backupd 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX installd[5332]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: Set responsibility to pid: 18223, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: Hosted team responsibility for script set to team:(Y93VXCB8Q5) 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX install_monitor[25762]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Warning: Expecting a LaunchDaemons path since the command was ran as root. Got LaunchAgents instead. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: `launchctl bootout` is a recommended alternative. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: /Library/LaunchAgents/com.elgato.StreamDeck.plist: No such file or directory 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Unload failed: 2: No such file or directory 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Warning: Expecting a LaunchDaemons path since the command was ran as root. Got LaunchAgents instead. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: `launchctl bootout` is a recommended alternative. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: /Users/savvas/Library/LaunchAgents/com.elgato.StreamDeck.plist: Could not find specified service 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Unload failed: 113: Could not find specified service 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: No matching processes were found 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Hosted team responsible for script has been cleared. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX package_script_service[24516]: Responsibility set back to self. 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/F7BF1475-A7BE-4C68-8287-4A2DF652AA89.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/F7BF1475-A7BE-4C68-8287-4A2DF652AA89.activeSandbox 2023-08-19 12:03:02+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/F7BF1475-A7BE-4C68-8287-4A2DF652AA89.activeSandbox/Root (1 items) to / 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX installd[5332]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: Set responsibility to pid: 18223, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: Hosted team responsibility for script set to team:(Y93VXCB8Q5) 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.sJOyYh/Scripts/com.elgato.StreamDeck.TLiHoY 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: /Users/savvas/Library/LaunchAgents/com.elgato.StreamDeck.plist: Could not find specified service 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: Boot-out failed: 113: Could not find specified service 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: Could not find service. 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: creating /Users/savvas/Library/Application Support/obs-studio/plugins 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: install Stream Deck OBS plugin to /Users/savvas/Library/Application Support/obs-studio/plugins 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: creating /Library/Application Support/obs-studio/plugins 2023-08-19 12:03:03+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: install Stream Deck OBS plugin to /Library/Application Support/obs-studio/plugins 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Hosted team responsible for script has been cleared. 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX package_script_service[24516]: Responsibility set back to self. 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Writing receipt for com.elgato.StreamDeck to / 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: No Intel binaries to translate. 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Touched bundle /Applications/Stream Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Touched bundle /Applications/Stream Deck.app 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: Installed "Stream Deck" () 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX installd[5332]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist 2023-08-19 12:03:04+02 savvas-LF0Y25WVCX install_monitor[25762]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: releasing backupd 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: allow user idle system sleep 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: ----- End install ----- 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: 5.5s elapsed install time 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Cleared responsibility for install from 25761. 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Hosted team responsible for install has been cleared. 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Running idle tasks 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Error getting application status info for file:///Applications/Stream%20Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „QtWebEngineProcess.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Stream%20Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app, NSFilePath=/Applications/Stream Deck.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app, NSUnderlyingError=0x600003a663d0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}} 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Error getting application status info for file:///Applications/Stream%20Deck.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „Stream Deck.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Stream%20Deck.app, NSFilePath=/Applications/Stream Deck.app, NSUnderlyingError=0x600003a761c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}} 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Removing client PKInstallDaemonClient pid=25761, uid=0 (/usr/sbin/installer) 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Done with sandbox removals 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Running install actions 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.257616in8ez" 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Finalize disk "Macintosh HD" 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: Notifying system of updated components 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: 2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: **** Summary Information ****
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:   Operation      Elapsed time
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]: -----------------------------
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:        disk      0.02 seconds
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:      script      0.00 seconds
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:        zero      0.00 seconds
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:     install      6.08 seconds
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:     -total-      6.10 seconds
2023-08-19 12:03:05+02 savvas-LF0Y25WVCX installer[25761]:

2023-08-19 12:03:07 : INFO  : elgatostreamdeck : Finishing... 2023-08-19 12:03:10 : INFO  : elgatostreamdeck : App(s) found: /Applications/Elgato Stream Deck.app 2023-08-19 12:03:11 : INFO  : elgatostreamdeck : found app at /Applications/Elgato Stream Deck.app, version 6.3.0, on versionKey CFBundleShortVersionString
2023-08-19 12:03:11 : REQ   : elgatostreamdeck : Installed Elgato Stream Deck, version 6.3.0
2023-08-19 12:03:11 : DEBUG : elgatostreamdeck : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK
2023-08-19 12:03:11 : DEBUG : elgatostreamdeck : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK/Elgato Stream Deck.pkg
2023-08-19 12:03:11 : DEBUG : elgatostreamdeck : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.9lh3s2MK
2023-08-19 12:03:11 : INFO  : elgatostreamdeck : App not closed, so no reopen.
2023-08-19 12:03:11 : REQ   : elgatostreamdeck : All done!
2023-08-19 12:03:11 : REQ   : elgatostreamdeck : ################## End Installomator, exit code 0

savvas-LF0Y25WVCX:utils savvas$ sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels elgatostreamdeck NOTIFY=silent DEBUG=0
2023-08-19 12:03:17 : REQ   : elgatostreamdeck : ################## Start Installomator v. 10.5beta, date 2023-08-19
2023-08-19 12:03:17 : INFO  : elgatostreamdeck : ################## Version: 10.5beta
2023-08-19 12:03:17 : INFO  : elgatostreamdeck : ################## Date: 2023-08-19
2023-08-19 12:03:17 : INFO  : elgatostreamdeck : ################## elgatostreamdeck
2023-08-19 12:03:17 : DEBUG : elgatostreamdeck : DEBUG mode 1 enabled.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 54863    0 54863    0     0   181k      0 --:--:-- --:--:-- --:--:--  184k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 65932    0 65932    0     0  99442      0 --:--:-- --:--:-- --:--:--   98k
2023-08-19 12:03:18 : INFO  : elgatostreamdeck : setting variable from argument NOTIFY=silent
2023-08-19 12:03:18 : INFO  : elgatostreamdeck : setting variable from argument DEBUG=0
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : name=Elgato Stream Deck
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : appName=
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : type=pkg
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : archiveName=
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : downloadURL=https://edge.elgato.com/egc/macos/sd/Stream_Deck_6.3.0.18948.pkg
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : curlOptions=
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : appNewVersion=6.3.0
2023-08-19 12:03:18 : DEBUG : elgatostreamdeck : appCustomVersion function: Not defined
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : versionKey=CFBundleShortVersionString
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : packageID=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : pkgName=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : choiceChangesXML=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : expectedTeamID=Y93VXCB8Q5
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : blockingProcesses=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : installerTool=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : CLIInstaller=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : CLIArguments=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : updateTool=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : updateToolArguments=
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : updateToolRunAsCurrentUser=
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : BLOCKING_PROCESS_ACTION=tell_user
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : NOTIFY=silent
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : LOGGING=DEBUG
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : Label type: pkg
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : archiveName: Elgato Stream Deck.pkg
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : no blocking processes defined, using Elgato Stream Deck as default
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.38CrUm8K
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : App(s) found: /Applications/Elgato Stream Deck.app
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : found app at /Applications/Elgato Stream Deck.app, version 6.3.0, on versionKey CFBundleShortVersionString
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : appversion: 6.3.0
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : Latest version of Elgato Stream Deck is 6.3.0
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : There is no newer version available.
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.38CrUm8K
2023-08-19 12:03:19 : DEBUG : elgatostreamdeck : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.38CrUm8K
2023-08-19 12:03:19 : INFO  : elgatostreamdeck : App not closed, so no reopen.
2023-08-19 12:03:19 : REQ   : elgatostreamdeck : No newer version.
2023-08-19 12:03:19 : REQ   : elgatostreamdeck : ################## End Installomator, exit code 0