### PR TITLE
Updated Skype label

### DIFF
--- a/fragments/labels/skype.sh
+++ b/fragments/labels/skype.sh
@@ -1,9 +1,10 @@
 skype)
     name="Skype"
     type="dmg"
-    downloadURL="https://get.skype.com/go/getskype-skypeformac"
-    appNewVersion=$(curl -is "https://get.skype.com/go/getskype-skypeformac" | grep ocation: | grep -o "Skype-.*dmg" | cut -d "-" -f 2 | sed 's/.dmg//')
+    downloadURL=$(curl -sfi https://get.skype.com/go/getskype-skypeformac | awk 'BEGIN{IGNORECASE=1} /location:/ {gsub(/\r/,"",$2); print $2}')
+    archiveName=$(basename "$downloadURL")
+    appNewVersion=$(awk -F'[-.]' '{print $2"."$3"."$4"."$5}' <<< "$archiveName")
     versionKey="CFBundleVersion"
+    blockingProcesses=( "Skype" , "Skype Helper" )
     expectedTeamID="AL798K98FX"
-    Company="Microsoft"
     ;;


### PR DESCRIPTION
Updated downloadURL, added archiveName, and blockingProcesses, and changed the way appNewVersion is extracted to make it more elegant.

2023-11-23 13:25:29 : REQ   : skype : ################## Start Installomator v. 10.6beta, date 2023-11-23
2023-11-23 13:25:29 : INFO  : skype : ################## Version: 10.6beta
2023-11-23 13:25:29 : INFO  : skype : ################## Date: 2023-11-23
2023-11-23 13:25:29 : INFO  : skype : ################## skype
2023-11-23 13:25:29 : DEBUG : skype : DEBUG mode 1 enabled.
2023-11-23 13:25:31 : DEBUG : skype : name=Skype
2023-11-23 13:25:31 : DEBUG : skype : appName=
2023-11-23 13:25:31 : DEBUG : skype : type=dmg
2023-11-23 13:25:31 : DEBUG : skype : archiveName=Skype-8.108.0.205.dmg
2023-11-23 13:25:31 : DEBUG : skype : downloadURL=https://download.skype.com/s4l/download/mac/Skype-8.108.0.205.dmg
2023-11-23 13:25:31 : DEBUG : skype : curlOptions=
2023-11-23 13:25:31 : DEBUG : skype : appNewVersion=8.108.0.205
2023-11-23 13:25:31 : DEBUG : skype : appCustomVersion function: Not defined
2023-11-23 13:25:31 : DEBUG : skype : versionKey=CFBundleVersion
2023-11-23 13:25:31 : DEBUG : skype : packageID=
2023-11-23 13:25:31 : DEBUG : skype : pkgName=
2023-11-23 13:25:31 : DEBUG : skype : choiceChangesXML=
2023-11-23 13:25:31 : DEBUG : skype : expectedTeamID=AL798K98FX
2023-11-23 13:25:31 : DEBUG : skype : blockingProcesses=Skype , Skype Helper
2023-11-23 13:25:31 : DEBUG : skype : installerTool=
2023-11-23 13:25:31 : DEBUG : skype : CLIInstaller=
2023-11-23 13:25:31 : DEBUG : skype : CLIArguments=
2023-11-23 13:25:31 : DEBUG : skype : updateTool=
2023-11-23 13:25:31 : DEBUG : skype : updateToolArguments=
2023-11-23 13:25:31 : DEBUG : skype : updateToolRunAsCurrentUser=
2023-11-23 13:25:31 : INFO  : skype : BLOCKING_PROCESS_ACTION=tell_user
2023-11-23 13:25:31 : INFO  : skype : NOTIFY=success
2023-11-23 13:25:31 : INFO  : skype : LOGGING=DEBUG
2023-11-23 13:25:31 : INFO  : skype : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-23 13:25:31 : INFO  : skype : Label type: dmg
2023-11-23 13:25:31 : INFO  : skype : archiveName: Skype-8.108.0.205.dmg
2023-11-23 13:25:31 : DEBUG : skype : Changing directory to /Users/someuser/Documents/GitHub/Installomator/build
2023-11-23 13:25:31 : INFO  : skype : App(s) found: /Applications/Skype.app
2023-11-23 13:25:31 : INFO  : skype : found app at /Applications/Skype.app, version 8.108.0.205, on versionKey CFBundleVersion
2023-11-23 13:25:31 : INFO  : skype : appversion: 8.108.0.205
2023-11-23 13:25:31 : INFO  : skype : Latest version of Skype is 8.108.0.205
2023-11-23 13:25:31 : WARN  : skype : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-11-23 13:25:31 : REQ   : skype : Downloading https://download.skype.com/s4l/download/mac/Skype-8.108.0.205.dmg to Skype-8.108.0.205.dmg
2023-11-23 13:25:31 : DEBUG : skype : No Dialog connection, just download
2023-11-23 13:26:08 : DEBUG : skype : File list: -rw-r--r--  1 someuser  staff   223M Nov 23 13:26 Skype-8.108.0.205.dmg
2023-11-23 13:26:08 : DEBUG : skype : File type: Skype-8.108.0.205.dmg: zlib compressed data
2023-11-23 13:26:08 : DEBUG : skype : curl output was:
*   Trying 23.50.252.171:443...
* Connected to download.skype.com (23.50.252.171) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3794 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=apps.skype.com
*  start date: Aug  4 16:07:11 2023 GMT
*  expire date: Jun 27 23:59:59 2024 GMT
*  subjectAltName: host "download.skype.com" matched cert's "download.skype.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure TLS Issuing CA 01
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /s4l/download/mac/Skype-8.108.0.205.dmg HTTP/1.1
> Host: download.skype.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 233630115
< Content-Type: application/x-apple-diskimage
< Content-MD5: gwD77PjSs8i1jCN733gFEQ==
< Last-Modified: Thu, 09 Nov 2023 13:58:27 GMT
< ETag: 0x8DBE12BF2F71F6B
< Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: d0982781-d01e-005a-7339-135066000000 < x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< Cache-Control: max-age=86400
< Date: Thu, 23 Nov 2023 10:25:33 GMT
< Connection: keep-alive
<
{ [15901 bytes data]
* Connection #0 to host download.skype.com left intact

2023-11-23 13:26:08 : DEBUG : skype : DEBUG mode 1, not checking for blocking processes
2023-11-23 13:26:08 : REQ   : skype : Installing Skype
2023-11-23 13:26:08 : INFO  : skype : Mounting /Users/someuser/Documents/GitHub/Installomator/build/Skype-8.108.0.205.dmg
2023-11-23 13:26:12 : DEBUG : skype : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A69CB705
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $EC9AC21C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $97A37510
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $3B6292B0
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $97A37510
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $8D128F62
verified   CRC32 $46A93FF2
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/Skype

2023-11-23 13:26:12 : INFO  : skype : Mounted: /Volumes/Skype 2023-11-23 13:26:12 : INFO  : skype : Verifying: /Volumes/Skype/Skype.app
2023-11-23 13:26:12 : DEBUG : skype : App size: 585M    /Volumes/Skype/Skype.app
2023-11-23 13:26:15 : DEBUG : skype : Debugging enabled, App Verification output was:
/Volumes/Skype/Skype.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Skype Communications S.a.r.l (AL798K98FX)

2023-11-23 13:26:15 : INFO  : skype : Team ID matching: AL798K98FX (expected: AL798K98FX ) 2023-11-23 13:26:15 : INFO  : skype : Downloaded version of Skype is 8.108.0.205 on versionKey CFBundleVersion, same as installed. 2023-11-23 13:26:15 : DEBUG : skype : Unmounting /Volumes/Skype 2023-11-23 13:26:16 : DEBUG : skype : Debugging enabled, Unmounting output was: "disk5" ejected.
2023-11-23 13:26:16 : DEBUG : skype : DEBUG mode 1, not reopening anything
2023-11-23 13:26:16 : REG   : skype : No new version to install
2023-11-23 13:26:16 : REQ   : skype : ################## End Installomator, exit code 0