### PR TITLE
Fixed: fix vlc label #1287

### DIFF
--- a/fragments/labels/vlc.sh
+++ b/fragments/labels/vlc.sh
@@ -6,6 +6,5 @@ vlc)
     downloadURL="${latestVersionURL}${archiveName}"
     appNewVersion=$(awk -F'[-.]' '{print $2"."$3"."$4}' <<< "$archiveName")
     versionKey="CFBundleShortVersionString"
-    blockingProcesses=( "VLC" )
     expectedTeamID="75GAHG3SZQ"
     ;;

--- a/fragments/labels/vlc.sh
+++ b/fragments/labels/vlc.sh
@@ -1,13 +1,11 @@
 vlc)
     name="VLC"
     type="dmg"
-    if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-arm64.xml | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 )
-        #appNewVersion=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-arm64.xml | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2 )
-    elif [[ $(arch) == "i386" ]]; then
-        downloadURL=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-intel64.xml | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 )
-        #appNewVersion=$(curl -fs http://update.videolan.org/vlc/sparkle/vlc-intel64.xml | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2 )
-    fi
-    appNewVersion=$(echo ${downloadURL} | sed -E 's/.*\/vlc-([0-9.]*).*\.dmg/\1/' )
+    latestVersionURL="https://get.videolan.org/vlc/last/macosx/"
+    archiveName=$(curl -sf "$latestVersionURL" | grep -ioE 'vlc-[0-9]+\.[0-9]+\.[0-9]+-universal\.dmg' | uniq)
+    downloadURL="${latestVersionURL}${archiveName}"
+    appNewVersion=$(awk -F'[-.]' '{print $2"."$3"."$4}' <<< "$archiveName")
+    versionKey="CFBundleShortVersionString"
+    blockingProcesses=( "VLC" )
     expectedTeamID="75GAHG3SZQ"
     ;;


### PR DESCRIPTION
Replaced the conditional URLs with universal URL and DMG and added recommended variables.  Made grep more flexible incase of file name change in the future.

