### PR TITLE
LogiTune label

### DIFF
--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -6,6 +6,5 @@ logitune)
     downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
-    CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"
     ;;

--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -1,0 +1,11 @@
+logitune)
+    name="LogiTune"
+    archiveName="LogiTuneInstaller.dmg"
+    appName="LogiTuneInstaller.app"
+    type="dmg"
+    downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
+    CLIArguments=(--quiet)
+    expectedTeamID="QED4VVPZWA"
+    ;;

--- a/fragments/labels/rancherdesktop.sh
+++ b/fragments/labels/rancherdesktop.sh
@@ -2,10 +2,10 @@ rancherdesktop)
     name="Rancher Desktop"
     type="zip"
     if [[ $(arch) == "arm64" ]]; then
-      archiveName="Rancher.Desktop-[0-9.]*-mac.aarch64.zip"
+      archiveName="Rancher.Desktop-[0-9.]*.aarch64.zip"
       downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
     elif [[ $(arch) == "i386" ]]; then
-      archiveName="Rancher.Desktop-[0-9.]*-mac.x86_64.zip"
+      archiveName="Rancher.Desktop-[0-9.]*.x86_64.zip"
       downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
     fi
     appNewVersion="$(versionFromGit rancher-sandbox rancher-desktop)"


### PR DESCRIPTION
Hi, this label is based on logitechoptionsplus. The main difference in this is that the --quiet of Logitech Options plus isn't in the LogiTune installer app. It will therefore open an additional window where a user need to click install. This isn't the biggest issue when a user decides to initiates the installation, but it is an issue when automatically installing (for example with an update). If someone has a way to check if there are other flags that we can add to make it silent, then I'm all in for it. For us..this label works, but I can imagine that in other cases this would suffice.