### PR TITLE
FIXED: Blender error -ERROR : blender : need to provide 'downloadURL' #1342

### DIFF
--- a/fragments/labels/blender.sh
+++ b/fragments/labels/blender.sh
@@ -1,6 +1,5 @@
 blender)
-    name="blender"
-    appName="$name.app"
+    name="Blender"
     type="dmg"
     versionKey="CFBundleShortVersionString"
     appNewVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/ | grep -o 'Blender[0-9]\+\.[0-9]\+' | cut -d 'r' -f 2 | sort -V | tail -1)
@@ -11,6 +10,5 @@ blender)
         archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/" | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-x64\.dmg' | sort -V | tail -1)
         downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/$archiveName"
     fi
-    blockingProcesses=( "Blender" )
     expectedTeamID="68UA947AUU"
     ;;

--- a/fragments/labels/blender.sh
+++ b/fragments/labels/blender.sh
@@ -1,11 +1,16 @@
 blender)
     name="blender"
+    appName="$name.app"
     type="dmg"
+    versionKey="CFBundleShortVersionString"
+    appNewVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/ | grep -o 'Blender[0-9]\+\.[0-9]\+' | cut -d 'r' -f 2 | sort -V | tail -1)
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -sfL "https://www.blender.org/download/" | xmllint --html --format - 2>/dev/null | grep -o "https://.*blender.*arm64.*.dmg" | sed '2p;d' | sed 's/www.blender.org\/download/download.blender.org/g')
+        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/"| grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-arm64\.dmg' | sort -V | tail -1)
+        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/$archiveName"
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL=$(curl -sfL "https://www.blender.org/download/" | xmllint --html --format - 2>/dev/null | grep -o "https://.*blender.*x64.*.dmg" | sed '2p;d' | sed 's/www.blender.org\/download/download.blender.org/g')
+        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/" | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-x64\.dmg' | sort -V | tail -1)
+        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/$archiveName"
     fi
-    appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)-.*/\1/g' )
+    blockingProcesses=( "Blender" )
     expectedTeamID="68UA947AUU"
     ;;


### PR DESCRIPTION
The old download url seems to be behind cloudflare and it is harder to scrape.  Fortunately Blender also uses a public ftp to download from which is much easier to scrape.  The label has been updated to fix this issue.

