### PR TITLE
sketch label: fix appNewVersion

### DIFF
--- a/fragments/labels/sketch.sh
+++ b/fragments/labels/sketch.sh
@@ -2,6 +2,6 @@ sketch)
     name="Sketch"
     type="zip"
     downloadURL=$(curl -sf https://www.sketch.com/downloads/mac/ | grep 'href="https://download.sketch.com' | tr '"' "\n" | grep -E "https.*.zip")
-    appNewVersion=$(curl -fs https://www.sketch.com/updates/ | grep "Sketch Version" | head -1 | sed -E 's/.*Version ([0-9.]*)<.*/\1/g') # version from update page
+    appNewVersion=$( grep -oE '\d+\.\d+' <<< $downloadURL)
     expectedTeamID="WUGMZZ5K46"
     ;;


### PR DESCRIPTION
Due to changes in the website, the old logic for appNewVersion no longer works. Updated logic to pull from the downloadURL.

Here is output from a run where the app was already installed (since that's the scenario where appNewVersion is important):

```
# ./utils/assemble.sh sketch DEBUG=0
2023-12-27 14:51:07 : REQ   : sketch : ################## Start Installomator v. 10.6beta, date 2023-12-27
2023-12-27 14:51:07 : INFO  : sketch : ################## Version: 10.6beta
2023-12-27 14:51:07 : INFO  : sketch : ################## Date: 2023-12-27
2023-12-27 14:51:07 : INFO  : sketch : ################## sketch
2023-12-27 14:51:07 : DEBUG : sketch : DEBUG mode 1 enabled.
2023-12-27 14:51:07 : INFO  : sketch : setting variable from argument DEBUG=0
2023-12-27 14:51:08 : DEBUG : sketch : name=Sketch
2023-12-27 14:51:08 : DEBUG : sketch : appName=
2023-12-27 14:51:08 : DEBUG : sketch : type=zip
2023-12-27 14:51:08 : DEBUG : sketch : archiveName=
2023-12-27 14:51:08 : DEBUG : sketch : downloadURL=https://download.sketch.com/sketch-99.1-178462.zip
2023-12-27 14:51:08 : DEBUG : sketch : curlOptions=
2023-12-27 14:51:08 : DEBUG : sketch : appNewVersion=99.1
2023-12-27 14:51:08 : DEBUG : sketch : appCustomVersion function: Not defined
2023-12-27 14:51:08 : DEBUG : sketch : versionKey=CFBundleShortVersionString
2023-12-27 14:51:08 : DEBUG : sketch : packageID=
2023-12-27 14:51:08 : DEBUG : sketch : pkgName=
2023-12-27 14:51:08 : DEBUG : sketch : choiceChangesXML=
2023-12-27 14:51:08 : DEBUG : sketch : expectedTeamID=WUGMZZ5K46
2023-12-27 14:51:08 : DEBUG : sketch : blockingProcesses=
2023-12-27 14:51:08 : DEBUG : sketch : installerTool=
2023-12-27 14:51:08 : DEBUG : sketch : CLIInstaller=
2023-12-27 14:51:08 : DEBUG : sketch : CLIArguments=
2023-12-27 14:51:08 : DEBUG : sketch : updateTool=
2023-12-27 14:51:08 : DEBUG : sketch : updateToolArguments=
2023-12-27 14:51:08 : DEBUG : sketch : updateToolRunAsCurrentUser=
2023-12-27 14:51:08 : INFO  : sketch : BLOCKING_PROCESS_ACTION=tell_user
2023-12-27 14:51:08 : INFO  : sketch : NOTIFY=success
2023-12-27 14:51:08 : INFO  : sketch : LOGGING=DEBUG
2023-12-27 14:51:08 : INFO  : sketch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-27 14:51:08 : INFO  : sketch : Label type: zip
2023-12-27 14:51:08 : INFO  : sketch : archiveName: Sketch.zip
2023-12-27 14:51:08 : INFO  : sketch : no blocking processes defined, using Sketch as default
2023-12-27 14:51:08 : DEBUG : sketch : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uRw9qXWwID
2023-12-27 14:51:08 : INFO  : sketch : App(s) found: /Applications/Sketch.app
2023-12-27 14:51:08 : INFO  : sketch : found app at /Applications/Sketch.app, version 99.1, on versionKey CFBundleShortVersionString
2023-12-27 14:51:08 : INFO  : sketch : appversion: 99.1
2023-12-27 14:51:09 : INFO  : sketch : Latest version of Sketch is 99.1
2023-12-27 14:51:09 : INFO  : sketch : There is no newer version available.
2023-12-27 14:51:09 : DEBUG : sketch : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uRw9qXWwID
2023-12-27 14:51:09 : DEBUG : sketch : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.uRw9qXWwID
2023-12-27 14:51:09 : INFO  : sketch : Installomator did not close any apps, so no need to reopen any apps.
2023-12-27 14:51:09 : REQ   : sketch : No newer version.
2023-12-27 14:51:09 : REQ   : sketch : ################## End Installomator, exit code 0

```