### PR TITLE
'smartnotebook.sh' added to labels

### DIFF
--- a/fragments/labels/smartnotebook.sh
+++ b/fragments/labels/smartnotebook.sh
@@ -1,0 +1,9 @@
+smartnotebook)
+    name="smart23-1-web"
+    type="pkgInDmg"
+    downloadURL="https://downloads.smarttech.com/software/education/23.1/mac/23.1.195.2/smart23-1-web.dmg"
+    appNewVersion="23.1"
+    appName="Notebook.app"
+    expectedTeamID="53V9BC2FMQ"
+    blockingProcesses=( "SMARTNotification" "SMARTBoardService" "SMART System Menu" "SMART Ink")
+    ;;


### PR DESCRIPTION
This label has been added, but it doesn't work yet.  I'm not sure I have the know-how to make it work, or that Installomator even _can_ work with something like this. 
Adding as much info as I can about the software in the hopes that someone smarter might be able to make it function:

- `smart-23-1-web.dmg` contains `SMART Education Software Installer.pkg`
- `SMART Education Software Installer.pkg` installs the `\Applications\SMART Technologies\` folder
- `SMART Technologies` folder contains a collection of apps, and a sub-folder (`SMART Tools`) with more apps
- `\Applications\SMART Technologies\Notebook.app` is the main app, and can be used for version comparison
- For an update, entire `SMART Technologies` folder could be cleared as the installer should repopulate it.

`assemble.sh` output:

```
user@computer~ % assemble.sh smartnotebook DEBUG=0
2023-11-10 18:00:15 : REQ   : smartnotebook : ################## Start Installomator v. 10.6beta, date 2023-11-10
2023-11-10 18:00:15 : INFO  : smartnotebook : ################## Version: 10.6beta
2023-11-10 18:00:15 : INFO  : smartnotebook : ################## Date: 2023-11-10
2023-11-10 18:00:15 : INFO  : smartnotebook : ################## smartnotebook
2023-11-10 18:00:15 : DEBUG : smartnotebook : DEBUG mode 1 enabled.
2023-11-10 18:00:16 : INFO  : smartnotebook : setting variable from argument DEBUG=0
2023-11-10 18:00:16 : DEBUG : smartnotebook : name=smart23-1-web
2023-11-10 18:00:16 : DEBUG : smartnotebook : appName=Notebook.app
2023-11-10 18:00:16 : DEBUG : smartnotebook : type=pkgInDmg
2023-11-10 18:00:16 : DEBUG : smartnotebook : archiveName=
2023-11-10 18:00:16 : DEBUG : smartnotebook : downloadURL=https://downloads.smarttech.com/software/education/23.1/mac/23.1.195.2/smart23-1-web.dmg
2023-11-10 18:00:16 : DEBUG : smartnotebook : curlOptions=
2023-11-10 18:00:16 : DEBUG : smartnotebook : appNewVersion=23.1
2023-11-10 18:00:16 : DEBUG : smartnotebook : appCustomVersion function: Not defined
2023-11-10 18:00:16 : DEBUG : smartnotebook : versionKey=CFBundleShortVersionString
2023-11-10 18:00:16 : DEBUG : smartnotebook : packageID=
2023-11-10 18:00:16 : DEBUG : smartnotebook : pkgName=
2023-11-10 18:00:16 : DEBUG : smartnotebook : choiceChangesXML=
2023-11-10 18:00:16 : DEBUG : smartnotebook : expectedTeamID=53V9BC2FMQ
2023-11-10 18:00:16 : DEBUG : smartnotebook : blockingProcesses=SMARTNotification SMARTBoardService SMART System Menu SMART Ink
2023-11-10 18:00:16 : DEBUG : smartnotebook : installerTool=
2023-11-10 18:00:16 : DEBUG : smartnotebook : CLIInstaller=
2023-11-10 18:00:16 : DEBUG : smartnotebook : CLIArguments=
2023-11-10 18:00:16 : DEBUG : smartnotebook : updateTool=
2023-11-10 18:00:16 : DEBUG : smartnotebook : updateToolArguments=
2023-11-10 18:00:16 : DEBUG : smartnotebook : updateToolRunAsCurrentUser=
2023-11-10 18:00:16 : INFO  : smartnotebook : BLOCKING_PROCESS_ACTION=tell_user
2023-11-10 18:00:16 : INFO  : smartnotebook : NOTIFY=success
2023-11-10 18:00:16 : INFO  : smartnotebook : LOGGING=DEBUG
2023-11-10 18:00:16 : INFO  : smartnotebook : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-10 18:00:16 : INFO  : smartnotebook : Label type: pkgInDmg
2023-11-10 18:00:16 : INFO  : smartnotebook : archiveName: smart23-1-web.dmg
2023-11-10 18:00:16 : DEBUG : smartnotebook : Changing directory to /var/folders/5k/ly2gkyyn2cx9wcdyplz6y5ph0000gq/T/tmp.43PSLUGLac
2023-11-10 18:00:16 : INFO  : smartnotebook : name: smart23-1-web, appName: Notebook.app
2023-11-10 18:00:16.249 mdfind[47045:476635] [UserQueryParser] Loading keywords and predicates for locale "en_CA"
2023-11-10 18:00:16.250 mdfind[47045:476635] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-10 18:00:16.326 mdfind[47045:476635] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-10 18:00:16 : WARN  : smartnotebook : No previous app found
2023-11-10 18:00:16 : WARN  : smartnotebook : could not find Notebook.app
2023-11-10 18:00:16 : INFO  : smartnotebook : appversion:
2023-11-10 18:00:16 : INFO  : smartnotebook : Latest version of smart23-1-web is 23.1
2023-11-10 18:00:16 : REQ   : smartnotebook : Downloading https://downloads.smarttech.com/software/education/23.1/mac/23.1.195.2/smart23-1-web.dmg to smart23-1-web.dmg
2023-11-10 18:00:16 : DEBUG : smartnotebook : No Dialog connection, just download
2023-11-10 18:00:46 : DEBUG : smartnotebook : File list: -rw-r--r--  1 kyle.kowalsky  staff   702M 10 Nov 18:00 smart23-1-web.dmg
2023-11-10 18:00:46 : DEBUG : smartnotebook : File type: smart23-1-web.dmg: zlib compressed data
2023-11-10 18:00:46 : DEBUG : smartnotebook : curl output was:
*   Trying 13.226.139.68:443...
* Connected to downloads.smarttech.com (13.226.139.68) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4970 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.smarttech.com
*  start date: Sep 11 00:00:00 2023 GMT
*  expire date: Oct  9 23:59:59 2024 GMT
*  subjectAltName: host "downloads.smarttech.com" matched cert's "*.smarttech.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /software/education/23.1/mac/23.1.195.2/smart23-1-web.dmg HTTP/1.1
> Host: downloads.smarttech.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: binary/octet-stream
< Content-Length: 735579341
< Connection: keep-alive
< Last-Modified: Mon, 30 Oct 2023 22:34:00 GMT
< x-amz-storage-class: INTELLIGENT_TIERING
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< Date: Fri, 10 Nov 2023 23:00:17 GMT
< Cache-Control: public, max-age=600
< ETag: "375fe05e6a87f0b6f9ef1b21faa52c17-88"
< Vary: Accept-Encoding
< X-Cache: RefreshHit from cloudfront
< Via: 1.1 6c2e1b939c753ac053c3f8fb52de1bbc.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: YTO50-C2
< X-Amz-Cf-Id: DmwELYokIo7sgMCrYTQr-9g0WMYhs0RLPu7TY5NreIP2slB1KnSYaA==
<
{ [16384 bytes data]
* Connection #0 to host downloads.smarttech.com left intact

2023-11-10 18:00:46 : INFO  : smartnotebook : found blocking process SMARTBoardService
2023-11-10 18:00:49 : INFO  : smartnotebook : telling app SMARTBoardService to quit
2023-11-10 18:00:49 : INFO  : smartnotebook : waiting 30 seconds for processes to quit
2023-11-10 18:01:19 : INFO  : smartnotebook : found blocking process SMART Ink
2023-11-10 18:01:21 : INFO  : smartnotebook : telling app SMART Ink to quit
2023-11-10 18:01:22 : INFO  : smartnotebook : waiting 30 seconds for processes to quit
2023-11-10 18:01:52 : REQ   : smartnotebook : no more blocking processes, continue with update
2023-11-10 18:01:52 : REQ   : smartnotebook : Installing smart23-1-web
2023-11-10 18:01:52 : INFO  : smartnotebook : Mounting /var/folders/5k/ly2gkyyn2cx9wcdyplz6y5ph0000gq/T/tmp.43PSLUGLac/smart23-1-web.dmg
2023-11-10 18:01:57 : DEBUG : smartnotebook : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D532C0F4
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F7E4B232
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D02F64A7
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $CCF53D63
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D02F64A7
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $D33F89D1
verified   CRC32 $E2638A33
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/smart23-1-web 1

2023-11-10 18:01:57 : INFO  : smartnotebook : Mounted: /Volumes/smart23-1-web 1
2023-11-10 18:01:57 : DEBUG : smartnotebook : Found pkg(s):
/Volumes/smart23-1-web 1/SMART Education Software Installer.pkg
2023-11-10 18:01:57 : INFO  : smartnotebook : found pkg: /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg
2023-11-10 18:01:57 : INFO  : smartnotebook : Verifying: /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg
2023-11-10 18:01:57 : DEBUG : smartnotebook : File list: -rw-r--r--@ 1 kyle.kowalsky  staff   701M 24 Oct 16:57 /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg
2023-11-10 18:01:57 : DEBUG : smartnotebook : File type: /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg: xar archive compressed TOC: 43976, SHA-1 checksum
2023-11-10 18:01:57 : DEBUG : smartnotebook : spctlOut is /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg: accepted
2023-11-10 18:01:57 : DEBUG : smartnotebook : source=Notarized Developer ID
2023-11-10 18:01:57 : DEBUG : smartnotebook : origin=Developer ID Installer: SMART Technologies ULC (53V9BC2FMQ)
2023-11-10 18:01:57 : INFO  : smartnotebook : Team ID: 53V9BC2FMQ (expected: 53V9BC2FMQ )
2023-11-10 18:01:57 : INFO  : smartnotebook : Installing /Volumes/smart23-1-web 1/SMART Education Software Installer.pkg to /
2023-11-10 18:02:00 : DEBUG : smartnotebook : Debugging enabled, installer output was:
installer: Must be run as root to install this package.
Output of /var/log/install.log below this line.----------------------------------------------------------

2023-11-10 18:02:00 : INFO  : smartnotebook : Finishing...
2023-11-10 18:02:03 : INFO  : smartnotebook : name: smart23-1-web, appName: Notebook.app
2023-11-10 18:02:03.279 mdfind[47370:478461] [UserQueryParser] Loading keywords and predicates for locale "en_CA"
2023-11-10 18:02:03.280 mdfind[47370:478461] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-10 18:02:03.371 mdfind[47370:478461] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-10 18:02:03 : WARN  : smartnotebook : No previous app found
2023-11-10 18:02:03 : WARN  : smartnotebook : could not find Notebook.app
2023-11-10 18:02:03 : REQ   : smartnotebook : Installed smart23-1-web, version 23.1
2023-11-10 18:02:03 : INFO  : smartnotebook : notifying
2023-11-10 18:02:03 : DEBUG : smartnotebook : Unmounting /Volumes/smart23-1-web 1
2023-11-10 18:02:03 : DEBUG : smartnotebook : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-11-10 18:02:03 : DEBUG : smartnotebook : Deleting /var/folders/5k/ly2gkyyn2cx9wcdyplz6y5ph0000gq/T/tmp.43PSLUGLac
2023-11-10 18:02:03 : DEBUG : smartnotebook : Debugging enabled, Deleting tmpDir output was:
/var/folders/5k/ly2gkyyn2cx9wcdyplz6y5ph0000gq/T/tmp.43PSLUGLac/smart23-1-web.dmg
2023-11-10 18:02:03 : DEBUG : smartnotebook : /var/folders/5k/ly2gkyyn2cx9wcdyplz6y5ph0000gq/T/tmp.43PSLUGLac
2023-11-10 18:02:03 : INFO  : smartnotebook : Telling app Notebook.app to open
Password:
2023-11-10 18:02:20 : INFO  : smartnotebook : Reopened Notebook.app as kyle.kowalsky
2023-11-10 18:02:20 : REQ   : smartnotebook : All done!
2023-11-10 18:02:20 : REQ   : smartnotebook : ################## End Installomator, exit code 0
```
