### PR TITLE
Add Hoppscotch Label

### DIFF
--- a/fragments/labels/hoppscotch.sh
+++ b/fragments/labels/hoppscotch.sh
@@ -1,0 +1,12 @@
+hoppscotch)
+    name="Hoppscotch"
+    type="dmg"
+    if [[ $(arch) == arm64 ]]; then
+        archiveName="Hoppscotch_mac_aarch64.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        archiveName="Hoppscotch_mac_x64.dmg" 
+    fi
+    downloadURL="$(downloadURLFromGit hoppscotch releases)"
+    appNewVersion="$(versionFromGit hoppscotch releases)"
+    expectedTeamID="XBK86CMQGZ"
+    ;;


### PR DESCRIPTION
Last login: Thu Nov  9 09:01:23 on ttys000
❯ cd Documents/GitHub/Installomator/build
❯ sudo ./Installomator.sh hoppscotch DEBUG=0
Password:
2023-11-09 09:21:20 : REQ   : hoppscotch : ################## Start Installomator v. 10.6beta, date 2023-11-09
2023-11-09 09:21:20 : INFO  : hoppscotch : ################## Version: 10.6beta
2023-11-09 09:21:20 : INFO  : hoppscotch : ################## Date: 2023-11-09
2023-11-09 09:21:20 : INFO  : hoppscotch : ################## hoppscotch
2023-11-09 09:21:20 : DEBUG : hoppscotch : DEBUG mode 1 enabled.
2023-11-09 09:21:20 : INFO  : hoppscotch : SwiftDialog is not installed, clear cmd file var
2023-11-09 09:21:21 : INFO  : hoppscotch : setting variable from argument DEBUG=0
2023-11-09 09:21:21 : DEBUG : hoppscotch : name=Hoppscotch
2023-11-09 09:21:21 : DEBUG : hoppscotch : appName=
2023-11-09 09:21:21 : DEBUG : hoppscotch : type=dmg
2023-11-09 09:21:21 : DEBUG : hoppscotch : archiveName=Hoppscotch_mac_x64.dmg
2023-11-09 09:21:21 : DEBUG : hoppscotch : downloadURL=https://github.com/hoppscotch/releases/releases/download/v23.8.3-1/Hoppscotch_mac_x64.dmg
2023-11-09 09:21:21 : DEBUG : hoppscotch : curlOptions=
2023-11-09 09:21:21 : DEBUG : hoppscotch : appNewVersion=23.8.31
2023-11-09 09:21:21 : DEBUG : hoppscotch : appCustomVersion function: Not defined
2023-11-09 09:21:21 : DEBUG : hoppscotch : versionKey=CFBundleShortVersionString
2023-11-09 09:21:21 : DEBUG : hoppscotch : packageID=
2023-11-09 09:21:21 : DEBUG : hoppscotch : pkgName=
2023-11-09 09:21:21 : DEBUG : hoppscotch : choiceChangesXML=
2023-11-09 09:21:21 : DEBUG : hoppscotch : expectedTeamID=XBK86CMQGZ
2023-11-09 09:21:21 : DEBUG : hoppscotch : blockingProcesses=
2023-11-09 09:21:21 : DEBUG : hoppscotch : installerTool=
2023-11-09 09:21:21 : DEBUG : hoppscotch : CLIInstaller=
2023-11-09 09:21:21 : DEBUG : hoppscotch : CLIArguments=
2023-11-09 09:21:21 : DEBUG : hoppscotch : updateTool=
2023-11-09 09:21:21 : DEBUG : hoppscotch : updateToolArguments=
2023-11-09 09:21:21 : DEBUG : hoppscotch : updateToolRunAsCurrentUser=
2023-11-09 09:21:21 : INFO  : hoppscotch : BLOCKING_PROCESS_ACTION=tell_user
2023-11-09 09:21:21 : INFO  : hoppscotch : NOTIFY=success
2023-11-09 09:21:21 : INFO  : hoppscotch : LOGGING=DEBUG
2023-11-09 09:21:21 : INFO  : hoppscotch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-09 09:21:21 : INFO  : hoppscotch : Label type: dmg
2023-11-09 09:21:21 : INFO  : hoppscotch : archiveName: Hoppscotch_mac_x64.dmg
2023-11-09 09:21:21 : INFO  : hoppscotch : no blocking processes defined, using Hoppscotch as default
2023-11-09 09:21:22 : DEBUG : hoppscotch : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vD0ZQiAfOm
2023-11-09 09:21:22 : INFO  : hoppscotch : name: Hoppscotch, appName: Hoppscotch.app
2023-11-09 09:21:22.096 mdfind[71131:1763927] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-11-09 09:21:22.096 mdfind[71131:1763927] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-09 09:21:22.241 mdfind[71131:1763927] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-09 09:21:22 : WARN  : hoppscotch : No previous app found
2023-11-09 09:21:22 : WARN  : hoppscotch : could not find Hoppscotch.app
2023-11-09 09:21:22 : INFO  : hoppscotch : appversion:
2023-11-09 09:21:22 : INFO  : hoppscotch : Latest version of Hoppscotch is 23.8.31
2023-11-09 09:21:22 : REQ   : hoppscotch : Downloading https://github.com/hoppscotch/releases/releases/download/v23.8.3-1/Hoppscotch_mac_x64.dmg to Hoppscotch_mac_x64.dmg
2023-11-09 09:21:22 : DEBUG : hoppscotch : No Dialog connection, just download
2023-11-09 09:21:22 : DEBUG : hoppscotch : File list: -rw-r--r--  1 root  wheel    17M Nov  9 09:21 Hoppscotch_mac_x64.dmg
2023-11-09 09:21:22 : DEBUG : hoppscotch : File type: Hoppscotch_mac_x64.dmg: zlib compressed data
2023-11-09 09:21:22 : DEBUG : hoppscotch : curl output was:
*   Trying 140.82.114.4:443...
* Connected to github.com (140.82.114.4) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /hoppscotch/releases/releases/download/v23.8.3-1/Hoppscotch_mac_x64.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fb026813c00)
> GET /hoppscotch/releases/releases/download/v23.8.3-1/Hoppscotch_mac_x64.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Thu, 09 Nov 2023 14:19:27 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/715960984/19d3d052-1cce-4514-a3bc-3573289f9622?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T141927Z&X-Amz-Expires=300&X-Amz-Signature=4c5169245516d413ec3c2ac7ce6fcb229e77a29feb232109ca7fda27b4acb349&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=715960984&response-content-disposition=attachment%3B%20filename%3DHoppscotch_mac_x64.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ staffwus201resultssa0.blob.core.windows.net/ staffwus201resultssa1.blob.core.windows.net/ prodweu01resultssa0.blob.core.windows.net/ prodweu01resultssa1.blob.core.windows.net/ prodweu01resultssa2.blob.core.windows.net/ prodweu01resultssa3.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: EADC:1379:460D139:6532762:654CEAE2
<
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/715960984/19d3d052-1cce-4514-a3bc-3573289f9622?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T141927Z&X-Amz-Expires=300&X-Amz-Signature=4c5169245516d413ec3c2ac7ce6fcb229e77a29feb232109ca7fda27b4acb349&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=715960984&response-content-disposition=attachment%3B%20filename%3DHoppscotch_mac_x64.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/715960984/19d3d052-1cce-4514-a3bc-3573289f9622?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T141927Z&X-Amz-Expires=300&X-Amz-Signature=4c5169245516d413ec3c2ac7ce6fcb229e77a29feb232109ca7fda27b4acb349&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=715960984&response-content-disposition=attachment%3B%20filename%3DHoppscotch_mac_x64.dmg&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fb026813c00)
> GET /github-production-release-asset-2e65be/715960984/19d3d052-1cce-4514-a3bc-3573289f9622?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231109T141927Z&X-Amz-Expires=300&X-Amz-Signature=4c5169245516d413ec3c2ac7ce6fcb229e77a29feb232109ca7fda27b4acb349&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=715960984&response-content-disposition=attachment%3B%20filename%3DHoppscotch_mac_x64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: Y6VNFQDvseOfSPHUaRrLFg==
< last-modified: Wed, 08 Nov 2023 17:08:40 GMT
< etag: "0x8DBE07D5AD1B40F"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: fdaf6de2-a01e-0033-3c66-12befe000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Wed, 08 Nov 2023 17:08:40 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Hoppscotch_mac_x64.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 874
< date: Thu, 09 Nov 2023 14:21:22 GMT
< x-served-by: cache-iad-kiad7000156-IAD, cache-nyc-kteb1890057-NYC
< x-cache: HIT, HIT
< x-cache-hits: 67, 0
< x-timer: S1699539683.591607,VS0,VE16
< content-length: 17468844
<
{ [19131 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-11-09 09:21:23 : REQ   : hoppscotch : no more blocking processes, continue with update
2023-11-09 09:21:23 : REQ   : hoppscotch : Installing Hoppscotch
2023-11-09 09:21:23 : INFO  : hoppscotch : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vD0ZQiAfOm/Hoppscotch_mac_x64.dmg
2023-11-09 09:21:26 : DEBUG : hoppscotch : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $E890B26C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $794C6A65
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $128096F8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A251BCCB
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $128096F8
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $3C052E94
verified   CRC32 $7D18854B
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Hoppscotch

2023-11-09 09:21:26 : INFO  : hoppscotch : Mounted: /Volumes/Hoppscotch
2023-11-09 09:21:26 : INFO  : hoppscotch : Verifying: /Volumes/Hoppscotch/Hoppscotch.app
2023-11-09 09:21:26 : DEBUG : hoppscotch : App size:  25M	/Volumes/Hoppscotch/Hoppscotch.app
2023-11-09 09:21:26 : DEBUG : hoppscotch : Debugging enabled, App Verification output was:
/Volumes/Hoppscotch/Hoppscotch.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: HOPPSCOTCH LIMITED (XBK86CMQGZ)

2023-11-09 09:21:26 : INFO  : hoppscotch : Team ID matching: XBK86CMQGZ (expected: XBK86CMQGZ )
2023-11-09 09:21:26 : INFO  : hoppscotch : Installing Hoppscotch version 23.8.3-1 on versionKey CFBundleShortVersionString.
2023-11-09 09:21:26 : INFO  : hoppscotch : App has LSMinimumSystemVersion: 10.13
2023-11-09 09:21:26 : INFO  : hoppscotch : Copy /Volumes/Hoppscotch/Hoppscotch.app to /Applications
2023-11-09 09:21:27 : DEBUG : hoppscotch : Debugging enabled, App copy output was:
Copying /Volumes/Hoppscotch/Hoppscotch.app

2023-11-09 09:21:27 : WARN  : hoppscotch : Changing owner to jakenichols
2023-11-09 09:21:27 : INFO  : hoppscotch : Finishing...
2023-11-09 09:21:30 : INFO  : hoppscotch : App(s) found: /Applications/Hoppscotch.app
2023-11-09 09:21:30 : INFO  : hoppscotch : found app at /Applications/Hoppscotch.app, version 23.8.3-1, on versionKey CFBundleShortVersionString
2023-11-09 09:21:30 : REQ   : hoppscotch : Installed Hoppscotch, version 23.8.3-1
2023-11-09 09:21:30 : INFO  : hoppscotch : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-11-09 09:21:30 : DEBUG : hoppscotch : Unmounting /Volumes/Hoppscotch
2023-11-09 09:21:30 : DEBUG : hoppscotch : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-11-09 09:21:30 : DEBUG : hoppscotch : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vD0ZQiAfOm
2023-11-09 09:21:30 : DEBUG : hoppscotch : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vD0ZQiAfOm/Hoppscotch_mac_x64.dmg
2023-11-09 09:21:30 : DEBUG : hoppscotch : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vD0ZQiAfOm
2023-11-09 09:21:30 : INFO  : hoppscotch : Installomator did not close any apps, so no need to reopen any apps.
2023-11-09 09:21:30 : REQ   : hoppscotch : All done!
2023-11-09 09:21:30 : REQ   : hoppscotch : ################## End Installomator, exit code 0