### PR TITLE
Update Labels.txt

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -389,7 +389,7 @@ microsoftofficebusinesspro
 microsoftofficefactoryreset
 microsoftofficeremoval
 microsoftonedrive
-microsoftonedrive-rollingout
+microsoftonedrive-deferred
 microsoftonedrive-rollingout
 microsoftonedrive-rollingoutdeferred
 microsoftonedrivereset


### PR DESCRIPTION
In labels.txt (both release 10.5 and the current main branch) the label "microsoftonedrive-rollingout" is listed twice, and the label "microsoftonedrive-deferred" was absent/not in labels.txt

Changed one of two instances of "microsoftonedrive-rollingout" in labels.txt to "microsoftonedrive-deferred" so labels.txt now accurately represents the available labels in Installomator 10.5

FYI @Theile this is what my comment was about yesterday. Not really the PR I left it on fixing the label in installomator.sh, but correcting the labels.txt to accurately match up with that other PR :-) 

My apologies for not making this PR in the first place and just leaving a random comment.