### PR TITLE
Add Label Suite

### DIFF
--- a/fragments/labels/suitestudio.sh
+++ b/fragments/labels/suitestudio.sh
@@ -1,7 +1,6 @@
 suitestudio)
-    name="Suite Studio"
+    name="Suite"
     type="pkg"
-    packageID="io.suite.suitefs"
     if [[ $(arch) == arm64 ]]; then
         downloadURL="https://saturn-installer-prd-124359286071-bucket.s3.amazonaws.com/suite-installer-osx-arm64.pkg"
     elif [[ $(arch) == i386 ]]; then

--- a/fragments/labels/suitestudio.sh
+++ b/fragments/labels/suitestudio.sh
@@ -1,0 +1,11 @@
+suitestudio)
+    name="Suite Studio"
+    type="pkg"
+    packageID="io.suite.suitefs"
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://saturn-installer-prd-124359286071-bucket.s3.amazonaws.com/suite-installer-osx-arm64.pkg"
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL="https://saturn-installer-prd-124359286071-bucket.s3.amazonaws.com/suite-installer-osx-x64.pkg"
+    fi
+    expectedTeamID="58KZ58VMJ8"
+    ;;


### PR DESCRIPTION
Add label for Suite Studio 

```
sudo ./Installomator.sh suitestudio DEBUG=0
2023-09-01 18:05:25 : REQ   : suitestudio : ################## Start Installomator v. 10.5beta, date 2023-09-01
2023-09-01 18:05:25 : INFO  : suitestudio : ################## Version: 10.5beta
2023-09-01 18:05:25 : INFO  : suitestudio : ################## Date: 2023-09-01
2023-09-01 18:05:25 : INFO  : suitestudio : ################## suitestudio
2023-09-01 18:05:25 : DEBUG : suitestudio : DEBUG mode 1 enabled.
2023-09-01 18:05:25 : INFO  : suitestudio : SwiftDialog is not installed, clear cmd file var
2023-09-01 18:05:26 : INFO  : suitestudio : setting variable from argument DEBUG=0
2023-09-01 18:05:26 : DEBUG : suitestudio : name=Suite
2023-09-01 18:05:26 : DEBUG : suitestudio : appName=
2023-09-01 18:05:26 : DEBUG : suitestudio : type=pkg
2023-09-01 18:05:26 : DEBUG : suitestudio : archiveName=
2023-09-01 18:05:26 : DEBUG : suitestudio : downloadURL=https://saturn-installer-prd-124359286071-bucket.s3.amazonaws.com/suite-installer-osx-x64.pkg
2023-09-01 18:05:26 : DEBUG : suitestudio : curlOptions=
2023-09-01 18:05:26 : DEBUG : suitestudio : appNewVersion=
2023-09-01 18:05:26 : DEBUG : suitestudio : appCustomVersion function: Not defined
2023-09-01 18:05:26 : DEBUG : suitestudio : versionKey=CFBundleShortVersionString
2023-09-01 18:05:26 : DEBUG : suitestudio : packageID=
2023-09-01 18:05:26 : DEBUG : suitestudio : pkgName=
2023-09-01 18:05:26 : DEBUG : suitestudio : choiceChangesXML=
2023-09-01 18:05:26 : DEBUG : suitestudio : expectedTeamID=58KZ58VMJ8
2023-09-01 18:05:26 : DEBUG : suitestudio : blockingProcesses=
2023-09-01 18:05:26 : DEBUG : suitestudio : installerTool=
2023-09-01 18:05:26 : DEBUG : suitestudio : CLIInstaller=
2023-09-01 18:05:26 : DEBUG : suitestudio : CLIArguments=
2023-09-01 18:05:26 : DEBUG : suitestudio : updateTool=
2023-09-01 18:05:26 : DEBUG : suitestudio : updateToolArguments=
2023-09-01 18:05:26 : DEBUG : suitestudio : updateToolRunAsCurrentUser=
2023-09-01 18:05:26 : INFO  : suitestudio : BLOCKING_PROCESS_ACTION=tell_user
2023-09-01 18:05:26 : INFO  : suitestudio : NOTIFY=success
2023-09-01 18:05:26 : INFO  : suitestudio : LOGGING=DEBUG
2023-09-01 18:05:26 : INFO  : suitestudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-09-01 18:05:26 : INFO  : suitestudio : Label type: pkg
2023-09-01 18:05:26 : INFO  : suitestudio : archiveName: Suite.pkg
2023-09-01 18:05:26 : INFO  : suitestudio : no blocking processes defined, using Suite as default
2023-09-01 18:05:26 : DEBUG : suitestudio : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ
2023-09-01 18:05:26 : INFO  : suitestudio : name: Suite, appName: Suite.app
2023-09-01 18:05:26.652 mdfind[27867:162965] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-09-01 18:05:26.652 mdfind[27867:162965] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-09-01 18:05:26.771 mdfind[27867:162965] Couldn't determine the mapping between prefab keywords and predicates.
2023-09-01 18:05:26 : WARN  : suitestudio : No previous app found
2023-09-01 18:05:26 : WARN  : suitestudio : could not find Suite.app
2023-09-01 18:05:26 : INFO  : suitestudio : appversion:
2023-09-01 18:05:26 : INFO  : suitestudio : Latest version not specified.
2023-09-01 18:05:26 : REQ   : suitestudio : Downloading https://saturn-installer-prd-124359286071-bucket.s3.amazonaws.com/suite-installer-osx-x64.pkg to Suite.pkg
2023-09-01 18:05:26 : DEBUG : suitestudio : No Dialog connection, just download
2023-09-01 18:05:31 : DEBUG : suitestudio : File list: -rw-r--r--  1 root  wheel   148M Sep  1 18:05 Suite.pkg
2023-09-01 18:05:31 : DEBUG : suitestudio : File type: Suite.pkg: xar archive compressed TOC: 4624, SHA-1 checksum
2023-09-01 18:05:31 : DEBUG : suitestudio : curl output was:
*   Trying 3.5.25.110:443...
* Connected to saturn-installer-prd-124359286071-bucket.s3.amazonaws.com (3.5.25.110) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [362 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [106 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4970 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Mar 21 00:00:00 2023 GMT
*  expire date: Dec 19 23:59:59 2023 GMT
*  subjectAltName: host "saturn-installer-prd-124359286071-bucket.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /suite-installer-osx-x64.pkg HTTP/1.1
> Host: saturn-installer-prd-124359286071-bucket.s3.amazonaws.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< x-amz-id-2: ZxIOg2LiIoaPO7AG4RtNkNgE7uvKyntRi1SG1HkZ/AMaRbciVCVPqCv/HE/WGTf7AiDXPDjRxDbdPtZ4/S08E9P5sYovSB5B5Y+c+3i3f2U=
< x-amz-request-id: JCNQ8X7AK13MGY8R
< Date: Fri, 01 Sep 2023 22:05:28 GMT
< Last-Modified: Wed, 30 Aug 2023 15:01:08 GMT
< ETag: "eda3db04f2a84ab4216e8a3f460640b2-19"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Content-Type: application/vnd.apple.installer+xml
< Server: AmazonS3
< Content-Length: 154880270
<
{ [16384 bytes data]
* Connection #0 to host saturn-installer-prd-124359286071-bucket.s3.amazonaws.com left intact

2023-09-01 18:05:31 : REQ   : suitestudio : no more blocking processes, continue with update
2023-09-01 18:05:31 : REQ   : suitestudio : Installing Suite
2023-09-01 18:05:31 : INFO  : suitestudio : Verifying: Suite.pkg
2023-09-01 18:05:31 : DEBUG : suitestudio : File list: -rw-r--r--  1 root  wheel   148M Sep  1 18:05 Suite.pkg
2023-09-01 18:05:31 : DEBUG : suitestudio : File type: Suite.pkg: xar archive compressed TOC: 4624, SHA-1 checksum
2023-09-01 18:05:31 : DEBUG : suitestudio : spctlOut is Suite.pkg: accepted
2023-09-01 18:05:31 : DEBUG : suitestudio : source=Notarized Developer ID
2023-09-01 18:05:31 : DEBUG : suitestudio : origin=Developer ID Installer: Suite Studios Inc (58KZ58VMJ8)
2023-09-01 18:05:31 : INFO  : suitestudio : Team ID: 58KZ58VMJ8 (expected: 58KZ58VMJ8 )
2023-09-01 18:05:31 : INFO  : suitestudio : Installing Suite.pkg to /
2023-09-01 18:05:44 : DEBUG : suitestudio : Debugging enabled, installer output was:
Sep  1 18:05:32  installer[27995] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg trustLevel=350
Sep  1 18:05:32  installer[27995] <Debug>: External component packages (1) trustLevel=350
Sep  1 18:05:32  installer[27995] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Sep  1 18:05:32  installer[27995] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg#io.suite.suitefs.pkg
Sep  1 18:05:32  installer[27995] <Info>: Set authorization level to root for session
Sep  1 18:05:32  installer[27995] <Info>: Authorization is being checked, waiting until authorization arrives.
Sep  1 18:05:32  installer[27995] <Info>: Administrator authorization granted.
Sep  1 18:05:32  installer[27995] <Info>: Packages have been authorized for installation.
Sep  1 18:05:32  installer[27995] <Debug>: Will use PK session
Sep  1 18:05:32  installer[27995] <Debug>: Using authorization level of root for IFPKInstallElement
Sep  1 18:05:32  installer[27995] <Info>: Starting installation:
Sep  1 18:05:32  installer[27995] <Notice>: Configuring volume "Macintosh HD"
Sep  1 18:05:32  installer[27995] <Info>: Preparing disk for local booted install.
Sep  1 18:05:32  installer[27995] <Notice>: Free space on "Macintosh HD": 128.23 GB (128225316864 bytes).
Sep  1 18:05:32  installer[27995] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27995zVfwMm"
Sep  1 18:05:32  installer[27995] <Notice>: IFPKInstallElement (1 packages)
Sep  1 18:05:32  installer[27995] <Info>: Current Path: /usr/sbin/installer
Sep  1 18:05:32  installer[27995] <Info>: Current Path: /bin/zsh
Sep  1 18:05:32  installer[27995] <Info>: Current Path: /usr/bin/sudo
Sep  1 18:05:32  installer[27995] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Suite
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Suite….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#Sep  1 18:05:40  installer[27995] <Info>: PackageKit: Registered bundle file:///Applications/Suite.app/ for uid 0

installer: Running package scripts….....
Last Log repeated 3 times
installer: Validating packages….....
#Sep  1 18:05:40  installer[27995] <Info>: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(GPU).app/ for uid 0
Sep  1 18:05:40  installer[27995] <Info>: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(Plugin).app/ for uid 0
Sep  1 18:05:40  installer[27995] <Info>: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(Renderer).app/ for uid 0
Sep  1 18:05:40  installer[27995] <Info>: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper.app/ for uid 0

installer: Registering updated applications….....
#Sep  1 18:05:41  installer[27995] <Notice>: Running install actions
Sep  1 18:05:41  installer[27995] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27995zVfwMm"
Sep  1 18:05:41  installer[27995] <Notice>: Finalize disk "Macintosh HD"
Sep  1 18:05:41  installer[27995] <Notice>: Notifying system of updated components
Sep  1 18:05:41  installer[27995] <Notice>:
Sep  1 18:05:41  installer[27995] <Notice>: **** Summary Information ****
Sep  1 18:05:41  installer[27995] <Notice>:   Operation      Elapsed time
Sep  1 18:05:41  installer[27995] <Notice>: -----------------------------
Sep  1 18:05:41  installer[27995] <Notice>:        disk      0.02 seconds
Sep  1 18:05:41  installer[27995] <Notice>:      script      0.00 seconds
Sep  1 18:05:41  installer[27995] <Notice>:        zero      0.00 seconds
Sep  1 18:05:41  installer[27995] <Notice>:     install      9.13 seconds
Sep  1 18:05:41  installer[27995] <Notice>:     -total-      9.15 seconds
Sep  1 18:05:41  installer[27995] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg trustLevel=350
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: External component packages (1) trustLevel=350
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg#io.suite.suitefs.pkg
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Set authorization level to root for session
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Authorization is being checked, waiting until authorization arrives.
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Administrator authorization granted.
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Packages have been authorized for installation.
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Will use PK session
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Using authorization level of root for IFPKInstallElement
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Starting installation:
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Configuring volume "Macintosh HD"
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Preparing disk for local booted install.
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Free space on "Macintosh HD": 128.23 GB (128225316864 bytes).
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27995zVfwMm"
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: IFPKInstallElement (1 packages)
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Current Path: /usr/sbin/installer
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Current Path: /bin/zsh
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: Current Path: /usr/bin/sudo
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Adding client PKInstallDaemonClient pid=27995, uid=0 (/usr/sbin/installer)
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Set reponsibility for install to 24016
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Hosted team responsibility for install set to team:(58KZ58VMJ8)
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: ----- Begin install -----
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: packages=(
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/E87DAEB1-124D-4826-AFF1-60D9EDC50574.activeSandbox
2023-09-01 18:05:32-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/58B6FFF2-00AB-4D0A-BE77-E6A23091BBE7.activeSandbox
2023-09-01 18:05:33-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg#io.suite.suitefs.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/9966B877-CF47-464D-B0BB-0D7368400F64.activeSandbox/Root/Applications, uid=0)
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: prevent user idle system sleep
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: suspending backupd
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro installd[25855]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro package_script_service[28033]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro package_script_service[28033]: Set responsibility to pid: 24016, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro package_script_service[28033]: Hosted team responsibility for script set to team:(58KZ58VMJ8)
2023-09-01 18:05:36-04 Jake’s-MacBook-Pro package_script_service[28033]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Product archive /private/tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC/./macFuseInstaller.pkg trustLevel=350
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: External component packages (2) trustLevel=350
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC/./macFuseInstaller.pkg#Core.pkg
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC/./macFuseInstaller.pkg#PreferencePane.pkg
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Set authorization level to root for session
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Authorization is being checked, waiting until authorization arrives.
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Administrator authorization granted.
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Packages have been authorized for installation.
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Will use PK session
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Using authorization level of root for IFPKInstallElement
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Starting installation:
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Configuring volume "Macintosh HD"
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Preparing disk for local booted install.
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Free space on "Macintosh HD": 127.84 GB (127836241920 bytes).
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.28040FiOBXP"
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: IFPKInstallElement (2 packages)
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Current Path: /usr/sbin/installer
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Current Path: /usr/bin/sudo
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Current Path: /bin/bash
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: Current Path: /System/Library/PrivateFrameworks/PackageKit.framework/Versions/A/XPCServices/package_script_service.xpc/Contents/MacOS/package_script_service
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Failed to set hosted team responsibility for install to team:(3T5GSNBU6W)
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: ----- Begin install -----
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: packages=(
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/E87DAEB1-124D-4826-AFF1-60D9EDC50574.activeSandbox
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/58B6FFF2-00AB-4D0A-BE77-E6A23091BBE7.activeSandbox
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Extracting file:///tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC/macFuseInstaller.pkg#Core.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/9307426D-F381-4AC6-849C-0E2CD6D4817E.activeSandbox/Root, uid=0)
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Extracting file:///tmp/PKInstallSandbox.LbLndx/Scripts/io.suite.suitefs.OZy4VC/macFuseInstaller.pkg#PreferencePane.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/9307426D-F381-4AC6-849C-0E2CD6D4817E.activeSandbox/Root, uid=0)
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Executing script "./preinstall" in /private/tmp/PKInstallSandbox.vEfADB/Scripts/io.macfuse.installer.components.core.tG4tmh
2023-09-01 18:05:37-04 Jake’s-MacBook-Pro installer[28040]: ./preinstall: Executing: /usr/bin/kmutil showloaded --list-only --bundle-identifier io.macfuse.filesystems.macfuse
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: ./preinstall: No variant specified, falling back to release
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Executing script "./preinstall" in /private/tmp/PKInstallSandbox.vEfADB/Scripts/io.macfuse.installer.components.preferencepane.eJDSgf
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/9307426D-F381-4AC6-849C-0E2CD6D4817E.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/9307426D-F381-4AC6-849C-0E2CD6D4817E.activeSandbox
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/9307426D-F381-4AC6-849C-0E2CD6D4817E.activeSandbox/Root (2 items) to /
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Executing script "./postinstall" in /private/tmp/PKInstallSandbox.vEfADB/Scripts/io.macfuse.installer.components.core.tG4tmh
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Writing receipt for io.macfuse.installer.components.core to /
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Writing receipt for io.macfuse.installer.components.preferencepane to /
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Touched bundle /Library/Filesystems/macfuse.fs/Contents/Resources/uninstall_macfuse.app
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: Installed "macFUSE" ()
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: ----- End install -----
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: 1.3s elapsed install time
2023-09-01 18:05:38-04 Jake’s-MacBook-Pro installer[28040]: PackageKit: Registered bundle file:///Library/Filesystems/macfuse.fs/Contents/Resources/uninstall_macfuse.app/ for uid 0
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: Running install actions
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.28040FiOBXP"
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: Finalize disk "Macintosh HD"
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: Notifying system of updated components
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: **** Summary Information ****
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:   Operation      Elapsed time
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]: -----------------------------
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:        disk      0.02 seconds
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:      script      0.00 seconds
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:        zero      0.00 seconds
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:     install      2.25 seconds
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:     -total-      2.28 seconds
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installer[28040]:
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro package_script_service[28033]: ./preinstall: installer: Package name is macFUSE
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro package_script_service[28033]: ./preinstall: installer: Upgrading at base path /
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro package_script_service[28033]: ./preinstall: installer: The upgrade was successful.
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro package_script_service[28033]: PackageKit: Hosted team responsible for script has been cleared.
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro package_script_service[28033]: Responsibility set back to self.
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/9966B877-CF47-464D-B0BB-0D7368400F64.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/9966B877-CF47-464D-B0BB-0D7368400F64.activeSandbox
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/9966B877-CF47-464D-B0BB-0D7368400F64.activeSandbox/Root (1 items) to /
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Writing receipt for io.suite.suitefs to /
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Touched bundle /Applications/Suite.app
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Touched bundle /Applications/Suite.app/Contents/Frameworks/Suite Helper (GPU).app
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Touched bundle /Applications/Suite.app/Contents/Frameworks/Suite Helper (Plugin).app
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Touched bundle /Applications/Suite.app/Contents/Frameworks/Suite Helper (Renderer).app
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Touched bundle /Applications/Suite.app/Contents/Frameworks/Suite Helper.app
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: Installed "Suite" (0.1.1)
2023-09-01 18:05:39-04 Jake’s-MacBook-Pro installd[25855]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: releasing backupd
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: allow user idle system sleep
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: ----- End install -----
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: 7.9s elapsed install time
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Cleared responsibility for install from 27995.
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Hosted team responsible for install has been cleared.
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Running idle tasks
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Done with sandbox removals
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Registered bundle file:///Applications/Suite.app/ for uid 0
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(GPU).app/ for uid 0
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(Plugin).app/ for uid 0
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper%20(Renderer).app/ for uid 0
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installer[27995]: PackageKit: Registered bundle file:///Applications/Suite.app/Contents/Frameworks/Suite%20Helper.app/ for uid 0
2023-09-01 18:05:40-04 Jake’s-MacBook-Pro installd[25855]: PackageKit: Removing client PKInstallDaemonClient pid=27995, uid=0 (/usr/sbin/installer)
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: Running install actions
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27995zVfwMm"
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: Finalize disk "Macintosh HD"
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: Notifying system of updated components
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: **** Summary Information ****
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:   Operation      Elapsed time
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]: -----------------------------
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:        disk      0.02 seconds
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:      script      0.00 seconds
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:        zero      0.00 seconds
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:     install      9.13 seconds
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:     -total-      9.15 seconds
2023-09-01 18:05:41-04 Jake’s-MacBook-Pro installer[27995]:

2023-09-01 18:05:44 : INFO  : suitestudio : Finishing...
2023-09-01 18:05:47 : INFO  : suitestudio : App(s) found: /Applications/Suite.app
2023-09-01 18:05:47 : INFO  : suitestudio : found app at /Applications/Suite.app, version 0.1.1, on versionKey CFBundleShortVersionString
2023-09-01 18:05:47 : REQ   : suitestudio : Installed Suite
2023-09-01 18:05:47 : INFO  : suitestudio : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-09-01 18:05:47 : DEBUG : suitestudio : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ
2023-09-01 18:05:47 : DEBUG : suitestudio : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ/Suite.pkg
2023-09-01 18:05:47 : DEBUG : suitestudio : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8j8xhODJ
2023-09-01 18:05:47 : INFO  : suitestudio : App not closed, so no reopen.
2023-09-01 18:05:47 : REQ   : suitestudio : All done!
2023-09-01 18:05:47 : REQ   : suitestudio : ################## End Installomator, exit code 0
```
