### PR TITLE
New label: Node.js LTS Version

### DIFF
--- a/fragments/labels/nodejslts.sh
+++ b/fragments/labels/nodejslts.sh
@@ -1,8 +1,8 @@
 nodejslts)
     name="nodejs"
     type="pkg"
-    downloadURL=$(curl -fsL 'https://nodejs.org/en/download' | grep -oE 'https://[^"]*node-v[0-9.]+.pkg' | head -1)
-    appNewVersion=$(sed -E 's/.*(v[0-9.]+)\.pkg/\1/g' <<< $downloadURL)
+    appNewVersion=$(curl -fsL https://nodejs.org/en | xmllint --html --xpath '//a[contains(text(),"LTS")]/@href' - 2>/dev/null | grep -oE 'v[0-9]+(\.[0-9]+)*' | head -1)
+    downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"
     ;;

--- a/fragments/labels/nodejslts.sh
+++ b/fragments/labels/nodejslts.sh
@@ -1,0 +1,8 @@
+nodejslts)
+    name="nodejs"
+    type="pkg"
+    downloadURL=$(curl -fsL 'https://nodejs.org/en/download' | grep -oE 'https://[^"]*node-v[0-9.]+.pkg' | head -1)
+    appNewVersion=$(sed -E 's/.*(v[0-9.]+)\.pkg/\1/g' <<< $downloadURL)
+    appCustomVersion(){/usr/local/bin/node -v}
+    expectedTeamID="HX7739G8FX"
+    ;;


### PR DESCRIPTION
The Node.js website states that the LTS version is "Recommended for Most Users", but Installomator only has a label that installs the "Current" version. This adds a new label for the LTS version.

