### PR TITLE
virtualbox has no ARM version

### DIFF
--- a/fragments/labels/virtualbox.sh
+++ b/fragments/labels/virtualbox.sh
@@ -3,12 +3,7 @@ virtualbox)
     name="VirtualBox"
     type="pkgInDmg"
     pkgName="VirtualBox.pkg"
-    if [[ $(arch) == i386 ]]; then
-        platform="OSX"
-    elif [[ $(arch) == arm64 ]]; then
-        platform="macOSArm64"
-    fi
-    downloadURL="https:$(curl -fsL "https://www.oracle.com/jp/virtualization/technologies/vm/downloads/virtualbox-downloads.html" | grep "${platform}.dmg" | xmllint --html --xpath 'string(//a/@href)' -)"
+    downloadURL="https:$(curl -fsL "https://www.oracle.com/virtualization/technologies/vm/downloads/virtualbox-downloads.html" | grep "OSX.dmg" | xmllint --html --xpath 'string(//a/@href)' -)"
     appNewVersion=$(echo "${downloadURL}" | awk -F '/' '{print $5}')
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
There's no ARM/Intel specific versions of Virtualbox. Previous version failed on ARM Macs.