### PR TITLE
FIXED: OBS file name format changed #1335

### DIFF
--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -2,11 +2,14 @@ obs)
     name="OBS"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="obs-studio-[0-9.]*-macos-arm64.dmg"
+        SUFeedURL="https://obsproject.com/osx_update/updates_arm64_v2.xml"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="obs-studio-[0-9.]*-macos-x86_64.dmg"
+        SUFeedURL="https://obsproject.com/osx_update/updates_x86_64_v2.xml"
     fi
-    downloadURL=$(downloadURLFromGit obsproject obs-studio )
-    appNewVersion=$(versionFromGit obsproject obs-studio )
+    appNewVersion=$(curl -fs "$SUFeedURL" | xpath '(//rss/channel/item[sparkle:channel="stable"]/sparkle:shortVersionString/text())[1]' 2>/dev/null)
+    downloadURL=$(curl -fs "$SUFeedURL" | xpath 'string(//rss/channel/item[sparkle:channel="stable"]/enclosure/@url[1])' 2>/dev/null)
+    archiveName=$(basename "$downloadURL")   
+    versionKey="CFBundleShortVersionString"
+    blockingProcesses=( "OBS Studio" )
     expectedTeamID="2MMRE5MTB8"
     ;;


### PR DESCRIPTION
Updated the OBS label to use the sparkle feed, it seems more robust than the github approach.

2023-11-22 17:35:33 : REQ   : obs : ################## Start Installomator v. 10.6beta, date 2023-11-22
2023-11-22 17:35:33 : INFO  : obs : ################## Version: 10.6beta
2023-11-22 17:35:33 : INFO  : obs : ################## Date: 2023-11-22
2023-11-22 17:35:33 : INFO  : obs : ################## obs
2023-11-22 17:35:33 : DEBUG : obs : DEBUG mode 1 enabled.
2023-11-22 17:35:35 : DEBUG : obs : name=OBS
2023-11-22 17:35:35 : DEBUG : obs : appName=
2023-11-22 17:35:35 : DEBUG : obs : type=dmg
2023-11-22 17:35:35 : DEBUG : obs : archiveName=obs-studio-30.0.0-macos-apple.dmg
2023-11-22 17:35:35 : DEBUG : obs : downloadURL=https://cdn-fastly.obsproject.com/downloads/obs-studio-30.0.0-macos-apple.dmg
2023-11-22 17:35:35 : DEBUG : obs : curlOptions=
2023-11-22 17:35:35 : DEBUG : obs : appNewVersion=30.0.0
2023-11-22 17:35:35 : DEBUG : obs : appCustomVersion function: Not defined
2023-11-22 17:35:35 : DEBUG : obs : versionKey=CFBundleShortVersionString
2023-11-22 17:35:35 : DEBUG : obs : packageID=
2023-11-22 17:35:35 : DEBUG : obs : pkgName=
2023-11-22 17:35:35 : DEBUG : obs : choiceChangesXML=
2023-11-22 17:35:35 : DEBUG : obs : expectedTeamID=2MMRE5MTB8
2023-11-22 17:35:35 : DEBUG : obs : blockingProcesses=OBS Studio
2023-11-22 17:35:35 : DEBUG : obs : installerTool=
2023-11-22 17:35:35 : DEBUG : obs : CLIInstaller=
2023-11-22 17:35:35 : DEBUG : obs : CLIArguments=
2023-11-22 17:35:35 : DEBUG : obs : updateTool=
2023-11-22 17:35:35 : DEBUG : obs : updateToolArguments=
2023-11-22 17:35:35 : DEBUG : obs : updateToolRunAsCurrentUser=
2023-11-22 17:35:35 : INFO  : obs : BLOCKING_PROCESS_ACTION=tell_user
2023-11-22 17:35:35 : INFO  : obs : NOTIFY=success
2023-11-22 17:35:35 : INFO  : obs : LOGGING=DEBUG
2023-11-22 17:35:35 : INFO  : obs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-22 17:35:35 : INFO  : obs : Label type: dmg
2023-11-22 17:35:35 : INFO  : obs : archiveName: obs-studio-30.0.0-macos-apple.dmg
2023-11-22 17:35:35 : DEBUG : obs : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-22 17:35:35 : INFO  : obs : App(s) found: /Applications/OBS.app
2023-11-22 17:35:35 : INFO  : obs : found app at /Applications/OBS.app, version 29.1.3, on versionKey CFBundleShortVersionString
2023-11-22 17:35:35 : INFO  : obs : appversion: 29.1.3
2023-11-22 17:35:35 : INFO  : obs : Latest version of OBS is 30.0.0
2023-11-22 17:35:35 : INFO  : obs : obs-studio-30.0.0-macos-apple.dmg exists and DEBUG mode 1 enabled, skipping download
2023-11-22 17:35:35 : DEBUG : obs : DEBUG mode 1, not checking for blocking processes
2023-11-22 17:35:35 : REQ   : obs : Installing OBS
2023-11-22 17:35:35 : INFO  : obs : Mounting /Users/someuser/Documents/GitHub/Installomator/build/obs-studio-30.0.0-macos-apple.dmg
2023-11-22 17:35:36 : DEBUG : obs : Debugging enabled, dmgmount output was:
expected   CRC32 $F2112CCD
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/OBS Studio 30.0.0 (Apple)

2023-11-22 17:35:36 : INFO  : obs : Mounted: /Volumes/OBS Studio 30.0.0 (Apple) 2023-11-22 17:35:36 : INFO  : obs : Verifying: /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app
2023-11-22 17:35:36 : DEBUG : obs : App size: 391M      /Volumes/OBS Studio 30.0.0 (Apple)/OBS.app
2023-11-22 17:35:40 : DEBUG : obs : Debugging enabled, App Verification output was:
/Volumes/OBS Studio 30.0.0 (Apple)/OBS.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Wizards of OBS LLC (2MMRE5MTB8)

2023-11-22 17:35:40 : INFO  : obs : Team ID matching: 2MMRE5MTB8 (expected: 2MMRE5MTB8 ) 2023-11-22 17:35:40 : INFO  : obs : Downloaded version of OBS is 30.0.0 on versionKey CFBundleShortVersionString (replacing version 29.1.3). 2023-11-22 17:35:40 : INFO  : obs : App has LSMinimumSystemVersion: 11.0 2023-11-22 17:35:40 : DEBUG : obs : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-11-22 17:35:40 : INFO  : obs : Finishing...
2023-11-22 17:35:43 : INFO  : obs : App(s) found: /Applications/OBS.app 2023-11-22 17:35:44 : INFO  : obs : found app at /Applications/OBS.app, version 29.1.3, on versionKey CFBundleShortVersionString
2023-11-22 17:35:44 : REQ   : obs : Installed OBS, version 30.0.0
2023-11-22 17:35:44 : INFO  : obs : notifying
2023-11-22 17:35:44 : DEBUG : obs : Unmounting /Volumes/OBS Studio 30.0.0 (Apple)
2023-11-22 17:35:44 : DEBUG : obs : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-11-22 17:35:44 : DEBUG : obs : DEBUG mode 1, not reopening anything
2023-11-22 17:35:44 : REQ   : obs : All done!
2023-11-22 17:35:44 : REQ   : obs : ################## End Installomator, exit code 0