### PR TITLE
Update thunderbird_intl.sh

### DIFF
--- a/fragments/labels/thunderbird_intl.sh
+++ b/fragments/labels/thunderbird_intl.sh
@@ -3,7 +3,7 @@ thunderbird_intl)
     # and install corrosponding version of Thunderbird
     name="Thunderbird"
     type="dmg"
-    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-')
+    userLanguage=$(if [ -e "/Applications/${name}.app/Contents/Resources/locale.ini" ]; then tail -1 "/Applications/${name}.app/Contents/Resources/locale.ini" | grep "locale=" | awk -F'=' '{ print $2 }'; else runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-'; fi)
     printlog "Found language $userLanguage to be used for $name."
     releaseURL="https://ftp.mozilla.org/pub/thunderbird/releases/latest/README.txt"
     until curl -fs $releaseURL | grep -q "=$userLanguage"; do


### PR DESCRIPTION
This would be a nice addition for update workflows since this would check the actual language/locale of the installed Thunderbird app (if installed) before reverting to checking the macOS locale if the Thunderbird app is not installed.