### PR TITLE
Update obs.sh 

### DIFF
--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -2,9 +2,9 @@ obs)
     name="OBS"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="obs-studio-[0-9.]*-macos-arm64.dmg"
+        archiveName="obs-studio-[0-9.]*-macOS-Apple.dmg"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="obs-studio-[0-9.]*-macos-x86_64.dmg"
+        archiveName="obs-studio-[0-9.]*-macOS-Intel.dmg"
     fi
     downloadURL=$(downloadURLFromGit obsproject obs-studio )
     appNewVersion=$(versionFromGit obsproject obs-studio )


### PR DESCRIPTION
 Due to file name changes  line 5831 and 5833 and need to be archiveName="obs-studio-[0-9.]*-macOS-Apple.dmg" and archiveName="obs-studio-[0-9.]*-macOS-Intel.dmg"

Script result: 2023-11-16 09:39:20 : REQ   :  : shifting arguments for Jamf
2023-11-16 09:39:20 : REQ   : obs : ################## Start Installomator v. 10.5, date 2023-10-15
2023-11-16 09:39:20 : INFO  : obs : ################## Version: 10.5
2023-11-16 09:39:20 : INFO  : obs : ################## Date: 2023-10-15
2023-11-16 09:39:20 : INFO  : obs : ################## obs
2023-11-16 09:39:20 : DEBUG : obs : DEBUG mode 1 enabled.
2023-11-16 09:39:21 : INFO  : obs : setting variable from argument NOTIFY=Silent
2023-11-16 09:39:21 : INFO  : obs : setting variable from argument DEBUG=0
2023-11-16 09:39:21 : DEBUG : obs : name=OBS
2023-11-16 09:39:21 : DEBUG : obs : appName=
2023-11-16 09:39:21 : DEBUG : obs : type=dmg
2023-11-16 09:39:21 : DEBUG : obs : archiveName=obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:21 : DEBUG : obs : downloadURL=https://github.com/obsproject/obs-studio/releases/download/30.0.0/OBS-Studio-30.0.0-macOS-Apple.dmg
2023-11-16 09:39:21 : DEBUG : obs : curlOptions=
2023-11-16 09:39:21 : DEBUG : obs : appNewVersion=30.0.0
2023-11-16 09:39:21 : DEBUG : obs : appCustomVersion function: Not defined
2023-11-16 09:39:21 : DEBUG : obs : versionKey=CFBundleShortVersionString
2023-11-16 09:39:21 : DEBUG : obs : packageID=
2023-11-16 09:39:21 : DEBUG : obs : pkgName=
2023-11-16 09:39:21 : DEBUG : obs : choiceChangesXML=
2023-11-16 09:39:21 : DEBUG : obs : expectedTeamID=2MMRE5MTB8
2023-11-16 09:39:21 : DEBUG : obs : blockingProcesses=
2023-11-16 09:39:21 : DEBUG : obs : installerTool=
2023-11-16 09:39:21 : DEBUG : obs : CLIInstaller=
2023-11-16 09:39:21 : DEBUG : obs : CLIArguments=
2023-11-16 09:39:21 : DEBUG : obs : updateTool=
2023-11-16 09:39:21 : DEBUG : obs : updateToolArguments=
2023-11-16 09:39:21 : DEBUG : obs : updateToolRunAsCurrentUser=
2023-11-16 09:39:21 : INFO  : obs : BLOCKING_PROCESS_ACTION=tell_user
2023-11-16 09:39:21 : INFO  : obs : NOTIFY=Silent
2023-11-16 09:39:21 : INFO  : obs : LOGGING=DEBUG
2023-11-16 09:39:21 : INFO  : obs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-16 09:39:21 : INFO  : obs : Label type: dmg
2023-11-16 09:39:21 : INFO  : obs : archiveName: obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:21 : INFO  : obs : no blocking processes defined, using OBS as default
2023-11-16 09:39:21 : DEBUG : obs : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uglPDxlMge
2023-11-16 09:39:21 : INFO  : obs : name: OBS, appName: OBS.app
2023-11-16 09:39:21.708 mdfind[51654:255745] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-11-16 09:39:21.708 mdfind[51654:255745] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-11-16 09:39:21.810 mdfind[51654:255745] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-16 09:39:21 : WARN  : obs : No previous app found
2023-11-16 09:39:21 : WARN  : obs : could not find OBS.app
2023-11-16 09:39:21 : INFO  : obs : appversion:
2023-11-16 09:39:21 : INFO  : obs : Latest version of OBS is 30.0.0
2023-11-16 09:39:21 : REQ   : obs : Downloading https://github.com/obsproject/obs-studio/releases/download/30.0.0/OBS-Studio-30.0.0-macOS-Apple.dmg to obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:21 : DEBUG : obs : No Dialog connection, just download
2023-11-16 09:39:24 : DEBUG : obs : File list: -rw-r--r--@ 1 root  wheel   159M Nov 16 09:39 obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:24 : DEBUG : obs : File type: obs-studio-[0-9.]*-macOS-Apple.dmg: lzfse encoded, lzvn compressed
2023-11-16 09:39:24 : DEBUG : obs : curl output was:
*   Trying 140.82.112.4:443...
* Connected to github.com (140.82.112.4) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/obsproject/obs-studio/releases/download/30.0.0/OBS-Studio-30.0.0-macOS-Apple.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /obsproject/obs-studio/releases/download/30.0.0/OBS-Studio-30.0.0-macOS-Apple.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /obsproject/obs-studio/releases/download/30.0.0/OBS-Studio-30.0.0-macOS-Apple.dmg HTTP/2

