### PR TITLE
FLStudio label

### DIFF
--- a/fragments/labels/flstudiomac.sh
+++ b/fragments/labels/flstudiomac.sh
@@ -1,0 +1,9 @@
+flstudiomac)
+    name="flstudio_mac"
+    type="pkgInDmg"
+    packageID="com.Image-Line.pkg.FL21.2ONLINE"
+    downloadURL="https://install.image-line.com/flstudio/flstudio_mac_21.2.2.3470.dmg"
+    appNewVersion="$(getJSONValue $(curl -fsL "https://support.image-line.com/api.php?call=get_version_info&callback=il_get_version") "prod.741.mac.version")"
+    expectedTeamID="N68WEP5ZZZ"
+    ;;
+    


### PR DESCRIPTION
Music Production Software
-------------------------------------
./utils/assemble.sh flstudiomac
2024-02-05 12:17:54 : REQ   : flstudiomac : ################## Start Installomator v. 10.6beta, date 2024-02-05
2024-02-05 12:17:54 : INFO  : flstudiomac : ################## Version: 10.6beta
2024-02-05 12:17:54 : INFO  : flstudiomac : ################## Date: 2024-02-05
2024-02-05 12:17:54 : INFO  : flstudiomac : ################## flstudiomac
2024-02-05 12:17:54 : DEBUG : flstudiomac : DEBUG mode 1 enabled.
2024-02-05 12:17:54 : INFO  : flstudiomac : SwiftDialog is not installed, clear cmd file var
execution error: Error: SyntaxError: JSON Parse error: Unexpected identifier "var" (-2700)
2024-02-05 12:17:55 : DEBUG : flstudiomac : name=flstudio_mac
2024-02-05 12:17:55 : DEBUG : flstudiomac : appName=
2024-02-05 12:17:55 : DEBUG : flstudiomac : type=pkgInDmg
2024-02-05 12:17:55 : DEBUG : flstudiomac : archiveName=
2024-02-05 12:17:55 : DEBUG : flstudiomac : downloadURL=https://install.image-line.com/flstudio/flstudio_mac_21.2.2.3470.dmg
2024-02-05 12:17:55 : DEBUG : flstudiomac : curlOptions=
2024-02-05 12:17:55 : DEBUG : flstudiomac : appNewVersion=
2024-02-05 12:17:55 : DEBUG : flstudiomac : appCustomVersion function: Not defined
2024-02-05 12:17:55 : DEBUG : flstudiomac : versionKey=CFBundleShortVersionString
2024-02-05 12:17:55 : DEBUG : flstudiomac : packageID=com.Image-Line.pkg.FL21.2ONLINE
2024-02-05 12:17:55 : DEBUG : flstudiomac : pkgName=
2024-02-05 12:17:55 : DEBUG : flstudiomac : choiceChangesXML=
2024-02-05 12:17:55 : DEBUG : flstudiomac : expectedTeamID=N68WEP5ZZZ
2024-02-05 12:17:55 : DEBUG : flstudiomac : blockingProcesses=
2024-02-05 12:17:55 : DEBUG : flstudiomac : installerTool=
2024-02-05 12:17:56 : DEBUG : flstudiomac : CLIInstaller=
2024-02-05 12:17:56 : DEBUG : flstudiomac : CLIArguments=
2024-02-05 12:17:56 : DEBUG : flstudiomac : updateTool=
2024-02-05 12:17:56 : DEBUG : flstudiomac : updateToolArguments=
2024-02-05 12:17:56 : DEBUG : flstudiomac : updateToolRunAsCurrentUser=
2024-02-05 12:17:56 : INFO  : flstudiomac : BLOCKING_PROCESS_ACTION=tell_user
2024-02-05 12:17:56 : INFO  : flstudiomac : NOTIFY=success
2024-02-05 12:17:56 : INFO  : flstudiomac : LOGGING=DEBUG
2024-02-05 12:17:56 : INFO  : flstudiomac : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-05 12:17:56 : INFO  : flstudiomac : Label type: pkgInDmg
2024-02-05 12:17:56 : INFO  : flstudiomac : archiveName: flstudio_mac.dmg
2024-02-05 12:17:56 : INFO  : flstudiomac : no blocking processes defined, using flstudio_mac as default
2024-02-05 12:17:56 : DEBUG : flstudiomac : Changing directory to /Users/localadmin/Documents/GitHub/Installomator/build
2024-02-05 12:17:56 : INFO  : flstudiomac : No version found using packageID com.Image-Line.pkg.FL21.2ONLINE
2024-02-05 12:17:56 : INFO  : flstudiomac : name: flstudio_mac, appName: flstudio_mac.app
2024-02-05 12:17:57 : WARN  : flstudiomac : No previous app found
2024-02-05 12:17:57 : WARN  : flstudiomac : could not find flstudio_mac.app
2024-02-05 12:17:57 : INFO  : flstudiomac : appversion:
2024-02-05 12:17:57 : INFO  : flstudiomac : Latest version not specified.
2024-02-05 12:17:57 : REQ   : flstudiomac : Downloading https://install.image-line.com/flstudio/flstudio_mac_21.2.2.3470.dmg to flstudio_mac.dmg
2024-02-05 12:17:57 : DEBUG : flstudiomac : No Dialog connection, just download

