### PR TITLE
New Label: Adium instant messenger

### DIFF
--- a/fragments/labels/adium.sh
+++ b/fragments/labels/adium.sh
@@ -1,0 +1,7 @@
+adium)
+    name="Adium"
+    type="dmg"
+    appNewVersion="$(curl -sL "https://adium.im" | grep -i 'class="downloadlink"' | sed -r 's/.*href="([^"]+).*/\1/g' | sed -n 's:.*Adium_\(.*\).dmg.*:\1:p')"
+    downloadURL="https://adiumx.cachefly.net/Adium_${appNewVersion}.dmg"
+    expectedTeamID="VQ6ZEL8UD3"
+    ;;


### PR DESCRIPTION
Adds new label for the [Adium IM app](https://adium.im)

appNewVersion is collected first as that is required for the download link. Naming convention appears to be consistent.