### PR TITLE
Fix vlc.sh fragment

### DIFF
--- a/fragments/labels/vlc.sh
+++ b/fragments/labels/vlc.sh
@@ -1,13 +1,7 @@
 vlc)
     name="VLC"
     type="dmg"
-    if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-arm64.xml | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 )
-        #appNewVersion=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-arm64.xml | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2 )
-    elif [[ $(arch) == "i386" ]]; then
-        downloadURL=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-intel64.xml | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 )
-        #appNewVersion=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-intel64.xml | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2 )
-    fi
-    appNewVersion=$(echo ${downloadURL} | sed -E 's/.*\/vlc-([0-9.]*).*\.dmg/\1/' )
+    downloadURL="https://download.videolan.org/pub/videolan/vlc/last/macosx/vlc-$(curl -fs https://download.videolan.org/pub/videolan/vlc/last/macosx/ | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)-universal.dmg"
+    appNewVersion=$(curl -fs https://download.videolan.org/pub/videolan/vlc/last/macosx/ | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
     expectedTeamID="75GAHG3SZQ"
     ;;


### PR DESCRIPTION
Fix VLC label

assemble.sh already runned

`./assemble.sh vlc
2023-10-25 12:40:11 : REQ   : vlc : ################## Start Installomator v. 10.6beta, date 2023-10-25
2023-10-25 12:40:11 : INFO  : vlc : ################## Version: 10.6beta
2023-10-25 12:40:11 : INFO  : vlc : ################## Date: 2023-10-25
2023-10-25 12:40:11 : INFO  : vlc : ################## vlc
2023-10-25 12:40:11 : DEBUG : vlc : DEBUG mode 1 enabled.
2023-10-25 12:40:11 : DEBUG : vlc : name=VLC
2023-10-25 12:40:11 : DEBUG : vlc : appName=
2023-10-25 12:40:11 : DEBUG : vlc : type=dmg
2023-10-25 12:40:11 : DEBUG : vlc : archiveName=
2023-10-25 12:40:11 : DEBUG : vlc : downloadURL=https://download.videolan.org/pub/videolan/vlc/last/macosx/vlc-3.0.18-universal.dmg
2023-10-25 12:40:11 : DEBUG : vlc : curlOptions=
2023-10-25 12:40:11 : DEBUG : vlc : appNewVersion=3.0.18
2023-10-25 12:40:11 : DEBUG : vlc : appCustomVersion function: Not defined
2023-10-25 12:40:11 : DEBUG : vlc : versionKey=CFBundleShortVersionString
2023-10-25 12:40:11 : DEBUG : vlc : packageID=
2023-10-25 12:40:11 : DEBUG : vlc : pkgName=
2023-10-25 12:40:11 : DEBUG : vlc : choiceChangesXML=
2023-10-25 12:40:11 : DEBUG : vlc : expectedTeamID=75GAHG3SZQ
2023-10-25 12:40:11 : DEBUG : vlc : blockingProcesses=
2023-10-25 12:40:11 : DEBUG : vlc : installerTool=
2023-10-25 12:40:11 : DEBUG : vlc : CLIInstaller=
2023-10-25 12:40:11 : DEBUG : vlc : CLIArguments=
2023-10-25 12:40:11 : DEBUG : vlc : updateTool=
2023-10-25 12:40:11 : DEBUG : vlc : updateToolArguments=
2023-10-25 12:40:11 : DEBUG : vlc : updateToolRunAsCurrentUser=
2023-10-25 12:40:11 : INFO  : vlc : BLOCKING_PROCESS_ACTION=tell_user
2023-10-25 12:40:11 : INFO  : vlc : NOTIFY=success
2023-10-25 12:40:11 : INFO  : vlc : LOGGING=DEBUG
2023-10-25 12:40:11 : INFO  : vlc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-10-25 12:40:11 : INFO  : vlc : Label type: dmg
2023-10-25 12:40:11 : INFO  : vlc : archiveName: VLC.dmg
2023-10-25 12:40:11 : INFO  : vlc : no blocking processes defined, using VLC as default
2023-10-25 12:40:11 : DEBUG : vlc : Changing directory to /Users/alexis/DEV/Installomator/build
2023-10-25 12:40:11 : INFO  : vlc : name: VLC, appName: VLC.app
2023-10-25 12:40:11.780 mdfind[45997:559388] [UserQueryParser] Loading keywords and predicates for locale "fr_FR"
2023-10-25 12:40:11.781 mdfind[45997:559388] [UserQueryParser] Loading keywords and predicates for locale "fr"
2023-10-25 12:40:11.862 mdfind[45997:559388] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-25 12:40:11.862 mdfind[45997:559388] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-25 12:40:12 : WARN  : vlc : No previous app found
2023-10-25 12:40:12 : WARN  : vlc : could not find VLC.app
2023-10-25 12:40:12 : INFO  : vlc : appversion: 
2023-10-25 12:40:12 : INFO  : vlc : Latest version of VLC is 3.0.18
2023-10-25 12:40:12 : REQ   : vlc : Downloading https://download.videolan.org/pub/videolan/vlc/last/macosx/vlc-3.0.18-universal.dmg to VLC.dmg
2023-10-25 12:40:12 : DEBUG : vlc : No Dialog connection, just download
2023-10-25 12:40:13 : DEBUG : vlc : File list: -rw-r--r--  1 alexis  staff    81M 25 oct 12:40 VLC.dmg
2023-10-25 12:40:13 : DEBUG : vlc : File type: VLC.dmg: bzip2 compressed data, block size = 100k
2023-10-25 12:40:13 : DEBUG : vlc : curl output was:
*   Trying 213.36.253.2:443...
* Connected to download.videolan.org (213.36.253.2) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4180 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.videolan.org
*  start date: Oct  7 01:34:29 2023 GMT
*  expire date: Jan  5 01:34:28 2024 GMT
*  subjectAltName: host "download.videolan.org" matched cert's "download.videolan.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download.videolan.org]
* h2 [:path: /pub/videolan/vlc/last/macosx/vlc-3.0.18-universal.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x15c00c600)
> GET /pub/videolan/vlc/last/macosx/vlc-3.0.18-universal.dmg HTTP/2
> Host: download.videolan.org
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 200 
< server: nginx/1.25.2
< date: Wed, 25 Oct 2023 10:40:12 GMT
< content-type: application/octet-stream
< content-length: 84489561
< last-modified: Thu, 13 Oct 2022 20:57:01 GMT
< etag: "63487b9d-5093559"
< x-clacks-overhead: GNU Terry Pratchett
< accept-ranges: bytes
< 
{ [16366 bytes data]
* Connection #0 to host download.videolan.org left intact

2023-10-25 12:40:13 : DEBUG : vlc : DEBUG mode 1, not checking for blocking processes
2023-10-25 12:40:13 : REQ   : vlc : Installing VLC
2023-10-25 12:40:13 : INFO  : vlc : Mounting /Users/alexis/DEV/Installomator/build/VLC.dmg
2023-10-25 12:40:22 : DEBUG : vlc : Debugging enabled, dmgmount output was:
Calcul de la somme de contrôle de Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR : : vérifiée   CRC32 $B3A9594E
Calcul de la somme de contrôle de GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1) : vérifiée   CRC32 $8064B750
Calcul de la somme de contrôle de GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl : vérifiée   CRC32 $EB396230
Calcul de la somme de contrôle de  (Apple_Free : 3)…
(Apple_Free : 3) : vérifiée   CRC32 $00000000
Calcul de la somme de contrôle de disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4) : vérifiée   CRC32 $93425EEC
Calcul de la somme de contrôle de  (Apple_Free : 5)…
(Apple_Free : 5) : vérifiée   CRC32 $00000000
Calcul de la somme de contrôle de GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table : vérifiée   CRC32 $EB396230
Calcul de la somme de contrôle de GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7) : vérifiée   CRC32 $C5C5A3FA
vérifiée   CRC32 $A64DB6DE
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/VLC media player

2023-10-25 12:40:22 : INFO  : vlc : Mounted: /Volumes/VLC media player
2023-10-25 12:40:22 : INFO  : vlc : Verifying: /Volumes/VLC media player/VLC.app
2023-10-25 12:40:22 : DEBUG : vlc : App size: 225M	/Volumes/VLC media player/VLC.app
2023-10-25 12:40:59 : DEBUG : vlc : Debugging enabled, App Verification output was:
/Volumes/VLC media player/VLC.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: VideoLAN (75GAHG3SZQ)

2023-10-25 12:40:59 : INFO  : vlc : Team ID matching: 75GAHG3SZQ (expected: 75GAHG3SZQ )
2023-10-25 12:40:59 : INFO  : vlc : Installing VLC version 3.0.18 on versionKey CFBundleShortVersionString.
2023-10-25 12:40:59 : INFO  : vlc : App has LSMinimumSystemVersion: 10.7.5
2023-10-25 12:40:59 : DEBUG : vlc : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-10-25 12:40:59 : INFO  : vlc : Finishing...
2023-10-25 12:41:02 : INFO  : vlc : name: VLC, appName: VLC.app
2023-10-25 12:41:02.777 mdfind[46125:560065] [UserQueryParser] Loading keywords and predicates for locale "fr_FR"
2023-10-25 12:41:02.778 mdfind[46125:560065] [UserQueryParser] Loading keywords and predicates for locale "fr"
2023-10-25 12:41:02.860 mdfind[46125:560065] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-25 12:41:02.860 mdfind[46125:560065] Couldn't determine the mapping between prefab keywords and predicates.
2023-10-25 12:41:03 : WARN  : vlc : No previous app found
2023-10-25 12:41:03 : WARN  : vlc : could not find VLC.app
2023-10-25 12:41:03 : REQ   : vlc : Installed VLC, version 3.0.18
2023-10-25 12:41:03 : INFO  : vlc : notifying
2023-10-25 12:41:03 : DEBUG : vlc : Unmounting /Volumes/VLC media player
2023-10-25 12:41:03 : DEBUG : vlc : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-10-25 12:41:03 : DEBUG : vlc : DEBUG mode 1, not reopening anything
2023-10-25 12:41:03 : REQ   : vlc : All done!
2023-10-25 12:41:03 : REQ   : vlc : ################## End Installomator, exit code 0 `