### PR TITLE
Update Duo Device Health to Duo Desktop

### DIFF
--- a/fragments/labels/duodesktop.sh
+++ b/fragments/labels/duodesktop.sh
@@ -1,0 +1,9 @@
+duodevicehealth|\
+duodesktop)
+    name="Duo Desktop"
+    type="pkg"
+    downloadURL="https://dl.duosecurity.com/DuoDesktop-latest.pkg"
+    appNewVersion=$(curl -fsLIXGET "https://dl.duosecurity.com/DuoDesktop-latest.pkg" | grep -i "^content-disposition" | sed -e 's/.*filename\=\"DuoDesktop\-\(.*\)\.pkg\".*/\1/')
+    appName="Duo Desktop.app"
+    expectedTeamID="FNN8Z5JMFP"
+    ;;

--- a/fragments/labels/duodevicehealth.sh
+++ b/fragments/labels/duodevicehealth.sh
@@ -1,8 +1,0 @@
-duodevicehealth)
-    name="Duo Device Health"
-    type="pkg"
-    downloadURL="https://dl.duosecurity.com/DuoDeviceHealth-latest.pkg"
-    appNewVersion=$(curl -fsLIXGET "https://dl.duosecurity.com/DuoDeviceHealth-latest.pkg" | grep -i "^content-disposition" | sed -e 's/.*filename\=\"DuoDeviceHealth\-\(.*\)\.pkg\".*/\1/')
-    appName="Duo Device Health.app"
-    expectedTeamID="FNN8Z5JMFP"
-    ;;


### PR DESCRIPTION
Duo Device Health has been rebranded as Duo Desktop
https://duo.com/docs/duo-desktop

```
2023-11-09 10:46:46 : REQ   : duodesktop : ################## Start Installomator v. 10.6beta, date 2023-11-09
2023-11-09 10:46:46 : INFO  : duodesktop : ################## Version: 10.6beta
2023-11-09 10:46:46 : INFO  : duodesktop : ################## Date: 2023-11-09
2023-11-09 10:46:46 : INFO  : duodesktop : ################## duodesktop
2023-11-09 10:46:46 : DEBUG : duodesktop : DEBUG mode 1 enabled.
2023-11-09 10:46:46 : INFO  : duodesktop : SwiftDialog is not installed, clear cmd file var
2023-11-09 10:46:47 : INFO  : duodesktop : setting variable from argument DEBUG=0
2023-11-09 10:46:47 : INFO  : duodesktop : setting variable from argument LOGGING=INFO
2023-11-09 10:46:47 : INFO  : duodesktop : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2023-11-09 10:46:47 : INFO  : duodesktop : setting variable from argument INSTALL=force
2023-11-09 10:46:47 : INFO  : duodesktop : BLOCKING_PROCESS_ACTION=kill
2023-11-09 10:46:47 : INFO  : duodesktop : NOTIFY=success
2023-11-09 10:46:47 : INFO  : duodesktop : LOGGING=INFO
2023-11-09 10:46:47 : INFO  : duodesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-09 10:46:47 : INFO  : duodesktop : Label type: pkg
2023-11-09 10:46:47 : INFO  : duodesktop : archiveName: Duo Desktop.pkg
2023-11-09 10:46:47 : INFO  : duodesktop : no blocking processes defined, using Duo Desktop as default
2023-11-09 10:46:47 : INFO  : duodesktop : App(s) found: /Applications/Duo Desktop.app
2023-11-09 10:46:47 : INFO  : duodesktop : found app at /Applications/Duo Desktop.app, version 6.0.0.0, on versionKey CFBundleShortVersionString
2023-11-09 10:46:47 : INFO  : duodesktop : appversion: 6.0.0.0
2023-11-09 10:46:47 : INFO  : duodesktop : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-11-09 10:46:47 : INFO  : duodesktop : Latest version of Duo Desktop is 6.0.0.0
2023-11-09 10:46:47 : INFO  : duodesktop : There is no newer version available.
2023-11-09 10:46:47 : REQ   : duodesktop : Downloading https://dl.duosecurity.com/DuoDesktop-latest.pkg to Duo Desktop.pkg
2023-11-09 10:46:47 : INFO  : duodesktop : found blocking process Duo Desktop
2023-11-09 10:46:47 : INFO  : duodesktop : killing process Duo Desktop
2023-11-09 10:46:53 : REQ   : duodesktop : no more blocking processes, continue with update
2023-11-09 10:46:53 : REQ   : duodesktop : Installing Duo Desktop
2023-11-09 10:46:53 : INFO  : duodesktop : Verifying: Duo Desktop.pkg
2023-11-09 10:46:53 : INFO  : duodesktop : Team ID: FNN8Z5JMFP (expected: FNN8Z5JMFP )
2023-11-09 10:46:53 : INFO  : duodesktop : Installing Duo Desktop.pkg to /
2023-11-09 10:47:03 : INFO  : duodesktop : Finishing...
2023-11-09 10:47:06 : INFO  : duodesktop : App(s) found: /Applications/Duo Desktop.app
2023-11-09 10:47:06 : INFO  : duodesktop : found app at /Applications/Duo Desktop.app, version 6.0.0.0, on versionKey CFBundleShortVersionString
2023-11-09 10:47:06 : REQ   : duodesktop : Installed Duo Desktop, version 6.0.0.0
2023-11-09 10:47:06 : INFO  : duodesktop : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-11-09 10:47:07 : INFO  : duodesktop : Telling app Duo Desktop.app to open
2023-11-09 10:47:07 : INFO  : duodesktop : Reopened Duo Desktop.app as user
2023-11-09 10:47:07 : INFO  : duodesktop : root
2023-11-09 10:47:07 : REQ   : duodesktop : All done!
2023-11-09 10:47:07 : REQ   : duodesktop : ################## End Installomator, exit code 0 
```