### PR TITLE
Update WhatsApp label

### DIFF
--- a/fragments/labels/whatsapp.sh
+++ b/fragments/labels/whatsapp.sh
@@ -2,6 +2,6 @@ whatsapp)
     name="WhatsApp"
     type="dmg"
     downloadURL="https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release"
-    appNewVersion=$(curl -fsLIXGET "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release" | grep -i "^location" | grep -m 1 -o "WhatsApp-.*dmg" | sed 's/.*WhatsApp-//g' | sed 's/.dmg//g')
+    appNewVersion=$(curl -fsLIXGET "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release" | grep -i "^location" | grep -m 1 -o "WhatsApp-.*dmg" | sed 's/.*WhatsApp-2.//g' | sed 's/.dmg//g')
     expectedTeamID="57T9237FN3"
     ;;

--- a/fragments/labels/whatsapp.sh
+++ b/fragments/labels/whatsapp.sh
@@ -1,6 +1,7 @@
 whatsapp)
     name="WhatsApp"
     type="dmg"
-    downloadURL="https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg"
+    downloadURL="https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release"
+    appNewVersion=$(curl -fsLIXGET "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release" | grep -i "^location" | grep -m 1 -o "WhatsApp-.*dmg" | sed 's/.*WhatsApp-//g' | sed 's/.dmg//g')
     expectedTeamID="57T9237FN3"
     ;;

--- a/fragments/labels/whatsappold.sh
+++ b/fragments/labels/whatsappold.sh
@@ -1,6 +1,0 @@
-whatsappold)
-    name="WhatsApp (old)"
-    type="dmg"
-    downloadURL="https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg"
-    expectedTeamID="57T9237FN3"
-    ;;

--- a/fragments/labels/whatsappold.sh
+++ b/fragments/labels/whatsappold.sh
@@ -1,0 +1,6 @@
+whatsappold)
+    name="WhatsApp (old)"
+    type="dmg"
+    downloadURL="https://web.whatsapp.com/desktop/mac/files/WhatsApp.dmg"
+    expectedTeamID="57T9237FN3"
+    ;;


### PR DESCRIPTION
```
2023-12-08 10:57:39 : REQ   : whatsapp : ################## Start Installomator v. 10.6beta, date 2023-12-08
2023-12-08 10:57:39 : INFO  : whatsapp : ################## Version: 10.6beta
2023-12-08 10:57:39 : INFO  : whatsapp : ################## Date: 2023-12-08
2023-12-08 10:57:39 : INFO  : whatsapp : ################## whatsapp
2023-12-08 10:57:39 : INFO  : whatsapp : SwiftDialog is not installed, clear cmd file var
2023-12-08 10:57:39 : INFO  : whatsapp : setting variable from argument DEBUG=0
2023-12-08 10:57:39 : INFO  : whatsapp : setting variable from argument LOGGING=INFO
2023-12-08 10:57:39 : INFO  : whatsapp : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2023-12-08 10:57:39 : INFO  : whatsapp : setting variable from argument INSTALL=force
2023-12-08 10:57:39 : INFO  : whatsapp : BLOCKING_PROCESS_ACTION=kill
2023-12-08 10:57:39 : INFO  : whatsapp : NOTIFY=success
2023-12-08 10:57:39 : INFO  : whatsapp : LOGGING=INFO
2023-12-08 10:57:39 : INFO  : whatsapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-08 10:57:39 : INFO  : whatsapp : Label type: dmg
2023-12-08 10:57:39 : INFO  : whatsapp : archiveName: WhatsApp.dmg
2023-12-08 10:57:39 : INFO  : whatsapp : no blocking processes defined, using WhatsApp as default
2023-12-08 10:57:40 : INFO  : whatsapp : App(s) found: /Applications/WhatsApp.app
2023-12-08 10:57:40 : INFO  : whatsapp : found app at /Applications/WhatsApp.app, version 23.24.80, on versionKey CFBundleShortVersionString
2023-12-08 10:57:40 : INFO  : whatsapp : appversion: 23.24.80
2023-12-08 10:57:40 : INFO  : whatsapp : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2023-12-08 10:57:40 : INFO  : whatsapp : Latest version of WhatsApp is 2.23.24.80
2023-12-08 10:57:40 : REQ   : whatsapp : Downloading https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release to WhatsApp.dmg
2023-12-08 10:57:46 : REQ   : whatsapp : no more blocking processes, continue with update
2023-12-08 10:57:46 : REQ   : whatsapp : Installing WhatsApp
2023-12-08 10:57:46 : INFO  : whatsapp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.IUCYDbhpwh/WhatsApp.dmg
2023-12-08 10:57:50 : INFO  : whatsapp : Mounted: /Volumes/WhatsApp Installer 2
2023-12-08 10:57:50 : INFO  : whatsapp : Verifying: /Volumes/WhatsApp Installer 2/WhatsApp.app
2023-12-08 10:57:54 : INFO  : whatsapp : Team ID matching: 57T9237FN3 (expected: 57T9237FN3 )
2023-12-08 10:57:54 : INFO  : whatsapp : Downloaded version of WhatsApp is 23.24.80 on versionKey CFBundleShortVersionString, same as installed.
2023-12-08 10:57:54 : INFO  : whatsapp : Using force to install anyway.
2023-12-08 10:57:54 : INFO  : whatsapp : App has LSMinimumSystemVersion: 11.0
2023-12-08 10:57:54 : WARN  : whatsapp : Removing existing /Applications/WhatsApp.app
2023-12-08 10:57:55 : INFO  : whatsapp : Copy /Volumes/WhatsApp Installer 2/WhatsApp.app to /Applications
2023-12-08 10:57:57 : WARN  : whatsapp : Changing owner to user
2023-12-08 10:57:57 : INFO  : whatsapp : Finishing...
2023-12-08 10:58:00 : INFO  : whatsapp : App(s) found: /Applications/WhatsApp.app
2023-12-08 10:58:00 : INFO  : whatsapp : found app at /Applications/WhatsApp.app, version 23.24.80, on versionKey CFBundleShortVersionString
2023-12-08 10:58:00 : REQ   : whatsapp : Installed WhatsApp, version 23.24.80
2023-12-08 10:58:00 : INFO  : whatsapp : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2023-12-08 10:58:00 : INFO  : whatsapp : Installomator did not close any apps, so no need to reopen any apps.
2023-12-08 10:58:00 : REQ   : whatsapp : All done!
2023-12-08 10:58:00 : REQ   : whatsapp : ################## End Installomator, exit code 0
```