### PR TITLE
Microsoft Teams classic and new

### DIFF
--- a/fragments/labels/microsoftteams.sh
+++ b/fragments/labels/microsoftteams.sh
@@ -14,5 +14,5 @@ microsoftteams)
         "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
     fi
     updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps TEAM01 ) # --wait 600
+    updateToolArguments=( --install --apps TEAMS10 ) # --wait 600 #TEAM01
     ;;

--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -1,13 +1,12 @@
-microsoftteamsclassic|\
-microsoftteams)
-    name="Microsoft Teams classic"
+microsoftteamsnew)
+    name="Microsoft Teams (work or school)"
     type="pkg"
-    #packageID="com.microsoft.teams"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869428"
+    #packageID="com.microsoft.teams2"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=2249065"
     appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | tail -1 | cut -d "/" -f5)
     versionKey="CFBundleGetInfoString"
     expectedTeamID="UBF8T346G9"
-    blockingProcesses=( Teams "Microsoft Teams classic Helper" )
+    blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher")
     # msupdate requires a PPPC profile pushed out from Jamf to work, https://github.com/pbowden-msft/MobileConfigs/tree/master/Jamf-MSUpdate
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"

--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -3,8 +3,8 @@ microsoftteamsnew)
     type="pkg"
     #packageID="com.microsoft.teams2"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=2249065"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | tail -1 | cut -d "/" -f5)
-    versionKey="CFBundleGetInfoString"
+    #appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | tail -1 | cut -d "/" -f5)
+    #versionKey="CFBundleGetInfoString"
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher" "Microsoft Teams (work preview)")
     # msupdate requires a PPPC profile pushed out from Jamf to work, https://github.com/pbowden-msft/MobileConfigs/tree/master/Jamf-MSUpdate
@@ -13,5 +13,5 @@ microsoftteamsnew)
         "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
     fi
     updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps TEAM01 ) # --wait 600
+    updateToolArguments=( --install --apps TEAMS21 ) # --wait 600 # TEAM01
     ;;

--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -6,7 +6,7 @@ microsoftteamsnew)
     appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | tail -1 | cut -d "/" -f5)
     versionKey="CFBundleGetInfoString"
     expectedTeamID="UBF8T346G9"
-    blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher")
+    blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher" "Microsoft Teams (work preview)")
     # msupdate requires a PPPC profile pushed out from Jamf to work, https://github.com/pbowden-msft/MobileConfigs/tree/master/Jamf-MSUpdate
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"


### PR DESCRIPTION
`microsoftteams` label is now also `microsoftteamsclassic` as Microsoft has chosen to rename the app and the Helper.

Added `microsoftteamsnew` to point to Teams version 2. (This label might not be correct for `msupdate`app, as I would guess that it should be `TEAM02` instead, but cannot locate what it should be.

Some time in the future, we will move `microsoftteams` from classic to new…