### PR TITLE
RØDE Cental, Connect, and Unify

### DIFF
--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -1,0 +1,8 @@
+rodecentral)
+    name="RODE Central"
+    type="pkgInZip"
+    #packageID="com.rodecentral.installer"
+    downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    expectedTeamID="Z9T72PWTJA"
+    ;;

--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -3,6 +3,6 @@ rodecentral)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
-    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | head -1 | cut -w -f2)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodeconnect.sh
+++ b/fragments/labels/rodeconnect.sh
@@ -3,6 +3,6 @@ rodeconnect)
     type="pkgInZip"
     #packageID="com.rodeconnect.installer" #Versioned wrong as 0 in 1.1.0 pkg
     downloadURL="https://update.rode.com/connect/RODE_Connect_MACOS.zip"
-    #appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-connect | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-connect | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | head -1 | cut -w -f2)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodeconnect.sh
+++ b/fragments/labels/rodeconnect.sh
@@ -3,6 +3,6 @@ rodeconnect)
     type="pkgInZip"
     #packageID="com.rodeconnect.installer" #Versioned wrong as 0 in 1.1.0 pkg
     downloadURL="https://cdn1.rode.com/rodeconnect_installer_mac.zip"
-    appNewVersion="$(curl -fs https://rode.com/software/rode-connect | grep -i -o ">Current version .*<" | cut -d " " -f4)"
+    #appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-connect | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodeconnect.sh
+++ b/fragments/labels/rodeconnect.sh
@@ -2,7 +2,7 @@ rodeconnect)
     name="RODE Connect"
     type="pkgInZip"
     #packageID="com.rodeconnect.installer" #Versioned wrong as 0 in 1.1.0 pkg
-    downloadURL="https://cdn1.rode.com/rodeconnect_installer_mac.zip"
+    downloadURL="https://update.rode.com/connect/RODE_Connect_MACOS.zip"
     #appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-connect | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodeunify.sh
+++ b/fragments/labels/rodeunify.sh
@@ -1,0 +1,8 @@
+rodecentral)
+    name="RODE Central"
+    type="pkgInZip"
+    #packageID="com.rodecentral.installer"
+    downloadURL="https://update.rode.com/unify_new/macos/RODE_UNIFY_MACOS.zip"
+    #appNewVersion=$(curl -fs https://rode.com/en/release-notes/unify | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    expectedTeamID="Z9T72PWTJA"
+    ;;

--- a/fragments/labels/rodeunify.sh
+++ b/fragments/labels/rodeunify.sh
@@ -3,6 +3,6 @@ rodeunify)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/unify_new/macos/RODE_UNIFY_MACOS.zip"
-    #appNewVersion=$(curl -fs https://rode.com/en/release-notes/unify | xmllint --html --format - 2>/dev/null | tr '"' '\n' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/unify | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | head -1 | cut -w -f2)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodeunify.sh
+++ b/fragments/labels/rodeunify.sh
@@ -1,5 +1,5 @@
-rodecentral)
-    name="RODE Central"
+rodeunify)
+    name="RODE UNIFY"
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/unify_new/macos/RODE_UNIFY_MACOS.zip"


### PR DESCRIPTION
RØDE Connect label was broken for `appNewVersion` and it seems Release Notes pages have moved. But for RØDE Connect and RØDE Unify they are not showing the latest version of showing incorrect version.