### PR TITLE
ChemDoodle: Add ARM version

### DIFF
--- a/fragments/labels/chemdoodle.sh
+++ b/fragments/labels/chemdoodle.sh
@@ -2,20 +2,22 @@ chemdoodle|\
 chemdoodle2d)
      name="ChemDoodle"
      type="dmg"
-     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | xmllint --html --format - 2>&1 | grep -e "ChemDoodle-macos" | sed -r 's/.*href="([^"]+).*/\1/g' | head -n1)"
+     [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
+     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
      expectedTeamID="9XP397UW95"
      folderName="ChemDoodle"
      appName="${folderName}/ChemDoodle.app"
-     appNewVersion=$(curl -s -L https://www.ichemlabs.com/download | xmllint --html --format - 2>&1 | grep -e "ChemDoodle-macos" | grep -Eo '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{0,2}' | head -n1)
+     appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
      versionKey="CFBundleVersion"
      ;;
 chemdoodle3d)
      name="ChemDoodle3D"
      type="dmg"
-     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | xmllint --html --format - 2>&1 | grep -e "ChemDoodle3D-macos" | sed -r 's/.*href="([^"]+).*/\1/g' | head -n1)"
+     [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
+     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle3D-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
      expectedTeamID="9XP397UW95"
      folderName="ChemDoodle3D"
      appName="${folderName}/ChemDoodle3D.app"
-     appNewVersion=$(curl -s -L https://www.ichemlabs.com/download | xmllint --html --format - 2>&1 | grep -e "ChemDoodle3D-macos" | grep -Eo '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{0,2}' | head -n1)
+     appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
      versionKey="CFBundleVersion"
      ;;


### PR DESCRIPTION
This adds the ARM version for ChemDoodle and ChemDoodle3D and also cleans up the code a bit

Output:
```
# ./Installomator/utils/assemble.sh chemdoodle DEBUG=0
2023-12-22 10:36:30 : REQ   : chemdoodle : ################## Start Installomator v. 10.6beta, date 2023-12-22
2023-12-22 10:36:31 : INFO  : chemdoodle : ################## Version: 10.6beta
2023-12-22 10:36:31 : INFO  : chemdoodle : ################## Date: 2023-12-22
2023-12-22 10:36:31 : INFO  : chemdoodle : ################## chemdoodle
2023-12-22 10:36:31 : DEBUG : chemdoodle : DEBUG mode 1 enabled.
2023-12-22 10:36:32 : INFO  : chemdoodle : setting variable from argument DEBUG=0
2023-12-22 10:36:32 : DEBUG : chemdoodle : name=ChemDoodle
2023-12-22 10:36:32 : DEBUG : chemdoodle : appName=ChemDoodle/ChemDoodle.app
2023-12-22 10:36:32 : DEBUG : chemdoodle : type=dmg
2023-12-22 10:36:33 : DEBUG : chemdoodle : archiveName=
2023-12-22 10:36:33 : DEBUG : chemdoodle : downloadURL=https://www.ichemlabs.com/downloads/ChemDoodle-macos-aarch64-12.3.0.dmg
2023-12-22 10:36:33 : DEBUG : chemdoodle : curlOptions=
2023-12-22 10:36:33 : DEBUG : chemdoodle : appNewVersion=12.3.0
2023-12-22 10:36:33 : DEBUG : chemdoodle : appCustomVersion function: Not defined
2023-12-22 10:36:33 : DEBUG : chemdoodle : versionKey=CFBundleVersion
2023-12-22 10:36:33 : DEBUG : chemdoodle : packageID=
2023-12-22 10:36:33 : DEBUG : chemdoodle : pkgName=
2023-12-22 10:36:33 : DEBUG : chemdoodle : choiceChangesXML=
2023-12-22 10:36:33 : DEBUG : chemdoodle : expectedTeamID=9XP397UW95
2023-12-22 10:36:33 : DEBUG : chemdoodle : blockingProcesses=
2023-12-22 10:36:33 : DEBUG : chemdoodle : installerTool=
2023-12-22 10:36:33 : DEBUG : chemdoodle : CLIInstaller=
2023-12-22 10:36:33 : DEBUG : chemdoodle : CLIArguments=
2023-12-22 10:36:33 : DEBUG : chemdoodle : updateTool=
2023-12-22 10:36:33 : DEBUG : chemdoodle : updateToolArguments=
2023-12-22 10:36:33 : DEBUG : chemdoodle : updateToolRunAsCurrentUser=
2023-12-22 10:36:33 : INFO  : chemdoodle : BLOCKING_PROCESS_ACTION=tell_user
2023-12-22 10:36:34 : INFO  : chemdoodle : NOTIFY=success
2023-12-22 10:36:34 : INFO  : chemdoodle : LOGGING=DEBUG
2023-12-22 10:36:34 : INFO  : chemdoodle : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-22 10:36:34 : INFO  : chemdoodle : Label type: dmg
2023-12-22 10:36:34 : INFO  : chemdoodle : archiveName: ChemDoodle.dmg
2023-12-22 10:36:34 : INFO  : chemdoodle : no blocking processes defined, using ChemDoodle as default
2023-12-22 10:36:34 : DEBUG : chemdoodle : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jwa8u3L5lj
2023-12-22 10:36:34 : INFO  : chemdoodle : name: ChemDoodle, appName: ChemDoodle/ChemDoodle.app
2023-12-22 10:36:34.692 mdfind[11548:819947] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-22 10:36:34.692 mdfind[11548:819947] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-22 10:36:34.880 mdfind[11548:819947] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-22 10:36:34 : WARN  : chemdoodle : No previous app found
2023-12-22 10:36:34 : WARN  : chemdoodle : could not find ChemDoodle/ChemDoodle.app
2023-12-22 10:36:34 : INFO  : chemdoodle : appversion:
2023-12-22 10:36:35 : INFO  : chemdoodle : Latest version of ChemDoodle is 12.3.0
2023-12-22 10:36:35 : REQ   : chemdoodle : Downloading https://www.ichemlabs.com/downloads/ChemDoodle-macos-aarch64-12.3.0.dmg to ChemDoodle.dmg
2023-12-22 10:36:35 : DEBUG : chemdoodle : No Dialog connection, just download
2023-12-22 10:36:49 : DEBUG : chemdoodle : File list: -rw-r--r--  1 root  wheel   101M Dec 22 10:36 ChemDoodle.dmg
2023-12-22 10:36:50 : DEBUG : chemdoodle : File type: ChemDoodle.dmg: zlib compressed data
2023-12-22 10:36:50 : DEBUG : chemdoodle : curl output was:
*   Trying 104.200.29.49:443...
* Connected to www.ichemlabs.com (104.200.29.49) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [81 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3493 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=ichemlabs.com
*  start date: Dec 11 09:32:44 2023 GMT
*  expire date: Mar 10 09:32:43 2024 GMT
*  subjectAltName: host "www.ichemlabs.com" matched cert's "www.ichemlabs.com"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /downloads/ChemDoodle-macos-aarch64-12.3.0.dmg HTTP/1.1
> Host: www.ichemlabs.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 22 Dec 2023 15:36:35 GMT
< Server: Apache/2.4.41
< Last-Modified: Tue, 14 Nov 2023 21:54:41 GMT
< ETag: "64bba2b-60a23d56baa40"
< Accept-Ranges: bytes
< Content-Length: 105626155
< Content-Type: application/x-apple-diskimage
<
{ [16384 bytes data]
* Connection #0 to host www.ichemlabs.com left intact

2023-12-22 10:36:50 : REQ   : chemdoodle : no more blocking processes, continue with update
2023-12-22 10:36:50 : REQ   : chemdoodle : Installing ChemDoodle
2023-12-22 10:36:50 : INFO  : chemdoodle : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jwa8u3L5lj/ChemDoodle.dmg
2023-12-22 10:36:56 : DEBUG : chemdoodle : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C7BAD63D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $A3164022
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2A7F6ACF
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $85853AD5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2A7F6ACF
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CF80CFFE
verified   CRC32 $7420D63B
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/ChemDoodle

2023-12-22 10:36:56 : INFO  : chemdoodle : Mounted: /Volumes/ChemDoodle
2023-12-22 10:36:56 : INFO  : chemdoodle : Verifying: /Volumes/ChemDoodle/ChemDoodle/ChemDoodle.app
2023-12-22 10:36:56 : DEBUG : chemdoodle : App size: 181M	/Volumes/ChemDoodle/ChemDoodle/ChemDoodle.app
2023-12-22 10:36:57 : DEBUG : chemdoodle : Debugging enabled, App Verification output was:
/Volumes/ChemDoodle/ChemDoodle/ChemDoodle.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: iChemLabs, LLC. (9XP397UW95)

2023-12-22 10:36:57 : INFO  : chemdoodle : Team ID matching: 9XP397UW95 (expected: 9XP397UW95 )
2023-12-22 10:36:57 : INFO  : chemdoodle : Installing ChemDoodle version 12.3.0 on versionKey CFBundleVersion.
2023-12-22 10:36:57 : INFO  : chemdoodle : App has LSMinimumSystemVersion: 10.11
2023-12-22 10:36:57 : INFO  : chemdoodle : Copy /Volumes/ChemDoodle/ChemDoodle/ChemDoodle.app to /Applications
2023-12-22 10:36:58 : DEBUG : chemdoodle : Debugging enabled, App copy output was:
Copying /Volumes/ChemDoodle/ChemDoodle

2023-12-22 10:36:58 : WARN  : chemdoodle : Changing owner to schwartzm
2023-12-22 10:36:59 : INFO  : chemdoodle : Finishing...
2023-12-22 10:37:02 : INFO  : chemdoodle : App(s) found: /Applications/ChemDoodle/ChemDoodle.app
2023-12-22 10:37:02 : INFO  : chemdoodle : found app at /Applications/ChemDoodle/ChemDoodle.app, version 12.3.0, on versionKey CFBundleVersion
2023-12-22 10:37:02 : REQ   : chemdoodle : Installed ChemDoodle, version 12.3.0
2023-12-22 10:37:02 : INFO  : chemdoodle : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-22 10:37:02 : DEBUG : chemdoodle : Unmounting /Volumes/ChemDoodle
2023-12-22 10:37:02 : DEBUG : chemdoodle : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-22 10:37:02 : DEBUG : chemdoodle : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jwa8u3L5lj
2023-12-22 10:37:02 : DEBUG : chemdoodle : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jwa8u3L5lj/ChemDoodle.dmg
2023-12-22 10:37:02 : DEBUG : chemdoodle : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jwa8u3L5lj
2023-12-22 10:37:03 : INFO  : chemdoodle : Installomator did not close any apps, so no need to reopen any apps.
2023-12-22 10:37:03 : REQ   : chemdoodle : All done!
2023-12-22 10:37:03 : REQ   : chemdoodle : ################## End Installomator, exit code 0

# ./Installomator/utils/assemble.sh chemdoodle3d DEBUG=0
2023-12-22 10:37:48 : REQ   : chemdoodle3d : ################## Start Installomator v. 10.6beta, date 2023-12-22
2023-12-22 10:37:48 : INFO  : chemdoodle3d : ################## Version: 10.6beta
2023-12-22 10:37:48 : INFO  : chemdoodle3d : ################## Date: 2023-12-22
2023-12-22 10:37:48 : INFO  : chemdoodle3d : ################## chemdoodle3d
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : DEBUG mode 1 enabled.
2023-12-22 10:37:48 : INFO  : chemdoodle3d : setting variable from argument DEBUG=0
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : name=ChemDoodle3D
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : appName=ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : type=dmg
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : archiveName=
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : downloadURL=https://www.ichemlabs.com/downloads/ChemDoodle3D-macos-aarch64-7.2.0.dmg
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : curlOptions=
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : appNewVersion=7.2.0
2023-12-22 10:37:48 : DEBUG : chemdoodle3d : appCustomVersion function: Not defined
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : versionKey=CFBundleVersion
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : packageID=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : pkgName=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : choiceChangesXML=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : expectedTeamID=9XP397UW95
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : blockingProcesses=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : installerTool=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : CLIInstaller=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : CLIArguments=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : updateTool=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : updateToolArguments=
2023-12-22 10:37:49 : DEBUG : chemdoodle3d : updateToolRunAsCurrentUser=
2023-12-22 10:37:49 : INFO  : chemdoodle3d : BLOCKING_PROCESS_ACTION=tell_user
2023-12-22 10:37:49 : INFO  : chemdoodle3d : NOTIFY=success
2023-12-22 10:37:49 : INFO  : chemdoodle3d : LOGGING=DEBUG
2023-12-22 10:37:49 : INFO  : chemdoodle3d : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-22 10:37:49 : INFO  : chemdoodle3d : Label type: dmg
2023-12-22 10:37:49 : INFO  : chemdoodle3d : archiveName: ChemDoodle3D.dmg
2023-12-22 10:37:49 : INFO  : chemdoodle3d : no blocking processes defined, using ChemDoodle3D as default
2023-12-22 10:37:50 : DEBUG : chemdoodle3d : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1TSaL8FJGK
2023-12-22 10:37:50 : INFO  : chemdoodle3d : name: ChemDoodle3D, appName: ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:37:50.219 mdfind[12059:822037] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-22 10:37:50.220 mdfind[12059:822037] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-22 10:37:50.334 mdfind[12059:822037] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-22 10:37:50 : WARN  : chemdoodle3d : No previous app found
2023-12-22 10:37:50 : WARN  : chemdoodle3d : could not find ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:37:50 : INFO  : chemdoodle3d : appversion:
2023-12-22 10:37:50 : INFO  : chemdoodle3d : Latest version of ChemDoodle3D is 7.2.0
2023-12-22 10:37:50 : REQ   : chemdoodle3d : Downloading https://www.ichemlabs.com/downloads/ChemDoodle3D-macos-aarch64-7.2.0.dmg to ChemDoodle3D.dmg
2023-12-22 10:37:50 : DEBUG : chemdoodle3d : No Dialog connection, just download
2023-12-22 10:38:04 : DEBUG : chemdoodle3d : File list: -rw-r--r--  1 root  wheel   104M Dec 22 10:38 ChemDoodle3D.dmg
2023-12-22 10:38:04 : DEBUG : chemdoodle3d : File type: ChemDoodle3D.dmg: zlib compressed data
2023-12-22 10:38:04 : DEBUG : chemdoodle3d : curl output was:
*   Trying 104.200.29.49:443...
* Connected to www.ichemlabs.com (104.200.29.49) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [81 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3493 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=ichemlabs.com
*  start date: Dec 11 09:32:44 2023 GMT
*  expire date: Mar 10 09:32:43 2024 GMT
*  subjectAltName: host "www.ichemlabs.com" matched cert's "www.ichemlabs.com"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /downloads/ChemDoodle3D-macos-aarch64-7.2.0.dmg HTTP/1.1
> Host: www.ichemlabs.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 22 Dec 2023 15:37:50 GMT
< Server: Apache/2.4.41
< Last-Modified: Mon, 23 Oct 2023 02:27:35 GMT
< ETag: "67be466-60858f70973c0"
< Accept-Ranges: bytes
< Content-Length: 108782694
< Content-Type: application/x-apple-diskimage
<
{ [16384 bytes data]
* Connection #0 to host www.ichemlabs.com left intact

2023-12-22 10:38:04 : REQ   : chemdoodle3d : no more blocking processes, continue with update
2023-12-22 10:38:04 : REQ   : chemdoodle3d : Installing ChemDoodle3D
2023-12-22 10:38:04 : INFO  : chemdoodle3d : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1TSaL8FJGK/ChemDoodle3D.dmg
2023-12-22 10:38:06 : DEBUG : chemdoodle3d : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $020FB017
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1080BF93
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $4F475EAB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $F6FB33B3
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $4F475EAB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E3BB4AF5
verified   CRC32 $F1C0D6B4
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/ChemDoodle3D

2023-12-22 10:38:06 : INFO  : chemdoodle3d : Mounted: /Volumes/ChemDoodle3D
2023-12-22 10:38:06 : INFO  : chemdoodle3d : Verifying: /Volumes/ChemDoodle3D/ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:38:06 : DEBUG : chemdoodle3d : App size: 184M	/Volumes/ChemDoodle3D/ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:38:07 : DEBUG : chemdoodle3d : Debugging enabled, App Verification output was:
/Volumes/ChemDoodle3D/ChemDoodle3D/ChemDoodle3D.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: iChemLabs, LLC. (9XP397UW95)

2023-12-22 10:38:07 : INFO  : chemdoodle3d : Team ID matching: 9XP397UW95 (expected: 9XP397UW95 )
2023-12-22 10:38:07 : INFO  : chemdoodle3d : Installing ChemDoodle3D version 7.2.0 on versionKey CFBundleVersion.
2023-12-22 10:38:08 : INFO  : chemdoodle3d : App has LSMinimumSystemVersion: 10.11
2023-12-22 10:38:08 : INFO  : chemdoodle3d : Copy /Volumes/ChemDoodle3D/ChemDoodle3D/ChemDoodle3D.app to /Applications
2023-12-22 10:38:08 : DEBUG : chemdoodle3d : Debugging enabled, App copy output was:
Copying /Volumes/ChemDoodle3D/ChemDoodle3D

2023-12-22 10:38:08 : WARN  : chemdoodle3d : Changing owner to schwartzm
2023-12-22 10:38:08 : INFO  : chemdoodle3d : Finishing...
2023-12-22 10:38:11 : INFO  : chemdoodle3d : App(s) found: /Applications/ChemDoodle3D/ChemDoodle3D.app
2023-12-22 10:38:11 : INFO  : chemdoodle3d : found app at /Applications/ChemDoodle3D/ChemDoodle3D.app, version 7.2.0, on versionKey CFBundleVersion
2023-12-22 10:38:11 : REQ   : chemdoodle3d : Installed ChemDoodle3D, version 7.2.0
2023-12-22 10:38:11 : INFO  : chemdoodle3d : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-22 10:38:11 : DEBUG : chemdoodle3d : Unmounting /Volumes/ChemDoodle3D
2023-12-22 10:38:12 : DEBUG : chemdoodle3d : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-22 10:38:13 : DEBUG : chemdoodle3d : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1TSaL8FJGK
2023-12-22 10:38:13 : DEBUG : chemdoodle3d : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1TSaL8FJGK/ChemDoodle3D.dmg
2023-12-22 10:38:13 : DEBUG : chemdoodle3d : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1TSaL8FJGK
2023-12-22 10:38:13 : INFO  : chemdoodle3d : Installomator did not close any apps, so no need to reopen any apps.
2023-12-22 10:38:13 : REQ   : chemdoodle3d : All done!
2023-12-22 10:38:13 : REQ   : chemdoodle3d : ################## End Installomator, exit code 0
```