### PR TITLE
Make `xpath` quiet with `-q`

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -213,7 +213,7 @@ xpath() {
 		# alternative: switch to xmllint (which is not perl)
 		#xmllint --xpath $@ -
 	else
-		/usr/bin/xpath $@
+		/usr/bin/xpath -q $@
 	fi
 }
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -209,7 +209,7 @@ versionFromGit() {
 xpath() {
 	# the xpath tool changes in Big Sur and now requires the `-e` option
 	if [[ $(sw_vers -buildVersion) > "20A" ]]; then
-		/usr/bin/xpath -e $@
+		/usr/bin/xpath -q -e $@
 		# alternative: switch to xmllint (which is not perl)
 		#xmllint --xpath $@ -
 	else


### PR DESCRIPTION
It actually makes `xpath` faster, as has been reported here: https://macadmins.slack.com/archives/C013HFTFQ13/p1698069397881329?thread_ts=1698065903.345819&cid=C013HFTFQ13

`xpath -e '(//rss/channel/item/enclosure/@sparkle:version)' 2> /dev/null` 0.03s user 0.01s system 8% cpu 0.585 total
vs.
`xpath -q -e '(//rss/channel/item/enclosure/@sparkle:version)'` 0.03s user 0.01s system 7% cpu 0.578 total