### PR TITLE
Update maxonapp.sh

### DIFF
--- a/fragments/labels/maxonapp.sh
+++ b/fragments/labels/maxonapp.sh
@@ -2,7 +2,7 @@ maxonapp)
     name="Maxon"
     type="dmg"
     versionKey="CFBundleShortVersionString"
-    appNewVersion="$(curl -s "https://packages.maxon.net/manifests?platform=macos&org=maxon&type=products&family=fuse" | tr { '\n' | tr , '\n' | tr } '\n' | grep "version" | awk  -F'"' '{print $4}' | sort -gru | head -n 1)"
+    appNewVersion="$(curl -s "https://packages.maxon.net/manifests?platform=macos&org=maxon&type=products&family=fuse" | tr { '\n' | tr , '\n' | tr } '\n' | grep "version" | awk  -F'"' '{print $4}' | sort -gr | head -n 1)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/${appNewVersion}/Maxon_App_${appNewVersion}_Mac.dmg"
     installerTool="Maxon App Installer.app"
     CLIInstaller="Maxon App Installer.app/Contents/MacOS/installbuilder.sh"

--- a/fragments/labels/maxonapp.sh
+++ b/fragments/labels/maxonapp.sh
@@ -2,7 +2,7 @@ maxonapp)
     name="Maxon"
     type="dmg"
     versionKey="CFBundleShortVersionString"
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://www.maxon.net/en/try" | grep "Download Maxon App" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
+    appNewVersion="$(curl -s "https://packages.maxon.net/manifests?platform=macos&org=maxon&type=products&family=fuse" | tr { '\n' | tr , '\n' | tr } '\n' | grep "version" | awk  -F'"' '{print $4}' | sort -gru | head -n 1)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/${appNewVersion}/Maxon_App_${appNewVersion}_Mac.dmg"
     installerTool="Maxon App Installer.app"
     CLIInstaller="Maxon App Installer.app/Contents/MacOS/installbuilder.sh"

--- a/fragments/labels/maxonapp.sh
+++ b/fragments/labels/maxonapp.sh
@@ -2,11 +2,10 @@ maxonapp)
     name="Maxon"
     type="dmg"
     versionKey="CFBundleShortVersionString"
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4405723902226--Maxon-App" | grep "#icon-star" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
-    #targetDir="/"
+    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://www.maxon.net/en/try" | grep "Download Maxon App" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/${appNewVersion}/Maxon_App_${appNewVersion}_Mac.dmg"
     installerTool="Maxon App Installer.app"
-    CLIInstaller="Maxon App Installer.app/Contents/Scripts/install.sh"
-    CLIArguments=()
+    CLIInstaller="Maxon App Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=(--mode unattended --unattendedmodeui none)
     expectedTeamID="4ZY22YGXQG"
     ;;

--- a/fragments/labels/maxonapp.sh
+++ b/fragments/labels/maxonapp.sh
@@ -2,7 +2,7 @@ maxonapp)
     name="Maxon"
     type="dmg"
     versionKey="CFBundleShortVersionString"
-    appNewVersion="$(curl -s "https://packages.maxon.net/manifests?platform=macos&org=maxon&type=products&family=fuse" | tr { '\n' | tr , '\n' | tr } '\n' | grep "version" | awk  -F'"' '{print $4}' | sort -gr | head -n 1)"
+    appNewVersion="$(curl -s "https://packages.maxon.net/manifests?platform=macos&org=maxon&type=products&family=fuse" | tr '{' '\n' | tr ',' '\n' | tr '}' '\n' | grep "version" | awk -F'"' '{print $4}' | sort -gr | head -n 1)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/${appNewVersion}/Maxon_App_${appNewVersion}_Mac.dmg"
     installerTool="Maxon App Installer.app"
     CLIInstaller="Maxon App Installer.app/Contents/MacOS/installbuilder.sh"


