### PR TITLE
Update rancherdesktop.sh

### DIFF
--- a/fragments/labels/rancherdesktop.sh
+++ b/fragments/labels/rancherdesktop.sh
@@ -2,10 +2,10 @@ rancherdesktop)
     name="Rancher Desktop"
     type="zip"
     if [[ $(arch) == "arm64" ]]; then
-      archiveName="Rancher.Desktop-[0-9.]*-mac.aarch64.zip"
+      archiveName="Rancher.Desktop-[0-9.]*.aarch64.zip"
       downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
     elif [[ $(arch) == "i386" ]]; then
-      archiveName="Rancher.Desktop-[0-9.]*-mac.x86_64.zip"
+      archiveName="Rancher.Desktop-[0-9.]*.x86_64.zip"
       downloadURL="$(downloadURLFromGit rancher-sandbox rancher-desktop)"
     fi
     appNewVersion="$(versionFromGit rancher-sandbox rancher-desktop)"


### PR DESCRIPTION
The latest 2 releases don't have "-mac" in the name, causing the installation to fail.