### PR TITLE
Adding new Label for DeepL

### DIFF
--- a/fragments/labels/deepl.sh
+++ b/fragments/labels/deepl.sh
@@ -1,0 +1,7 @@
+deepl)
+    name="DeepL"
+    type="dmg"
+    downloadURL="https://www.deepl.com/macos/download/bigsur/DeepL.dmg"
+    appNewVersion=""
+    expectedTeamID="4N8BGCG336"
+    ;;


### PR DESCRIPTION
❯ sudo ./assemble.sh DeepL DEBUG=0
Password:
2023-12-13 10:44:22 : REQ   : deepl : ################## Start Installomator v. 10.6beta, date 2023-12-13
2023-12-13 10:44:22 : INFO  : deepl : ################## Version: 10.6beta
2023-12-13 10:44:22 : INFO  : deepl : ################## Date: 2023-12-13
2023-12-13 10:44:22 : INFO  : deepl : ################## deepl
2023-12-13 10:44:22 : DEBUG : deepl : DEBUG mode 1 enabled.
2023-12-13 10:44:22 : INFO  : deepl : setting variable from argument DEBUG=0
2023-12-13 10:44:22 : DEBUG : deepl : name=DeepL
2023-12-13 10:44:22 : DEBUG : deepl : appName=
2023-12-13 10:44:22 : DEBUG : deepl : type=dmg
2023-12-13 10:44:22 : DEBUG : deepl : archiveName=
2023-12-13 10:44:22 : DEBUG : deepl : downloadURL=https://www.deepl.com/macos/download/bigsur/DeepL.dmg
2023-12-13 10:44:22 : DEBUG : deepl : curlOptions=
2023-12-13 10:44:22 : DEBUG : deepl : appNewVersion=
2023-12-13 10:44:22 : DEBUG : deepl : appCustomVersion function: Not defined
2023-12-13 10:44:22 : DEBUG : deepl : versionKey=CFBundleShortVersionString
2023-12-13 10:44:22 : DEBUG : deepl : packageID=
2023-12-13 10:44:22 : DEBUG : deepl : pkgName=
2023-12-13 10:44:22 : DEBUG : deepl : choiceChangesXML=
2023-12-13 10:44:22 : DEBUG : deepl : expectedTeamID=4N8BGCG336
2023-12-13 10:44:22 : DEBUG : deepl : blockingProcesses=
2023-12-13 10:44:22 : DEBUG : deepl : installerTool=
2023-12-13 10:44:22 : DEBUG : deepl : CLIInstaller=
2023-12-13 10:44:22 : DEBUG : deepl : CLIArguments=
2023-12-13 10:44:23 : DEBUG : deepl : updateTool=
2023-12-13 10:44:23 : DEBUG : deepl : updateToolArguments=
2023-12-13 10:44:23 : DEBUG : deepl : updateToolRunAsCurrentUser=
2023-12-13 10:44:23 : INFO  : deepl : BLOCKING_PROCESS_ACTION=tell_user
2023-12-13 10:44:23 : INFO  : deepl : NOTIFY=success
2023-12-13 10:44:23 : INFO  : deepl : LOGGING=DEBUG
2023-12-13 10:44:23 : INFO  : deepl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-13 10:44:23 : INFO  : deepl : Label type: dmg
2023-12-13 10:44:23 : INFO  : deepl : archiveName: DeepL.dmg
2023-12-13 10:44:23 : INFO  : deepl : no blocking processes defined, using DeepL as default
2023-12-13 10:44:23 : DEBUG : deepl : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vvy8aJyFvm
2023-12-13 10:44:23 : INFO  : deepl : name: DeepL, appName: DeepL.app
2023-12-13 10:44:23.186 mdfind[43488:250815] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-13 10:44:23.186 mdfind[43488:250815] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-13 10:44:23.267 mdfind[43488:250815] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-13 10:44:23 : WARN  : deepl : No previous app found
2023-12-13 10:44:23 : WARN  : deepl : could not find DeepL.app
2023-12-13 10:44:23 : INFO  : deepl : appversion:
2023-12-13 10:44:23 : INFO  : deepl : Latest version not specified.
2023-12-13 10:44:23 : REQ   : deepl : Downloading https://www.deepl.com/macos/download/bigsur/DeepL.dmg to DeepL.dmg
2023-12-13 10:44:23 : DEBUG : deepl : No Dialog connection, just download
2023-12-13 10:44:25 : DEBUG : deepl : File list: -rw-r--r--  1 root  wheel    56M Dec 13 10:44 DeepL.dmg
2023-12-13 10:44:25 : DEBUG : deepl : File type: DeepL.dmg: lzfse encoded, lzvn compressed
2023-12-13 10:44:25 : DEBUG : deepl : curl output was:
*   Trying 172.64.151.134:443...
* Connected to www.deepl.com (172.64.151.134) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2326 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Jul  4 00:00:00 2023 GMT
*  expire date: Jul  3 23:59:59 2024 GMT
*  subjectAltName: host "www.deepl.com" matched cert's "*.deepl.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.deepl.com/macos/download/bigsur/DeepL.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.deepl.com]
* [HTTP/2] [1] [:path: /macos/download/bigsur/DeepL.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /macos/download/bigsur/DeepL.dmg HTTP/2
> Host: www.deepl.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< date: Wed, 13 Dec 2023 15:44:23 GMT
< content-type: text/html
< location: https://appdownload.deepl.com/macos/bigsur/DeepL.dmg
< vary: Origin
< strict-transport-security: max-age=63072000; includeSubDomains; preload
< server-timing: l7_lb_tls;dur=97, l7_lb_idle;dur=0, l7_lb_receive;dur=0, l7_lb_total;dur=98
< access-control-expose-headers: Server-Timing
< cf-cache-status: EXPIRED
< set-cookie: __cf_bm=2QjN7L_ilCIE1JA.uTvbLBH1xc0quC0j_LNqpOy4HIY-1702482263-1-Aa9yrlaM8TUImRxVj0JFs3v4vWG5FGI5pnOKQPWLe7byw0kS8T6k4bz1p99oDYHt2I2YfGslhjcH8+HAksrBfA4=; path=/; expires=Wed, 13-Dec-23 16:14:23 GMT; domain=.deepl.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 834f5402da00238e-EWR
< alt-svc: h3=":443"; ma=86400
<
* Ignoring the response-body
{ [151 bytes data]
* Connection #0 to host www.deepl.com left intact
* Issue another request to this URL: 'https://appdownload.deepl.com/macos/bigsur/DeepL.dmg'
*   Trying 172.64.151.134:443...
* Connected to appdownload.deepl.com (172.64.151.134) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2326 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: Jul  4 00:00:00 2023 GMT
*  expire date: Jul  3 23:59:59 2024 GMT
*  subjectAltName: host "appdownload.deepl.com" matched cert's "*.deepl.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://appdownload.deepl.com/macos/bigsur/DeepL.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: appdownload.deepl.com]
* [HTTP/2] [1] [:path: /macos/bigsur/DeepL.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /macos/bigsur/DeepL.dmg HTTP/2
> Host: appdownload.deepl.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< date: Wed, 13 Dec 2023 15:44:23 GMT
< content-type: application/octet-stream
< content-length: 59113927
< last-modified: Tue, 12 Dec 2023 07:46:00 GMT
< etag: "65780fb8-38601c7"
< x-robots-tag: none
< cf-cache-status: HIT
< age: 2447
< accept-ranges: bytes
< set-cookie: __cf_bm=qEA9c99vkzZ5oXmMrzbvI58VwfnMmCoEPAD_1ju0IjQ-1702482263-1-AZ9KyDaHsfPJry4kyvRseSk7DLKt5PBIb8doawoZCqEjLS7w4HTuFYiE+s3JrvliA8kCVw4/4jQWxOgsWTtHzb0=; path=/; expires=Wed, 13-Dec-23 16:14:23 GMT; domain=.deepl.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 834f5404fed74319-EWR
< alt-svc: h3=":443"; ma=86400
<
{ [5467 bytes data]
* Connection #1 to host appdownload.deepl.com left intact

2023-12-13 10:44:26 : REQ   : deepl : no more blocking processes, continue with update
2023-12-13 10:44:26 : REQ   : deepl : Installing DeepL
2023-12-13 10:44:26 : INFO  : deepl : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vvy8aJyFvm/DeepL.dmg
2023-12-13 10:44:29 : DEBUG : deepl : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8554C91E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $77FE857B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $51B4DB64
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $2383873C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $51B4DB64
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $6D96F5DC
verified   CRC32 $943187E8
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/DeepL

2023-12-13 10:44:29 : INFO  : deepl : Mounted: /Volumes/DeepL
2023-12-13 10:44:29 : INFO  : deepl : Verifying: /Volumes/DeepL/DeepL.app
2023-12-13 10:44:29 : DEBUG : deepl : App size: 144M	/Volumes/DeepL/DeepL.app
2023-12-13 10:44:30 : DEBUG : deepl : Debugging enabled, App Verification output was:
/Volumes/DeepL/DeepL.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Linguee GmbH (4N8BGCG336)

2023-12-13 10:44:30 : INFO  : deepl : Team ID matching: 4N8BGCG336 (expected: 4N8BGCG336 )
2023-12-13 10:44:30 : INFO  : deepl : Installing DeepL version 23.9.1591123 on versionKey CFBundleShortVersionString.
2023-12-13 10:44:30 : INFO  : deepl : App has LSMinimumSystemVersion: 11.0
2023-12-13 10:44:30 : INFO  : deepl : Copy /Volumes/DeepL/DeepL.app to /Applications
2023-12-13 10:44:30 : DEBUG : deepl : Debugging enabled, App copy output was:
Copying /Volumes/DeepL/DeepL.app

2023-12-13 10:44:30 : WARN  : deepl : Changing owner to brian.sullivan
2023-12-13 10:44:30 : INFO  : deepl : Finishing...
2023-12-13 10:44:33 : INFO  : deepl : App(s) found: /Applications/DeepL.app
2023-12-13 10:44:33 : INFO  : deepl : found app at /Applications/DeepL.app, version 23.9.1591123, on versionKey CFBundleShortVersionString
2023-12-13 10:44:33 : REQ   : deepl : Installed DeepL, version 23.9.1591123
2023-12-13 10:44:33 : INFO  : deepl : notifying
2023-12-13 10:44:33 : DEBUG : deepl : Unmounting /Volumes/DeepL
2023-12-13 10:44:34 : DEBUG : deepl : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-13 10:44:34 : DEBUG : deepl : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vvy8aJyFvm
2023-12-13 10:44:34 : DEBUG : deepl : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vvy8aJyFvm/DeepL.dmg
2023-12-13 10:44:34 : DEBUG : deepl : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vvy8aJyFvm
2023-12-13 10:44:34 : INFO  : deepl : Installomator did not close any apps, so no need to reopen any apps.
2023-12-13 10:44:34 : REQ   : deepl : All done!
2023-12-13 10:44:34 : REQ   : deepl : ################## End Installomator, exit code 0
