### PR TITLE
Update splashtopbusiness.sh

### DIFF
--- a/fragments/labels/splashtopbusiness.sh
+++ b/fragments/labels/splashtopbusiness.sh
@@ -2,7 +2,7 @@ splashtopbusiness)
     name="Splashtop Business"
     type="pkgInDmg"
     splashtopbusinessVersions=$(curl -fsL "https://www.splashtop.com/wp-content/themes/responsive/downloadx.php?product=stb&platform=mac-client")
-    downloadURL=$(getJSONValue "$splashtopbusinessVersions" "url")
+    downloadURL=$(curl -Ls -w %{url_effective} -o /dev/null $(getJSONValue "$splashtopbusinessVersions" "url"))
     appNewVersion="${${downloadURL#*INSTALLER_v}%*.dmg}"
     expectedTeamID="CPQQ3AW49Y"
     ;;


### PR DESCRIPTION
Fix downloadURL to follow redirect and provide actual downloaded filename. This also fixes issue with not properly determining appNewVersion.