### PR TITLE
now prevents 'chown'ing app to _mbsetupuser

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -568,7 +568,7 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
         fi
 
         # set ownership to current user
-        if [[ "$currentUser" != "loginwindow" && $SYSTEMOWNER -ne 1 ]]; then
+        if [[ "$currentUser" != "loginwindow" && "$currentUser" != "_mbsetupuser" && $SYSTEMOWNER -ne 1 ]]; then
             printlog "Changing owner to $currentUser" WARN
             chown -R "$currentUser" "$targetDir/$appName"
         else


### PR DESCRIPTION
When Installomator runs during the Setup Assistant, it may chown an app to `_mbsetupuser` unless `SYSTEMOWNER=1`.

This will change the default behavior should when running over Setup Assistant 