2023-11-23 12:02:03 : REQ   : vlc : ################## Start Installomator v. 10.6beta, date 2023-11-23
2023-11-23 12:02:03 : INFO  : vlc : ################## Version: 10.6beta
2023-11-23 12:02:03 : INFO  : vlc : ################## Date: 2023-11-23
2023-11-23 12:02:03 : INFO  : vlc : ################## vlc
2023-11-23 12:02:03 : DEBUG : vlc : DEBUG mode 1 enabled.
2023-11-23 12:02:06 : DEBUG : vlc : name=VLC
2023-11-23 12:02:06 : DEBUG : vlc : appName=
2023-11-23 12:02:06 : DEBUG : vlc : type=dmg
2023-11-23 12:02:06 : DEBUG : vlc : archiveName=vlc-3.0.20-universal.dmg
2023-11-23 12:02:06 : DEBUG : vlc : downloadURL=https://get.videolan.org/vlc/last/macosx/vlc-3.0.20-universal.dmg
2023-11-23 12:02:06 : DEBUG : vlc : curlOptions=
2023-11-23 12:02:06 : DEBUG : vlc : appNewVersion=3.0.20
2023-11-23 12:02:06 : DEBUG : vlc : appCustomVersion function: Not defined
2023-11-23 12:02:06 : DEBUG : vlc : versionKey=CFBundleShortVersionString
2023-11-23 12:02:06 : DEBUG : vlc : packageID=
2023-11-23 12:02:06 : DEBUG : vlc : pkgName=
2023-11-23 12:02:06 : DEBUG : vlc : choiceChangesXML=
2023-11-23 12:02:06 : DEBUG : vlc : expectedTeamID=75GAHG3SZQ
2023-11-23 12:02:06 : DEBUG : vlc : blockingProcesses=VLC
2023-11-23 12:02:06 : DEBUG : vlc : installerTool=
2023-11-23 12:02:06 : DEBUG : vlc : CLIInstaller=
2023-11-23 12:02:06 : DEBUG : vlc : CLIArguments=
2023-11-23 12:02:06 : DEBUG : vlc : updateTool=
2023-11-23 12:02:06 : DEBUG : vlc : updateToolArguments=
2023-11-23 12:02:06 : DEBUG : vlc : updateToolRunAsCurrentUser=
2023-11-23 12:02:06 : INFO  : vlc : BLOCKING_PROCESS_ACTION=tell_user
2023-11-23 12:02:06 : INFO  : vlc : NOTIFY=success
2023-11-23 12:02:06 : INFO  : vlc : LOGGING=DEBUG
2023-11-23 12:02:06 : INFO  : vlc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-23 12:02:06 : INFO  : vlc : Label type: dmg
2023-11-23 12:02:06 : INFO  : vlc : archiveName: vlc-3.0.20-universal.dmg
2023-11-23 12:02:06 : DEBUG : vlc : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-23 12:02:06 : INFO  : vlc : App(s) found: /Applications/VLC.app
2023-11-23 12:02:06 : INFO  : vlc : found app at /Applications/VLC.app, version 3.0.18, on versionKey CFBundleShortVersionString
2023-11-23 12:02:06 : INFO  : vlc : appversion: 3.0.18
2023-11-23 12:02:06 : INFO  : vlc : Latest version of VLC is 3.0.20
2023-11-23 12:02:06 : REQ   : vlc : Downloading https://get.videolan.org/vlc/last/macosx/vlc-3.0.20-universal.dmg to vlc-3.0.20-universal.dmg
2023-11-23 12:02:06 : DEBUG : vlc : No Dialog connection, just download
2023-11-23 12:02:51 : DEBUG : vlc : File list: -rw-r--r--  1 someuser  staff    81M Nov 23 12:02 vlc-3.0.20-universal.dmg
2023-11-23 12:02:51 : DEBUG : vlc : File type: vlc-3.0.20-universal.dmg: bzip2 compressed data, block size = 100k
2023-11-23 12:02:51 : DEBUG : vlc : curl output was:
*   Trying 62.210.246.226:443...
* Connected to get.videolan.org (62.210.246.226) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4059 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=get-dc2.videolan.org
*  start date: Oct 17 01:12:07 2023 GMT
*  expire date: Jan 15 01:12:06 2024 GMT
*  subjectAltName: host "get.videolan.org" matched cert's "get.videolan.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: get.videolan.org]
* h2 [:path: /vlc/last/macosx/vlc-3.0.20-universal.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12c00a800)
> GET /vlc/last/macosx/vlc-3.0.20-universal.dmg HTTP/2
> Host: get.videolan.org
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 302
< server: nginx
< date: Thu, 23 Nov 2023 09:02:08 GMT
< content-type: text/html; charset=UTF-8
< location: https://mirror.rasanegar.com/videolan/vlc/3.0.20/macosx/vlc-3.0.20-universal.dmg < alt-svc: h2=":443"
<
* Ignoring the response-body { [124 bytes data]
* Connection #0 to host get.videolan.org left intact
* Issue another request to this URL: 'https://mirror.rasanegar.com/videolan/vlc/3.0.20/macosx/vlc-3.0.20-universal.dmg'
*   Trying 5.160.200.196:443...
* Connected to mirror.rasanegar.com (5.160.200.196) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2446 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [181 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-ECDSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=ir.mirror.rasanegar.com
*  start date: Oct 31 20:12:36 2023 GMT
*  expire date: Jan 29 20:12:35 2024 GMT
*  subjectAltName: host "mirror.rasanegar.com" matched cert's "mirror.rasanegar.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: mirror.rasanegar.com]
* h2 [:path: /videolan/vlc/3.0.20/macosx/vlc-3.0.20-universal.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x12c00a800)
> GET /videolan/vlc/3.0.20/macosx/vlc-3.0.20-universal.dmg HTTP/2
> Host: mirror.rasanegar.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< server: nginx
< date: Thu, 23 Nov 2023 09:02:10 GMT
< content-type: application/octet-stream
< content-length: 85166688
< last-modified: Wed, 01 Nov 2023 22:17:15 GMT
< etag: "6542ce6b-5138a60"
< accept-ranges: bytes
<
{ [16238 bytes data]
* Connection #1 to host mirror.rasanegar.com left intact

2023-11-23 12:02:51 : DEBUG : vlc : DEBUG mode 1, not checking for blocking processes
2023-11-23 12:02:51 : REQ   : vlc : Installing VLC
2023-11-23 12:02:51 : INFO  : vlc : Mounting /Users/someuser/Documents/GitHub/Installomator/build/vlc-3.0.20-universal.dmg
2023-11-23 12:02:57 : DEBUG : vlc : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1A4FDA35
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $339E94F1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $13C5254A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $AF5647D5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $13C5254A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $1C4D11CA
verified   CRC32 $34B86637
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/VLC media player

2023-11-23 12:02:57 : INFO  : vlc : Mounted: /Volumes/VLC media player 2023-11-23 12:02:57 : INFO  : vlc : Verifying: /Volumes/VLC media player/VLC.app
2023-11-23 12:02:57 : DEBUG : vlc : App size: 238M      /Volumes/VLC media player/VLC.app
2023-11-23 12:03:25 : DEBUG : vlc : Debugging enabled, App Verification output was:
/Volumes/VLC media player/VLC.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: VideoLAN (75GAHG3SZQ)

2023-11-23 12:03:25 : INFO  : vlc : Team ID matching: 75GAHG3SZQ (expected: 75GAHG3SZQ ) 2023-11-23 12:03:25 : INFO  : vlc : Downloaded version of VLC is 3.0.20 on versionKey CFBundleShortVersionString (replacing version 3.0.18). 2023-11-23 12:03:25 : INFO  : vlc : App has LSMinimumSystemVersion: 10.7.5 2023-11-23 12:03:25 : DEBUG : vlc : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2023-11-23 12:03:25 : INFO  : vlc : Finishing...
2023-11-23 12:03:28 : INFO  : vlc : App(s) found: /Applications/VLC.app 2023-11-23 12:03:28 : INFO  : vlc : found app at /Applications/VLC.app, version 3.0.18, on versionKey CFBundleShortVersionString
2023-11-23 12:03:28 : REQ   : vlc : Installed VLC, version 3.0.20
2023-11-23 12:03:28 : INFO  : vlc : notifying
2023-11-23 12:03:29 : DEBUG : vlc : Unmounting /Volumes/VLC media player
2023-11-23 12:03:29 : DEBUG : vlc : Debugging enabled, Unmounting output was:
"disk5" ejected.
2023-11-23 12:03:29 : DEBUG : vlc : DEBUG mode 1, not reopening anything
2023-11-23 12:03:29 : REQ   : vlc : All done!
2023-11-23 12:03:29 : REQ   : vlc : ################## End Installomator, exit code 0