### PR TITLE
Filezilla: filename fix and ARM vs x86

### DIFF
--- a/fragments/labels/filezilla.sh
+++ b/fragments/labels/filezilla.sh
@@ -2,8 +2,13 @@ filezilla)
     name="FileZilla"
     type="tbz"
     packageID="org.filezilla-project.filezilla"
-    downloadURL=$(curl -fsL https://filezilla-project.org/download.php\?show_all=1 | grep macosx | head -n 1 | awk -F '"' '{print $2}' )
-    appNewVersion=$( curl -fsL https://filezilla-project.org/download.php\?show_all=1 | grep macosx | head -n 1 | awk -F '_' '{print $2}' )
+    if [[ $(arch) == "arm64" ]]; then
+        cpu_arch="arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        cpu_arch="x86"
+    fi
+    downloadURL=$(curl -fsL https://filezilla-project.org/download.php\?show_all=1 | grep macos-$cpu_arch | head -n 1 | awk -F '"' '{print $2}' )
+    appNewVersion=$( curl -fsL https://filezilla-project.org/download.php\?show_all=1 | grep macos-$cpu_arch | head -n 1 | awk -F '_' '{print $2}' )
     expectedTeamID="5VPGKXL75N"
     blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
Output:
```
# Installomator/utils/assemble.sh filezilla DEBUG=0
2023-12-21 10:46:46 : REQ   : filezilla : ################## Start Installomator v. 10.6beta, date 2023-12-21
2023-12-21 10:46:46 : INFO  : filezilla : ################## Version: 10.6beta
2023-12-21 10:46:46 : INFO  : filezilla : ################## Date: 2023-12-21
2023-12-21 10:46:46 : INFO  : filezilla : ################## filezilla
2023-12-21 10:46:47 : DEBUG : filezilla : DEBUG mode 1 enabled.
2023-12-21 10:46:48 : INFO  : filezilla : setting variable from argument DEBUG=0
2023-12-21 10:46:48 : DEBUG : filezilla : name=FileZilla
2023-12-21 10:46:48 : DEBUG : filezilla : appName=
2023-12-21 10:46:48 : DEBUG : filezilla : type=tbz
2023-12-21 10:46:48 : DEBUG : filezilla : archiveName=
2023-12-21 10:46:48 : DEBUG : filezilla : downloadURL=https://dl4.cdn.filezilla-project.org/client/FileZilla_3.66.4_macos-arm64.app.tar.bz2?h=GOiVvdRojNlh6QbR2UfhAw&x=1703177207
2023-12-21 10:46:48 : DEBUG : filezilla : curlOptions=
2023-12-21 10:46:48 : DEBUG : filezilla : appNewVersion=3.66.4
2023-12-21 10:46:48 : DEBUG : filezilla : appCustomVersion function: Not defined
2023-12-21 10:46:48 : DEBUG : filezilla : versionKey=CFBundleShortVersionString
2023-12-21 10:46:48 : DEBUG : filezilla : packageID=org.filezilla-project.filezilla
2023-12-21 10:46:48 : DEBUG : filezilla : pkgName=
2023-12-21 10:46:49 : DEBUG : filezilla : choiceChangesXML=
2023-12-21 10:46:49 : DEBUG : filezilla : expectedTeamID=5VPGKXL75N
2023-12-21 10:46:49 : DEBUG : filezilla : blockingProcesses=NONE
2023-12-21 10:46:49 : DEBUG : filezilla : installerTool=
2023-12-21 10:46:49 : DEBUG : filezilla : CLIInstaller=
2023-12-21 10:46:49 : DEBUG : filezilla : CLIArguments=
2023-12-21 10:46:49 : DEBUG : filezilla : updateTool=
2023-12-21 10:46:49 : DEBUG : filezilla : updateToolArguments=
2023-12-21 10:46:49 : DEBUG : filezilla : updateToolRunAsCurrentUser=
2023-12-21 10:46:49 : INFO  : filezilla : BLOCKING_PROCESS_ACTION=tell_user
2023-12-21 10:46:49 : INFO  : filezilla : NOTIFY=success
2023-12-21 10:46:49 : INFO  : filezilla : LOGGING=DEBUG
2023-12-21 10:46:49 : INFO  : filezilla : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-21 10:46:49 : INFO  : filezilla : Label type: tbz
2023-12-21 10:46:49 : INFO  : filezilla : archiveName: FileZilla.tbz
2023-12-21 10:46:49 : DEBUG : filezilla : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98
2023-12-21 10:46:49 : INFO  : filezilla : No version found using packageID org.filezilla-project.filezilla
2023-12-21 10:46:49 : INFO  : filezilla : name: FileZilla, appName: FileZilla.app
2023-12-21 10:46:49.756 mdfind[31983:146419] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-21 10:46:49.756 mdfind[31983:146419] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-21 10:46:49.910 mdfind[31983:146419] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-21 10:46:49 : WARN  : filezilla : No previous app found
2023-12-21 10:46:49 : WARN  : filezilla : could not find FileZilla.app
2023-12-21 10:46:49 : INFO  : filezilla : appversion: 
2023-12-21 10:46:50 : INFO  : filezilla : Latest version of FileZilla is 3.66.4
2023-12-21 10:46:50 : REQ   : filezilla : Downloading https://dl4.cdn.filezilla-project.org/client/FileZilla_3.66.4_macos-arm64.app.tar.bz2?h=GOiVvdRojNlh6QbR2UfhAw&x=1703177207 to FileZilla.tbz
2023-12-21 10:46:50 : DEBUG : filezilla : No Dialog connection, just download
2023-12-21 10:46:55 : DEBUG : filezilla : File list: -rw-r--r--  1 root  wheel    13M Dec 21 10:46 FileZilla.tbz
2023-12-21 10:46:55 : DEBUG : filezilla : File type: FileZilla.tbz: bzip2 compressed data, block size = 900k
2023-12-21 10:46:55 : DEBUG : filezilla : curl output was:
*   Trying 95.216.163.111:443...
* Connected to dl4.cdn.filezilla-project.org (95.216.163.111) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3490 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=dl4.cdn.filezilla-project.org
*  start date: Dec  8 07:38:28 2023 GMT
*  expire date: Mar  7 07:38:27 2024 GMT
*  subjectAltName: host "dl4.cdn.filezilla-project.org" matched cert's "dl4.cdn.filezilla-project.org"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /client/FileZilla_3.66.4_macos-arm64.app.tar.bz2?h=GOiVvdRojNlh6QbR2UfhAw&x=1703177207 HTTP/1.1
> Host: dl4.cdn.filezilla-project.org
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx
< Date: Thu, 21 Dec 2023 15:46:50 GMT
< Content-Type: application/octet-stream
< Content-Length: 13885725
< Last-Modified: Wed, 20 Dec 2023 13:22:04 GMT
< Connection: keep-alive
< ETag: "6582ea7c-d3e11d"
< X-Robots-Tag: noindex, nofollow
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< Accept-Ranges: bytes
< 
{ [16024 bytes data]
* Connection #0 to host dl4.cdn.filezilla-project.org left intact

2023-12-21 10:46:55 : REQ   : filezilla : Installing FileZilla
2023-12-21 10:46:56 : INFO  : filezilla : Unzipping FileZilla.tbz
2023-12-21 10:46:57 : INFO  : filezilla : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app
2023-12-21 10:46:57 : DEBUG : filezilla : App size:  43M	/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app
2023-12-21 10:46:57 : DEBUG : filezilla : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Tim Kosse (5VPGKXL75N)

2023-12-21 10:46:57 : INFO  : filezilla : Team ID matching: 5VPGKXL75N (expected: 5VPGKXL75N )
2023-12-21 10:46:57 : INFO  : filezilla : Installing FileZilla version 3.66.4 on versionKey CFBundleShortVersionString.
2023-12-21 10:46:57 : INFO  : filezilla : App has LSMinimumSystemVersion: 10.13.2
2023-12-21 10:46:57 : INFO  : filezilla : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app to /Applications
2023-12-21 10:46:58 : DEBUG : filezilla : Debugging enabled, App copy output was:
Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app

2023-12-21 10:46:58 : WARN  : filezilla : Changing owner to schwartzm
2023-12-21 10:46:58 : INFO  : filezilla : Finishing...
2023-12-21 10:47:01 : INFO  : filezilla : No version found using packageID org.filezilla-project.filezilla
2023-12-21 10:47:01 : INFO  : filezilla : App(s) found: /Applications/FileZilla.app
2023-12-21 10:47:01 : INFO  : filezilla : found app at /Applications/FileZilla.app, version 3.66.4, on versionKey CFBundleShortVersionString
2023-12-21 10:47:01 : REQ   : filezilla : Installed FileZilla, version 3.66.4
2023-12-21 10:47:01 : INFO  : filezilla : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-21 10:47:01 : DEBUG : filezilla : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98
2023-12-21 10:47:02 : DEBUG : filezilla : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.tbz
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/CodeResources
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/_CodeSignature/CodeResources
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/_CodeSignature
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/MacOS/fzstorj
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/MacOS/fzputtygen
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/MacOS/fzsftp
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/MacOS/filezilla

[Hundreds of similar lines deleted...]

2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/Frameworks
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents/Info.plist
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app/Contents
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98/FileZilla.app
2023-12-21 10:47:02 : DEBUG : filezilla : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.vU53rs5q98
2023-12-21 10:47:16 : INFO  : filezilla : Installomator did not close any apps, so no need to reopen any apps.
2023-12-21 10:47:16 : REQ   : filezilla : All done!
2023-12-21 10:47:16 : REQ   : filezilla : ################## End Installomator, exit code 0 
```