### PR TITLE
New Label: Elgato Camera Hub

### DIFF
--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -1,0 +1,9 @@
+elgatocamerahub)
+    name="Elgato Camera Hub"
+    type="pkg"
+    # packageID="com.elgato.CameraHub.Installer"
+    releaseURL="https://help.elgato.com/hc/en-us/sections/4880787756941-Elgato-Camera-Hub-Release-Notes"
+    downloadURL=$(redirect=$(curl -A "Mozilla" $releaseURL | grep -A 2 'class="article-list-item "' | head -3 | tail -1 | sed -r 's/.*href="(.*)" class.*/\1/') && curl -A "Mozilla" "https://help.elgato.com$redirect" | grep -e 'macos.*.pkg' | sed -r 's/.*href="(.*)" target.*/\1/')
+    appNewVersion=$(sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' <<< $downloadURL | sed 's/\.[^.]*//3')
+    expectedTeamID="Y93VXCB8Q5"
+    ;;

--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -2,8 +2,7 @@ elgatocamerahub)
     name="Elgato Camera Hub"
     type="pkg"
     # packageID="com.elgato.CameraHub.Installer"
-    releaseURL="https://help.elgato.com/hc/en-us/sections/4880787756941-Elgato-Camera-Hub-Release-Notes"
-    downloadURL=$(redirect=$(curl -A "Mozilla" $releaseURL | grep -A 2 'class="article-list-item "' | head -3 | tail -1 | sed -r 's/.*href="(.*)" class.*/\1/') && curl -A "Mozilla" "https://help.elgato.com$redirect" | grep -e 'macos.*.pkg' | sed -r 's/.*href="(.*)" target.*/\1/')
-    appNewVersion=$(sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' <<< $downloadURL | sed 's/\.[^.]*//3')
+    downloadURL="https://gc-updates.elgato.com/mac/echm-update/final/download-website.php"
+    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3')
     expectedTeamID="Y93VXCB8Q5"
     ;;

--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -5,4 +5,5 @@ elgatocamerahub)
     downloadURL="https://gc-updates.elgato.com/mac/echm-update/final/download-website.php"
     appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3')
     expectedTeamID="Y93VXCB8Q5"
+    blockingProcesses=( "Camera Hub" )
     ;;


