### PR TITLE
Correct label for OneDrive instead of Outlook

### DIFF
--- a/fragments/labels/microsoftonedrivereset.sh
+++ b/fragments/labels/microsoftonedrivereset.sh
@@ -1,7 +1,7 @@
 microsoftonedrivereset)
-    name="Microsoft Outlook Reset"
+    name="Microsoft OneDrive Reset"
     type="pkg"
-    packageID="com.microsoft.reset.Outlook"
-    downloadURL="https://office-reset.com"$(curl -fs https://office-reset.com/macadmins/ | grep -o -i "href.*\".*\"*Outlook_Reset.*.pkg" | cut -d '"' -f2)
+    packageID="com.microsoft.reset.OneDrive"
+    downloadURL="https://office-reset.com"$(curl -fs https://office-reset.com/macadmins/ | grep -o -i "href.*\".*\"*OneDrive_Reset.*.pkg" | cut -d '"' -f2)
     expectedTeamID="QGS93ZLCU7"
     ;;


### PR DESCRIPTION
I assume the Outlook Reset and OneDrive reset got mixed up in my initial commit.