### PR TITLE
Vagrant: Add ARM Version

### DIFF
--- a/fragments/labels/vagrant.sh
+++ b/fragments/labels/vagrant.sh
@@ -2,7 +2,8 @@ vagrant)
     name="Vagrant"
     type="pkgInDmg"
     pkgName="vagrant.pkg"
-    downloadURL=$(curl -fs "https://developer.hashicorp.com/vagrant/downloads" | tr '"' '\n' | grep "^https.*\.dmg$" | head -1)
+    cpu_arch="${$(arch)/i386/amd64}"
+    downloadURL=$(curl -fsL "https://developer.hashicorp.com/vagrant/downloads" | grep -oE 'http[^"]*'$cpu_arch'[^"]*.dmg' | head -1)
     appNewVersion=$( echo $downloadURL | cut -d "/" -f5 )
     expectedTeamID="D38WU7D763"
     ;;

--- a/fragments/labels/vagrant.sh
+++ b/fragments/labels/vagrant.sh
@@ -3,7 +3,7 @@ vagrant)
     type="pkgInDmg"
     pkgName="vagrant.pkg"
     cpu_arch="${$(arch)/i386/amd64}"
-    downloadURL=$(curl -fsL "https://developer.hashicorp.com/vagrant/downloads" | grep -oE 'http[^"]*'$cpu_arch'[^"]*.dmg' | head -1)
+    downloadURL=$(curl -fsL "https://developer.hashicorp.com/vagrant/downloads" | grep -oE 'https[^"]*'$cpu_arch'[^"]*.dmg' | head -1)
     appNewVersion=$( echo $downloadURL | cut -d "/" -f5 )
     expectedTeamID="D38WU7D763"
     ;;


### PR DESCRIPTION
This adds the ARM version and also adds a curl -L switch to follow redirects.

