### PR TITLE
Update scaleft.sh

### DIFF
--- a/fragments/labels/scaleft.sh
+++ b/fragments/labels/scaleft.sh
@@ -1,8 +1,8 @@
 scaleft)
     name="ScaleFT"
     type="pkg"
-    downloadURL="https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg"
-    appNewVersion=$(curl -sf "https://dist.scaleft.com/client-tools/mac/" | awk '/dir/{i++}i==2' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+    downloadURL="https://dist.scaleft.com/repos/macos/stable/all/macos-client/$(curl -s "https://dist.scaleft.com/repos/macos/stable/all/macos-client/" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n 1)/ScaleFT-$(curl -s "https://dist.scaleft.com/repos/macos/stable/all/macos-client/" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n 1 | sed 's/^v//').pkg"
+    appNewVersion=$(curl -s "https://dist.scaleft.com/repos/macos/stable/all/macos-client/" | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n 1 | sed 's/^v//')
     expectedTeamID="B7F62B65BN"
     blockingProcesses=( ScaleFT )
     ;;


### PR DESCRIPTION
URL has moved. Updated detection for new URL and directory structure.

sudo Installomator/utils/assemble.sh scaleft DEBUG=0
2023-12-14 16:15:38 : REQ   : scaleft : ################## Start Installomator v. 10.6beta, date 2023-12-14
2023-12-14 16:15:38 : INFO  : scaleft : ################## Version: 10.6beta
2023-12-14 16:15:38 : INFO  : scaleft : ################## Date: 2023-12-14
2023-12-14 16:15:38 : INFO  : scaleft : ################## scaleft
2023-12-14 16:15:38 : DEBUG : scaleft : DEBUG mode 1 enabled.
2023-12-14 16:15:39 : INFO  : scaleft : setting variable from argument DEBUG=0
2023-12-14 16:15:39 : DEBUG : scaleft : name=ScaleFT
2023-12-14 16:15:39 : DEBUG : scaleft : appName=
2023-12-14 16:15:39 : DEBUG : scaleft : type=pkg
2023-12-14 16:15:39 : DEBUG : scaleft : archiveName=
2023-12-14 16:15:39 : DEBUG : scaleft : downloadURL=https://dist.scaleft.com/repos/macos/stable/all/macos-client/v1.76.2/ScaleFT-1.76.2.pkg
2023-12-14 16:15:39 : DEBUG : scaleft : curlOptions=
2023-12-14 16:15:39 : DEBUG : scaleft : appNewVersion=1.76.2
2023-12-14 16:15:39 : DEBUG : scaleft : appCustomVersion function: Not defined
2023-12-14 16:15:39 : DEBUG : scaleft : versionKey=CFBundleShortVersionString
2023-12-14 16:15:39 : DEBUG : scaleft : packageID=
2023-12-14 16:15:39 : DEBUG : scaleft : pkgName=
2023-12-14 16:15:39 : DEBUG : scaleft : choiceChangesXML=
2023-12-14 16:15:39 : DEBUG : scaleft : expectedTeamID=B7F62B65BN
2023-12-14 16:15:39 : DEBUG : scaleft : blockingProcesses=ScaleFT
2023-12-14 16:15:39 : DEBUG : scaleft : installerTool=
2023-12-14 16:15:39 : DEBUG : scaleft : CLIInstaller=
2023-12-14 16:15:39 : DEBUG : scaleft : CLIArguments=
2023-12-14 16:15:39 : DEBUG : scaleft : updateTool=
2023-12-14 16:15:39 : DEBUG : scaleft : updateToolArguments=
2023-12-14 16:15:39 : DEBUG : scaleft : updateToolRunAsCurrentUser=
2023-12-14 16:15:39 : INFO  : scaleft : BLOCKING_PROCESS_ACTION=tell_user
2023-12-14 16:15:39 : INFO  : scaleft : NOTIFY=success
2023-12-14 16:15:39 : INFO  : scaleft : LOGGING=DEBUG
2023-12-14 16:15:39 : INFO  : scaleft : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-14 16:15:39 : INFO  : scaleft : Label type: pkg
2023-12-14 16:15:39 : INFO  : scaleft : archiveName: ScaleFT.pkg
2023-12-14 16:15:39 : DEBUG : scaleft : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN
2023-12-14 16:15:39 : INFO  : scaleft : App(s) found: /Applications/ScaleFT.app
2023-12-14 16:15:39 : INFO  : scaleft : found app at /Applications/ScaleFT.app, version 1.67.4, on versionKey CFBundleShortVersionString
2023-12-14 16:15:39 : INFO  : scaleft : appversion: 1.67.4
2023-12-14 16:15:39 : INFO  : scaleft : Latest version of ScaleFT is 1.76.2
2023-12-14 16:15:39 : REQ   : scaleft : Downloading https://dist.scaleft.com/repos/macos/stable/all/macos-client/v1.76.2/ScaleFT-1.76.2.pkg to ScaleFT.pkg
2023-12-14 16:15:39 : DEBUG : scaleft : No Dialog connection, just download
2023-12-14 16:15:43 : DEBUG : scaleft : File list: -rw-r--r--  1 root  wheel    25M Dec 14 16:15 ScaleFT.pkg
2023-12-14 16:15:43 : DEBUG : scaleft : File type: ScaleFT.pkg: xar archive compressed TOC: 4970, SHA-1 checksum
2023-12-14 16:15:43 : DEBUG : scaleft : curl output was:
*   Trying 18.154.101.97:443...
* Connected to dist.scaleft.com (18.154.101.97) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4958 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=dist.scaleft.com
*  start date: May 22 00:00:00 2023 GMT
*  expire date: Jun 19 23:59:59 2024 GMT
*  subjectAltName: host "dist.scaleft.com" matched cert's "dist.scaleft.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dist.scaleft.com/repos/macos/stable/all/macos-client/v1.76.2/ScaleFT-1.76.2.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dist.scaleft.com]
* [HTTP/2] [1] [:path: /repos/macos/stable/all/macos-client/v1.76.2/ScaleFT-1.76.2.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /repos/macos/stable/all/macos-client/v1.76.2/ScaleFT-1.76.2.pkg HTTP/2
> Host: dist.scaleft.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 26698678
< x-amz-meta-mtime: 1701896799
< last-modified: Wed, 06 Dec 2023 21:10:32 GMT
< x-amz-storage-class: INTELLIGENT_TIERING
< server: AmazonS3
< date: Thu, 14 Dec 2023 23:15:41 GMT
< cache-control: max-age=300,public
< etag: "3e89eddd6dc05905df817bbb9d3f8cc7"
< x-cache: RefreshHit from cloudfront
< via: 1.1 66fbb9efab6146079af1497f336edf9e.cloudfront.net (CloudFront) < x-amz-cf-pop: DEN52-P3
< x-amz-cf-id: Jqrx4I9INsK80Q61ph5WkrdWhJUUD3Osr-cP9gYbP6NqJZRwukc99Q== <
{ [15982 bytes data]
* Connection #0 to host dist.scaleft.com left intact

2023-12-14 16:15:43 : REQ   : scaleft : no more blocking processes, continue with update
2023-12-14 16:15:43 : REQ   : scaleft : Installing ScaleFT
2023-12-14 16:15:43 : INFO  : scaleft : Verifying: ScaleFT.pkg
2023-12-14 16:15:43 : DEBUG : scaleft : File list: -rw-r--r--  1 root  wheel    25M Dec 14 16:15 ScaleFT.pkg
2023-12-14 16:15:43 : DEBUG : scaleft : File type: ScaleFT.pkg: xar archive compressed TOC: 4970, SHA-1 checksum
2023-12-14 16:15:43 : DEBUG : scaleft : spctlOut is ScaleFT.pkg: accepted
2023-12-14 16:15:43 : DEBUG : scaleft : source=Notarized Developer ID
2023-12-14 16:15:43 : DEBUG : scaleft : override=security disabled
2023-12-14 16:15:43 : DEBUG : scaleft : origin=Developer ID Installer: Okta, Inc. (B7F62B65BN)
2023-12-14 16:15:43 : INFO  : scaleft : Team ID: B7F62B65BN (expected: B7F62B65BN )
2023-12-14 16:15:43 : INFO  : scaleft : Installing ScaleFT.pkg to /
2023-12-14 16:15:47 : DEBUG : scaleft : Debugging enabled, installer output was:
Dec 14 16:15:44  installer[98903] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg trustLevel=350
Dec 14 16:15:44  installer[98903] <Debug>: External component packages (1) trustLevel=350
Dec 14 16:15:44  installer[98903] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Dec 14 16:15:44  installer[98903] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg#ScaleFTApp.pkg
Dec 14 16:15:44  installer[98903] <Info>: Set authorization level to root for session
Dec 14 16:15:44  installer[98903] <Info>: Authorization is being checked, waiting until authorization arrives.
Dec 14 16:15:44  installer[98903] <Info>: Administrator authorization granted.
Dec 14 16:15:44  installer[98903] <Info>: Packages have been authorized for installation.
Dec 14 16:15:44  installer[98903] <Debug>: Will use PK session
Dec 14 16:15:44  installer[98903] <Debug>: Using authorization level of root for IFPKInstallElement
Dec 14 16:15:44  installer[98903] <Info>: Starting installation:
Dec 14 16:15:44  installer[98903] <Notice>: Configuring volume "Macintosh HD"
Dec 14 16:15:44  installer[98903] <Info>: Preparing disk for local booted install.
Dec 14 16:15:44  installer[98903] <Notice>: Free space on "Macintosh HD": 1.05 TB (1047611138048 bytes).
Dec 14 16:15:44  installer[98903] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.98903Mxxjjn"
Dec 14 16:15:44  installer[98903] <Notice>: IFPKInstallElement (1 packages)
Dec 14 16:15:44  installer[98903] <Info>: Current Path: /usr/sbin/installer
Dec 14 16:15:44  installer[98903] <Info>: Current Path: /bin/zsh
Dec 14 16:15:44  installer[98903] <Info>: Current Path: /usr/bin/sudo
Dec 14 16:15:44  installer[98903] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing ….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#Dec 14 16:15:45  installer[98903] <Info>: PackageKit: Registered bundle file:///Applications/ScaleFT.app/ for uid 0
Dec 14 16:15:45  installer[98903] <Info>: Bundle path file:///Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Updater.app/ is not an application
Dec 14 16:15:45  installer[98903] <Info>: PackageKit: Registered bundle file:///Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app/ for uid 0

installer: Running package scripts….....
installer: Validating packages….....
#Dec 14 16:15:46  installer[98903] <Notice>: Running install actions Dec 14 16:15:46  installer[98903] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.98903Mxxjjn" Dec 14 16:15:46  installer[98903] <Notice>: Finalize disk "Macintosh HD" Dec 14 16:15:46  installer[98903] <Notice>: Notifying system of updated components Dec 14 16:15:46  installer[98903] <Notice>:
Dec 14 16:15:46  installer[98903] <Notice>: **** Summary Information ****
Dec 14 16:15:46  installer[98903] <Notice>:   Operation      Elapsed time
Dec 14 16:15:46  installer[98903] <Notice>: -----------------------------
Dec 14 16:15:46  installer[98903] <Notice>:        disk      0.01 seconds
Dec 14 16:15:46  installer[98903] <Notice>:      script      0.00 seconds
Dec 14 16:15:46  installer[98903] <Notice>:        zero      0.00 seconds
Dec 14 16:15:46  installer[98903] <Notice>:     install      2.08 seconds
Dec 14 16:15:46  installer[98903] <Notice>:     -total-      2.09 seconds
Dec 14 16:15:46  installer[98903] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed...... installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2023-12-14 16:15:44-07  installer[98903]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg trustLevel=350 2023-12-14 16:15:44-07  installer[98903]: External component packages (1) trustLevel=350 2023-12-14 16:15:44-07  installer[98903]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost 2023-12-14 16:15:44-07  installer[98903]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg#ScaleFTApp.pkg 2023-12-14 16:15:44-07  installer[98903]: Set authorization level to root for session 2023-12-14 16:15:44-07  installer[98903]: Authorization is being checked, waiting until authorization arrives. 2023-12-14 16:15:44-07  installer[98903]: Administrator authorization granted. 2023-12-14 16:15:44-07  installer[98903]: Packages have been authorized for installation. 2023-12-14 16:15:44-07  installer[98903]: Will use PK session 2023-12-14 16:15:44-07  installer[98903]: Using authorization level of root for IFPKInstallElement 2023-12-14 16:15:44-07  installer[98903]: Starting installation: 2023-12-14 16:15:44-07  installer[98903]: Configuring volume "Macintosh HD" 2023-12-14 16:15:44-07  installer[98903]: Preparing disk for local booted install. 2023-12-14 16:15:44-07  installer[98903]: Free space on "Macintosh HD": 1.05 TB (1047611138048 bytes). 2023-12-14 16:15:44-07  installer[98903]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.98903Mxxjjn" 2023-12-14 16:15:44-07  installer[98903]: IFPKInstallElement (1 packages) 2023-12-14 16:15:44-07  installer[98903]: Current Path: /usr/sbin/installer 2023-12-14 16:15:44-07  installer[98903]: Current Path: /bin/zsh Last Log repeated 2 times
2023-12-14 16:15:44-07  installer[98903]: Current Path: /usr/bin/sudo 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Adding client PKInstallDaemonClient pid=98903, uid=0 (/usr/sbin/installer) 2023-12-14 16:15:44-07  installer[98903]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Set reponsibility for install to 36852 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Hosted team responsibility for install set to team:(B7F62B65BN) 2023-12-14 16:15:44-07  installd[2707]: PackageKit: ----- Begin install -----
2023-12-14 16:15:44-07  installd[2707]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2023-12-14 16:15:44-07  installd[2707]: PackageKit: packages=( 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/9910916F-D200-4F26-BCA1-D143464D072E.activeSandbox 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/B6CC9BA0-CD8A-4E12-BF1F-4FABC03A4BB3.activeSandbox 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/4C20EC0A-65F2-40E6-9BF7-EB9971FCAAC4.activeSandbox 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/9B32F989-1349-4B13-8942-D86FC63782F4.activeSandbox 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg#ScaleFTApp.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/4DF7D26C-3338-44D0-93C7-3092D9B1C18C.activeSandbox/Root, uid=0) 2023-12-14 16:15:44-07  installd[2707]: PackageKit: prevent user idle system sleep 2023-12-14 16:15:44-07  installd[2707]: PackageKit: suspending backupd 2023-12-14 16:15:44-07  installd[2707]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:44-07  package_script_service[36810]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:44-07  package_script_service[36810]: Set responsibility to pid: 36852, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2 2023-12-14 16:15:44-07  package_script_service[36810]: Hosted team responsibility for script set to team:(B7F62B65BN) 2023-12-14 16:15:44-07  package_script_service[36810]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:44-07  package_script_service[36810]: PackageKit: Hosted team responsible for script has been cleared. 2023-12-14 16:15:44-07  package_script_service[36810]: Responsibility set back to self. 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/4DF7D26C-3338-44D0-93C7-3092D9B1C18C.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/4DF7D26C-3338-44D0-93C7-3092D9B1C18C.activeSandbox 2023-12-14 16:15:44-07  install_monitor[98904]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-12-14 16:15:44-07  installd[2707]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/4DF7D26C-3338-44D0-93C7-3092D9B1C18C.activeSandbox/Root (1 items) to / 2023-12-14 16:15:44-07  installd[2707]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:44-07  package_script_service[36810]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:44-07  package_script_service[36810]: Set responsibility to pid: 36852, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2 2023-12-14 16:15:44-07  package_script_service[36810]: Hosted team responsibility for script set to team:(B7F62B65BN) 2023-12-14 16:15:44-07  package_script_service[36810]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.ieWNKX/Scripts/com.scaleft.ScaleFT.RZ2mNG 2023-12-14 16:15:45-07  package_script_service[36810]: PackageKit: Hosted team responsible for script has been cleared. 2023-12-14 16:15:45-07  package_script_service[36810]: Responsibility set back to self. 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Writing receipt for com.scaleft.ScaleFT to / 2023-12-14 16:15:45-07  installd[2707]: PackageKit: No Intel binaries to translate. 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Touched bundle /Applications/ScaleFT.app 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Touched bundle /Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Updater.app 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Touched bundle /Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app 2023-12-14 16:15:45-07  installd[2707]: Installed "" () 2023-12-14 16:15:45-07  installd[2707]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist 2023-12-14 16:15:45-07  install_monitor[98904]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2023-12-14 16:15:45-07  installd[2707]: PackageKit: releasing backupd 2023-12-14 16:15:45-07  installd[2707]: PackageKit: allow user idle system sleep 2023-12-14 16:15:45-07  installd[2707]: PackageKit: ----- End install ----- 2023-12-14 16:15:45-07  installd[2707]: PackageKit: 1.3s elapsed install time 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Cleared responsibility for install from 98903. 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Hosted team responsible for install has been cleared. 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Running idle tasks 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Done with sandbox removals 2023-12-14 16:15:45-07  installer[98903]: PackageKit: Registered bundle file:///Applications/ScaleFT.app/ for uid 0 2023-12-14 16:15:45-07  installer[98903]: Bundle path file:///Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Updater.app/ is not an application 2023-12-14 16:15:45-07  installer[98903]: PackageKit: Registered bundle file:///Applications/ScaleFT.app/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app/ for uid 0 2023-12-14 16:15:45-07  installd[2707]: PackageKit: Removing client PKInstallDaemonClient pid=98903, uid=0 (/usr/sbin/installer) 2023-12-14 16:15:46-07  installer[98903]: Running install actions 2023-12-14 16:15:46-07  installer[98903]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.98903Mxxjjn" 2023-12-14 16:15:46-07  installer[98903]: Finalize disk "Macintosh HD" 2023-12-14 16:15:46-07  installer[98903]: Notifying system of updated components 2023-12-14 16:15:46-07  installer[98903]:
2023-12-14 16:15:46-07  installer[98903]: **** Summary Information ****
2023-12-14 16:15:46-07  installer[98903]:   Operation      Elapsed time
2023-12-14 16:15:46-07  installer[98903]: -----------------------------
2023-12-14 16:15:46-07  installer[98903]:        disk      0.01 seconds
2023-12-14 16:15:46-07  installer[98903]:      script      0.00 seconds
2023-12-14 16:15:46-07  installer[98903]:        zero      0.00 seconds
2023-12-14 16:15:46-07  installer[98903]:     install      2.08 seconds
2023-12-14 16:15:46-07  installer[98903]:     -total-      2.09 seconds
2023-12-14 16:15:46-07  installer[98903]:

2023-12-14 16:15:47 : INFO  : scaleft : Finishing... 2023-12-14 16:15:50 : INFO  : scaleft : App(s) found: /Applications/ScaleFT.app 2023-12-14 16:15:50 : INFO  : scaleft : found app at /Applications/ScaleFT.app, version 1.76.2, on versionKey CFBundleShortVersionString
2023-12-14 16:15:50 : REQ   : scaleft : Installed ScaleFT, version 1.76.2
2023-12-14 16:15:50 : INFO  : scaleft : notifying
2023-12-14 16:15:51 : DEBUG : scaleft : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN
2023-12-14 16:15:51 : DEBUG : scaleft : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN/ScaleFT.pkg
2023-12-14 16:15:51 : DEBUG : scaleft : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BilDUPKeiN
2023-12-14 16:15:51 : INFO  : scaleft : Installomator did not close any apps, so no need to reopen any apps.
2023-12-14 16:15:51 : REQ   : scaleft : All done!
2023-12-14 16:15:51 : REQ   : scaleft : ################## End Installomator, exit code 0