### PR TITLE
Revise snagit.sh for SnagIt 2024 and add snagit2023.sh

### DIFF
--- a/fragments/labels/snagit.sh
+++ b/fragments/labels/snagit.sh
@@ -1,8 +1,8 @@
 snagit|\
-snagit2023)
-    name="Snagit 2023"
+snagit2024)
+    name="Snagit 2024"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2023" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2023" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2024" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2024" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/snagit2023.sh
+++ b/fragments/labels/snagit2023.sh
@@ -1,0 +1,7 @@
+snagit2023)
+    name="Snagit 2023"
+    type="dmg"
+    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2023" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2023" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    expectedTeamID="7TQL462TU8"
+    ;;


### PR DESCRIPTION
REDACTED@REDACTED Installomator % ./utils/assemble.sh snagit
2023-10-04 13:43:04 : REQ   : snagit : ################## Start Installomator v. 10.5beta, date 2023-10-04
2023-10-04 13:43:04 : INFO  : snagit : ################## Version: 10.5beta
2023-10-04 13:43:04 : INFO  : snagit : ################## Date: 2023-10-04
2023-10-04 13:43:04 : INFO  : snagit : ################## snagit
2023-10-04 13:43:04 : DEBUG : snagit : DEBUG mode 1 enabled.
2023-10-04 13:43:04 : INFO  : snagit : SwiftDialog is not installed, clear cmd file var
2023-10-04 13:43:05 : DEBUG : snagit : name=Snagit 2024
2023-10-04 13:43:05 : DEBUG : snagit : appName=
2023-10-04 13:43:05 : DEBUG : snagit : type=dmg
2023-10-04 13:43:05 : DEBUG : snagit : archiveName=
2023-10-04 13:43:05 : DEBUG : snagit : downloadURL=https://download.techsmith.com/snagitmac/releases/snagit.dmg
2023-10-04 13:43:05 : DEBUG : snagit : curlOptions=
2023-10-04 13:43:05 : DEBUG : snagit : appNewVersion=2024.0.0</p>
2023-10-04 13:43:05 : DEBUG : snagit : appCustomVersion function: Not defined
2023-10-04 13:43:05 : DEBUG : snagit : versionKey=CFBundleShortVersionString
2023-10-04 13:43:05 : DEBUG : snagit : packageID=
2023-10-04 13:43:05 : DEBUG : snagit : pkgName=
2023-10-04 13:43:05 : DEBUG : snagit : choiceChangesXML=
2023-10-04 13:43:05 : DEBUG : snagit : expectedTeamID=7TQL462TU8
2023-10-04 13:43:05 : DEBUG : snagit : blockingProcesses=
2023-10-04 13:43:05 : DEBUG : snagit : installerTool=
2023-10-04 13:43:05 : DEBUG : snagit : CLIInstaller=
2023-10-04 13:43:05 : DEBUG : snagit : CLIArguments=
2023-10-04 13:43:05 : DEBUG : snagit : updateTool=
2023-10-04 13:43:05 : DEBUG : snagit : updateToolArguments=
2023-10-04 13:43:05 : DEBUG : snagit : updateToolRunAsCurrentUser=
2023-10-04 13:43:05 : INFO  : snagit : BLOCKING_PROCESS_ACTION=tell_user
2023-10-04 13:43:05 : INFO  : snagit : NOTIFY=success
2023-10-04 13:43:05 : INFO  : snagit : LOGGING=DEBUG
2023-10-04 13:43:05 : INFO  : snagit : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-04 13:43:05 : INFO  : snagit : Label type: dmg
2023-10-04 13:43:05 : INFO  : snagit : archiveName: Snagit 2024.dmg
2023-10-04 13:43:05 : INFO  : snagit : no blocking processes defined, using Snagit 2024 as default
2023-10-04 13:43:05 : DEBUG : snagit : Changing directory to /Users/REDACTED/Documents/GitHub/Installomator/build
2023-10-04 13:43:05 : INFO  : snagit : name: Snagit 2024, appName: Snagit 2024.app
2023-10-04 13:43:05.633 mdfind[23583:1965148] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-10-04 13:43:05.634 mdfind[23583:1965148] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-10-04 13:43:05.762 mdfind[23583:1965148] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-04 13:43:05 : WARN  : snagit : No previous app found
2023-10-04 13:43:05 : WARN  : snagit : could not find Snagit 2024.app
2023-10-04 13:43:06 : INFO  : snagit : appversion:
2023-10-04 13:43:06 : INFO  : snagit : Latest version of Snagit 2024 is 2024.0.0</p>
2023-10-04 13:43:06 : REQ   : snagit : Downloading https://download.techsmith.com/snagitmac/releases/snagit.dmg to Snagit 2024.dmg
2023-10-04 13:43:06 : DEBUG : snagit : No Dialog connection, just download
2023-10-04 13:43:15 : DEBUG : snagit : File list: -rw-r--r--@ 1 REDACTED  staff   268M Oct  4 13:43 Snagit 2024.dmg
2023-10-04 13:43:15 : DEBUG : snagit : File type: Snagit 2024.dmg: zlib compressed data
2023-10-04 13:43:15 : DEBUG : snagit : curl output was:
*   Trying 23.75.47.27:443...
* Connected to download.techsmith.com (23.75.47.27) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3076 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Michigan; L=East Lansing; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 15 00:00:00 2023 GMT
*  expire date: Aug 19 23:59:59 2024 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download.techsmith.com]
* h2 [:path: /snagitmac/releases/snagit.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15700a800)
> GET /snagitmac/releases/snagit.dmg HTTP/2
> Host: download.techsmith.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Fri, 29 Sep 2023 13:20:27 GMT
< accept-ranges: bytes
< etag: "752e39b6d7f2d91:0"
< server: Microsoft-IIS/8.5
< content-length: 281069577
< cache-control: max-age=4356
< date: Wed, 04 Oct 2023 20:43:06 GMT
<
{ [16384 bytes data]
* Connection #0 to host download.techsmith.com left intact

2023-10-04 13:43:15 : DEBUG : snagit : DEBUG mode 1, not checking for blocking processes
2023-10-04 13:43:15 : REQ   : snagit : Installing Snagit 2024
2023-10-04 13:43:15 : INFO  : snagit : Mounting /Users/REDACTED/Documents/GitHub/Installomator/build/Snagit 2024.dmg
2023-10-04 13:43:16 : DEBUG : snagit : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $0C4B11E9
verified   CRC32 $9D527B49
/dev/disk5                                              /Volumes/Snagit

2023-10-04 13:43:16 : INFO  : snagit : Mounted: /Volumes/Snagit 2023-10-04 13:43:16 : INFO  : snagit : Verifying: /Volumes/Snagit/Snagit 2024.app
2023-10-04 13:43:16 : DEBUG : snagit : App size: 595M   /Volumes/Snagit/Snagit 2024.app
2023-10-04 13:43:20 : DEBUG : snagit : Debugging enabled, App Verification output was:
/Volumes/Snagit/Snagit 2024.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2023-10-04 13:43:20 : INFO  : snagit : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 ) 2023-10-04 13:43:20 : INFO  : snagit : Installing Snagit 2024 version 2024.0.0 on versionKey CFBundleShortVersionString. 2023-10-04 13:43:20 : INFO  : snagit : App has LSMinimumSystemVersion: 12.0 2023-10-04 13:43:20 : DEBUG : snagit : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-10-04 13:43:20 : INFO  : snagit : Finishing... 2023-10-04 13:43:23 : INFO  : snagit : name: Snagit 2024, appName: Snagit 2024.app 2023-10-04 13:43:23.271 mdfind[23689:1965627] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-10-04 13:43:23.271 mdfind[23689:1965627] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-10-04 13:43:23.335 mdfind[23689:1965627] Couldn't determine the mapping between prefab keywords and predicates. 2023-10-04 13:43:23 : WARN  : snagit : No previous app found 2023-10-04 13:43:23 : WARN  : snagit : could not find Snagit 2024.app
2023-10-04 13:43:23 : REQ   : snagit : Installed Snagit 2024, version 2024.0.0
2023-10-04 13:43:23 : INFO  : snagit : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2023-10-04 13:43:23 : DEBUG : snagit : Unmounting /Volumes/Snagit
2023-10-04 13:43:23 : DEBUG : snagit : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-10-04 13:43:23 : DEBUG : snagit : DEBUG mode 1, not reopening anything
2023-10-04 13:43:23 : REQ   : snagit : All done!
2023-10-04 13:43:23 : REQ   : snagit : ################## End Installomator, exit code 0

