### PR TITLE
Enable "-" in versionFromGit

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -194,7 +194,7 @@ versionFromGit() {
     gitreponame=${2?:"no git repo name"}
 
     #appNewVersion=$(curl -L --silent --fail "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | grep tag_name | cut -d '"' -f 4 | sed 's/[^0-9\.]//g')
-    appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.]//g')
+    appNewVersion=$(curl -sLI "https://github.com/$gitusername/$gitreponame/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed 's/[^0-9\.\-]//g')
     if [ -z "$appNewVersion" ]; then
         printlog "could not retrieve version number for $gitusername/$gitreponame" WARN
         appNewVersion=""


### PR DESCRIPTION
Previously 1.2-3 would be read as 1.23, making it hard for some git projects to be read correctly (eg. Swift dialog)