### PR DESCRIPTION
sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels elgatocamerahub NOTIFY=silent DEBUG=0
2023-08-19 12:18:53 : REQ   : elgatocamerahub : ################## Start Installomator v. 10.5beta, date 2023-08-19
2023-08-19 12:18:53 : INFO  : elgatocamerahub : ################## Version: 10.5beta
2023-08-19 12:18:53 : INFO  : elgatocamerahub : ################## Date: 2023-08-19
2023-08-19 12:18:53 : INFO  : elgatocamerahub : ################## elgatocamerahub
2023-08-19 12:18:53 : DEBUG : elgatocamerahub : DEBUG mode 1 enabled.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 53703    0 53703    0     0  47184      0 --:--:--  0:00:01 --:--:-- 47357
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 63906    0 63906    0     0   497k      0 --:--:-- --:--:-- --:--:--  524k
2023-08-19 12:18:55 : INFO  : elgatocamerahub : setting variable from argument NOTIFY=silent
2023-08-19 12:18:55 : INFO  : elgatocamerahub : setting variable from argument DEBUG=0
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : name=Elgato Camera Hub
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : appName=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : type=pkg
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : archiveName=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : downloadURL=https://edge.elgato.com/egc/macos/echm/1.7/Camera_Hub_1.7.0.1124.pkg
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : curlOptions=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : appNewVersion=1.7.0
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : appCustomVersion function: Not defined
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : versionKey=CFBundleShortVersionString
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : packageID=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : pkgName=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : choiceChangesXML=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : expectedTeamID=Y93VXCB8Q5
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : blockingProcesses=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : installerTool=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : CLIInstaller=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : CLIArguments=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : updateTool=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : updateToolArguments=
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : updateToolRunAsCurrentUser=
2023-08-19 12:18:55 : INFO  : elgatocamerahub : BLOCKING_PROCESS_ACTION=tell_user
2023-08-19 12:18:55 : INFO  : elgatocamerahub : NOTIFY=silent
2023-08-19 12:18:55 : INFO  : elgatocamerahub : LOGGING=DEBUG
2023-08-19 12:18:55 : INFO  : elgatocamerahub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-19 12:18:55 : INFO  : elgatocamerahub : Label type: pkg
2023-08-19 12:18:55 : INFO  : elgatocamerahub : archiveName: Elgato Camera Hub.pkg
2023-08-19 12:18:55 : INFO  : elgatocamerahub : no blocking processes defined, using Elgato Camera Hub as default
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE
2023-08-19 12:18:55 : INFO  : elgatocamerahub : App(s) found: /Applications/Elgato Camera Hub.app
2023-08-19 12:18:55 : INFO  : elgatocamerahub : found app at /Applications/Elgato Camera Hub.app, version 1.4.0, on versionKey CFBundleShortVersionString
2023-08-19 12:18:55 : INFO  : elgatocamerahub : appversion: 1.4.0
2023-08-19 12:18:55 : INFO  : elgatocamerahub : Latest version of Elgato Camera Hub is 1.7.0
2023-08-19 12:18:55 : REQ   : elgatocamerahub : Downloading https://edge.elgato.com/egc/macos/echm/1.7/Camera_Hub_1.7.0.1124.pkg to Elgato Camera Hub.pkg
2023-08-19 12:18:55 : DEBUG : elgatocamerahub : No Dialog connection, just download
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : File list: -rw-r--r--  1 root  wheel   217M 19 Aug 12:19 Elgato Camera Hub.pkg
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : File type: Elgato Camera Hub.pkg: xar archive compressed TOC: 6724, SHA-1 checksum
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : curl output was:
*   Trying 104.102.36.166:443...
* Connected to edge.elgato.com (104.102.36.166) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2760 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Fremont; O=Corsair Memory, Inc.; CN=*.elgato.com
*  start date: Jan  3 00:00:00 2023 GMT
*  expire date: Jan  6 23:59:59 2024 GMT
*  subjectAltName: host "edge.elgato.com" matched cert's "*.elgato.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /egc/macos/echm/1.7/Camera_Hub_1.7.0.1124.pkg HTTP/1.1
> Host: edge.elgato.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< x-amz-id-2: qLN2JvvJ4ztVt9qW7hmNSnDxZFoAE91a1u+08iBrF5+Sq/YLhm7ip2MJt/9zaElrETlCcYCwLyg= < x-amz-request-id: WEQA99YXCBKDDJ1Q
< x-amz-server-side-encryption: AES256
< x-amz-version-id: 1B.LQsmKpmkSH46kpjwu1PDs6TwwGxMl < Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AmazonS3
< Last-Modified: Thu, 20 Jul 2023 11:37:49 GMT
< ETag: "e33fd148b44ce7acd8fada17b21ff1d7-28"
< Content-Length: 227473196
< Date: Sat, 19 Aug 2023 10:18:55 GMT
< Connection: keep-alive
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: GET, OPTIONS
< Access-Control-Allow-Origin: https://kc.smm.io
<
{ [15758 bytes data]
* Connection #0 to host edge.elgato.com left intact

2023-08-19 12:19:03 : REQ   : elgatocamerahub : no more blocking processes, continue with update
2023-08-19 12:19:03 : REQ   : elgatocamerahub : Installing Elgato Camera Hub
2023-08-19 12:19:03 : INFO  : elgatocamerahub : Verifying: Elgato Camera Hub.pkg
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : File list: -rw-r--r--  1 root  wheel   217M 19 Aug 12:19 Elgato Camera Hub.pkg
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : File type: Elgato Camera Hub.pkg: xar archive compressed TOC: 6724, SHA-1 checksum
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : spctlOut is Elgato Camera Hub.pkg: accepted
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : source=Notarized Developer ID
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : override=security disabled
2023-08-19 12:19:03 : DEBUG : elgatocamerahub : origin=Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)
2023-08-19 12:19:03 : INFO  : elgatocamerahub : Team ID: Y93VXCB8Q5 (expected: Y93VXCB8Q5 )
2023-08-19 12:19:03 : INFO  : elgatocamerahub : Installing Elgato Camera Hub.pkg to /
2023-08-19 12:19:11 : DEBUG : elgatocamerahub : Debugging enabled, installer output was:
Aug 19 12:19:04  installer[27670] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato Camera Hub.pkg trustLevel=350
Aug 19 12:19:04  installer[27670] <Debug>: External component packages (1) trustLevel=350
Aug 19 12:19:04  installer[27670] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Aug 19 12:19:04  installer[27670] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato%20Camera%20Hub.pkg#Camera_Hub.pkg
Aug 19 12:19:04  installer[27670] <Info>: Set authorization level to root for session
Aug 19 12:19:04  installer[27670] <Info>: Authorization is being checked, waiting until authorization arrives.
Aug 19 12:19:04  installer[27670] <Info>: Administrator authorization granted.
Aug 19 12:19:04  installer[27670] <Info>: Packages have been authorized for installation.
Aug 19 12:19:04  installer[27670] <Debug>: Will use PK session
Aug 19 12:19:04  installer[27670] <Debug>: Using authorization level of root for IFPKInstallElement
Aug 19 12:19:04  installer[27670] <Info>: Starting installation:
Aug 19 12:19:04  installer[27670] <Notice>: Configuring volume "Macintosh HD"
Aug 19 12:19:04  installer[27670] <Info>: Preparing disk for local booted install.
Aug 19 12:19:04  installer[27670] <Notice>: Free space on "Macintosh HD": 412,38 GB (412377567232 bytes).
Aug 19 12:19:04  installer[27670] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27670hQrcYW"
Aug 19 12:19:04  installer[27670] <Notice>: IFPKInstallElement (1 packages)
Aug 19 12:19:04  installer[27670] <Info>: Current Path: /usr/sbin/installer
Aug 19 12:19:04  installer[27670] <Info>: Current Path: /bin/zsh
Aug 19 12:19:04  installer[27670] <Info>: Current Path: /usr/bin/sudo
Aug 19 12:19:04  installer[27670] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Camera Hub
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „Camera Hub“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Aug 19 12:19:09  installer[27670] <Info>: Error getting application status info for file:///Applications/Camera%20Hub.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „Camera Hub.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Camera%20Hub.app, NSFilePath=/Applications/Camera Hub.app, NSUnderlyingError=0x600000e900c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

