### PR TITLE
Update trapcode.sh

### DIFF
--- a/fragments/labels/trapcode.sh
+++ b/fragments/labels/trapcode.sh
@@ -5,7 +5,17 @@ trapcode)
       ls "/Users/Shared/Red Giant/uninstall" | grep trapcode | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
     }
     appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/articles/8642154839580" | grep "current_record_title" | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
-    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/${appNewVersion}/TrapcodeSuite-${appNewVersion}_mac.zip"
+    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/${appNewVersion}/TrapcodeSuite-${appNewVersion}_Mac.zip"
+    trapcodeResponse=$(curl -s -I -L "$downloadURL")
+    trapcodeHttpStatus=$(echo "$trapcodeResponse" | head -n 1 | cut -d ' ' -f 2)
+    if [[ "trapcodeHttpStatus" == "200" ]]; then
+      printlog "DownloadURL HTTP status code: $trapcodeHttpStatus" INFO
+    elif [[ "$trapcodeHttpStatus" == "404" ]]; then
+      downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/${appNewVersion}/TrapcodeSuite-${appNewVersion}_mac.zip"
+      printlog "Had to change DownloadURL due HTTP Status." INFO
+    else
+      printlog "Unexpected HTTP status code: $trapcodeHttpStatus" ERROR
+    fi
     installerTool="Trapcode Suite Installer.app"
     CLIInstaller="Trapcode Suite Installer.app/Contents/MacOS/Trapcode Suite Installer"
     expectedTeamID="4ZY22YGXQG"

--- a/fragments/labels/trapcode.sh
+++ b/fragments/labels/trapcode.sh
@@ -4,7 +4,7 @@ trapcode)
     appCustomVersion(){
       ls "/Users/Shared/Red Giant/uninstall" | grep trapcode | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
     }
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/articles/8642154839580" | grep "current_record_title" | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru)"
+    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405448722-Trapcode-Suite" | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 1 | sort -gru)"
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/${appNewVersion}/TrapcodeSuite-${appNewVersion}_Mac.zip"
     trapcodeResponse=$(curl -s -I -L "$downloadURL")
     trapcodeHttpStatus=$(echo "$trapcodeResponse" | head -n 1 | cut -d ' ' -f 2)


