### PR TITLE
New Label: Eclipse Temurin 11

### DIFF
--- a/fragments/labels/eclipsetemurin11.sh
+++ b/fragments/labels/eclipsetemurin11.sh
@@ -1,0 +1,9 @@
+eclipsetemurin11)
+    name="Temurin 11"
+    type="pkg"
+    packageID="net.temurin.11.jdk"
+    downloadURL="$(downloadURLFromGit adoptium temurin11-binaries)"
+    appNewVersion="$(downloadURLFromGit adoptium temurin11-binaries | grep -oE 'jdk-11\.0\.[0-9]+(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    expectedTeamID="JCDTMS22B4"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //'; fi }
+    ;;

--- a/fragments/labels/eclipsetemurin11.sh
+++ b/fragments/labels/eclipsetemurin11.sh
@@ -3,7 +3,7 @@ eclipsetemurin11)
     type="pkg"
     packageID="net.temurin.11.jdk"
     downloadURL="$(downloadURLFromGit adoptium temurin11-binaries)"
-    appNewVersion="$(downloadURLFromGit adoptium temurin11-binaries | grep -oE 'jdk-11\.0\.[0-9]+(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    appNewVersion="$(downloadURLFromGit adoptium temurin11-binaries | grep -oE 'jdk-11(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //'; fi }
     ;;


### PR DESCRIPTION
2024-01-23 11:13:55 : REQ   : eclipsetemurin11 : ################## Start Installomator v. 10.6beta, date 2024-01-23
2024-01-23 11:13:55 : INFO  : eclipsetemurin11 : ################## Version: 10.6beta
2024-01-23 11:13:55 : INFO  : eclipsetemurin11 : ################## Date: 2024-01-23
2024-01-23 11:13:55 : INFO  : eclipsetemurin11 : ################## eclipsetemurin11
2024-01-23 11:13:55 : INFO  : eclipsetemurin11 : SwiftDialog is not installed, clear cmd file var
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : setting variable from argument DEBUG=0
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : BLOCKING_PROCESS_ACTION=tell_user
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : NOTIFY=success
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : LOGGING=INFO
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : Label type: pkg
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : archiveName: Temurin 11.pkg
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : no blocking processes defined, using Temurin 11 as default
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : Custom App Version detection is used, found
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : appversion:
2024-01-23 11:13:56 : INFO  : eclipsetemurin11 : Latest version of Temurin 11 is 11.0.22+7.1
2024-01-23 11:13:56 : REQ   : eclipsetemurin11 : Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.22%2B7.1/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.22_7.pkg to Temurin 11.pkg
2024-01-23 11:13:58 : REQ   : eclipsetemurin11 : no more blocking processes, continue with update
2024-01-23 11:13:58 : REQ   : eclipsetemurin11 : Installing Temurin 11
2024-01-23 11:13:58 : INFO  : eclipsetemurin11 : Verifying: Temurin 11.pkg
2024-01-23 11:13:58 : INFO  : eclipsetemurin11 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2024-01-23 11:13:58 : INFO  : eclipsetemurin11 : Installing Temurin 11.pkg to /
2024-01-23 11:14:03 : INFO  : eclipsetemurin11 : Finishing...
2024-01-23 11:14:06 : INFO  : eclipsetemurin11 : Custom App Version detection is used, found 11.0.22+7
2024-01-23 11:14:06 : REQ   : eclipsetemurin11 : Installed Temurin 11, version 11.0.22+7.1
2024-01-23 11:14:06 : INFO  : eclipsetemurin11 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-01-23 11:14:06 : INFO  : eclipsetemurin11 : Installomator did not close any apps, so no need to reopen any apps.
2024-01-23 11:14:06 : REQ   : eclipsetemurin11 : All done!
2024-01-23 11:14:06 : REQ   : eclipsetemurin11 : ################## End Installomator, exit code 0