> Host: github.com

> User-Agent: curl/8.4.0

> Accept: */*

>

< HTTP/2 302

< server: GitHub.com

< date: Thu, 16 Nov 2023 14:39:22 GMT

< content-type: text/html; charset=utf-8

< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With

< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/168a00c3-5303-4f7d-a66a-de6f132e715f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231116%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231116T143922Z&X-Amz-Expires=300&X-Amz-Signature=40688f968c0b961fdf3106dcf11f4c95c9a4feefd0af722afc71a6985dac8066&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.0.0-macOS-Apple.dmg&response-content-type=application%2Foctet-stream

< cache-control: no-cache

< strict-transport-security: max-age=31536000; includeSubdomains; preload

< x-frame-options: deny

< x-content-type-options: nosniff

< x-xss-protection: 0

< referrer-policy: no-referrer-when-downgrade

< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ staffwus201resultssa0.blob.core.windows.net/ staffwus201resultssa1.blob.core.windows.net/ prodweu01resultssa0.blob.core.windows.net/ prodweu01resultssa1.blob.core.windows.net/ prodweu01resultssa2.blob.core.windows.net/ prodweu01resultssa3.blob.core.windows.net/ wss://*.actions.githubusercontent.com github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/

< content-length: 0

< x-github-request-id: CFE3:7108:473D55:68E890:65562999

<

{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/168a00c3-5303-4f7d-a66a-de6f132e715f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231116%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231116T143922Z&X-Amz-Expires=300&X-Amz-Signature=40688f968c0b961fdf3106dcf11f4c95c9a4feefd0af722afc71a6985dac8066&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.0.0-macOS-Apple.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/168a00c3-5303-4f7d-a66a-de6f132e715f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231116%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231116T143922Z&X-Amz-Expires=300&X-Amz-Signature=40688f968c0b961fdf3106dcf11f4c95c9a4feefd0af722afc71a6985dac8066&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.0.0-macOS-Apple.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/13233158/168a00c3-5303-4f7d-a66a-de6f132e715f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231116%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231116T143922Z&X-Amz-Expires=300&X-Amz-Signature=40688f968c0b961fdf3106dcf11f4c95c9a4feefd0af722afc71a6985dac8066&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.0.0-macOS-Apple.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/13233158/168a00c3-5303-4f7d-a66a-de6f132e715f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231116%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231116T143922Z&X-Amz-Expires=300&X-Amz-Signature=40688f968c0b961fdf3106dcf11f4c95c9a4feefd0af722afc71a6985dac8066&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.0.0-macOS-Apple.dmg&response-content-type=application%2Foctet-stream HTTP/2

> Host: objects.githubusercontent.com

> User-Agent: curl/8.4.0

> Accept: */*