2024-02-05 12:19:48 : DEBUG : flstudiomac : File list: -rw-r--r--  1 localadmin  staff   1.1G  5 Feb 12:19 flstudio_mac.dmg
2024-02-05 12:19:48 : DEBUG : flstudiomac : File type: flstudio_mac.dmg: zlib compressed data
2024-02-05 12:19:48 : DEBUG : flstudiomac : curl output was:
*   Trying [2606:4700::6810:5f36]:443...
* Connected to install.image-line.com (2606:4700::6810:5f36) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4161 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=install.image-line.com
*  start date: Jan 11 15:13:16 2024 GMT
*  expire date: Apr 10 15:13:15 2024 GMT
*  subjectAltName: host "install.image-line.com" matched cert's "install.image-line.com"
*  issuer: C=US; O=Let's Encrypt; CN=E1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: install.image-line.com]
* h2 [:path: /flstudio/flstudio_mac_21.2.2.3470.dmg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fbc4080c600)
> GET /flstudio/flstudio_mac_21.2.2.3470.dmg HTTP/2
> Host: install.image-line.com
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< date: Mon, 05 Feb 2024 04:17:58 GMT
< content-type: application/zlib
< content-length: 1200860079
< etag: "a870f6cc78f48c0e4879a49bfcd45b13"
< last-modified: Mon, 11 Dec 2023 10:09:11 GMT
< vary: Accept-Encoding
< cf-cache-status: HIT
< age: 6322
< expires: Mon, 05 Feb 2024 06:17:58 GMT
< cache-control: public, max-age=7200
< accept-ranges: bytes
< set-cookie: _cfuvid=dI7uQK6rGOj_mdwiAv4UqeAh7RIS7x.AsJa.FvgBYPI-1707106678208-0-604800000; path=/; domain=.image-line.com; HttpOnly; Secure; SameSite=None < server: cloudflare
< cf-ray: 850858c2ae0f866b-PER
<
{ [6836 bytes data]
* Connection #0 to host install.image-line.com left intact

2024-02-05 12:19:48 : DEBUG : flstudiomac : DEBUG mode 1, not checking for blocking processes
2024-02-05 12:19:48 : REQ   : flstudiomac : Installing flstudio_mac
2024-02-05 12:19:48 : INFO  : flstudiomac : Mounting /Users/localadmin/Documents/GitHub/Installomator/build/flstudio_mac.dmg
2024-02-05 12:19:52 : DEBUG : flstudiomac : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $41D4D33C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $C89ABFFA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9095B52C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $478D3640
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9095B52C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $AEF35F6B
verified   CRC32 $B894567D
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/FL Studio

2024-02-05 12:19:52 : INFO  : flstudiomac : Mounted: /Volumes/FL Studio 2024-02-05 12:19:52 : DEBUG : flstudiomac : Found pkg(s): /Volumes/FL Studio/Install FL Studio.pkg
2024-02-05 12:19:52 : INFO  : flstudiomac : found pkg: /Volumes/FL Studio/Install FL Studio.pkg 2024-02-05 12:19:52 : INFO  : flstudiomac : Verifying: /Volumes/FL Studio/Install FL Studio.pkg
2024-02-05 12:19:52 : DEBUG : flstudiomac : File list: -rw-r--r--  1 localadmin  staff   1.1G  2 Dec 00:31 /Volumes/FL Studio/Install FL Studio.pkg
2024-02-05 12:19:52 : DEBUG : flstudiomac : File type: /Volumes/FL Studio/Install FL Studio.pkg: xar archive compressed TOC: 7116, SHA-1 checksum
2024-02-05 12:19:53 : DEBUG : flstudiomac : spctlOut is /Volumes/FL Studio/Install FL Studio.pkg: accepted
2024-02-05 12:19:53 : DEBUG : flstudiomac : source=Notarized Developer ID
2024-02-05 12:19:53 : DEBUG : flstudiomac : origin=Developer ID Installer: image-line (N68WEP5ZZZ)
2024-02-05 12:19:53 : INFO  : flstudiomac : Team ID: N68WEP5ZZZ (expected: N68WEP5ZZZ )
2024-02-05 12:19:53 : DEBUG : flstudiomac : DEBUG enabled, skipping installation
2024-02-05 12:19:53 : INFO  : flstudiomac : Finishing...
2024-02-05 12:19:56 : INFO  : flstudiomac : No version found using packageID com.Image-Line.pkg.FL21.2ONLINE
2024-02-05 12:19:56 : INFO  : flstudiomac : name: flstudio_mac, appName: flstudio_mac.app
2024-02-05 12:19:56 : WARN  : flstudiomac : No previous app found
2024-02-05 12:19:56 : WARN  : flstudiomac : could not find flstudio_mac.app
2024-02-05 12:19:57 : REQ   : flstudiomac : Installed flstudio_mac
2024-02-05 12:19:57 : INFO  : flstudiomac : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-05 12:19:57 : DEBUG : flstudiomac : Unmounting /Volumes/FL Studio
2024-02-05 12:19:57 : DEBUG : flstudiomac : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-02-05 12:19:57 : DEBUG : flstudiomac : DEBUG mode 1, not reopening anything
2024-02-05 12:19:57 : REQ   : flstudiomac : All done!
2024-02-05 12:19:57 : REQ   : flstudiomac : ################## End Installomator, exit code 0