### PR TITLE
New Label: texshop

### DIFF
--- a/fragments/labels/texshop.sh
+++ b/fragments/labels/texshop.sh
@@ -1,0 +1,7 @@
+texshop)
+    name="TeXShop"
+    type="zip"
+    downloadURL="$(downloadURLFromGit TeXShop TeXShop)"
+    appNewVersion="$(versionFromGit TeXShop TeXShop)"
+    expectedTeamID="RBGCY5RJWM"
+    ;;


### PR DESCRIPTION
Label for TeXShop obtained from the unofficial TeXShop source code repository on github (which is linked to from the original sources https://pages.uoregon.edu/koch/texshop/obtaining.html)

It doesn't appear to be in lock step with that source currently being one version behind however it's a much more reliable source to download from 