### PR TITLE
Reworking Wireshark label to pull from platform specific Sparkle feed

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,12 +1,13 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    appNewVersion=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xpath '//rss/channel/item/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2)
-    urlToParse=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xmllint --xpath '/rss/channel/item/enclosure/@url' - | head -1 | cut -d ':' -f 2 | cut -d '%' -f 1)
     if [[ $(arch) == i386 ]]; then
-      downloadURL="https:$urlToParse%20Latest%20Intel%2064.dmg"
+      sparkleFeedURL="https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml"
     elif [[ $(arch) == arm64 ]]; then
-      downloadURL="https:$urlToParse%20Latest%20Arm%2064.dmg"
+      sparkleFeedURL="https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/arm64/en-US/stable.xml"
     fi
+    sparkleFeed=$(curl -fs "$sparkleFeedURL")
+    appNewVersion=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@sparkle:version)[1]' 2>/dev/null | cut -d '"' -f 2)
+    downloadURL=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f 2)
     expectedTeamID="7Z6EMTD2C6"
     ;;

--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,7 +1,7 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    appNewVersion=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xmllint --xpath '/rss/channel/item/enclosure/@url' - | head -1 | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xpath '//rss/channel/item/enclosure/@sparkle:version' 2>/dev/null | cut -d '"' -f 2)
     urlToParse=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml" | xmllint --xpath '/rss/channel/item/enclosure/@url' - | head -1 | cut -d ':' -f 2 | cut -d '%' -f 1)
     if [[ $(arch) == i386 ]]; then
       downloadURL="https:$urlToParse%20Latest%20Intel%2064.dmg"


### PR DESCRIPTION
Output:
```
2023-12-14 14:51:51 : REQ   : wireshark : ################## Start Installomator v. 10.6beta, date 2023-12-14
2023-12-14 14:51:51 : INFO  : wireshark : ################## Version: 10.6beta
2023-12-14 14:51:51 : INFO  : wireshark : ################## Date: 2023-12-14
2023-12-14 14:51:51 : INFO  : wireshark : ################## wireshark
2023-12-14 14:51:51 : DEBUG : wireshark : DEBUG mode 1 enabled.
2023-12-14 14:51:51 : INFO  : wireshark : SwiftDialog is not installed, clear cmd file var
2023-12-14 14:51:52 : DEBUG : wireshark : name=Wireshark
2023-12-14 14:51:52 : DEBUG : wireshark : appName=
2023-12-14 14:51:52 : DEBUG : wireshark : type=dmg
2023-12-14 14:51:52 : DEBUG : wireshark : archiveName=
2023-12-14 14:51:52 : DEBUG : wireshark : downloadURL=https://1.na.dl.wireshark.org/osx/Wireshark%204.2.0%20Arm%2064.dmg
2023-12-14 14:51:52 : DEBUG : wireshark : curlOptions=
2023-12-14 14:51:52 : DEBUG : wireshark : appNewVersion=4.2.0
2023-12-14 14:51:52 : DEBUG : wireshark : appCustomVersion function: Not defined
2023-12-14 14:51:52 : DEBUG : wireshark : versionKey=CFBundleShortVersionString
2023-12-14 14:51:52 : DEBUG : wireshark : packageID=
2023-12-14 14:51:52 : DEBUG : wireshark : pkgName=
2023-12-14 14:51:52 : DEBUG : wireshark : choiceChangesXML=
2023-12-14 14:51:52 : DEBUG : wireshark : expectedTeamID=7Z6EMTD2C6
2023-12-14 14:51:52 : DEBUG : wireshark : blockingProcesses=
2023-12-14 14:51:52 : DEBUG : wireshark : installerTool=
2023-12-14 14:51:52 : DEBUG : wireshark : CLIInstaller=
2023-12-14 14:51:52 : DEBUG : wireshark : CLIArguments=
2023-12-14 14:51:52 : DEBUG : wireshark : updateTool=
2023-12-14 14:51:52 : DEBUG : wireshark : updateToolArguments=
2023-12-14 14:51:52 : DEBUG : wireshark : updateToolRunAsCurrentUser=
2023-12-14 14:51:52 : INFO  : wireshark : BLOCKING_PROCESS_ACTION=tell_user
2023-12-14 14:51:52 : INFO  : wireshark : NOTIFY=success
2023-12-14 14:51:52 : INFO  : wireshark : LOGGING=DEBUG
2023-12-14 14:51:52 : INFO  : wireshark : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-14 14:51:52 : INFO  : wireshark : Label type: dmg
2023-12-14 14:51:52 : INFO  : wireshark : archiveName: Wireshark.dmg
2023-12-14 14:51:52 : INFO  : wireshark : no blocking processes defined, using Wireshark as default
2023-12-14 14:51:52 : DEBUG : wireshark : Changing directory to /Users/hessf/Documents/GitHub/Installomator/build
2023-12-14 14:51:52 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2023-12-14 14:51:52 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 4.2.0, on versionKey CFBundleShortVersionString
2023-12-14 14:51:52 : INFO  : wireshark : appversion: 4.2.0
2023-12-14 14:51:52 : INFO  : wireshark : Latest version of Wireshark is 4.2.0
2023-12-14 14:51:52 : WARN  : wireshark : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-12-14 14:51:52 : INFO  : wireshark : Wireshark.dmg exists and DEBUG mode 1 enabled, skipping download
2023-12-14 14:51:52 : DEBUG : wireshark : DEBUG mode 1, not checking for blocking processes
2023-12-14 14:51:52 : REQ   : wireshark : Installing Wireshark
2023-12-14 14:51:52 : INFO  : wireshark : Mounting /Users/hessf/Documents/GitHub/Installomator/build/Wireshark.dmg
2023-12-14 14:51:53 : DEBUG : wireshark : Debugging enabled, dmgmount output was:
expected   CRC32 $3B0F2069
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Wireshark 4.2.0

2023-12-14 14:51:53 : INFO  : wireshark : Mounted: /Volumes/Wireshark 4.2.0
2023-12-14 14:51:53 : INFO  : wireshark : Verifying: /Volumes/Wireshark 4.2.0/Wireshark.app
2023-12-14 14:51:53 : DEBUG : wireshark : App size: 220M	/Volumes/Wireshark 4.2.0/Wireshark.app
2023-12-14 14:51:55 : DEBUG : wireshark : Debugging enabled, App Verification output was:
/Volumes/Wireshark 4.2.0/Wireshark.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Wireshark Foundation (7Z6EMTD2C6)

2023-12-14 14:51:55 : INFO  : wireshark : Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2023-12-14 14:51:55 : INFO  : wireshark : Downloaded version of Wireshark is 4.2.0 on versionKey CFBundleShortVersionString, same as installed.
2023-12-14 14:51:55 : DEBUG : wireshark : Unmounting /Volumes/Wireshark 4.2.0
2023-12-14 14:51:55 : DEBUG : wireshark : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-14 14:51:55 : DEBUG : wireshark : DEBUG mode 1, not reopening anything
2023-12-14 14:51:55 : REG   : wireshark : No new version to install
2023-12-14 14:51:55 : REQ   : wireshark : ################## End Installomator, exit code 0
```