### PR TITLE
Create new label for AutoMounter from Pixeleyes

### DIFF
--- a/fragments/labels/automounter.sh
+++ b/fragments/labels/automounter.sh
@@ -1,0 +1,11 @@
+automounter)
+    name="AutoMounter"
+    type="dmg"
+    downloadURL="https://www.pixeleyes.co.nz/automounter/AutoMounter.dmg"
+    appNewVersion="$( curl -fs https://www.pixeleyes.co.nz/automounter/version )"
+    versionKey="CFBundleShortVersionString"
+    appName="$name.app"
+    archiveName="$name.$type"
+    blockingProcesses=( $name )
+    expectedTeamID="UKWABN4MGL"
+    ;;

--- a/fragments/labels/automounter.sh
+++ b/fragments/labels/automounter.sh
@@ -4,8 +4,5 @@ automounter)
     downloadURL="https://www.pixeleyes.co.nz/automounter/AutoMounter.dmg"
     appNewVersion="$( curl -fs https://www.pixeleyes.co.nz/automounter/version )"
     versionKey="CFBundleShortVersionString"
-    appName="$name.app"
-    archiveName="$name.$type"
-    blockingProcesses=( $name )
     expectedTeamID="UKWABN4MGL"
     ;;


### PR DESCRIPTION
2023-11-01 12:05:27 : REQ   : automounter : ################## Start Installomator v. 10.6beta, date 2023-11-01
2023-11-01 12:05:27 : INFO  : automounter : ################## Version: 10.6beta
2023-11-01 12:05:27 : INFO  : automounter : ################## Date: 2023-11-01
2023-11-01 12:05:27 : INFO  : automounter : ################## automounter
2023-11-01 12:05:27 : DEBUG : automounter : DEBUG mode 1 enabled.
2023-11-01 12:05:29 : DEBUG : automounter : name=AutoMounter
2023-11-01 12:05:29 : DEBUG : automounter : appName=AutoMounter.app
2023-11-01 12:05:29 : DEBUG : automounter : type=dmg
2023-11-01 12:05:29 : DEBUG : automounter : archiveName=AutoMounter.dmg
2023-11-01 12:05:29 : DEBUG : automounter : downloadURL=https://www.pixeleyes.co.nz/automounter/AutoMounter.dmg
2023-11-01 12:05:29 : DEBUG : automounter : curlOptions=
2023-11-01 12:05:29 : DEBUG : automounter : appNewVersion=1.8.1
2023-11-01 12:05:30 : DEBUG : automounter : appCustomVersion function: Not defined
2023-11-01 12:05:30 : DEBUG : automounter : versionKey=CFBundleShortVersionString
2023-11-01 12:05:30 : DEBUG : automounter : packageID=
2023-11-01 12:05:30 : DEBUG : automounter : pkgName=
2023-11-01 12:05:30 : DEBUG : automounter : choiceChangesXML=
2023-11-01 12:05:30 : DEBUG : automounter : expectedTeamID=UKWABN4MGL
2023-11-01 12:05:30 : DEBUG : automounter : blockingProcesses=AutoMounter
2023-11-01 12:05:30 : DEBUG : automounter : installerTool=
2023-11-01 12:05:30 : DEBUG : automounter : CLIInstaller=
2023-11-01 12:05:30 : DEBUG : automounter : CLIArguments=
2023-11-01 12:05:30 : DEBUG : automounter : updateTool=
2023-11-01 12:05:30 : DEBUG : automounter : updateToolArguments=
2023-11-01 12:05:30 : DEBUG : automounter : updateToolRunAsCurrentUser=
2023-11-01 12:05:30 : INFO  : automounter : BLOCKING_PROCESS_ACTION=tell_user
2023-11-01 12:05:30 : INFO  : automounter : NOTIFY=success
2023-11-01 12:05:30 : INFO  : automounter : LOGGING=DEBUG
2023-11-01 12:05:30 : INFO  : automounter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-01 12:05:30 : INFO  : automounter : Label type: dmg
2023-11-01 12:05:30 : INFO  : automounter : archiveName: AutoMounter.dmg
2023-11-01 12:05:30 : DEBUG : automounter : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-01 12:05:30 : INFO  : automounter : App(s) found: /Applications/AutoMounter.app
2023-11-01 12:05:30 : INFO  : automounter : found app at /Applications/AutoMounter.app, version 1.8.0, on versionKey CFBundleShortVersionString
2023-11-01 12:05:30 : INFO  : automounter : appversion: 1.8.0
2023-11-01 12:05:30 : INFO  : automounter : Latest version of AutoMounter is 1.8.1
2023-11-01 12:05:30 : REQ   : automounter : Downloading https://www.pixeleyes.co.nz/automounter/AutoMounter.dmg to AutoMounter.dmg
2023-11-01 12:05:30 : DEBUG : automounter : No Dialog connection, just download
2023-11-01 12:05:32 : DEBUG : automounter : File list: -rw-r--r--  1 someuser  staff   3.0M Nov  1 12:05 AutoMounter.dmg
2023-11-01 12:05:32 : DEBUG : automounter : File type: AutoMounter.dmg: bzip2 compressed data, block size = 100k
2023-11-01 12:05:32 : DEBUG : automounter : curl output was:
*   Trying 216.146.201.10:443...
* Connected to www.pixeleyes.co.nz (216.146.201.10) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3992 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=pixeleyes.co.nz
*  start date: Sep 15 22:04:54 2023 GMT
*  expire date: Dec 14 22:04:53 2023 GMT
*  subjectAltName: host "www.pixeleyes.co.nz" matched cert's "www.pixeleyes.co.nz"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /automounter/AutoMounter.dmg HTTP/1.1
> Host: www.pixeleyes.co.nz
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 01 Nov 2023 09:05:31 GMT
< Server: Apache
< Last-Modified: Fri, 20 Oct 2023 18:46:27 GMT
< ETag: "30b685-6082a4a3686c0"
< Accept-Ranges: bytes
< Content-Length: 3192453
< Content-Type: application/x-apple-diskimage
<
{ [7952 bytes data]
* Connection #0 to host www.pixeleyes.co.nz left intact

2023-11-01 12:05:32 : DEBUG : automounter : DEBUG mode 1, not checking for blocking processes
2023-11-01 12:05:32 : REQ   : automounter : Installing AutoMounter
2023-11-01 12:05:32 : INFO  : automounter : Mounting /Users/someuser/Documents/GitHub/Installomator/build/AutoMounter.dmg
2023-11-01 12:05:36 : DEBUG : automounter : Debugging enabled, dmgmount output was:
AUTOMOUNTER LICENSE AGREEMENT

AUTOMOUNTER IS COPYRIGHT PIXELEYES LTD, ALL RIGHTS RESERVED.

BY INSTALLING, DOWNLOADING, COPYING, OR OTHERWISE USING AUTOMOUNTER, YOU ACKNOWLEDGE THAT YOU HAVE READ THIS LICENSE AGREEMENT, UNDERSTAND IT, AND AGREE TO BE BOUND BY IT. IF YOU DO NOT AGREE WITH THIS LICENSE AGREEMENT, YOU ARE NOT AUTHORIZED AND MAY NOT USE AUTOMOUNTER.

AUTOMOUNTER PROVIDED TO THE LICENSEE UNDER THIS AGREEMENT IS LICENSED, NOT SOLD, TO THE LICENSEE BY PIXELEYES LTD., AND PIXELEYES LTD. RESERVES ALL RIGHTS NOT EXPRESSLY GRANTED UNDER THIS AGREEMENT.

PIXELEYES LTD. HEREBY GRANTS THE LICENSEE A NON-EXCLUSIVE LICENSE TO USE AUTOMOUNTER ON THE TERMS OF THIS LICENSE AGREEMENT. THE LICENSEE MAY NOT SELL, RENT, LEASE, LOAN, SUBLICENSE, OR OTHERWISE REDISTRIBUTE AUTOMOUNTER, IN WHOLE OR IN PART. THE LICENSEE MAY NOT DECOMPILE, REVERSE ENGINEER, DISASSEMBLE, MODIFY, OR CREATE DERIVATIVE WORKS OF AUTOMOUNTER OR ANY PART THEREOF.

AUTOMOUNTER IS PROVIDED AS IS, WITHOUT REPRESENTATION AS TO ITS FITNESS FOR ANY PURPOSE, AND WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.THE DEVELOPER SHALL NOT BE LIABLE FOR ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING OUT OF OR IN CONNECTION WITH THE USE OF THE SOFTWARE, EVEN IF IT HAS BEEN OR IS HEREAFTER ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OF LIABILITY FOR PERSONAL INJURY, OR OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT APPLY TO YOU. IN NO EVENT SHALL PIXELEYES LTD'S) TOTAL LIABILITY TO YOU FOR ALL DAMAGES (OTHER THAN AS MAY BE REQUIRED BY APPLICABLE LAW IN CASES INVOLVING PERSONAL INJURY) EXCEED THE AMOUNT OF FIFTY US DOLLARS ($50.00). THE FOREGOING LIMITATIONS WILL APPLY EVEN IF THE ABOVE STATED REMEDY FAILS OF ITS ESSENTIAL PURPOSE.
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D88B899F
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B5811FB8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $8C8FD7A1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $E61463BA
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $8C8FD7A1
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $5AA88348
verified   CRC32 $00208D98
/dev/disk14             GUID_partition_scheme
/dev/disk14s1           Apple_APFS
/dev/disk15             EF57347C-0000-11AA-AA11-0030654
/dev/disk15s1           41504653-0000-11AA-AA11-0030654 /Volumes/AutoMounter

2023-11-01 12:05:36 : INFO  : automounter : Mounted: /Volumes/AutoMounter 2023-11-01 12:05:36 : INFO  : automounter : Verifying: /Volumes/AutoMounter/AutoMounter.app
2023-11-01 12:05:36 : DEBUG : automounter : App size: 8.0M      /Volumes/AutoMounter/AutoMounter.app
2023-11-01 12:05:37 : DEBUG : automounter : Debugging enabled, App Verification output was:
/Volumes/AutoMounter/AutoMounter.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Pixeleyes Ltd (UKWABN4MGL)

2023-11-01 12:05:37 : INFO  : automounter : Team ID matching: UKWABN4MGL (expected: UKWABN4MGL ) 2023-11-01 12:05:37 : INFO  : automounter : Downloaded version of AutoMounter is 1.8.1 on versionKey CFBundleShortVersionString (replacing version 1.8.0). 2023-11-01 12:05:37 : INFO  : automounter : App has LSMinimumSystemVersion: 12.0 2023-11-01 12:05:37 : DEBUG : automounter : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-11-01 12:05:37 : INFO  : automounter : Finishing... 2023-11-01 12:05:40 : INFO  : automounter : App(s) found: /Applications/AutoMounter.app 2023-11-01 12:05:41 : INFO  : automounter : found app at /Applications/AutoMounter.app, version 1.8.0, on versionKey CFBundleShortVersionString
2023-11-01 12:05:41 : REQ   : automounter : Installed AutoMounter, version 1.8.1
2023-11-01 12:05:41 : INFO  : automounter : notifying
2023-11-01 12:05:41 : DEBUG : automounter : Unmounting /Volumes/AutoMounter
2023-11-01 12:05:41 : DEBUG : automounter : Debugging enabled, Unmounting output was:
"disk14" ejected.
2023-11-01 12:05:41 : DEBUG : automounter : DEBUG mode 1, not reopening anything
2023-11-01 12:05:41 : REQ   : automounter : All done!
2023-11-01 12:05:41 : REQ   : automounter : ################## End Installomator, exit code 0