### PR TITLE
Update kimplusclientmodul.sh

### DIFF
--- a/fragments/labels/kimplusclientmodul.sh
+++ b/fragments/labels/kimplusclientmodul.sh
@@ -2,8 +2,8 @@ kimplusclientmodul)
     name="KIMplus Clientmodul"
     # appName="KIMplus Clientmodul.app"
     type="dmg"
-    downloadName=$(curl -fs "https://cm.kimplus.de/download/current/updates.xml" | grep -i 'targetMediaFileId="mac"' | sed "s|.*fileName=\(.*\)newVersion.*|\\1|" | cut -d '"' -f 2)
-    appNewVersion=$(curl -fs "https://cm.kimplus.de/download/current/updates.xml" | grep -i 'targetMediaFileId="mac"' | sed "s|.*newVersion=\(.*\)newMedia.*|\\1|" | cut -d '"' -f 2)
+    downloadName=$(curl -fs "https://cm.kimplus.de/download/current/" | grep "macos" | sed "s|.*href=\"\(.*\)\">kimplus-clientmodul.*|\\1|")
+    appNewVersion=$(curl -fs "https://cm.kimplus.de/download/current/" | grep "macos" | sed "s|.*kimplus-clientmodul_\(.*\)_macos.dmg.*|\\1|" | sed s/_/./g)
     downloadURL=https://cm.kimplus.de/download/current/$downloadName
     installerTool="KIMplus Clientmodul Installationsprogramm.app"
     CLIInstaller="KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub"


