### PR TITLE
Fixing Label: arcbrowser

### DIFF
--- a/fragments/labels/arcbrowser.sh
+++ b/fragments/labels/arcbrowser.sh
@@ -1,7 +1,8 @@
-arcbrowser)
+arcbrowser\
+|arc)
 name="Arc"
 type="dmg"
 downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
-appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*/\1/')"
+appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | tail -n 1 |sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]).*/\1/')"
 expectedTeamID="S6N382Y83G"
     ;;


### PR DESCRIPTION
Adding "arc" as an optional label name. This is the name of the app and doesn't appear to have any overlap with anything else. 

Also fixed the `AppNewVersion` variable, as the previous one was not functional. Previous label included a build number, causing Installomator to always reinstall the app. Also, `tail -n 1` is needed to omit a superfluous line.

```
./assemble.sh arc
2023-11-08 22:49:27 : REQ   : arc : ################## Start Installomator v. 10.6beta, date 2023-11-08
2023-11-08 22:49:27 : INFO  : arc : ################## Version: 10.6beta
2023-11-08 22:49:27 : INFO  : arc : ################## Date: 2023-11-08
2023-11-08 22:49:27 : INFO  : arc : ################## arc
2023-11-08 22:49:27 : DEBUG : arc : DEBUG mode 1 enabled.
2023-11-08 22:49:28 : DEBUG : arc : name=Arc
2023-11-08 22:49:28 : DEBUG : arc : appName=
2023-11-08 22:49:28 : DEBUG : arc : type=dmg
2023-11-08 22:49:28 : DEBUG : arc : archiveName=
2023-11-08 22:49:28 : DEBUG : arc : downloadURL=https://releases.arc.net/release/Arc-latest.dmg
2023-11-08 22:49:28 : DEBUG : arc : curlOptions=
2023-11-08 22:49:28 : DEBUG : arc : appNewVersion=1.15.1
2023-11-08 22:49:28 : DEBUG : arc : appCustomVersion function: Not defined
2023-11-08 22:49:28 : DEBUG : arc : versionKey=CFBundleShortVersionString
2023-11-08 22:49:28 : DEBUG : arc : packageID=
2023-11-08 22:49:28 : DEBUG : arc : pkgName=
2023-11-08 22:49:28 : DEBUG : arc : choiceChangesXML=
2023-11-08 22:49:28 : DEBUG : arc : expectedTeamID=S6N382Y83G
2023-11-08 22:49:28 : DEBUG : arc : blockingProcesses=
2023-11-08 22:49:28 : DEBUG : arc : installerTool=
2023-11-08 22:49:28 : DEBUG : arc : CLIInstaller=
2023-11-08 22:49:28 : DEBUG : arc : CLIArguments=
2023-11-08 22:49:28 : DEBUG : arc : updateTool=
2023-11-08 22:49:28 : DEBUG : arc : updateToolArguments=
2023-11-08 22:49:28 : DEBUG : arc : updateToolRunAsCurrentUser=
2023-11-08 22:49:28 : INFO  : arc : BLOCKING_PROCESS_ACTION=tell_user
2023-11-08 22:49:28 : INFO  : arc : NOTIFY=success
2023-11-08 22:49:28 : INFO  : arc : LOGGING=DEBUG
2023-11-08 22:49:28 : INFO  : arc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-08 22:49:28 : INFO  : arc : Label type: dmg
2023-11-08 22:49:28 : INFO  : arc : archiveName: Arc.dmg
2023-11-08 22:49:28 : INFO  : arc : no blocking processes defined, using Arc as default
2023-11-08 22:49:28 : DEBUG : arc : Changing directory to /Users/bigmacadmin/Documents/GitHub/installomator/build
2023-11-08 22:49:28 : INFO  : arc : App(s) found: /Applications/Arc.app
2023-11-08 22:49:28 : INFO  : arc : found app at /Applications/Arc.app, version 1.15.1, on versionKey CFBundleShortVersionString
2023-11-08 22:49:28 : INFO  : arc : appversion: 1.15.1
2023-11-08 22:49:28 : INFO  : arc : Latest version of Arc is 1.15.1
2023-11-08 22:49:28 : WARN  : arc : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-11-08 22:49:28 : REQ   : arc : Downloading https://releases.arc.net/release/Arc-latest.dmg to Arc.dmg
2023-11-08 22:49:28 : DEBUG : arc : No Dialog connection, just download
2023-11-08 22:49:35 : DEBUG : arc : File list: -rw-r--r--  1 root  staff   352M Nov  8 22:49 Arc.dmg
2023-11-08 22:49:35 : DEBUG : arc : File type: Arc.dmg: zlib compressed data
2023-11-08 22:49:35 : DEBUG : arc : curl output was:
*   Trying 104.18.31.160:443...
* Connected to releases.arc.net (104.18.31.160) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2286 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=arc.net
*  start date: Oct 20 00:00:00 2023 GMT
*  expire date: Oct 19 23:59:59 2024 GMT
*  subjectAltName: host "releases.arc.net" matched cert's "*.arc.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: releases.arc.net]
* h2 [:path: /release/Arc-latest.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12a814200)
> GET /release/Arc-latest.dmg HTTP/2
> Host: releases.arc.net
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 301
< date: Thu, 09 Nov 2023 06:49:28 GMT
< location: https://arc.net/release/Arc-latest.dmg
< cache-control: max-age=3600
< expires: Thu, 09 Nov 2023 07:49:28 GMT
< server: cloudflare
< cf-ray: 82341db3b8d22ea8-LAX
<
{ [0 bytes data]
* Connection #0 to host releases.arc.net left intact
* Issue another request to this URL: 'https://arc.net/release/Arc-latest.dmg'
*   Trying 104.18.31.160:443...
* Connected to arc.net (104.18.31.160) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [312 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2286 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=arc.net
*  start date: Oct 20 00:00:00 2023 GMT
*  expire date: Oct 19 23:59:59 2024 GMT
*  subjectAltName: host "arc.net" matched cert's "arc.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: arc.net]
* h2 [:path: /release/Arc-latest.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12a814200)
> GET /release/Arc-latest.dmg HTTP/2
> Host: arc.net
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< date: Thu, 09 Nov 2023 06:49:29 GMT
< content-length: 53
< location: https://releases.arc.net/release/Arc-1.15.1-43023.dmg
< cache-control: public, max-age=14400
< strict-transport-security: max-age=63072000
< x-matched-path: /api/release/download
< x-vercel-cache: MISS
< x-vercel-id: sfo1::iad1::7f54x-1699512569024-9d1d26f8f224
< cf-cache-status: MISS
< expires: Thu, 09 Nov 2023 10:49:29 GMT
< server: cloudflare
< cf-ray: 82341db42931dbe9-LAX
<
* Ignoring the response-body
{ [53 bytes data]
* Connection #1 to host arc.net left intact
* Issue another request to this URL: 'https://releases.arc.net/release/Arc-1.15.1-43023.dmg'
* Found bundle for host: 0x6000010cc7e0 [can multiplex]
* Re-using existing connection #0 with host releases.arc.net
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: releases.arc.net]
* h2 [:path: /release/Arc-1.15.1-43023.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 3 (easy handle 0x12a814200)
> GET /release/Arc-1.15.1-43023.dmg HTTP/2
> Host: releases.arc.net
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< date: Thu, 09 Nov 2023 06:49:29 GMT
< content-type: application/x-apple-diskimage
< content-length: 369335954
< x-amz-id-2: dn7cq1XVU17wl5NvZPijo6Pam4Z+qaDUiianl/LCPmOrpna0zsc42lU8QKi8Jip+qpqsD3ZtAdA=
< x-amz-request-id: 17N4P9CDBK9H0XGS
< last-modified: Thu, 02 Nov 2023 22:34:08 GMT
< x-amz-version-id: R31kVDtXHwmQFeApHNANiDftgRohQy5V
< etag: "f1322f139ce0d2624e454ef663d6b283"
< cf-cache-status: HIT
< age: 743
< expires: Thu, 09 Nov 2023 10:49:29 GMT
< cache-control: public, max-age=14400
< accept-ranges: bytes
< server: cloudflare
< cf-ray: 82341db5cad72ea8-LAX
<
{ [19139 bytes data]
* Connection #0 to host releases.arc.net left intact

2023-11-08 22:49:35 : DEBUG : arc : DEBUG mode 1, not checking for blocking processes
2023-11-08 22:49:35 : REQ   : arc : Installing Arc
2023-11-08 22:49:35 : INFO  : arc : Mounting /Users/bigmacadmin/Documents/GitHub/installomator/build/Arc.dmg
2023-11-08 22:49:40 : DEBUG : arc : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $AA1364C0
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $01EC0113
Checksumming disk image (Apple_HFSX : 2)…
disk image (Apple_HFSX : 2): verified   CRC32 $E0BEB311
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $700280B8
/dev/disk9          	Apple_partition_scheme
/dev/disk9s1        	Apple_partition_map
/dev/disk9s2        	Apple_HFSX                     	/Volumes/Arc 1

2023-11-08 22:49:40 : INFO  : arc : Mounted: /Volumes/Arc 1
2023-11-08 22:49:40 : INFO  : arc : Verifying: /Volumes/Arc 1/Arc.app
2023-11-08 22:49:40 : DEBUG : arc : App size: 702M	/Volumes/Arc 1/Arc.app
2023-11-08 22:49:43 : DEBUG : arc : Debugging enabled, App Verification output was:
/Volumes/Arc 1/Arc.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G)

2023-11-08 22:49:43 : INFO  : arc : Team ID matching: S6N382Y83G (expected: S6N382Y83G )
2023-11-08 22:49:43 : INFO  : arc : Downloaded version of Arc is 1.15.1 on versionKey CFBundleShortVersionString, same as installed.
2023-11-08 22:49:43 : DEBUG : arc : Unmounting /Volumes/Arc 1
2023-11-08 22:49:44 : DEBUG : arc : Debugging enabled, Unmounting output was:
"disk9" ejected.
2023-11-08 22:49:44 : DEBUG : arc : DEBUG mode 1, not reopening anything
2023-11-08 22:49:44 : REG   : arc : No new version to install
2023-11-08 22:49:44 : REQ   : arc : ################## End Installomator, exit code 0
```