>

< HTTP/2 200

< content-type: application/octet-stream

< content-md5: lS2ozKmCCMb5v7LV9CxUYA==

< last-modified: Fri, 10 Nov 2023 22:36:27 GMT

< etag: "0x8DBE23D7A527F00"

< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0

< x-ms-request-id: 97aff2f6-a01e-0041-5afd-14b9b1000000

< x-ms-version: 2020-04-08

< x-ms-creation-time: Fri, 10 Nov 2023 22:36:27 GMT

< x-ms-lease-status: unlocked

< x-ms-lease-state: available

< x-ms-blob-type: BlockBlob

< content-disposition: attachment; filename=OBS-Studio-30.0.0-macOS-Apple.dmg

< x-ms-server-encrypted: true

< via: 1.1 varnish, 1.1 varnish

< accept-ranges: bytes

< age: 3372

< date: Thu, 16 Nov 2023 14:39:22 GMT

< x-served-by: cache-iad-kjyo7100080-IAD, cache-chi-klot8100151-CHI

< x-cache: HIT, HIT

< x-cache-hits: 320, 0

< x-timer: S1700145562.129490,VS0,VE49

< content-length: 167185085

<

{ [8259 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-11-16 09:39:24 : REQ   : obs : no more blocking processes, continue with update
2023-11-16 09:39:24 : REQ   : obs : Installing OBS
2023-11-16 09:39:24 : INFO  : obs : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uglPDxlMge/obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:26 : DEBUG : obs : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $4F1E1C6E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $507B608B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $B02C609C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $921846D8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $B02C609C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $85E1E85B
verified   CRC32 $F2112CCD
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/OBS Studio 30.0.0 (Apple)

2023-11-16 09:39:26 : INFO  : obs : Mounted: /Volumes/OBS Studio 30.0.0 (Apple) 2023-11-16 09:39:26 : INFO  : obs : Verifying: /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app 2023-11-16 09:39:26 : DEBUG : obs : App size: 391M	/Volumes/OBS Studio 30.0.0 (Apple)/OBS.app 2023-11-16 09:39:29 : DEBUG : obs : Debugging enabled, App Verification output was: /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Wizards of OBS LLC (2MMRE5MTB8)

2023-11-16 09:39:29 : INFO  : obs : Team ID matching: 2MMRE5MTB8 (expected: 2MMRE5MTB8 ) 2023-11-16 09:39:29 : INFO  : obs : Installing OBS version 30.0.0 on versionKey CFBundleShortVersionString. 2023-11-16 09:39:29 : INFO  : obs : App has LSMinimumSystemVersion: 11.0 2023-11-16 09:39:29 : INFO  : obs : Copy /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app to /Applications 2023-11-16 09:39:33 : DEBUG : obs : Debugging enabled, App copy output was: Copying /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app

2023-11-16 09:39:33 : WARN  : obs : Changing owner to mam5hs 2023-11-16 09:39:33 : INFO  : obs : Finishing...
2023-11-16 09:39:36 : INFO  : obs : App(s) found: /Applications/OBS.app 2023-11-16 09:39:36 : INFO  : obs : found app at /Applications/OBS.app, version 30.0.0, on versionKey CFBundleShortVersionString
2023-11-16 09:39:36 : REQ   : obs : Installed OBS, version 30.0.0
2023-11-16 09:39:36 : DEBUG : obs : Unmounting /Volumes/OBS Studio 30.0.0 (Apple)
2023-11-16 09:39:37 : DEBUG : obs : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-11-16 09:39:37 : DEBUG : obs : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uglPDxlMge
2023-11-16 09:39:37 : DEBUG : obs : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uglPDxlMge/obs-studio-[0-9.]*-macOS-Apple.dmg
2023-11-16 09:39:37 : DEBUG : obs : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uglPDxlMge
2023-11-16 09:39:37 : INFO  : obs : Installomator did not close any apps, so no need to reopen any apps.
2023-11-16 09:39:37 : REQ   : obs : All done!
2023-11-16 09:39:37 : REQ   : obs : ################## End Installomator, exit code 0