### PR TITLE
keeperpasswordmanager: Add appNewVersion

### DIFF
--- a/fragments/labels/keeperpasswordmanager.sh
+++ b/fragments/labels/keeperpasswordmanager.sh
@@ -2,7 +2,7 @@ keeperpasswordmanager)
     name="Keeper Password Manager"
     type="dmg"
     downloadURL="https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg"
-    appNewVersion=""
+    appNewVersion=$(getJSONValue "$(curl -fsL 'https://keepersecurity.com/desktop_electron/desktop_electron_version.txt')" "version" )
     expectedTeamID="234QNB7GCA"
     blockingProcess=( "Keeper Password Manager" )
     ;;


### PR DESCRIPTION
The current label for Keeper Password Manager is missing the appNewVersion variable.

Output:
```
# ./utils/assemble.sh keeperpasswordmanager DEBUG=0
2023-12-27 14:43:40 : REQ   : keeperpasswordmanager : ################## Start Installomator v. 10.6beta, date 2023-12-27
2023-12-27 14:43:40 : INFO  : keeperpasswordmanager : ################## Version: 10.6beta
2023-12-27 14:43:40 : INFO  : keeperpasswordmanager : ################## Date: 2023-12-27
2023-12-27 14:43:40 : INFO  : keeperpasswordmanager : ################## keeperpasswordmanager
2023-12-27 14:43:40 : DEBUG : keeperpasswordmanager : DEBUG mode 1 enabled.
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : setting variable from argument DEBUG=0
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : name=Keeper Password Manager
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : appName=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : type=dmg
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : archiveName=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : downloadURL=https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : curlOptions=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : appNewVersion=16.10.11
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : appCustomVersion function: Not defined
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : versionKey=CFBundleShortVersionString
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : packageID=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : pkgName=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : choiceChangesXML=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : expectedTeamID=234QNB7GCA
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : blockingProcesses=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : installerTool=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : CLIInstaller=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : CLIArguments=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : updateTool=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : updateToolArguments=
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : updateToolRunAsCurrentUser=
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : BLOCKING_PROCESS_ACTION=tell_user
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : NOTIFY=success
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : LOGGING=DEBUG
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : Label type: dmg
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : archiveName: Keeper Password Manager.dmg
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : no blocking processes defined, using Keeper Password Manager as default
2023-12-27 14:43:41 : DEBUG : keeperpasswordmanager : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dcTvtG9cR9
2023-12-27 14:43:41 : INFO  : keeperpasswordmanager : name: Keeper Password Manager, appName: Keeper Password Manager.app
2023-12-27 14:43:41.855 mdfind[64022:8146724] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-27 14:43:41.855 mdfind[64022:8146724] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-27 14:43:41.933 mdfind[64022:8146724] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-27 14:43:41 : WARN  : keeperpasswordmanager : No previous app found
2023-12-27 14:43:41 : WARN  : keeperpasswordmanager : could not find Keeper Password Manager.app
2023-12-27 14:43:42 : INFO  : keeperpasswordmanager : appversion:
2023-12-27 14:43:42 : INFO  : keeperpasswordmanager : Latest version of Keeper Password Manager is 16.10.11
2023-12-27 14:43:42 : REQ   : keeperpasswordmanager : Downloading https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg to Keeper Password Manager.dmg
2023-12-27 14:43:42 : DEBUG : keeperpasswordmanager : No Dialog connection, just download
2023-12-27 14:43:50 : DEBUG : keeperpasswordmanager : File list: -rw-r--r--  1 root  wheel   286M Dec 27 14:43 Keeper Password Manager.dmg
2023-12-27 14:43:50 : DEBUG : keeperpasswordmanager : File type: Keeper Password Manager.dmg: zlib compressed data
2023-12-27 14:43:50 : DEBUG : keeperpasswordmanager : curl output was:
*   Trying 100.25.27.45:443...
* Connected to www.keepersecurity.com (100.25.27.45) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4986 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=keepersecurity.com
*  start date: Jul 24 00:00:00 2023 GMT
*  expire date: Aug 22 23:59:59 2024 GMT
*  subjectAltName: host "www.keepersecurity.com" matched cert's "www.keepersecurity.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.keepersecurity.com]
* [HTTP/2] [1] [:path: /desktop_electron/Darwin/KeeperSetup.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /desktop_electron/Darwin/KeeperSetup.dmg HTTP/2
> Host: www.keepersecurity.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 301
< date: Wed, 27 Dec 2023 19:43:42 GMT
< content-type: text/html
< content-length: 162
< location: https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
< server: nginx
< content-security-policy: default-src 'self';
< x-frame-options: DENY
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< expect-ct: max-age=10, report-uri="https://keepersecurity.report-uri.com/r/t/ct/reportOnly"
<
* Ignoring the response-body
{ [162 bytes data]
* Connection #0 to host www.keepersecurity.com left intact
* Issue another request to this URL: 'https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg'
*   Trying 100.25.27.45:443...
* Connected to keepersecurity.com (100.25.27.45) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4986 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=keepersecurity.com
*  start date: Jul 24 00:00:00 2023 GMT
*  expire date: Aug 22 23:59:59 2024 GMT
*  subjectAltName: host "keepersecurity.com" matched cert's "keepersecurity.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: keepersecurity.com]
* [HTTP/2] [1] [:path: /desktop_electron/Darwin/KeeperSetup.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /desktop_electron/Darwin/KeeperSetup.dmg HTTP/2
> Host: keepersecurity.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< date: Wed, 27 Dec 2023 19:43:42 GMT
< content-type: application/x-apple-diskimage
< content-length: 299756148
< server: nginx
< last-modified: Wed, 20 Dec 2023 16:47:40 GMT
< etag: "8998cf5c03a59f1f0bbaa7b5dbbfc3c5-36"
< content-security-policy: default-src 'self';
< x-frame-options: DENY
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< expect-ct: max-age=10, report-uri="https://keepersecurity.report-uri.com/r/t/ct/reportOnly"
< accept-ranges: bytes
<
{ [32187 bytes data]
* Connection #1 to host keepersecurity.com left intact

2023-12-27 14:43:50 : REQ   : keeperpasswordmanager : no more blocking processes, continue with update
2023-12-27 14:43:50 : REQ   : keeperpasswordmanager : Installing Keeper Password Manager
2023-12-27 14:43:50 : INFO  : keeperpasswordmanager : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dcTvtG9cR9/Keeper Password Manager.dmg
2023-12-27 14:43:53 : DEBUG : keeperpasswordmanager : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0BD998CD
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $44FF7326
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7F4790AB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $4F509212
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7F4790AB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FD2CAB7A
verified   CRC32 $22BED253
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Keeper Password Manager

2023-12-27 14:43:53 : INFO  : keeperpasswordmanager : Mounted: /Volumes/Keeper Password Manager
2023-12-27 14:43:53 : INFO  : keeperpasswordmanager : Verifying: /Volumes/Keeper Password Manager/Keeper Password Manager.app
2023-12-27 14:43:53 : DEBUG : keeperpasswordmanager : App size: 628M	/Volumes/Keeper Password Manager/Keeper Password Manager.app
2023-12-27 14:44:02 : DEBUG : keeperpasswordmanager : Debugging enabled, App Verification output was:
/Volumes/Keeper Password Manager/Keeper Password Manager.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Callpod Inc. (234QNB7GCA)

2023-12-27 14:44:02 : INFO  : keeperpasswordmanager : Team ID matching: 234QNB7GCA (expected: 234QNB7GCA )
2023-12-27 14:44:02 : INFO  : keeperpasswordmanager : Installing Keeper Password Manager version 16.10.11 on versionKey CFBundleShortVersionString.
2023-12-27 14:44:02 : INFO  : keeperpasswordmanager : App has LSMinimumSystemVersion: 10.15
2023-12-27 14:44:02 : INFO  : keeperpasswordmanager : Copy /Volumes/Keeper Password Manager/Keeper Password Manager.app to /Applications
2023-12-27 14:44:03 : DEBUG : keeperpasswordmanager : Debugging enabled, App copy output was:
Copying /Volumes/Keeper Password Manager/Keeper Password Manager.app

2023-12-27 14:44:03 : WARN  : keeperpasswordmanager : Changing owner to schwartzm
2023-12-27 14:44:03 : INFO  : keeperpasswordmanager : Finishing...
2023-12-27 14:44:06 : INFO  : keeperpasswordmanager : App(s) found: /Applications/Keeper Password Manager.app
2023-12-27 14:44:06 : INFO  : keeperpasswordmanager : found app at /Applications/Keeper Password Manager.app, version 16.10.11, on versionKey CFBundleShortVersionString
2023-12-27 14:44:06 : REQ   : keeperpasswordmanager : Installed Keeper Password Manager, version 16.10.11
2023-12-27 14:44:06 : INFO  : keeperpasswordmanager : notifying
ERROR: Cannot find swiftDialog binary at /Library/Application Support/Dialog/Dialog.app/Contents/MacOS/Dialog
2023-12-27 14:44:06 : DEBUG : keeperpasswordmanager : Unmounting /Volumes/Keeper Password Manager
2023-12-27 14:44:07 : DEBUG : keeperpasswordmanager : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-27 14:44:07 : DEBUG : keeperpasswordmanager : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dcTvtG9cR9
2023-12-27 14:44:07 : DEBUG : keeperpasswordmanager : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dcTvtG9cR9/Keeper Password Manager.dmg
2023-12-27 14:44:07 : DEBUG : keeperpasswordmanager : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dcTvtG9cR9
2023-12-27 14:44:07 : INFO  : keeperpasswordmanager : Installomator did not close any apps, so no need to reopen any apps.
2023-12-27 14:44:07 : REQ   : keeperpasswordmanager : All done!
2023-12-27 14:44:07 : REQ   : keeperpasswordmanager : ################## End Installomator, exit code 0
```