### PR TITLE
Create new label for NordVPN

### DIFF
--- a/fragments/labels/nordvpn.sh
+++ b/fragments/labels/nordvpn.sh
@@ -1,0 +1,11 @@
+nordvpn)
+    name="NordVPN"
+    type="pkg"
+    appName="$name.app"
+    packageID="com.nordvpn.macos"
+    downloadURL="https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg"
+    appNewVersion=$( curl -s https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/update_pkg.xml | xpath -e '(//sparkle:shortVersionString/text())[1]' 2>/dev/null )
+    versionKey="CFBundleShortVersionString"
+    blockingProcesses=( $name )
+    expectedTeamID="W5W395V82Y"
+    ;;

--- a/fragments/labels/nordvpn.sh
+++ b/fragments/labels/nordvpn.sh
@@ -1,11 +1,9 @@
 nordvpn)
     name="NordVPN"
     type="pkg"
-    appName="$name.app"
     packageID="com.nordvpn.macos"
     downloadURL="https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg"
-    appNewVersion=$( curl -s https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/update_pkg.xml | xpath -e '(//sparkle:shortVersionString/text())[1]' 2>/dev/null )
+    appNewVersion=$( curl -s https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/update_pkg.xml | xpath '(//sparkle:shortVersionString/text())[1]' 2>/dev/null )
     versionKey="CFBundleShortVersionString"
-    blockingProcesses=( $name )
     expectedTeamID="W5W395V82Y"
     ;;