### PR DESCRIPTION
The updates.xml page lags behind the released versions, so I adjusted the downloadURL and appNewVersion to get the information directly from the downloads page.

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels kimplusclientmodul NOTIFY=silent DEBUG=0 Password:
2023-10-14 07:41:39 : REQ   : kimplusclientmodul : ################## Start Installomator v. 10.5beta, date 2023-10-14
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : ################## Version: 10.5beta
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : ################## Date: 2023-10-14
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : ################## kimplusclientmodul
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : DEBUG mode 1 enabled.
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : setting variable from argument NOTIFY=silent
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : setting variable from argument DEBUG=0
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : name=KIMplus Clientmodul
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : appName=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : type=dmg
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : archiveName=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : downloadURL=https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_1_PU_macos.dmg
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : curlOptions=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : appNewVersion=1.4.7.1.PU
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : appCustomVersion function: Not defined
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : versionKey=CFBundleShortVersionString
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : packageID=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : pkgName=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : choiceChangesXML=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : expectedTeamID=7QZS8E98SZ
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : blockingProcesses=JavaApplicationStub
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : installerTool=KIMplus Clientmodul Installationsprogramm.app
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : CLIInstaller=KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : CLIArguments=-q -overwrite
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : updateTool=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : updateToolArguments=
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : updateToolRunAsCurrentUser=
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : BLOCKING_PROCESS_ACTION=tell_user
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : NOTIFY=silent
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : LOGGING=DEBUG
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : Label type: dmg
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : archiveName: KIMplus Clientmodul.dmg
2023-10-14 07:41:39 : DEBUG : kimplusclientmodul : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ArMCJNTi
2023-10-14 07:41:39 : INFO  : kimplusclientmodul : App(s) found: /Applications/KIMplus Clientmodul.app
2023-10-14 07:41:40 : INFO  : kimplusclientmodul : found app at /Applications/KIMplus Clientmodul.app, version 1.4.7.0.PU, on versionKey CFBundleShortVersionString
2023-10-14 07:41:40 : INFO  : kimplusclientmodul : appversion: 1.4.7.0.PU
2023-10-14 07:41:40 : INFO  : kimplusclientmodul : Latest version of KIMplus Clientmodul is 1.4.7.1.PU
2023-10-14 07:41:40 : REQ   : kimplusclientmodul : Downloading https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_1_PU_macos.dmg to KIMplus Clientmodul.dmg
2023-10-14 07:41:40 : DEBUG : kimplusclientmodul : No Dialog connection, just download
2023-10-14 07:41:48 : DEBUG : kimplusclientmodul : File list: -rw-r--r--  1 root  wheel   249M 14 Okt 07:41 KIMplus Clientmodul.dmg
2023-10-14 07:41:48 : DEBUG : kimplusclientmodul : File type: KIMplus Clientmodul.dmg: Apple Driver Map, blocksize 512, blockcount 509456, devtype 0, devid 0, driver count 0, contains[@0x200]: Apple Partition Map, map block count 2, start block 1, block count 63, name Apple, type Apple_partition_map, valid, allocated, contains[@0x400]: Apple Partition Map, map block count 2, start block 64, block count 509392, name disk image, type Apple_HFS, valid, allocated, readable, writable
2023-10-14 07:41:48 : DEBUG : kimplusclientmodul : curl output was:
*   Trying 146.185.115.98:443...
* Connected to cm.kimplus.de (146.185.115.98) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [383 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [187 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3796 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=DE; L=Leipzig; O=Arvato Systems Digital GmbH; CN=am.kimplus.de
*  start date: Feb  6 00:00:00 2023 GMT
*  expire date: Mar  4 23:59:59 2024 GMT
*  subjectAltName: host "cm.kimplus.de" matched cert's "cm.kimplus.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=GeoTrust RSA CA 2018
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /download/current/kimplus-clientmodul_1_4_7_1_PU_macos.dmg HTTP/1.1
> Host: cm.kimplus.de
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sat, 14 Oct 2023 05:41:40 GMT
< Server: Apache
< Last-Modified: Mon, 09 Oct 2023 08:51:52 GMT
< ETag: "f8c6445-60744b39313a2"
< Accept-Ranges: bytes
< Content-Length: 260858949
< Vary: User-Agent
< Content-Type: application/x-apple-diskimage
<
{ [7931 bytes data]
* Connection #0 to host cm.kimplus.de left intact

2023-10-14 07:41:48 : REQ   : kimplusclientmodul : no more blocking processes, continue with update
2023-10-14 07:41:48 : REQ   : kimplusclientmodul : Installing KIMplus Clientmodul
2023-10-14 07:41:48 : REQ   : kimplusclientmodul : installerTool used: KIMplus Clientmodul Installationsprogramm.app
2023-10-14 07:41:48 : INFO  : kimplusclientmodul : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ArMCJNTi/KIMplus Clientmodul.dmg
2023-10-14 07:41:49 : DEBUG : kimplusclientmodul : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $511C9332
Die überprüfte CRC32-Prüfsumme ist $D5726596
/dev/disk8          	Apple_partition_scheme
/dev/disk8s1        	Apple_partition_map
/dev/disk8s2        	Apple_HFS                      	/Volumes/kimplus-clientmodul

2023-10-14 07:41:49 : INFO  : kimplusclientmodul : Mounted: /Volumes/kimplus-clientmodul 2023-10-14 07:41:49 : INFO  : kimplusclientmodul : Verifying: /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app 2023-10-14 07:41:49 : DEBUG : kimplusclientmodul : App size: 249M	/Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app 2023-10-14 07:41:49 : DEBUG : kimplusclientmodul : Debugging enabled, App Verification output was: /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: arvato Systems GmbH (7QZS8E98SZ)

2023-10-14 07:41:49 : INFO  : kimplusclientmodul : Team ID matching: 7QZS8E98SZ (expected: 7QZS8E98SZ ) 2023-10-14 07:41:49 : INFO  : kimplusclientmodul : Downloaded version of KIMplus Clientmodul is 1.4.7.1.PU on versionKey CFBundleShortVersionString (replacing version 1.4.7.0.PU). 2023-10-14 07:41:49 : INFO  : kimplusclientmodul : App has LSMinimumSystemVersion: 10.11 2023-10-14 07:41:49 : INFO  : kimplusclientmodul : CLIInstaller exists, running installer command /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub -q -overwrite 2023-10-14 07:42:12 : INFO  : kimplusclientmodul : Succesfully ran /Volumes/kimplus-clientmodul/KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub -q -overwrite 2023-10-14 07:42:12 : DEBUG : kimplusclientmodul : Debugging enabled, update tool output was: Deinstalliere vorherige Version
Dateien werden ausgepackt ...
Installation wird beendet ...

2023-10-14 07:42:12 : INFO  : kimplusclientmodul : Finishing... 2023-10-14 07:42:15 : INFO  : kimplusclientmodul : name: KIMplus Clientmodul, appName: KIMplus Clientmodul Installationsprogramm.app 2023-10-14 07:42:15.987 mdfind[63428:2397251] [UserQueryParser] Loading keywords and predicates for locale "de_DE" 2023-10-14 07:42:15.988 mdfind[63428:2397251] [UserQueryParser] Loading keywords and predicates for locale "de" 2023-10-14 07:42:16.082 mdfind[63428:2397251] Couldn't determine the mapping between prefab keywords and predicates. 2023-10-14 07:42:16 : WARN  : kimplusclientmodul : No previous app found 2023-10-14 07:42:16 : WARN  : kimplusclientmodul : could not find KIMplus Clientmodul Installationsprogramm.app
2023-10-14 07:42:16 : REQ   : kimplusclientmodul : Installed KIMplus Clientmodul, version 1.4.7.1.PU
2023-10-14 07:42:16 : DEBUG : kimplusclientmodul : Unmounting /Volumes/kimplus-clientmodul
2023-10-14 07:42:16 : DEBUG : kimplusclientmodul : Debugging enabled, Unmounting output was:
"disk8" ejected.
2023-10-14 07:42:16 : DEBUG : kimplusclientmodul : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ArMCJNTi
2023-10-14 07:42:16 : DEBUG : kimplusclientmodul : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ArMCJNTi/KIMplus Clientmodul.dmg
2023-10-14 07:42:16 : DEBUG : kimplusclientmodul : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ArMCJNTi
2023-10-14 07:42:16 : INFO  : kimplusclientmodul : App not closed, so no reopen.
2023-10-14 07:42:16 : REQ   : kimplusclientmodul : All done!
2023-10-14 07:42:16 : REQ   : kimplusclientmodul : ################## End Installomator, exit code 0

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels kimplusclientmodul NOTIFY=silent DEBUG=0
2023-10-14 07:42:37 : REQ   : kimplusclientmodul : ################## Start Installomator v. 10.5beta, date 2023-10-14
2023-10-14 07:42:37 : INFO  : kimplusclientmodul : ################## Version: 10.5beta
2023-10-14 07:42:37 : INFO  : kimplusclientmodul : ################## Date: 2023-10-14
2023-10-14 07:42:37 : INFO  : kimplusclientmodul : ################## kimplusclientmodul
2023-10-14 07:42:37 : DEBUG : kimplusclientmodul : DEBUG mode 1 enabled.
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : setting variable from argument NOTIFY=silent
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : setting variable from argument DEBUG=0
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : name=KIMplus Clientmodul
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : appName=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : type=dmg
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : archiveName=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : downloadURL=https://cm.kimplus.de/download/current/kimplus-clientmodul_1_4_7_1_PU_macos.dmg
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : curlOptions=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : appNewVersion=1.4.7.1.PU
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : appCustomVersion function: Not defined
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : versionKey=CFBundleShortVersionString
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : packageID=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : pkgName=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : choiceChangesXML=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : expectedTeamID=7QZS8E98SZ
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : blockingProcesses=JavaApplicationStub
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : installerTool=KIMplus Clientmodul Installationsprogramm.app
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : CLIInstaller=KIMplus Clientmodul Installationsprogramm.app/Contents/MacOS/JavaApplicationStub
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : CLIArguments=-q -overwrite
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : updateTool=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : updateToolArguments=
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : updateToolRunAsCurrentUser=
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : BLOCKING_PROCESS_ACTION=tell_user
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : NOTIFY=silent
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : LOGGING=DEBUG
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : Label type: dmg
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : archiveName: KIMplus Clientmodul.dmg
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4FOW0uQH
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : App(s) found: /Applications/KIMplus Clientmodul.app
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : found app at /Applications/KIMplus Clientmodul.app, version 1.4.7.1.PU, on versionKey CFBundleShortVersionString
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : appversion: 1.4.7.1.PU
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : Latest version of KIMplus Clientmodul is 1.4.7.1.PU
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : There is no newer version available.
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4FOW0uQH
2023-10-14 07:42:38 : DEBUG : kimplusclientmodul : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.4FOW0uQH
2023-10-14 07:42:38 : INFO  : kimplusclientmodul : App not closed, so no reopen.
2023-10-14 07:42:38 : REQ   : kimplusclientmodul : No newer version.
2023-10-14 07:42:38 : REQ   : kimplusclientmodul : ################## End Installomator, exit code 0