### PR TITLE
Fix cinema4d label

### DIFF
--- a/fragments/labels/cinema4d.sh
+++ b/fragments/labels/cinema4d.sh
@@ -1,13 +1,16 @@
 cinema4d)
     name="Cinema 4D"
     type="dmg"
-    appCustomVersion(){
-      defaults read "/Applications/Maxon Cinema 4D 2023/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+"
-    }
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4405723907986-Cinema-4D" | grep "#icon-star" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
+    productDownloadsPage=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*downloads/cinema-4d[^"]*' | head -1)
+    downloadURL=$(curl -fsL $productDownloadsPage | grep -oE 'https://[^"]*\.dmg' | head -1)
+    appNewVersion=$(sed -E 's/.*_([0-9.]*)_Mac\.dmg/\1/g' <<< $downloadURL)
     targetDir="/Applications/Maxon Cinema 4D ${appNewVersion:0:4}"
-    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/${appNewVersion}/Cinema4D_${appNewVersion:0:4}_${appNewVersion}_Mac.dmg"
+    appCustomVersion(){
+      defaults read "$targetDir/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+"
+    }
     installerTool="Maxon Cinema 4D Installer.app"
     CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=( --mode unattended --unattendedmodeui none )
     expectedTeamID="4ZY22YGXQG"
     ;;
+


### PR DESCRIPTION
The current label breaks when the website presents the version number as x.y instead of x.y.z. This fixes that, and also adds the CLIArguments necessary for a silent install.

output:

```
# ./utils/assemble.sh cinema4d DEBUG=0
2023-12-27 13:55:34 : REQ   : cinema4d : ################## Start Installomator v. 10.6beta, date 2023-12-27
2023-12-27 13:55:34 : INFO  : cinema4d : ################## Version: 10.6beta
2023-12-27 13:55:34 : INFO  : cinema4d : ################## Date: 2023-12-27
2023-12-27 13:55:34 : INFO  : cinema4d : ################## cinema4d
2023-12-27 13:55:34 : DEBUG : cinema4d : DEBUG mode 1 enabled.
2023-12-27 13:55:36 : INFO  : cinema4d : setting variable from argument DEBUG=0
2023-12-27 13:55:36 : DEBUG : cinema4d : name=Cinema 4D
2023-12-27 13:55:36 : DEBUG : cinema4d : appName=
2023-12-27 13:55:36 : DEBUG : cinema4d : type=dmg
2023-12-27 13:55:36 : DEBUG : cinema4d : archiveName=
2023-12-27 13:55:36 : DEBUG : cinema4d : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg
2023-12-27 13:55:36 : DEBUG : cinema4d : curlOptions=
2023-12-27 13:55:36 : DEBUG : cinema4d : appNewVersion=2024.2.0
2023-12-27 13:55:36 : DEBUG : cinema4d : appCustomVersion function: Defined.
2023-12-27 13:55:36 : DEBUG : cinema4d : versionKey=CFBundleShortVersionString
2023-12-27 13:55:36 : DEBUG : cinema4d : packageID=
2023-12-27 13:55:36 : DEBUG : cinema4d : pkgName=
2023-12-27 13:55:36 : DEBUG : cinema4d : choiceChangesXML=
2023-12-27 13:55:36 : DEBUG : cinema4d : expectedTeamID=4ZY22YGXQG
2023-12-27 13:55:36 : DEBUG : cinema4d : blockingProcesses=
2023-12-27 13:55:36 : DEBUG : cinema4d : installerTool=Maxon Cinema 4D Installer.app
2023-12-27 13:55:36 : DEBUG : cinema4d : CLIInstaller=Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh
2023-12-27 13:55:36 : DEBUG : cinema4d : CLIArguments=--mode unattended --unattendedmodeui none
2023-12-27 13:55:37 : DEBUG : cinema4d : updateTool=
2023-12-27 13:55:37 : DEBUG : cinema4d : updateToolArguments=
2023-12-27 13:55:37 : DEBUG : cinema4d : updateToolRunAsCurrentUser=
2023-12-27 13:55:37 : INFO  : cinema4d : BLOCKING_PROCESS_ACTION=tell_user
2023-12-27 13:55:37 : INFO  : cinema4d : NOTIFY=success
2023-12-27 13:55:37 : INFO  : cinema4d : LOGGING=DEBUG
2023-12-27 13:55:37 : INFO  : cinema4d : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-27 13:55:37 : INFO  : cinema4d : Label type: dmg
2023-12-27 13:55:37 : INFO  : cinema4d : archiveName: Cinema 4D.dmg
2023-12-27 13:55:37 : INFO  : cinema4d : no blocking processes defined, using Cinema 4D as default
2023-12-27 13:55:37 : DEBUG : cinema4d : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QuF5vLjtk7
2023-12-27 13:55:37.400 defaults[57381:8093695]
The domain/default pair of (/Applications/Maxon Cinema 4D 2024/Cinema 4D.app/Contents/Info.plist, CFBundleGetInfoString) does not exist
2023-12-27 13:55:37 : INFO  : cinema4d : Custom App Version detection is used, found
2023-12-27 13:55:37 : INFO  : cinema4d : appversion:
2023-12-27 13:55:37 : INFO  : cinema4d : Latest version of Cinema 4D is 2024.2.0
2023-12-27 13:55:37 : REQ   : cinema4d : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg to Cinema 4D.dmg
2023-12-27 13:55:37 : DEBUG : cinema4d : No Dialog connection, just download
2023-12-27 14:04:28 : DEBUG : cinema4d : File list: -rw-r--r--  1 root  wheel   2.3G Dec 27 14:04 Cinema 4D.dmg
2023-12-27 14:04:28 : DEBUG : cinema4d : File type: Cinema 4D.dmg: zlib compressed data
2023-12-27 14:04:28 : DEBUG : cinema4d : curl output was:
*   Trying 172.64.145.239:443...
* Connected to mx-app-blob-prod.maxon.net (172.64.145.239) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3378 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg HTTP/1.1
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 27 Dec 2023 18:55:37 GMT
< Content-Type: application/octet-stream
< Content-Length: 2471522762
< Connection: keep-alive
< Content-MD5: 4ksjerS5Ab/tcUiASI7Wow==
< Last-Modified: Mon, 11 Dec 2023 14:00:01 GMT
< ETag: 0x8DBFA5177B354E7
< x-ms-request-id: eb893a94-601e-00c9-7f45-2c2fe2000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< CF-Cache-Status: HIT
< Age: 11843
< Expires: Thu, 26 Dec 2024 18:55:37 GMT
< Cache-Control: public, max-age=31536000
< Accept-Ranges: bytes
< Content-Security-Policy: frame-ancestors 'self' *.maxon.net
< Permissions-Policy: camera=()
< Referrer-Policy: no-referrer-when-downgrade
< Strict-Transport-Security: max-age=31536000; includeSubDomains
< X-CONTENT-TYPE-OPTIONS: nosniff
< Server: cloudflare
< CF-RAY: 83c3c7646ad13b80-IAD
<
{ [553 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2023-12-27 14:04:28 : REQ   : cinema4d : no more blocking processes, continue with update
2023-12-27 14:04:28 : REQ   : cinema4d : Installing Cinema 4D
2023-12-27 14:04:28 : REQ   : cinema4d : installerTool used: Maxon Cinema 4D Installer.app
2023-12-27 14:04:28 : INFO  : cinema4d : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QuF5vLjtk7/Cinema 4D.dmg
2023-12-27 14:04:34 : DEBUG : cinema4d : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $CFC0A513
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $058DBA63
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $23D54099
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $3080C16D
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $23D54099
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $38E31A2C
verified   CRC32 $3BB43505
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Maxon Cinema 4D

2023-12-27 14:04:34 : INFO  : cinema4d : Mounted: /Volumes/Maxon Cinema 4D
2023-12-27 14:04:34 : INFO  : cinema4d : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2023-12-27 14:04:34 : DEBUG : cinema4d : App size: 2.3G	/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2023-12-27 14:04:37 : DEBUG : cinema4d : Debugging enabled, App Verification output was:
/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2023-12-27 14:04:37 : INFO  : cinema4d : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2023-12-27 14:04:37 : INFO  : cinema4d : Installing Cinema 4D version 2024 on versionKey CFBundleShortVersionString.
2023-12-27 14:04:37 : INFO  : cinema4d : CLIInstaller exists, running installer command /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --unattendedmodeui none
2023-12-27 14:05:17 : INFO  : cinema4d : Succesfully ran /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --unattendedmodeui none
2023-12-27 14:05:17 : DEBUG : cinema4d : Debugging enabled, update tool output was:
Log

2023-12-27 14:05:17 : INFO  : cinema4d : Finishing...
2023-12-27 14:05:20 : INFO  : cinema4d : Custom App Version detection is used, found 2024.2.0
2023-12-27 14:05:20 : REQ   : cinema4d : Installed Cinema 4D, version 2024
2023-12-27 14:05:20 : INFO  : cinema4d : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-27 14:05:20 : DEBUG : cinema4d : Unmounting /Volumes/Maxon Cinema 4D
2023-12-27 14:05:20 : DEBUG : cinema4d : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-27 14:05:21 : DEBUG : cinema4d : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QuF5vLjtk7
2023-12-27 14:05:21 : DEBUG : cinema4d : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QuF5vLjtk7/Cinema 4D.dmg
2023-12-27 14:05:21 : DEBUG : cinema4d : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QuF5vLjtk7
2023-12-27 14:05:21 : INFO  : cinema4d : Installomator did not close any apps, so no need to reopen any apps.
2023-12-27 14:05:21 : REQ   : cinema4d : All done!
2023-12-27 14:05:21 : REQ   : cinema4d : ################## End Installomator, exit code 0

```