### PR TITLE
Add ignoreInstallScriptExitCode label variable

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -585,7 +585,11 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
         deduplicatelogs "$CLIoutput"
 
         if [ $CLIstatus -ne 0 ] ; then
-            cleanupAndExit 16 "Error installing $mountname/$CLIInstaller $CLIArguments error:\n$logoutput" ERROR
+            if [[ $ignoreInstallScriptExitCode == 1 ]]; then
+                printlog "The label for this installer has ignoreInstallExitCode set to 1, so pretending everything went great regardless of its actual exit code which was: $CLIstatus" WARN
+            else
+                cleanupAndExit 16 "Error installing $mountname/$CLIInstaller $CLIArguments error:\n$logoutput" ERROR
+            fi
         else
             printlog "Succesfully ran $mountname/$CLIInstaller $CLIArguments" INFO
         fi

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -297,6 +297,8 @@ NOTIFY_DIALOG=0
 #   differently than the installed app, then this variable can be used to name the
 #   installer that should be located after mounting/expanding the downloaded archive.
 #   See label adobecreativeclouddesktop
+# - ignoreInstallScriptExitCode:
+#   If this is set to one, then any non-zero exit code from a CLIInstaller will not be counted as a failure.
 #
 ### Logging
 # Logging behavior

--- a/fragments/labels/magicbullet.sh
+++ b/fragments/labels/magicbullet.sh
@@ -10,4 +10,5 @@ magicbullet)
     CLIInstaller="Magic Bullet Suite Installer.app/Contents/Scripts/install.sh"
     CLIArguments=()
     expectedTeamID="4ZY22YGXQG"
+    ignoreInstallScriptExitCode=1
     ;;

--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -10,4 +10,5 @@ vfx)
     CLIInstaller="VFX Suite Installer.app/Contents/Scripts/install.sh"
     CLIArguments=()
     expectedTeamID="4ZY22YGXQG"
+    ignoreInstallScriptExitCode=1
     ;;


### PR DESCRIPTION
Some CLI installers, like those for Maxon Magic Bullet and VFX Suite, exit with a non-zero code despite a success condition. In Jamf Self Service, this would result in a "failed" message despite a successful install.

I've added a new label variable called ignoreInstallScriptExitCode, and a check in the code that calls the CLI installer to ignore a non-zero exit code if it's set. 

I've added this new variable to the "magicbullet" and "vfx" labels.