### PR TITLE
Create New Label for Apache Directory Studio

### DIFF
--- a/fragments/labels/apachedirectorystudio.sh
+++ b/fragments/labels/apachedirectorystudio.sh
@@ -4,8 +4,5 @@ apachedirectorystudio)
     downloadURL=$( curl -fs https://directory.apache.org/studio/download/download-macosx.html | grep -o 'http[^"]*downloads[^"]*ApacheDirectoryStudio[^"]*.dmg' | head -1 )
     appNewVersion=$( curl -fs $downloadURL | grep -o 'studio/\([^/]*\)/ApacheDirectoryStudio' | cut -d'/' -f2 )
     versionKey="CFBundleVersion"
-    appName="$name.app"
-    archiveName="$name.$type"
-    blockingProcesses=( $name )
     expectedTeamID="2GLGAFWEQD"
     ;;

--- a/fragments/labels/apachedirectorystudio.sh
+++ b/fragments/labels/apachedirectorystudio.sh
@@ -2,7 +2,7 @@ apachedirectorystudio)
     name="ApacheDirectoryStudio"
     type="dmg"
     downloadURL=$( curl -fs https://directory.apache.org/studio/download/download-macosx.html | grep -o 'http[^"]*downloads[^"]*ApacheDirectoryStudio[^"]*.dmg' | head -1 )
-    appNewVersion=$( curl -fs $downloadURL | grep -o 'studio/\([^/]*\)/ApacheDirectoryStudio' | cut -d'/' -f2 )
+    appNewVersion=$( curl -fs https://directory.apache.org/studio/download/download-macosx.html  | grep -o 'studio/\([^/]*\)/ApacheDirectoryStudio' | cut -d'/' -f2 | head -1)
     versionKey="CFBundleVersion"
     expectedTeamID="2GLGAFWEQD"
     ;;

--- a/fragments/labels/apachedirectorystudio.sh
+++ b/fragments/labels/apachedirectorystudio.sh
@@ -1,0 +1,11 @@
+apachedirectorystudio)
+    name="ApacheDirectoryStudio"
+    type="dmg"
+    downloadURL=$( curl -fs https://directory.apache.org/studio/download/download-macosx.html | grep -o 'http[^"]*downloads[^"]*ApacheDirectoryStudio[^"]*.dmg' | head -1 )
+    appNewVersion=$( curl -fs $downloadURL | grep -o 'studio/\([^/]*\)/ApacheDirectoryStudio' | cut -d'/' -f2 )
+    versionKey="CFBundleVersion"
+    appName="$name.app"
+    archiveName="$name.$type"
+    blockingProcesses=( $name )
+    expectedTeamID="2GLGAFWEQD"
+    ;;


### PR DESCRIPTION
2023-11-01 13:21:41 : REQ   : apachedirectorystudio : ################## Start Installomator v. 10.6beta, date 2023-11-01
2023-11-01 13:21:41 : INFO  : apachedirectorystudio : ################## Version: 10.6beta
2023-11-01 13:21:41 : INFO  : apachedirectorystudio : ################## Date: 2023-11-01
2023-11-01 13:21:41 : INFO  : apachedirectorystudio : ################## apachedirectorystudio
2023-11-01 13:21:41 : DEBUG : apachedirectorystudio : DEBUG mode 1 enabled.
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : name=ApacheDirectoryStudio
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : appName=ApacheDirectoryStudio.app
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : type=dmg
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : archiveName=ApacheDirectoryStudio.dmg
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : downloadURL=https://downloads.apache.org/directory/studio/2.0.0.v20210717-M17/ApacheDirectoryStudio-2.0.0.v20210717-M17-macosx.cocoa.x86_64.dmg
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : curlOptions=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : appNewVersion=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : appCustomVersion function: Not defined
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : versionKey=CFBundleVersion
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : packageID=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : pkgName=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : choiceChangesXML=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : expectedTeamID=2GLGAFWEQD
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : blockingProcesses=ApacheDirectoryStudio
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : installerTool=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : CLIInstaller=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : CLIArguments=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : updateTool=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : updateToolArguments=
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : updateToolRunAsCurrentUser=
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : BLOCKING_PROCESS_ACTION=tell_user
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : NOTIFY=success
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : LOGGING=DEBUG
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : Label type: dmg
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : archiveName: ApacheDirectoryStudio.dmg
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : App(s) found: /Applications/ApacheDirectoryStudio.app
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : found app at /Applications/ApacheDirectoryStudio.app, version 2.0.0.v20210717-M17, on versionKey CFBundleVersion
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : appversion: 2.0.0.v20210717-M17
2023-11-01 13:21:58 : INFO  : apachedirectorystudio : Latest version not specified.
2023-11-01 13:21:58 : REQ   : apachedirectorystudio : Downloading https://downloads.apache.org/directory/studio/2.0.0.v20210717-M17/ApacheDirectoryStudio-2.0.0.v20210717-M17-macosx.cocoa.x86_64.dmg to ApacheDirectoryStudio.dmg
2023-11-01 13:21:58 : DEBUG : apachedirectorystudio : No Dialog connection, just download
2023-11-01 13:22:15 : DEBUG : apachedirectorystudio : File list: -rw-r--r--  1 someuser  staff   134M Nov  1 13:22 ApacheDirectoryStudio.dmg
2023-11-01 13:22:15 : DEBUG : apachedirectorystudio : File type: ApacheDirectoryStudio.dmg: zlib compressed data
2023-11-01 13:22:15 : DEBUG : apachedirectorystudio : curl output was:
*   Trying 135.181.214.104:443...
* Connected to downloads.apache.org (135.181.214.104) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4835 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.apache.org
*  start date: Jul 25 00:00:00 2023 GMT
*  expire date: Aug 24 23:59:59 2024 GMT
*  subjectAltName: host "downloads.apache.org" matched cert's "*.apache.org"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /directory/studio/2.0.0.v20210717-M17/ApacheDirectoryStudio-2.0.0.v20210717-M17-macosx.cocoa.x86_64.dmg HTTP/1.1
> Host: downloads.apache.org
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 01 Nov 2023 10:22:00 GMT
< Server: Apache
< Last-Modified: Sat, 17 Jul 2021 18:53:18 GMT
< ETag: "867c8f3-5c75637a27aba"
< Accept-Ranges: bytes
< Content-Length: 141019379
< Access-Control-Allow-Origin: *
< Content-Type: application/x-apple-diskimage
<
{ [16384 bytes data]
* Connection #0 to host downloads.apache.org left intact

2023-11-01 13:22:15 : DEBUG : apachedirectorystudio : DEBUG mode 1, not checking for blocking processes
2023-11-01 13:22:15 : REQ   : apachedirectorystudio : Installing ApacheDirectoryStudio
2023-11-01 13:22:15 : INFO  : apachedirectorystudio : Mounting /Users/someuser/Documents/GitHub/Installomator/build/ApacheDirectoryStudio.dmg
2023-11-01 13:22:18 : DEBUG : apachedirectorystudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $254051D4
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8F5BCED9
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D6541F21
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $0486BAE5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D6541F21
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $39429EE1
verified   CRC32 $24D2B72C
/dev/disk14             GUID_partition_scheme
/dev/disk14s1           Apple_APFS
/dev/disk15             EF57347C-0000-11AA-AA11-0030654
/dev/disk15s1           41504653-0000-11AA-AA11-0030654 /Volumes/ApacheDirectoryStudio

2023-11-01 13:22:18 : INFO  : apachedirectorystudio : Mounted: /Volumes/ApacheDirectoryStudio 2023-11-01 13:22:18 : INFO  : apachedirectorystudio : Verifying: /Volumes/ApacheDirectoryStudio/ApacheDirectoryStudio.app
2023-11-01 13:22:18 : DEBUG : apachedirectorystudio : App size: 148M    /Volumes/ApacheDirectoryStudio/ApacheDirectoryStudio.app
2023-11-01 13:22:19 : DEBUG : apachedirectorystudio : Debugging enabled, App Verification output was:
/Volumes/ApacheDirectoryStudio/ApacheDirectoryStudio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Apache Software Foundation (2GLGAFWEQD)

2023-11-01 13:22:19 : INFO  : apachedirectorystudio : Team ID matching: 2GLGAFWEQD (expected: 2GLGAFWEQD ) 2023-11-01 13:22:20 : INFO  : apachedirectorystudio : Downloaded version of ApacheDirectoryStudio is 2.0.0.v20210717-M17 on versionKey CFBundleVersion, same as installed. 2023-11-01 13:22:20 : DEBUG : apachedirectorystudio : Unmounting /Volumes/ApacheDirectoryStudio 2023-11-01 13:22:20 : DEBUG : apachedirectorystudio : Debugging enabled, Unmounting output was: "disk14" ejected.
2023-11-01 13:22:20 : DEBUG : apachedirectorystudio : DEBUG mode 1, not reopening anything
2023-11-01 13:22:20 : REG   : apachedirectorystudio : No new version to install
2023-11-01 13:22:20 : REQ   : apachedirectorystudio : ################## End Installomator, exit code 0