### PR TITLE
Updated Label: MySQL Workbench CE

### DIFF
--- a/fragments/labels/mysqlworkbenchce.sh
+++ b/fragments/labels/mysqlworkbenchce.sh
@@ -1,7 +1,11 @@
 mysqlworkbenchce)
     name="MySQLWorkbench"
     type="dmg"
-    downloadURL="https://dev.mysql.com/get/Downloads/MySQLGUITools/$(curl -s "https://dev.mysql.com/downloads/workbench/?os=33" | grep mysql-workbench-community | head -1 | cut -d\( -f2 | cut -d\) -f1)"
-    appNewVersion="$(curl -s 'http://workbench.mysql.com/current-release' | grep fullversion | cut -d\" -f4).CE"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://dev.mysql.com/get/Downloads/MySQLGUITools/$(curl -fsL "https://dev.mysql.com/downloads/workbench/?os=33" | grep -o "mysql-workbench-community-.*-macos-arm64.dmg" | head -1)"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://dev.mysql.com/get/Downloads/MySQLGUITools/$(curl -fsL "https://dev.mysql.com/downloads/workbench/?os=33" | grep -o "mysql-workbench-community-.*-macos-x86_64.dmg" | head -1)"
+    fi
+    appNewVersion="$(curl -fsL 'http://workbench.mysql.com/current-release' | grep fullversion | cut -d\" -f4).CE"
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
A package for Apple Silicon devices was added from version 8.0.33 (current version is 8.0.34) and the current label does not have logic for that. The appNewVersion variable seems to be broken in the current label as well. This update fixes these problems.

