### PR TITLE
BeyondComparePro: Fix URL

### DIFF
--- a/fragments/labels/beyondcomparepro.sh
+++ b/fragments/labels/beyondcomparepro.sh
@@ -1,7 +1,7 @@
 beyondcomparepro)
     name="Beyond Compare"
     type="zip"
-    downloadURL=$( curl -sL "https://www.scootersoftware.com/checkupdates.php?product=bc4&edition=pro&platform=osx&lang=silent" | cut -d= -f5 | cut -d\" -f2 )
-    appNewVersion=$( curl -sL "https://www.scootersoftware.com/checkupdates.php?product=bc4&edition=pro&platform=osx&lang=silent" | cut -d= -f7 | cut -d\" -f2 | awk '{gsub(" build ", ".");print}' )
+    downloadURL="https://www.scootersoftware.com"$(curl -fsL 'https://www.scootersoftware.com/download' | sed -nE 's/.*"(.*OSX-[^"]*)".*/\1/p')
+    appNewVersion=$( grep -oE '(\d+\.){2}(\d+)' <<< $downloadURL )
     expectedTeamID="BS29TEJF86"
     ;;

--- a/fragments/labels/beyondcomparepro.sh
+++ b/fragments/labels/beyondcomparepro.sh
@@ -1,7 +1,7 @@
 beyondcomparepro)
     name="Beyond Compare"
     type="zip"
-    downloadURL="https://www.scootersoftware.com"$(curl -fsL 'https://www.scootersoftware.com/download' | sed -nE 's/.*"(.*OSX-[^"]*)".*/\1/p')
-    appNewVersion=$( grep -oE '(\d+\.){2}(\d+)' <<< $downloadURL )
+    downloadURL=$( curl -sL "https://www.scootersoftware.com/checkupdates.php?product=bc4&edition=pro&platform=osx&lang=silent" | cut -d= -f5 | cut -d\" -f2 )
+    appNewVersion=$( curl -sL "https://www.scootersoftware.com/checkupdates.php?product=bc4&edition=pro&platform=osx&lang=silent" | cut -d= -f7 | cut -d\" -f2 | awk '{gsub(" build ", ".");print}' )
     expectedTeamID="BS29TEJF86"
     ;;


### PR DESCRIPTION
The behavior of the site's "checkupdates.php" page has changed and it now returns an old and invalid version. This updates the label to pull from the downloads page directly.

Output:
```
# ./Installomator/utils/assemble.sh beyondcomparepro DEBUG=0
2023-12-22 15:56:50 : REQ : beyondcomparepro : ################## Start Installomator v. 10.6beta, date 2023-12-22
2023-12-22 15:56:50 : INFO : beyondcomparepro : ################## Version: 10.6beta
2023-12-22 15:56:50 : INFO : beyondcomparepro : ################## Date: 2023-12-22
2023-12-22 15:56:50 : INFO : beyondcomparepro : ################## beyondcomparepro
2023-12-22 15:56:50 : DEBUG : beyondcomparepro : DEBUG mode 1 enabled.
2023-12-22 15:56:50 : INFO : beyondcomparepro : setting variable from argument DEBUG=0
2023-12-22 15:56:50 : DEBUG : beyondcomparepro : name=Beyond Compare
2023-12-22 15:56:50 : DEBUG : beyondcomparepro : appName=
2023-12-22 15:56:50 : DEBUG : beyondcomparepro : type=zip
2023-12-22 15:56:50 : DEBUG : beyondcomparepro : archiveName=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : downloadURL=https://www.scootersoftware.com/files/BCompareOSX-4.4.7.28397.zip
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : curlOptions=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : appNewVersion=4.4.7
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : appCustomVersion function: Not defined
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : versionKey=CFBundleShortVersionString
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : packageID=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : pkgName=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : choiceChangesXML=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : expectedTeamID=BS29TEJF86
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : blockingProcesses=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : installerTool=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : CLIInstaller=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : CLIArguments=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : updateTool=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : updateToolArguments=
2023-12-22 15:56:51 : DEBUG : beyondcomparepro : updateToolRunAsCurrentUser=
2023-12-22 15:56:51 : INFO : beyondcomparepro : BLOCKING_PROCESS_ACTION=tell_user
2023-12-22 15:56:51 : INFO : beyondcomparepro : NOTIFY=success
2023-12-22 15:56:51 : INFO : beyondcomparepro : LOGGING=DEBUG
2023-12-22 15:56:51 : INFO : beyondcomparepro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-22 15:56:51 : INFO : beyondcomparepro : Label type: zip
2023-12-22 15:56:51 : INFO : beyondcomparepro : archiveName: Beyond Compare.zip
2023-12-22 15:56:52 : INFO : beyondcomparepro : no blocking processes defined, using Beyond Compare as default
2023-12-22 15:56:52 : DEBUG : beyondcomparepro : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7
2023-12-22 15:56:52 : INFO : beyondcomparepro : name: Beyond Compare, appName: Beyond Compare.app
2023-12-22 15:56:52.134 mdfind[53989:1130470] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-22 15:56:52.134 mdfind[53989:1130470] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-22 15:56:52.232 mdfind[53989:1130470] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-22 15:56:52 : WARN : beyondcomparepro : No previous app found
2023-12-22 15:56:52 : WARN : beyondcomparepro : could not find Beyond Compare.app
2023-12-22 15:56:52 : INFO : beyondcomparepro : appversion:
2023-12-22 15:56:52 : INFO : beyondcomparepro : Latest version of Beyond Compare is 4.4.7
2023-12-22 15:56:52 : REQ : beyondcomparepro : Downloading https://www.scootersoftware.com/files/BCompareOSX-4.4.7.28397.zip to Beyond Compare.zip
2023-12-22 15:56:52 : DEBUG : beyondcomparepro : No Dialog connection, just download
2023-12-22 15:56:58 : DEBUG : beyondcomparepro : File list: -rw-r--r-- 1 root wheel 26M Dec 22 15:56 Beyond Compare.zip
2023-12-22 15:56:58 : DEBUG : beyondcomparepro : File type: Beyond Compare.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-12-22 15:56:58 : DEBUG : beyondcomparepro : curl output was:
* Trying 72.32.90.251:443...
* Connected to www.scootersoftware.com (72.32.90.251) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
* CAfile: /etc/ssl/cert.pem
* CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [81 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3486 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
* subject: CN=*.scootersoftware.com
* start date: Mar 23 00:00:00 2023 GMT
* expire date: Apr 8 23:59:59 2024 GMT
* subjectAltName: host "www.scootersoftware.com" matched cert's "*.scootersoftware.com"
* issuer: O=Leidos; CN=Leidos Perimeter FW CA
* SSL certificate verify ok.
* using HTTP/1.x
> GET /files/BCompareOSX-4.4.7.28397.zip HTTP/1.1
> Host: www.scootersoftware.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 22 Dec 2023 20:56:53 GMT
< Server: Apache
< X-Content-Type-Options: nosniff
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< Set-Cookie: scootersoftwarewebsite=gojauhgkrh0nn3evsfncmrr9h4; path=/; domain=.www.scootersoftware.com; secure; HttpOnly
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Set-Cookie: ss_lang=en; expires=Sun, 21-Jan-2024 20:56:53 GMT; Max-Age=2592000; path=/; domain=.www.scootersoftware.com; secure; HttpOnly; SameSite=Lax
< Set-Cookie: RESET=2021-09-09%2000%3A00%3A00; expires=Sun, 21-Jan-2024 20:56:53 GMT; Max-Age=2592000; path=/; domain=.www.scootersoftware.com; secure; HttpOnly; SameSite=Lax
< Set-Cookie: sticky_inputs=eyJsb2dpbl9wZXJzaXN0IjowfQ%3D%3D; expires=Sat, 21-Dec-2024 20:56:53 GMT; Max-Age=31536000; path=/; domain=.www.scootersoftware.com; secure; HttpOnly; SameSite=Lax
< Set-Cookie: device_id=8d1dbd53-d986-421c-93ee-54833882f711; expires=Sat, 21-Dec-2024 20:56:53 GMT; Max-Age=31536000; path=/; domain=.www.scootersoftware.com; secure; HttpOnly; SameSite=Lax
< Set-Cookie: uuid=4b95a5f5-7714-4fce-b5a9-ca091bdf6216; expires=Sat, 21-Dec-2024 20:56:53 GMT; Max-Age=31536000; path=/; domain=.www.scootersoftware.com; secure; HttpOnly; SameSite=Lax
< Content-Description: File Transfer
< Content-Disposition: attachment; filename="BCompareOSX-4.4.7.28397.zip"
< Content-Length: 27415403
< X-Frame-Options: SAMEORIGIN
< Content-Type: application/zip
<
{ [16384 bytes data]
* Connection [#0](https://github.com/Installomator/Installomator/issues/0) to host www.scootersoftware.com left intact

2023-12-22 15:56:59 : REQ : beyondcomparepro : no more blocking processes, continue with update
2023-12-22 15:56:59 : REQ : beyondcomparepro : Installing Beyond Compare
2023-12-22 15:56:59 : INFO : beyondcomparepro : Unzipping Beyond Compare.zip
2023-12-22 15:56:59 : INFO : beyondcomparepro : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app
2023-12-22 15:56:59 : DEBUG : beyondcomparepro : App size: 89M /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app
2023-12-22 15:57:00 : DEBUG : beyondcomparepro : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Scooter Software Inc. (BS29TEJF86)

2023-12-22 15:57:00 : INFO : beyondcomparepro : Team ID matching: BS29TEJF86 (expected: BS29TEJF86 )
2023-12-22 15:57:00 : INFO : beyondcomparepro : Installing Beyond Compare version 4.4.7.28397 on versionKey CFBundleShortVersionString.
2023-12-22 15:57:00 : INFO : beyondcomparepro : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app to /Applications
2023-12-22 15:57:01 : DEBUG : beyondcomparepro : Debugging enabled, App copy output was:
Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app

2023-12-22 15:57:01 : WARN : beyondcomparepro : Changing owner to schwartzm
2023-12-22 15:57:01 : INFO : beyondcomparepro : Finishing...
2023-12-22 15:57:04 : INFO : beyondcomparepro : App(s) found: /Applications/Beyond Compare.app
2023-12-22 15:57:05 : INFO : beyondcomparepro : found app at /Applications/Beyond Compare.app, version 4.4.7.28397, on versionKey CFBundleShortVersionString
2023-12-22 15:57:05 : REQ : beyondcomparepro : Installed Beyond Compare, version 4.4.7.28397
2023-12-22 15:57:05 : INFO : beyondcomparepro : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-22 15:57:05 : DEBUG : beyondcomparepro : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7
2023-12-22 15:57:05 : DEBUG : beyondcomparepro : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app/Contents/CodeResources
2023-12-22 15:57:05 : DEBUG : beyondcomparepro : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app/Contents/_CodeSignature/CodeResources
2023-12-22 15:57:05 : DEBUG : beyondcomparepro : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app/Contents/_CodeSignature
2023-12-22 15:57:05 : DEBUG : beyondcomparepro : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7/Beyond Compare.app/Contents/MacOS/libunrar.dylib

[over 1500 similar lines deleted....]

2023-12-22 15:57:05 : DEBUG : beyondcomparepro : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rePnOYAZK7
2023-12-22 15:57:28 : INFO : beyondcomparepro : Installomator did not close any apps, so no need to reopen any apps.
2023-12-22 15:57:28 : REQ : beyondcomparepro : All done!
2023-12-22 15:57:28 : REQ : beyondcomparepro : ################## End Installomator, exit code 0

```