### PR TITLE
New Label: Jetbrainsdataspell

### DIFF
--- a/fragments/labels/jetbrainsdataspell.sh
+++ b/fragments/labels/jetbrainsdataspell.sh
@@ -1,0 +1,13 @@
+jetbrainsdataspell)
+    name="DataSpell"
+    type="dmg"
+    jetbrainscode="DS"
+    if [[ $(arch) == i386 ]]; then
+        jetbrainsdistribution="mac"
+    elif [[ $(arch) == arm64 ]]; then
+        jetbrainsdistribution="macM1"
+    fi
+    downloadURL="https://download.jetbrains.com/product?code=${jetbrainscode}&latest&distribution=${jetbrainsdistribution}"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "location" | tail -1 | sed -E 's/.*\/[a-zA-Z-]*-([0-9.]*).*[-.].*dmg/\1/g' )
+    expectedTeamID="2ZEFAR8TH3"
+    ;;

--- a/fragments/labels/jetbrainsgoland.sh
+++ b/fragments/labels/jetbrainsgoland.sh
@@ -1,0 +1,13 @@
+jetbrainsgoland)
+    name="GoLand"
+    type="dmg"
+    jetbrainscode="GO"
+    if [[ $(arch) == i386 ]]; then
+        jetbrainsdistribution="mac"
+    elif [[ $(arch) == arm64 ]]; then
+        jetbrainsdistribution="macM1"
+    fi
+    downloadURL="https://download.jetbrains.com/product?code=${jetbrainscode}&latest&distribution=${jetbrainsdistribution}"
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "location" | tail -1 | sed -E 's/.*\/[a-zA-Z-]*-([0-9.]*).*[-.].*dmg/\1/g' )
+    expectedTeamID="2ZEFAR8TH3"
+    ;;


### PR DESCRIPTION
Output:
 ~/Installomator/assemble.sh jetbrainsdataspell
