### PR TITLE
Fix postman label

### DIFF
--- a/fragments/labels/postman.sh
+++ b/fragments/labels/postman.sh
@@ -1,12 +1,12 @@
 postman)
     name="Postman"
     type="zip"
+    curlOptions=( -H "accept-encoding: gzip, deflate, br")
     if [[ $(arch) == "arm64" ]]; then
     	downloadURL="https://dl.pstmn.io/download/latest/osx_arm64"
-		appNewVersion=$(curl -fsL --head "${downloadURL}" | grep "content-disposition:" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
 	elif [[ $(arch) == "i386" ]]; then
 		downloadURL="https://dl.pstmn.io/download/latest/osx_64"
-		appNewVersion=$(curl -fsL --head "${downloadURL}" | grep "content-disposition:" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')
 	fi
+	appNewVersion=$(getJSONValue "$(curl -fsL 'https://www.postman.com/mkapi/release.json?t=')" 'notes[0].version')
     expectedTeamID="H7H8Q7M5CK"
     ;;


### PR DESCRIPTION
The current logic for appNewVersion no longer works because the content-disposition header no longer includes a version number.

The current download links fail unless the request includes an accept-encoding header, so added curlOptions.

Output:
```
# ./utils/assemble.sh postman DEBUG=0
2023-12-27 14:37:04 : REQ   : postman : ################## Start Installomator v. 10.6beta, date 2023-12-27
2023-12-27 14:37:04 : INFO  : postman : ################## Version: 10.6beta
2023-12-27 14:37:04 : INFO  : postman : ################## Date: 2023-12-27
2023-12-27 14:37:04 : INFO  : postman : ################## postman
2023-12-27 14:37:04 : DEBUG : postman : DEBUG mode 1 enabled.
2023-12-27 14:37:04 : INFO  : postman : setting variable from argument DEBUG=0
2023-12-27 14:37:04 : DEBUG : postman : name=Postman
2023-12-27 14:37:04 : DEBUG : postman : appName=
2023-12-27 14:37:04 : DEBUG : postman : type=zip
2023-12-27 14:37:04 : DEBUG : postman : archiveName=
2023-12-27 14:37:04 : DEBUG : postman : downloadURL=https://dl.pstmn.io/download/latest/osx_arm64
2023-12-27 14:37:04 : DEBUG : postman : curlOptions=-H accept-encoding: gzip, deflate, br
2023-12-27 14:37:04 : DEBUG : postman : appNewVersion=10.21.0
2023-12-27 14:37:04 : DEBUG : postman : appCustomVersion function: Not defined
2023-12-27 14:37:04 : DEBUG : postman : versionKey=CFBundleShortVersionString
2023-12-27 14:37:04 : DEBUG : postman : packageID=
2023-12-27 14:37:04 : DEBUG : postman : pkgName=
2023-12-27 14:37:04 : DEBUG : postman : choiceChangesXML=
2023-12-27 14:37:04 : DEBUG : postman : expectedTeamID=H7H8Q7M5CK
2023-12-27 14:37:05 : DEBUG : postman : blockingProcesses=
2023-12-27 14:37:05 : DEBUG : postman : installerTool=
2023-12-27 14:37:05 : DEBUG : postman : CLIInstaller=
2023-12-27 14:37:05 : DEBUG : postman : CLIArguments=
2023-12-27 14:37:05 : DEBUG : postman : updateTool=
2023-12-27 14:37:05 : DEBUG : postman : updateToolArguments=
2023-12-27 14:37:05 : DEBUG : postman : updateToolRunAsCurrentUser=
2023-12-27 14:37:05 : INFO  : postman : BLOCKING_PROCESS_ACTION=tell_user
2023-12-27 14:37:05 : INFO  : postman : NOTIFY=success
2023-12-27 14:37:05 : INFO  : postman : LOGGING=DEBUG
2023-12-27 14:37:05 : INFO  : postman : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-27 14:37:05 : INFO  : postman : Label type: zip
2023-12-27 14:37:05 : INFO  : postman : archiveName: Postman.zip
2023-12-27 14:37:05 : INFO  : postman : no blocking processes defined, using Postman as default
2023-12-27 14:37:05 : DEBUG : postman : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo
2023-12-27 14:37:05 : INFO  : postman : name: Postman, appName: Postman.app
2023-12-27 14:37:05.474 mdfind[62545:8137948] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-27 14:37:05.474 mdfind[62545:8137948] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-27 14:37:05.562 mdfind[62545:8137948] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-27 14:37:05 : WARN  : postman : No previous app found
2023-12-27 14:37:05 : WARN  : postman : could not find Postman.app
2023-12-27 14:37:05 : INFO  : postman : appversion:
2023-12-27 14:37:05 : INFO  : postman : Latest version of Postman is 10.21.0
2023-12-27 14:37:05 : REQ   : postman : Downloading https://dl.pstmn.io/download/latest/osx_arm64 to Postman.zip
2023-12-27 14:37:05 : DEBUG : postman : No Dialog connection, just download
2023-12-27 14:37:09 : DEBUG : postman : File list: -rw-r--r--  1 root  wheel   125M Dec 27 14:37 Postman.zip
2023-12-27 14:37:09 : DEBUG : postman : File type: Postman.zip: Zip archive data, at least v1.0 to extract, compression method=store
2023-12-27 14:37:09 : DEBUG : postman : curl output was:
*   Trying 13.32.208.126:443...
* Connected to dl.pstmn.io (13.32.208.126) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4954 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.pstmn.io
*  start date: Jul 29 00:00:00 2023 GMT
*  expire date: Aug 26 23:59:59 2024 GMT
*  subjectAltName: host "dl.pstmn.io" matched cert's "*.pstmn.io"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.pstmn.io/download/latest/osx_arm64
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.pstmn.io]
* [HTTP/2] [1] [:path: /download/latest/osx_arm64]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [accept-encoding: gzip, deflate, br]
> GET /download/latest/osx_arm64 HTTP/2
> Host: dl.pstmn.io
> User-Agent: curl/8.4.0
> Accept: */*
> accept-encoding: gzip, deflate, br
>
< HTTP/2 200
< content-length: 130985595
< date: Fri, 15 Dec 2023 06:55:19 GMT
< last-modified: Fri, 08 Dec 2023 05:57:26 GMT
< etag: "7a1d249ae161e6a3191583ad2ae07c3f-25"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< content-disposition: attachment; filename=Postman%20for%20macOS%20(arm64).zip
< cache-control: max-age=604800, s-maxage=604800
< x-cache: Hit from cloudfront
< via: 1.1 6f35734da951dcb591462352ba037614.cloudfront.net (CloudFront)
< x-amz-cf-pop: IAD66-C1
< x-amz-cf-id: lctabg0w5Ub5_HkEgqU7zw185tSkdOltXZtmUWA4-VeEbhM6VVOCWQ==
< age: 1082507
<
{ [15939 bytes data]
* Connection #0 to host dl.pstmn.io left intact

2023-12-27 14:37:09 : REQ   : postman : no more blocking processes, continue with update
2023-12-27 14:37:09 : REQ   : postman : Installing Postman
2023-12-27 14:37:09 : INFO  : postman : Unzipping Postman.zip
2023-12-27 14:37:10 : INFO  : postman : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app
2023-12-27 14:37:10 : DEBUG : postman : App size: 375M	/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app
2023-12-27 14:37:11 : DEBUG : postman : Debugging enabled, App Verification output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Postdot Technologies, Inc (H7H8Q7M5CK)

2023-12-27 14:37:11 : INFO  : postman : Team ID matching: H7H8Q7M5CK (expected: H7H8Q7M5CK )
2023-12-27 14:37:11 : INFO  : postman : Installing Postman version 10.21.0 on versionKey CFBundleShortVersionString.
2023-12-27 14:37:11 : INFO  : postman : App has LSMinimumSystemVersion: 10.11.0
2023-12-27 14:37:11 : INFO  : postman : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app to /Applications
2023-12-27 14:37:11 : DEBUG : postman : Debugging enabled, App copy output was:
Copying /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app

2023-12-27 14:37:11 : WARN  : postman : Changing owner to schwartzm
2023-12-27 14:37:11 : INFO  : postman : Finishing...
2023-12-27 14:37:14 : INFO  : postman : App(s) found: /Applications/Postman.app
2023-12-27 14:37:14 : INFO  : postman : found app at /Applications/Postman.app, version 10.21.0, on versionKey CFBundleShortVersionString
2023-12-27 14:37:14 : REQ   : postman : Installed Postman, version 10.21.0
2023-12-27 14:37:14 : INFO  : postman : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-27 14:37:15 : DEBUG : postman : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo
2023-12-27 14:37:15 : DEBUG : postman : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.zip
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/MacOS/Postman
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/MacOS
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources/app.asar
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources/Credits.rtf
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources/app.icns
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources/data
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources/profile.json
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Electron Framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/chrome_200_percent.pak
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/chrome_100_percent.pak
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/icudtl.dat
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/MainMenu.nib/keyedobjects-101300.nib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/MainMenu.nib/keyedobjects.nib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/MainMenu.nib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/v8_context_snapshot.arm64.bin
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/resources.pak
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libEGL.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/vk_swiftshader_icd.json
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libEGL.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libvk_swiftshader.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libswiftshader_libGLESv2.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Helpers/chrome_crashpad_handler
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Helpers
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/A
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions/Current
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Versions
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Libraries
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework/Helpers
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Electron Framework.framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/ReactiveObjC
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/Resources/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/ReactiveObjC
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions/Current
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework/Versions
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/ReactiveObjC.framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A/Squirrel
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/A
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions/Current
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Versions
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework/Squirrel
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Squirrel.framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/MacOS/Postman Helper
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/MacOS
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents/PkgInfo
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app/Contents
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper.app
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Mantle
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A/Mantle
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A/Resources/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A/Resources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/A
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions/Current
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework/Versions
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Mantle.framework
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/MacOS/Postman Helper (Renderer)
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/MacOS
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents/PkgInfo
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app/Contents
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Renderer).app
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/MacOS/Postman Helper (GPU)
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/MacOS
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents/PkgInfo
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app/Contents
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (GPU).app
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/_CodeSignature/CodeResources
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/_CodeSignature
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/MacOS/Postman Helper (Plugin)
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/MacOS
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents/PkgInfo
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app/Contents
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks/Postman Helper (Plugin).app
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Frameworks
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/Info.plist
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents/PkgInfo
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app/Contents
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo/Postman.app
2023-12-27 14:37:15 : DEBUG : postman : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nHpo1MNNUo
2023-12-27 14:37:17 : INFO  : postman : Installomator did not close any apps, so no need to reopen any apps.
2023-12-27 14:37:17 : REQ   : postman : All done!
2023-12-27 14:37:17 : REQ   : postman : ################## End Installomator, exit code 0

```