### PR TITLE
Update virtualbox.sh

### DIFF
--- a/fragments/labels/virtualbox.sh
+++ b/fragments/labels/virtualbox.sh
@@ -8,7 +8,7 @@ virtualbox)
     elif [[ $(arch) == arm64 ]]; then
         platform="macOSArm64"
     fi
-    downloadURL="https:$(curl -fsL "https://www.oracle.com/jp/virtualization/technologies/vm/downloads/virtualbox-downloads.html" | grep "${platform}.dmg" | xmllint --html --xpath 'string(//a/@href)' -)"
+    downloadURL="https:$(curl -fsL "https://www.oracle.com/virtualization/technologies/vm/downloads/virtualbox-downloads.html" | grep "${platform}.dmg" | xmllint --html --xpath 'string(//a/@href)' -)"
     appNewVersion=$(echo "${downloadURL}" | awk -F '/' '{print $5}')
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
The VirtualBox label/fragment now downloads from the Japanese URL and is returning an old version: 7.0.10, while the URL without a country specified is giving the latest version 7.0.12.

We could change the url from:
https://www.oracle.com/jp/virtualization/technologies/vm/downloads/virtualbox-downloads.html
to
https://www.oracle.com/virtualization/technologies/vm/downloads/virtualbox-downloads.html