### PR TITLE
New Label: Azul Zulu JDK 21

### DIFF
--- a/fragments/labels/zulujdk21.sh
+++ b/fragments/labels/zulujdk21.sh
@@ -1,0 +1,13 @@
+zulujdk21)
+    name="Zulu JDK 21"
+    type="pkgInDmg"
+    packageID="com.azulsystems.zulu.21"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu21.*ca-jdk21.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu21.*ca-jdk21.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+    fi
+    expectedTeamID="TDTHCUPYFR"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; fi }
+    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    ;;


### PR DESCRIPTION
2024-01-22 14:37:13 : REQ   : zulujdk21 : ################## Start Installomator v. 10.6beta, date 2024-01-22
2024-01-22 14:37:13 : INFO  : zulujdk21 : ################## Version: 10.6beta
2024-01-22 14:37:13 : INFO  : zulujdk21 : ################## Date: 2024-01-22
2024-01-22 14:37:13 : INFO  : zulujdk21 : ################## zulujdk21
2024-01-22 14:37:13 : INFO  : zulujdk21 : SwiftDialog is not installed, clear cmd file var
2024-01-22 14:37:26 : INFO  : zulujdk21 : setting variable from argument DEBUG=0
2024-01-22 14:37:26 : INFO  : zulujdk21 : BLOCKING_PROCESS_ACTION=tell_user
2024-01-22 14:37:26 : INFO  : zulujdk21 : NOTIFY=success
2024-01-22 14:37:26 : INFO  : zulujdk21 : LOGGING=INFO
2024-01-22 14:37:26 : INFO  : zulujdk21 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-22 14:37:26 : INFO  : zulujdk21 : Label type: pkgInDmg
2024-01-22 14:37:26 : INFO  : zulujdk21 : archiveName: Zulu JDK 21.dmg
2024-01-22 14:37:26 : INFO  : zulujdk21 : no blocking processes defined, using Zulu JDK 21 as default
2024-01-22 14:37:26 : INFO  : zulujdk21 : Custom App Version detection is used, found
2024-01-22 14:37:26 : INFO  : zulujdk21 : appversion:
2024-01-22 14:37:26 : INFO  : zulujdk21 : Latest version of Zulu JDK 21 is 21.32.17
2024-01-22 14:37:26 : REQ   : zulujdk21 : Downloading https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-macosx_aarch64.dmg to Zulu JDK 21.dmg
2024-01-22 14:37:55 : REQ   : zulujdk21 : no more blocking processes, continue with update
2024-01-22 14:37:55 : REQ   : zulujdk21 : Installing Zulu JDK 21
2024-01-22 14:37:55 : INFO  : zulujdk21 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZqvPb2wfPa/Zulu JDK 21.dmg
2024-01-22 14:38:04 : INFO  : zulujdk21 : Mounted: /Volumes/Azul Zulu JDK 21.32+17
2024-01-22 14:38:04 : INFO  : zulujdk21 : found pkg: /Volumes/Azul Zulu JDK 21.32+17/Double-Click to Install Azul Zulu JDK 21.pkg
2024-01-22 14:38:04 : INFO  : zulujdk21 : Verifying: /Volumes/Azul Zulu JDK 21.32+17/Double-Click to Install Azul Zulu JDK 21.pkg
2024-01-22 14:38:04 : INFO  : zulujdk21 : Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2024-01-22 14:38:04 : INFO  : zulujdk21 : Installing /Volumes/Azul Zulu JDK 21.32+17/Double-Click to Install Azul Zulu JDK 21.pkg to /
2024-01-22 14:38:18 : INFO  : zulujdk21 : Finishing...
2024-01-22 14:38:21 : INFO  : zulujdk21 : Custom App Version detection is used, found 21.32.17
2024-01-22 14:38:21 : REQ   : zulujdk21 : Installed Zulu JDK 21, version 21.32.17
2024-01-22 14:38:21 : INFO  : zulujdk21 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-01-22 14:38:21 : INFO  : zulujdk21 : Installomator did not close any apps, so no need to reopen any apps.
2024-01-22 14:38:21 : REQ   : zulujdk21 : All done!
2024-01-22 14:38:21 : REQ   : zulujdk21 : ################## End Installomator, exit code 0