### PR TITLE
Update vfx.sh

### DIFF
--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -4,7 +4,7 @@ vfx)
     appCustomVersion(){
           ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | head -n 30 | sort -gru
     }
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i vfx | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i "Red Giant" | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
     if [[ "$appNewVersion" =~ ^[^.]*\.[^.]*$ ]]; then
 	    appNewVersion=$(sed 's/\([0-9]*\.[0-9]*\)/\1.0/' <<<"$appNewVersion")
     fi

--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -2,9 +2,9 @@ vfx)
     name="VFX Suite"
     type="zip"
     appCustomVersion(){
-          ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
+          ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | head -n 30 | sort -gru
     }
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i vfx | grep -Eo "(202[0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i vfx | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
     if [[ "$appNewVersion" =~ ^[^.]*\.[^.]*$ ]]; then
 	    appNewVersion=$(sed 's/\([0-9]*\.[0-9]*\)/\1.0/' <<<"$appNewVersion")
     fi

--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -4,8 +4,21 @@ vfx)
     appCustomVersion(){
           ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
     }
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405445394-VFX-Suite" | grep "#icon-star" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i vfx | grep -Eo "(202[0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
+    if [[ "$appNewVersion" =~ ^[^.]*\.[^.]*$ ]]; then
+	    appNewVersion=$(sed 's/\([0-9]*\.[0-9]*\)/\1.0/' <<<"$appNewVersion")
+    fi
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/${appNewVersion}/VfxSuite-${appNewVersion}_Mac.zip"
+    vfxResponse=$(curl -s -I -L "$downloadURL")
+    vfxHttpStatus=$(echo "$vfxResponse" | head -n 1 | cut -d ' ' -f 2)
+    if [[ "$vfxHttpStatus" == "200" ]]; then
+	    printlog "DownloadURL HTTP status code: $vfxHttpStatus" INFO
+    elif [[ "$vfxHttpStatus" == "404" ]]; then
+	    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/${appNewVersion}/VfxSuite-${appNewVersion}_mac.zip"
+	    printlog "Had to change DownloadURL due HTTP Status." INFO
+    else
+	    printlog "Unexpected HTTP status code: $vfxHttpStatus" ERROR
+    fi
     installerTool="VFX Suite Installer.app"
     CLIInstaller="VFX Suite Installer.app/Contents/MacOS/VFX Suite Installer"
     CLIArguments=()

--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -2,12 +2,12 @@ vfx)
     name="VFX Suite"
     type="zip"
     appCustomVersion(){
-      ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
+          ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
     }
     appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405445394-VFX-Suite" | grep "#icon-star" -B3 | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/${appNewVersion}/VfxSuite-${appNewVersion}_Mac.zip"
     installerTool="VFX Suite Installer.app"
-    CLIInstaller="VFX Suite Installer.app/Contents/Scripts/install.sh"
+    CLIInstaller="VFX Suite Installer.app/Contents/MacOS/VFX Suite Installer"
     CLIArguments=()
     expectedTeamID="4ZY22YGXQG"
     ;;

--- a/fragments/labels/vfx.sh
+++ b/fragments/labels/vfx.sh
@@ -4,7 +4,7 @@ vfx)
     appCustomVersion(){
           ls "/Users/Shared/Red Giant/uninstall" | grep vfx | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | head -n 30 | sort -gru
     }
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i "Red Giant" | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/13336955539228-Red-Giant" | grep -i "vfx" | grep -Eo "([0-9][0-9][0-9][0-9]\.[0-9]+(\.[0-9])?)" | sort -gru | head -n 1)
     if [[ "$appNewVersion" =~ ^[^.]*\.[^.]*$ ]]; then
 	    appNewVersion=$(sed 's/\([0-9]*\.[0-9]*\)/\1.0/' <<<"$appNewVersion")
     fi