```
2023-08-31 09:05:00 : REQ   : mysqlworkbenchce : ################## Start Installomator v. 10.5beta, date 2023-08-31
2023-08-31 09:05:00 : INFO  : mysqlworkbenchce : ################## Version: 10.5beta
2023-08-31 09:05:00 : INFO  : mysqlworkbenchce : ################## Date: 2023-08-31
2023-08-31 09:05:00 : INFO  : mysqlworkbenchce : ################## mysqlworkbenchce
2023-08-31 09:05:00 : DEBUG : mysqlworkbenchce : DEBUG mode 1 enabled.
2023-08-31 09:05:00 : INFO  : mysqlworkbenchce : SwiftDialog is not installed, clear cmd file var
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : setting variable from argument DEBUG=0
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : name=MySQLWorkbench
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : appName=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : type=dmg
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : archiveName=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : downloadURL=https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : curlOptions=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : appNewVersion=8.0.34.CE
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : appCustomVersion function: Not defined
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : versionKey=CFBundleShortVersionString
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : packageID=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : pkgName=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : choiceChangesXML=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : expectedTeamID=VB5E2TV963
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : blockingProcesses=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : installerTool=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : CLIInstaller=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : CLIArguments=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : updateTool=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : updateToolArguments=
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : updateToolRunAsCurrentUser=
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : BLOCKING_PROCESS_ACTION=tell_user
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : NOTIFY=success
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : LOGGING=DEBUG
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : Label type: dmg
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : archiveName: MySQLWorkbench.dmg
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : no blocking processes defined, using MySQLWorkbench as default
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.T4lk2F6m
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : App(s) found: /Applications/MySQLWorkbench.app
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : found app at /Applications/MySQLWorkbench.app, version 8.0.32.CE, on versionKey CFBundleShortVersionString
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : appversion: 8.0.32.CE
2023-08-31 09:05:01 : INFO  : mysqlworkbenchce : Latest version of MySQLWorkbench is 8.0.34.CE
2023-08-31 09:05:01 : REQ   : mysqlworkbenchce : Downloading https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg to MySQLWorkbench.dmg
2023-08-31 09:05:01 : DEBUG : mysqlworkbenchce : No Dialog connection, just download
2023-08-31 09:05:03 : DEBUG : mysqlworkbenchce : File list: -rw-r--r--  1 root  wheel   122M Aug 31 09:05 MySQLWorkbench.dmg
2023-08-31 09:05:03 : DEBUG : mysqlworkbenchce : File type: MySQLWorkbench.dmg: bzip2 compressed data, block size = 900k
2023-08-31 09:05:03 : DEBUG : mysqlworkbenchce : curl output was:
*   Trying 23.13.40.241:443...
* Connected to dev.mysql.com (23.13.40.241) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3014 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Oracle Corporation; CN=www.mysql.com
*  start date: Apr 11 00:00:00 2023 GMT
*  expire date: Apr 11 23:59:59 2024 GMT
*  subjectAltName: host "dev.mysql.com" matched cert's "dev.mysql.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: dev.mysql.com]
* h2 [:path: /get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x11d811a00)
> GET /get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg HTTP/2
> Host: dev.mysql.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< content-type: text/html; charset=UTF-8
< content-length: 0
< x-frame-options: SAMEORIGIN
< strict-transport-security: max-age=15768000
< expires: Thu, 19 Nov 1981 08:52:00 GMT
< cache-control: no-store, no-cache, must-revalidate < pragma: no-cache
< location: https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg < x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< date: Thu, 31 Aug 2023 07:05:09 GMT
< set-cookie: MySQL_S=rcqebm30evifftavquf9j8njg1lse4k5; path=/; domain=mysql.com; HttpOnly < server-timing: cdn-cache; desc=MISS
< server-timing: edge; dur=129
< server-timing: origin; dur=65
< akamai-grn: 0.1d5cda17.1693465508.2de37fb
< server-timing: ak_p; desc="1693465508930_400186397_48117755_19351_5689_2_3_15";dur=1 <
{ [0 bytes data]
* Connection #0 to host dev.mysql.com left intact
* Issue another request to this URL: 'https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg'
*   Trying 95.101.144.218:443...
* Connected to cdn.mysql.com (95.101.144.218) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2839 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Oracle Corporation; CN=cdn.mysql.com
*  start date: Jun  5 00:00:00 2023 GMT
*  expire date: Jun  4 23:59:59 2024 GMT
*  subjectAltName: host "cdn.mysql.com" matched cert's "cdn.mysql.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=GeoTrust RSA CA 2018
*  SSL certificate verify ok.
* using HTTP/1.1
> GET //Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-macos-arm64.dmg HTTP/1.1
> Host: cdn.mysql.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Server: AkamaiNetStorage
< Last-Modified: Thu, 13 Jul 2023 12:03:12 GMT
< ETag: "93c0326a15578b16e938f9f0a2f28bd9:1689582711.529453" < Content-Length: 127670422
< Date: Thu, 31 Aug 2023 07:05:09 GMT
< Connection: keep-alive
< Content-Type: application/x-apple-diskimage
<
{ [16078 bytes data]
* Connection #1 to host cdn.mysql.com left intact

2023-08-31 09:05:03 : REQ   : mysqlworkbenchce : no more blocking processes, continue with update
2023-08-31 09:05:03 : REQ   : mysqlworkbenchce : Installing MySQLWorkbench
2023-08-31 09:05:03 : INFO  : mysqlworkbenchce : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.T4lk2F6m/MySQLWorkbench.dmg
2023-08-31 09:05:10 : DEBUG : mysqlworkbenchce : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified CRC32 $04FAFD9E
verified CRC32 $A0D09FFE
/dev/disk4          	                               	/Volumes/MySQL Workbench community-8.0.34

2023-08-31 09:05:10 : INFO  : mysqlworkbenchce : Mounted: /Volumes/MySQL Workbench community-8.0.34 2023-08-31 09:05:10 : INFO  : mysqlworkbenchce : Verifying: /Volumes/MySQL Workbench community-8.0.34/MySQLWorkbench.app 2023-08-31 09:05:10 : DEBUG : mysqlworkbenchce : App size: 242M	/Volumes/MySQL Workbench community-8.0.34/MySQLWorkbench.app 2023-08-31 09:05:44 : DEBUG : mysqlworkbenchce : Debugging enabled, App Verification output was: /Volumes/MySQL Workbench community-8.0.34/MySQLWorkbench.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Oracle America, Inc. (VB5E2TV963)

2023-08-31 09:05:44 : INFO  : mysqlworkbenchce : Team ID matching: VB5E2TV963 (expected: VB5E2TV963 ) 2023-08-31 09:05:44 : INFO  : mysqlworkbenchce : Downloaded version of MySQLWorkbench is 8.0.34.CE on versionKey CFBundleShortVersionString (replacing version 8.0.32.CE). 2023-08-31 09:05:44 : INFO  : mysqlworkbenchce : App has LSMinimumSystemVersion: 13.0 2023-08-31 09:05:44 : WARN  : mysqlworkbenchce : Removing existing /Applications/MySQLWorkbench.app 2023-08-31 09:05:45 : DEBUG : mysqlworkbenchce : Debugging enabled, App removing output was: /Applications/MySQLWorkbench.app/Contents/
Last Log repeated 4928 times
/Applications/MySQLWorkbench.app/Contents
/Applications/MySQLWorkbench.app

2023-08-31 09:05:45 : INFO  : mysqlworkbenchce : Copy /Volumes/MySQL Workbench community-8.0.34/MySQLWorkbench.app to /Applications 2023-08-31 09:05:52 : DEBUG : mysqlworkbenchce : Debugging enabled, App copy output was: Copying /Volumes/MySQL Workbench community-8.0.34/MySQLWorkbench.app

2023-08-31 09:05:52 : WARN  : mysqlworkbenchce : Changing owner to kryptonit 2023-08-31 09:05:53 : INFO  : mysqlworkbenchce : Finishing... 2023-08-31 09:05:56 : INFO  : mysqlworkbenchce : App(s) found: /Applications/MySQLWorkbench.app 2023-08-31 09:05:56 : INFO  : mysqlworkbenchce : found app at /Applications/MySQLWorkbench.app, version 8.0.34.CE, on versionKey CFBundleShortVersionString
2023-08-31 09:05:56 : REQ   : mysqlworkbenchce : Installed MySQLWorkbench, version 8.0.34.CE
2023-08-31 09:05:56 : INFO  : mysqlworkbenchce : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-08-31 09:05:56 : DEBUG : mysqlworkbenchce : Unmounting /Volumes/MySQL Workbench community-8.0.34
2023-08-31 09:05:56 : DEBUG : mysqlworkbenchce : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-08-31 09:05:57 : DEBUG : mysqlworkbenchce : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.T4lk2F6m
2023-08-31 09:05:57 : DEBUG : mysqlworkbenchce : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.T4lk2F6m/MySQLWorkbench.dmg
2023-08-31 09:05:57 : DEBUG : mysqlworkbenchce : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.T4lk2F6m
2023-08-31 09:05:57 : INFO  : mysqlworkbenchce : App not closed, so no reopen.
2023-08-31 09:05:57 : REQ   : mysqlworkbenchce : All done!
2023-08-31 09:05:57 : REQ   : mysqlworkbenchce : ################## End Installomator, exit code 0
```