### PR TITLE
fix displaylinkmanager downloadURL & appNewVersion

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -2,7 +2,7 @@ displaylinkmanager)
     name="DisplayLink Manager"
     type="pkg"
     #packageID="com.displaylink.displaylinkmanagerapp"
-    downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep 'class="download-link">Download' | head -n 1 | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep Accept | head -n 1 | sed 's/.*href="//' | sed 's/".*//')
-    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep "Release:" | head -n 1 | cut -d ' ' -f2)
+    downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep 'class="download-link">Download' | sed -n '2p' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
+    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep "Release:" | sed -n '2p' | cut -d ' ' -f2)
     expectedTeamID="73YQY62QM3"
     ;;


### PR DESCRIPTION
current label is failing to download pkg:

```
2023-10-02 15:31:17 : REQ   : displaylinkmanager : Downloading https://www.synaptics.com(()=>{ to DisplayLink Manager.pkg
2023-10-02 15:31:17 : ERROR : displaylinkmanager : error downloading https://www.synaptics.com(()=>{
ls: DisplayLink Manager.pkg: No such file or directory
2023-10-02 15:31:17 : ERROR : displaylinkmanager : File list: 
2023-10-02 15:31:17 : ERROR : displaylinkmanager : File type: DisplayLink Manager.pkg: cannot open `DisplayLink Manager.pkg' (No such file or directory)
2023-10-02 15:31:17 : INFO  : displaylinkmanager : App not closed, so no reopen.
2023-10-02 15:31:17 : ERROR : displaylinkmanager : ERROR: Error downloading https://www.synaptics.com(()=>{ error:
curl: (3) unmatched brace in URL position 31:
https://www.synaptics.com(()=>{
^

2023-10-02 15:31:17 : REQ   : displaylinkmanager : ################## End Installomator, exit code 2 
```

Fix for #1225 
Current label is grabbing downloadURL & appNewVersion for Alpha version, modified to grab the stable release instead

```
2023-10-02 16:02:48 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.5beta, date 2023-10-02
2023-10-02 16:02:48 : INFO  : displaylinkmanager : ################## Version: 10.5beta
2023-10-02 16:02:48 : INFO  : displaylinkmanager : ################## Date: 2023-10-02
2023-10-02 16:02:48 : INFO  : displaylinkmanager : ################## displaylinkmanager
2023-10-02 16:02:48 : DEBUG : displaylinkmanager : DEBUG mode 1 enabled.
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : name=DisplayLink Manager
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : appName=
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : type=pkg
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : archiveName=
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : downloadURL=https://www.synaptics.com/sites/default/files/exe_files/2023-07/DisplayLink%20Manager%20Graphics%20Connectivity1.9-EXE.pkg
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : curlOptions=
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : appNewVersion=1.9
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : appCustomVersion function: Not defined
2023-10-02 16:02:54 : DEBUG : displaylinkmanager : versionKey=CFBundleShortVersionString
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : packageID=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : pkgName=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : choiceChangesXML=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : expectedTeamID=73YQY62QM3
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : blockingProcesses=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : installerTool=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : CLIInstaller=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : CLIArguments=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : updateTool=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : updateToolArguments=
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : updateToolRunAsCurrentUser=
2023-10-02 16:02:55 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2023-10-02 16:02:55 : INFO  : displaylinkmanager : NOTIFY=success
2023-10-02 16:02:55 : INFO  : displaylinkmanager : LOGGING=DEBUG
2023-10-02 16:02:55 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-02 16:02:55 : INFO  : displaylinkmanager : Label type: pkg
2023-10-02 16:02:55 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.pkg
2023-10-02 16:02:55 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : Changing directory to /Users/asri/Documents/dev/Installomator/build
2023-10-02 16:02:55 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2023-10-02 16:02:55 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 1.9.0, on versionKey CFBundleShortVersionString
2023-10-02 16:02:55 : INFO  : displaylinkmanager : appversion: 1.9.0
2023-10-02 16:02:55 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 1.9
2023-10-02 16:02:55 : INFO  : displaylinkmanager : DisplayLink Manager.pkg exists and DEBUG mode 1 enabled, skipping download
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : DEBUG mode 1, not checking for blocking processes
2023-10-02 16:02:55 : REQ   : displaylinkmanager : Installing DisplayLink Manager
2023-10-02 16:02:55 : INFO  : displaylinkmanager : Verifying: DisplayLink Manager.pkg
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : File list: -rw-r--r--  1 asri  staff   6.4M Oct  2 16:00 DisplayLink Manager.pkg
2023-10-02 16:02:55 : DEBUG : displaylinkmanager : File type: DisplayLink Manager.pkg: xar archive compressed TOC: 4996, SHA-1 checksum
2023-10-02 16:02:56 : DEBUG : displaylinkmanager : spctlOut is DisplayLink Manager.pkg: accepted
2023-10-02 16:02:56 : DEBUG : displaylinkmanager : source=Notarized Developer ID
2023-10-02 16:02:56 : DEBUG : displaylinkmanager : origin=Developer ID Installer: DisplayLink Corp (73YQY62QM3)
2023-10-02 16:02:57 : INFO  : displaylinkmanager : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2023-10-02 16:02:57 : DEBUG : displaylinkmanager : DEBUG enabled, skipping installation
2023-10-02 16:02:57 : INFO  : displaylinkmanager : Finishing...
2023-10-02 16:03:00 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2023-10-02 16:03:00 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 1.9.0, on versionKey CFBundleShortVersionString
2023-10-02 16:03:00 : REQ   : displaylinkmanager : Installed DisplayLink Manager, version 1.9
2023-10-02 16:03:00 : INFO  : displaylinkmanager : notifying
2023-10-02 16:03:00 : DEBUG : displaylinkmanager : DEBUG mode 1, not reopening anything
2023-10-02 16:03:00 : REQ   : displaylinkmanager : All done!
2023-10-02 16:03:00 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0
```