### PR TITLE
New label: NWEA Secure Testing Browser

### DIFF
--- a/fragments/labels/nweasecuretestingbrowser.sh
+++ b/fragments/labels/nweasecuretestingbrowser.sh
@@ -1,0 +1,7 @@
+nweasecuretestingbrowser)
+    name="NWEA Secure Testing Browser"
+    type="dmg"
+    downloadURL="https://cdn.nwea.org/docs/NWEA-Secure-Testing-Browser-Mac.dmg"
+    appNewVersion=""
+    expectedTeamID="SRTXZJ7SQ3"
+    ;;


### PR DESCRIPTION
Couldn't curl the version from a source anywhere. Their site never shows the version html when curling. Version also not present in link. Current version is 5.5.4.5 released on 9/20/2023 shown here, https://connection.nwea.org/s/technical-resources?language=en_US


2023-12-29 09:09:36 : REQ : nweasecuretestingbrowser : ################## Start Installomator v. 10.6beta, date 2023-12-29
2023-12-29 09:09:36 : INFO : nweasecuretestingbrowser : ################## Version: 10.6beta
2023-12-29 09:09:36 : INFO : nweasecuretestingbrowser : ################## Date: 2023-12-29
2023-12-29 09:09:36 : INFO : nweasecuretestingbrowser : ################## nweasecuretestingbrowser
2023-12-29 09:09:36 : DEBUG : nweasecuretestingbrowser : DEBUG mode 1 enabled.
2023-12-29 09:09:36 : INFO : nweasecuretestingbrowser : SwiftDialog is not installed, clear cmd file var
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : name=NWEA Secure Testing Browser
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : appName=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : type=dmg
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : archiveName=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : downloadURL=https://cdn.nwea.org/docs/NWEA-Secure-Testing-Browser-Mac.dmg
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : curlOptions=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : appNewVersion=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : appCustomVersion function: Not defined
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : versionKey=CFBundleShortVersionString
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : packageID=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : pkgName=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : choiceChangesXML=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : expectedTeamID=SRTXZJ7SQ3
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : blockingProcesses=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : installerTool=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : CLIInstaller=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : CLIArguments=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : updateTool=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : updateToolArguments=
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : updateToolRunAsCurrentUser=
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : BLOCKING_PROCESS_ACTION=tell_user
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : NOTIFY=success
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : LOGGING=DEBUG
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : Label type: dmg
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : archiveName: NWEA Secure Testing Browser.dmg
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : no blocking processes defined, using NWEA Secure Testing Browser as default
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : Changing directory to /Users/user/Documents/GitHub/Installomator/build
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : name: NWEA Secure Testing Browser, appName: NWEA Secure Testing Browser.app
2023-12-29 09:09:37.200 mdfind[69734:533598] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-29 09:09:37.201 mdfind[69734:533598] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-29 09:09:37.259 mdfind[69734:533598] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-29 09:09:37 : WARN : nweasecuretestingbrowser : No previous app found
2023-12-29 09:09:37 : WARN : nweasecuretestingbrowser : could not find NWEA Secure Testing Browser.app
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : appversion:
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : Latest version not specified.
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : NWEA Secure Testing Browser.dmg exists and DEBUG mode 1 enabled, skipping download
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : DEBUG mode 1, not checking for blocking processes
2023-12-29 09:09:37 : REQ : nweasecuretestingbrowser : Installing NWEA Secure Testing Browser
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : Mounting /Users/user/Documents/GitHub/Installomator/build/NWEA Secure Testing Browser.dmg
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : Debugging enabled, dmgmount output was:
expected CRC32 $4823A153
/dev/disk4 GUID_partition_scheme
/dev/disk4s1 Apple_HFS /Volumes/NWEA Secure Testing Browser

2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : Mounted: /Volumes/NWEA Secure Testing Browser
2023-12-29 09:09:37 : INFO : nweasecuretestingbrowser : Verifying: /Volumes/NWEA Secure Testing Browser/NWEA Secure Testing Browser.app
2023-12-29 09:09:37 : DEBUG : nweasecuretestingbrowser : App size: 240M /Volumes/NWEA Secure Testing Browser/NWEA Secure Testing Browser.app
2023-12-29 09:09:39 : DEBUG : nweasecuretestingbrowser : Debugging enabled, App Verification output was:
/Volumes/NWEA Secure Testing Browser/NWEA Secure Testing Browser.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Northwest Evaluation Association (SRTXZJ7SQ3)

2023-12-29 09:09:39 : INFO : nweasecuretestingbrowser : Team ID matching: SRTXZJ7SQ3 (expected: SRTXZJ7SQ3 )
2023-12-29 09:09:39 : INFO : nweasecuretestingbrowser : Installing NWEA Secure Testing Browser version 5.5.4.5 on versionKey CFBundleShortVersionString.
2023-12-29 09:09:39 : INFO : nweasecuretestingbrowser : App has LSMinimumSystemVersion: 11.0
2023-12-29 09:09:39 : DEBUG : nweasecuretestingbrowser : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2023-12-29 09:09:39 : INFO : nweasecuretestingbrowser : Finishing...
2023-12-29 09:09:42 : INFO : nweasecuretestingbrowser : name: NWEA Secure Testing Browser, appName: NWEA Secure Testing Browser.app
2023-12-29 09:09:42.093 mdfind[69804:533838] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2023-12-29 09:09:42.094 mdfind[69804:533838] [UserQueryParser] Loading keywords and predicates for locale "en"
2023-12-29 09:09:42.141 mdfind[69804:533838] Couldn't determine the mapping between prefab keywords and predicates.
2023-12-29 09:09:42 : WARN : nweasecuretestingbrowser : No previous app found
2023-12-29 09:09:42 : WARN : nweasecuretestingbrowser : could not find NWEA Secure Testing Browser.app
2023-12-29 09:09:42 : REQ : nweasecuretestingbrowser : Installed NWEA Secure Testing Browser, version 5.5.4.5
2023-12-29 09:09:42 : INFO : nweasecuretestingbrowser : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2023-12-29 09:09:42 : DEBUG : nweasecuretestingbrowser : Unmounting /Volumes/NWEA Secure Testing Browser
2023-12-29 09:09:42 : DEBUG : nweasecuretestingbrowser : Debugging enabled, Unmounting output was:
"disk4" ejected.
2023-12-29 09:09:42 : DEBUG : nweasecuretestingbrowser : DEBUG mode 1, not reopening anything
2023-12-29 09:09:42 : REQ : nweasecuretestingbrowser : All done!
2023-12-29 09:09:42 : REQ : nweasecuretestingbrowser : ################## End Installomator, exit code 0