### PR TITLE
Create gosign.sh

### DIFF
--- a/fragments/labels/gosign.sh
+++ b/fragments/labels/gosign.sh
@@ -1,0 +1,7 @@
+gosign)
+    name="GoSign-Desktop"
+    type="dmg"
+    downloadURL="https://rinnovofirma.infocert.it/gosign/download/darwin/latest/"
+    expectedTeamID="QC25859FX9"
+    appName="GoSign-Desktop.app"
+    ;;


### PR DESCRIPTION
adding a Label for Gosign, (https://www.infocert.it/firma-infocert-it/prodotti/gosign/),

An APP for sign with digital sign / certificate documents or file. This App is very common in italy.
AppNewVersion is not avaiable because there aren't documentation on developer site.