### PR TITLE
Update pritunl.sh

### DIFF
--- a/fragments/labels/pritunl.sh
+++ b/fragments/labels/pritunl.sh
@@ -2,11 +2,7 @@ pritunl)
     name="Pritunl"
     type="pkgInZip"
     packageID="com.pritunl.pkg.Pritunl"
-    if [[ $(arch) == "arm64" ]]; then
-        archiveName="Pritunl.arm64.pkg.zip"
-    elif [[ $(arch) == "i386" ]]; then
-        archiveName="Pritunl.pkg.zip"
-    fi
+    archiveName="Pritunl.pkg.zip"
     downloadURL=$(downloadURLFromGit pritunl pritunl-client-electron)
     appNewVersion=$(versionFromGit pritunl pritunl-client-electron)
     expectedTeamID="U22BLATN63"


### PR DESCRIPTION
Since version https://github.com/pritunl/pritunl-client-electron/releases/tag/1.3.3772.10 Pritunl has been a universal app. Removes logic from the label to distinguish between architectures. Resolves https://github.com/Installomator/Installomator/issues/1426. 

```
$ utils/assemble.sh pritunl 
2024-01-18 09:53:45 : REQ   : pritunl : ################## Start Installomator v. 10.6beta, date 2024-01-18
2024-01-18 09:53:45 : INFO  : pritunl : ################## Version: 10.6beta
2024-01-18 09:53:45 : INFO  : pritunl : ################## Date: 2024-01-18
2024-01-18 09:53:45 : INFO  : pritunl : ################## pritunl
2024-01-18 09:53:45 : DEBUG : pritunl : DEBUG mode 1 enabled.
2024-01-18 09:53:46 : DEBUG : pritunl : name=Pritunl
2024-01-18 09:53:46 : DEBUG : pritunl : appName=
2024-01-18 09:53:46 : DEBUG : pritunl : type=pkgInZip
2024-01-18 09:53:46 : DEBUG : pritunl : archiveName=Pritunl.pkg.zip
2024-01-18 09:53:46 : DEBUG : pritunl : downloadURL=https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.3772.10/Pritunl.pkg.zip
2024-01-18 09:53:46 : DEBUG : pritunl : curlOptions=
2024-01-18 09:53:46 : DEBUG : pritunl : appNewVersion=1.3.3772.10
2024-01-18 09:53:46 : DEBUG : pritunl : appCustomVersion function: Not defined
2024-01-18 09:53:46 : DEBUG : pritunl : versionKey=CFBundleShortVersionString
2024-01-18 09:53:46 : DEBUG : pritunl : packageID=com.pritunl.pkg.Pritunl
2024-01-18 09:53:46 : DEBUG : pritunl : pkgName=
2024-01-18 09:53:46 : DEBUG : pritunl : choiceChangesXML=
2024-01-18 09:53:46 : DEBUG : pritunl : expectedTeamID=U22BLATN63
2024-01-18 09:53:46 : DEBUG : pritunl : blockingProcesses=
2024-01-18 09:53:46 : DEBUG : pritunl : installerTool=
2024-01-18 09:53:46 : DEBUG : pritunl : CLIInstaller=
2024-01-18 09:53:46 : DEBUG : pritunl : CLIArguments=
2024-01-18 09:53:46 : DEBUG : pritunl : updateTool=
2024-01-18 09:53:46 : DEBUG : pritunl : updateToolArguments=
2024-01-18 09:53:46 : DEBUG : pritunl : updateToolRunAsCurrentUser=
2024-01-18 09:53:46 : INFO  : pritunl : BLOCKING_PROCESS_ACTION=tell_user
2024-01-18 09:53:47 : INFO  : pritunl : NOTIFY=success
2024-01-18 09:53:47 : INFO  : pritunl : LOGGING=DEBUG
2024-01-18 09:53:47 : INFO  : pritunl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-18 09:53:47 : INFO  : pritunl : Label type: pkgInZip
2024-01-18 09:53:47 : INFO  : pritunl : archiveName: Pritunl.pkg.zip
2024-01-18 09:53:47 : INFO  : pritunl : no blocking processes defined, using Pritunl as default
2024-01-18 09:53:47 : DEBUG : pritunl : Changing directory to /Users/ns/git/Installomator/build
2024-01-18 09:53:47 : INFO  : pritunl : found packageID com.pritunl.pkg.Pritunl installed, version 1.3.3772.10
2024-01-18 09:53:47 : INFO  : pritunl : appversion: 1.3.3772.10
2024-01-18 09:53:47 : INFO  : pritunl : Latest version of Pritunl is 1.3.3772.10
2024-01-18 09:53:47 : WARN  : pritunl : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-01-18 09:53:47 : REQ   : pritunl : Downloading https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.3772.10/Pritunl.pkg.zip to Pritunl.pkg.zip
2024-01-18 09:53:47 : DEBUG : pritunl : No Dialog connection, just download
2024-01-18 09:53:53 : DEBUG : pritunl : File list: -rw-r--r--  1 ns  staff   232M Jan 18 09:53 Pritunl.pkg.zip
2024-01-18 09:53:53 : DEBUG : pritunl : File type: Pritunl.pkg.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2024-01-18 09:53:53 : DEBUG : pritunl : curl output was:
*   Trying 140.82.113.3:443...
* Connected to github.com (140.82.113.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.3772.10/Pritunl.pkg.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /pritunl/pritunl-client-electron/releases/download/1.3.3772.10/Pritunl.pkg.zip]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /pritunl/pritunl-client-electron/releases/download/1.3.3772.10/Pritunl.pkg.zip HTTP/2
> Host: github.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 302 
< server: GitHub.com
< date: Thu, 18 Jan 2024 15:53:47 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/35986723/c5bf012c-4359-4363-bed2-f53168abc748?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T155347Z&X-Amz-Expires=300&X-Amz-Signature=a8c69b9ea2037ddd26b1d22b2277ecfc787491c349499183b2f3c02a97570b10&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=35986723&response-content-disposition=attachment%3B%20filename%3DPritunl.pkg.zip&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events api.githubcopilot.com objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: EEF5:1C10:A6A2EB:F933A4:65A9498B
< 
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/35986723/c5bf012c-4359-4363-bed2-f53168abc748?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T155347Z&X-Amz-Expires=300&X-Amz-Signature=a8c69b9ea2037ddd26b1d22b2277ecfc787491c349499183b2f3c02a97570b10&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=35986723&response-content-disposition=attachment%3B%20filename%3DPritunl.pkg.zip&response-content-type=application%2Foctet-stream'
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/35986723/c5bf012c-4359-4363-bed2-f53168abc748?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T155347Z&X-Amz-Expires=300&X-Amz-Signature=a8c69b9ea2037ddd26b1d22b2277ecfc787491c349499183b2f3c02a97570b10&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=35986723&response-content-disposition=attachment%3B%20filename%3DPritunl.pkg.zip&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/35986723/c5bf012c-4359-4363-bed2-f53168abc748?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T155347Z&X-Amz-Expires=300&X-Amz-Signature=a8c69b9ea2037ddd26b1d22b2277ecfc787491c349499183b2f3c02a97570b10&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=35986723&response-content-disposition=attachment%3B%20filename%3DPritunl.pkg.zip&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/35986723/c5bf012c-4359-4363-bed2-f53168abc748?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240118%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240118T155347Z&X-Amz-Expires=300&X-Amz-Signature=a8c69b9ea2037ddd26b1d22b2277ecfc787491c349499183b2f3c02a97570b10&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=35986723&response-content-disposition=attachment%3B%20filename%3DPritunl.pkg.zip&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-md5: jw3Y7z75MSznf2zG1Oci3w==
< last-modified: Wed, 10 Jan 2024 05:09:48 GMT
< etag: "0x8DC119A5E7FC90D"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 1ba3fa2d-801e-0034-7783-43d29d000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Wed, 10 Jan 2024 05:09:48 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Pritunl.pkg.zip
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 2499
< date: Thu, 18 Jan 2024 15:53:47 GMT
< x-served-by: cache-iad-kcgs7200167-IAD, cache-msp11855-MSP
< x-cache: HIT, HIT
< x-cache-hits: 3605, 0
< x-timer: S1705593227.431385,VS0,VE134
< content-length: 243449394
< 
{ [31936 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-01-18 09:53:53 : DEBUG : pritunl : DEBUG mode 1, not checking for blocking processes
2024-01-18 09:53:53 : REQ   : pritunl : Installing Pritunl
2024-01-18 09:53:53 : INFO  : pritunl : Unzipping Pritunl.pkg.zip
2024-01-18 09:53:54 : DEBUG : pritunl : Found pkg(s):
/Users/ns/git/Installomator/build/Pritunl.pkg
2024-01-18 09:53:54 : INFO  : pritunl : found pkg: /Users/ns/git/Installomator/build/Pritunl.pkg
2024-01-18 09:53:54 : INFO  : pritunl : Verifying: /Users/ns/git/Installomator/build/Pritunl.pkg
2024-01-18 09:53:54 : DEBUG : pritunl : File list: -rw-r--r--  1 ns  staff   233M Jan  9 20:45 /Users/ns/git/Installomator/build/Pritunl.pkg
2024-01-18 09:53:54 : DEBUG : pritunl : File type: /Users/ns/git/Installomator/build/Pritunl.pkg: xar archive compressed TOC: 4818, SHA-1 checksum
2024-01-18 09:53:54 : DEBUG : pritunl : spctlOut is /Users/ns/git/Installomator/build/Pritunl.pkg: accepted
2024-01-18 09:53:54 : DEBUG : pritunl : source=Notarized Developer ID
2024-01-18 09:53:54 : DEBUG : pritunl : origin=Developer ID Installer: Pritunl, Inc. (U22BLATN63)
2024-01-18 09:53:54 : INFO  : pritunl : Team ID: U22BLATN63 (expected: U22BLATN63 )
2024-01-18 09:53:54 : INFO  : pritunl : Checking package version.
2024-01-18 09:53:54 : INFO  : pritunl : Downloaded package com.pritunl.pkg.Pritunl version 1.3.3772.10
2024-01-18 09:53:54 : INFO  : pritunl : Downloaded version of Pritunl is the same as installed.
2024-01-18 09:53:54 : DEBUG : pritunl : DEBUG mode 1, not reopening anything
2024-01-18 09:53:54 : REQ   : pritunl : No new version to install
2024-01-18 09:53:54 : REQ   : pritunl : ################## End Installomator, exit code 0 
``