2023-11-22 13:12:19 : REQ   : blender : ################## Start Installomator v. 10.6beta, date 2023-11-22
2023-11-22 13:12:19 : INFO  : blender : ################## Version: 10.6beta
2023-11-22 13:12:19 : INFO  : blender : ################## Date: 2023-11-22
2023-11-22 13:12:19 : INFO  : blender : ################## blender
2023-11-22 13:12:19 : DEBUG : blender : DEBUG mode 1 enabled.
2023-11-22 13:12:22 : DEBUG : blender : name=blender
2023-11-22 13:12:22 : DEBUG : blender : appName=blender.app
2023-11-22 13:12:22 : DEBUG : blender : type=dmg
2023-11-22 13:12:22 : DEBUG : blender : archiveName=blender-4.0.1-macos-arm64.dmg
2023-11-22 13:12:22 : DEBUG : blender : downloadURL=https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.0/blender-4.0.1-macos-arm64.dmg
2023-11-22 13:12:22 : DEBUG : blender : curlOptions=
2023-11-22 13:12:22 : DEBUG : blender : appNewVersion=4.0
2023-11-22 13:12:22 : DEBUG : blender : appCustomVersion function: Not defined
2023-11-22 13:12:22 : DEBUG : blender : versionKey=CFBundleShortVersionString
2023-11-22 13:12:22 : DEBUG : blender : packageID=
2023-11-22 13:12:22 : DEBUG : blender : pkgName=
2023-11-22 13:12:22 : DEBUG : blender : choiceChangesXML=
2023-11-22 13:12:22 : DEBUG : blender : expectedTeamID=68UA947AUU
2023-11-22 13:12:22 : DEBUG : blender : blockingProcesses=Blender
2023-11-22 13:12:22 : DEBUG : blender : installerTool=
2023-11-22 13:12:22 : DEBUG : blender : CLIInstaller=
2023-11-22 13:12:22 : DEBUG : blender : CLIArguments=
2023-11-22 13:12:22 : DEBUG : blender : updateTool=
2023-11-22 13:12:22 : DEBUG : blender : updateToolArguments=
2023-11-22 13:12:22 : DEBUG : blender : updateToolRunAsCurrentUser=
2023-11-22 13:12:22 : INFO  : blender : BLOCKING_PROCESS_ACTION=tell_user
2023-11-22 13:12:22 : INFO  : blender : NOTIFY=success
2023-11-22 13:12:22 : INFO  : blender : LOGGING=DEBUG
2023-11-22 13:12:22 : INFO  : blender : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-22 13:12:22 : INFO  : blender : Label type: dmg
2023-11-22 13:12:23 : INFO  : blender : archiveName: blender-4.0.1-macos-arm64.dmg
2023-11-22 13:12:23 : DEBUG : blender : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-22 13:12:23 : INFO  : blender : App(s) found: /Applications/blender.app
2023-11-22 13:12:23 : INFO  : blender : found app at /Applications/blender.app, version 3.6.4, on versionKey CFBundleShortVersionString
2023-11-22 13:12:23 : INFO  : blender : appversion: 3.6.4
2023-11-22 13:12:23 : INFO  : blender : Latest version of blender is 4.0
2023-11-22 13:12:23 : REQ   : blender : Downloading https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.0/blender-4.0.1-macos-arm64.dmg to blender-4.0.1-macos-arm64.dmg
2023-11-22 13:12:23 : DEBUG : blender : No Dialog connection, just download
2023-11-22 13:13:07 : DEBUG : blender : File list: -rw-r--r--  1 someuser  staff   241M Nov 22 13:13 blender-4.0.1-macos-arm64.dmg
2023-11-22 13:13:08 : DEBUG : blender : File type: blender-4.0.1-macos-arm64.dmg: zlib compressed data
2023-11-22 13:13:08 : DEBUG : blender : curl output was:
*   Trying 145.220.21.40:443...
* Connected to ftp.nluug.nl (145.220.21.40) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4262 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=ftp.nluug.nl
*  start date: Oct 16 04:07:10 2023 GMT
*  expire date: Jan 14 04:07:09 2024 GMT
*  subjectAltName: host "ftp.nluug.nl" matched cert's "ftp.nluug.nl"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /pub/graphics/blender/release/Blender4.0/blender-4.0.1-macos-arm64.dmg HTTP/1.1
> Host: ftp.nluug.nl
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 22 Nov 2023 10:12:24 GMT
< Server: Apache/2.2.15 (CentOS)
< Last-Modified: Fri, 17 Nov 2023 10:03:55 GMT
< ETag: "6050ee247-f0a7b74-60a56410ee3b2"
< Accept-Ranges: bytes
< Content-Length: 252345204
< Content-Type: application/octet-stream
<
{ [8000 bytes data]
* Connection #0 to host ftp.nluug.nl left intact

2023-11-22 13:13:08 : DEBUG : blender : DEBUG mode 1, not checking for blocking processes
2023-11-22 13:13:08 : REQ   : blender : Installing blender
2023-11-22 13:13:08 : INFO  : blender : Mounting /Users/someuser/Documents/GitHub/Installomator/build/blender-4.0.1-macos-arm64.dmg
2023-11-22 13:13:12 : DEBUG : blender : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1BDBB139
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $68A3D584
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $603B1024
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A2335723
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $603B1024
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $F5749613
verified   CRC32 $047AD310
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/Blender

2023-11-22 13:13:12 : INFO  : blender : Mounted: /Volumes/Blender 2023-11-22 13:13:12 : INFO  : blender : Verifying: /Volumes/Blender/blender.app 2023-11-22 13:13:12 : DEBUG : blender : App size: 678M  /Volumes/Blender/blender.app 2023-11-22 13:13:16 : DEBUG : blender : Debugging enabled, App Verification output was: /Volumes/Blender/blender.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Stichting Blender Foundation (68UA947AUU)

2023-11-22 13:13:16 : INFO  : blender : Team ID matching: 68UA947AUU (expected: 68UA947AUU ) 2023-11-22 13:13:16 : INFO  : blender : Downloaded version of blender is 4.0.1 on versionKey CFBundleShortVersionString (replacing version 3.6.4). 2023-11-22 13:13:16 : INFO  : blender : App has LSMinimumSystemVersion: 10.13 2023-11-22 13:13:16 : DEBUG : blender : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-11-22 13:13:16 : INFO  : blender : Finishing... 2023-11-22 13:13:19 : INFO  : blender : App(s) found: /Applications/blender.app 2023-11-22 13:13:19 : INFO  : blender : found app at /Applications/blender.app, version 3.6.4, on versionKey CFBundleShortVersionString
2023-11-22 13:13:19 : REQ   : blender : Installed blender, version 4.0.1
2023-11-22 13:13:19 : INFO  : blender : notifying
2023-11-22 13:13:20 : DEBUG : blender : Unmounting /Volumes/Blender
2023-11-22 13:13:20 : DEBUG : blender : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-11-22 13:13:20 : DEBUG : blender : DEBUG mode 1, not reopening anything
2023-11-22 13:13:20 : REQ   : blender : All done!
2023-11-22 13:13:20 : REQ   : blender : ################## End Installomator, exit code 0