### PR TITLE
Adding new label: Baseline

### DIFF
--- a/fragments/labels/baseline-noagent.sh
+++ b/fragments/labels/baseline-noagent.sh
@@ -1,9 +1,9 @@
-baseline)
+baseline-noagent)
     #Baseline by @BigMacAdmin and Second Son Consulting
-    #Use this label if you want Baseline to run immediately upon install
+    #Use this label if you DO NOT want Baseline to run immediately upon install
     name="Baseline"
     type="pkg"
-    archiveName="Baseline_v[0-9.]*.pkg"
+    archiveName="Baseline_NoAgent_v[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit secondsonconsulting Baseline )
     expectedTeamID="7Q6XP5698G"
     ;;

--- a/fragments/labels/baseline-nodaemon.sh
+++ b/fragments/labels/baseline-nodaemon.sh
@@ -1,9 +1,9 @@
-baseline-noagent)
+baseline-nodaemon)
     #Baseline by @BigMacAdmin and Second Son Consulting
     #Use this label if you DO NOT want Baseline to run immediately upon install
     name="Baseline"
     type="pkg"
-    archiveName="Baseline_NoAgent_v[0-9.]*.pkg"
+    archiveName="Baseline_NoDaemon_v[0-9.]*.pkg"
     downloadURL=$(downloadURLFromGit secondsonconsulting Baseline )
     expectedTeamID="7Q6XP5698G"
     ;;

--- a/fragments/labels/baseline.sh
+++ b/fragments/labels/baseline.sh
@@ -1,0 +1,8 @@
+baseline)
+    #Baseline by @BigMacAdmin and Second Son Consulting
+    name="Baseline"
+    type="pkg"
+    archiveName="Baseline_v[0-9.]*.pkg"
+    downloadURL=$(downloadURLFromGit secondsonconsulting Baseline )
+    expectedTeamID="7Q6XP5698G"
+    ;;


### PR DESCRIPTION
I'm adding a label for Baseline - https://github.com/secondsonconsulting/Baseline

