### PR TITLE
Update 1password8.sh to remove 1Password Safari from the list

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -4,6 +4,6 @@
     packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
     expectedTeamID="2BUA8C4S2C"
-    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1Password (Safari)" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES
     ;;


### PR DESCRIPTION
Removed 1Password Safari from the blocking process list. It technically does not block updating the app. Safari should probably be re-launched after the update, but it doesn't prevent the update to the 1Password app