### PR DESCRIPTION
```
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh maxonapp

2024-01-18 16:16:44 : REQ   : maxonapp : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 16:16:45 : INFO  : maxonapp : ################## Version: 10.6beta
2024-01-18 16:16:45 : INFO  : maxonapp : ################## Date: 2024-01-18
2024-01-18 16:16:45 : INFO  : maxonapp : ################## maxonapp
2024-01-18 16:16:45 : DEBUG : maxonapp : DEBUG mode 1 enabled.
2024-01-18 16:16:45 : DEBUG : maxonapp : name=Maxon
2024-01-18 16:16:45 : DEBUG : maxonapp : appName=
2024-01-18 16:16:45 : DEBUG : maxonapp : type=dmg
2024-01-18 16:16:45 : DEBUG : maxonapp : archiveName=
2024-01-18 16:16:45 : DEBUG : maxonapp : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/2024.1.1/Maxon_App_2024.1.1_Mac.dmg
2024-01-18 16:16:45 : DEBUG : maxonapp : curlOptions=
2024-01-18 16:16:45 : DEBUG : maxonapp : appNewVersion=2024.1.1
2024-01-18 16:16:45 : DEBUG : maxonapp : appCustomVersion function: Not defined
2024-01-18 16:16:45 : DEBUG : maxonapp : versionKey=CFBundleShortVersionString
2024-01-18 16:16:45 : DEBUG : maxonapp : packageID=
2024-01-18 16:16:45 : DEBUG : maxonapp : pkgName=
2024-01-18 16:16:45 : DEBUG : maxonapp : choiceChangesXML=
2024-01-18 16:16:45 : DEBUG : maxonapp : expectedTeamID=4ZY22YGXQG
2024-01-18 16:16:45 : DEBUG : maxonapp : blockingProcesses=
2024-01-18 16:16:45 : DEBUG : maxonapp : installerTool=Maxon App Installer.app
2024-01-18 16:16:45 : DEBUG : maxonapp : CLIInstaller=Maxon App Installer.app/Contents/MacOS/installbuilder.sh
2024-01-18 16:16:45 : DEBUG : maxonapp : CLIArguments=--mode unattended --unattendedmodeui none
2024-01-18 16:16:45 : DEBUG : maxonapp : updateTool=
2024-01-18 16:16:45 : DEBUG : maxonapp : updateToolArguments=
2024-01-18 16:16:45 : DEBUG : maxonapp : updateToolRunAsCurrentUser=
2024-01-18 16:16:45 : INFO  : maxonapp : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 16:16:45 : INFO  : maxonapp : NOTIFY=success
2024-01-18 16:16:45 : INFO  : maxonapp : LOGGING=DEBUG
2024-01-18 16:16:45 : INFO  : maxonapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 16:16:45 : INFO  : maxonapp : Label type: dmg
2024-01-18 16:16:45 : INFO  : maxonapp : archiveName: Maxon.dmg
2024-01-18 16:16:45 : INFO  : maxonapp : no blocking processes defined, using Maxon as default
2024-01-18 16:16:45 : DEBUG : maxonapp : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-18 16:16:45 : INFO  : maxonapp : App(s) found: /Applications/Maxon.app
2024-01-18 16:16:45 : INFO  : maxonapp : found app at /Applications/Maxon.app, version 2023.2.3, on versionKey CFBundleShortVersionString
2024-01-18 16:16:45 : INFO  : maxonapp : appversion: 2023.2.3
2024-01-18 16:16:45 : INFO  : maxonapp : Latest version of Maxon is 2024.1.1
2024-01-18 16:16:45 : REQ   : maxonapp : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/2024.1.1/Maxon_App_2024.1.1_Mac.dmg to Maxon.dmg
2024-01-18 16:16:45 : DEBUG : maxonapp : No Dialog connection, just download
2024-01-18 16:16:49 : DEBUG : maxonapp : File list: -rw-r--r--  1 root  staff    37M 18 Jan 16:16 Maxon.dmg
2024-01-18 16:16:49 : DEBUG : maxonapp : File type: Maxon.dmg: zlib compressed data
2024-01-18 16:16:49 : DEBUG : maxonapp : curl output was:
*   Trying [2606:4700:4400::6812:2a11]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700:4400::6812:2a11) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/maxonapp/releases/2024.1.1/Maxon_App_2024.1.1_Mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mx-app-blob-prod.maxon.net]
* [HTTP/2] [1] [:path: /mx-package-production/website/macos/maxon/maxonapp/releases/2024.1.1/Maxon_App_2024.1.1_Mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mx-package-production/website/macos/maxon/maxonapp/releases/2024.1.1/Maxon_App_2024.1.1_Mac.dmg HTTP/2
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Thu, 18 Jan 2024 15:16:46 GMT
< content-type: application/x-apple-diskimage
< content-length: 39294713
< content-md5: Ktst0EgTYhaFlKrVXrrRRA==
< last-modified: Thu, 14 Dec 2023 16:19:26 GMT
< etag: 0x8DBFCC07119BABD
< x-ms-request-id: 092dd7a8-101e-0006-52aa-2e22b9000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: HIT
< age: 27475
< expires: Fri, 17 Jan 2025 15:16:46 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8477cd0be83c9a2f-FRA
< 
{ [48240 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2024-01-18 16:16:49 : DEBUG : maxonapp : DEBUG mode 1, not checking for blocking processes
2024-01-18 16:16:49 : REQ   : maxonapp : Installing Maxon
2024-01-18 16:16:49 : REQ   : maxonapp : installerTool used: Maxon App Installer.app
2024-01-18 16:16:49 : INFO  : maxonapp : Mounting /Users/duf0002a/workdir/GitHub/Installomator/build/Maxon.dmg
2024-01-18 16:16:51 : DEBUG : maxonapp : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $57E5073E
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $9937C749
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $622B14CC
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $CB4B6737
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $622B14CC
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $992D4B5E
Die überprüfte CRC32-Prüfsumme ist $EBD59B70
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Maxon App Installer

2024-01-18 16:16:51 : INFO  : maxonapp : Mounted: /Volumes/Maxon App Installer
2024-01-18 16:16:51 : INFO  : maxonapp : Verifying: /Volumes/Maxon App Installer/Maxon App Installer.app
2024-01-18 16:16:51 : DEBUG : maxonapp : App size:  38M	/Volumes/Maxon App Installer/Maxon App Installer.app
2024-01-18 16:16:51 : DEBUG : maxonapp : Debugging enabled, App Verification output was:
/Volumes/Maxon App Installer/Maxon App Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-01-18 16:16:51 : INFO  : maxonapp : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-01-18 16:16:51 : INFO  : maxonapp : Downloaded version of Maxon is 2024.1.1 on versionKey CFBundleShortVersionString (replacing version 2023.2.3).
2024-01-18 16:16:51 : DEBUG : maxonapp : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-01-18 16:16:51 : INFO  : maxonapp : Finishing...
2024-01-18 16:16:54 : INFO  : maxonapp : name: Maxon, appName: Maxon App Installer.app
2024-01-18 16:16:54.629 mdfind[17549:3823235] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-01-18 16:16:54.633 mdfind[17549:3823235] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-01-18 16:16:54.906 mdfind[17549:3823235] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-18 16:16:54 : WARN  : maxonapp : No previous app found
2024-01-18 16:16:54 : WARN  : maxonapp : could not find Maxon App Installer.app
2024-01-18 16:16:54 : REQ   : maxonapp : Installed Maxon, version 2024.1.1
2024-01-18 16:16:54 : INFO  : maxonapp : notifying
2024-01-18 16:16:55 : DEBUG : maxonapp : Unmounting /Volumes/Maxon App Installer
2024-01-18 16:16:55 : DEBUG : maxonapp : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-01-18 16:16:55 : DEBUG : maxonapp : DEBUG mode 1, not reopening anything
2024-01-18 16:16:55 : REQ   : maxonapp : All done!
2024-01-18 16:16:55 : REQ   : maxonapp : ################## End Installomator, exit code 0
```