AppNewVersion and AppVersion are intentionally left out, as Baseline is meant to be a "run once" utility, and by default it deletes itself after it runs.
```
./assemble.sh baseline
2023-11-08 22:21:30 : REQ   : baseline : ################## Start Installomator v. 10.6beta, date 2023-11-08
2023-11-08 22:21:30 : INFO  : baseline : ################## Version: 10.6beta
2023-11-08 22:21:30 : INFO  : baseline : ################## Date: 2023-11-08
2023-11-08 22:21:30 : INFO  : baseline : ################## baseline
2023-11-08 22:21:30 : DEBUG : baseline : DEBUG mode 1 enabled.
2023-11-08 22:21:30 : DEBUG : baseline : name=Baseline
2023-11-08 22:21:30 : DEBUG : baseline : appName=
2023-11-08 22:21:30 : DEBUG : baseline : type=pkg
2023-11-08 22:21:30 : DEBUG : baseline : archiveName=Baseline_v[0-9.]*.pkg
2023-11-08 22:21:30 : DEBUG : baseline : downloadURL=https://github.com/SecondSonConsulting/Baseline/releases/download/v1.2.1/Baseline_v1.2.1.pkg
2023-11-08 22:21:30 : DEBUG : baseline : curlOptions=
2023-11-08 22:21:30 : DEBUG : baseline : appNewVersion=
2023-11-08 22:21:30 : DEBUG : baseline : appCustomVersion function: Not defined
2023-11-08 22:21:30 : DEBUG : baseline : versionKey=CFBundleShortVersionString
2023-11-08 22:21:30 : DEBUG : baseline : packageID=
2023-11-08 22:21:30 : DEBUG : baseline : pkgName=
2023-11-08 22:21:30 : DEBUG : baseline : choiceChangesXML=
2023-11-08 22:21:30 : DEBUG : baseline : expectedTeamID=7Q6XP5698G
2023-11-08 22:21:30 : DEBUG : baseline : blockingProcesses=
2023-11-08 22:21:30 : DEBUG : baseline : installerTool=
2023-11-08 22:21:30 : DEBUG : baseline : CLIInstaller=
2023-11-08 22:21:30 : DEBUG : baseline : CLIArguments=
2023-11-08 22:21:30 : DEBUG : baseline : updateTool=
2023-11-08 22:21:30 : DEBUG : baseline : updateToolArguments=
2023-11-08 22:21:30 : DEBUG : baseline : updateToolRunAsCurrentUser=
2023-11-08 22:21:30 : INFO  : baseline : BLOCKING_PROCESS_ACTION=tell_user
2023-11-08 22:21:30 : INFO  : baseline : NOTIFY=success
2023-11-08 22:21:30 : INFO  : baseline : LOGGING=DEBUG
2023-11-08 22:21:30 : INFO  : baseline : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-08 22:21:30 : INFO  : baseline : Label type: pkg
2023-11-08 22:21:30 : INFO  : baseline : archiveName: Baseline_v[0-9.]*.pkg
2023-11-08 22:21:30 : INFO  : baseline : no blocking processes defined, using Baseline as default
2023-11-08 22:21:30 : DEBUG : baseline : Changing directory to /Users/bigmacadmin/Documents/GitHub/installomator/build
2023-11-08 22:21:30 : INFO  : baseline : name: Baseline, appName: Baseline.app
2023-11-08 22:21:30.867 mdfind[6843:264780] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-11-08 22:21:30.867 mdfind[6843:264780] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-08 22:21:30.935 mdfind[6843:264780] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-08 22:21:30 : WARN  : baseline : No previous app found
2023-11-08 22:21:30 : WARN  : baseline : could not find Baseline.app
2023-11-08 22:21:30 : INFO  : baseline : appversion:
2023-11-08 22:21:30 : INFO  : baseline : Latest version not specified.
2023-11-08 22:21:30 : REQ   : baseline : Downloading https://github.com/SecondSonConsulting/Baseline/releases/download/v1.2.1/Baseline_v1.2.1.pkg to Baseline_v[0-9.]*.pkg
2023-11-08 22:21:30 : DEBUG : baseline : No Dialog connection, just download
2023-11-08 22:21:31 : DEBUG : baseline : File list: -rw-r--r--  1 root  staff    41K Nov  8 22:21 Baseline_v[0-9.]*.pkg
2023-11-08 22:21:31 : DEBUG : baseline : File type: Baseline_v[0-9.]*.pkg: xar archive compressed TOC: 4924, SHA-1 checksum
2023-11-08 22:21:31 : DEBUG : baseline : curl output was:
*   Trying 192.30.255.112:443...
* Connected to github.com (192.30.255.112) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /SecondSonConsulting/Baseline/releases/download/v1.2.1/Baseline_v1.2.1.pkg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x149814200)
> GET /SecondSonConsulting/Baseline/releases/download/v1.2.1/Baseline_v1.2.1.pkg HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Thu, 09 Nov 2023 06:21:31 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/585402821/8280a6cd-3c9d-4558-b7c9-bc5f052c2a05?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T062131Z&X-Amz-Expires=300&X-Amz-Signature=c5c0557d45df87dbd4d038e7c7fe7cc03c96a3e34337ebce60801b7dbf84a99c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=585402821&response-content-disposition=attachment%3B%20filename%3DBaseline_v1.2.1.pkg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ staffwus201resultssa0.blob.core.windows.net/ staffwus201resultssa1.blob.core.windows.net/ prodweu01resultssa0.blob.core.windows.net/ prodweu01resultssa1.blob.core.windows.net/ prodweu01resultssa2.blob.core.windows.net/ prodweu01resultssa3.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: C169:2FBC:58CBCE0:5D8D3FF:654C7A6B <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/585402821/8280a6cd-3c9d-4558-b7c9-bc5f052c2a05?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T062131Z&X-Amz-Expires=300&X-Amz-Signature=c5c0557d45df87dbd4d038e7c7fe7cc03c96a3e34337ebce60801b7dbf84a99c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=585402821&response-content-disposition=attachment%3B%20filename%3DBaseline_v1.2.1.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/585402821/8280a6cd-3c9d-4558-b7c9-bc5f052c2a05?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T062131Z&X-Amz-Expires=300&X-Amz-Signature=c5c0557d45df87dbd4d038e7c7fe7cc03c96a3e34337ebce60801b7dbf84a99c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=585402821&response-content-disposition=attachment%3B%20filename%3DBaseline_v1.2.1.pkg&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x149814200)
> GET /github-production-release-asset-2e65be/585402821/8280a6cd-3c9d-4558-b7c9-bc5f052c2a05?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T062131Z&X-Amz-Expires=300&X-Amz-Signature=c5c0557d45df87dbd4d038e7c7fe7cc03c96a3e34337ebce60801b7dbf84a99c&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=585402821&response-content-disposition=attachment%3B%20filename%3DBaseline_v1.2.1.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: UO4LJ4eei9QuZXTmM88PAg==
< last-modified: Tue, 29 Aug 2023 16:04:38 GMT
< etag: "0x8DBA8A9A56B0CB1"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 33d0de37-901e-0007-4143-0d8d36000000 < x-ms-version: 2020-04-08
< x-ms-creation-time: Tue, 29 Aug 2023 16:04:38 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Baseline_v1.2.1.pkg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< date: Thu, 09 Nov 2023 06:21:31 GMT
< age: 3899
< x-served-by: cache-iad-kcgs7200127-IAD, cache-lax-kwhp1940084-LAX < x-cache: MISS, HIT
< x-cache-hits: 0, 1
< x-timer: S1699510891.364070,VS0,VE67
< content-length: 41797
<
{ [5503 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-11-08 22:21:31 : DEBUG : baseline : DEBUG mode 1, not checking for blocking processes
2023-11-08 22:21:31 : REQ   : baseline : Installing Baseline
2023-11-08 22:21:31 : INFO  : baseline : Verifying: Baseline_v[0-9.]*.pkg
2023-11-08 22:21:31 : DEBUG : baseline : File list: -rw-r--r--  1 root  staff    41K Nov  8 22:21 Baseline_v[0-9.]*.pkg
2023-11-08 22:21:31 : DEBUG : baseline : File type: Baseline_v[0-9.]*.pkg: xar archive compressed TOC: 4924, SHA-1 checksum
2023-11-08 22:21:31 : DEBUG : baseline : spctlOut is Baseline_v[0-9.]*.pkg: accepted
2023-11-08 22:21:31 : DEBUG : baseline : source=Notarized Developer ID
2023-11-08 22:21:31 : DEBUG : baseline : origin=Developer ID Installer: Second Son Consulting Inc. (7Q6XP5698G)
2023-11-08 22:21:31 : INFO  : baseline : Team ID: 7Q6XP5698G (expected: 7Q6XP5698G )
2023-11-08 22:21:31 : DEBUG : baseline : DEBUG enabled, skipping installation
2023-11-08 22:21:31 : INFO  : baseline : Finishing...
2023-11-08 22:21:34 : INFO  : baseline : name: Baseline, appName: Baseline.app
2023-11-08 22:21:34.966 mdfind[6943:265061] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-11-08 22:21:34.966 mdfind[6943:265061] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-08 22:21:35.019 mdfind[6943:265061] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-08 22:21:35 : WARN  : baseline : No previous app found
2023-11-08 22:21:35 : WARN  : baseline : could not find Baseline.app
2023-11-08 22:21:35 : REQ   : baseline : Installed Baseline
2023-11-08 22:21:35 : INFO  : baseline : notifying
2023-11-08 22:21:35 : DEBUG : baseline : DEBUG mode 1, not reopening anything
2023-11-08 22:21:35 : REQ   : baseline : All done!
2023-11-08 22:21:35 : REQ   : baseline : ################## End Installomator, exit code 0
```