### PR TITLE
Update Progress 1st swiftDialog.sh to use native checkmark

### DIFF
--- a/MDM/Progress 1st swiftDialog.sh
+++ b/MDM/Progress 1st swiftDialog.sh
@@ -212,7 +212,7 @@ function appCheck(){
         sleep 2
     done
     dialog_command "progresstext: Install of “$(echo "$app" | cut -d ',' -f1)” complete"
-    dialog_command "listitem: $(echo "$app" | cut -d ',' -f1): ✅"
+    dialog_command "listitem: $(echo "$app" | cut -d ',' -f1): success"
     progress_index=$(defaults read $counterFile step)
     progress_index=$(( progress_index + 1 ))
     defaults write $counterFile step -int $progress_index


### PR DESCRIPTION
Updating the installed checkmark to use the native swift dialog "success" status instead of the emoji checkmark. 

There are probably other Swift Dialog files that need to be updated to match this change.