### PR TITLE
SwiftDialog Version Check - Consider Tag Bundle/Build for Swift Dialog to Update

### DIFF
--- a/MDM/Jamf/-0_Install swiftDialog direct.sh
+++ b/MDM/Jamf/-0_Install swiftDialog direct.sh
@@ -119,26 +119,36 @@ if [[ "$(echo $downloadURL | grep -ioE "https.*.$filetype")" == "" ]]; then
     #downloadURL="https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)"
     downloadURL="https://github.com$(curl -sfL "$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "expanded_assets" | head -1)" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)"
 fi
-#echo "$downloadURL"
-appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
+#echo "$downloadURL"rawVersionString=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1)
+
+# Get Github Version
+appNewVersion=$(echo "$rawVersionString" | awk -F '-' '{print $1}' | sed 's/[^0-9\.]//g' | sed 's/\.$//')
+
+# Get Github BundleVersion
+appNewBundleVersion=$(echo "$rawVersionString" | awk '{sub(/-/," ")}1' | awk '{print $2}' | sed 's/\r//g')
+
 #echo "$appNewVersion"
 expectedTeamID="PWA5E9TQ59"
 destFile="/Library/Application Support/Dialog/Dialog.app"
-versionKey="CFBundleShortVersionString" #CFBundleVersion
+versionKey="CFBundleShortVersionString"
+bundleVersionKey="CFBundleVersion"
+
 currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$versionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
-echo "${name} version installed: $currentInstalledVersion"
+currentInstalledBundleVersion="$(/usr/libexec/PlistBuddy -c "Print :$bundleVersionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
+
+echo "${name} version installed: $currentInstalledVersion bundleVersion: $currentInstalledBundleVersion"
 
 destFile2="/usr/local/bin/dialog"
 # NOTE: Condition for installation
-if [[ ! -d "${destFile}" || ! -x "${destFile2}" || "$currentInstalledVersion" != "$appNewVersion" || "$INSTALL" == "force" ]]; then
+if [[ ! -d "${destFile}" || ! -x "${destFile2}" || "$currentInstalledVersion" != "$appNewVersion" || "$currentInstalledBundleVersion" != "$appNewBundleVersion" || "$INSTALL" == "force" ]]; then
     echo "$name not found, version not latest, icon for Dialog was changed."
     echo "${destFile}"
-    echo "Installing version ${appNewVersion}…"
+    echo "Installing version ${appNewVersion} ${appNewBundleVersion}…"
     # Create temporary working directory
     tmpDir="$(mktemp -d || true)"
     echo "Created working directory '$tmpDir'"
     # Download the installer package
-    echo "Downloading $name package version $appNewVersion from: $downloadURL"
+    echo "Downloading $name package version $appNewVersion $appNewBundleVersion from: $downloadURL"
     installationCount=0
     exitCode=9
     while [[ $installationCount -lt 3 && $exitCode -gt 0 ]]; do