### PR DESCRIPTION
```
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh trapcode

2024-01-18 16:41:18 : REQ   : trapcode : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 16:41:18 : INFO  : trapcode : ################## Version: 10.6beta
2024-01-18 16:41:18 : INFO  : trapcode : ################## Date: 2024-01-18
2024-01-18 16:41:18 : INFO  : trapcode : ################## trapcode
2024-01-18 16:41:18 : DEBUG : trapcode : DEBUG mode 1 enabled.
2024-01-18 16:41:19 : INFO  : trapcode : Had to change DownloadURL due HTTP Status.
2024-01-18 16:41:19 : DEBUG : trapcode : name=Trapcode Suite
2024-01-18 16:41:19 : DEBUG : trapcode : appName=
2024-01-18 16:41:19 : DEBUG : trapcode : type=zip
2024-01-18 16:41:19 : DEBUG : trapcode : archiveName=
2024-01-18 16:41:19 : DEBUG : trapcode : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/2024.1.0/TrapcodeSuite-2024.1.0_mac.zip
2024-01-18 16:41:19 : DEBUG : trapcode : curlOptions=
2024-01-18 16:41:19 : DEBUG : trapcode : appNewVersion=2024.1.0
2024-01-18 16:41:19 : DEBUG : trapcode : appCustomVersion function: Defined. 
2024-01-18 16:41:19 : DEBUG : trapcode : versionKey=CFBundleShortVersionString
2024-01-18 16:41:19 : DEBUG : trapcode : packageID=
2024-01-18 16:41:19 : DEBUG : trapcode : pkgName=
2024-01-18 16:41:19 : DEBUG : trapcode : choiceChangesXML=
2024-01-18 16:41:19 : DEBUG : trapcode : expectedTeamID=4ZY22YGXQG
2024-01-18 16:41:19 : DEBUG : trapcode : blockingProcesses=
2024-01-18 16:41:19 : DEBUG : trapcode : installerTool=Trapcode Suite Installer.app
2024-01-18 16:41:19 : DEBUG : trapcode : CLIInstaller=Trapcode Suite Installer.app/Contents/MacOS/Trapcode Suite Installer
2024-01-18 16:41:19 : DEBUG : trapcode : CLIArguments=
2024-01-18 16:41:19 : DEBUG : trapcode : updateTool=
2024-01-18 16:41:19 : DEBUG : trapcode : updateToolArguments=
2024-01-18 16:41:19 : DEBUG : trapcode : updateToolRunAsCurrentUser=
2024-01-18 16:41:19 : INFO  : trapcode : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 16:41:19 : INFO  : trapcode : NOTIFY=success
2024-01-18 16:41:19 : INFO  : trapcode : LOGGING=DEBUG
2024-01-18 16:41:19 : INFO  : trapcode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 16:41:19 : INFO  : trapcode : Label type: zip
2024-01-18 16:41:19 : INFO  : trapcode : archiveName: Trapcode Suite.zip
2024-01-18 16:41:19 : INFO  : trapcode : no blocking processes defined, using Trapcode Suite as default
2024-01-18 16:41:19 : DEBUG : trapcode : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-18 16:41:19 : INFO  : trapcode : Custom App Version detection is used, found 
2024-01-18 16:41:19 : INFO  : trapcode : appversion: 
2024-01-18 16:41:19 : INFO  : trapcode : Latest version of Trapcode Suite is 2024.1.0
2024-01-18 16:41:19 : REQ   : trapcode : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/2024.1.0/TrapcodeSuite-2024.1.0_mac.zip to Trapcode Suite.zip
2024-01-18 16:41:19 : DEBUG : trapcode : No Dialog connection, just download
2024-01-18 16:42:42 : DEBUG : trapcode : File list: -rw-r--r--  1 root  staff   971M 18 Jan 16:42 Trapcode Suite.zip
2024-01-18 16:42:42 : DEBUG : trapcode : File type: Trapcode Suite.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-01-18 16:42:42 : DEBUG : trapcode : curl output was:
*   Trying [2606:4700:4400::6812:2a11]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700:4400::6812:2a11) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/trapcode/releases/2024.1.0/TrapcodeSuite-2024.1.0_mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mx-app-blob-prod.maxon.net]
* [HTTP/2] [1] [:path: /mx-package-production/installer/macos/redgiant/trapcode/releases/2024.1.0/TrapcodeSuite-2024.1.0_mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mx-package-production/installer/macos/redgiant/trapcode/releases/2024.1.0/TrapcodeSuite-2024.1.0_mac.zip HTTP/2
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Thu, 18 Jan 2024 15:41:20 GMT
< content-type: application/octet-stream
< content-length: 1018236011
< content-md5: 1vv26XAq7XDMdaxgkgdsPA==
< last-modified: Wed, 17 Jan 2024 14:00:00 GMT
< etag: 0x8DC176498C19663
< x-ms-request-id: 6fce0c8a-d01e-004e-4756-49a9b9000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: HIT
< expires: Fri, 17 Jan 2025 15:41:20 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8477f1089c779c07-FRA
< 
{ [23246 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2024-01-18 16:42:42 : DEBUG : trapcode : DEBUG mode 1, not checking for blocking processes
2024-01-18 16:42:42 : REQ   : trapcode : Installing Trapcode Suite
2024-01-18 16:42:42 : REQ   : trapcode : installerTool used: Trapcode Suite Installer.app
2024-01-18 16:42:42 : INFO  : trapcode : Unzipping Trapcode Suite.zip
2024-01-18 16:42:43 : INFO  : trapcode : Verifying: /Users/duf0002a/workdir/GitHub/Installomator/build/Trapcode Suite Installer.app
2024-01-18 16:42:43 : DEBUG : trapcode : App size: 982M	/Users/duf0002a/workdir/GitHub/Installomator/build/Trapcode Suite Installer.app
2024-01-18 16:42:44 : DEBUG : trapcode : Debugging enabled, App Verification output was:
/Users/duf0002a/workdir/GitHub/Installomator/build/Trapcode Suite Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-01-18 16:42:44 : INFO  : trapcode : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-01-18 16:42:44 : INFO  : trapcode : Installing Trapcode Suite version 2024.1.0 on versionKey CFBundleShortVersionString.
2024-01-18 16:42:44 : INFO  : trapcode : App has LSMinimumSystemVersion: 10.11
2024-01-18 16:42:44 : DEBUG : trapcode : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-01-18 16:42:44 : INFO  : trapcode : Finishing...
2024-01-18 16:42:47 : INFO  : trapcode : Custom App Version detection is used, found 
2024-01-18 16:42:47 : REQ   : trapcode : Installed Trapcode Suite, version 2024.1.0
2024-01-18 16:42:47 : INFO  : trapcode : notifying
2024-01-18 16:42:48 : DEBUG : trapcode : DEBUG mode 1, not reopening anything
2024-01-18 16:42:48 : REQ   : trapcode : All done!
2024-01-18 16:42:48 : REQ   : trapcode : ################## End Installomator, exit code 0 
```