### PR TITLE
Create labels for Processing

### DIFF
--- a/fragments/labels/processing3.sh
+++ b/fragments/labels/processing3.sh
@@ -1,0 +1,10 @@
+processing3)
+    name="Processing"
+    type="zip"
+    downloadURL=$(downloadURLFromGit processing processing)
+    appNewVersion=$(versionFromGit processing processing)
+    expectedTeamID="8SBRM6J77J"
+    # Github returned version number resulves in build and version numbers being combined, so this provides the best match.
+    # if you are manually replicating the label with valuesfromarguements use 'appNewVersion="3.$(versionFromGit processing processing | cut -d "." -f 2-)"' instead.
+    appCustomVersion(){ echo "$(defaults read /Applications/Processing.app/Contents/Info.plist CFBundleVersion )$( defaults read /Applications/Processing.app/Contents/Info.plist CFBundleShortVersionString )" }
+    ;;

--- a/fragments/labels/processing4.sh
+++ b/fragments/labels/processing4.sh
@@ -1,0 +1,10 @@
+processing4)
+    name="Processing"
+    type="zip"
+    downloadURL=$(downloadURLFromGit processing processing4)
+    appNewVersion=$(versionFromGit processing processing4)
+    expectedTeamID="8SBRM6J77J"
+    # Github returned version number resulves in build and version numbers being combined, so this provides the best match.
+    # if you are manually replicating the label with valuesfromarguements use 'appNewVersion="4.$(versionFromGit processing processing | cut -d "." -f 2-)"' instead.
+    appCustomVersion(){ echo "$(defaults read /Applications/Processing.app/Contents/Info.plist CFBundleVersion )$( defaults read /Applications/Processing.app/Contents/Info.plist CFBundleShortVersionString )" }
+    ;;


### PR DESCRIPTION
Installs the Processing app from Github and resolves a version matching issue. Covers both version 3.* and 4.* as they are in separate github repos.