Output:
```
# ./utils/assemble.sh nodejslts DEBUG=0
2024-01-16 13:13:39 : REQ   : nodejslts : ################## Start Installomator v. 10.6beta, date 2024-01-16
2024-01-16 13:13:39 : INFO  : nodejslts : ################## Version: 10.6beta
2024-01-16 13:13:39 : INFO  : nodejslts : ################## Date: 2024-01-16
2024-01-16 13:13:39 : INFO  : nodejslts : ################## nodejslts
2024-01-16 13:13:39 : DEBUG : nodejslts : DEBUG mode 1 enabled.
2024-01-16 13:13:40 : INFO  : nodejslts : setting variable from argument DEBUG=0
2024-01-16 13:13:40 : DEBUG : nodejslts : name=nodejs
2024-01-16 13:13:40 : DEBUG : nodejslts : appName=
2024-01-16 13:13:40 : DEBUG : nodejslts : type=pkg
2024-01-16 13:13:40 : DEBUG : nodejslts : archiveName=
2024-01-16 13:13:40 : DEBUG : nodejslts : downloadURL=https://nodejs.org/dist/v20.11.0/node-v20.11.0.pkg
2024-01-16 13:13:40 : DEBUG : nodejslts : curlOptions=
2024-01-16 13:13:40 : DEBUG : nodejslts : appNewVersion=v20.11.0
2024-01-16 13:13:40 : DEBUG : nodejslts : appCustomVersion function: Defined.
2024-01-16 13:13:40 : DEBUG : nodejslts : versionKey=CFBundleShortVersionString
2024-01-16 13:13:40 : DEBUG : nodejslts : packageID=
2024-01-16 13:13:40 : DEBUG : nodejslts : pkgName=
2024-01-16 13:13:40 : DEBUG : nodejslts : choiceChangesXML=
2024-01-16 13:13:40 : DEBUG : nodejslts : expectedTeamID=HX7739G8FX
2024-01-16 13:13:40 : DEBUG : nodejslts : blockingProcesses=
2024-01-16 13:13:41 : DEBUG : nodejslts : installerTool=
2024-01-16 13:13:41 : DEBUG : nodejslts : CLIInstaller=
2024-01-16 13:13:41 : DEBUG : nodejslts : CLIArguments=
2024-01-16 13:13:41 : DEBUG : nodejslts : updateTool=
2024-01-16 13:13:41 : DEBUG : nodejslts : updateToolArguments=
2024-01-16 13:13:41 : DEBUG : nodejslts : updateToolRunAsCurrentUser=
2024-01-16 13:13:41 : INFO  : nodejslts : BLOCKING_PROCESS_ACTION=tell_user
2024-01-16 13:13:41 : INFO  : nodejslts : NOTIFY=success
2024-01-16 13:13:41 : INFO  : nodejslts : LOGGING=DEBUG
2024-01-16 13:13:41 : INFO  : nodejslts : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-16 13:13:41 : INFO  : nodejslts : Label type: pkg
2024-01-16 13:13:41 : INFO  : nodejslts : archiveName: nodejs.pkg
2024-01-16 13:13:41 : INFO  : nodejslts : no blocking processes defined, using nodejs as default
2024-01-16 13:13:41 : DEBUG : nodejslts : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ
appCustomVersion: no such file or directory: /usr/local/bin/node
2024-01-16 13:13:41 : INFO  : nodejslts : Custom App Version detection is used, found
2024-01-16 13:13:41 : INFO  : nodejslts : appversion:
2024-01-16 13:13:41 : INFO  : nodejslts : Latest version of nodejs is v20.11.0
2024-01-16 13:13:41 : REQ   : nodejslts : Downloading https://nodejs.org/dist/v20.11.0/node-v20.11.0.pkg to nodejs.pkg
2024-01-16 13:13:41 : DEBUG : nodejslts : No Dialog connection, just download
2024-01-16 13:13:53 : DEBUG : nodejslts : File list: -rw-r--r--  1 root  wheel    70M Jan 16 13:13 nodejs.pkg
2024-01-16 13:13:53 : DEBUG : nodejslts : File type: nodejs.pkg: xar archive compressed TOC: 5334, SHA-1 checksum
2024-01-16 13:13:53 : DEBUG : nodejslts : curl output was:
*   Trying 104.20.22.46:443...
* Connected to nodejs.org (104.20.22.46) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3722 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.nodejs.org
*  start date: Feb  3 00:00:00 2023 GMT
*  expire date: Mar  5 23:59:59 2024 GMT
*  subjectAltName: host "nodejs.org" matched cert's "nodejs.org"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /dist/v20.11.0/node-v20.11.0.pkg HTTP/1.1
> Host: nodejs.org
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Tue, 16 Jan 2024 18:13:42 GMT
< Content-Type: application/octet-stream
< Content-Length: 73826489
< Connection: keep-alive
< Last-Modified: Tue, 09 Jan 2024 09:31:28 GMT
< ETag: "659d1270-46680b9"
< Cache-Control: public, max-age=3600, s-maxage=14400
< CF-Cache-Status: HIT
< Age: 12642
< Accept-Ranges: bytes
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< X-Content-Type-Options: nosniff
< Server: cloudflare
< CF-RAY: 8468557a7ed53ade-IAD
<
{ [886 bytes data]
* Connection #0 to host nodejs.org left intact

2024-01-16 13:13:54 : REQ   : nodejslts : no more blocking processes, continue with update
2024-01-16 13:13:54 : REQ   : nodejslts : Installing nodejs
2024-01-16 13:13:54 : INFO  : nodejslts : Verifying: nodejs.pkg
2024-01-16 13:13:54 : DEBUG : nodejslts : File list: -rw-r--r--  1 root  wheel    70M Jan 16 13:13 nodejs.pkg
2024-01-16 13:13:54 : DEBUG : nodejslts : File type: nodejs.pkg: xar archive compressed TOC: 5334, SHA-1 checksum
2024-01-16 13:13:54 : DEBUG : nodejslts : spctlOut is nodejs.pkg: accepted
2024-01-16 13:13:54 : DEBUG : nodejslts : source=Notarized Developer ID
2024-01-16 13:13:54 : DEBUG : nodejslts : origin=Developer ID Installer: Node.js Foundation (HX7739G8FX)
2024-01-16 13:13:54 : INFO  : nodejslts : Team ID: HX7739G8FX (expected: HX7739G8FX )
2024-01-16 13:13:54 : INFO  : nodejslts : Installing nodejs.pkg to /
2024-01-16 13:14:01 : DEBUG : nodejslts : Debugging enabled, installer output was:
Jan 16 13:13:54  installer[10605] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg trustLevel=350
Jan 16 13:13:54  installer[10605] <Debug>: External component packages (2) trustLevel=350
Jan 16 13:13:54  installer[10605] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Jan 16 13:13:54  installer[10605] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#node-v20.11.0.pkg
Jan 16 13:13:54  installer[10605] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#npm-v10.2.4.pkg
Jan 16 13:13:54  installer[10605] <Info>: Set authorization level to root for session
Jan 16 13:13:54  installer[10605] <Info>: Authorization is being checked, waiting until authorization arrives.
Jan 16 13:13:54  installer[10605] <Info>: Administrator authorization granted.
Jan 16 13:13:54  installer[10605] <Info>: Packages have been authorized for installation.
Jan 16 13:13:54  installer[10605] <Debug>: Will use PK session
Jan 16 13:13:54  installer[10605] <Debug>: Using authorization level of root for IFPKInstallElement
Jan 16 13:13:55  installer[10605] <Info>: Starting installation:
Jan 16 13:13:55  installer[10605] <Notice>: Configuring volume "Macintosh HD"
Jan 16 13:13:55  installer[10605] <Info>: Preparing disk for local booted install.
Jan 16 13:13:55  installer[10605] <Notice>: Free space on "Macintosh HD": 455.29 GB (455290892288 bytes).
Jan 16 13:13:55  installer[10605] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10605TIaBdm"
Jan 16 13:13:55  installer[10605] <Notice>: IFPKInstallElement (2 packages)
Jan 16 13:13:55  installer[10605] <Info>: Current Path: /usr/sbin/installer
Jan 16 13:13:55  installer[10605] <Info>: Current Path: /bin/zsh
Last Log repeated 2 times
Jan 16 13:13:55  installer[10605] <Info>: Current Path: /usr/bin/sudo
Jan 16 13:13:55  installer[10605] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Node.js
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Node.js….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Writing package receipts….....
installer: Validating packages….....
#Jan 16 13:14:00  installer[10605] <Notice>: Running install actions
Jan 16 13:14:00  installer[10605] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10605TIaBdm"
Jan 16 13:14:00  installer[10605] <Notice>: Finalize disk "Macintosh HD"
Jan 16 13:14:00  installer[10605] <Notice>: Notifying system of updated components
Jan 16 13:14:00  installer[10605] <Notice>:
Jan 16 13:14:00  installer[10605] <Notice>: **** Summary Information ****
Jan 16 13:14:00  installer[10605] <Notice>:   Operation      Elapsed time
Jan 16 13:14:00  installer[10605] <Notice>: -----------------------------
Jan 16 13:14:00  installer[10605] <Notice>:        disk      0.01 seconds
Jan 16 13:14:00  installer[10605] <Notice>:      script      0.00 seconds
Jan 16 13:14:00  installer[10605] <Notice>:        zero      0.01 seconds
Jan 16 13:14:00  installer[10605] <Notice>:     install      5.14 seconds
Jan 16 13:14:00  installer[10605] <Notice>:     -total-      5.15 seconds
Jan 16 13:14:00  installer[10605] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The install was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-01-16 13:13:54-05 redacted installer[10605]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg trustLevel=350
2024-01-16 13:13:54-05 redacted installer[10605]: External component packages (2) trustLevel=350
2024-01-16 13:13:54-05 redacted installer[10605]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-01-16 13:13:54-05 redacted installer[10605]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#node-v20.11.0.pkg
2024-01-16 13:13:54-05 redacted installer[10605]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#npm-v10.2.4.pkg
2024-01-16 13:13:54-05 redacted installer[10605]: Set authorization level to root for session
2024-01-16 13:13:54-05 redacted installer[10605]: Authorization is being checked, waiting until authorization arrives.
2024-01-16 13:13:54-05 redacted installer[10605]: Administrator authorization granted.
2024-01-16 13:13:54-05 redacted installer[10605]: Packages have been authorized for installation.
2024-01-16 13:13:54-05 redacted installer[10605]: Will use PK session
2024-01-16 13:13:54-05 redacted installer[10605]: Using authorization level of root for IFPKInstallElement
2024-01-16 13:13:55-05 redacted installer[10605]: Starting installation:
2024-01-16 13:13:55-05 redacted installer[10605]: Configuring volume "Macintosh HD"
2024-01-16 13:13:55-05 redacted installer[10605]: Preparing disk for local booted install.
2024-01-16 13:13:55-05 redacted installer[10605]: Free space on "Macintosh HD": 455.29 GB (455290892288 bytes).
2024-01-16 13:13:55-05 redacted installer[10605]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10605TIaBdm"
2024-01-16 13:13:55-05 redacted installer[10605]: IFPKInstallElement (2 packages)
2024-01-16 13:13:55-05 redacted installer[10605]: Current Path: /usr/sbin/installer
2024-01-16 13:13:55-05 redacted installer[10605]: Current Path: /bin/zsh
Last Log repeated 3 times
2024-01-16 13:13:55-05 redacted installer[10605]: Current Path: /usr/bin/sudo
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: Adding client PKInstallDaemonClient pid=10605, uid=0 (/usr/sbin/installer)
2024-01-16 13:13:55-05 redacted installer[10605]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: Set reponsibility for install to 7755
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: Hosted team responsibility for install set to team:(HX7739G8FX)
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: ----- Begin install -----
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2024-01-16 13:13:55-05 redacted installd[1628]: PackageKit: packages=(
2024-01-16 13:13:56-05 redacted installd[1628]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#node-v20.11.0.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/597ED244-F8B5-43AE-9774-159799A1810C.activeSandbox/Root, uid=0)
2024-01-16 13:13:57-05 redacted installd[1628]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg#npm-v10.2.4.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/597ED244-F8B5-43AE-9774-159799A1810C.activeSandbox/Root, uid=0)
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit: prevent user idle system sleep
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit: suspending backupd
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:58-05 redacted package_script_service[3365]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:58-05 redacted package_script_service[3365]: Set responsibility to pid: 7755, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-01-16 13:13:58-05 redacted package_script_service[3365]: Hosted team responsibility for script set to team:(HX7739G8FX)
2024-01-16 13:13:58-05 redacted package_script_service[3365]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:58-05 redacted install_monitor[10612]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-01-16 13:13:58-05 redacted package_script_service[3365]: PackageKit: Hosted team responsible for script has been cleared.
2024-01-16 13:13:58-05 redacted package_script_service[3365]: Responsibility set back to self.
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/597ED244-F8B5-43AE-9774-159799A1810C.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/597ED244-F8B5-43AE-9774-159799A1810C.activeSandbox
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/597ED244-F8B5-43AE-9774-159799A1810C.activeSandbox/Root (1 items) to /
2024-01-16 13:13:58-05 redacted installd[1628]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:58-05 redacted package_script_service[3365]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:58-05 redacted package_script_service[3365]: Set responsibility to pid: 7755, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-01-16 13:13:58-05 redacted package_script_service[3365]: Hosted team responsibility for script set to team:(HX7739G8FX)
2024-01-16 13:13:58-05 redacted package_script_service[3365]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.9QEZsO/Scripts/org.nodejs.npm.pkg.j0TES6
2024-01-16 13:13:59-05 redacted package_script_service[3365]: PackageKit: Hosted team responsible for script has been cleared.
2024-01-16 13:13:59-05 redacted package_script_service[3365]: Responsibility set back to self.
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Writing receipt for org.nodejs.node.pkg to /
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Writing receipt for org.nodejs.npm.pkg to /
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: No Intel binaries to translate.
2024-01-16 13:13:59-05 redacted installd[1628]: Installed "Node.js" ()
2024-01-16 13:13:59-05 redacted installd[1628]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-01-16 13:13:59-05 redacted install_monitor[10612]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: releasing backupd
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: allow user idle system sleep
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: ----- End install -----
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: 3.8s elapsed install time
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Cleared responsibility for install from 10605.
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Hosted team responsible for install has been cleared.
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Running idle tasks
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Removing client PKInstallDaemonClient pid=10605, uid=0 (/usr/sbin/installer)
2024-01-16 13:13:59-05 redacted installd[1628]: PackageKit: Done with sandbox removals
2024-01-16 13:14:00-05 redacted installer[10605]: Running install actions
2024-01-16 13:14:00-05 redacted installer[10605]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10605TIaBdm"
2024-01-16 13:14:00-05 redacted installer[10605]: Finalize disk "Macintosh HD"
2024-01-16 13:14:00-05 redacted installer[10605]: Notifying system of updated components
2024-01-16 13:14:00-05 redacted installer[10605]:
2024-01-16 13:14:00-05 redacted installer[10605]: **** Summary Information ****
2024-01-16 13:14:00-05 redacted installer[10605]:   Operation      Elapsed time
2024-01-16 13:14:00-05 redacted installer[10605]: -----------------------------
2024-01-16 13:14:00-05 redacted installer[10605]:        disk      0.01 seconds
2024-01-16 13:14:00-05 redacted installer[10605]:      script      0.00 seconds
2024-01-16 13:14:00-05 redacted installer[10605]:        zero      0.01 seconds
2024-01-16 13:14:00-05 redacted installer[10605]:     install      5.14 seconds
2024-01-16 13:14:00-05 redacted installer[10605]:     -total-      5.15 seconds
2024-01-16 13:14:00-05 redacted installer[10605]:

2024-01-16 13:14:01 : INFO  : nodejslts : Finishing...
2024-01-16 13:14:06 : INFO  : nodejslts : Custom App Version detection is used, found v20.11.0
2024-01-16 13:14:06 : REQ   : nodejslts : Installed nodejs, version v20.11.0
2024-01-16 13:14:06 : INFO  : nodejslts : notifying
2024-01-16 13:14:06 : DEBUG : nodejslts : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ
2024-01-16 13:14:06 : DEBUG : nodejslts : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ/nodejs.pkg
2024-01-16 13:14:06 : DEBUG : nodejslts : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XW57KrXoUQ
2024-01-16 13:14:06 : INFO  : nodejslts : Installomator did not close any apps, so no need to reopen any apps.
2024-01-16 13:14:06 : REQ   : nodejslts : All done!
2024-01-16 13:14:06 : REQ   : nodejslts : ################## End Installomator, exit code 0

```