### PR TITLE
Added label for Garmin Express

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -2,9 +2,6 @@ garminexpress)
     name="Garmin Express"
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
-    # https://support.garmin.com/en-US/?faq=9MuiEv9c2y2wgcXvzEVEe8 could possibly be used for a simpler query, but it looks like an auto generated url that might be randomly changed
-    # Therefore that url is fetched from the much longer url for the Garmin Express support
-    # Also, currently, app bundle has an extra 0 in version number compared to what's readable on Garmin's support site
     garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')
     appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print$2}').0"
     expectedTeamID="72ES32VZUA"

--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -1,0 +1,12 @@
+garminexpress)
+    name="Garmin Express"
+    type="pkgInDmg"
+    downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
+    # https://support.garmin.com/en-US/?faq=9MuiEv9c2y2wgcXvzEVEe8 could possibly be used for a simpler query, but it looks like an auto generated url that might be randomly changed
+    # Therefore that url is fetched from the much longer url for the Garmin Express support
+    # Also, currently, app bundle has an extra 0 in version number compared to what's readable on Garmin's support site
+    garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')
+    appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print$2}').0"
+    expectedTeamID="72ES32VZUA"
+    appName="Garmin Express.app"
+    ;;


### PR DESCRIPTION
2024-01-08 17:55:20 : REQ   : garminexpress : ################## Start Installomator v. 10.6beta, date 2024-01-08
2024-01-08 17:55:20 : INFO  : garminexpress : ################## Version: 10.6beta
2024-01-08 17:55:20 : INFO  : garminexpress : ################## Date: 2024-01-08
2024-01-08 17:55:20 : INFO  : garminexpress : ################## garminexpress
2024-01-08 17:55:20 : DEBUG : garminexpress : DEBUG mode 1 enabled.
2024-01-08 17:55:24 : DEBUG : garminexpress : name=Garmin Express
2024-01-08 17:55:24 : DEBUG : garminexpress : appName=Garmin Express.app
2024-01-08 17:55:24 : DEBUG : garminexpress : type=pkgInDmg
2024-01-08 17:55:24 : DEBUG : garminexpress : archiveName=
2024-01-08 17:55:24 : DEBUG : garminexpress : downloadURL=https://download.garmin.com/omt/express/GarminExpress.dmg
2024-01-08 17:55:24 : DEBUG : garminexpress : curlOptions=
2024-01-08 17:55:24 : DEBUG : garminexpress : appNewVersion=7.19.0.0
2024-01-08 17:55:24 : DEBUG : garminexpress : appCustomVersion function: Not defined
2024-01-08 17:55:24 : DEBUG : garminexpress : versionKey=CFBundleShortVersionString
2024-01-08 17:55:24 : DEBUG : garminexpress : packageID=
2024-01-08 17:55:24 : DEBUG : garminexpress : pkgName=
2024-01-08 17:55:24 : DEBUG : garminexpress : choiceChangesXML=
2024-01-08 17:55:24 : DEBUG : garminexpress : expectedTeamID=72ES32VZUA
2024-01-08 17:55:24 : DEBUG : garminexpress : blockingProcesses=
2024-01-08 17:55:24 : DEBUG : garminexpress : installerTool=
2024-01-08 17:55:24 : DEBUG : garminexpress : CLIInstaller=
2024-01-08 17:55:24 : DEBUG : garminexpress : CLIArguments=
2024-01-08 17:55:24 : DEBUG : garminexpress : updateTool=
2024-01-08 17:55:24 : DEBUG : garminexpress : updateToolArguments=
2024-01-08 17:55:24 : DEBUG : garminexpress : updateToolRunAsCurrentUser=
2024-01-08 17:55:24 : INFO  : garminexpress : BLOCKING_PROCESS_ACTION=tell_user
2024-01-08 17:55:24 : INFO  : garminexpress : NOTIFY=success
2024-01-08 17:55:24 : INFO  : garminexpress : LOGGING=DEBUG
2024-01-08 17:55:24 : INFO  : garminexpress : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-08 17:55:24 : INFO  : garminexpress : Label type: pkgInDmg
2024-01-08 17:55:24 : INFO  : garminexpress : archiveName: Garmin Express.dmg
2024-01-08 17:55:24 : INFO  : garminexpress : no blocking processes defined, using Garmin Express as default
2024-01-08 17:55:24 : DEBUG : garminexpress : Changing directory to /Volumes/Data/Power/Programmerat/Installomator/build
2024-01-08 17:55:24 : INFO  : garminexpress : App(s) found: /Applications/Garmin Express.app
2024-01-08 17:55:24 : INFO  : garminexpress : found app at /Applications/Garmin Express.app, version 7.19.0.0, on versionKey CFBundleShortVersionString
2024-01-08 17:55:24 : INFO  : garminexpress : appversion: 7.19.0.0
2024-01-08 17:55:24 : INFO  : garminexpress : Latest version of Garmin Express is 7.19.0.0
2024-01-08 17:55:24 : WARN  : garminexpress : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-01-08 17:55:24 : REQ   : garminexpress : Downloading https://download.garmin.com/omt/express/GarminExpress.dmg to Garmin Express.dmg
2024-01-08 17:55:24 : DEBUG : garminexpress : No Dialog connection, just download
2024-01-08 17:55:27 : DEBUG : garminexpress : File list: -rw-r--r--  1 username  group_name    44M Jan  8 17:55 Garmin Express.dmg
2024-01-08 17:55:27 : DEBUG : garminexpress : File type: Garmin Express.dmg: zlib compressed data
2024-01-08 17:55:27 : DEBUG : garminexpress : curl output was:
*   Trying 104.18.89.59:443...
* Connected to download.garmin.com (104.18.89.59) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2325 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May 18 00:00:00 2023 GMT
*  expire date: May 17 23:59:59 2024 GMT
*  subjectAltName: host "download.garmin.com" matched cert's "download.garmin.com"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.garmin.com/omt/express/GarminExpress.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.garmin.com]
* [HTTP/2] [1] [:path: /omt/express/GarminExpress.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /omt/express/GarminExpress.dmg HTTP/2
> Host: download.garmin.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Mon, 08 Jan 2024 16:55:27 GMT
< content-type: application/octet-stream
< content-length: 46403024
< last-modified: Wed, 08 Nov 2023 18:03:35 GMT
< etag: "2c40dd0-609a7e7e6f294"
< cf-cache-status: HIT
< age: 1583097
< expires: Mon, 08 Jan 2024 20:55:27 GMT
< cache-control: public, max-age=14400
< accept-ranges: bytes
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v3?s=XjO9NQI9IYaQIA5qRsn2jrQY1kP2PoutFq6ou8g6jzviw2OMdiNSQChPsYuXti88agRqawq%2FFH4nFJZ128LUX8tKhWScYacAJXVYkHtGzE4uZnzxHMTY0gEq5uwZ2XIZ0Wz5okk%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
< cf-ray: 8425f7dcbbd40d46-ARN
< 
{ [101691 bytes data]
* Connection #0 to host download.garmin.com left intact

2024-01-08 17:55:28 : DEBUG : garminexpress : DEBUG mode 1, not checking for blocking processes
2024-01-08 17:55:28 : REQ   : garminexpress : Installing Garmin Express
2024-01-08 17:55:28 : INFO  : garminexpress : Mounting /Volumes/Data/Power/Programmerat/Installomator/build/Garmin Express.dmg
2024-01-08 17:55:31 : DEBUG : garminexpress : Debugging enabled, dmgmount output was:
Beräknar kontrollsumma för Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verifierade   CRC32 $520391B7
Beräknar kontrollsumma för GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verifierade   CRC32 $072C47D8
Beräknar kontrollsumma för GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verifierade   CRC32 $9EE2A83A
Beräknar kontrollsumma för  (Apple_Free : 3)…
(Apple_Free : 3): verifierade   CRC32 $00000000
Beräknar kontrollsumma för disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verifierade   CRC32 $0D417B5E
Beräknar kontrollsumma för  (Apple_Free : 5)…
(Apple_Free : 5): verifierade   CRC32 $00000000
Beräknar kontrollsumma för GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verifierade   CRC32 $9EE2A83A
Beräknar kontrollsumma för GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verifierade   CRC32 $54C72B0A
verifierade   CRC32 $058DDDF3
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/Garmin Express

2024-01-08 17:55:31 : INFO  : garminexpress : Mounted: /Volumes/Garmin Express
2024-01-08 17:55:31 : DEBUG : garminexpress : Found pkg(s):
/Volumes/Garmin Express/Install Garmin Express.pkg
2024-01-08 17:55:31 : INFO  : garminexpress : found pkg: /Volumes/Garmin Express/Install Garmin Express.pkg
2024-01-08 17:55:31 : INFO  : garminexpress : Verifying: /Volumes/Garmin Express/Install Garmin Express.pkg
2024-01-08 17:55:31 : DEBUG : garminexpress : File list: -rw-r--r--@ 1 username  group_name    43M Nov  8 18:49 /Volumes/Garmin Express/Install Garmin Express.pkg
2024-01-08 17:55:31 : DEBUG : garminexpress : File type: /Volumes/Garmin Express/Install Garmin Express.pkg: xar archive compressed TOC: 9509, SHA-1 checksum
2024-01-08 17:55:31 : DEBUG : garminexpress : spctlOut is /Volumes/Garmin Express/Install Garmin Express.pkg: accepted
2024-01-08 17:55:31 : DEBUG : garminexpress : source=Notarized Developer ID
2024-01-08 17:55:31 : DEBUG : garminexpress : origin=Developer ID Installer: Garmin International (72ES32VZUA)
2024-01-08 17:55:31 : INFO  : garminexpress : Team ID: 72ES32VZUA (expected: 72ES32VZUA )
2024-01-08 17:55:31 : DEBUG : garminexpress : DEBUG enabled, skipping installation
2024-01-08 17:55:31 : INFO  : garminexpress : Finishing...
2024-01-08 17:55:34 : INFO  : garminexpress : App(s) found: /Applications/Garmin Express.app
2024-01-08 17:55:34 : INFO  : garminexpress : found app at /Applications/Garmin Express.app, version 7.19.0.0, on versionKey CFBundleShortVersionString
2024-01-08 17:55:34 : REQ   : garminexpress : Installed Garmin Express, version 7.19.0.0
2024-01-08 17:55:34 : INFO  : garminexpress : notifying
2024-01-08 17:55:35 : DEBUG : garminexpress : Unmounting /Volumes/Garmin Express
2024-01-08 17:55:35 : DEBUG : garminexpress : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-01-08 17:55:35 : DEBUG : garminexpress : DEBUG mode 1, not reopening anything
2024-01-08 17:55:35 : REQ   : garminexpress : All done!
2024-01-08 17:55:35 : REQ   : garminexpress : ################## End Installomator, exit code 0 