### PR TITLE
Create airtamepkg.sh

### DIFF
--- a/fragments/labels/airtamepkg.sh
+++ b/fragments/labels/airtamepkg.sh
@@ -1,0 +1,8 @@
+airtamepkg)
+    name="Airtame"
+    type="pkg"
+    packageID="com.airtame.airtame-application"
+    appNewVersion="$(curl -fs https://airtame.com/download/ | grep -i platform=mac | head -1 | grep -o -i -E "https.*" | cut -d '"' -f1 | xargs curl -fsIL | grep -i ^location | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')"
+    downloadURL="https://airtame-app.b-cdn.net/app/latest/mac/Airtame-${appNewVersion}.pkg"
+    expectedTeamID="4TPSP88HN2"
+    ;;


### PR DESCRIPTION
The current airtame label installs the .dmg version, which doesn't install the audio driver. They have a separate installer 'For IT admins (.pkg)' that installs the audio driver as well. The .dmg version isn't friendly for environments where end-users don't have admin rights.

2023-12-18 18:01:16 : REQ   : airtamepkg : ################## Start Installomator v. 10.6beta, date 2023-12-18
2023-12-18 18:01:16 : INFO  : airtamepkg : ################## Version: 10.6beta
2023-12-18 18:01:16 : INFO  : airtamepkg : ################## Date: 2023-12-18
2023-12-18 18:01:16 : INFO  : airtamepkg : ################## airtamepkg
2023-12-18 18:01:16 : DEBUG : airtamepkg : DEBUG mode 1 enabled.
2023-12-18 18:01:17 : DEBUG : airtamepkg : name=Airtame
2023-12-18 18:01:17 : DEBUG : airtamepkg : appName=
2023-12-18 18:01:17 : DEBUG : airtamepkg : type=pkg
2023-12-18 18:01:17 : DEBUG : airtamepkg : archiveName=
2023-12-18 18:01:17 : DEBUG : airtamepkg : downloadURL=https://airtame-app.b-cdn.net/app/latest/mac/Airtame-4.8.0.pkg
2023-12-18 18:01:17 : DEBUG : airtamepkg : curlOptions=
2023-12-18 18:01:17 : DEBUG : airtamepkg : appNewVersion=4.8.0
2023-12-18 18:01:17 : DEBUG : airtamepkg : appCustomVersion function: Not defined
2023-12-18 18:01:17 : DEBUG : airtamepkg : versionKey=CFBundleShortVersionString
2023-12-18 18:01:17 : DEBUG : airtamepkg : packageID=com.airtame.airtame-application
2023-12-18 18:01:17 : DEBUG : airtamepkg : pkgName=
2023-12-18 18:01:17 : DEBUG : airtamepkg : choiceChangesXML=
2023-12-18 18:01:17 : DEBUG : airtamepkg : expectedTeamID=4TPSP88HN2
2023-12-18 18:01:17 : DEBUG : airtamepkg : blockingProcesses=
2023-12-18 18:01:17 : DEBUG : airtamepkg : installerTool=
2023-12-18 18:01:17 : DEBUG : airtamepkg : CLIInstaller=
2023-12-18 18:01:17 : DEBUG : airtamepkg : CLIArguments=
2023-12-18 18:01:17 : DEBUG : airtamepkg : updateTool=
2023-12-18 18:01:17 : DEBUG : airtamepkg : updateToolArguments=
2023-12-18 18:01:17 : DEBUG : airtamepkg : updateToolRunAsCurrentUser=
2023-12-18 18:01:17 : INFO  : airtamepkg : BLOCKING_PROCESS_ACTION=tell_user
2023-12-18 18:01:17 : INFO  : airtamepkg : NOTIFY=success
2023-12-18 18:01:17 : INFO  : airtamepkg : LOGGING=DEBUG
2023-12-18 18:01:17 : INFO  : airtamepkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-18 18:01:17 : INFO  : airtamepkg : Label type: pkg
2023-12-18 18:01:17 : INFO  : airtamepkg : archiveName: Airtame.pkg
2023-12-18 18:01:17 : INFO  : airtamepkg : no blocking processes defined, using Airtame as default
2023-12-18 18:01:17 : DEBUG : airtamepkg : Changing directory to /Users/whiteb/Documents/GitHub/Installomator/build
2023-12-18 18:01:17 : INFO  : airtamepkg : found packageID com.airtame.airtame-application installed, version 4.8.0
2023-12-18 18:01:17 : INFO  : airtamepkg : appversion: 4.8.0
2023-12-18 18:01:17 : INFO  : airtamepkg : Latest version of Airtame is 4.8.0
2023-12-18 18:01:17 : WARN  : airtamepkg : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2023-12-18 18:01:17 : REQ   : airtamepkg : Downloading https://airtame-app.b-cdn.net/app/latest/mac/Airtame-4.8.0.pkg to Airtame.pkg
2023-12-18 18:01:17 : DEBUG : airtamepkg : No Dialog connection, just download
2023-12-18 18:01:19 : DEBUG : airtamepkg : File list: -rw-r--r--  1 whiteb  staff   108M Dec 18 18:01 Airtame.pkg
2023-12-18 18:01:19 : DEBUG : airtamepkg : File type: Airtame.pkg: xar archive compressed TOC: 4627, SHA-1 checksum
2023-12-18 18:01:19 : DEBUG : airtamepkg : curl output was:
*   Trying 143.244.50.84:443...
* Connected to airtame-app.b-cdn.net (143.244.50.84) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4579 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.b-cdn.net
*  start date: Nov  5 00:00:00 2023 GMT
*  expire date: Nov 11 23:59:59 2024 GMT
*  subjectAltName: host "airtame-app.b-cdn.net" matched cert's "*.b-cdn.net"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://airtame-app.b-cdn.net/app/latest/mac/Airtame-4.8.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: airtame-app.b-cdn.net]
* [HTTP/2] [1] [:path: /app/latest/mac/Airtame-4.8.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /app/latest/mac/Airtame-4.8.0.pkg HTTP/2
> Host: airtame-app.b-cdn.net
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< date: Tue, 19 Dec 2023 02:01:17 GMT
< content-type: binary/octet-stream
< content-length: 113592084
< server: BunnyCDN-LA1-984
< cdn-pullzone: 165381
< cdn-uid: 1bb2b5f4-178f-48be-8817-9cd4ee5b4993
< cdn-requestcountrycode: US
< cache-control: public, max-age=31919000
< etag: "65608b4c-6c54714"
< last-modified: Fri, 24 Nov 2023 11:38:52 GMT
< cdn-storageserver: NY-427
< cdn-requestpullsuccess: True
< cdn-fileserver: 717
< perma-cache: HIT
< cdn-proxyver: 1.04
< cdn-requestpullcode: 200
< cdn-cachedat: 11/25/2023 02:51:03
< cdn-edgestorageid: 996
< cdn-status: 200
< cdn-requestid: 04aaaac9ede9d1b7576a6d95e63b217a
< cdn-cache: HIT
< accept-ranges: bytes
<
{ [16384 bytes data]
* Connection #0 to host airtame-app.b-cdn.net left intact

2023-12-18 18:01:19 : DEBUG : airtamepkg : DEBUG mode 1, not checking for blocking processes
2023-12-18 18:01:19 : REQ   : airtamepkg : Installing Airtame
2023-12-18 18:01:20 : INFO  : airtamepkg : Verifying: Airtame.pkg
2023-12-18 18:01:20 : DEBUG : airtamepkg : File list: -rw-r--r--  1 whiteb  staff   108M Dec 18 18:01 Airtame.pkg
2023-12-18 18:01:20 : DEBUG : airtamepkg : File type: Airtame.pkg: xar archive compressed TOC: 4627, SHA-1 checksum
2023-12-18 18:01:20 : DEBUG : airtamepkg : spctlOut is Airtame.pkg: accepted
2023-12-18 18:01:20 : DEBUG : airtamepkg : source=Notarized Developer ID
2023-12-18 18:01:20 : DEBUG : airtamepkg : origin=Developer ID Installer: AIRTAME APS (4TPSP88HN2)
2023-12-18 18:01:20 : INFO  : airtamepkg : Team ID: 4TPSP88HN2 (expected: 4TPSP88HN2 )
2023-12-18 18:01:20 : INFO  : airtamepkg : Checking package version.
2023-12-18 18:01:20 : INFO  : airtamepkg : Downloaded package com.airtame.airtame-application version 4.8.0
2023-12-18 18:01:20 : INFO  : airtamepkg : Downloaded version of Airtame is the same as installed.
2023-12-18 18:01:20 : DEBUG : airtamepkg : DEBUG mode 1, not reopening anything
2023-12-18 18:01:20 : REQ   : airtamepkg : No new version to install
2023-12-18 18:01:20 : REQ   : airtamepkg : ################## End Installomator, exit code 0