### PR TITLE
Added Pulsar from Pulsar Edit

### DIFF
--- a/fragments/labels/pulsar.sh
+++ b/fragments/labels/pulsar.sh
@@ -1,0 +1,16 @@
+pulsar)
+    name="Pulsar"
+    type="zip"
+    appNewVersion=$(versionFromGit pulsar-edit pulsar)
+    if [[ $(arch) = "arm64" ]]; then
+        printlog "Architecture: arm64"
+        downloadURL="https://github.com/pulsar-edit/pulsar/releases/download/v${appNewVersion}/Silicon.Mac.Pulsar-${appNewVersion}-arm64-mac.zip"
+        archiveName="Silicon.Mac.Pulsar-${appNewVersion}-arm64-mac.zip"
+    else
+        printlog "Architecture: i386 (not arm64)"
+        downloadURL="https://github.com/pulsar-edit/pulsar/releases/download/v${appNewVersion}/Intel.Mac.Pulsar-${appNewVersion}-mac.zip"
+        archiveName="Intel.Mac.Pulsar-${appNewVersion}-mac.zip"
+    fi
+    expectedTeamID="D3KV2P2CZ8"
+    ;;
+


### PR DESCRIPTION
´´´
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh pulsar

2024-01-18 15:58:30 : REQ   : pulsar : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 15:58:30 : INFO  : pulsar : ################## Version: 10.6beta
2024-01-18 15:58:30 : INFO  : pulsar : ################## Date: 2024-01-18
2024-01-18 15:58:30 : INFO  : pulsar : ################## pulsar
2024-01-18 15:58:30 : DEBUG : pulsar : DEBUG mode 1 enabled.
2024-01-18 15:58:31 : INFO  : pulsar : Architecture: arm64
2024-01-18 15:58:31 : DEBUG : pulsar : name=Pulsar
2024-01-18 15:58:31 : DEBUG : pulsar : appName=
2024-01-18 15:58:31 : DEBUG : pulsar : type=zip
2024-01-18 15:58:31 : DEBUG : pulsar : archiveName=Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:31 : DEBUG : pulsar : downloadURL=https://github.com/pulsar-edit/pulsar/releases/download/v1.113.0/Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:31 : DEBUG : pulsar : curlOptions=
2024-01-18 15:58:31 : DEBUG : pulsar : appNewVersion=1.113.0
2024-01-18 15:58:31 : DEBUG : pulsar : appCustomVersion function: Not defined
2024-01-18 15:58:31 : DEBUG : pulsar : versionKey=CFBundleShortVersionString
2024-01-18 15:58:31 : DEBUG : pulsar : packageID=
2024-01-18 15:58:31 : DEBUG : pulsar : pkgName=
2024-01-18 15:58:31 : DEBUG : pulsar : choiceChangesXML=
2024-01-18 15:58:31 : DEBUG : pulsar : expectedTeamID=D3KV2P2CZ8
2024-01-18 15:58:31 : DEBUG : pulsar : blockingProcesses=
2024-01-18 15:58:31 : DEBUG : pulsar : installerTool=
2024-01-18 15:58:31 : DEBUG : pulsar : CLIInstaller=
2024-01-18 15:58:31 : DEBUG : pulsar : CLIArguments=
2024-01-18 15:58:31 : DEBUG : pulsar : updateTool=
2024-01-18 15:58:31 : DEBUG : pulsar : updateToolArguments=
2024-01-18 15:58:31 : DEBUG : pulsar : updateToolRunAsCurrentUser=
2024-01-18 15:58:31 : INFO  : pulsar : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 15:58:31 : INFO  : pulsar : NOTIFY=success
2024-01-18 15:58:31 : INFO  : pulsar : LOGGING=DEBUG
2024-01-18 15:58:31 : INFO  : pulsar : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 15:58:31 : INFO  : pulsar : Label type: zip
2024-01-18 15:58:31 : INFO  : pulsar : archiveName: Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:31 : INFO  : pulsar : no blocking processes defined, using Pulsar as default
2024-01-18 15:58:31 : DEBUG : pulsar : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-18 15:58:31 : INFO  : pulsar : App(s) found: /Applications/Pulsar.app
2024-01-18 15:58:31 : INFO  : pulsar : found app at /Applications/Pulsar.app, version 1.113.0, on versionKey CFBundleShortVersionString
2024-01-18 15:58:31 : INFO  : pulsar : appversion: 1.113.0
2024-01-18 15:58:31 : INFO  : pulsar : Latest version of Pulsar is 1.113.0
2024-01-18 15:58:31 : WARN  : pulsar : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-01-18 15:58:31 : REQ   : pulsar : Downloading https://github.com/pulsar-edit/pulsar/releases/download/v1.113.0/Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip to Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:31 : DEBUG : pulsar : No Dialog connection, just download
2024-01-18 15:58:50 : DEBUG : pulsar : File list: -rw-r--r--  1 root  staff   207M 18 Jan 15:58 Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:50 : DEBUG : pulsar : File type: Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip: Zip archive data, at least v2.0 to extract, compression method=store
2024-01-18 15:58:50 : DEBUG : pulsar : curl output was:
*   Trying 140.82.121.4:443...
* Connected to github.com (140.82.121.4) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/pulsar-edit/pulsar/releases/download/v1.113.0/Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /pulsar-edit/pulsar/releases/download/v1.113.0/Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /pulsar-edit/pulsar/releases/download/v1.113.0/Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip HTTP/2
> Host: github.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 18 Jan 2024 14:58:32 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/513196750/61beddde-9b85-4c23-9a66-2062ce4d51ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T145832Z&X-Amz-Expires=300&X-Amz-Signature=50b25b4324d81925628a03527ce34392d634f9945ed5d25b07c6bc7e78db744b&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=513196750&response-content-disposition=attachment%3B%20filename%3DSilicon.Mac.Pulsar-1.113.0-arm64-mac.zip&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events api.githubcopilot.com objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: E54C:3CA080:12A978A2:12DBBA3C:65A93C97
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/513196750/61beddde-9b85-4c23-9a66-2062ce4d51ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T145832Z&X-Amz-Expires=300&X-Amz-Signature=50b25b4324d81925628a03527ce34392d634f9945ed5d25b07c6bc7e78db744b&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=513196750&response-content-disposition=attachment%3B%20filename%3DSilicon.Mac.Pulsar-1.113.0-arm64-mac.zip&response-content-type=application%2Foctet-stream'
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/513196750/61beddde-9b85-4c23-9a66-2062ce4d51ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T145832Z&X-Amz-Expires=300&X-Amz-Signature=50b25b4324d81925628a03527ce34392d634f9945ed5d25b07c6bc7e78db744b&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=513196750&response-content-disposition=attachment%3B%20filename%3DSilicon.Mac.Pulsar-1.113.0-arm64-mac.zip&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/513196750/61beddde-9b85-4c23-9a66-2062ce4d51ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T145832Z&X-Amz-Expires=300&X-Amz-Signature=50b25b4324d81925628a03527ce34392d634f9945ed5d25b07c6bc7e78db744b&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=513196750&response-content-disposition=attachment%3B%20filename%3DSilicon.Mac.Pulsar-1.113.0-arm64-mac.zip&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/513196750/61beddde-9b85-4c23-9a66-2062ce4d51ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T145832Z&X-Amz-Expires=300&X-Amz-Signature=50b25b4324d81925628a03527ce34392d634f9945ed5d25b07c6bc7e78db744b&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=513196750&response-content-disposition=attachment%3B%20filename%3DSilicon.Mac.Pulsar-1.113.0-arm64-mac.zip&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: L0sBf5l9VMI36YMCwEdmEA==
< last-modified: Tue, 16 Jan 2024 03:25:52 GMT
< etag: "0x8DC1642D7DFE260"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 9fc5ba91-801e-0024-22e0-4817f5000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Tue, 16 Jan 2024 03:25:52 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 0
< date: Thu, 18 Jan 2024 14:58:33 GMT
< x-served-by: cache-iad-kjyo7100134-IAD, cache-muc13939-MUC
< x-cache: HIT, HIT
< x-cache-hits: 41, 0
< x-timer: S1705589913.524874,VS0,VE476
< content-length: 217533693
< 
{ [10711 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-01-18 15:58:50 : DEBUG : pulsar : DEBUG mode 1, not checking for blocking processes
2024-01-18 15:58:50 : REQ   : pulsar : Installing Pulsar
2024-01-18 15:58:50 : INFO  : pulsar : Unzipping Silicon.Mac.Pulsar-1.113.0-arm64-mac.zip
2024-01-18 15:58:57 : INFO  : pulsar : Verifying: /Users/duf0002a/workdir/GitHub/Installomator/build/Pulsar.app
2024-01-18 15:58:57 : DEBUG : pulsar : App size: 714M	/Users/duf0002a/workdir/GitHub/Installomator/build/Pulsar.app
2024-01-18 15:59:01 : DEBUG : pulsar : Debugging enabled, App Verification output was:
/Users/duf0002a/workdir/GitHub/Installomator/build/Pulsar.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Alexander Liu (D3KV2P2CZ8)

2024-01-18 15:59:01 : INFO  : pulsar : Team ID matching: D3KV2P2CZ8 (expected: D3KV2P2CZ8 )
2024-01-18 15:59:01 : INFO  : pulsar : Downloaded version of Pulsar is 1.113.0 on versionKey CFBundleShortVersionString, same as installed.
2024-01-18 15:59:01 : DEBUG : pulsar : DEBUG mode 1, not reopening anything
2024-01-18 15:59:01 : REG   : pulsar : No new version to install
2024-01-18 15:59:01 : REQ   : pulsar : ################## End Installomator, exit code 0 
´´´