### PR TITLE
Theadamcraig notify if open

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -328,6 +328,10 @@ checkRunningProcesses() {
 
                 case $BLOCKING_PROCESS_ACTION in
                     quit|quit_kill)
+                        if [[ $NOTIFY = *"_if_open" ]] ; then
+                          printlog "NOTIFY was ${NOTIFY}. setting to ${NOTIFY%_if_open}"
+                          NOTIFY="${NOTIFY%_if_open}"
+                        fi
                         printlog "telling app $x to quit"
                         runAsUser osascript -e "tell app \"$x\" to quit"
                         if [[ $i > 2 && $BLOCKING_PROCESS_ACTION = "quit_kill" ]]; then
@@ -340,11 +344,19 @@ checkRunningProcesses() {
                         fi
                         ;;
                     kill)
+                      if [[ $NOTIFY = *"_if_open" ]] ; then
+                        printlog "NOTIFY was ${NOTIFY}. setting to ${NOTIFY%_if_open}"
+                        NOTIFY="${NOTIFY%_if_open}"
+                      fi
                       printlog "killing process $x"
                       pkill $x
                       sleep 5
                       ;;
                     prompt_user|prompt_user_then_kill)
+                      if [[ $NOTIFY = *"_if_open" ]] ; then
+                        printlog "NOTIFY was ${NOTIFY}. setting to ${NOTIFY%_if_open}"
+                        NOTIFY="${NOTIFY%_if_open}"
+                      fi
                       button=$(displaydialog "Quit “$x” to continue updating? $([[ -n $appNewVersion ]] && echo "Version $appversion is installed, but version $appNewVersion is available.") (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")
                       if [[ $button = "Not Now" ]]; then
                         appClosed=0
@@ -372,6 +384,10 @@ checkRunningProcesses() {
                       fi
                       ;;
                     prompt_user_loop)
+                      if [[ $NOTIFY = *"_if_open" ]] ; then
+                        printlog "NOTIFY was ${NOTIFY}. setting to ${NOTIFY%_if_open}"
+                        NOTIFY="${NOTIFY%_if_open}"
+                      fi
                       button=$(displaydialog "Quit “$x” to continue updating? $([[ -n $appNewVersion ]] && echo "Version $appversion is installed, but version $appNewVersion is available.") (Click “Not Now” to be asked in 1 hour, or leave this open until you are ready)." "The application “$x” needs to be updated.")
                       if [[ $button = "Not Now" ]]; then
                         if [[ $i < 2 ]]; then
@@ -390,6 +406,10 @@ checkRunningProcesses() {
                       fi
                       ;;
                     tell_user|tell_user_then_kill)
+                      if [[ $NOTIFY = *"_if_open" ]] ; then
+                        printlog "NOTIFY was ${NOTIFY}. setting to ${NOTIFY%_if_open}"
+                        NOTIFY="${NOTIFY%_if_open}"
+                      fi
                       button=$(displaydialogContinue "Quit “$x” to continue updating? (This is an important update). Wait for notification of update before launching app again." "The application “$x” needs to be updated.")
                       printlog "telling app $x to quit"
                       runAsUser osascript -e "tell app \"$x\" to quit"
@@ -402,12 +422,25 @@ checkRunningProcesses() {
                       fi
                       ;;
                     silent_fail)
+                      if [[ $NOTIFY = *"_if_open" ]] ; then
+                        printlog "NOTIFY was ${NOTIFY}. setting to silent"
+                        NOTIFY="silent"
+                      fi
                       appClosed=0
                       cleanupAndExit 12 "blocking process '$x' found, aborting" ERROR
                       ;;
                 esac
 
                 countedProcesses=$((countedProcesses + 1))
+            else
+                ## ONLY on the first time through
+                if [[ $i = 1 ]] ; then
+                  printlog "No blockingProcesses found"
+                  if [[ $NOTIFY = *"_if_open" ]] ; then
+                    printlog "NOTIFY was ${NOTIFY}. setting to silent"
+                    NOTIFY="silent"
+                  fi
+                fi
             fi
         done
 

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -33,6 +33,9 @@ NOTIFY=success
 #   - success      notify the user on success
 #   - silent       no notifications
 #   - all          all notifications (great for Self Service installation)
+#   - success_if_open  notify user on success if the application was open, but silent if the application was closed.
+#   - all_if_open  send user all notifications if the application was open, but silent if the application was closed.
+
 
 # time in seconds to wait for a prompt to be answered before exiting the script
 PROMPT_TIMEOUT=86400


### PR DESCRIPTION
Added more options for NOTIFY behavior.

success_if_open and all_if_open
Adjusted the checkRunningProcesses function to account for these.

In our using of installomator we find that users who receive a prompt from a BLOCKING_PROCESS_ACTION want to know when the update completes. But users who don't receive the prompt don't care about the fact that we've silently updated an application in the background.

These new notify options will make installomator run silently for users when the application is closed, but allow the users who have a blocking process to either receive a success notification or all notifications.