### PR TITLE
new label: stats

### DIFF
--- a/fragments/labels/stats.sh
+++ b/fragments/labels/stats.sh
@@ -1,0 +1,7 @@
+stats)
+    name="Stats"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit exelban stats)"
+    appNewVersion="$(versionFromGit exelban stats)"
+    expectedTeamID="RP2S87B72W"
+    ;;


### PR DESCRIPTION
Created a label for the stats.app. It is like iStat Menu, but open source.

Output:

```
2023-11-02 01:06:23 : REQ   : stats : ################## Start Installomator v. 10.6beta, date 2023-11-02
2023-11-02 01:06:23 : INFO  : stats : ################## Version: 10.6beta
2023-11-02 01:06:23 : INFO  : stats : ################## Date: 2023-11-02
2023-11-02 01:06:23 : INFO  : stats : ################## stats
2023-11-02 01:06:23 : DEBUG : stats : DEBUG mode 1 enabled.
2023-11-02 01:06:24 : INFO  : stats : setting variable from argument DEBUG=0
2023-11-02 01:06:24 : DEBUG : stats : name=Stats
2023-11-02 01:06:24 : DEBUG : stats : appName=
2023-11-02 01:06:24 : DEBUG : stats : type=dmg
2023-11-02 01:06:24 : DEBUG : stats : archiveName=
2023-11-02 01:06:24 : DEBUG : stats : downloadURL=https://github.com/exelban/stats/releases/download/v2.9.10/Stats.dmg
2023-11-02 01:06:24 : DEBUG : stats : curlOptions=
2023-11-02 01:06:24 : DEBUG : stats : appNewVersion=2.9.10
2023-11-02 01:06:24 : DEBUG : stats : appCustomVersion function: Not defined
2023-11-02 01:06:24 : DEBUG : stats : versionKey=CFBundleShortVersionString
2023-11-02 01:06:24 : DEBUG : stats : packageID=
2023-11-02 01:06:24 : DEBUG : stats : pkgName=
2023-11-02 01:06:24 : DEBUG : stats : choiceChangesXML=
2023-11-02 01:06:24 : DEBUG : stats : expectedTeamID=RP2S87B72W
2023-11-02 01:06:24 : DEBUG : stats : blockingProcesses=
2023-11-02 01:06:24 : DEBUG : stats : installerTool=
2023-11-02 01:06:24 : DEBUG : stats : CLIInstaller=
2023-11-02 01:06:24 : DEBUG : stats : CLIArguments=
2023-11-02 01:06:24 : DEBUG : stats : updateTool=
2023-11-02 01:06:24 : DEBUG : stats : updateToolArguments=
2023-11-02 01:06:24 : DEBUG : stats : updateToolRunAsCurrentUser=
2023-11-02 01:06:24 : INFO  : stats : BLOCKING_PROCESS_ACTION=tell_user
2023-11-02 01:06:24 : INFO  : stats : NOTIFY=success
2023-11-02 01:06:24 : INFO  : stats : LOGGING=DEBUG
2023-11-02 01:06:24 : INFO  : stats : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-02 01:06:24 : INFO  : stats : Label type: dmg
2023-11-02 01:06:24 : INFO  : stats : archiveName: Stats.dmg
2023-11-02 01:06:24 : INFO  : stats : no blocking processes defined, using Stats as default
2023-11-02 01:06:24 : DEBUG : stats : Changing directory to /var/folders/t3/_n8xzdnd7jl3grrxtgbxhw400000gq/T/tmp.I6VVvUCsb2
2023-11-02 01:06:24 : INFO  : stats : name: Stats, appName: Stats.app
2023-11-02 01:06:24.571 mdfind[65161:1843455] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-11-02 01:06:24.571 mdfind[65161:1843455] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-02 01:06:24.649 mdfind[65161:1843455] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-02 01:06:24 : INFO  : stats : App(s) found: /Users/dominik/Documents/Composer/Stats-2.9.9/ROOT/Applications/Stats.app
2023-11-02 01:06:24 : WARN  : stats : could not determine location of Stats.app
2023-11-02 01:06:24 : INFO  : stats : appversion:
2023-11-02 01:06:24 : INFO  : stats : Latest version of Stats is 2.9.10
2023-11-02 01:06:24 : REQ   : stats : Downloading https://github.com/exelban/stats/releases/download/v2.9.10/Stats.dmg to Stats.dmg
2023-11-02 01:06:24 : DEBUG : stats : No Dialog connection, just download
2023-11-02 01:06:25 : DEBUG : stats : File list: -rw-r--r--  1 dominik  staff   4.8M Nov  2 01:06 Stats.dmg
2023-11-02 01:06:25 : DEBUG : stats : File type: Stats.dmg: zlib compressed data
2023-11-02 01:06:25 : DEBUG : stats : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /exelban/stats/releases/download/v2.9.10/Stats.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14b812400)
> GET /exelban/stats/releases/download/v2.9.10/Stats.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Thu, 02 Nov 2023 00:06:24 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/189285554/9acc154d-8df3-4420-af8c-78eed6db2078?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231102T000624Z&X-Amz-Expires=300&X-Amz-Signature=75c465f936ed3626dd5b6b6fc99be823081e1c767d8a62afe48ecce7b240f1b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=189285554&response-content-disposition=attachment%3B%20filename%3DStats.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: F399:7B1A:1B7E211:1BE9546:6542E800
<
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/189285554/9acc154d-8df3-4420-af8c-78eed6db2078?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231102T000624Z&X-Amz-Expires=300&X-Amz-Signature=75c465f936ed3626dd5b6b6fc99be823081e1c767d8a62afe48ecce7b240f1b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=189285554&response-content-disposition=attachment%3B%20filename%3DStats.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/189285554/9acc154d-8df3-4420-af8c-78eed6db2078?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231102T000624Z&X-Amz-Expires=300&X-Amz-Signature=75c465f936ed3626dd5b6b6fc99be823081e1c767d8a62afe48ecce7b240f1b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=189285554&response-content-disposition=attachment%3B%20filename%3DStats.dmg&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x14b812400)
> GET /github-production-release-asset-2e65be/189285554/9acc154d-8df3-4420-af8c-78eed6db2078?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231102T000624Z&X-Amz-Expires=300&X-Amz-Signature=75c465f936ed3626dd5b6b6fc99be823081e1c767d8a62afe48ecce7b240f1b6&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=189285554&response-content-disposition=attachment%3B%20filename%3DStats.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: BVWv7U0kl6RpWZ1l/2BIoA==
< last-modified: Sun, 22 Oct 2023 11:42:30 GMT
< etag: "0x8DBD2F3F98D6FC2"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 7b784495-e01e-001d-49dc-04ece9000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Sun, 22 Oct 2023 11:42:30 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Stats.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< date: Thu, 02 Nov 2023 00:06:25 GMT
< age: 2611
< x-served-by: cache-iad-kcgs7200167-IAD, cache-fra-eddf8230075-FRA
< x-cache: HIT, HIT
< x-cache-hits: 1, 1
< x-timer: S1698883585.081884,VS0,VE350
< content-length: 5072830
<
{ [26021 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-11-02 01:06:25 : REQ   : stats : no more blocking processes, continue with update
2023-11-02 01:06:25 : REQ   : stats : Installing Stats
2023-11-02 01:06:25 : INFO  : stats : Mounting /var/folders/t3/_n8xzdnd7jl3grrxtgbxhw400000gq/T/tmp.I6VVvUCsb2/Stats.dmg
2023-11-02 01:06:26 : DEBUG : stats : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $6CF8C8EF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $D24CAA53
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $14006F8E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $6894DA3A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $14006F8E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $0E4959F1
verified CRC32 $7740297D
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Stats

2023-11-02 01:06:26 : INFO  : stats : Mounted: /Volumes/Stats
2023-11-02 01:06:26 : INFO  : stats : Verifying: /Volumes/Stats/Stats.app
2023-11-02 01:06:26 : DEBUG : stats : App size:  11M	/Volumes/Stats/Stats.app
2023-11-02 01:06:26 : DEBUG : stats : Debugging enabled, App Verification output was:
/Volumes/Stats/Stats.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Serhiy Mytrovtsiy (RP2S87B72W)

2023-11-02 01:06:26 : INFO  : stats : Team ID matching: RP2S87B72W (expected: RP2S87B72W )
2023-11-02 01:06:26 : INFO  : stats : Installing Stats version 2.9.10 on versionKey CFBundleShortVersionString.
2023-11-02 01:06:26 : INFO  : stats : App has LSMinimumSystemVersion: 10.15
2023-11-02 01:06:26 : INFO  : stats : Copy /Volumes/Stats/Stats.app to /Applications
2023-11-02 01:06:26 : DEBUG : stats : Debugging enabled, App copy output was:
Copying /Volumes/Stats/Stats.app

2023-11-02 01:06:26 : WARN  : stats : Changing owner to dominik
2023-11-02 01:06:26 : INFO  : stats : Finishing...
2023-11-02 01:06:29 : INFO  : stats : App(s) found: /Applications/Stats.app
2023-11-02 01:06:29 : INFO  : stats : found app at /Applications/Stats.app, version 2.9.10, on versionKey CFBundleShortVersionString
2023-11-02 01:06:29 : REQ   : stats : Installed Stats, version 2.9.10
2023-11-02 01:06:29 : INFO  : stats : notifying
2023-11-02 01:06:29 : DEBUG : stats : Unmounting /Volumes/Stats
2023-11-02 01:06:30 : DEBUG : stats : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-11-02 01:06:30 : DEBUG : stats : Deleting /var/folders/t3/_n8xzdnd7jl3grrxtgbxhw400000gq/T/tmp.I6VVvUCsb2
2023-11-02 01:06:30 : DEBUG : stats : Debugging enabled, Deleting tmpDir output was:
/var/folders/t3/_n8xzdnd7jl3grrxtgbxhw400000gq/T/tmp.I6VVvUCsb2/Stats.dmg
2023-11-02 01:06:30 : DEBUG : stats : /var/folders/t3/_n8xzdnd7jl3grrxtgbxhw400000gq/T/tmp.I6VVvUCsb2
2023-11-02 01:06:30 : INFO  : stats : Installomator did not close any apps, so no need to reopen any apps.
2023-11-02 01:06:30 : REQ   : stats : All done!
2023-11-02 01:06:30 : REQ   : stats : ################## End Installomator, exit code 0
```