### PR TITLE
Create raindropio.sh

### DIFF
--- a/fragments/labels/raindropio.sh
+++ b/fragments/labels/raindropio.sh
@@ -1,0 +1,13 @@
+raindropio)
+    name="Raindrop.io"
+    type="dmg"
+    if [[ $(arch) == i386 ]]; then
+        archiveName="Raindrop-x64.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        archiveName="Raindrop-arm64.dmg"
+    fi
+
+    downloadURL=$(downloadURLFromGit raindropio desktop )
+    appNewVersion=$(versionFromGit raindropio desktop )
+    expectedTeamID="7459JWM5TY"
+    ;;


### PR DESCRIPTION
./assemble.sh raindropio
2024-01-31 11:42:28 : REQ   : raindropio : ################## Start Installomator v. 10.6beta, date 2024-01-31
2024-01-31 11:42:28 : INFO  : raindropio : ################## Version: 10.6beta
2024-01-31 11:42:28 : INFO  : raindropio : ################## Date: 2024-01-31
2024-01-31 11:42:28 : INFO  : raindropio : ################## raindropio
2024-01-31 11:42:28 : DEBUG : raindropio : DEBUG mode 1 enabled.
2024-01-31 11:42:30 : DEBUG : raindropio : name=Raindrop.io
2024-01-31 11:42:30 : DEBUG : raindropio : appName=
2024-01-31 11:42:30 : DEBUG : raindropio : type=dmg
2024-01-31 11:42:30 : DEBUG : raindropio : archiveName=Raindrop-arm64.dmg
2024-01-31 11:42:30 : DEBUG : raindropio : downloadURL=https://github.com/raindropio/desktop/releases/download/v5.6.5/Raindrop-arm64.dmg
2024-01-31 11:42:30 : DEBUG : raindropio : curlOptions=
2024-01-31 11:42:30 : DEBUG : raindropio : appNewVersion=5.6.5
2024-01-31 11:42:30 : DEBUG : raindropio : appCustomVersion function: Not defined
2024-01-31 11:42:30 : DEBUG : raindropio : versionKey=CFBundleShortVersionString
2024-01-31 11:42:30 : DEBUG : raindropio : packageID=
2024-01-31 11:42:30 : DEBUG : raindropio : pkgName=
2024-01-31 11:42:30 : DEBUG : raindropio : choiceChangesXML=
2024-01-31 11:42:30 : DEBUG : raindropio : expectedTeamID=7459JWM5TY
2024-01-31 11:42:30 : DEBUG : raindropio : blockingProcesses=
2024-01-31 11:42:30 : DEBUG : raindropio : installerTool=
2024-01-31 11:42:30 : DEBUG : raindropio : CLIInstaller=
2024-01-31 11:42:30 : DEBUG : raindropio : CLIArguments=
2024-01-31 11:42:30 : DEBUG : raindropio : updateTool=
2024-01-31 11:42:30 : DEBUG : raindropio : updateToolArguments=
2024-01-31 11:42:30 : DEBUG : raindropio : updateToolRunAsCurrentUser=
2024-01-31 11:42:30 : INFO  : raindropio : BLOCKING_PROCESS_ACTION=tell_user
2024-01-31 11:42:30 : INFO  : raindropio : NOTIFY=success
2024-01-31 11:42:30 : INFO  : raindropio : LOGGING=DEBUG
2024-01-31 11:42:30 : INFO  : raindropio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-01-31 11:42:30 : INFO  : raindropio : Label type: dmg
2024-01-31 11:42:30 : INFO  : raindropio : archiveName: Raindrop-arm64.dmg
2024-01-31 11:42:30 : INFO  : raindropio : no blocking processes defined, using Raindrop.io as default
2024-01-31 11:42:30 : DEBUG : raindropio : Changing directory to /Users/Shared/_GithubRepos/Installomator/build
2024-01-31 11:42:30 : INFO  : raindropio : name: Raindrop.io, appName: Raindrop.io.app
2024-01-31 11:42:31.058 mdfind[8642:165241] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-01-31 11:42:31.060 mdfind[8642:165241] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-01-31 11:42:31.383 mdfind[8642:165241] Couldn't determine the mapping between prefab keywords and predicates.
2024-01-31 11:42:31 : WARN  : raindropio : No previous app found
2024-01-31 11:42:31 : WARN  : raindropio : could not find Raindrop.io.app
2024-01-31 11:42:31 : INFO  : raindropio : appversion:
2024-01-31 11:42:31 : INFO  : raindropio : Latest version of Raindrop.io is 5.6.5
2024-01-31 11:42:31 : REQ   : raindropio : Downloading https://github.com/raindropio/desktop/releases/download/v5.6.5/Raindrop-arm64.dmg to Raindrop-arm64.dmg
2024-01-31 11:42:31 : DEBUG : raindropio : No Dialog connection, just download
2024-01-31 11:42:33 : DEBUG : raindropio : File list: -rw-r--r--  1 username  staff    74M Jan 31 11:42 Raindrop-arm64.dmg
2024-01-31 11:42:33 : DEBUG : raindropio : File type: Raindrop-arm64.dmg: bzip2 compressed data, block size = 100k
2024-01-31 11:42:33 : DEBUG : raindropio : curl output was:
*   Trying 192.30.255.113:443...
* Connected to github.com (192.30.255.113) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Feb 14 00:00:00 2023 GMT
*  expire date: Mar 14 23:59:59 2024 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/raindropio/desktop/releases/download/v5.6.5/Raindrop-arm64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /raindropio/desktop/releases/download/v5.6.5/Raindrop-arm64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /raindropio/desktop/releases/download/v5.6.5/Raindrop-arm64.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Wed, 31 Jan 2024 19:42:31 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/211905151/e844df93-6989-4f20-b051-8741c4568298?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240131T194231Z&X-Amz-Expires=300&X-Amz-Signature=5b598f13682c944d243c0bd24d2f0e2c772dc060f699f566eb5ef8c80f6d2de5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=211905151&response-content-disposition=attachment%3B%20filename%3DRaindrop-arm64.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events api.githubcopilot.com objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: D161:8AA3:2AF8638:2CF763C:65BAA2A7 <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/211905151/e844df93-6989-4f20-b051-8741c4568298?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240131T194231Z&X-Amz-Expires=300&X-Amz-Signature=5b598f13682c944d243c0bd24d2f0e2c772dc060f699f566eb5ef8c80f6d2de5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=211905151&response-content-disposition=attachment%3B%20filename%3DRaindrop-arm64.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Feb 21 00:00:00 2023 GMT
*  expire date: Mar 20 23:59:59 2024 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/211905151/e844df93-6989-4f20-b051-8741c4568298?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240131T194231Z&X-Amz-Expires=300&X-Amz-Signature=5b598f13682c944d243c0bd24d2f0e2c772dc060f699f566eb5ef8c80f6d2de5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=211905151&response-content-disposition=attachment%3B%20filename%3DRaindrop-arm64.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/211905151/e844df93-6989-4f20-b051-8741c4568298?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240131T194231Z&X-Amz-Expires=300&X-Amz-Signature=5b598f13682c944d243c0bd24d2f0e2c772dc060f699f566eb5ef8c80f6d2de5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=211905151&response-content-disposition=attachment%3B%20filename%3DRaindrop-arm64.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/211905151/e844df93-6989-4f20-b051-8741c4568298?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240131T194231Z&X-Amz-Expires=300&X-Amz-Signature=5b598f13682c944d243c0bd24d2f0e2c772dc060f699f566eb5ef8c80f6d2de5&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=211905151&response-content-disposition=attachment%3B%20filename%3DRaindrop-arm64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: mBujFsRpte0B+gA9uHfRpQ==
< last-modified: Mon, 05 Jun 2023 08:37:59 GMT
< etag: "0x8DB65A02AF1317F"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 6774133d-a01e-0033-5f8f-51befe000000 < x-ms-version: 2020-10-02
< x-ms-creation-time: Mon, 05 Jun 2023 08:37:59 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Raindrop-arm64.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 889
< date: Wed, 31 Jan 2024 19:42:32 GMT
< x-served-by: cache-iad-kjyo7100026-IAD, cache-lax-kwhp1940031-LAX < x-cache: HIT, HIT
< x-cache-hits: 249, 0
< x-timer: S1706730152.040927,VS0,VE233
< content-length: 77368300
<
{ [9111 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-01-31 11:42:33 : DEBUG : raindropio : DEBUG mode 1, not checking for blocking processes
2024-01-31 11:42:33 : REQ   : raindropio : Installing Raindrop.io
2024-01-31 11:42:33 : INFO  : raindropio : Mounting /Users/Shared/_GithubRepos/Installomator/build/Raindrop-arm64.dmg
2024-01-31 11:42:42 : DEBUG : raindropio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7348A074
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $5F42AF0F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $6A38857C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $B0C25271
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $6A38857C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $308BFAF2
verified   CRC32 $0A77AE48
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Raindrop.io 5.6.5-arm64 1

2024-01-31 11:42:42 : INFO  : raindropio : Mounted: /Volumes/Raindrop.io 5.6.5-arm64 1 2024-01-31 11:42:42 : INFO  : raindropio : Verifying: /Volumes/Raindrop.io 5.6.5-arm64 1/Raindrop.io.app 2024-01-31 11:42:42 : DEBUG : raindropio : App size: 197M	/Volumes/Raindrop.io 5.6.5-arm64 1/Raindrop.io.app 2024-01-31 11:42:51 : DEBUG : raindropio : Debugging enabled, App Verification output was: /Volumes/Raindrop.io 5.6.5-arm64 1/Raindrop.io.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Rustem Mussabekov (7459JWM5TY)

2024-01-31 11:42:51 : INFO  : raindropio : Team ID matching: 7459JWM5TY (expected: 7459JWM5TY ) 2024-01-31 11:42:51 : INFO  : raindropio : Installing Raindrop.io version 5.6.5 on versionKey CFBundleShortVersionString. 2024-01-31 11:42:51 : INFO  : raindropio : App has LSMinimumSystemVersion: 10.11.0 2024-01-31 11:42:51 : DEBUG : raindropio : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-01-31 11:42:51 : INFO  : raindropio : Finishing... 2024-01-31 11:42:54 : INFO  : raindropio : name: Raindrop.io, appName: Raindrop.io.app 2024-01-31 11:42:54.469 mdfind[8731:165745] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-01-31 11:42:54.469 mdfind[8731:165745] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-01-31 11:42:54.558 mdfind[8731:165745] Couldn't determine the mapping between prefab keywords and predicates. 2024-01-31 11:42:54 : WARN  : raindropio : No previous app found 2024-01-31 11:42:54 : WARN  : raindropio : could not find Raindrop.io.app
2024-01-31 11:42:54 : REQ   : raindropio : Installed Raindrop.io, version 5.6.5
2024-01-31 11:42:54 : INFO  : raindropio : notifying
2024-01-31 11:42:55 : DEBUG : raindropio : Unmounting /Volumes/Raindrop.io 5.6.5-arm64 1
2024-01-31 11:42:55 : DEBUG : raindropio : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-01-31 11:42:55 : DEBUG : raindropio : DEBUG mode 1, not reopening anything
2024-01-31 11:42:55 : REQ   : raindropio : All done!
2024-01-31 11:42:55 : REQ   : raindropio : ################## End Installomator, exit code 0