### PR TITLE
Update cinema4d.sh

### DIFF
--- a/fragments/labels/cinema4d.sh
+++ b/fragments/labels/cinema4d.sh
@@ -2,12 +2,14 @@ cinema4d)
     name="Cinema 4D"
     type="dmg"
     appCustomVersion(){
-      defaults read "/Applications/Maxon Cinema 4D 2023/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+"
+          defaults read "/Applications/Maxon Cinema 4D 2023/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+"
     }
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4405723907986-Cinema-4D" | grep "#icon-star" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4405723907986-Cinema-4D" | grep "#icon-star" -B3 | grep -Eo "[0-9][0-9][0-9][0-9]+\.[0-9]+(\.[0-9]+)?" | head -n 30 | sort -gru)
+    if [[ $(grep -o "\." <<< "$appNewVersion" | wc -l) -eq 1 ]]; then appNewVersion="${appNewVersion}.0"; fi
     targetDir="/Applications/Maxon Cinema 4D ${appNewVersion:0:4}"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/${appNewVersion}/Cinema4D_${appNewVersion:0:4}_${appNewVersion}_Mac.dmg"
     installerTool="Maxon Cinema 4D Installer.app"
     CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=(--mode unattended --unattendedmodeui none)
     expectedTeamID="4ZY22YGXQG"
     ;;


