### PR TITLE
Fix Island label appNewVersion string

### DIFF
--- a/fragments/labels/island.sh
+++ b/fragments/labels/island.sh
@@ -2,7 +2,7 @@ island)
     name="Island"
     type="dmg"
     downloadURL="https://d3qqq7lqx3rf23.internal.island.io/E5QCaudFDx5FE5OX4INk/stable/latest/mac/IslandX64.dmg"
-    appNewVersion=$(curl -fsLIXGET "https://d3qqq7lqx3rf23.internal.island.io/E5QCaudFDx5FE5OX4INk/stable/latest/mac/IslandX64.dmg" | grep -i "^x-amz-meta-version" | sed -e 's/x-amz-meta-version\: //')
     appCustomVersion() { echo "$(defaults read /Applications/Island.app/Contents/Info.plist CFBundleShortVersionString | sed 's/[^.]*.//' | sed -e 's/*\.//')" }
+    appNewVersion=$(curl -fsLIXGET "https://d3qqq7lqx3rf23.internal.island.io/E5QCaudFDx5FE5OX4INk/stable/latest/mac/IslandX64.dmg" | grep -i "^x-amz-meta-version" | sed -e 's/x-amz-meta-version\: //' | tr -d '\r')
     expectedTeamID="38ZC4T8AWY"
     ;;


### PR DESCRIPTION
Update appNewVersion to remove invisible characters.

```
2023-12-05 14:03:52 : REQ   : island : ################## Start Installomator v. 10.6beta, date 2023-12-05
2023-12-05 14:03:52 : INFO  : island : ################## Version: 10.6beta
2023-12-05 14:03:52 : INFO  : island : ################## Date: 2023-12-05
2023-12-05 14:03:52 : INFO  : island : ################## island
2023-12-05 14:03:52 : INFO  : island : SwiftDialog is not installed, clear cmd file var
2023-12-05 14:03:53 : INFO  : island : setting variable from argument DEBUG=0
2023-12-05 14:03:53 : INFO  : island : setting variable from argument LOGGING=INFO
2023-12-05 14:03:53 : INFO  : island : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2023-12-05 14:03:53 : INFO  : island : setting variable from argument INSTALL=
2023-12-05 14:03:53 : INFO  : island : BLOCKING_PROCESS_ACTION=kill
2023-12-05 14:03:53 : INFO  : island : NOTIFY=success
2023-12-05 14:03:53 : INFO  : island : LOGGING=INFO
2023-12-05 14:03:53 : INFO  : island : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-05 14:03:53 : INFO  : island : Label type: dmg
2023-12-05 14:03:53 : INFO  : island : archiveName: Island.dmg
2023-12-05 14:03:53 : INFO  : island : no blocking processes defined, using Island as default
2023-12-05 14:03:53 : INFO  : island : Custom App Version detection is used, found 1.29.20
2023-12-05 14:03:53 : INFO  : island : appversion: 1.29.20
2023-12-05 14:03:53 : INFO  : island : Latest version of Island is 1.29.20
2023-12-05 14:03:53 : INFO  : island : There is no newer version available.
2023-12-05 14:03:53 : INFO  : island : Installomator did not close any apps, so no need to reopen any apps.
2023-12-05 14:03:53 : REQ   : island : No newer version.
2023-12-05 14:03:53 : REQ   : island : ################## End Installomator, exit code 0 
```