### PR TITLE
Create i1Profiler.sh

### DIFF
--- a/fragments/labels/i1Profiler.sh
+++ b/fragments/labels/i1Profiler.sh
@@ -1,0 +1,7 @@
+i1profiler)
+    name="i1Profiler"
+    type="pkgInZip"
+    downloadURL=$(curl -fs "https://downloads.xrite.com/downloads/autoupdate/i1profiler_mac_appcast.xml" | xmllint --xpath '//rss/channel/item[1]/enclosure/@url' - | sed -E 's/.*url="([^"]+)".*/\1/')
+    appNewVersion=$(curl -fs "https://downloads.xrite.com/downloads/autoupdate/i1profiler_mac_appcast.xml" | xmllint --xpath '//rss/channel/item[1]/enclosure/@sparkle:shortVersionString' - | sed -E 's/.*shortVersionString="([^"]+)".*/\1/')
+    expectedTeamID="2K7GT73B4R"
+    ;;


### PR DESCRIPTION
Debug Output:

2023-11-27 15:29:43 : REQ   : i1profiler : ################## Start Installomator v. 10.6beta, date 2023-11-27
2023-11-27 15:29:43 : INFO  : i1profiler : ################## Version: 10.6beta
2023-11-27 15:29:43 : INFO  : i1profiler : ################## Date: 2023-11-27
2023-11-27 15:29:43 : INFO  : i1profiler : ################## i1profiler
2023-11-27 15:29:43 : DEBUG : i1profiler : DEBUG mode 1 enabled.
XPath error : Undefined namespace prefix
XPath evaluation failure
2023-11-27 15:29:43 : DEBUG : i1profiler : name=i1Profiler
2023-11-27 15:29:43 : DEBUG : i1profiler : appName=
2023-11-27 15:29:43 : DEBUG : i1profiler : type=pkgInZip
2023-11-27 15:29:43 : DEBUG : i1profiler : archiveName=
2023-11-27 15:29:43 : DEBUG : i1profiler : downloadURL=http://downloads.xrite.com/Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip
2023-11-27 15:29:43 : DEBUG : i1profiler : curlOptions=
2023-11-27 15:29:43 : DEBUG : i1profiler : appNewVersion=
2023-11-27 15:29:43 : DEBUG : i1profiler : appCustomVersion function: Not defined
2023-11-27 15:29:43 : DEBUG : i1profiler : versionKey=CFBundleShortVersionString
2023-11-27 15:29:43 : DEBUG : i1profiler : packageID=
2023-11-27 15:29:43 : DEBUG : i1profiler : pkgName=
2023-11-27 15:29:43 : DEBUG : i1profiler : choiceChangesXML=
2023-11-27 15:29:43 : DEBUG : i1profiler : expectedTeamID=2K7GT73B4R
2023-11-27 15:29:43 : DEBUG : i1profiler : blockingProcesses=
2023-11-27 15:29:43 : DEBUG : i1profiler : installerTool=
2023-11-27 15:29:43 : DEBUG : i1profiler : CLIInstaller=
2023-11-27 15:29:43 : DEBUG : i1profiler : CLIArguments=
2023-11-27 15:29:43 : DEBUG : i1profiler : updateTool=
2023-11-27 15:29:43 : DEBUG : i1profiler : updateToolArguments=
2023-11-27 15:29:43 : DEBUG : i1profiler : updateToolRunAsCurrentUser=
2023-11-27 15:29:43 : INFO  : i1profiler : BLOCKING_PROCESS_ACTION=tell_user
2023-11-27 15:29:43 : INFO  : i1profiler : NOTIFY=success
2023-11-27 15:29:43 : INFO  : i1profiler : LOGGING=DEBUG
2023-11-27 15:29:43 : INFO  : i1profiler : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-11-27 15:29:43 : INFO  : i1profiler : Label type: pkgInZip
2023-11-27 15:29:43 : INFO  : i1profiler : archiveName: i1Profiler.zip
2023-11-27 15:29:43 : INFO  : i1profiler : no blocking processes defined, using i1Profiler as default
2023-11-27 15:29:44 : DEBUG : i1profiler : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2023-11-27 15:29:44 : INFO  : i1profiler : name: i1Profiler, appName: i1Profiler.app
2023-11-27 15:29:44.023 mdfind[40593:4947683] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-11-27 15:29:44.024 mdfind[40593:4947683] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-11-27 15:29:44.134 mdfind[40593:4947683] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-27 15:29:44 : WARN  : i1profiler : No previous app found
2023-11-27 15:29:44 : WARN  : i1profiler : could not find i1Profiler.app
2023-11-27 15:29:44 : INFO  : i1profiler : appversion:
2023-11-27 15:29:44 : INFO  : i1profiler : Latest version not specified.
2023-11-27 15:29:44 : REQ   : i1profiler : Downloading http://downloads.xrite.com/Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip to i1Profiler.zip
2023-11-27 15:29:44 : DEBUG : i1profiler : No Dialog connection, just download
2023-11-27 15:29:57 : DEBUG : i1profiler : File list: -rw-r--r--@ 1 root  staff   255M 27 Nov 15:29 i1Profiler.zip
2023-11-27 15:29:57 : DEBUG : i1profiler : File type: i1Profiler.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2023-11-27 15:29:57 : DEBUG : i1profiler : curl output was:
*   Trying 108.138.7.33:80...
* Connected to downloads.xrite.com (108.138.7.33) port 80 (#0)
> GET /Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip HTTP/1.1
> Host: downloads.xrite.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: CloudFront
< Date: Mon, 27 Nov 2023 14:29:44 GMT
< Content-Type: text/html
< Content-Length: 167
< Connection: keep-alive
< Location: https://downloads.xrite.com/Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip < X-Cache: Redirect from cloudfront
< Via: 1.1 f13110b40e6214ad566c753a838f49f4.cloudfront.net (CloudFront) < X-Amz-Cf-Pop: FRA56-P6
< X-Amz-Cf-Id: 1apbkCQJXmSOCKXYpdqVXyUhM7jizk8lioHXXbzAjDvXesNj2toLuw== <
* Ignoring the response-body { [167 bytes data]
* Connection #0 to host downloads.xrite.com left intact
* Clear auth, redirects to port from 80 to 443
* Issue another request to this URL: 'https://downloads.xrite.com/Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip'
*   Trying 108.138.7.33:443...
* Connected to downloads.xrite.com (108.138.7.33) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4947 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.xrite.com
*  start date: Oct  9 00:00:00 2023 GMT
*  expire date: Nov  4 23:59:59 2024 GMT
*  subjectAltName: host "downloads.xrite.com" matched cert's "*.xrite.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: downloads.xrite.com]
* h2 [:path: /Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x154814200)
> GET /Downloads/Software/i1Profiler/3.7.1/mac/i1Profiler.zip HTTP/2
> Host: downloads.xrite.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< content-type: application/x-zip-compressed
< content-length: 267852124
< date: Mon, 27 Nov 2023 14:29:44 GMT
< set-cookie: AWSALB=/upigtfyG87E9+MuFNs0j2MPv5nM5NM99VrzOSWQRjqamdtT8RJOuhCl7O0Cd8eN68UFDjXHUSHTIlyWxknDk/pm7WkmyoxGGMMDbB/Jmn1aGqWdraTQoQ+5kX8m; Expires=Mon, 04 Dec 2023 14:29:44 GMT; Path=/ < set-cookie: AWSALBCORS=/upigtfyG87E9+MuFNs0j2MPv5nM5NM99VrzOSWQRjqamdtT8RJOuhCl7O0Cd8eN68UFDjXHUSHTIlyWxknDk/pm7WkmyoxGGMMDbB/Jmn1aGqWdraTQoQ+5kX8m; Expires=Mon, 04 Dec 2023 14:29:44 GMT; Path=/; SameSite=None; Secure < last-modified: Tue, 24 Oct 2023 15:24:13 GMT
< accept-ranges: bytes
< etag: "5fe9da248e6da1:0"
< server: Microsoft-IIS/8.5
< x-powered-by: ASP.NET
< strict-transport-security: max-age=31536000;includeSubdomains; < x-content-type-options: nosniff
< x-cache: Miss from cloudfront
< via: 1.1 61c90c70feca5f532bf48bc0dc85d516.cloudfront.net (CloudFront) < x-amz-cf-pop: FRA56-P6
< x-amz-cf-id: jVG1YwEJ_pSLYg8eQBZdmOzNUYwoRmKp5IQ9RKbsiial2DI-7m2EZA== <
{ [32400 bytes data]
* Connection #1 to host downloads.xrite.com left intact

2023-11-27 15:29:57 : DEBUG : i1profiler : DEBUG mode 1, not checking for blocking processes
2023-11-27 15:29:57 : REQ   : i1profiler : Installing i1Profiler
2023-11-27 15:29:57 : INFO  : i1profiler : Unzipping i1Profiler.zip
2023-11-27 15:29:57 : DEBUG : i1profiler : Found pkg(s):
/Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg
2023-11-27 15:29:57 : INFO  : i1profiler : found pkg: /Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg
2023-11-27 15:29:57 : INFO  : i1profiler : Verifying: /Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg
2023-11-27 15:29:57 : DEBUG : i1profiler : File list: -rw-r--r--@ 1 b.kollmer  staff   257M 17 Okt 21:37 /Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg
2023-11-27 15:29:57 : DEBUG : i1profiler : File type: /Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg: xar archive compressed TOC: 8863, SHA-1 checksum
2023-11-27 15:29:57 : DEBUG : i1profiler : spctlOut is /Users/b.kollmer/Development/Installomator/Installomator/build/i1Profiler.pkg: accepted
2023-11-27 15:29:57 : DEBUG : i1profiler : source=Notarized Developer ID
2023-11-27 15:29:57 : DEBUG : i1profiler : origin=Developer ID Installer: X-Rite, Incorporated (2K7GT73B4R)
2023-11-27 15:29:57 : INFO  : i1profiler : Team ID: 2K7GT73B4R (expected: 2K7GT73B4R )
2023-11-27 15:29:57 : DEBUG : i1profiler : DEBUG enabled, skipping installation
2023-11-27 15:29:57 : INFO  : i1profiler : Finishing...
2023-11-27 15:30:00 : INFO  : i1profiler : name: i1Profiler, appName: i1Profiler.app
2023-11-27 15:30:00.774 mdfind[40735:4948646] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-11-27 15:30:00.774 mdfind[40735:4948646] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-11-27 15:30:00.835 mdfind[40735:4948646] Couldn't determine the mapping between prefab keywords and predicates.
2023-11-27 15:30:00 : WARN  : i1profiler : No previous app found
2023-11-27 15:30:00 : WARN  : i1profiler : could not find i1Profiler.app
2023-11-27 15:30:00 : REQ   : i1profiler : Installed i1Profiler
2023-11-27 15:30:00 : INFO  : i1profiler : notifying
2023-11-27 15:30:01 : DEBUG : i1profiler : DEBUG mode 1, not reopening anything
2023-11-27 15:30:01 : REQ   : i1profiler : All done!
2023-11-27 15:30:01 : REQ   : i1profiler : ################## End Installomator, exit code 0