### PR DESCRIPTION
```
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh cinema4d

2024-01-18 16:08:38 : REQ   : cinema4d : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 16:08:38 : INFO  : cinema4d : ################## Version: 10.6beta
2024-01-18 16:08:38 : INFO  : cinema4d : ################## Date: 2024-01-18
2024-01-18 16:08:38 : INFO  : cinema4d : ################## cinema4d
2024-01-18 16:08:38 : DEBUG : cinema4d : DEBUG mode 1 enabled.
2024-01-18 16:08:39 : DEBUG : cinema4d : name=Cinema 4D
2024-01-18 16:08:39 : DEBUG : cinema4d : appName=
2024-01-18 16:08:39 : DEBUG : cinema4d : type=dmg
2024-01-18 16:08:39 : DEBUG : cinema4d : archiveName=
2024-01-18 16:08:39 : DEBUG : cinema4d : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg
2024-01-18 16:08:39 : DEBUG : cinema4d : curlOptions=
2024-01-18 16:08:39 : DEBUG : cinema4d : appNewVersion=2024.2.0
2024-01-18 16:08:39 : DEBUG : cinema4d : appCustomVersion function: Defined. 
2024-01-18 16:08:39 : DEBUG : cinema4d : versionKey=CFBundleShortVersionString
2024-01-18 16:08:39 : DEBUG : cinema4d : packageID=
2024-01-18 16:08:39 : DEBUG : cinema4d : pkgName=
2024-01-18 16:08:39 : DEBUG : cinema4d : choiceChangesXML=
2024-01-18 16:08:39 : DEBUG : cinema4d : expectedTeamID=4ZY22YGXQG
2024-01-18 16:08:39 : DEBUG : cinema4d : blockingProcesses=
2024-01-18 16:08:39 : DEBUG : cinema4d : installerTool=Maxon Cinema 4D Installer.app
2024-01-18 16:08:39 : DEBUG : cinema4d : CLIInstaller=Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh
2024-01-18 16:08:39 : DEBUG : cinema4d : CLIArguments=--mode unattended --unattendedmodeui none
2024-01-18 16:08:39 : DEBUG : cinema4d : updateTool=
2024-01-18 16:08:39 : DEBUG : cinema4d : updateToolArguments=
2024-01-18 16:08:39 : DEBUG : cinema4d : updateToolRunAsCurrentUser=
2024-01-18 16:08:39 : INFO  : cinema4d : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 16:08:39 : INFO  : cinema4d : NOTIFY=success
2024-01-18 16:08:39 : INFO  : cinema4d : LOGGING=DEBUG
2024-01-18 16:08:39 : INFO  : cinema4d : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 16:08:39 : INFO  : cinema4d : Label type: dmg
2024-01-18 16:08:39 : INFO  : cinema4d : archiveName: Cinema 4D.dmg
2024-01-18 16:08:39 : INFO  : cinema4d : no blocking processes defined, using Cinema 4D as default
2024-01-18 16:08:39 : DEBUG : cinema4d : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-18 16:08:39 : INFO  : cinema4d : Custom App Version detection is used, found 2023.2.1
2024-01-18 16:08:39 : INFO  : cinema4d : appversion: 2023.2.1
2024-01-18 16:08:39 : INFO  : cinema4d : Latest version of Cinema 4D is 2024.2.0
2024-01-18 16:08:39 : REQ   : cinema4d : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg to Cinema 4D.dmg
2024-01-18 16:08:39 : DEBUG : cinema4d : No Dialog connection, just download
2024-01-18 16:12:00 : DEBUG : cinema4d : File list: -rw-r--r--  1 root  staff   2,3G 18 Jan 16:12 Cinema 4D.dmg
2024-01-18 16:12:00 : DEBUG : cinema4d : File type: Cinema 4D.dmg: zlib compressed data
2024-01-18 16:12:00 : DEBUG : cinema4d : curl output was:
*   Trying [2606:4700:4400::ac40:91ef]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700:4400::ac40:91ef) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mx-app-blob-prod.maxon.net]
* [HTTP/2] [1] [:path: /mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mx-package-production/installer/macos/maxon/cinema4d/releases/2024.2.0/Cinema4D_2024_2024.2.0_Mac.dmg HTTP/2
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Thu, 18 Jan 2024 15:08:39 GMT
< content-type: application/octet-stream
< content-length: 2471522762
< content-md5: 4ksjerS5Ab/tcUiASI7Wow==
< last-modified: Mon, 11 Dec 2023 14:00:01 GMT
< etag: 0x8DBFA5177B354E7
< x-ms-request-id: a463780a-f01e-010c-09f3-317370000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: HIT
< age: 10678
< expires: Fri, 17 Jan 2025 15:08:39 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8477c12bda564d9c-FRA
< 
{ [19139 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2024-01-18 16:12:00 : DEBUG : cinema4d : DEBUG mode 1, not checking for blocking processes
2024-01-18 16:12:00 : REQ   : cinema4d : Installing Cinema 4D
2024-01-18 16:12:00 : REQ   : cinema4d : installerTool used: Maxon Cinema 4D Installer.app
2024-01-18 16:12:00 : INFO  : cinema4d : Mounting /Users/duf0002a/workdir/GitHub/Installomator/build/Cinema 4D.dmg
2024-01-18 16:12:05 : DEBUG : cinema4d : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $CFC0A513
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $058DBA63
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $23D54099
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4) berechnen …
EFI System Partition (C12A7328-F81F-: Die überprüfte CRC32-Prüfsumme ist $B54B659C
Prüfsumme für disk image (Apple_HFS : 5) berechnen …
disk image (Apple_HFS : 5): Die überprüfte CRC32-Prüfsumme ist $3080C16D
Prüfsumme für  (Apple_Free : 6) berechnen …
(Apple_Free : 6): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 7) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $23D54099
Prüfsumme für GPT Header (Backup GPT Header : 8) berechnen …
GPT Header (Backup GPT Header : 8): Die überprüfte CRC32-Prüfsumme ist $38E31A2C
Die überprüfte CRC32-Prüfsumme ist $3BB43505
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Maxon Cinema 4D

2024-01-18 16:12:05 : INFO  : cinema4d : Mounted: /Volumes/Maxon Cinema 4D
2024-01-18 16:12:05 : INFO  : cinema4d : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-01-18 16:12:05 : DEBUG : cinema4d : App size: 2,3G	/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-01-18 16:12:08 : DEBUG : cinema4d : Debugging enabled, App Verification output was:
/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-01-18 16:12:08 : INFO  : cinema4d : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-01-18 16:12:08 : INFO  : cinema4d : Downloaded version of Cinema 4D is 2024 on versionKey CFBundleShortVersionString (replacing version 2023.2.1).
2024-01-18 16:12:08 : DEBUG : cinema4d : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-01-18 16:12:08 : INFO  : cinema4d : Finishing...
2024-01-18 16:12:11 : INFO  : cinema4d : Custom App Version detection is used, found 2023.2.1
2024-01-18 16:12:11 : REQ   : cinema4d : Installed Cinema 4D, version 2024
2024-01-18 16:12:11 : INFO  : cinema4d : notifying
2024-01-18 16:12:11 : DEBUG : cinema4d : Unmounting /Volumes/Maxon Cinema 4D
2024-01-18 16:12:12 : DEBUG : cinema4d : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-01-18 16:12:12 : DEBUG : cinema4d : DEBUG mode 1, not reopening anything
2024-01-18 16:12:12 : REQ   : cinema4d : All done!
2024-01-18 16:12:12 : REQ   : cinema4d : ################## End Installomator, exit code 0 
```