### PR TITLE
New label: Node.js LTS version

### DIFF
--- a/fragments/labels/beyondcompare.sh
+++ b/fragments/labels/beyondcompare.sh
@@ -1,0 +1,9 @@
+beyondcompare)
+    name="Beyond Compare"
+    type="zip"
+    fileName=$(curl -sfL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" https://www.scootersoftware.com/download.php | grep -oE 'BCompareOSX.*\.zip')
+    downloadURL="https://www.scootersoftware.com/$fileName"
+    appNewVersion=$( sed -nE s/'.*OSX-(.*)\.zip/\1/p' <<< $fileName )
+    expectedTeamID="BS29TEJF86"
+    ;;
+

--- a/fragments/labels/keeperpasswordmanager.sh
+++ b/fragments/labels/keeperpasswordmanager.sh
@@ -2,7 +2,7 @@ keeperpasswordmanager)
     name="Keeper Password Manager"
     type="dmg"
     downloadURL="https://www.keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg"
-    appNewVersion=""
+    appNewVersion="$(curl -s https://keepersecurity.com/desktop_electron/desktop_electron_version.txt | grep -oE '[0-9.]*')"
     expectedTeamID="234QNB7GCA"
-    blockingProcess=( "Keeper Password Manager" )
     ;;
+

--- a/fragments/labels/macpass.sh
+++ b/fragments/labels/macpass.sh
@@ -1,0 +1,8 @@
+macpass)
+    name="MacPass"
+    type="zip"
+    downloadURL="$(downloadURLFromGit MacPass MacPass)"
+    appNewVersion="$(versionFromGit MacPass MacPass)"
+    expectedTeamID="55SM4L4Z97"
+    ;;
+

--- a/fragments/labels/misterhorseproductmanager.sh
+++ b/fragments/labels/misterhorseproductmanager.sh
@@ -1,0 +1,8 @@
+misterhorseproductmanager)
+    name="Mister Horse Product Manager"
+    type="dmg"
+    downloadURL="https://misterhorse.com/downloads/product-manager/osx"
+    appNewVersion=$(curl -fsIL "$downloadURL" | sed -nE 's/location.*Manager_([0-9.]*)\.dmg.*/\1/p')
+    expectedTeamID="H6366SAGL3"
+    ;;
+

--- a/fragments/labels/nodejslts.sh
+++ b/fragments/labels/nodejslts.sh
@@ -1,0 +1,8 @@
+nodejslts)
+    name="nodejs"
+    type="pkg"
+    downloadURL=$(curl -fsL 'https://nodejs.org/en/download' | grep -oE 'https://[^"]*node-v[0-9.]+.pkg' | head -1)
+    appNewVersion=$(sed -E 's/.*(v[0-9.]+)\.pkg/\1/g' <<< $downloadURL)
+    appCustomVersion(){/usr/local/bin/node -v}
+    expectedTeamID="HX7739G8FX"
+    ;;

--- a/fragments/labels/openjdk11ujdk.sh
+++ b/fragments/labels/openjdk11ujdk.sh
@@ -1,0 +1,12 @@
+openjdk11ujdk)
+    name="OpenJDK11U"
+    type="pkg"
+    packageID="net.temurin.11.jdk"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://api.adoptium.net/v3/installer/latest/11/ga/mac/aarch64/jdk/hotspot/normal/eclipse?project=jdk"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://api.adoptium.net/v3/installer/latest/11/ga/mac/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    fi
+    appNewVersion="$(curl -fsIL "${downloadURL}" | sed -nE 's/.*filename=OpenJDK.*_(11[0-9.]*).*/\1/p')"
+    expectedTeamID="JCDTMS22B4"
+    ;;

--- a/fragments/labels/openjdk17ujdk.sh
+++ b/fragments/labels/openjdk17ujdk.sh
@@ -1,0 +1,12 @@
+openjdk17ujdk)
+    name="OpenJDK17U"
+    type="pkg"
+    packageID="net.temurin.17.jdk"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://api.adoptium.net/v3/installer/latest/17/ga/mac/aarch64/jdk/hotspot/normal/eclipse?project=jdk"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://api.adoptium.net/v3/installer/latest/17/ga/mac/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    fi
+    appNewVersion="$(curl -fsIL "${downloadURL}" | sed -nE 's/.*filename=OpenJDK.*_(17[0-9.]*).*/\1/p')"
+    expectedTeamID="JCDTMS22B4"
+    ;;

--- a/fragments/labels/openjdk8ujdk.sh
+++ b/fragments/labels/openjdk8ujdk.sh
@@ -1,0 +1,13 @@
+openjdk8ujdk)
+    name="OpenJDK8U"
+    type="pkg"
+    packageID="net.temurin.8.jdk"
+    if [[ $(arch) == "arm64" ]]; then
+        # Note: no arm64 version available for v8. Use x64/i386 instead:
+        downloadURL="https://api.adoptium.net/v3/installer/latest/8/ga/mac/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://api.adoptium.net/v3/installer/latest/8/ga/mac/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    fi
+    appNewVersion="$(curl -fsIL "${downloadURL}" | sed -nE 's/.*filename=OpenJDK.*_(8u.*).pkg/\1/p')"
+    expectedTeamID="JCDTMS22B4"
+    ;;


### PR DESCRIPTION
The Node.js website states that the LTS version is "Recommended for Most Users", but Installomator only has a label that installs the "Current" version. This adds a new label for the LTS version.