### PR TITLE
Update zohoworkdrivetruesync.sh

### DIFF
--- a/fragments/labels/zohoworkdrivetruesync.sh
+++ b/fragments/labels/zohoworkdrivetruesync.sh
@@ -5,7 +5,6 @@ zohoworkdrivetruesync)
     name="Zoho WorkDrive TrueSync"
     type="pkg"
     #https://www.zoho.com/workdrive/truesync.html
-    #https://files-accl.zohopublic.com/public/tsbin/download/c488f53fb0fe339a8a3868a16d56ede6
-    downloadURL=$(curl -fs "https://www.zoho.com/workdrive/truesync.html" | tr '<' '\n' | grep -B3 "For Mac" | grep -o -m1 "https.*\"" | cut -d '"' -f1)
+    downloadURL="https://files-accl.zohopublic.com/public/tsbin/download/c488f53fb0fe339a8a3868a16d56ede6"
     expectedTeamID="TZ824L8Y37"
     ;;


### PR DESCRIPTION
If only I kept the original found `downloadURL`, it would still work. Hope it continues to be this strange URL.