--- a/MDM/Jamf/-0_Install swiftDialog direct.sh
+++ b/MDM/Jamf/-0_Install swiftDialog direct.sh
@@ -201,8 +201,8 @@ if [[ ! -d "${destFile}" || ! -x "${destFile2}" || "$currentInstalledVersion" !=
         echo "ERROR : Installation of $name failed. Aborting."
         caffexit $exitCode
     else
-        echo "$name version $appNewVersion installed!"
+        echo "$name version $appNewVersion $appNewBundleVersion installed!"
     fi
 else
-    echo "$name version $appNewVersion already found. Perfect!"
+    echo "$name version $appNewVersion $appNewBundleVersion already found. Perfect!"
 fi

--- a/MDM/Progress 1st swiftDialog.sh
+++ b/MDM/Progress 1st swiftDialog.sh
@@ -335,10 +335,10 @@ if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" || "$
         printlog "ERROR. Installation of $name failed. Aborting."
         caffexit $exitCode
     else
-        printlog "$name version $appNewVersion installed!"
+        printlog "$name version $appNewVersion $appNewBundleVersion installed!"
     fi
 else
-    printlog "$name version $appNewVersion already found. Perfect!"
+    printlog "$name version $appNewVersion $appNewBundleVersion already found. Perfect!"
 fi
 
 

--- a/MDM/Progress 1st swiftDialog.sh
+++ b/MDM/Progress 1st swiftDialog.sh
@@ -89,7 +89,8 @@ errorMessage="A problem was encountered setting up this Mac. Please contact IT."
 #      Or fonts, like:
 #       "Apple SF Pro Font,/Library/Fonts/SF-Pro.ttf"
 ######################################################################
-scriptVersion="9.8"
+scriptVersion="9.9"
+# v.  9.9   : 2023-11-19 : Consider the bundle version where if the bundle version differs it will update, fixes problem where bundleversion and bundle get concatenated and it updates all the time even if version is the same.
 # v.  9.8   : 2023-10-06 : Support for FileWave, and previously Kandji. Update Progress 1st swiftDialog.sh to use native checkmark #1220
 # v.  9.7   : 2022-12-19 : Fix for LOGO_PATH for ws1
 # v.  9.6   : 2022-11-15 : GitHub API call is first, only try alternative if that fails.
@@ -276,12 +277,12 @@ destFile="/usr/local/bin/dialog"
 if [[ ! -e "${destFile}" || "$currentInstalledVersion" != "$appNewVersion" || "$currentInstalledBundleVersion" != "$appNewBundleVersion" ]]; then
     printlog "$name not found or version not latest."
     printlog "${destFile}"
-    printlog "Installing version ${appNewVersion}…"
+    printlog "Installing version ${appNewVersion} ${appNewBundleVersion}…"
     # Create temporary working directory
     tmpDir="$(mktemp -d || true)"
     printlog "Created working directory '$tmpDir'"
     # Download the installer package
-    printlog "Downloading $name package version $appNewVersion from: $downloadURL"
+    printlog "Downloading $name package version $appNewVersion $appNewBundleVersion from: $downloadURL"
     installationCount=0
     exitCode=9
     while [[ $installationCount -lt 3 && $exitCode -gt 0 ]]; do

--- a/MDM/install swiftDialog direct.sh
+++ b/MDM/install swiftDialog direct.sh
@@ -142,25 +142,38 @@ if [[ "$(echo $downloadURL | grep -ioE "https.*.$filetype")" == "" ]]; then
     downloadURL="https://github.com$(curl -sfL "$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "expanded_assets" | head -1)" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1)"
 fi
 #printlog "$downloadURL"
-appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
-#printlog "$appNewVersion"
+rawVersionString=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1)
+
+# Get Github Version
+appNewVersion=$(echo "$rawVersionString" | awk -F '-' '{print $1}' | sed 's/[^0-9\.]//g' | sed 's/\.$//')
+
+# Get Github BundleVersion
+appNewBundleVersion=$(echo "$rawVersionString" | awk '{sub(/-/," ")}1' | awk '{print $2}' | sed 's/\r//g')
+
 expectedTeamID="PWA5E9TQ59"
 destFile="/Library/Application Support/Dialog/Dialog.app"
-versionKey="CFBundleShortVersionString" #CFBundleVersion
-currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$versionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
-printlog "${name} version installed: $currentInstalledVersion"
+versionKey="CFBundleShortVersionString"
+bundleVersionKey="CFBundleVersion"
 
+# Get App Version
+currentInstalledVersion="$(defaults read "${destFile}/Contents/Info.plist" $versionKey || true)"
+# currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$versionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
+
+# Get App BundleVersion
+currentInstalledBundleVersion="$(defaults read "${destFile}/Contents/Info.plist" $bundleVersionKey || true)"
+
+printlog "${name} version: $currentInstalledVersion bundleVersion: $currentInstalledBundleVersion"
 destFile2="/usr/local/bin/dialog"
 # NOTE: Condition for installation
-if [[ ! -d "${destFile}" || ! -x "${destFile2}" || "$currentInstalledVersion" != "$appNewVersion" || "$INSTALL" == "force" ]]; then
+if [[ ! -d "${destFile}" || ! -x "${destFile2}" || || "$currentInstalledVersion" != "$appNewVersion" || "$currentInstalledBundleVersion" != "$appNewBundleVersion" || "$INSTALL" == "force" ]]; then
     printlog "$name not found, version not latest, icon for Dialog was changed."
     printlog "${destFile}"
