### PR TITLE
New Label: Enpass

### DIFF
--- a/fragments/labels/enpass.sh
+++ b/fragments/labels/enpass.sh
@@ -1,0 +1,7 @@
+enpass)
+    name="Enpass"
+    type="pkg"
+    downloadURL=$(curl -fs "https://www.enpass.io/downloads/" | grep -o 'https://dl.enpass.io/stable/mac/package/[0-9.]*/Enpass.pkg' | head -1)
+    appNewVersion=$(curl -fs "https://www.enpass.io/downloads/" | grep -o 'version [0-9.]*' | head -1 | sed -E 's/version //')
+    expectedTeamID="7ADB8CC6TF"
+    ;;


### PR DESCRIPTION
2024-01-22 15:08:52 : REQ   : enpass : ################## Start Installomator v. 10.6beta, date 2024-01-22
2024-01-22 15:08:52 : INFO  : enpass : ################## Version: 10.6beta
2024-01-22 15:08:52 : INFO  : enpass : ################## Date: 2024-01-22
2024-01-22 15:08:52 : INFO  : enpass : ################## enpass
2024-01-22 15:08:52 : DEBUG : enpass : DEBUG mode 1 enabled.
2024-01-22 15:08:54 : DEBUG : enpass : name=Enpass
2024-01-22 15:08:54 : DEBUG : enpass : appName=
2024-01-22 15:08:54 : DEBUG : enpass : type=pkg
2024-01-22 15:08:54 : DEBUG : enpass : archiveName=
2024-01-22 15:08:54 : DEBUG : enpass : downloadURL=https://dl.enpass.io/stable/mac/package/6.9.3.1595/Enpass.pkg
2024-01-22 15:08:54 : DEBUG : enpass : curlOptions=
2024-01-22 15:08:54 : DEBUG : enpass : appNewVersion=6.9.3
2024-01-22 15:08:54 : DEBUG : enpass : appCustomVersion function: Not defined
2024-01-22 15:08:54 : DEBUG : enpass : versionKey=CFBundleShortVersionString
2024-01-22 15:08:54 : DEBUG : enpass : packageID=
2024-01-22 15:08:54 : DEBUG : enpass : pkgName=
2024-01-22 15:08:54 : DEBUG : enpass : choiceChangesXML=
2024-01-22 15:08:54 : DEBUG : enpass : expectedTeamID=7ADB8CC6TF
2024-01-22 15:08:54 : DEBUG : enpass : blockingProcesses=
2024-01-22 15:08:54 : DEBUG : enpass : installerTool=
2024-01-22 15:08:54 : DEBUG : enpass : CLIInstaller=
2024-01-22 15:08:54 : DEBUG : enpass : CLIArguments=
2024-01-22 15:08:54 : DEBUG : enpass : updateTool=
2024-01-22 15:08:54 : DEBUG : enpass : updateToolArguments=
2024-01-22 15:08:54 : DEBUG : enpass : updateToolRunAsCurrentUser=
2024-01-22 15:08:54 : INFO  : enpass : BLOCKING_PROCESS_ACTION=tell_user
2024-01-22 15:08:54 : INFO  : enpass : NOTIFY=success
2024-01-22 15:08:54 : INFO  : enpass : LOGGING=DEBUG
2024-01-22 15:08:54 : INFO  : enpass : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-22 15:08:54 : INFO  : enpass : Label type: pkg
2024-01-22 15:08:54 : INFO  : enpass : archiveName: Enpass.pkg
2024-01-22 15:08:54 : INFO  : enpass : no blocking processes defined, using Enpass as default
2024-01-22 15:08:54 : DEBUG : enpass : Changing directory to /Users/b.kollmer/Development/Installomator/Installomator/build
2024-01-22 15:08:54 : INFO  : enpass : App(s) found: /Applications/Enpass.app
2024-01-22 15:08:54 : INFO  : enpass : found app at /Applications/Enpass.app, version 6.9.3, on versionKey CFBundleShortVersionString
2024-01-22 15:08:54 : INFO  : enpass : appversion: 6.9.3
2024-01-22 15:08:54 : INFO  : enpass : Latest version of Enpass is 6.9.3
2024-01-22 15:08:54 : WARN  : enpass : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-01-22 15:08:54 : REQ   : enpass : Downloading https://dl.enpass.io/stable/mac/package/6.9.3.1595/Enpass.pkg to Enpass.pkg
2024-01-22 15:08:54 : DEBUG : enpass : No Dialog connection, just download
2024-01-22 15:08:55 : DEBUG : enpass : File list: -rw-r--r--  1 root  staff    86M 22 Jan 15:08 Enpass.pkg
2024-01-22 15:08:55 : DEBUG : enpass : File type: Enpass.pkg: xar archive compressed TOC: 4591, SHA-1 checksum
2024-01-22 15:08:55 : DEBUG : enpass : curl output was:
*   Trying 18.173.233.89:443...
* Connected to dl.enpass.io (18.173.233.89) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4948 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.enpass.io
*  start date: Sep 12 00:00:00 2023 GMT
*  expire date: Oct 10 23:59:59 2024 GMT
*  subjectAltName: host "dl.enpass.io" matched cert's "*.enpass.io"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.enpass.io/stable/mac/package/6.9.3.1595/Enpass.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.enpass.io]
* [HTTP/2] [1] [:path: /stable/mac/package/6.9.3.1595/Enpass.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /stable/mac/package/6.9.3.1595/Enpass.pkg HTTP/2
> Host: dl.enpass.io
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 90667178
< last-modified: Tue, 02 Jan 2024 05:48:40 GMT
< x-amz-server-side-encryption: AES256
< x-amz-version-id: g.l7Rh8L.fE1L6it3G_gzHdFlUC3GsiB < accept-ranges: bytes
< server: AmazonS3
< date: Mon, 22 Jan 2024 07:28:17 GMT
< etag: "6d966b76d179ace2a58a998c3ac13090-6"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 1c31a54ff1a1fff247c318d7b71b21d4.cloudfront.net (CloudFront) < x-amz-cf-pop: DUS51-P3
< x-amz-cf-id: uNgshXtNqdEDnBAk2Ojj4dfIOS3pAqY6ChQUzv-JSxOT99PYb_kvAQ== < age: 24038
<
{ [15959 bytes data]
* Connection #0 to host dl.enpass.io left intact

2024-01-22 15:08:55 : DEBUG : enpass : DEBUG mode 1, not checking for blocking processes
2024-01-22 15:08:55 : REQ   : enpass : Installing Enpass
2024-01-22 15:08:55 : INFO  : enpass : Verifying: Enpass.pkg
2024-01-22 15:08:55 : DEBUG : enpass : File list: -rw-r--r--  1 root  staff    86M 22 Jan 15:08 Enpass.pkg
2024-01-22 15:08:55 : DEBUG : enpass : File type: Enpass.pkg: xar archive compressed TOC: 4591, SHA-1 checksum
2024-01-22 15:08:55 : DEBUG : enpass : spctlOut is Enpass.pkg: accepted
2024-01-22 15:08:55 : DEBUG : enpass : source=Notarized Developer ID
2024-01-22 15:08:55 : DEBUG : enpass : origin=Developer ID Installer: Enpass Technologies Private Limited (7ADB8CC6TF)
2024-01-22 15:08:55 : INFO  : enpass : Team ID: 7ADB8CC6TF (expected: 7ADB8CC6TF )
2024-01-22 15:08:55 : DEBUG : enpass : DEBUG enabled, skipping installation
2024-01-22 15:08:55 : INFO  : enpass : Finishing...