### PR TITLE
Label Update: virtualbox - downloadUrl and appNewVersion

### DIFF
--- a/fragments/labels/virtualbox.sh
+++ b/fragments/labels/virtualbox.sh
@@ -8,7 +8,7 @@ virtualbox)
     elif [[ $(arch) == arm64 ]]; then
         platform="macOSArm64"
     fi
-    downloadURL=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" | awk -F '"' "/$platform.dmg/ { print \$4 }")
-    appNewVersion=$(curl -fs "https://www.virtualbox.org/wiki/Downloads" | awk -F '"' "/$platform.dmg/ { print \$4 }" | sed -E 's/.*virtualbox\/([0-9.]*)\/.*/\1/')
+    downloadURL="https:$(curl -fsL "https://www.oracle.com/jp/virtualization/technologies/vm/downloads/virtualbox-downloads.html" | grep "${platform}.dmg" | xmllint --html --xpath 'string(//a/@href)' -)"
+    appNewVersion=$(echo "${downloadURL}" | awk -F '/' '{print $5}')
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
Unfortunately, the apple silicon version no longer appears on https://www.virtualbox.org/wiki/Downloads.
Therefore, I have changed the referring URL to https://www.oracle.com/jp/virtualization/technologies/vm/downloads/virtualbox-downloads.html.