-    printlog "Installing version ${appNewVersion}…"
+    printlog "Installing version ${appNewVersion} ${appNewBundleVersion}…"
     # Create temporary working directory
     tmpDir="$(mktemp -d || true)"
     printlog "Created working directory '$tmpDir'"
     # Download the installer package
-    printlog "Downloading $name package version $appNewVersion from: $downloadURL"
+    printlog "Downloading $name package version $appNewVersion $appNewBundleVersion from: $downloadURL"
     installationCount=0
     exitCode=9
     while [[ $installationCount -lt 3 && $exitCode -gt 0 ]]; do

--- a/MDM/install swiftDialog direct.sh
+++ b/MDM/install swiftDialog direct.sh
@@ -156,11 +156,10 @@ versionKey="CFBundleShortVersionString"
 bundleVersionKey="CFBundleVersion"
 
 # Get App Version
-currentInstalledVersion="$(defaults read "${destFile}/Contents/Info.plist" $versionKey || true)"
-# currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$versionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
+currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$versionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
 
 # Get App BundleVersion
-currentInstalledBundleVersion="$(defaults read "${destFile}/Contents/Info.plist" $bundleVersionKey || true)"
+currentInstalledVersion="$(/usr/libexec/PlistBuddy -c "Print :$bundleVersionKey" "${destFile}/Contents/Info.plist" | tr -d "[:special:]" || true)"
 
 printlog "${name} version: $currentInstalledVersion bundleVersion: $currentInstalledBundleVersion"
 destFile2="/usr/local/bin/dialog"

--- a/MDM/install swiftDialog direct.sh
+++ b/MDM/install swiftDialog direct.sh
@@ -226,10 +226,10 @@ if [[ ! -d "${destFile}" || ! -x "${destFile2}" || || "$currentInstalledVersion"
         printlog "ERROR : Installation of $name failed. Aborting."
         caffexit $exitCode
     else
-        printlog "$name version $appNewVersion installed!"
+        printlog "$name version $appNewVersion $appNewBundleVersion installed!"
     fi
 else
-    printlog "$name version $appNewVersion already found. Perfect!"
+    printlog "$name version $appNewVersion $appNewBundleVersion already found. Perfect!"
 fi
 
 printlog "$(date +%F\ %T) : [LOG-END] ${log_message}"


### PR DESCRIPTION
There is an issue in checking version for Swift Dialog update install scripts.

Swift Dialog Github release tags now include a build/bundle id in its tags. For example: [v2.3.3-4734](https://github.com/swiftDialog/swiftDialog/releases/tag/v2.3.3-4734)

This means the old way of checking versions was as follows:

```bash
appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
echo $appNewVersion
$> "2.3.34734"
```

And comparing "2.3.34734" against "2.3.3" from the defaults plist are different and so it will attempt to reinstall every time.

The changes in this PR allows to split the tag by version (2.3.3) and build (4734) and comparing against the plist CFBundleShortVersionString and CFBundleVersion

The logic is if Version don't match (e.g.  2.3.1 and 2.3.0) OR build don't match (e.g. 4734 and 3425) then update.



```
ACCTECH@mac Installomator % ./MDM/Progress\ 1st\ swiftDialog.sh 
2023-11-19 01:06:17 :: P1st-v9.9 : [LOG-BEGIN] e: Progress 1st with Dialog, v9.9
2023-11-19 01:06:17 :: P1st-v9.9 : Total watched installations: 25
2023-11-19 01:06:17 :: P1st-v9.9 : LOGO: appstore – LOGO_PATH: /System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-19 01:06:17 :: P1st-v9.9 : Dialog check for installation
2023-11-19 01:06:19 :: P1st-v9.9 : Dialog version: 2.3.3 bundleVersion: 4734
2023-11-19 01:06:19 :: P1st-v9.9 : Dialog version 2.3.3 4734 already found. Perfect!
2023-11-19 01:06:19 :: P1st-v9.9 : Out of Setup Assistant.
2023-11-19 01:06:19 :: P1st-v9.9 : Finder is running…
```