### PR DESCRIPTION
2023-11-01 15:11:43 : REQ   : nordvpn : ################## Start Installomator v. 10.6beta, date 2023-11-01
2023-11-01 15:11:43 : INFO  : nordvpn : ################## Version: 10.6beta
2023-11-01 15:11:43 : INFO  : nordvpn : ################## Date: 2023-11-01
2023-11-01 15:11:43 : INFO  : nordvpn : ################## nordvpn
2023-11-01 15:11:43 : DEBUG : nordvpn : DEBUG mode 1 enabled.
2023-11-01 15:11:44 : DEBUG : nordvpn : name=NordVPN
2023-11-01 15:11:44 : DEBUG : nordvpn : appName=NordVPN.app
2023-11-01 15:11:44 : DEBUG : nordvpn : type=pkg
2023-11-01 15:11:44 : DEBUG : nordvpn : archiveName=
2023-11-01 15:11:44 : DEBUG : nordvpn : downloadURL=https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg
2023-11-01 15:11:44 : DEBUG : nordvpn : curlOptions=
2023-11-01 15:11:44 : DEBUG : nordvpn : appNewVersion=
2023-11-01 15:11:44 : DEBUG : nordvpn : appCustomVersion function: Not defined
2023-11-01 15:11:44 : DEBUG : nordvpn : versionKey=CFBundleShortVersionString
2023-11-01 15:11:44 : DEBUG : nordvpn : packageID=com.nordvpn.macos
2023-11-01 15:11:44 : DEBUG : nordvpn : pkgName=
2023-11-01 15:11:44 : DEBUG : nordvpn : choiceChangesXML=
2023-11-01 15:11:44 : DEBUG : nordvpn : expectedTeamID=W5W395V82Y
2023-11-01 15:11:44 : DEBUG : nordvpn : blockingProcesses=NordVPN
2023-11-01 15:11:44 : DEBUG : nordvpn : installerTool=
2023-11-01 15:11:44 : DEBUG : nordvpn : CLIInstaller=
2023-11-01 15:11:44 : DEBUG : nordvpn : CLIArguments=
2023-11-01 15:11:44 : DEBUG : nordvpn : updateTool=
2023-11-01 15:11:44 : DEBUG : nordvpn : updateToolArguments=
2023-11-01 15:11:44 : DEBUG : nordvpn : updateToolRunAsCurrentUser=
2023-11-01 15:11:44 : INFO  : nordvpn : BLOCKING_PROCESS_ACTION=tell_user
2023-11-01 15:11:44 : INFO  : nordvpn : NOTIFY=success
2023-11-01 15:11:44 : INFO  : nordvpn : LOGGING=DEBUG
2023-11-01 15:11:44 : INFO  : nordvpn : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-01 15:11:44 : INFO  : nordvpn : Label type: pkg
2023-11-01 15:11:44 : INFO  : nordvpn : archiveName: NordVPN.pkg
2023-11-01 15:11:44 : DEBUG : nordvpn : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-01 15:11:45 : INFO  : nordvpn : found packageID com.nordvpn.macos installed, version 8.8.3
2023-11-01 15:11:45 : INFO  : nordvpn : appversion: 8.8.3
2023-11-01 15:11:45 : INFO  : nordvpn : Latest version not specified.
2023-11-01 15:11:45 : REQ   : nordvpn : Downloading https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg to NordVPN.pkg
2023-11-01 15:11:45 : DEBUG : nordvpn : No Dialog connection, just download
2023-11-01 15:11:54 : DEBUG : nordvpn : File list: -rw-r--r--  1 someuser  staff   151M Nov  1 15:11 NordVPN.pkg
2023-11-01 15:11:54 : DEBUG : nordvpn : File type: NordVPN.pkg: xar archive compressed TOC: 4648, SHA-1 checksum
2023-11-01 15:11:54 : DEBUG : nordvpn : curl output was:
*   Trying 104.17.207.237:443...
* Connected to downloads.nordcdn.com (104.17.207.237) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3049 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.nordcdn.com
*  start date: Feb 28 13:33:42 2023 GMT
*  expire date: Mar 31 13:33:41 2024 GMT
*  subjectAltName: host "downloads.nordcdn.com" matched cert's "*.nordcdn.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=AlphaSSL CA - SHA256 - G4
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: downloads.nordcdn.com]
* h2 [:path: /apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x11800a800)
> GET /apps/macos/generic/NordVPN-OpenVPN/latest/NordVPN.pkg HTTP/2
> Host: downloads.nordcdn.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< date: Wed, 01 Nov 2023 12:11:45 GMT
< content-type: application/octet-stream
< content-length: 158571427
< last-modified: Thu, 26 Oct 2023 14:01:28 GMT
< etag: 653a71389739ba3
< x-authorization: key-id="rsa-key-1",algorithm="rsa-sha256" < x-digest: a4a1fff5752392c0e3e5474ce783fe261b83bf084f6d4650c2bdc512c2bf810f < x-accept-before: 1698780735
< x-signature: J+M1gh75po1qgyok4lG/DjXmPneGNgMAgCJzbzW2YGslc1bp6NoC9Nu0/5Agmo28ssst86EqSaJieUWGgbAlw967z/rTzZID7P684bpz8qJOc7fEmjAP15Nj54qeX8/b0u2oR1jcc1q24gPhwxeZsqLFNXJnwkLkAHSCXsmxq+aYahDSc+8m7jaBJPlmu96f+ZzJzQwp3EHfTfrK25wrII+17vbdif9sZfrxHUQqWrNYPb2ckdrgEYF1nJJVVkNetgIIdNlsMNBZWetvoEvSZlr68bKGr8JzkHPlepuqBm7gJBwO3AeSVy8XsaPDlEkPcBpIjhJbfRy+vrPunm8yQmhrVK+RMHsgD64hmnHsEtqp8TQtA1u3j9q3gMyZBNtYRdRyGnKoozRStCcptaUISIQc8S1KcNmMEWDQnukADgf9aO4T7m0oj2wEjRp3rHnQtTkC6CWVXwN1hYnaH4+5UncerrYZv6rfVjq3mbJZGAOwsxNymLXVzEjiBK92GR4I6j9KN6bOzZU0ZzzURN+ruiPq5VYNrop1B+bgNKW1YKqCatg+B9UamwEiUQm4hT9uBL21m3OXRkiZxfT3WzRd6eiutWQjIqBCJS/9/obGTGPSTP6aim2xjSdMqI30qztvCWeQCBO2qhJjiwcVhwV2VgsVK4SE2aCTKsMsNncRCoc= < x-frame-options: SAMEORIGIN
< cf-cache-status: HIT
< age: 1706
< expires: Wed, 01 Nov 2023 12:41:45 GMT
< cache-control: public, max-age=1800
< accept-ranges: bytes
< strict-transport-security: max-age=15552000; includeSubDomains; preload < server: cloudflare
< cf-ray: 81f40acc4d1d824a-IAD
<
{ [4098 bytes data]
* Connection #0 to host downloads.nordcdn.com left intact

2023-11-01 15:11:54 : DEBUG : nordvpn : DEBUG mode 1, not checking for blocking processes
2023-11-01 15:11:54 : REQ   : nordvpn : Installing NordVPN
2023-11-01 15:11:54 : INFO  : nordvpn : Verifying: NordVPN.pkg
2023-11-01 15:11:54 : DEBUG : nordvpn : File list: -rw-r--r--  1 someuser  staff   151M Nov  1 15:11 NordVPN.pkg
2023-11-01 15:11:54 : DEBUG : nordvpn : File type: NordVPN.pkg: xar archive compressed TOC: 4648, SHA-1 checksum
2023-11-01 15:11:55 : DEBUG : nordvpn : spctlOut is NordVPN.pkg: accepted
2023-11-01 15:11:55 : DEBUG : nordvpn : source=Notarized Developer ID
2023-11-01 15:11:55 : DEBUG : nordvpn : origin=Developer ID Installer: Nordvpn S.A. (W5W395V82Y)
2023-11-01 15:11:55 : INFO  : nordvpn : Team ID: W5W395V82Y (expected: W5W395V82Y )
2023-11-01 15:11:55 : INFO  : nordvpn : Checking package version.
2023-11-01 15:11:55 : INFO  : nordvpn : Downloaded package com.nordvpn.macos version 8.11.2
2023-11-01 15:11:55 : DEBUG : nordvpn : DEBUG enabled, skipping installation
2023-11-01 15:11:55 : INFO  : nordvpn : Finishing...
2023-11-01 15:11:58 : INFO  : nordvpn : found packageID com.nordvpn.macos installed, version 8.8.3
2023-11-01 15:11:58 : REQ   : nordvpn : Installed NordVPN, version 8.11.2
2023-11-01 15:11:58 : INFO  : nordvpn : notifying
2023-11-01 15:11:59 : DEBUG : nordvpn : DEBUG mode 1, not reopening anything
2023-11-01 15:11:59 : REQ   : nordvpn : All done!
2023-11-01 15:11:59 : REQ   : nordvpn : ################## End Installomator, exit code 0