```
2023-10-05 22:11:37 : REQ   : virtualbox : ################## Start Installomator v. 10.5beta, date 2023-10-05
2023-10-05 22:11:37 : INFO  : virtualbox : ################## Version: 10.5beta
2023-10-05 22:11:37 : INFO  : virtualbox : ################## Date: 2023-10-05
2023-10-05 22:11:37 : INFO  : virtualbox : ################## virtualbox
2023-10-05 22:11:37 : DEBUG : virtualbox : DEBUG mode 1 enabled.
2023-10-05 22:11:37 : DEBUG : virtualbox : name=VirtualBox
2023-10-05 22:11:37 : DEBUG : virtualbox : appName=
2023-10-05 22:11:37 : DEBUG : virtualbox : type=pkgInDmg
2023-10-05 22:11:37 : DEBUG : virtualbox : archiveName=
2023-10-05 22:11:37 : DEBUG : virtualbox : downloadURL=https://download.virtualbox.org/virtualbox/7.0.8/VirtualBox-7.0.8_BETA4-156879-macOSArm64.dmg
2023-10-05 22:11:37 : DEBUG : virtualbox : curlOptions=
2023-10-05 22:11:37 : DEBUG : virtualbox : appNewVersion=7.0.8
2023-10-05 22:11:37 : DEBUG : virtualbox : appCustomVersion function: Not defined
2023-10-05 22:11:37 : DEBUG : virtualbox : versionKey=CFBundleShortVersionString
2023-10-05 22:11:37 : DEBUG : virtualbox : packageID=
2023-10-05 22:11:37 : DEBUG : virtualbox : pkgName=VirtualBox.pkg
2023-10-05 22:11:37 : DEBUG : virtualbox : choiceChangesXML=
2023-10-05 22:11:37 : DEBUG : virtualbox : expectedTeamID=VB5E2TV963
2023-10-05 22:11:37 : DEBUG : virtualbox : blockingProcesses=
2023-10-05 22:11:37 : DEBUG : virtualbox : installerTool=
2023-10-05 22:11:37 : DEBUG : virtualbox : CLIInstaller=
2023-10-05 22:11:37 : DEBUG : virtualbox : CLIArguments=
2023-10-05 22:11:37 : DEBUG : virtualbox : updateTool=
2023-10-05 22:11:37 : DEBUG : virtualbox : updateToolArguments=
2023-10-05 22:11:37 : DEBUG : virtualbox : updateToolRunAsCurrentUser=
2023-10-05 22:11:37 : INFO  : virtualbox : BLOCKING_PROCESS_ACTION=tell_user
2023-10-05 22:11:37 : INFO  : virtualbox : NOTIFY=success
2023-10-05 22:11:37 : INFO  : virtualbox : LOGGING=DEBUG
2023-10-05 22:11:37 : INFO  : virtualbox : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-05 22:11:37 : INFO  : virtualbox : Label type: pkgInDmg
2023-10-05 22:11:37 : INFO  : virtualbox : archiveName: VirtualBox.dmg
2023-10-05 22:11:37 : INFO  : virtualbox : no blocking processes defined, using VirtualBox as default
2023-10-05 22:11:37 : DEBUG : virtualbox : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2023-10-05 22:11:37 : INFO  : virtualbox : name: VirtualBox, appName: VirtualBox.app
2023-10-05 22:11:38 : WARN  : virtualbox : No previous app found
2023-10-05 22:11:38 : WARN  : virtualbox : could not find VirtualBox.app
2023-10-05 22:11:38 : INFO  : virtualbox : appversion:
2023-10-05 22:11:38 : INFO  : virtualbox : Latest version of VirtualBox is 7.0.8
2023-10-05 22:11:38 : REQ   : virtualbox : Downloading https://download.virtualbox.org/virtualbox/7.0.8/VirtualBox-7.0.8_BETA4-156879-macOSArm64.dmg to VirtualBox.dmg
2023-10-05 22:11:38 : DEBUG : virtualbox : No Dialog connection, just download
2023-10-05 22:11:45 : DEBUG : virtualbox : File list: -rw-r--r--  1 kenchan0130  staff   111M 10  5 22:11 VirtualBox.dmg
2023-10-05 22:11:45 : DEBUG : virtualbox : File type: VirtualBox.dmg: bzip2 compressed data, block size = 100k
2023-10-05 22:11:45 : DEBUG : virtualbox : curl output was:
*   Trying 23.210.40.79:443...
* Connected to download.virtualbox.org (23.210.40.79) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2961 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Oracle Corporation; CN=download.oracle.com
*  start date: Jun  5 00:00:00 2023 GMT
*  expire date: Jun  4 23:59:59 2024 GMT
*  subjectAltName: host "download.virtualbox.org" matched cert's "download.virtualbox.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /virtualbox/7.0.8/VirtualBox-7.0.8_BETA4-156879-macOSArm64.dmg HTTP/1.1
> Host: download.virtualbox.org
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/octet-stream
< Server: AkamaiNetStorage
< Last-Modified: Mon, 17 Apr 2023 19:11:41 GMT
< ETag: "a7837467be951c0c3f615c80e0e1f0a9:1681827648.161593"
< Content-Length: 116840698
< Date: Thu, 05 Oct 2023 13:11:38 GMT
< Connection: keep-alive
<
{ [16083 bytes data]
* Connection #0 to host download.virtualbox.org left intact

2023-10-05 22:11:45 : DEBUG : virtualbox : DEBUG mode 1, not checking for blocking processes
2023-10-05 22:11:45 : REQ   : virtualbox : Installing VirtualBox
2023-10-05 22:11:45 : INFO  : virtualbox : Mounting /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build/VirtualBox.dmg
2023-10-05 22:11:52 : DEBUG : virtualbox : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $B504D816
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $9FCF3681
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $F7269C9E
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
disk image (Apple_APFS : 4)のチェックサムを計算中…
disk image (Apple_APFS : 4): 検証済み CRC32 $D5C5505D
(Apple_Free : 5)のチェックサムを計算中…
(Apple_Free : 5): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 6)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $F7269C9E
GPT Header (Backup GPT Header : 7)のチェックサムを計算中…
GPT Header (Backup GPT Header : 7): 検証済み CRC32 $F66A9F1A
検証済み CRC32 $F22A6DB9
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/VirtualBox

2023-10-05 22:11:52 : INFO  : virtualbox : Mounted: /Volumes/VirtualBox
2023-10-05 22:11:52 : INFO  : virtualbox : found pkg: /Volumes/VirtualBox/VirtualBox.pkg
2023-10-05 22:11:52 : INFO  : virtualbox : Verifying: /Volumes/VirtualBox/VirtualBox.pkg
2023-10-05 22:11:52 : DEBUG : virtualbox : File list: -rw-r--r--  1 kenchan0130  staff   105M  4 18 03:53 /Volumes/VirtualBox/VirtualBox.pkg
2023-10-05 22:11:53 : DEBUG : virtualbox : File type: /Volumes/VirtualBox/VirtualBox.pkg: xar archive compressed TOC: 5341, SHA-1 checksum
2023-10-05 22:11:53 : DEBUG : virtualbox : spctlOut is /Volumes/VirtualBox/VirtualBox.pkg: accepted
2023-10-05 22:11:53 : DEBUG : virtualbox : source=Notarized Developer ID
2023-10-05 22:11:53 : DEBUG : virtualbox : origin=Developer ID Installer: Oracle America, Inc. (VB5E2TV963)
2023-10-05 22:11:53 : INFO  : virtualbox : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2023-10-05 22:11:53 : DEBUG : virtualbox : DEBUG enabled, skipping installation
2023-10-05 22:11:53 : INFO  : virtualbox : Finishing...
2023-10-05 22:11:56 : INFO  : virtualbox : name: VirtualBox, appName: VirtualBox.app
2023-10-05 22:11:56 : WARN  : virtualbox : No previous app found
2023-10-05 22:11:56 : WARN  : virtualbox : could not find VirtualBox.app
2023-10-05 22:11:56 : REQ   : virtualbox : Installed VirtualBox, version 7.0.8
2023-10-05 22:11:56 : INFO  : virtualbox : notifying
2023-10-05 22:11:57 : DEBUG : virtualbox : Unmounting /Volumes/VirtualBox
2023-10-05 22:11:57 : DEBUG : virtualbox : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-10-05 22:11:57 : DEBUG : virtualbox : DEBUG mode 1, not reopening anything
2023-10-05 22:11:57 : REQ   : virtualbox : All done!
2023-10-05 22:11:57 : REQ   : virtualbox : ################## End Installomator, exit code 0
```