### PR TITLE
Create logitune.sh

### DIFF
--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -6,5 +6,6 @@ logitune)
     downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
+    CLIArguments=(-silent)
     expectedTeamID="QED4VVPZWA"
     ;;

--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -1,0 +1,10 @@
+logitune)
+    name="LogiTune"
+    archiveName="LogiTuneInstaller.dmg"
+    appName="LogiTuneInstaller.app"
+    type="dmg"
+    downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
+    expectedTeamID="QED4VVPZWA"
+    ;;


### PR DESCRIPTION
Hi, this label is based on logitechoptionsplus. The main difference in this is that the --quiet of Logitech Options plus isn't in the LogiTune installer app. It will therefore open an additional window where a user need to click install. This isn't the biggest issue when a user decides to initiates the installation, but it is an issue when automatically installing (for example with an update). If someone has a way to check if there are other flags that we can add to make it silent, then I'm all in for it. For us..this label works, but I can imagine that in other cases this would suffice.