### PR TITLE
Update magicbullet.sh

### DIFF
--- a/fragments/labels/magicbullet.sh
+++ b/fragments/labels/magicbullet.sh
@@ -4,7 +4,10 @@ magicbullet)
     appCustomVersion(){
     	ls "/Users/Shared/Red Giant/uninstall" | grep bullet | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | head -n 30 | sort -gru
     }
-    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405444242-Magic-Bullet-Suite" | grep -Eo "202[0-9]+\.[0-9]+\.[0-9]+" | sort -gru | head -n 1)"
+    appNewVersion="$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.maxon.net/hc/en-us/sections/4406405444242-Magic-Bullet-Suite" | grep -Eo "[0-9][0-9][0-9][0-9]+\.[0-9]+(\.[0-9]+)?" | sort -gru | head -n 1)"
+    if [[ "$appNewVersion" =~ ^[^.]*\.[^.]*$ ]]; then
+    	appNewVersion=$(echo "$appNewVersion" | sed 's/\([0-9]*\.[0-9]*\)/\1.0/')
+    fi
     downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/$appNewVersion/MagicBulletSuite-${appNewVersion}_mac.zip"
     installerTool="Magic Bullet Suite Installer.app"
     CLIInstaller="Magic Bullet Suite Installer.app/Contents/Scripts/install.sh"


### PR DESCRIPTION
Updated the logic for $appNewVersion 😄 

