### PR TITLE
new label:logitune

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -343,6 +343,7 @@ linear
 logioptions
 logitechoptions
 logitechoptionsplus
+logitune
 logseq
 loom
 lowprofile

--- a/fragments/labels/logitunes.sh
+++ b/fragments/labels/logitunes.sh
@@ -1,8 +1,8 @@
-logitunes)
+logitune)
     name="Logi Tune"
     type="dmg"
     downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/tune/.*\.dmg" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
-    appName="LogiTune.app"   
+    appName="LogiTuneInstaller.app"   
     expectedTeamID="QED4VVPZWA"
     ;;

--- a/fragments/labels/logitunes.sh
+++ b/fragments/labels/logitunes.sh
@@ -1,7 +1,6 @@
 logitunes)
     name="Logi Tune"
     type="dmg"
-    #downloadURL=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -oie "https.*/.*/tune/.*\.dmg" | head -1)
     downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/tune/.*\.dmg" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     appName="LogiTune.app"   

--- a/fragments/labels/logitunes.sh
+++ b/fragments/labels/logitunes.sh
@@ -1,0 +1,9 @@
+logitunes)
+    name="Logi Tune"
+    type="dmg"
+    #downloadURL=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -oie "https.*/.*/tune/.*\.dmg" | head -1)
+    downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/tune/.*\.dmg" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    appName="LogiTune.app"   
+    expectedTeamID="QED4VVPZWA"
+    ;;


### PR DESCRIPTION
Created a label for Logitech LogiTune software and added logitune to the Labels.txt file. LogiTune simplifies headset and webcam control.

I was not able to test the label because it wasn't found in the labels.txt file when using the assemble.sh command (I'm new to this but assume the label has to exist first?) 