installer: Paketskripte ausführen ….....
installer: Pakete überprüfen ….....
#Aug 19 12:19:09  installer[27670] <Notice>: Running install actions Aug 19 12:19:09  installer[27670] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27670hQrcYW" Aug 19 12:19:09  installer[27670] <Notice>: Finalize disk "Macintosh HD" Aug 19 12:19:09  installer[27670] <Notice>: Notifying system of updated components Aug 19 12:19:09  installer[27670] <Notice>:
Aug 19 12:19:09  installer[27670] <Notice>: **** Summary Information ****
Aug 19 12:19:09  installer[27670] <Notice>:   Operation      Elapsed time
Aug 19 12:19:09  installer[27670] <Notice>: -----------------------------
Aug 19 12:19:09  installer[27670] <Notice>:        disk      0.02 seconds
Aug 19 12:19:09  installer[27670] <Notice>:      script      0.00 seconds
Aug 19 12:19:09  installer[27670] <Notice>:        zero      0.00 seconds
Aug 19 12:19:09  installer[27670] <Notice>:     install      5.08 seconds
Aug 19 12:19:09  installer[27670] <Notice>:     -total-      5.10 seconds
Aug 19 12:19:09  installer[27670] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert...... installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato Camera Hub.pkg trustLevel=350 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: External component packages (1) trustLevel=350 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato%20Camera%20Hub.pkg#Camera_Hub.pkg 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Set authorization level to root for session 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Authorization is being checked, waiting until authorization arrives. 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Administrator authorization granted. 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Packages have been authorized for installation. 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Will use PK session 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Using authorization level of root for IFPKInstallElement 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Starting installation: 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Configuring volume "Macintosh HD" 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Preparing disk for local booted install. 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Free space on "Macintosh HD": 412,38 GB (412377567232 bytes). 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27670hQrcYW" 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: IFPKInstallElement (1 packages) 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Current Path: /usr/sbin/installer 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Current Path: /bin/zsh Last Log repeated 2 times
2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: Current Path: /usr/bin/sudo 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Adding client PKInstallDaemonClient pid=27670, uid=0 (/usr/sbin/installer) 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installer[27670]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Set reponsibility for install to 18223 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Hosted team responsibility for install set to team:(Y93VXCB8Q5) 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: ----- Begin install -----
2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: packages=( 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/B74B1466-ADF9-494E-8D4A-9D61E4731092.activeSandbox 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/32AA90C2-8717-4CE4-A0D6-A1313380B657.activeSandbox 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/0BD34AEF-D776-4E4A-9B3C-52CA7C5F5977.activeSandbox 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/45C2D2B7-FFF5-45A6-82F3-AC326DD0CA1F.activeSandbox 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Will do receipt-based obsoleting for package identifier com.elgato.CameraHub.Installer (prefix path=) 2023-08-19 12:19:04+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato%20Camera%20Hub.pkg#Camera_Hub.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/43B6177A-7FEA-4527-8B77-5C8377D99A10.activeSandbox/Root, uid=0) 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: prevent user idle system sleep 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: suspending backupd 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: Set responsibility to pid: 18223, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: Hosted team responsibility for script set to team:(Y93VXCB8Q5) 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX install_monitor[27673]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Warning: Expecting a LaunchDaemons path since the command was ran as root. Got LaunchAgents instead. 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: `launchctl bootout` is a recommended alternative. 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: /Users/savvas/Library/LaunchAgents/com.elgato.CameraHub.plist: Could not find specified service 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: Unload failed: 113: Could not find specified service 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: ./preinstall: /tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN/preinstall: line 13: /Library/CoreMediaIO/Plug-Ins/DAL/EpocCamPlugIn.plugin/Contents/Resources/uninst.sh: No such file or directory 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Hosted team responsible for script has been cleared. 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: Responsibility set back to self. 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/43B6177A-7FEA-4527-8B77-5C8377D99A10.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/43B6177A-7FEA-4527-8B77-5C8377D99A10.activeSandbox 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/43B6177A-7FEA-4527-8B77-5C8377D99A10.activeSandbox/Root (2 items) to / 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX installd[5332]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: Set responsibility to pid: 18223, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: Hosted team responsibility for script set to team:(Y93VXCB8Q5) 2023-08-19 12:19:07+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.dKFI2n/Scripts/com.elgato.CameraHub.Installer.cIzYmN 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: macOS: 13.5.1 (required: 12.3) 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX package_script_service[24516]: ./postinstall: Greater than or equal to 12.3 -> remove DAL plugin 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX package_script_service[24516]: PackageKit: Hosted team responsible for script has been cleared. 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX package_script_service[24516]: Responsibility set back to self. 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Writing receipt for com.elgato.CameraHub.Installer to / 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: No Intel binaries to translate. 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Touched bundle /Applications/Camera Hub.app 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX installd[5332]: Installed "Camera Hub" () 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX installd[5332]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist 2023-08-19 12:19:08+02 savvas-LF0Y25WVCX install_monitor[27673]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: releasing backupd 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: allow user idle system sleep 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: ----- End install ----- 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: 4.6s elapsed install time 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Cleared responsibility for install from 27670. 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Hosted team responsible for install has been cleared. 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Running idle tasks 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: Error getting application status info for file:///Applications/Camera%20Hub.app: Error Domain=NSCocoaErrorDomain Code=260 "Die Datei „Camera Hub.app“ konnte nicht geöffnet werden, da sie nicht existiert." UserInfo={NSURL=file:///Applications/Camera%20Hub.app, NSFilePath=/Applications/Camera Hub.app, NSUnderlyingError=0x600000e900c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}} 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Removing client PKInstallDaemonClient pid=27670, uid=0 (/usr/sbin/installer) 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installd[5332]: PackageKit: Done with sandbox removals 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: Running install actions 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27670hQrcYW" 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: Finalize disk "Macintosh HD" 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: Notifying system of updated components 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: 2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: **** Summary Information ****
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:   Operation      Elapsed time
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]: -----------------------------
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:        disk      0.02 seconds
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:      script      0.00 seconds
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:        zero      0.00 seconds
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:     install      5.08 seconds
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:     -total-      5.10 seconds
2023-08-19 12:19:09+02 savvas-LF0Y25WVCX installer[27670]:

