### PR TITLE
Update krisp.sh

### DIFF
--- a/fragments/labels/krisp.sh
+++ b/fragments/labels/krisp.sh
@@ -1,7 +1,11 @@
 krisp)
-    # credit: Tadayuki Onishi (@kenchan0130)
     name="Krisp"
     type="pkg"
-    downloadURL="https://download.krisp.ai/mac"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.krisp.ai/mac?package=package_arm"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.krisp.ai/mac?package=package_64"
+    fi
+    appNewVersion="$(curl -fsIL $downloadURL | grep -i "^location" | tail -1 | awk -F'/' '{ print $(NF-2) }')"
     expectedTeamID="U5R26XM5Z2"
     ;;


### PR DESCRIPTION
Current label is broken. Added logic for selecting download URL based on architecture and a appNewVersion variable.

-----

2024-02-06 10:43:01 : REQ   : krisp : ################## Start Installomator v. 10.6beta, date 2024-02-06
2024-02-06 10:43:01 : INFO  : krisp : ################## Version: 10.6beta
2024-02-06 10:43:01 : INFO  : krisp : ################## Date: 2024-02-06
2024-02-06 10:43:01 : INFO  : krisp : ################## krisp
2024-02-06 10:43:01 : INFO  : krisp : SwiftDialog is not installed, clear cmd file var
2024-02-06 10:43:02 : INFO  : krisp : BLOCKING_PROCESS_ACTION=tell_user
2024-02-06 10:43:02 : INFO  : krisp : NOTIFY=success
2024-02-06 10:43:02 : INFO  : krisp : LOGGING=INFO
2024-02-06 10:43:02 : INFO  : krisp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-06 10:43:02 : INFO  : krisp : Label type: pkg
2024-02-06 10:43:02 : INFO  : krisp : archiveName: Krisp.pkg
2024-02-06 10:43:02 : INFO  : krisp : no blocking processes defined, using Krisp as default
2024-02-06 10:43:02 : INFO  : krisp : name: Krisp, appName: Krisp.app
2024-02-06 10:43:02.267 mdfind[59498:1634295] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-06 10:43:02.267 mdfind[59498:1634295] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-06 10:43:02.421 mdfind[59498:1634295] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-06 10:43:02 : WARN  : krisp : No previous app found
2024-02-06 10:43:02 : WARN  : krisp : could not find Krisp.app
2024-02-06 10:43:02 : INFO  : krisp : appversion:
2024-02-06 10:43:02 : INFO  : krisp : Latest version of Krisp is 2.33.3
2024-02-06 10:43:02 : REQ   : krisp : Downloading https://download.krisp.ai/mac?package=package_arm to Krisp.pkg
2024-02-06 10:43:05 : REQ   : krisp : no more blocking processes, continue with update
2024-02-06 10:43:05 : REQ   : krisp : Installing Krisp
2024-02-06 10:43:05 : INFO  : krisp : Verifying: Krisp.pkg
2024-02-06 10:43:05 : INFO  : krisp : Team ID: U5R26XM5Z2 (expected: U5R26XM5Z2 )
2024-02-06 10:43:05 : INFO  : krisp : Installing Krisp.pkg to /
2024-02-06 10:43:12 : INFO  : krisp : Finishing...
2024-02-06 10:43:15 : INFO  : krisp : App(s) found: /Applications/Krisp.app
2024-02-06 10:43:15 : INFO  : krisp : found app at /Applications/Krisp.app, version 2.33.3, on versionKey CFBundleShortVersionString
2024-02-06 10:43:15 : REQ   : krisp : Installed Krisp, version 2.33.3
2024-02-06 10:43:15 : INFO  : krisp : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-06 10:43:15 : INFO  : krisp : Installomator did not close any apps, so no need to reopen any apps.
2024-02-06 10:43:15 : REQ   : krisp : All done!
2024-02-06 10:43:15 : REQ   : krisp : ################## End Installomator, exit code 0