### PR TITLE
Improving label: mkuser

### DIFF
--- a/fragments/labels/mkuser.sh
+++ b/fragments/labels/mkuser.sh
@@ -6,6 +6,11 @@ mkuser)
     # appNewVersion="$(versionFromGit freegeek-pdx mkuser unfiltered)"
     # mkuser does not adhere to numbers and dots only for version numbers.
     # Pull request submitted to add an unfiltered option to versionFromGit
-    appNewVersion="$(curl -sLI "https://github.com/freegeek-pdx/mkuser/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1)"
+    appNewVersion="$(osascript -l 'JavaScript' -e 'run = argv => JSON.parse(argv[0]).tag_name' -- "$(curl -m 5 -sfL 'https://update.mkuser.sh' 2> /dev/null)" 2> /dev/null)"
+    appCustomVersion(){
+        if [ -e /usr/local/bin/mkuser ]; then
+            awk -F " |=|'" '($2 == "MKUSER_VERSION") { print $(NF-1); exit }' /usr/local/bin/mkuser
+        fi
+    }
     expectedTeamID="YRW6NUGA63"
     ;;


### PR DESCRIPTION
Pico provided me with a suggestion for `appNewVersion` improvement. This command matches what he uses for this product's internal update system, so it will continue to work going forward.

I also added an `appCustomVersion` function so that `appNewVersion` is meaningful. Previously, Installomator would install the label even when no updates were needed.

```
./assemble.sh mkuser
2023-11-08 23:17:51 : REQ   : mkuser : ################## Start Installomator v. 10.6beta, date 2023-11-08
2023-11-08 23:17:51 : INFO  : mkuser : ################## Version: 10.6beta
2023-11-08 23:17:51 : INFO  : mkuser : ################## Date: 2023-11-08
2023-11-08 23:17:51 : INFO  : mkuser : ################## mkuser
2023-11-08 23:17:51 : DEBUG : mkuser : DEBUG mode 1 enabled.
2023-11-08 23:17:52 : DEBUG : mkuser : name=mkuser
2023-11-08 23:17:52 : DEBUG : mkuser : appName=
2023-11-08 23:17:52 : DEBUG : mkuser : type=pkg
2023-11-08 23:17:52 : DEBUG : mkuser : archiveName=
2023-11-08 23:17:52 : DEBUG : mkuser : downloadURL=https://github.com/freegeek-pdx/mkuser/releases/download/2023.9.12-1/mkuser-2023.9.12-1.pkg
2023-11-08 23:17:52 : DEBUG : mkuser : curlOptions=
2023-11-08 23:17:52 : DEBUG : mkuser : appNewVersion=2023.9.12-1
2023-11-08 23:17:52 : DEBUG : mkuser : appCustomVersion function: Defined.
2023-11-08 23:17:52 : DEBUG : mkuser : versionKey=CFBundleShortVersionString
2023-11-08 23:17:52 : DEBUG : mkuser : packageID=org.freegeek.pkg.mkuser
2023-11-08 23:17:52 : DEBUG : mkuser : pkgName=
2023-11-08 23:17:52 : DEBUG : mkuser : choiceChangesXML=
2023-11-08 23:17:52 : DEBUG : mkuser : expectedTeamID=YRW6NUGA63
2023-11-08 23:17:52 : DEBUG : mkuser : blockingProcesses=
2023-11-08 23:17:52 : DEBUG : mkuser : installerTool=
2023-11-08 23:17:52 : DEBUG : mkuser : CLIInstaller=
2023-11-08 23:17:52 : DEBUG : mkuser : CLIArguments=
2023-11-08 23:17:52 : DEBUG : mkuser : updateTool=
2023-11-08 23:17:52 : DEBUG : mkuser : updateToolArguments=
2023-11-08 23:17:52 : DEBUG : mkuser : updateToolRunAsCurrentUser=
2023-11-08 23:17:52 : INFO  : mkuser : BLOCKING_PROCESS_ACTION=tell_user
2023-11-08 23:17:52 : INFO  : mkuser : NOTIFY=success
2023-11-08 23:17:52 : INFO  : mkuser : LOGGING=DEBUG
2023-11-08 23:17:52 : INFO  : mkuser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-08 23:17:52 : INFO  : mkuser : Label type: pkg
2023-11-08 23:17:52 : INFO  : mkuser : archiveName: mkuser.pkg
2023-11-08 23:17:52 : INFO  : mkuser : no blocking processes defined, using mkuser as default
2023-11-08 23:17:52 : DEBUG : mkuser : Changing directory to /Users/bigmacadmin/Documents/GitHub/installomator/build
2023-11-08 23:17:52 : INFO  : mkuser : Custom App Version detection is used, found
2023-11-08 23:17:52 : INFO  : mkuser : appversion:
2023-11-08 23:17:52 : INFO  : mkuser : Latest version of mkuser is 2023.9.12-1
2023-11-08 23:17:52 : INFO  : mkuser : mkuser.pkg exists and DEBUG mode 1 enabled, skipping download
2023-11-08 23:17:52 : DEBUG : mkuser : DEBUG mode 1, not checking for blocking processes
2023-11-08 23:17:52 : REQ   : mkuser : Installing mkuser
2023-11-08 23:17:52 : INFO  : mkuser : Verifying: mkuser.pkg
2023-11-08 23:17:52 : DEBUG : mkuser : File list: -rw-r--r--  1 root  staff   160K Nov  8 23:17 mkuser.pkg
2023-11-08 23:17:52 : DEBUG : mkuser : File type: mkuser.pkg: xar archive compressed TOC: 4474, SHA-1 checksum
2023-11-08 23:17:52 : DEBUG : mkuser : spctlOut is mkuser.pkg: accepted
2023-11-08 23:17:52 : DEBUG : mkuser : source=Notarized Developer ID
2023-11-08 23:17:52 : DEBUG : mkuser : origin=Developer ID Installer: Pico Mitchell (YRW6NUGA63)
2023-11-08 23:17:52 : INFO  : mkuser : Team ID: YRW6NUGA63 (expected: YRW6NUGA63 )
2023-11-08 23:17:52 : DEBUG : mkuser : DEBUG enabled, skipping installation
2023-11-08 23:17:52 : INFO  : mkuser : Finishing...
2023-11-08 23:17:55 : INFO  : mkuser : Custom App Version detection is used, found
2023-11-08 23:17:55 : REQ   : mkuser : Installed mkuser, version 2023.9.12-1
2023-11-08 23:17:55 : INFO  : mkuser : notifying
2023-11-08 23:17:55 : DEBUG : mkuser : DEBUG mode 1, not reopening anything
2023-11-08 23:17:55 : REQ   : mkuser : All done!
2023-11-08 23:17:55 : REQ   : mkuser : ################## End Installomator, exit code 0
```