REDACTED@REDACTED Installomator %

REDACTED@REDACTED Installomator % ./utils/assemble.sh snagit2023
2023-10-04 13:45:08 : REQ   : snagit2023 : ################## Start Installomator v. 10.5beta, date 2023-10-04
2023-10-04 13:45:08 : INFO  : snagit2023 : ################## Version: 10.5beta
2023-10-04 13:45:08 : INFO  : snagit2023 : ################## Date: 2023-10-04
2023-10-04 13:45:08 : INFO  : snagit2023 : ################## snagit2023
2023-10-04 13:45:08 : DEBUG : snagit2023 : DEBUG mode 1 enabled.
2023-10-04 13:45:08 : INFO  : snagit2023 : SwiftDialog is not installed, clear cmd file var
2023-10-04 13:45:08 : DEBUG : snagit2023 : name=Snagit 2023
2023-10-04 13:45:08 : DEBUG : snagit2023 : appName=
2023-10-04 13:45:09 : DEBUG : snagit2023 : type=dmg
2023-10-04 13:45:09 : DEBUG : snagit2023 : archiveName=
2023-10-04 13:45:09 : DEBUG : snagit2023 : downloadURL=https://download.techsmith.com/snagitmac/releases/2323/snagit.dmg
2023-10-04 13:45:09 : DEBUG : snagit2023 : curlOptions=
2023-10-04 13:45:09 : DEBUG : snagit2023 : appNewVersion=2023.2.3
2023-10-04 13:45:09 : DEBUG : snagit2023 : appCustomVersion function: Not defined
2023-10-04 13:45:09 : DEBUG : snagit2023 : versionKey=CFBundleShortVersionString
2023-10-04 13:45:09 : DEBUG : snagit2023 : packageID=
2023-10-04 13:45:09 : DEBUG : snagit2023 : pkgName=
2023-10-04 13:45:09 : DEBUG : snagit2023 : choiceChangesXML=
2023-10-04 13:45:09 : DEBUG : snagit2023 : expectedTeamID=7TQL462TU8
2023-10-04 13:45:09 : DEBUG : snagit2023 : blockingProcesses=
2023-10-04 13:45:09 : DEBUG : snagit2023 : installerTool=
2023-10-04 13:45:09 : DEBUG : snagit2023 : CLIInstaller=
2023-10-04 13:45:09 : DEBUG : snagit2023 : CLIArguments=
2023-10-04 13:45:09 : DEBUG : snagit2023 : updateTool=
2023-10-04 13:45:09 : DEBUG : snagit2023 : updateToolArguments=
2023-10-04 13:45:09 : DEBUG : snagit2023 : updateToolRunAsCurrentUser=
2023-10-04 13:45:09 : INFO  : snagit2023 : BLOCKING_PROCESS_ACTION=tell_user
2023-10-04 13:45:09 : INFO  : snagit2023 : NOTIFY=success
2023-10-04 13:45:09 : INFO  : snagit2023 : LOGGING=DEBUG
2023-10-04 13:45:09 : INFO  : snagit2023 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-04 13:45:09 : INFO  : snagit2023 : Label type: dmg
2023-10-04 13:45:09 : INFO  : snagit2023 : archiveName: Snagit 2023.dmg
2023-10-04 13:45:09 : INFO  : snagit2023 : no blocking processes defined, using Snagit 2023 as default
2023-10-04 13:45:09 : DEBUG : snagit2023 : Changing directory to /Users/REDACTED/Documents/GitHub/Installomator/build
2023-10-04 13:45:09 : INFO  : snagit2023 : name: Snagit 2023, appName: Snagit 2023.app
2023-10-04 13:45:09.188 mdfind[23993:1967823] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-10-04 13:45:09.188 mdfind[23993:1967823] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-10-04 13:45:09.249 mdfind[23993:1967823] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-04 13:45:09 : WARN  : snagit2023 : No previous app found
2023-10-04 13:45:09 : WARN  : snagit2023 : could not find Snagit 2023.app
2023-10-04 13:45:09 : INFO  : snagit2023 : appversion:
2023-10-04 13:45:09 : INFO  : snagit2023 : Latest version of Snagit 2023 is 2023.2.3
2023-10-04 13:45:09 : REQ   : snagit2023 : Downloading https://download.techsmith.com/snagitmac/releases/2323/snagit.dmg to Snagit 2023.dmg
2023-10-04 13:45:09 : DEBUG : snagit2023 : No Dialog connection, just download
2023-10-04 13:45:16 : DEBUG : snagit2023 : File list: -rw-r--r--  1 REDACTED  staff   212M Oct  4 13:45 Snagit 2023.dmg
2023-10-04 13:45:16 : DEBUG : snagit2023 : File type: Snagit 2023.dmg: zlib compressed data
2023-10-04 13:45:16 : DEBUG : snagit2023 : curl output was:
*   Trying 104.79.134.121:443...
* Connected to download.techsmith.com (104.79.134.121) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3076 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Michigan; L=East Lansing; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 15 00:00:00 2023 GMT
*  expire date: Aug 19 23:59:59 2024 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download.techsmith.com]
* h2 [:path: /snagitmac/releases/2323/snagit.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12000a800)
> GET /snagitmac/releases/2323/snagit.dmg HTTP/2
> Host: download.techsmith.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Thu, 21 Sep 2023 14:19:46 GMT
< accept-ranges: bytes
< etag: "50968fac96ecd91:0"
< server: Microsoft-IIS/8.5
< content-length: 221964780
< cache-control: max-age=7705
< date: Wed, 04 Oct 2023 20:45:09 GMT
<
{ [1437 bytes data]
* Connection #0 to host download.techsmith.com left intact

2023-10-04 13:45:16 : DEBUG : snagit2023 : DEBUG mode 1, not checking for blocking processes
2023-10-04 13:45:16 : REQ   : snagit2023 : Installing Snagit 2023
2023-10-04 13:45:16 : INFO  : snagit2023 : Mounting /Users/REDACTED/Documents/GitHub/Installomator/build/Snagit 2023.dmg
2023-10-04 13:45:17 : DEBUG : snagit2023 : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $31022EA4
verified   CRC32 $B0EBFA6B
/dev/disk5                                              /Volumes/Snagit

2023-10-04 13:45:17 : INFO  : snagit2023 : Mounted: /Volumes/Snagit 2023-10-04 13:45:17 : INFO  : snagit2023 : Verifying: /Volumes/Snagit/Snagit 2023.app
2023-10-04 13:45:17 : DEBUG : snagit2023 : App size: 493M       /Volumes/Snagit/Snagit 2023.app
2023-10-04 13:45:20 : DEBUG : snagit2023 : Debugging enabled, App Verification output was:
/Volumes/Snagit/Snagit 2023.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2023-10-04 13:45:20 : INFO  : snagit2023 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 ) 2023-10-04 13:45:20 : INFO  : snagit2023 : Installing Snagit 2023 version 2023.2.3 on versionKey CFBundleShortVersionString. 2023-10-04 13:45:20 : INFO  : snagit2023 : App has LSMinimumSystemVersion: 11.0 2023-10-04 13:45:20 : DEBUG : snagit2023 : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-10-04 13:45:20 : INFO  : snagit2023 : Finishing... 2023-10-04 13:45:23 : INFO  : snagit2023 : name: Snagit 2023, appName: Snagit 2023.app 2023-10-04 13:45:23.481 mdfind[24094:1968295] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2023-10-04 13:45:23.481 mdfind[24094:1968295] [UserQueryParser] Loading keywords and predicates for locale "en" 2023-10-04 13:45:23.548 mdfind[24094:1968295] Couldn't determine the mapping between prefab keywords and predicates. 2023-10-04 13:45:23 : WARN  : snagit2023 : No previous app found 2023-10-04 13:45:23 : WARN  : snagit2023 : could not find Snagit 2023.app
2023-10-04 13:45:23 : REQ   : snagit2023 : Installed Snagit 2023, version 2023.2.3
2023-10-04 13:45:23 : INFO  : snagit2023 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2023-10-04 13:45:23 : DEBUG : snagit2023 : Unmounting /Volumes/Snagit
2023-10-04 13:45:24 : DEBUG : snagit2023 : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-10-04 13:45:24 : DEBUG : snagit2023 : DEBUG mode 1, not reopening anything
2023-10-04 13:45:24 : REQ   : snagit2023 : All done!
2023-10-04 13:45:24 : REQ   : snagit2023 : ################## End Installomator, exit code 0