### PR TITLE
Add new label for SAP Power Monitor.app

### DIFF
--- a/fragments/labels/powermonitor.sh
+++ b/fragments/labels/powermonitor.sh
@@ -1,0 +1,7 @@
+powermonitor)
+    name="Power Monitor"
+    type="pkg"
+    downloadURL=$(downloadURLFromGit sap power-monitoring-tool-for-macos )
+    appNewVersion=$(versionFromGit sap power-monitoring-tool-for-macos )
+    expectedTeamID="7R5ZEU67FQ"
+    ;;


### PR DESCRIPTION
```
sudo ./assemble.sh -l fragments/labels/powermonitor.sh powermonitor DEBUG=0                                                                                      (Label-powermonitor)Installomator
# fragments/labels/powermonitor.sh not a directory, skipping...
2023-12-06 14:43:22 : REQ   : powermonitor : ################## Start Installomator v. 10.6beta, date 2023-12-06
2023-12-06 14:43:22 : INFO  : powermonitor : ################## Version: 10.6beta
2023-12-06 14:43:22 : INFO  : powermonitor : ################## Date: 2023-12-06
2023-12-06 14:43:22 : INFO  : powermonitor : ################## powermonitor
2023-12-06 14:43:22 : DEBUG : powermonitor : DEBUG mode 1 enabled.
2023-12-06 14:43:23 : INFO  : powermonitor : setting variable from argument DEBUG=0
2023-12-06 14:43:23 : DEBUG : powermonitor : name=Power Monitor
2023-12-06 14:43:23 : DEBUG : powermonitor : appName=
2023-12-06 14:43:23 : DEBUG : powermonitor : type=pkg
2023-12-06 14:43:23 : DEBUG : powermonitor : archiveName=
2023-12-06 14:43:23 : DEBUG : powermonitor : downloadURL=https://github.com/SAP/power-monitoring-tool-for-macos/releases/download/1.0.2/PowerMonitor_1.0.2.pkg
2023-12-06 14:43:23 : DEBUG : powermonitor : curlOptions=
2023-12-06 14:43:23 : DEBUG : powermonitor : appNewVersion=1.0.2
2023-12-06 14:43:23 : DEBUG : powermonitor : appCustomVersion function: Not defined
2023-12-06 14:43:23 : DEBUG : powermonitor : versionKey=CFBundleShortVersionString
2023-12-06 14:43:23 : DEBUG : powermonitor : packageID=
2023-12-06 14:43:23 : DEBUG : powermonitor : pkgName=
2023-12-06 14:43:23 : DEBUG : powermonitor : choiceChangesXML=
2023-12-06 14:43:23 : DEBUG : powermonitor : expectedTeamID=7R5ZEU67FQ
2023-12-06 14:43:23 : DEBUG : powermonitor : blockingProcesses=
2023-12-06 14:43:23 : DEBUG : powermonitor : installerTool=
2023-12-06 14:43:23 : DEBUG : powermonitor : CLIInstaller=
2023-12-06 14:43:23 : DEBUG : powermonitor : CLIArguments=
2023-12-06 14:43:23 : DEBUG : powermonitor : updateTool=
2023-12-06 14:43:23 : DEBUG : powermonitor : updateToolArguments=
2023-12-06 14:43:23 : DEBUG : powermonitor : updateToolRunAsCurrentUser=
2023-12-06 14:43:23 : INFO  : powermonitor : BLOCKING_PROCESS_ACTION=tell_user
2023-12-06 14:43:23 : INFO  : powermonitor : NOTIFY=success
2023-12-06 14:43:23 : INFO  : powermonitor : LOGGING=DEBUG
2023-12-06 14:43:23 : INFO  : powermonitor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-06 14:43:23 : INFO  : powermonitor : Label type: pkg
2023-12-06 14:43:23 : INFO  : powermonitor : archiveName: Power Monitor.pkg
2023-12-06 14:43:23 : INFO  : powermonitor : no blocking processes defined, using Power Monitor as default
2023-12-06 14:43:23 : DEBUG : powermonitor : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz
2023-12-06 14:43:23 : INFO  : powermonitor : name: Power Monitor, appName: Power Monitor.app
2023-12-06 14:43:23.874 mdfind[87280:2579156] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2023-12-06 14:43:23.874 mdfind[87280:2579156] [UserQueryParser] Loading keywords and predicates for locale "de"
2023-12-06 14:43:23.933 mdfind[87280:2579156] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-06 14:43:23 : WARN  : powermonitor : No previous app found
2023-12-06 14:43:23 : WARN  : powermonitor : could not find Power Monitor.app
2023-12-06 14:43:23 : INFO  : powermonitor : appversion: 
2023-12-06 14:43:24 : INFO  : powermonitor : Latest version of Power Monitor is 1.0.2
2023-12-06 14:43:24 : REQ   : powermonitor : Downloading https://github.com/SAP/power-monitoring-tool-for-macos/releases/download/1.0.2/PowerMonitor_1.0.2.pkg to Power Monitor.pkg
2023-12-06 14:43:24 : DEBUG : powermonitor : No Dialog connection, just download
2023-12-06 14:43:24 : DEBUG : powermonitor : File list: -rw-r--r--  1 root  wheel   472K  6 Dez 14:43 Power Monitor.pkg
2023-12-06 14:43:24 : DEBUG : powermonitor : File type: Power Monitor.pkg: xar archive compressed TOC: 5643, SHA-1 checksum
2023-12-06 14:43:24 : DEBUG : powermonitor : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: github.com]
* h2 [:path: /SAP/power-monitoring-tool-for-macos/releases/download/1.0.2/PowerMonitor_1.0.2.pkg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x144814200)
> GET /SAP/power-monitoring-tool-for-macos/releases/download/1.0.2/PowerMonitor_1.0.2.pkg HTTP/2
> Host: github.com
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Wed, 06 Dec 2023 13:43:11 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/681720240/149470b3-080c-42a2-b663-4a2cc42d5e83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231206T134311Z&X-Amz-Expires=300&X-Amz-Signature=e8d6dbef4a24ae4ad1840c379f69af3266eea52684978e42eec8aa75b72a9f84&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=681720240&response-content-disposition=attachment%3B%20filename%3DPowerMonitor_1.0.2.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.githubcopilot.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com support.github.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: B88C:CC87:6824F1:692400:65707A7C
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/681720240/149470b3-080c-42a2-b663-4a2cc42d5e83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231206T134311Z&X-Amz-Expires=300&X-Amz-Signature=e8d6dbef4a24ae4ad1840c379f69af3266eea52684978e42eec8aa75b72a9f84&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=681720240&response-content-disposition=attachment%3B%20filename%3DPowerMonitor_1.0.2.pkg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: objects.githubusercontent.com]
* h2 [:path: /github-production-release-asset-2e65be/681720240/149470b3-080c-42a2-b663-4a2cc42d5e83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231206T134311Z&X-Amz-Expires=300&X-Amz-Signature=e8d6dbef4a24ae4ad1840c379f69af3266eea52684978e42eec8aa75b72a9f84&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=681720240&response-content-disposition=attachment%3B%20filename%3DPowerMonitor_1.0.2.pkg&response-content-type=application%2Foctet-stream]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x144814200)
> GET /github-production-release-asset-2e65be/681720240/149470b3-080c-42a2-b663-4a2cc42d5e83?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231206%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231206T134311Z&X-Amz-Expires=300&X-Amz-Signature=e8d6dbef4a24ae4ad1840c379f69af3266eea52684978e42eec8aa75b72a9f84&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=681720240&response-content-disposition=attachment%3B%20filename%3DPowerMonitor_1.0.2.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: nksSdyJTf8i+JXh+qOlCRw==
< last-modified: Thu, 30 Nov 2023 15:07:22 GMT
< etag: "0x8DBF1B60DF35866"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 891dab62-601e-0061-6516-28c216000000
< x-ms-version: 2020-04-08
< x-ms-creation-time: Thu, 30 Nov 2023 15:07:22 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=PowerMonitor_1.0.2.pkg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< date: Wed, 06 Dec 2023 13:43:24 GMT
< age: 1175
< x-served-by: cache-iad-kcgs7200046-IAD, cache-fra-eddf8230089-FRA
< x-cache: HIT, HIT
< x-cache-hits: 4, 1
< x-timer: S1701870204.079725,VS0,VE93
< content-length: 483656
< 
{ [2222 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2023-12-06 14:43:24 : REQ   : powermonitor : no more blocking processes, continue with update
2023-12-06 14:43:24 : REQ   : powermonitor : Installing Power Monitor
2023-12-06 14:43:24 : INFO  : powermonitor : Verifying: Power Monitor.pkg
2023-12-06 14:43:24 : DEBUG : powermonitor : File list: -rw-r--r--  1 root  wheel   472K  6 Dez 14:43 Power Monitor.pkg
2023-12-06 14:43:24 : DEBUG : powermonitor : File type: Power Monitor.pkg: xar archive compressed TOC: 5643, SHA-1 checksum
2023-12-06 14:43:24 : DEBUG : powermonitor : spctlOut is Power Monitor.pkg: accepted
2023-12-06 14:43:24 : DEBUG : powermonitor : source=Notarized Developer ID
2023-12-06 14:43:24 : DEBUG : powermonitor : origin=Developer ID Installer: SAP SE (7R5ZEU67FQ)
2023-12-06 14:43:24 : INFO  : powermonitor : Team ID: 7R5ZEU67FQ (expected: 7R5ZEU67FQ )
2023-12-06 14:43:24 : INFO  : powermonitor : Installing Power Monitor.pkg to /
2023-12-06 14:43:28 : DEBUG : powermonitor : Debugging enabled, installer output was:
Dec  6 14:43:24  installer[87371] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power Monitor.pkg trustLevel=350
Dec  6 14:43:24  installer[87371] <Debug>: External component packages (1) trustLevel=350
Dec  6 14:43:24  installer[87371] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Dec  6 14:43:24  installer[87371] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power%20Monitor.pkg#SAPCorp_PowerMonitor.pkg
Dec  6 14:43:24  installer[87371] <Info>: Set authorization level to root for session
Dec  6 14:43:24  installer[87371] <Info>: Authorization is being checked, waiting until authorization arrives.
Dec  6 14:43:24  installer[87371] <Info>: Administrator authorization granted.
Dec  6 14:43:24  installer[87371] <Info>: Packages have been authorized for installation.
Dec  6 14:43:24  installer[87371] <Debug>: Will use PK session
Dec  6 14:43:24  installer[87371] <Debug>: Using authorization level of root for IFPKInstallElement
Dec  6 14:43:24  installer[87371] <Info>: Starting installation:
Dec  6 14:43:24  installer[87371] <Notice>: Configuring volume "Macintosh HD"
Dec  6 14:43:24  installer[87371] <Info>: Preparing disk for local booted install.
Dec  6 14:43:24  installer[87371] <Notice>: Free space on "Macintosh HD": 118.69 GB (118691618816 bytes).
Dec  6 14:43:24  installer[87371] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.87371qnUVqd"
Dec  6 14:43:24  installer[87371] <Notice>: IFPKInstallElement (1 packages)
Dec  6 14:43:24  installer[87371] <Info>: Current Path: /usr/sbin/installer
Dec  6 14:43:24  installer[87371] <Info>: Current Path: /bin/zsh
Dec  6 14:43:24  installer[87371] <Info>: Current Path: /usr/bin/sudo
Dec  6 14:43:24  installer[87371] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Leistungsanzeige
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „Leistungsanzeige“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Dec  6 14:43:27  installer[87371] <Info>: PackageKit: Registered bundle file:///Applications/Power%20Monitor.app/ for uid 0

installer: Paketskripte ausführen ….....
Last Log repeated 2 times
installer: Pakete überprüfen ….....
#Dec  6 14:43:27  installer[87371] <Notice>: Running install actions
Dec  6 14:43:27  installer[87371] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.87371qnUVqd"
Dec  6 14:43:27  installer[87371] <Notice>: Finalize disk "Macintosh HD"
Dec  6 14:43:27  installer[87371] <Notice>: Notifying system of updated components
Dec  6 14:43:27  installer[87371] <Notice>:
Dec  6 14:43:27  installer[87371] <Notice>: **** Summary Information ****
Dec  6 14:43:27  installer[87371] <Notice>:   Operation      Elapsed time
Dec  6 14:43:27  installer[87371] <Notice>: -----------------------------
Dec  6 14:43:27  installer[87371] <Notice>:        disk      0.01 seconds
Dec  6 14:43:27  installer[87371] <Notice>:      script      0.00 seconds
Dec  6 14:43:27  installer[87371] <Notice>:        zero      0.00 seconds
Dec  6 14:43:27  installer[87371] <Notice>:     install      3.05 seconds
Dec  6 14:43:27  installer[87371] <Notice>:     -total-      3.07 seconds
Dec  6 14:43:27  installer[87371] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-12-06 14:43:24+01 mac-yb installer[87371]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power Monitor.pkg trustLevel=350
2023-12-06 14:43:24+01 mac-yb installer[87371]: External component packages (1) trustLevel=350
2023-12-06 14:43:24+01 mac-yb installer[87371]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2023-12-06 14:43:24+01 mac-yb installer[87371]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power%20Monitor.pkg#SAPCorp_PowerMonitor.pkg
2023-12-06 14:43:24+01 mac-yb installer[87371]: Set authorization level to root for session
2023-12-06 14:43:24+01 mac-yb installer[87371]: Authorization is being checked, waiting until authorization arrives.
2023-12-06 14:43:24+01 mac-yb installer[87371]: Administrator authorization granted.
2023-12-06 14:43:24+01 mac-yb installer[87371]: Packages have been authorized for installation.
2023-12-06 14:43:24+01 mac-yb installer[87371]: Will use PK session
2023-12-06 14:43:24+01 mac-yb installer[87371]: Using authorization level of root for IFPKInstallElement
2023-12-06 14:43:24+01 mac-yb installer[87371]: Starting installation:
2023-12-06 14:43:24+01 mac-yb installer[87371]: Configuring volume "Macintosh HD"
2023-12-06 14:43:24+01 mac-yb installer[87371]: Preparing disk for local booted install.
2023-12-06 14:43:24+01 mac-yb installer[87371]: Free space on "Macintosh HD": 118.69 GB (118691618816 bytes).
2023-12-06 14:43:24+01 mac-yb installer[87371]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.87371qnUVqd"
2023-12-06 14:43:24+01 mac-yb installer[87371]: IFPKInstallElement (1 packages)
2023-12-06 14:43:24+01 mac-yb installer[87371]: Current Path: /usr/sbin/installer
2023-12-06 14:43:24+01 mac-yb installer[87371]: Current Path: /bin/zsh
2023-12-06 14:43:24+01 mac-yb installer[87371]: Current Path: /usr/bin/sudo
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Adding client PKInstallDaemonClient pid=87371, uid=0 (/usr/sbin/installer)
2023-12-06 14:43:24+01 mac-yb installer[87371]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Set reponsibility for install to 17848
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Hosted team responsibility for install set to team:(7R5ZEU67FQ)
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: ----- Begin install -----
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: packages=(
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/CB451D85-B669-4B7D-85C4-EFF232497245.activeSandbox
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/673C8B50-5A9B-4CF1-A7D3-E12F9224B4C3.activeSandbox
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Will do receipt-based obsoleting for package identifier corp.sap.PowerMonitor.pkg (prefix path=)
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power%20Monitor.pkg#SAPCorp_PowerMonitor.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/D70D1B8A-1629-4BEA-B3E5-88DE90A24BE1.activeSandbox/Root, uid=0)
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: prevent user idle system sleep
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit: suspending backupd
2023-12-06 14:43:24+01 mac-yb installd[2189]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:24+01 mac-yb package_script_service[87374]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:24+01 mac-yb package_script_service[87374]: Set responsibility to pid: 17848, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2023-12-06 14:43:24+01 mac-yb package_script_service[87374]: Hosted team responsibility for script set to team:(7R5ZEU67FQ)
2023-12-06 14:43:24+01 mac-yb package_script_service[87374]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:24+01 mac-yb install_monitor[87373]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2023-12-06 14:43:26+01 mac-yb package_script_service[87374]: PackageKit: Hosted team responsible for script has been cleared.
2023-12-06 14:43:26+01 mac-yb package_script_service[87374]: Responsibility set back to self.
2023-12-06 14:43:26+01 mac-yb installd[2189]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/D70D1B8A-1629-4BEA-B3E5-88DE90A24BE1.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/D70D1B8A-1629-4BEA-B3E5-88DE90A24BE1.activeSandbox
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/D70D1B8A-1629-4BEA-B3E5-88DE90A24BE1.activeSandbox/Root (1 items) to /
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: Set responsibility to pid: 17848, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: Hosted team responsibility for script set to team:(7R5ZEU67FQ)
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.CkbpG8/Scripts/corp.sap.PowerMonitor.pkg.NYBRyj
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: PackageKit: Hosted team responsible for script has been cleared.
2023-12-06 14:43:27+01 mac-yb package_script_service[87374]: Responsibility set back to self.
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Writing receipt for corp.sap.PowerMonitor.pkg to /
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: No Intel binaries to translate.
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Touched bundle /Applications/Power Monitor.app
2023-12-06 14:43:27+01 mac-yb installd[2189]: Installed "Leistungsanzeige" ()
2023-12-06 14:43:27+01 mac-yb installd[2189]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2023-12-06 14:43:27+01 mac-yb install_monitor[87373]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: releasing backupd
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: allow user idle system sleep
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: ----- End install -----
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: 2.8s elapsed install time
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Cleared responsibility for install from 87371.
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Hosted team responsible for install has been cleared.
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Running idle tasks
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Done with sandbox removals
2023-12-06 14:43:27+01 mac-yb installer[87371]: PackageKit: Registered bundle file:///Applications/Power%20Monitor.app/ for uid 0
2023-12-06 14:43:27+01 mac-yb installd[2189]: PackageKit: Removing client PKInstallDaemonClient pid=87371, uid=0 (/usr/sbin/installer)
2023-12-06 14:43:27+01 mac-yb installer[87371]: Running install actions
2023-12-06 14:43:27+01 mac-yb installer[87371]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.87371qnUVqd"
2023-12-06 14:43:27+01 mac-yb installer[87371]: Finalize disk "Macintosh HD"
2023-12-06 14:43:27+01 mac-yb installer[87371]: Notifying system of updated components
2023-12-06 14:43:27+01 mac-yb installer[87371]:
2023-12-06 14:43:27+01 mac-yb installer[87371]: **** Summary Information ****
2023-12-06 14:43:27+01 mac-yb installer[87371]:   Operation      Elapsed time
2023-12-06 14:43:27+01 mac-yb installer[87371]: -----------------------------
2023-12-06 14:43:27+01 mac-yb installer[87371]:        disk      0.01 seconds
2023-12-06 14:43:27+01 mac-yb installer[87371]:      script      0.00 seconds
2023-12-06 14:43:27+01 mac-yb installer[87371]:        zero      0.00 seconds
2023-12-06 14:43:27+01 mac-yb installer[87371]:     install      3.05 seconds
2023-12-06 14:43:27+01 mac-yb installer[87371]:     -total-      3.07 seconds
2023-12-06 14:43:27+01 mac-yb installer[87371]:

2023-12-06 14:43:28 : INFO  : powermonitor : Finishing...
2023-12-06 14:43:31 : INFO  : powermonitor : App(s) found: /Applications/Power Monitor.app
2023-12-06 14:43:31 : INFO  : powermonitor : found app at /Applications/Power Monitor.app, version 1.0.2, on versionKey CFBundleShortVersionString
2023-12-06 14:43:31 : REQ   : powermonitor : Installed Power Monitor, version 1.0.2
2023-12-06 14:43:32 : INFO  : powermonitor : notifying
2023-12-06 14:43:32 : DEBUG : powermonitor : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz
2023-12-06 14:43:32 : DEBUG : powermonitor : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz/Power Monitor.pkg
2023-12-06 14:43:32 : DEBUG : powermonitor : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BwNO1XIJzz
2023-12-06 14:43:32 : INFO  : powermonitor : Installomator did not close any apps, so no need to reopen any apps.
2023-12-06 14:43:32 : REQ   : powermonitor : All done!
2023-12-06 14:43:32 : REQ   : powermonitor : ################## End Installomator, exit code 0
```