### PR DESCRIPTION
```
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh vfx

2024-01-18 16:28:40 : REQ   : vfx : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 16:28:40 : INFO  : vfx : ################## Version: 10.6beta
2024-01-18 16:28:40 : INFO  : vfx : ################## Date: 2024-01-18
2024-01-18 16:28:40 : INFO  : vfx : ################## vfx
2024-01-18 16:28:40 : DEBUG : vfx : DEBUG mode 1 enabled.
2024-01-18 16:28:41 : DEBUG : vfx : name=VFX Suite
2024-01-18 16:28:41 : DEBUG : vfx : appName=
2024-01-18 16:28:41 : DEBUG : vfx : type=zip
2024-01-18 16:28:41 : DEBUG : vfx : archiveName=
2024-01-18 16:28:41 : DEBUG : vfx : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/2024.1.0/VfxSuite-2024.1.0_Mac.zip
2024-01-18 16:28:41 : DEBUG : vfx : curlOptions=
2024-01-18 16:28:41 : DEBUG : vfx : appNewVersion=2024.1.0
2024-01-18 16:28:41 : DEBUG : vfx : appCustomVersion function: Defined. 
2024-01-18 16:28:41 : DEBUG : vfx : versionKey=CFBundleShortVersionString
2024-01-18 16:28:41 : DEBUG : vfx : packageID=
2024-01-18 16:28:41 : DEBUG : vfx : pkgName=
2024-01-18 16:28:41 : DEBUG : vfx : choiceChangesXML=
2024-01-18 16:28:41 : DEBUG : vfx : expectedTeamID=4ZY22YGXQG
2024-01-18 16:28:41 : DEBUG : vfx : blockingProcesses=
2024-01-18 16:28:41 : DEBUG : vfx : installerTool=VFX Suite Installer.app
2024-01-18 16:28:41 : DEBUG : vfx : CLIInstaller=VFX Suite Installer.app/Contents/MacOS/VFX Suite Installer
2024-01-18 16:28:41 : DEBUG : vfx : CLIArguments=
2024-01-18 16:28:41 : DEBUG : vfx : updateTool=
2024-01-18 16:28:41 : DEBUG : vfx : updateToolArguments=
2024-01-18 16:28:41 : DEBUG : vfx : updateToolRunAsCurrentUser=
2024-01-18 16:28:41 : INFO  : vfx : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 16:28:41 : INFO  : vfx : NOTIFY=success
2024-01-18 16:28:41 : INFO  : vfx : LOGGING=DEBUG
2024-01-18 16:28:41 : INFO  : vfx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 16:28:41 : INFO  : vfx : Label type: zip
2024-01-18 16:28:41 : INFO  : vfx : archiveName: VFX Suite.zip
2024-01-18 16:28:41 : INFO  : vfx : no blocking processes defined, using VFX Suite as default
2024-01-18 16:28:41 : DEBUG : vfx : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-18 16:28:41 : INFO  : vfx : Custom App Version detection is used, found 
2024-01-18 16:28:41 : INFO  : vfx : appversion: 
2024-01-18 16:28:41 : INFO  : vfx : Latest version of VFX Suite is 2024.1.0
2024-01-18 16:28:41 : REQ   : vfx : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/2024.1.0/VfxSuite-2024.1.0_Mac.zip to VFX Suite.zip
2024-01-18 16:28:41 : DEBUG : vfx : No Dialog connection, just download
2024-01-18 16:29:07 : DEBUG : vfx : File list: -rw-r--r--  1 root  staff   301M 18 Jan 16:29 VFX Suite.zip
2024-01-18 16:29:07 : DEBUG : vfx : File type: VFX Suite.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-01-18 16:29:07 : DEBUG : vfx : curl output was:
*   Trying [2606:4700:4400::6812:2a11]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700:4400::6812:2a11) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/vfx/releases/2024.1.0/VfxSuite-2024.1.0_Mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mx-app-blob-prod.maxon.net]
* [HTTP/2] [1] [:path: /mx-package-production/installer/macos/redgiant/vfx/releases/2024.1.0/VfxSuite-2024.1.0_Mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mx-package-production/installer/macos/redgiant/vfx/releases/2024.1.0/VfxSuite-2024.1.0_Mac.zip HTTP/2
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Thu, 18 Jan 2024 15:28:41 GMT
< content-type: application/octet-stream
< content-length: 315353907
< content-md5: HXFN8tvJhEoRVBJL0px6oQ==
< last-modified: Wed, 17 Jan 2024 14:00:01 GMT
< etag: 0x8DC17649902DBAA
< x-ms-request-id: 8c62c534-f01e-0008-1451-4980a4000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: HIT
< expires: Fri, 17 Jan 2025 15:28:41 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8477de83ed722bb8-FRA
< 
{ [50994 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2024-01-18 16:29:07 : DEBUG : vfx : DEBUG mode 1, not checking for blocking processes
2024-01-18 16:29:07 : REQ   : vfx : Installing VFX Suite
2024-01-18 16:29:07 : REQ   : vfx : installerTool used: VFX Suite Installer.app
2024-01-18 16:29:07 : INFO  : vfx : Unzipping VFX Suite.zip
2024-01-18 16:29:07 : INFO  : vfx : Verifying: /Users/duf0002a/workdir/GitHub/Installomator/build/VFX Suite Installer.app
2024-01-18 16:29:07 : DEBUG : vfx : App size: 312M	/Users/duf0002a/workdir/GitHub/Installomator/build/VFX Suite Installer.app
2024-01-18 16:29:08 : DEBUG : vfx : Debugging enabled, App Verification output was:
/Users/duf0002a/workdir/GitHub/Installomator/build/VFX Suite Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-01-18 16:29:08 : INFO  : vfx : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-01-18 16:29:08 : INFO  : vfx : Installing VFX Suite version 2024.1.0 on versionKey CFBundleShortVersionString.
2024-01-18 16:29:08 : INFO  : vfx : App has LSMinimumSystemVersion: 10.11
2024-01-18 16:29:08 : DEBUG : vfx : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-01-18 16:29:08 : INFO  : vfx : Finishing...
2024-01-18 16:29:11 : INFO  : vfx : Custom App Version detection is used, found 
2024-01-18 16:29:11 : REQ   : vfx : Installed VFX Suite, version 2024.1.0
2024-01-18 16:29:11 : INFO  : vfx : notifying
2024-01-18 16:29:11 : DEBUG : vfx : DEBUG mode 1, not reopening anything
2024-01-18 16:29:11 : REQ   : vfx : All done!
2024-01-18 16:29:11 : REQ   : vfx : ################## End Installomator, exit code 0
```