### PR TITLE
Arguments declared before using

### DIFF
--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -71,6 +71,17 @@ printlog "################## Version: $VERSION" INFO
 printlog "################## Date: $VERSIONDATE" INFO
 printlog "################## $label" INFO
 
+# MARK: finish reading the arguments:
+while [[ -n $1 ]]; do
+    if [[ $1 =~ ".*\=.*" ]]; then
+        # if an argument contains an = character, send it to eval
+        printlog "setting variable from argument $1" INFO
+        eval $1
+    fi
+    # shift to next argument
+    shift 1
+done
+
 # Check for DEBUG mode
 if [[ $DEBUG -gt 0 ]]; then
     printlog "DEBUG mode $DEBUG enabled." DEBUG

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -5,17 +5,6 @@
     ;;
 esac
 
-# MARK: finish reading the arguments:
-while [[ -n $1 ]]; do
-    if [[ $1 =~ ".*\=.*" ]]; then
-        # if an argument contains an = character, send it to eval
-        printlog "setting variable from argument $1" INFO
-        eval $1
-    fi
-    # shift to next argument
-    shift 1
-done
-
 # verify we have everything we need
 if [[ -z $name ]]; then
     printlog "need to provide 'name'" ERROR


### PR DESCRIPTION
The DEBUG variable is used before it is declared (as an argument). For example the DEBUG variable in the check root function. By changing the reading arguments place in the script this problem is solved.