### PR TITLE
New Label: Acorn image editor

### DIFF
--- a/fragments/labels/acorn.sh
+++ b/fragments/labels/acorn.sh
@@ -1,0 +1,7 @@
+acorn)
+    name="Acorn"
+    type="zip"
+    downloadURL="https://flyingmeat.com/download/Acorn.zip"
+    appNewVersion="$(curl -sL https://flyingmeat.com/acorn/releasenotes.html | grep -i 'class="releaseTitleT"' | head -n1 | sed -n 's:.*<div\(.*\)>\(.*\)</div>.*:\2:p' | awk '{print $NF}')"
+    expectedTeamID="WZCN9HJ4VP"
+    ;;


### PR DESCRIPTION
Adds label for the [Acorn image editor](https://flyingmeat.com/acorn/)

This software is non-free but has a 14 day trial. Also as far as I can tell the download is the same as the update