### PR TITLE
Add Groove OmniDialer label

### DIFF
--- a/fragments/labels/grooveomnidialer.sh
+++ b/fragments/labels/grooveomnidialer.sh
@@ -1,0 +1,7 @@
+groove-omnidialer-enterprise-edition)
+	name="Groove Omnidialer Enterprise Edition"
+	type="zip"
+	appNewVersion=$( curl -fs 'https://groove-dialer.s3.us-west-2.amazonaws.com/electron/enterprise/latest-mac.yml' | grep ^version: | cut -c 10-21 ) 
+	downloadURL="https://groove-dialer.s3.us-west-2.amazonaws.com/electron/enterprise/Groove+OmniDialer+Enterprise+Edition-"$appNewVersion"-universal-mac.zip" 
+	expectedTeamID="ZDYDJ5XPF3"
+;;

--- a/fragments/labels/grooveomnidialerenterpriseedition.sh
+++ b/fragments/labels/grooveomnidialerenterpriseedition.sh
@@ -1,4 +1,4 @@
-groove-omnidialer-enterprise-edition)
+grooveomnidialerenterpriseedition)
 	name="Groove Omnidialer Enterprise Edition"
 	type="zip"
 	appNewVersion=$( curl -fs 'https://groove-dialer.s3.us-west-2.amazonaws.com/electron/enterprise/latest-mac.yml' | grep ^version: | cut -c 10-21 ) 


