### PR TITLE
Clarifying log entries about app reopen and blocking process behavior…

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -445,7 +445,7 @@ reopenClosedProcess() {
         processuser=$(ps aux | grep -i "${appName}" | grep -vi "grep" | awk '{print $1}')
         printlog "Reopened ${appName} as $processuser"
     else
-        printlog "App not closed, so no reopen." INFO
+        printlog "Installomator did not close any apps, so no need to reopen any apps." INFO
     fi
 }
 

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -44,6 +44,7 @@ PROMPT_TIMEOUT=86400
 # 86400 = 24 hours (default)
 
 # behavior when blocking processes are found
+# BLOCKING_PROCESS_ACTION is ignored if app label uses updateTool
 BLOCKING_PROCESS_ACTION=tell_user
 # options:
 #   - ignore       continue even when blocking processes are found

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -126,7 +126,7 @@ case $LOGO in
         # FileWave
         LOGO="/usr/local/sbin/FileWave.app/Contents/Resources/fwGUI.app/Contents/Resources/kiosk.icns"
         if [[ -z $MDMProfileName ]]; then; MDMProfileName="FileWave MDM Configuration"; fi
-        ;;    
+        ;;
 esac
 if [[ ! -a "${LOGO}" ]]; then
     if [[ $(sw_vers -buildVersion) > "19" ]]; then
@@ -238,7 +238,7 @@ fi
 
 # MARK: check if this is an Update and we can use updateTool
 if [[ (-n $appversion && -n "$updateTool") || "$type" == "updateronly" ]]; then
-    printlog "appversion & updateTool"
+    printlog "App needs to be updated and uses $updateTool. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now."
     updateDialog "wait" "Updating..."
 
     if [[ $DEBUG -ne 1 ]]; then


### PR DESCRIPTION
… when updateTool is used

Code comments and log entries make it unclear that BLOCKING_PROCESS_ACTION is ignored when a label uses updateTool. Also clarified log entry regarding reopening apps.