2023-08-19 12:19:11 : INFO  : elgatocamerahub : Finishing... 2023-08-19 12:19:14 : INFO  : elgatocamerahub : App(s) found: /Applications/Elgato Camera Hub.app 2023-08-19 12:19:14 : INFO  : elgatocamerahub : found app at /Applications/Elgato Camera Hub.app, version 1.7.0, on versionKey CFBundleShortVersionString
2023-08-19 12:19:14 : REQ   : elgatocamerahub : Installed Elgato Camera Hub, version 1.7.0
2023-08-19 12:19:14 : DEBUG : elgatocamerahub : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE
2023-08-19 12:19:14 : DEBUG : elgatocamerahub : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE/Elgato Camera Hub.pkg
2023-08-19 12:19:14 : DEBUG : elgatocamerahub : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.z0BO4abE
2023-08-19 12:19:14 : INFO  : elgatocamerahub : App not closed, so no reopen.
2023-08-19 12:19:14 : REQ   : elgatocamerahub : All done!
2023-08-19 12:19:14 : REQ   : elgatocamerahub : ################## End Installomator, exit code 0

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels elgatocamerahub NOTIFY=silent DEBUG=0
2023-08-19 12:19:37 : REQ   : elgatocamerahub : ################## Start Installomator v. 10.5beta, date 2023-08-19
2023-08-19 12:19:37 : INFO  : elgatocamerahub : ################## Version: 10.5beta
2023-08-19 12:19:37 : INFO  : elgatocamerahub : ################## Date: 2023-08-19
2023-08-19 12:19:37 : INFO  : elgatocamerahub : ################## elgatocamerahub
2023-08-19 12:19:37 : DEBUG : elgatocamerahub : DEBUG mode 1 enabled.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 53703    0 53703    0     0  57130      0 --:--:-- --:--:-- --:--:-- 57313
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 63906    0 63906    0     0   119k      0 --:--:-- --:--:-- --:--:--  120k
2023-08-19 12:19:38 : INFO  : elgatocamerahub : setting variable from argument NOTIFY=silent
2023-08-19 12:19:38 : INFO  : elgatocamerahub : setting variable from argument DEBUG=0
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : name=Elgato Camera Hub
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : appName=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : type=pkg
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : archiveName=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : downloadURL=https://edge.elgato.com/egc/macos/echm/1.7/Camera_Hub_1.7.0.1124.pkg
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : curlOptions=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : appNewVersion=1.7.0
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : appCustomVersion function: Not defined
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : versionKey=CFBundleShortVersionString
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : packageID=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : pkgName=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : choiceChangesXML=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : expectedTeamID=Y93VXCB8Q5
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : blockingProcesses=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : installerTool=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : CLIInstaller=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : CLIArguments=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : updateTool=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : updateToolArguments=
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : updateToolRunAsCurrentUser=
2023-08-19 12:19:38 : INFO  : elgatocamerahub : BLOCKING_PROCESS_ACTION=tell_user
2023-08-19 12:19:38 : INFO  : elgatocamerahub : NOTIFY=silent
2023-08-19 12:19:38 : INFO  : elgatocamerahub : LOGGING=DEBUG
2023-08-19 12:19:38 : INFO  : elgatocamerahub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-19 12:19:38 : INFO  : elgatocamerahub : Label type: pkg
2023-08-19 12:19:38 : INFO  : elgatocamerahub : archiveName: Elgato Camera Hub.pkg
2023-08-19 12:19:38 : INFO  : elgatocamerahub : no blocking processes defined, using Elgato Camera Hub as default
2023-08-19 12:19:38 : DEBUG : elgatocamerahub : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gud6EqM6
2023-08-19 12:19:38 : INFO  : elgatocamerahub : App(s) found: /Applications/Elgato Camera Hub.app
2023-08-19 12:19:39 : INFO  : elgatocamerahub : found app at /Applications/Elgato Camera Hub.app, version 1.7.0, on versionKey CFBundleShortVersionString
2023-08-19 12:19:39 : INFO  : elgatocamerahub : appversion: 1.7.0
2023-08-19 12:19:39 : INFO  : elgatocamerahub : Latest version of Elgato Camera Hub is 1.7.0
2023-08-19 12:19:39 : INFO  : elgatocamerahub : There is no newer version available.
2023-08-19 12:19:39 : DEBUG : elgatocamerahub : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gud6EqM6
2023-08-19 12:19:39 : DEBUG : elgatocamerahub : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gud6EqM6
2023-08-19 12:19:39 : INFO  : elgatocamerahub : App not closed, so no reopen.
2023-08-19 12:19:39 : REQ   : elgatocamerahub : No newer version.
2023-08-19 12:19:39 : REQ   : elgatocamerahub : ################## End Installomator, exit code 0