### PR TITLE
new label: yubikeymanager

### DIFF
--- a/fragments/labels/yubikeymanager.sh
+++ b/fragments/labels/yubikeymanager.sh
@@ -1,0 +1,10 @@
+yubikeymanager)
+    # credit: Reuven Cohen
+    name="YubiKey Manager"
+    type="pkg"
+    #downloadURL="https://github.com/Yubico/yubikey-manager/releases/download/5.0.1/yubikey-manager-5.0.1-mac.pkg"
+	  downloadURL=$(downloadURLFromGit Yubico yubikey-manager)
+    appNewVersion=$(versionFromGit Yubico yubikey-manager)
+    expectedTeamID="LQA3CS5MM7"
+    #CLI for YubikeyManager which is not installed via the QT version.
+    ;;

--- a/fragments/labels/yubikeymanager.sh
+++ b/fragments/labels/yubikeymanager.sh
@@ -2,8 +2,8 @@ yubikeymanager)
     # credit: Reuven Cohen
     name="YubiKey Manager"
     type="pkg"
-    #downloadURL="https://github.com/Yubico/yubikey-manager/releases/download/5.0.1/yubikey-manager-5.0.1-mac.pkg"
-	  downloadURL=$(downloadURLFromGit Yubico yubikey-manager)
+    appCustomVersion(){/usr/local/ykman/ykman -v | awk '{print $5}'}
+	downloadURL=$(downloadURLFromGit Yubico yubikey-manager)
     appNewVersion=$(versionFromGit Yubico yubikey-manager)
     expectedTeamID="LQA3CS5MM7"
     #CLI for YubikeyManager which is not installed via the QT version.

--- a/fragments/labels/yubikeymanager.sh
+++ b/fragments/labels/yubikeymanager.sh
@@ -1,5 +1,4 @@
 yubikeymanager)
-    # credit: Reuven Cohen
     name="YubiKey Manager"
     type="pkg"
     appCustomVersion(){/usr/local/ykman/ykman -v | awk '{print $5}'}


### PR DESCRIPTION
Label for YubiKey Manager CLI Installer.
This installer is not included in the QT version thus requires its own label.