Output:
```
# ./Installomator/utils/assemble.sh vagrant DEBUG=0
2023-12-22 12:44:02 : REQ   : vagrant : ################## Start Installomator v. 10.6beta, date 2023-12-22
2023-12-22 12:44:02 : INFO  : vagrant : ################## Version: 10.6beta
2023-12-22 12:44:02 : INFO  : vagrant : ################## Date: 2023-12-22
2023-12-22 12:44:02 : INFO  : vagrant : ################## vagrant
2023-12-22 12:44:02 : DEBUG : vagrant : DEBUG mode 1 enabled.
2023-12-22 12:44:03 : INFO  : vagrant : setting variable from argument DEBUG=0
2023-12-22 12:44:03 : DEBUG : vagrant : name=Vagrant
2023-12-22 12:44:03 : DEBUG : vagrant : appName=
2023-12-22 12:44:03 : DEBUG : vagrant : type=pkgInDmg
2023-12-22 12:44:03 : DEBUG : vagrant : archiveName=
2023-12-22 12:44:03 : DEBUG : vagrant : downloadURL=https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0_darwin_arm64.dmg
2023-12-22 12:44:03 : DEBUG : vagrant : curlOptions=
2023-12-22 12:44:03 : DEBUG : vagrant : appNewVersion=2.4.0
2023-12-22 12:44:03 : DEBUG : vagrant : appCustomVersion function: Not defined
2023-12-22 12:44:03 : DEBUG : vagrant : versionKey=CFBundleShortVersionString
2023-12-22 12:44:03 : DEBUG : vagrant : packageID=
2023-12-22 12:44:03 : DEBUG : vagrant : pkgName=vagrant.pkg
2023-12-22 12:44:03 : DEBUG : vagrant : choiceChangesXML=
2023-12-22 12:44:03 : DEBUG : vagrant : expectedTeamID=D38WU7D763
2023-12-22 12:44:03 : DEBUG : vagrant : blockingProcesses=
2023-12-22 12:44:03 : DEBUG : vagrant : installerTool=
2023-12-22 12:44:03 : DEBUG : vagrant : CLIInstaller=
2023-12-22 12:44:03 : DEBUG : vagrant : CLIArguments=
2023-12-22 12:44:03 : DEBUG : vagrant : updateTool=
2023-12-22 12:44:03 : DEBUG : vagrant : updateToolArguments=
2023-12-22 12:44:03 : DEBUG : vagrant : updateToolRunAsCurrentUser=
2023-12-22 12:44:03 : INFO  : vagrant : BLOCKING_PROCESS_ACTION=tell_user
2023-12-22 12:44:03 : INFO  : vagrant : NOTIFY=success
2023-12-22 12:44:03 : INFO  : vagrant : LOGGING=DEBUG
2023-12-22 12:44:03 : INFO  : vagrant : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-22 12:44:03 : INFO  : vagrant : Label type: pkgInDmg
2023-12-22 12:44:03 : INFO  : vagrant : archiveName: Vagrant.dmg
2023-12-22 12:44:03 : INFO  : vagrant : no blocking processes defined, using Vagrant as default
2023-12-22 12:44:04 : DEBUG : vagrant : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iSobAGAkl9
2023-12-22 12:44:04 : INFO  : vagrant : name: Vagrant, appName: Vagrant.app
2023-12-22 12:44:04.076 mdfind[27658:943043] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-22 12:44:04.076 mdfind[27658:943043] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-22 12:44:04.169 mdfind[27658:943043] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-22 12:44:04 : WARN  : vagrant : No previous app found
2023-12-22 12:44:04 : WARN  : vagrant : could not find Vagrant.app
2023-12-22 12:44:04 : INFO  : vagrant : appversion:
2023-12-22 12:44:04 : INFO  : vagrant : Latest version of Vagrant is 2.4.0
2023-12-22 12:44:04 : REQ   : vagrant : Downloading https://releases.hashicorp.com/vagrant/2.4.0/vagrant_2.4.0_darwin_arm64.dmg to Vagrant.dmg
2023-12-22 12:44:04 : DEBUG : vagrant : No Dialog connection, just download
2023-12-22 12:44:31 : DEBUG : vagrant : File list: -rw-r--r--  1 root  wheel   127M Dec 22 12:44 Vagrant.dmg
2023-12-22 12:44:31 : DEBUG : vagrant : File type: Vagrant.dmg: zlib compressed data
2023-12-22 12:44:31 : DEBUG : vagrant : curl output was:
*   Trying 18.238.4.25:443...
* Connected to releases.hashicorp.com (18.238.4.25) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3473 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=releases.hashicorp.com
*  start date: May 29 00:00:00 2023 GMT
*  expire date: Jun 27 23:59:59 2024 GMT
*  subjectAltName: host "releases.hashicorp.com" matched cert's "releases.hashicorp.com"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /vagrant/2.4.0/vagrant_2.4.0_darwin_arm64.dmg HTTP/1.1
> Host: releases.hashicorp.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 133091671
< Connection: keep-alive
< Date: Mon, 16 Oct 2023 19:31:11 GMT
< Last-Modified: Mon, 16 Oct 2023 19:20:52 GMT
< ETag: "fafb6fdbd2e1fdabd70c5947f46f0031"
< x-amz-server-side-encryption: AES256
< Cache-Control: max-age=31536000, stale-while-revalidate=86400, stale-if-error=604800, public
< Content-Disposition: attachment
< Accept-Ranges: bytes
< Server: AmazonS3
< surrogate-control: max-age=31536000, stale-while-revalidate=86400, stale-if-error=604800, public
< surrogate-key: vagrant vagrant-2.4.0
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: sameorigin
< X-Xss-Protection: 1; mode=block
< X-Cache: Hit from cloudfront
< Via: 1.1 ccbf01f3e1fbbe27e81779a9bd6e91de.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: PHL51-P1
< X-Amz-Cf-Id: sh2cxzx4mN1nvm3QawpbUvJ8yPaMgh5XbnrP_RIEtsksESi2Q3kQRw==
< Age: 5782374
< Vary: Origin
<
{ [16384 bytes data]
* Connection #0 to host releases.hashicorp.com left intact

2023-12-22 12:44:31 : REQ   : vagrant : no more blocking processes, continue with update
2023-12-22 12:44:31 : REQ   : vagrant : Installing Vagrant
2023-12-22 12:44:31 : INFO  : vagrant : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iSobAGAkl9/Vagrant.dmg
2023-12-22 12:44:36 : DEBUG : vagrant : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $81ACF46C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B8DDEE6C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $278715DB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $90F65690
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $278715DB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $DC9FDDED
verified   CRC32 $46C2FE10
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Vagrant

2023-12-22 12:44:36 : INFO  : vagrant : Mounted: /Volumes/Vagrant
2023-12-22 12:44:36 : INFO  : vagrant : found pkg: /Volumes/Vagrant/vagrant.pkg
2023-12-22 12:44:36 : INFO  : vagrant : Verifying: /Volumes/Vagrant/vagrant.pkg
2023-12-22 12:44:36 : DEBUG : vagrant : File list: -rw-r--r--  1 mfe  staff   127M Oct 16 13:11 /Volumes/Vagrant/vagrant.pkg
2023-12-22 12:44:36 : DEBUG : vagrant : File type: /Volumes/Vagrant/vagrant.pkg: xar archive compressed TOC: 4629, SHA-1 checksum
2023-12-22 12:44:37 : DEBUG : vagrant : spctlOut is /Volumes/Vagrant/vagrant.pkg: accepted
2023-12-22 12:44:37 : DEBUG : vagrant : source=Notarized Developer ID
2023-12-22 12:44:37 : DEBUG : vagrant : origin=Developer ID Installer: Hashicorp, Inc. (D38WU7D763)
2023-12-22 12:44:37 : INFO  : vagrant : Team ID: D38WU7D763 (expected: D38WU7D763 )
2023-12-22 12:44:37 : INFO  : vagrant : Installing /Volumes/Vagrant/vagrant.pkg to /
2023-12-22 12:45:03 : DEBUG : vagrant : Debugging enabled, installer output was:
Dec 22 12:44:40  installer[27858] <Debug>: Product archive /Volumes/Vagrant/vagrant.pkg trustLevel=350
Dec 22 12:44:40  installer[27858] <Debug>: External component packages (1) trustLevel=350
Dec 22 12:44:40  installer[27858] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Dec 22 12:44:40  installer[27858] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/Vagrant/vagrant.pkg#core.pkg
Dec 22 12:44:40  installer[27858] <Info>: Set authorization level to root for session
Dec 22 12:44:40  installer[27858] <Info>: Authorization is being checked, waiting until authorization arrives.
Dec 22 12:44:40  installer[27858] <Info>: Administrator authorization granted.
Dec 22 12:44:40  installer[27858] <Info>: Packages have been authorized for installation.
Dec 22 12:44:40  installer[27858] <Debug>: Will use PK session
Dec 22 12:44:40  installer[27858] <Debug>: Using authorization level of root for IFPKInstallElement
Dec 22 12:44:41  installer[27858] <Info>: Starting installation:
Dec 22 12:44:41  installer[27858] <Notice>: Configuring volume "Macintosh HD"
Dec 22 12:44:41  installer[27858] <Info>: Preparing disk for local booted install.
Dec 22 12:44:41  installer[27858] <Notice>: Free space on "Macintosh HD": 441.42 GB (441420468224 bytes).
Dec 22 12:44:41  installer[27858] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27858ZzexxE"
Dec 22 12:44:41  installer[27858] <Notice>: IFPKInstallElement (1 packages)
Dec 22 12:44:41  installer[27858] <Info>: Current Path: /usr/sbin/installer
Dec 22 12:44:41  installer[27858] <Info>: Current Path: /bin/zsh
Last Log repeated 2 times
Dec 22 12:44:41  installer[27858] <Info>: Current Path: /usr/bin/sudo
Dec 22 12:44:41  installer[27858] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Vagrant
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Vagrant….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
Last Log repeated 2 times
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Registering package with system….....
#
installer: Running package scripts….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
Last Log repeated 8 times
installer: Validating packages….....
#Dec 22 12:45:02  installer[27858] <Notice>: Running install actions
Dec 22 12:45:02  installer[27858] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.27858ZzexxE"
Dec 22 12:45:02  installer[27858] <Notice>: Finalize disk "Macintosh HD"
Dec 22 12:45:02  installer[27858] <Notice>: Notifying system of updated components
Dec 22 12:45:02  installer[27858] <Notice>:
Dec 22 12:45:02  installer[27858] <Notice>: **** Summary Information ****
Dec 22 12:45:02  installer[27858] <Notice>:   Operation      Elapsed time
Dec 22 12:45:02  installer[27858] <Notice>: -----------------------------
Dec 22 12:45:02  installer[27858] <Notice>:        disk      0.01 seconds
Dec 22 12:45:02  installer[27858] <Notice>:      script      0.00 seconds
Dec 22 12:45:02  installer[27858] <Notice>:        zero      0.01 seconds
Dec 22 12:45:02  installer[27858] <Notice>:     install      21.20 seconds
Dec 22 12:45:02  installer[27858] <Notice>:     -total-      21.21 seconds
Dec 22 12:45:02  installer[27858] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The install was successful.

[install log deleted]

2023-12-22 12:45:03 : INFO  : vagrant : Finishing...
2023-12-22 12:45:06 : INFO  : vagrant : name: Vagrant, appName: Vagrant.app
2023-12-22 12:45:06.612 mdfind[28017:944934] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-22 12:45:06.612 mdfind[28017:944934] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-22 12:45:06.716 mdfind[28017:944934] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-22 12:45:06 : WARN  : vagrant : No previous app found
2023-12-22 12:45:06 : WARN  : vagrant : could not find Vagrant.app
2023-12-22 12:45:06 : REQ   : vagrant : Installed Vagrant, version 2.4.0
2023-12-22 12:45:06 : INFO  : vagrant : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-22 12:45:06 : DEBUG : vagrant : Unmounting /Volumes/Vagrant
2023-12-22 12:45:07 : DEBUG : vagrant : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-22 12:45:07 : DEBUG : vagrant : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iSobAGAkl9
2023-12-22 12:45:07 : DEBUG : vagrant : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iSobAGAkl9/Vagrant.dmg
2023-12-22 12:45:07 : DEBUG : vagrant : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iSobAGAkl9
2023-12-22 12:45:07 : INFO  : vagrant : Installomator did not close any apps, so no need to reopen any apps.
2023-12-22 12:45:07 : REQ   : vagrant : All done!
2023-12-22 12:45:07 : REQ   : vagrant : ################## End Installomator, exit code 0
```