### PR DESCRIPTION
clintonragsdale@clintonragsdale's-Mac utils % ./assemble.sh -l /Users/clintonragsdale/Desktop/Labels groove-omnidialer-enterprise-edition
2023-11-07 14:21:36 : REQ   : groove-omnidialer-enterprise-edition : ################## Start Installomator v. 10.6beta, date 2023-11-07
2023-11-07 14:21:36 : INFO  : groove-omnidialer-enterprise-edition : ################## Version: 10.6beta
2023-11-07 14:21:36 : INFO  : groove-omnidialer-enterprise-edition : ################## Date: 2023-11-07
2023-11-07 14:21:36 : INFO  : groove-omnidialer-enterprise-edition : ################## groove-omnidialer-enterprise-edition
2023-11-07 14:21:36 : DEBUG : groove-omnidialer-enterprise-edition : DEBUG mode 1 enabled.
2023-11-07 14:21:36 : DEBUG : groove-omnidialer-enterprise-edition : name=Groove Omnidialer Enterprise Edition
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : appName=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : type=zip
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : archiveName=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : downloadURL=https://groove-dialer.s3.us-west-2.amazonaws.com/electron/enterprise/Groove+OmniDialer+Enterprise+Edition-23.10.2892-universal-mac.zip
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : curlOptions=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : appNewVersion=23.10.2892
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : appCustomVersion function: Not defined
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : versionKey=CFBundleShortVersionString
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : packageID=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : pkgName=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : choiceChangesXML=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : expectedTeamID=ZDYDJ5XPF3
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : blockingProcesses=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : installerTool=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : CLIInstaller=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : CLIArguments=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : updateTool=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : updateToolArguments=
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : updateToolRunAsCurrentUser=
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : BLOCKING_PROCESS_ACTION=tell_user
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : NOTIFY=success
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : LOGGING=DEBUG
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : Label type: zip
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : archiveName: Groove Omnidialer Enterprise Edition.zip
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : no blocking processes defined, using Groove Omnidialer Enterprise Edition as default
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : Changing directory to /Users/clintonragsdale/Documents/GitHub/Installomator/build
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : App(s) found: /Applications/Groove Omnidialer Enterprise Edition.app
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : found app at /Applications/Groove Omnidialer Enterprise Edition.app, version 23.10.2892, on versionKey CFBundleShortVersionString
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : appversion: 23.10.2892
2023-11-07 14:21:37 : INFO  : groove-omnidialer-enterprise-edition : Latest version of Groove Omnidialer Enterprise Edition is 23.10.2892
2023-11-07 14:21:37 : WARN  : groove-omnidialer-enterprise-edition : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-11-07 14:21:37 : REQ   : groove-omnidialer-enterprise-edition : Downloading https://groove-dialer.s3.us-west-2.amazonaws.com/electron/enterprise/Groove+OmniDialer+Enterprise+Edition-23.10.2892-universal-mac.zip to Groove Omnidialer Enterprise Edition.zip
2023-11-07 14:21:37 : DEBUG : groove-omnidialer-enterprise-edition : No Dialog connection, just download
2023-11-07 14:21:52 : DEBUG : groove-omnidialer-enterprise-edition : File list: -rw-r--r--  1 clintonragsdale  staff   170M Nov  7 14:21 Groove Omnidialer Enterprise Edition.zip
2023-11-07 14:21:52 : DEBUG : groove-omnidialer-enterprise-edition : File type: Groove Omnidialer Enterprise Edition.zip: Zip archive data, at least v2.0 to extract, compression method=store
2023-11-07 14:21:52 : DEBUG : groove-omnidialer-enterprise-edition : curl output was:
*   Trying 52.92.225.234:443...
* Connected to groove-dialer.s3.us-west-2.amazonaws.com (52.92.225.234) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [345 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [106 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5503 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3-us-west-2.amazonaws.com
*  start date: Oct 10 00:00:00 2023 GMT
*  expire date: Aug  3 23:59:59 2024 GMT
*  subjectAltName: host "groove-dialer.s3.us-west-2.amazonaws.com" matched cert's "*.s3.us-west-2.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /electron/enterprise/Groove+OmniDialer+Enterprise+Edition-23.10.2892-universal-mac.zip HTTP/1.1
> Host: groove-dialer.s3.us-west-2.amazonaws.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< x-amz-id-2: s2vujP0DHpgsOo0asmo9gaLbHmRyUUbQ6uiM0K1a6rRIPqo4PJOu3x7h+lNQEuu3c8WrtJ0G/RA= < x-amz-request-id: 6VTH2GVDPB3QX6KD
< Date: Tue, 07 Nov 2023 19:21:38 GMT
< Last-Modified: Thu, 19 Oct 2023 20:33:58 GMT
< ETag: "da86beac2e4d3380c84b3066429ec3b1-34"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: 1rE1jHDm9v5Ua5IHiiyWXb4EH5muDgaj < Accept-Ranges: bytes
< Content-Type: application/zip
< Server: AmazonS3
< Content-Length: 178139609
<
{ [16384 bytes data]
* Connection #0 to host groove-dialer.s3.us-west-2.amazonaws.com left intact

2023-11-07 14:21:52 : DEBUG : groove-omnidialer-enterprise-edition : DEBUG mode 1, not checking for blocking processes
2023-11-07 14:21:52 : REQ   : groove-omnidialer-enterprise-edition : Installing Groove Omnidialer Enterprise Edition
2023-11-07 14:21:52 : INFO  : groove-omnidialer-enterprise-edition : Unzipping Groove Omnidialer Enterprise Edition.zip
2023-11-07 14:21:52 : INFO  : groove-omnidialer-enterprise-edition : Verifying: /Users/clintonragsdale/Documents/GitHub/Installomator/build/Groove Omnidialer Enterprise Edition.app
2023-11-07 14:21:52 : DEBUG : groove-omnidialer-enterprise-edition : App size: 482M	/Users/clintonragsdale/Documents/GitHub/Installomator/build/Groove Omnidialer Enterprise Edition.app
2023-11-07 14:21:53 : DEBUG : groove-omnidialer-enterprise-edition : Debugging enabled, App Verification output was:
/Users/clintonragsdale/Documents/GitHub/Installomator/build/Groove Omnidialer Enterprise Edition.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Groove Labs Inc (ZDYDJ5XPF3)

2023-11-07 14:21:53 : INFO  : groove-omnidialer-enterprise-edition : Team ID matching: ZDYDJ5XPF3 (expected: ZDYDJ5XPF3 )
2023-11-07 14:21:53 : INFO  : groove-omnidialer-enterprise-edition : Downloaded version of Groove Omnidialer Enterprise Edition is 23.10.2892 on versionKey CFBundleShortVersionString, same as installed.
2023-11-07 14:21:53 : DEBUG : groove-omnidialer-enterprise-edition : DEBUG mode 1, not reopening anything
2023-11-07 14:21:53 : REG   : groove-omnidialer-enterprise-edition : No new version to install
2023-11-07 14:21:53 : REQ   : groove-omnidialer-enterprise-edition : ################## End Installomator, exit code 0