2023-08-22 15:31:23 : REQ   : jetbrainsdataspell : ################## Start Installomator v. 10.5beta, date 2023-08-22
2023-08-22 15:31:23 : INFO  : jetbrainsdataspell : ################## Version: 10.5beta
2023-08-22 15:31:23 : INFO  : jetbrainsdataspell : ################## Date: 2023-08-22
2023-08-22 15:31:23 : INFO  : jetbrainsdataspell : ################## jetbrainsdataspell
2023-08-22 15:31:23 : DEBUG : jetbrainsdataspell : DEBUG mode 1 enabled.
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : name=DataSpell
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : appName=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : type=dmg
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : archiveName=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : downloadURL=https://download.jetbrains.com/product?code=DS&latest&distribution=macM1
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : curlOptions=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : appNewVersion=2023.2
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : appCustomVersion function: Not defined
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : versionKey=CFBundleShortVersionString
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : packageID=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : pkgName=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : choiceChangesXML=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : expectedTeamID=2ZEFAR8TH3
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : blockingProcesses=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : installerTool=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : CLIInstaller=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : CLIArguments=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : updateTool=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : updateToolArguments=
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : updateToolRunAsCurrentUser=
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : BLOCKING_PROCESS_ACTION=tell_user
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : NOTIFY=success
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : LOGGING=DEBUG
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : Label type: dmg
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : archiveName: DataSpell.dmg
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : no blocking processes defined, using DataSpell as default
2023-08-22 15:31:25 : DEBUG : jetbrainsdataspell : Changing directory to /Users/david.minnema/Documents/GitHub/Installomator/build
2023-08-22 15:31:25 : INFO  : jetbrainsdataspell : name: DataSpell, appName: DataSpell.app
2023-08-22 15:31:25.678 mdfind[28576:4957913] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-08-22 15:31:25.679 mdfind[28576:4957913] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-08-22 15:31:25.716 mdfind[28576:4957913] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-22 15:31:26 : WARN  : jetbrainsdataspell : No previous app found
2023-08-22 15:31:26 : WARN  : jetbrainsdataspell : could not find DataSpell.app
2023-08-22 15:31:26 : INFO  : jetbrainsdataspell : appversion:
2023-08-22 15:31:26 : INFO  : jetbrainsdataspell : Latest version of DataSpell is 2023.2
2023-08-22 15:31:26 : REQ   : jetbrainsdataspell : Downloading https://download.jetbrains.com/product?code=DS&latest&distribution=macM1 to DataSpell.dmg
2023-08-22 15:31:26 : DEBUG : jetbrainsdataspell : No Dialog connection, just download
2023-08-22 15:32:15 : DEBUG : jetbrainsdataspell : File list: -rw-r--r--  1 david.minnema  staff   751M Aug 22 15:32 DataSpell.dmg
2023-08-22 15:32:15 : DEBUG : jetbrainsdataspell : File type: DataSpell.dmg: lzfse encoded, lzvn compressed
2023-08-22 15:32:15 : DEBUG : jetbrainsdataspell : curl output was:
*   Trying 34.246.102.22:443...
* Connected to download.jetbrains.com (34.246.102.22) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4994 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.jetbrains.com
*  start date: Mar  6 00:00:00 2023 GMT
*  expire date: Apr  3 23:59:59 2024 GMT
*  subjectAltName: host "download.jetbrains.com" matched cert's "download.jetbrains.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download.jetbrains.com]
* h2 [:path: /product?code=DS&latest&distribution=macM1]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13c013400)
> GET /product?code=DS&latest&distribution=macM1 HTTP/2
> Host: download.jetbrains.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< date: Tue, 22 Aug 2023 20:31:26 GMT
< content-length: 0
< location: https://download.jetbrains.com/python/dataspell-2023.2-aarch64.dmg < server: nginx
< access-control-allow-origin: *
< strict-transport-security: max-age=31536000; includeSubdomains; < x-frame-options: DENY
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block;
< x-geocountry: United States
< x-geocode: US
< x-geocity: Saint Paul
<
{ [0 bytes data]
* Connection #0 to host download.jetbrains.com left intact
* Issue another request to this URL: 'https://download.jetbrains.com/python/dataspell-2023.2-aarch64.dmg'
* Found bundle for host: 0x600000b28fc0 [can multiplex]
* Re-using existing connection #0 with host download.jetbrains.com
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download.jetbrains.com]
* h2 [:path: /python/dataspell-2023.2-aarch64.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 3 (easy handle 0x13c013400)
> GET /python/dataspell-2023.2-aarch64.dmg HTTP/2
> Host: download.jetbrains.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< date: Tue, 22 Aug 2023 20:31:26 GMT
< content-type: text/html
< content-length: 138
< location: https://download-cdn.jetbrains.com/python/dataspell-2023.2-aarch64.dmg < server: nginx
< strict-transport-security: max-age=31536000; includeSubdomains; < x-frame-options: DENY
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block;
< x-geocountry: United States
< x-geocode: US
< x-geocity: Saint Paul
<
* Ignoring the response-body { [138 bytes data]
* Connection #0 to host download.jetbrains.com left intact
* Issue another request to this URL: 'https://download-cdn.jetbrains.com/python/dataspell-2023.2-aarch64.dmg'
*   Trying 13.225.47.71:443...
* Connected to download-cdn.jetbrains.com (13.225.47.71) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5004 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download-cdn.jetbrains.com
*  start date: Mar 12 00:00:00 2023 GMT
*  expire date: Apr  9 23:59:59 2024 GMT
*  subjectAltName: host "download-cdn.jetbrains.com" matched cert's "download-cdn.jetbrains.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download-cdn.jetbrains.com]
* h2 [:path: /python/dataspell-2023.2-aarch64.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x13c013400)
> GET /python/dataspell-2023.2-aarch64.dmg HTTP/2
> Host: download-cdn.jetbrains.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 787108657
< date: Tue, 22 Aug 2023 20:31:28 GMT
< x-amz-replication-status: COMPLETED
< last-modified: Thu, 27 Jul 2023 14:58:01 GMT
< etag: "91fe299994dd9cafc52b9303ae234288-94"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: 6wH3MFUfpsQinoQQjKH1cGu1f0TXK41S < accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 bed6203f0e4d3598b0a0e1df97f721c4.cloudfront.net (CloudFront) < x-amz-cf-pop: DFW50-C1
< x-amz-cf-id: wmhd2GChaocv9KOhpvpdCmDNWPaea7EaHVN4IsZPrUqs6kC1X0R66Q== <
{ [16894 bytes data]
* Connection #1 to host download-cdn.jetbrains.com left intact

2023-08-22 15:32:15 : DEBUG : jetbrainsdataspell : DEBUG mode 1, not checking for blocking processes
2023-08-22 15:32:15 : REQ   : jetbrainsdataspell : Installing DataSpell
2023-08-22 15:32:15 : INFO  : jetbrainsdataspell : Mounting /Users/david.minnema/Documents/GitHub/Installomator/build/DataSpell.dmg
2023-08-22 15:32:20 : DEBUG : jetbrainsdataspell : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $FB2E9753
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F15E51B3
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $97F2861B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $56982DFD
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $97F2861B
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $A7972AB7
verified   CRC32 $6F1A1086
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	EFI
/dev/disk5s2        	Apple_HFS                      	/Volumes/DataSpell

2023-08-22 15:32:20 : INFO  : jetbrainsdataspell : Mounted: /Volumes/DataSpell 2023-08-22 15:32:20 : INFO  : jetbrainsdataspell : Verifying: /Volumes/DataSpell/DataSpell.app 2023-08-22 15:32:20 : DEBUG : jetbrainsdataspell : App size: 1.8G	/Volumes/DataSpell/DataSpell.app 2023-08-22 15:32:24 : DEBUG : jetbrainsdataspell : Debugging enabled, App Verification output was: /Volumes/DataSpell/DataSpell.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: JetBrains s.r.o. (2ZEFAR8TH3)

2023-08-22 15:32:24 : INFO  : jetbrainsdataspell : Team ID matching: 2ZEFAR8TH3 (expected: 2ZEFAR8TH3 ) 2023-08-22 15:32:25 : INFO  : jetbrainsdataspell : Installing DataSpell version 2023.2 on versionKey CFBundleShortVersionString. 2023-08-22 15:32:25 : INFO  : jetbrainsdataspell : App has LSMinimumSystemVersion: 10.15 2023-08-22 15:32:25 : DEBUG : jetbrainsdataspell : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-08-22 15:32:25 : INFO  : jetbrainsdataspell : Finishing... 2023-08-22 15:32:28 : INFO  : jetbrainsdataspell : name: DataSpell, appName: DataSpell.app 2023-08-22 15:32:28.428 mdfind[28758:4959648] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-08-22 15:32:28.428 mdfind[28758:4959648] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-08-22 15:32:28.475 mdfind[28758:4959648] Couldn't determine the mapping between prefab keywords and predicates. 2023-08-22 15:32:28 : WARN  : jetbrainsdataspell : No previous app found 2023-08-22 15:32:28 : WARN  : jetbrainsdataspell : could not find DataSpell.app
2023-08-22 15:32:28 : REQ   : jetbrainsdataspell : Installed DataSpell, version 2023.2
2023-08-22 15:32:28 : INFO  : jetbrainsdataspell : notifying
2023-08-22 15:32:29 : DEBUG : jetbrainsdataspell : Unmounting /Volumes/DataSpell
2023-08-22 15:32:29 : DEBUG : jetbrainsdataspell : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-08-22 15:32:29 : DEBUG : jetbrainsdataspell : DEBUG mode 1, not reopening anything
2023-08-22 15:32:29 : REQ   : jetbrainsdataspell : All done!
2023-08-22 15:32:29 : REQ   : jetbrainsdataspell : ################## End Installomator, exit code 0