### PR TITLE
Update zerotier.sh

### DIFF
--- a/fragments/labels/zerotier.sh
+++ b/fragments/labels/zerotier.sh
@@ -3,6 +3,7 @@ zerotier)
     name="ZeroTier%20One"
     type="pkg"
     packageID="com.zerotier.pkg.ZeroTierOne"
+    appNewVersion=$(versionFromGit zerotier ZeroTierOne )
     downloadURL="https://download.zerotier.com/dist/ZeroTier%20One.pkg"
     expectedTeamID="8ZD9JUCZ4V"
     ;;


### PR DESCRIPTION
ZeroTier publishes releases to GitHub, however those releases do not include the macOS pkg (just the source code.)

This means we can use the github function to get the current version, and keep the existing downloadURL to download from their website.

```
./assemble.sh zerotier DEBUG=1
2024-01-13 21:46:39 : REQ   : zerotier : ################## Start Installomator v. 10.6beta, date 2024-01-13
2024-01-13 21:46:39 : INFO  : zerotier : ################## Version: 10.6beta
2024-01-13 21:46:39 : INFO  : zerotier : ################## Date: 2024-01-13
2024-01-13 21:46:39 : INFO  : zerotier : ################## zerotier
2024-01-13 21:46:39 : DEBUG : zerotier : DEBUG mode 1 enabled.
2024-01-13 21:46:40 : INFO  : zerotier : setting variable from argument DEBUG=1
2024-01-13 21:46:40 : DEBUG : zerotier : name=ZeroTier%20One
2024-01-13 21:46:40 : DEBUG : zerotier : appName=
2024-01-13 21:46:40 : DEBUG : zerotier : type=pkg
2024-01-13 21:46:40 : DEBUG : zerotier : archiveName=
2024-01-13 21:46:40 : DEBUG : zerotier : downloadURL=https://download.zerotier.com/dist/ZeroTier%20One.pkg
2024-01-13 21:46:40 : DEBUG : zerotier : curlOptions=
2024-01-13 21:46:40 : DEBUG : zerotier : appNewVersion=1.12.2
2024-01-13 21:46:40 : DEBUG : zerotier : appCustomVersion function: Not defined
2024-01-13 21:46:40 : DEBUG : zerotier : versionKey=CFBundleShortVersionString
2024-01-13 21:46:40 : DEBUG : zerotier : packageID=com.zerotier.pkg.ZeroTierOne
2024-01-13 21:46:40 : DEBUG : zerotier : pkgName=
2024-01-13 21:46:40 : DEBUG : zerotier : choiceChangesXML=
2024-01-13 21:46:40 : DEBUG : zerotier : expectedTeamID=8ZD9JUCZ4V
2024-01-13 21:46:40 : DEBUG : zerotier : blockingProcesses=
2024-01-13 21:46:40 : DEBUG : zerotier : installerTool=
2024-01-13 21:46:40 : DEBUG : zerotier : CLIInstaller=
2024-01-13 21:46:40 : DEBUG : zerotier : CLIArguments=
2024-01-13 21:46:40 : DEBUG : zerotier : updateTool=
2024-01-13 21:46:40 : DEBUG : zerotier : updateToolArguments=
2024-01-13 21:46:40 : DEBUG : zerotier : updateToolRunAsCurrentUser=
2024-01-13 21:46:40 : INFO  : zerotier : BLOCKING_PROCESS_ACTION=tell_user
2024-01-13 21:46:40 : INFO  : zerotier : NOTIFY=success
2024-01-13 21:46:40 : INFO  : zerotier : LOGGING=DEBUG
2024-01-13 21:46:40 : INFO  : zerotier : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-13 21:46:40 : INFO  : zerotier : Label type: pkg
2024-01-13 21:46:40 : INFO  : zerotier : archiveName: ZeroTier%20One.pkg
2024-01-13 21:46:40 : INFO  : zerotier : no blocking processes defined, using ZeroTier%20One as default
2024-01-13 21:46:40 : DEBUG : zerotier : Changing directory to /Users/bigmacadmin/Documents/GitHub/installomator/build
2024-01-13 21:46:40 : INFO  : zerotier : No version found using packageID com.zerotier.pkg.ZeroTierOne
2024-01-13 21:46:40 : INFO  : zerotier : name: ZeroTier%20One, appName: ZeroTier%20One.app
2024-01-13 21:46:40.645 mdfind[95948:8039666] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-01-13 21:46:40.646 mdfind[95948:8039666] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-01-13 21:46:40.693 mdfind[95948:8039666] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-13 21:46:40 : WARN  : zerotier : No previous app found
2024-01-13 21:46:40 : WARN  : zerotier : could not find ZeroTier%20One.app
2024-01-13 21:46:40 : INFO  : zerotier : appversion:
2024-01-13 21:46:40 : INFO  : zerotier : Latest version of ZeroTier%20One is 1.12.2
2024-01-13 21:46:40 : REQ   : zerotier : Downloading https://download.zerotier.com/dist/ZeroTier%20One.pkg to ZeroTier%20One.pkg
2024-01-13 21:46:40 : DEBUG : zerotier : No Dialog connection, just download
2024-01-13 21:46:41 : DEBUG : zerotier : File list: -rw-r--r--  1 root  staff    12M Jan 13 21:46 ZeroTier%20One.pkg
2024-01-13 21:46:41 : DEBUG : zerotier : File type: ZeroTier%20One.pkg: xar archive compressed TOC: 4635, SHA-1 checksum
2024-01-13 21:46:41 : DEBUG : zerotier : curl output was:
*   Trying 151.101.129.91:443...
* Connected to download.zerotier.com (151.101.129.91) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2824 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.zerotier.com
*  start date: Jun  3 21:50:15 2023 GMT
*  expire date: Jul  4 21:50:14 2024 GMT
*  subjectAltName: host "download.zerotier.com" matched cert's "*.zerotier.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2023 Q2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.zerotier.com/dist/ZeroTier%20One.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.zerotier.com]
* [HTTP/2] [1] [:path: /dist/ZeroTier%20One.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /dist/ZeroTier%20One.pkg HTTP/2
> Host: download.zerotier.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< server: nginx/1.18.0 (Ubuntu)
< content-type: application/octet-stream
< last-modified: Thu, 14 Sep 2023 19:07:12 GMT
< etag: "650359e0-c1f39e"
< accept-ranges: bytes
< date: Sun, 14 Jan 2024 05:46:40 GMT
< via: 1.1 varnish
< age: 1220
< x-served-by: cache-lax-kwhp1940088-LAX
< x-cache: HIT
< x-cache-hits: 1
< x-timer: S1705211201.956687,VS0,VE30
< alt-svc: h3=":443";ma=86400,h3-29=":443";ma=86400,h3-27=":443";ma=86400
< content-length: 12710814
<
{ [7855 bytes data]
* Connection #0 to host download.zerotier.com left intact

2024-01-13 21:46:41 : DEBUG : zerotier : DEBUG mode 1, not checking for blocking processes
2024-01-13 21:46:41 : REQ   : zerotier : Installing ZeroTier%20One
2024-01-13 21:46:41 : INFO  : zerotier : Verifying: ZeroTier%20One.pkg
2024-01-13 21:46:41 : DEBUG : zerotier : File list: -rw-r--r--  1 root  staff    12M Jan 13 21:46 ZeroTier%20One.pkg
2024-01-13 21:46:41 : DEBUG : zerotier : File type: ZeroTier%20One.pkg: xar archive compressed TOC: 4635, SHA-1 checksum
2024-01-13 21:46:42 : DEBUG : zerotier : spctlOut is ZeroTier%20One.pkg: accepted
2024-01-13 21:46:42 : DEBUG : zerotier : source=Notarized Developer ID
2024-01-13 21:46:42 : DEBUG : zerotier : origin=Developer ID Installer: ZeroTier, Inc (8ZD9JUCZ4V)
2024-01-13 21:46:42 : INFO  : zerotier : Team ID: 8ZD9JUCZ4V (expected: 8ZD9JUCZ4V )
2024-01-13 21:46:42 : DEBUG : zerotier : DEBUG enabled, skipping installation
2024-01-13 21:46:42 : INFO  : zerotier : Finishing...
2024-01-13 21:46:45 : INFO  : zerotier : No version found using packageID com.zerotier.pkg.ZeroTierOne
2024-01-13 21:46:45 : INFO  : zerotier : name: ZeroTier%20One, appName: ZeroTier%20One.app
2024-01-13 21:46:45.100 mdfind[96056:8039907] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-01-13 21:46:45.100 mdfind[96056:8039907] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-01-13 21:46:45.163 mdfind[96056:8039907] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-13 21:46:45 : WARN  : zerotier : No previous app found
2024-01-13 21:46:45 : WARN  : zerotier : could not find ZeroTier%20One.app
2024-01-13 21:46:45 : REQ   : zerotier : Installed ZeroTier%20One, version 1.12.2
2024-01-13 21:46:45 : INFO  : zerotier : notifying
2024-01-13 21:46:45 : DEBUG : zerotier : DEBUG mode 1, not reopening anything
2024-01-13 21:46:45 : REQ   : zerotier : All done!
2024-01-13 21:46:45 : REQ   : zerotier : ################## End Installomator, exit code 0
```