```
$ sudo /Users/duf0002a/workdir/GitHub/Installomator/assemble.sh magicbullet

2024-01-24 14:51:41 : REQ   : magicbullet : ################## Start Installomator v. 10.6beta, date 2024-01-24
2024-01-24 14:51:41 : INFO  : magicbullet : ################## Version: 10.6beta
2024-01-24 14:51:41 : INFO  : magicbullet : ################## Date: 2024-01-24
2024-01-24 14:51:41 : INFO  : magicbullet : ################## magicbullet
2024-01-24 14:51:41 : DEBUG : magicbullet : DEBUG mode 1 enabled.
2024-01-24 14:51:41 : DEBUG : magicbullet : name=Magic Bullet Suite
2024-01-24 14:51:41 : DEBUG : magicbullet : appName=
2024-01-24 14:51:41 : DEBUG : magicbullet : type=zip
2024-01-24 14:51:41 : DEBUG : magicbullet : archiveName=
2024-01-24 14:51:41 : DEBUG : magicbullet : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/2024.1.0/MagicBulletSuite-2024.1.0_mac.zip
2024-01-24 14:51:41 : DEBUG : magicbullet : curlOptions=
2024-01-24 14:51:41 : DEBUG : magicbullet : appNewVersion=2024.1.0
2024-01-24 14:51:41 : DEBUG : magicbullet : appCustomVersion function: Defined. 
2024-01-24 14:51:41 : DEBUG : magicbullet : versionKey=CFBundleShortVersionString
2024-01-24 14:51:41 : DEBUG : magicbullet : packageID=
2024-01-24 14:51:41 : DEBUG : magicbullet : pkgName=
2024-01-24 14:51:41 : DEBUG : magicbullet : choiceChangesXML=
2024-01-24 14:51:41 : DEBUG : magicbullet : expectedTeamID=4ZY22YGXQG
2024-01-24 14:51:41 : DEBUG : magicbullet : blockingProcesses=
2024-01-24 14:51:41 : DEBUG : magicbullet : installerTool=Magic Bullet Suite Installer.app
2024-01-24 14:51:41 : DEBUG : magicbullet : CLIInstaller=Magic Bullet Suite Installer.app/Contents/Scripts/install.sh
2024-01-24 14:51:41 : DEBUG : magicbullet : CLIArguments=
2024-01-24 14:51:41 : DEBUG : magicbullet : updateTool=
2024-01-24 14:51:41 : DEBUG : magicbullet : updateToolArguments=
2024-01-24 14:51:41 : DEBUG : magicbullet : updateToolRunAsCurrentUser=
2024-01-24 14:51:41 : INFO  : magicbullet : BLOCKING_PROCESS_ACTION=tell_user
2024-01-24 14:51:41 : INFO  : magicbullet : NOTIFY=success
2024-01-24 14:51:41 : INFO  : magicbullet : LOGGING=DEBUG
2024-01-24 14:51:41 : INFO  : magicbullet : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-24 14:51:41 : INFO  : magicbullet : Label type: zip
2024-01-24 14:51:41 : INFO  : magicbullet : archiveName: Magic Bullet Suite.zip
2024-01-24 14:51:41 : INFO  : magicbullet : no blocking processes defined, using Magic Bullet Suite as default
2024-01-24 14:51:41 : DEBUG : magicbullet : Changing directory to /Users/duf0002a/workdir/GitHub/Installomator/build
2024-01-24 14:51:41 : INFO  : magicbullet : Custom App Version detection is used, found 2023.2.1
2024-01-24 14:51:41 : INFO  : magicbullet : appversion: 2023.2.1
2024-01-24 14:51:41 : INFO  : magicbullet : Latest version of Magic Bullet Suite is 2024.1.0
2024-01-24 14:51:42 : REQ   : magicbullet : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/2024.1.0/MagicBulletSuite-2024.1.0_mac.zip to Magic Bullet Suite.zip
2024-01-24 14:51:42 : DEBUG : magicbullet : No Dialog connection, just download
2024-01-24 14:52:22 : DEBUG : magicbullet : File list: -rw-r--r--  1 root  staff   481M 24 Jan 14:52 Magic Bullet Suite.zip
2024-01-24 14:52:22 : DEBUG : magicbullet : File type: Magic Bullet Suite.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-01-24 14:52:22 : DEBUG : magicbullet : curl output was:
*   Trying [2606:4700:4400::ac40:91ef]:443...
* Connected to mx-app-blob-prod.maxon.net (2606:4700:4400::ac40:91ef) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2330 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=sni.cloudflaressl.com
*  start date: May  2 00:00:00 2023 GMT
*  expire date: May  1 23:59:59 2024 GMT
*  subjectAltName: host "mx-app-blob-prod.maxon.net" matched cert's "*.maxon.net"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/redgiant/magicbullet/releases/2024.1.0/MagicBulletSuite-2024.1.0_mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: mx-app-blob-prod.maxon.net]
* [HTTP/2] [1] [:path: /mx-package-production/installer/macos/redgiant/magicbullet/releases/2024.1.0/MagicBulletSuite-2024.1.0_mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mx-package-production/installer/macos/redgiant/magicbullet/releases/2024.1.0/MagicBulletSuite-2024.1.0_mac.zip HTTP/2
> Host: mx-app-blob-prod.maxon.net
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Wed, 24 Jan 2024 13:51:42 GMT
< content-type: application/octet-stream
< content-length: 503869453
< content-md5: zyT2Ub+DtwSKuWcG/INVUw==
< last-modified: Wed, 17 Jan 2024 14:00:00 GMT
< etag: 0x8DC17649895F8D8
< x-ms-request-id: 4a386091-001e-0077-4f56-49fbbb000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< cf-cache-status: HIT
< expires: Thu, 23 Jan 2025 13:51:42 GMT
< cache-control: public, max-age=31536000
< accept-ranges: bytes
< content-security-policy: frame-ancestors 'self' *.maxon.net
< permissions-policy: camera=()
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000; includeSubDomains
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 84a8c0b09c3e9bb6-FRA
< 
{ [16401 bytes data]
* Connection #0 to host mx-app-blob-prod.maxon.net left intact

2024-01-24 14:52:22 : DEBUG : magicbullet : DEBUG mode 1, not checking for blocking processes
2024-01-24 14:52:22 : REQ   : magicbullet : Installing Magic Bullet Suite
2024-01-24 14:52:22 : REQ   : magicbullet : installerTool used: Magic Bullet Suite Installer.app
2024-01-24 14:52:23 : INFO  : magicbullet : Unzipping Magic Bullet Suite.zip
2024-01-24 14:52:23 : INFO  : magicbullet : Verifying: /Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app
2024-01-24 14:52:23 : DEBUG : magicbullet : App size: 491M	/Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app
2024-01-24 14:52:24 : DEBUG : magicbullet : Debugging enabled, App Verification output was:
/Users/duf0002a/workdir/GitHub/Installomator/build/Magic Bullet Suite Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-01-24 14:52:24 : INFO  : magicbullet : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-01-24 14:52:24 : INFO  : magicbullet : Downloaded version of Magic Bullet Suite is 2024.1.0 on versionKey CFBundleShortVersionString (replacing version 2023.2.1).
2024-01-24 14:52:24 : INFO  : magicbullet : App has LSMinimumSystemVersion: 10.11
2024-01-24 14:52:24 : DEBUG : magicbullet : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-01-24 14:52:24 : INFO  : magicbullet : Finishing...
2024-01-24 14:52:27 : INFO  : magicbullet : Custom App Version detection is used, found 2023.2.1
2024-01-24 14:52:27 : REQ   : magicbullet : Installed Magic Bullet Suite, version 2024.1.0
2024-01-24 14:52:27 : INFO  : magicbullet : notifying
2024-01-24 14:52:27 : DEBUG : magicbullet : DEBUG mode 1, not reopening anything
2024-01-24 14:52:27 : REQ   : magicbullet : All done!
2024-01-24 14:52:27 : REQ   : magicbullet : ################## End Installomator, exit code 0 
```