### PR TITLE
New Label: Digiexam

### DIFF
--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -2,6 +2,6 @@ digiexam)
 	name="Digiexam"
 	type="dmg"
 	downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg"
-    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.digiexam.se/hc/sv/articles/7119593625628-Klientuppdateringar | grep "Mac" | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
+    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.digiexam.se/hc/en-us/articles/7119593625628-Client-updates | perl -ne 'print if /Version(?!.*Only(?!.*Mac))(?=.*Mac)?/' | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
 	expectedTeamID="73T9H7VE4P"
 	;;

--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -1,0 +1,7 @@
+digiexam)
+	name="Digiexam"
+	type="dmg"
+	downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg"
+    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.digiexam.se/hc/sv/articles/7119593625628-Klientuppdateringar | grep "Mac" | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
+	expectedTeamID="73T9H7VE4P"
+	;;


### PR DESCRIPTION
My first contribution to an open source project, please be kind... 😊 

https://www.digiexam.com/
"Digiexam is the leading exam platform in terms of user experience and reliability. It provides a easy-to-use software to manage your end-to-end exam workflow. During 10+ years in business, 500 000+ end-users have submitted 12 000 000+ exams via Digiexam. The platform is powerful on its own but connects to your LMS, via the LTI standard."

Output:

./assemble.sh digiexam DEBUG=0
2023-08-23 20:19:32 : REQ   : digiexam : ################## Start Installomator v. 10.5beta, date 2023-08-23
2023-08-23 20:19:32 : INFO  : digiexam : ################## Version: 10.5beta
2023-08-23 20:19:32 : INFO  : digiexam : ################## Date: 2023-08-23
2023-08-23 20:19:32 : INFO  : digiexam : ################## digiexam
2023-08-23 20:19:32 : DEBUG : digiexam : DEBUG mode 1 enabled.
2023-08-23 20:19:32 : INFO  : digiexam : setting variable from argument DEBUG=0
2023-08-23 20:19:32 : DEBUG : digiexam : name=Digiexam
2023-08-23 20:19:32 : DEBUG : digiexam : appName=
2023-08-23 20:19:32 : DEBUG : digiexam : type=dmg
2023-08-23 20:19:32 : DEBUG : digiexam : archiveName=
2023-08-23 20:19:32 : DEBUG : digiexam : downloadURL=https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg
2023-08-23 20:19:32 : DEBUG : digiexam : curlOptions=
2023-08-23 20:19:32 : DEBUG : digiexam : appNewVersion=14.1.2
2023-08-23 20:19:32 : DEBUG : digiexam : appCustomVersion function: Not defined
2023-08-23 20:19:32 : DEBUG : digiexam : versionKey=CFBundleShortVersionString
2023-08-23 20:19:32 : DEBUG : digiexam : packageID=
2023-08-23 20:19:32 : DEBUG : digiexam : pkgName=
2023-08-23 20:19:32 : DEBUG : digiexam : choiceChangesXML=
2023-08-23 20:19:32 : DEBUG : digiexam : expectedTeamID=73T9H7VE4P
2023-08-23 20:19:32 : DEBUG : digiexam : blockingProcesses=
2023-08-23 20:19:32 : DEBUG : digiexam : installerTool=
2023-08-23 20:19:32 : DEBUG : digiexam : CLIInstaller=
2023-08-23 20:19:32 : DEBUG : digiexam : CLIArguments=
2023-08-23 20:19:32 : DEBUG : digiexam : updateTool=
2023-08-23 20:19:32 : DEBUG : digiexam : updateToolArguments=
2023-08-23 20:19:32 : DEBUG : digiexam : updateToolRunAsCurrentUser=
2023-08-23 20:19:32 : INFO  : digiexam : BLOCKING_PROCESS_ACTION=tell_user
2023-08-23 20:19:32 : INFO  : digiexam : NOTIFY=success
2023-08-23 20:19:32 : INFO  : digiexam : LOGGING=DEBUG
2023-08-23 20:19:32 : INFO  : digiexam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-23 20:19:32 : INFO  : digiexam : Label type: dmg
2023-08-23 20:19:32 : INFO  : digiexam : archiveName: Digiexam.dmg
2023-08-23 20:19:32 : INFO  : digiexam : no blocking processes defined, using Digiexam as default
2023-08-23 20:19:32 : DEBUG : digiexam : Changing directory to /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.abcRHgch
2023-08-23 20:19:32 : INFO  : digiexam : name: Digiexam, appName: Digiexam.app
2023-08-23 20:19:32.851 mdfind[95597:3337226] [UserQueryParser] Loading keywords and predicates for locale "sv_SE"
2023-08-23 20:19:32.852 mdfind[95597:3337226] [UserQueryParser] Loading keywords and predicates for locale "sv"
2023-08-23 20:19:32.905 mdfind[95597:3337226] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-23 20:19:32.905 mdfind[95597:3337226] Couldn't determine the mapping between prefab keywords and predicates.
2023-08-23 20:19:33 : WARN  : digiexam : No previous app found
2023-08-23 20:19:33 : WARN  : digiexam : could not find Digiexam.app
2023-08-23 20:19:33 : INFO  : digiexam : appversion:
2023-08-23 20:19:33 : INFO  : digiexam : Latest version of Digiexam is 14.1.2
2023-08-23 20:19:33 : REQ   : digiexam : Downloading https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg to Digiexam.dmg
2023-08-23 20:19:33 : DEBUG : digiexam : No Dialog connection, just download
2023-08-23 20:19:37 : DEBUG : digiexam : File list: -rw-r--r--@ 1 olof.hennig  staff    87M Aug 23 20:19 Digiexam.dmg
2023-08-23 20:19:37 : DEBUG : digiexam : File type: Digiexam.dmg: zlib compressed data
2023-08-23 20:19:37 : DEBUG : digiexam : curl output was:
*   Trying 199.60.103.30:443...
* Connected to www.digiexam.com (199.60.103.30) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4214 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.digiexam.com
*  start date: Jul 25 20:48:25 2023 GMT
*  expire date: Oct 23 20:48:24 2023 GMT
*  subjectAltName: host "www.digiexam.com" matched cert's "www.digiexam.com"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1P5
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: www.digiexam.com]
* h2 [:path: /hubfs/client/Digiexam_Mac.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15380a800)
> GET /hubfs/client/Digiexam_Mac.dmg HTTP/2
> Host: www.digiexam.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< date: Wed, 23 Aug 2023 18:19:33 GMT
< content-type: application/x-apple-diskimage
< content-length: 91723455
< cf-ray: 7fb55d4d7b45ac1d-GOT
< cf-cache-status: HIT
< accept-ranges: bytes
< access-control-allow-origin: *
< age: 541061
< cache-control: s-maxage=1814400, max-age=1209600, stale-while-revalidate=900 < etag: "cd96e3d8457386ab257ae9f7eb9868b4"
< last-modified: Wed, 05 Jul 2023 19:06:03 GMT
< strict-transport-security: max-age=31536000
< vary: Accept-Encoding
< via: 1.1 9803a30a87f1ec1047cb2b8ad5ecc43e.cloudfront.net (CloudFront) < access-control-allow-methods: GET
< cache-tag: F-121269691649,FD-121269926261,P-8994452,FLS-ALL < content-security-policy: upgrade-insecure-requests < edge-cache-tag: F-121269691649,FD-121269926261,P-8994452,FLS-ALL < x-amz-cf-id: lkqeiQWQacYuIGYE-y8RvcQBpAIKLb0WshXAi8N7IUWnxKlj8XkgoA== < x-amz-cf-pop: ARN56-P1
< x-amz-id-2: ru8JMauuzSMDCJrVXQCNU5IjBqk2hREjlruiCmY3c43f4f9BwCNQ+RZjBrY+mJczGokPFblLFr/nU6CFuJCvQw== < x-amz-meta-cache-tag: F-121269691649,FD-121269926261,P-8994452,FLS-ALL < x-amz-meta-created-unix-time-millis: 1687165946601 < x-amz-meta-index-tag: all
< x-amz-replication-status: COMPLETED
< x-amz-request-id: 1W8Y8HBTBF05H26B
< x-amz-server-side-encryption: AES256
< x-amz-storage-class: INTELLIGENT_TIERING
< x-amz-version-id: ksfC9JuG05S97sI.lxfGHr1ub7gXD53A < x-cache: RefreshHit from cloudfront
< x-hs-alternate-content-type: text/plain
< x-hs-cf-lambda: us-east-1.EnforceAclForReads 2
< x-hs-cf-lambda-enforce: us-east-1.EnforceAclForReads 2 < x-hs-https-only: worker
< x-robots-tag: all
< set-cookie: __cf_bm=7y4.nFzQvJ2U.hdMrj56IBTmRktBBtoZkT2GXe_laMs-1692814773-0-AdTqYJi8mFVURE/LyPdQOZr3w8SjjsbjRtPgYegftUaHS9oKLPCdS/OIvYdPtwSASWC48ygoQLLPYIk8KzPDy9A=; path=/; expires=Wed, 23-Aug-23 18:49:33 GMT; domain=.www.digiexam.com; HttpOnly; Secure; SameSite=None < report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v3?s=I5FuB8gdO7xjW7UsrEZuUsL82UXndFl6YbNLU%2Bkh%2B6Tiaj%2FWHSxPiU405BZr1IsdjuGdlWc2FzDLkT7JtswdKx0VOF8DGqkwgEQfOcQBVGurhp0du1lwjlIrvVdar%2BJGSPY%3D"}],"group":"cf-nel","max_age":604800} < nel: {"success_fraction":0.01,"report_to":"cf-nel","max_age":604800} < set-cookie: __cfruid=469f124e6b3396db9b66268343dd86bb6823e579-1692814773; path=/; domain=.www.digiexam.com; HttpOnly; Secure; SameSite=None < server: cloudflare
< alt-svc: h3=":443"; ma=86400
<
{ [32768 bytes data]
* Connection #0 to host www.digiexam.com left intact

2023-08-23 20:19:37 : REQ   : digiexam : no more blocking processes, continue with update
2023-08-23 20:19:37 : REQ   : digiexam : Installing Digiexam
2023-08-23 20:19:37 : INFO  : digiexam : Mounting /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.abcRHgch/Digiexam.dmg
2023-08-23 20:19:42 : DEBUG : digiexam : Debugging enabled, dmgmount output was:
Beräknar kontrollsumma för Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verifierade   CRC32 $4EDD32DD
Beräknar kontrollsumma för GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verifierade   CRC32 $A7500C66
Beräknar kontrollsumma för GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verifierade   CRC32 $8671AC38
Beräknar kontrollsumma för  (Apple_Free : 3)…
(Apple_Free : 3): verifierade   CRC32 $00000000
Beräknar kontrollsumma för disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verifierade   CRC32 $824C3635
Beräknar kontrollsumma för  (Apple_Free : 5)…
(Apple_Free : 5): verifierade   CRC32 $00000000
Beräknar kontrollsumma för GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verifierade   CRC32 $8671AC38
Beräknar kontrollsumma för GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verifierade   CRC32 $5D38617F
verifierade   CRC32 $37F607BE
/dev/disk14         	GUID_partition_scheme
/dev/disk14s1       	Apple_HFS                      	/Volumes/Digiexam 14.1.2

2023-08-23 20:19:42 : INFO  : digiexam : Mounted: /Volumes/Digiexam 14.1.2 2023-08-23 20:19:42 : INFO  : digiexam : Verifying: /Volumes/Digiexam 14.1.2/Digiexam.app 2023-08-23 20:19:42 : DEBUG : digiexam : App size: 209M	/Volumes/Digiexam 14.1.2/Digiexam.app 2023-08-23 20:19:44 : DEBUG : digiexam : Debugging enabled, App Verification output was: /Volumes/Digiexam 14.1.2/Digiexam.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DigiExam Solutions Sweden AB (73T9H7VE4P)

2023-08-23 20:19:44 : INFO  : digiexam : Team ID matching: 73T9H7VE4P (expected: 73T9H7VE4P ) 2023-08-23 20:19:45 : INFO  : digiexam : Installing Digiexam version 14.1.2 on versionKey CFBundleShortVersionString. 2023-08-23 20:19:45 : INFO  : digiexam : App has LSMinimumSystemVersion: 10.10 2023-08-23 20:19:45 : INFO  : digiexam : Copy /Volumes/Digiexam 14.1.2/Digiexam.app to /Applications 2023-08-23 20:19:46 : DEBUG : digiexam : Debugging enabled, App copy output was: Copying /Volumes/Digiexam 14.1.2/Digiexam.app

2023-08-23 20:19:46 : WARN  : digiexam : Changing owner to olof.hennig 2023-08-23 20:19:46 : INFO  : digiexam : Finishing... 2023-08-23 20:19:49 : INFO  : digiexam : App(s) found: /Applications/Digiexam.app 2023-08-23 20:19:50 : INFO  : digiexam : found app at /Applications/Digiexam.app, version 14.1.2, on versionKey CFBundleShortVersionString
2023-08-23 20:19:50 : REQ   : digiexam : Installed Digiexam, version 14.1.2
2023-08-23 20:19:50 : INFO  : digiexam : notifying
2023-08-23 20:19:50 : DEBUG : digiexam : Unmounting /Volumes/Digiexam 14.1.2
2023-08-23 20:19:50 : DEBUG : digiexam : Debugging enabled, Unmounting output was:
"disk14" ejected.
2023-08-23 20:19:50 : DEBUG : digiexam : Deleting /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.abcRHgch
2023-08-23 20:19:50 : DEBUG : digiexam : Debugging enabled, Deleting tmpDir output was:
/var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.abcRHgch/Digiexam.dmg
2023-08-23 20:19:50 : DEBUG : digiexam : /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.abcRHgch
2023-08-23 20:19:50 : INFO  : digiexam : App not closed, so no reopen.
2023-08-23 20:19:50 : REQ   : digiexam : All done!
2023-08-23 20:19:50 : REQ   : digiexam : ################## End Installomator, exit code 0

√ ~/D/G/I/utils ❱❱❱
20:19:50
./assemble.sh digiexam DEBUG=0
2023-08-23 20:19:54 : REQ   : digiexam : ################## Start Installomator v. 10.5beta, date 2023-08-23
2023-08-23 20:19:54 : INFO  : digiexam : ################## Version: 10.5beta
2023-08-23 20:19:54 : INFO  : digiexam : ################## Date: 2023-08-23
2023-08-23 20:19:54 : INFO  : digiexam : ################## digiexam
2023-08-23 20:19:54 : DEBUG : digiexam : DEBUG mode 1 enabled.
2023-08-23 20:19:55 : INFO  : digiexam : setting variable from argument DEBUG=0
2023-08-23 20:19:55 : DEBUG : digiexam : name=Digiexam
2023-08-23 20:19:55 : DEBUG : digiexam : appName=
2023-08-23 20:19:55 : DEBUG : digiexam : type=dmg
2023-08-23 20:19:55 : DEBUG : digiexam : archiveName=
2023-08-23 20:19:55 : DEBUG : digiexam : downloadURL=https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg
2023-08-23 20:19:55 : DEBUG : digiexam : curlOptions=
2023-08-23 20:19:55 : DEBUG : digiexam : appNewVersion=14.1.2
2023-08-23 20:19:55 : DEBUG : digiexam : appCustomVersion function: Not defined
2023-08-23 20:19:55 : DEBUG : digiexam : versionKey=CFBundleShortVersionString
2023-08-23 20:19:55 : DEBUG : digiexam : packageID=
2023-08-23 20:19:55 : DEBUG : digiexam : pkgName=
2023-08-23 20:19:55 : DEBUG : digiexam : choiceChangesXML=
2023-08-23 20:19:55 : DEBUG : digiexam : expectedTeamID=73T9H7VE4P
2023-08-23 20:19:55 : DEBUG : digiexam : blockingProcesses=
2023-08-23 20:19:55 : DEBUG : digiexam : installerTool=
2023-08-23 20:19:55 : DEBUG : digiexam : CLIInstaller=
2023-08-23 20:19:55 : DEBUG : digiexam : CLIArguments=
2023-08-23 20:19:55 : DEBUG : digiexam : updateTool=
2023-08-23 20:19:55 : DEBUG : digiexam : updateToolArguments=
2023-08-23 20:19:55 : DEBUG : digiexam : updateToolRunAsCurrentUser=
2023-08-23 20:19:55 : INFO  : digiexam : BLOCKING_PROCESS_ACTION=tell_user
2023-08-23 20:19:55 : INFO  : digiexam : NOTIFY=success
2023-08-23 20:19:55 : INFO  : digiexam : LOGGING=DEBUG
2023-08-23 20:19:55 : INFO  : digiexam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-23 20:19:55 : INFO  : digiexam : Label type: dmg
2023-08-23 20:19:55 : INFO  : digiexam : archiveName: Digiexam.dmg
2023-08-23 20:19:55 : INFO  : digiexam : no blocking processes defined, using Digiexam as default
2023-08-23 20:19:55 : DEBUG : digiexam : Changing directory to /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.duybZmVe
2023-08-23 20:19:55 : INFO  : digiexam : App(s) found: /Applications/Digiexam.app
2023-08-23 20:19:55 : INFO  : digiexam : found app at /Applications/Digiexam.app, version 14.1.2, on versionKey CFBundleShortVersionString
2023-08-23 20:19:55 : INFO  : digiexam : appversion: 14.1.2
2023-08-23 20:19:55 : INFO  : digiexam : Latest version of Digiexam is 14.1.2
2023-08-23 20:19:55 : INFO  : digiexam : There is no newer version available.
2023-08-23 20:19:55 : DEBUG : digiexam : Deleting /var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.duybZmVe
2023-08-23 20:19:55 : DEBUG : digiexam : Debugging enabled, Deleting tmpDir output was:
/var/folders/jh/2b02zl191zbbhnh_4n8v6kw00000gp/T/tmp.duybZmVe
2023-08-23 20:19:55 : INFO  : digiexam : App not closed, so no reopen.
2023-08-23 20:19:55 : REQ   : digiexam : No newer version.
2023-08-23 20:19:55 : REQ   : digiexam : ################## End Installomator, exit code 0