### PR TITLE
Mdm script SwiftDdialog fix

### DIFF
--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
@@ -29,13 +29,13 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
     if [ -n "$archiveName" ]; then
         downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*$archiveName" | head -1 || true)
         if [[ "$(echo $downloadURL | grep -ioE "https.*$archiveName" || true)" == "" ]]; then
-            #printlog "Trying GitHub API for download URL."
+            #echo "Trying GitHub API for download URL."
             downloadURL=$(curl -sfL "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }" || true)
         fi
     else
         downloadURL=https://github.com$(curl -sfL "https://github.com/$gitusername/$gitreponame/releases/latest" | tr '"' "\n" | grep -i "^/.*\/releases\/download\/.*\.$filetype" | head -1 || true)
         if [[ "$(echo $downloadURL | grep -ioE "https.*.$filetype" || true)" == "" ]]; then
-            #printlog "Trying GitHub API for download URL."
+            #echo "Trying GitHub API for download URL."
             downloadURL=$(curl -sfL "https://api.github.com/repos/$gitusername/$gitreponame/releases/latest" | awk -F '"' "/browser_download_url/ && /$filetype\"/ { print \$4; exit }" || true)
         fi
     fi
@@ -286,7 +286,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
@@ -73,8 +73,9 @@ appNewVersion="$(versionFromGit codykrieger gfxCardStatus)"
 versionKey=""
 expectedTeamID="LF22FTQC25"
 
-# Dialog icon
+# Dialog icon and overlay icon
 icon=""
+overlayicon=""
 # icon should be a file system path or an URL to an online PNG.
 # In Mosyle an URL can be found by copy picture address from a Custom Command icon.
 
@@ -84,7 +85,7 @@ appPath="/Applications/$name.app"
 
 # Other variables
 dialog_command_file="/var/tmp/dialog.log"
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 
 installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dialog_command_file}" # Separated by space
@@ -194,8 +195,8 @@ if [[ $installomatorVersion -lt 10 ]] || [[ $(sw_vers -buildVersion | cut -c1-2)
 else
     installomatorNotify="NOTIFY=silent"
     # check for Swift Dialog
-    if [[ ! -d $dialogApp ]]; then
-        echo "Cannot find dialog at $dialogApp"
+    if [[ ! -x $dialogBinary ]]; then
+        echo "Cannot find dialog at $dialogBinary"
         # Install using Installlomator
         cmdOutput="$(${destFile} dialog LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"
         checkCmdOutput "${cmdOutput}"
@@ -297,15 +298,26 @@ else
     echo "icon: ${icon}"
 
     # display first screen
-    open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+    dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+    )
+
+    if [[ -n "$overlayicon" ]]; then
+        dialogCMD+=("--overlayicon" ${overlayicon})
+    fi
+
+    echo "dialogCMD: ${dialogCMD[@]}"
+
+    "${dialogCMD[@]}" &
+
+    echo "$(date +%F\ %T) : SwiftDialog started!"
 
     # give everything a moment to catch up
     sleep 0.1

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
@@ -112,6 +112,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # Fill out the label variables above, and those will be included in the Installomator call, circa on line 248
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -125,11 +127,11 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
-
 if [[ -z "$item" ]]; then
     item="$name"
 fi
+
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS github.sh
@@ -315,7 +315,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
@@ -231,7 +231,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
@@ -260,7 +260,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
@@ -30,7 +30,7 @@ appPath="/Applications/$name.app"
 
 # Other variables
 dialog_command_file="/var/tmp/dialog.log"
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 
 installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dialog_command_file}" # Separated by space
@@ -140,8 +140,8 @@ if [[ $installomatorVersion -lt 10 ]] || [[ $(sw_vers -buildVersion | cut -c1-2)
 else
     installomatorNotify="NOTIFY=silent"
     # check for Swift Dialog
-    if [[ ! -d $dialogApp ]]; then
-        echo "Cannot find dialog at $dialogApp"
+    if [[ ! -x $dialogBinary ]]; then
+        echo "Cannot find dialog at $dialogBinary"
         # Install using Installlomator
         cmdOutput="$(${destFile} dialog LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"
         checkCmdOutput "${cmdOutput}"
@@ -243,15 +243,26 @@ else
     echo "icon: ${icon}"
 
     # display first screen
-    open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+    dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+    )
+
+    if [[ -n "$overlayicon" ]]; then
+        dialogCMD+=("--overlayicon" ${overlayicon})
+    fi
+
+    echo "dialogCMD: ${dialogCMD[@]}"
+
+    "${dialogCMD[@]}" &
+
+    echo "$(date +%F\ %T) : SwiftDialog started!"
 
     # give everything a moment to catch up
     sleep 0.1

--- a/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App VFA SS.sh
@@ -57,6 +57,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # Fill out the label variables above, and those will be included in the Installomator call, circa on line 248
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -70,11 +72,11 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
-
 if [[ -z "$item" ]]; then
     item="$name"
 fi
+
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
@@ -245,7 +245,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
@@ -46,6 +46,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=tell_user_then_quit DIALOG_CMD_FIL
 # Fill the variable "item" above with a label.
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -59,7 +61,7 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=tell_user_then_quit DIALOG_CMD_FIL
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App browser-security SS.sh
@@ -216,7 +216,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
@@ -245,7 +245,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
@@ -7,8 +7,9 @@ LOGO="" # "mosyleb", "mosylem", "addigy", "microsoft", "ws1", "kandji", "filewav
 item="microsoftoffice365" # enter the software to install
 # Examples: microsoftofficebusinesspro, microsoftoffice365
 
-# Dialog icon
+# Dialog icon and overlay icon
 icon=""
+overlayicon=""
 # icon should be a file system path or an URL to an online PNG.
 # In Mosyle an URL can be found by copy picture address from a Custom Command icon.
 
@@ -18,7 +19,7 @@ appPaths=("/Applications/Microsoft Outlook.app" "/Applications/Microsoft Word.ap
 
 # Other variables
 dialog_command_file="/var/tmp/dialog.log"
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 
 installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dialog_command_file}" # Separated by space
@@ -124,8 +125,8 @@ if [[ $installomatorVersion -lt 10 ]] || [[ $(sw_vers -buildVersion | cut -c1-2)
 else
     installomatorNotify="NOTIFY=silent"
     # check for Swift Dialog
-    if [[ ! -d $dialogApp ]]; then
-        echo "Cannot find dialog at $dialogApp"
+    if [[ ! -x $dialogBinary ]]; then
+        echo "Cannot find dialog at $dialogBinary"
         # Install using Installlomator
         cmdOutput="$(${destFile} dialog LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"
         checkCmdOutput "${cmdOutput}"
@@ -227,15 +228,26 @@ else
     echo "icon: ${icon}"
 
     # display first screen
-    open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+    dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+    )
+
+    if [[ -n "$overlayicon" ]]; then
+        dialogCMD+=("--overlayicon" ${overlayicon})
+    fi
+
+    echo "dialogCMD: ${dialogCMD[@]}"
+
+    "${dialogCMD[@]}" &
+
+    echo "$(date +%F\ %T) : SwiftDialog started!"
 
     # give everything a moment to catch up
     sleep 0.1

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
@@ -216,7 +216,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS multi-app.sh
@@ -46,6 +46,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # Fill the variable "item" above with a label.
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -59,7 +61,7 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -242,7 +242,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -7,8 +7,9 @@ LOGO="" # "mosyleb", "mosylem", "addigy", "microsoft", "ws1", "kandji", "filewav
 item="" # enter the software to install
 # Examples: adobecreativeclouddesktop, canva, cyberduck, handbrake, inkscape, textmate, vlc
 
-# Dialog icon
+# Dialog icon and overlay icon
 icon=""
+overlayicon=""
 # icon should be a file system path or an URL to an online PNG, so beginning with either “/” or “http”.
 # In Mosyle an URL can be found by copy picture address from a Custom Command icon.
 
@@ -18,7 +19,7 @@ appPath="/Applications/Cyberduck.app"
 
 # Other variables
 dialog_command_file="/var/tmp/dialog.log"
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 
 installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dialog_command_file}" # Separated by space
@@ -121,8 +122,8 @@ if [[ $installomatorVersion -lt 10 ]] || [[ $(sw_vers -buildVersion | cut -c1-2)
 else
     installomatorNotify="NOTIFY=silent"
     # check for Swift Dialog
-    if [[ ! -d $dialogApp ]]; then
-        echo "Cannot find dialog at $dialogApp"
+    if [[ ! -x $dialogBinary ]]; then
+        echo "Cannot find dialog at $dialogBinary"
         # Install using Installlomator
         cmdOutput="$(${destFile} dialog LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"
         checkCmdOutput "${cmdOutput}"
@@ -224,15 +225,26 @@ else
     echo "icon: ${icon}"
 
     # display first screen
-    open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+    dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+    )
+
+    if [[ -n "$overlayicon" ]]; then
+        dialogCMD+=("--overlayicon" ${overlayicon})
+    fi
+
+    echo "dialogCMD: ${dialogCMD[@]}"
+
+    "${dialogCMD[@]}" &
+
+    echo "$(date +%F\ %T) : SwiftDialog started!"
 
     # give everything a moment to catch up
     sleep 0.1

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -213,7 +213,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -43,6 +43,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # Fill the variable "item" above with a label.
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -56,7 +58,7 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=prompt_user DIALOG_CMD_FILE=${dial
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
@@ -245,7 +245,7 @@ else
         dialogCMD+=("--overlayicon" ${overlayicon})
     fi
 
-    echo "dialogCMD: ${dialogCMD[@]}"
+    echo "dialogCMD: ${dialogCMD[*]}"
 
     "${dialogCMD[@]}" &
 

--- a/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
@@ -46,6 +46,8 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=ignore DIALOG_CMD_FILE=${dialog_co
 # Fill the variable "item" above with a label.
 # Script will run this label through Installomator.
 ######################################################################
+scriptVersion="10.1"
+# v. 10.1   : 2024-02-13 : Improved Dialog call. Support for overlay icon as well.
 # v. 10.0.5 : Support for FileWave, and previously Kandji
 # v. 10.0.4 : Fix for LOGO_PATH for ws1, and only kill the caffeinate process we create
 # v. 10.0.3 : A bit more logging on succes, and change in ending Dialog part.
@@ -59,7 +61,7 @@ installomatorOptions="BLOCKING_PROCESS_ACTION=ignore DIALOG_CMD_FILE=${dialog_co
 # PATH declaration
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-echo "$(date +%F\ %T) [LOG-BEGIN] $item"
+echo "$(date +%F\ %T) [LOG-BEGIN] $item, v$scriptVersion"
 
 dialogUpdate() {
     # $1: dialog command

--- a/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
@@ -216,7 +216,7 @@ else
                     ;;
             esac
             if [[ ! -a "${LOGO_PATH}" ]]; then
-                printlog "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
+                echo "ERROR in LOGO_PATH '${LOGO_PATH}', setting Mac App Store."
                 if [[ $(/usr/bin/sw_vers -buildVersion) > "19" ]]; then
                     LOGO_PATH="/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"
                 else

--- a/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
+++ b/MDM/App-install SS with swiftDialog and dockutil/App service SS.sh
@@ -7,8 +7,9 @@ LOGO="" # "mosyleb", "mosylem", "addigy", "microsoft", "ws1", "kandji", "filewav
 item="" # enter the software to install
 # Examples: applenyfonts, applesfarabic, applesfcompact, applesfmono, applesfpro, applesfsymbols, desktoppr, dialog, dockutil, knockknock, lulu, nomad, nudge, shield, supportapp, wordservice, xcreds, xink
 
-# Dialog icon
+# Dialog icon and overlay icon
 icon=""
+overlayicon=""
 # icon should be a file system path or an URL to an online PNG.
 # In Mosyle an URL can be found by copy picture address from a Custom Command icon.
 
@@ -18,7 +19,7 @@ appPath="/Applications/Xink.app"
 
 # Other variables
 dialog_command_file="/var/tmp/dialog.log"
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 
 installomatorOptions="BLOCKING_PROCESS_ACTION=ignore DIALOG_CMD_FILE=${dialog_command_file}" # Separated by space
@@ -124,8 +125,8 @@ if [[ $installomatorVersion -lt 10 ]] || [[ $(sw_vers -buildVersion | cut -c1-2)
 else
     installomatorNotify="NOTIFY=silent"
     # check for Swift Dialog
-    if [[ ! -d $dialogApp ]]; then
-        echo "Cannot find dialog at $dialogApp"
+    if [[ ! -x $dialogBinary ]]; then
+        echo "Cannot find dialog at $dialogBinary"
         # Install using Installlomator
         cmdOutput="$(${destFile} dialog LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"
         checkCmdOutput "${cmdOutput}"
@@ -227,15 +228,26 @@ else
     echo "icon: ${icon}"
 
     # display first screen
-    open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+    dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+    )
+
+    if [[ -n "$overlayicon" ]]; then
+        dialogCMD+=("--overlayicon" ${overlayicon})
+    fi
+
+    echo "dialogCMD: ${dialogCMD[@]}"
+
+    "${dialogCMD[@]}" &
+
+    echo "$(date +%F\ %T) : SwiftDialog started!"
 
     # give everything a moment to catch up
     sleep 0.1

--- a/MDM/Jamf/-0_Install icon for swiftDialog.sh
+++ b/MDM/Jamf/-0_Install icon for swiftDialog.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# MARK: Arguments/Parameters
+
+# Parameter 4: Custom icon for swiftDialog. Value can be a path on the client or a URL.
+icon=${4}
+
+# Parameter 5: Remove old icon (if value is `1`) or not (default `0`). Removing the icon forces a new install of swiftDialog regardless of installed version.
+removeOldIcon=${5:-0}
+
+# MARK: sanity checks
+
+# check minimal macOS requirement
+if [[ $(sw_vers -buildVersion ) < "20A" ]]; then
+    echo "This script requires at least macOS 11 Big Sur."
+    exit 98
+fi
+
+# check we are running as root
+if [[ $DEBUG -eq 0 && $(id -u) -ne 0 ]]; then
+    echo "This script should be run as root"
+    exit 97
+fi
+
+# MARK: Script
+
+# Download icon for swiftDialog
+if [[ -n $icon ]]; then
+    echo "icon defined, so downloading that for Dialog!"
+    dialogIconLocation="/Library/Application Support/Dialog/Dialog.png"
+    if [[ $removeOldIcon -eq 1 ]]; then
+        echo "Removing old icon first"
+        rm "$dialogIconLocation"
+    fi
+    echo "$(mkdir -p "/Library/Application Support/Dialog")"
+    echo "$(ls -l "/Library/Application Support/Dialog")"
+    if [ -f "$dialogIconLocation" ]; then
+        echo "swiftDialog icon already exists, so skipping this."
+    elif ! curl -fs "$icon" -o "$dialogIconLocation"; then
+        echo "ERROR downloading $icon"
+        echo "No icon logo for swiftDialog has been set."
+    else
+        echo "Icon for Dialog downloaded."
+        echo "$(ls -l "${dialogIconLocation}")"
+        INSTALL=force
+    fi
+fi

--- a/MDM/Jamf/-0_Install swiftDialog direct.sh
+++ b/MDM/Jamf/-0_Install swiftDialog direct.sh
@@ -5,12 +5,10 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 # MARK: Arguments/Parameters
 
-# Parameter 4: Custom icon web-link in png-format for swiftDialog app (if no icon is provided Self Service icon will be used)
-# Must be a link to a web image or a file system path
+# Parameter 4: Custom icon for swiftDialog. Value can be a path on the client or a URL. If no icon is provided Self Service icon will be used.
 icon=${4}
 
-# Parameter 5: Remove old icon (1) or not
-# Removing the icon forces a new install of swiftDialog regardless of installed version
+# Parameter 5: Remove old icon (if value is `1`) or not (default `0`). Removing the icon forces a new install of swiftDialog regardless of installed version.
 removeOldIcon=${5:-0}
 
 # MARK: sanity checks

--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 

--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -2,22 +2,30 @@
 
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
+
 # MARK: Arguments/Parameters
 
-# Parameter 4: path to the swiftDialog command file
+# Parameter 4: SwiftDialog command file path (`/var/tmp/dialog.log`)
 dialog_command_file=${4:-"/var/tmp/dialog.log"}
 
-# Parameter 5: message displayed over the progress bar
-message=${5:-"Self Service Progress"}
+# Parameter 5: Text shown in the swiftDialog window above the progress bar (`Installing Microsoft Office`)
+message=${5:-"Installing …"}
 
-# Parameter 6: path or URL to an icon
+# Parameter 6: Icon as Path or URL in swiftDialog, see https://rumble.com/v119x6y-harvesting-self-service-icons.html
 icon=${6:-"/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"}
 # see Dan Snelson's advice on how to get a URL to an icon in Self Service
 # https://rumble.com/v119x6y-harvesting-self-service-icons.html
 
+# Parameter 7: Overlayicon as Path or URL in swiftDialog (like a company logo) (if not configured, custom Dialog icon will be used, or Jamf Self Service icon)
+overlayicon=${7}
+
+
 # MARK: Constants
 
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
+
+echo "$(date +%F\ %T) : Installomator starting up SwiftDialog"
+
 
 # MARK: Functions
 
@@ -30,6 +38,7 @@ dialogUpdate() {
         echo "Dialog: $dcommand"
     fi
 }
+
 
 # MARK: sanity checks
 
@@ -46,28 +55,49 @@ if [[ $DEBUG -eq 0 && $(id -u) -ne 0 ]]; then
 fi
 
 # check for Swift Dialog
-if [[ ! -d $dialogApp ]]; then
-    echo "Cannot find dialog at $dialogApp"
+if [[ ! -x $dialogBinary ]]; then
+    echo "Cannot find dialog at $dialogBinary"
     exit 95
 fi
 
 
 # MARK: Configure and display swiftDialog
 
-# Use Self Service's icon for the overlayicon
-overlayicon=$( defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_app_path )
+# Determining overlayicon
+if [[ -n $overlayicon ]]; then
+    echo "overlayicon defined from script argument."
+elif [[ -f "/Library/Application Support/Dialog/Dialog.png" ]]; then
+    echo "overlayicon used from Dialog.png"
+    overlayicon="/Library/Application Support/Dialog/Dialog.png"
+else
+    overlayicon=$( defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_app_path )
+    echo "overlayicon used from Jamf Pro Self Service icon."
+fi
+
+echo "dialog_command_file: $dialog_command_file"
+echo "message: $message"
+echo "icon: $icon"
+echo "overlayicon: $overlayicon"
 
 # display first screen
-open -a "$dialogApp" --args \
-        --title none \
-        --icon "$icon" \
-        --overlayicon "$overlayicon" \
-        --message "$message" \
-        --mini \
-        --progress 100 \
-        --position bottomright \
-        --movable \
-        --commandfile "$dialog_command_file"
+dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --overlayicon "$overlayicon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+)
+
+#echo "dialogCMD: $(echo $dialogCMD | tr -s '[:blank:]')"
+echo "dialogCMD: ${dialogCMD[@]}"
+
+"${dialogCMD[@]}" &
+
+echo "$(date +%F\ %T) : SwiftDialog started!"
 
 # give everything a moment to catch up
 sleep 0.1

--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -92,7 +92,6 @@ dialogCMD=("$dialogBinary"
            --commandfile "$dialog_command_file"
 )
 
-#echo "dialogCMD: $(echo $dialogCMD | tr -s '[:blank:]')"
 echo "dialogCMD: ${dialogCMD[@]}"
 
 "${dialogCMD[@]}" &

--- a/MDM/Jamf/ReadMe.md
+++ b/MDM/Jamf/ReadMe.md
@@ -1,6 +1,6 @@
 # Display Installomator Progress with SwiftDialog in Jamf
 
-Installomator 10 has functionality to communicate with [Bart Reardon's swiftDialog](https://github.com/swiftDialog/swiftDialog). When you set the `DIALOG_CMD_FILE` variable Installomator will write progress for downloads and installation (with pkgs) to the command file which allows swiftDialog to display the progress.
+Installomator 10 has functionality to communicate with [Bart Reardon's swiftDialog](https://github.com/bartreardon/swiftDialog). When you set the `DIALOG_CMD_FILE` variable Installomator will write progress for downloads and installation (with pkgs) to the command file which allows swiftDialog to display the progress.
 
 However, you have to launch and setup swiftDialog to display a window with a progress bar before Installomator launches and also make sure swiftDialog quits after Installomator has run. This may seem complex at first but allows to configure swiftDialog just for your case without needing to modify the Installomator script.
 
@@ -18,15 +18,17 @@ Add these three scripts to your Jamf Pro and create a policy with these three sc
 
 The different scripts require a set of parameters. We will use the `googlechromepkg` label as an example.
 
-### 00_Prepare_SwiftDialog.sh
+### `00_Prepare_SwiftDialog.sh`
 
 Parameter 4: `/var/tmp/dialog.log` (Path to the swiftDialog command file)
 
 Parameter 5: `Installing Google Chrome...` (text shown in the swiftDialog window above the progress bar)
 
-Parameter 6: Path to or URL for an icon in swiftDialog. This can be a path on the client or a URL. See Dan Snelson's advice on how to get icon URLs for Self Service icons: https://rumble.com/v119x6y-harvesting-self-service-icons.html
+Parameter 6: Path to or URL for an icon in swiftDialog. Value can be a path on the client or a URL. See Dan Snelson's advice on how to get icon URLs for Self Service icons: https://rumble.com/v119x6y-harvesting-self-service-icons.html
 
-### Installomator.sh
+Parameter 7: Path to or URL for an overlay icon in swiftDialog. Could be company logo. Value can be a path on the client or a URL. If not configured, custom Dialog icon will be used, or fallback Jamf Self Service icon.
+
+### `Installomator.sh`
 
 Parameter 4: `googlechromepkg` (the label to install)
 
@@ -36,13 +38,32 @@ Parameter 6: `NOTIFY=silent` (disable Installomator notifications, optional)
 
 You can add more configurations to the Installomator script when needed.
 
-### zz_Quit_SwiftDialog.sh
+### `zz_Quit_SwiftDialog`
 
 Parameter 4: `/var/tmp/dialog.log` (the swiftDialog command file, this has to be the same value as parameter 4 in the first script)
+
+Parameter 5: Jamf recon (if value is `1`) done as part of this script, so the user gets the progress in the dialog window (default `0`)
 
 Then setup the remainder of the Jamf Policy to your needs. This works best with Self Service policies.
 
 When you run the policy, the first script will configure and display swiftDialog. Installomator.sh will download and install the app while writing the proper update commands to the file set in `DIALOG_CMD_FILE`. The final script will quit swiftDialog.
 
 ![](SelfServiceProgress.png)
+
+## Extra scripts for Jamf Pro
+
+- `-0_Install icon for swiftDialog.sh`: Will install an icon for SwiftDialog so that it will be used in notifications and as optional overlay icon
+- `-0_Install swiftDialog direct.sh`: Will directly download latest version of SwiftDialog from GitHub, and install it on the client Mac. This is great to be run periodically, like weekly
+
+### `-0_Install icon for swiftDialog.sh`
+
+Parameter 4: Custom icon for swiftDialog. Value can be a path on the client or a URL.
+
+Parameter 5: Remove old icon (if value is `1`) or not (default `0`). Removing the icon forces a new install of swiftDialog regardless of installed version.
+
+### `-0_Install swiftDialog direct.sh`
+
+Parameter 4: Custom icon for swiftDialog. Value can be a path on the client or a URL. If no icon is provided Self Service icon will be used.
+
+Parameter 5: Remove old icon (if value is `1`) or not (default `0`). Removing the icon forces a new install of swiftDialog regardless of installed version.
 

--- a/MDM/Jamf/zz_Quit_SwiftDialog.sh
+++ b/MDM/Jamf/zz_Quit_SwiftDialog.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh --no-rcs
 
 # MARK: Arguments/Parameters
 

--- a/MDM/Jamf/zz_Quit_SwiftDialog.sh
+++ b/MDM/Jamf/zz_Quit_SwiftDialog.sh
@@ -2,11 +2,15 @@
 
 # MARK: Arguments/Parameters
 
-# Parameter 4: path to the swiftDialog command file
+# Parameter 4: SwiftDialog command file path (`/var/tmp/dialog.log`)
 dialog_command_file=${4:-"/var/tmp/dialog.log"}
 
+# Parameter 5: Jamf recon (if value is `1`) done as part of this script, so the user gets the progress in the dialog window (default `0`)
+jamf_recon=${5:-"0"}
+
+
 # MARK: Constants
-dialogApp="/Library/Application Support/Dialog/Dialog.app"
+dialogBinary="/usr/local/bin/dialog"
 
 dialogUpdate() {
     # $1: dialog command
@@ -17,6 +21,10 @@ dialogUpdate() {
         echo "Dialog: $dcommand"
     fi
 }
+
+
+# MARK: sanity checks
+echo "$(date +%F\ %T) : Installomator finishing off SwiftDialog"
 
 # check minimal macOS requirement
 if [[ $(sw_vers -buildVersion ) < "20A" ]]; then
@@ -31,13 +39,24 @@ if [[ $DEBUG -eq 0 && $(id -u) -ne 0 ]]; then
 fi
 
 # check for Swift Dialog
-if [[ ! -d $dialogApp ]]; then
-    echo "Cannot find dialog at $dialogApp"
+if [[ ! -x $dialogBinary ]]; then
+    echo "Cannot find dialog at $dialogBinary"
     exit 95
 fi
 
 
+# MARK: Script
+
+# doing jamf recon in script
+if [[ $jamf_recon -eq 1 ]]; then
+    echo "$(date +%F\ %T) : Doing Jamf recon"
+    dialogUpdate "progress: 0"
+    dialogUpdate "progresstext: Reporting …"
+    jamf recon
+fi
+
 # close and quit dialog
+echo "$(date +%F\ %T) : Ending SwiftDialog"
 dialogUpdate "progress: complete"
 dialogUpdate "progresstext: Done"
 
@@ -52,6 +71,7 @@ sleep 0.5
 # just to be safe
 killall "Dialog"
 
-# the killall command above will return error when Dialog is already quit
-# but we don't want that to register as a failure in Jamf,  so always exit 0
+echo "$(date +%F\ %T) : SwiftDialog stopped!"
+
+# we don't want script to register as a failure in Jamf,  so always exit 0
 exit 0

--- a/MDM/Jamf/zz_Quit_SwiftDialog.sh
+++ b/MDM/Jamf/zz_Quit_SwiftDialog.sh
@@ -5,7 +5,7 @@
 # Parameter 4: SwiftDialog command file path (`/var/tmp/dialog.log`)
 dialog_command_file=${4:-"/var/tmp/dialog.log"}
 
-# Parameter 5: Jamf recon (if value is `1`) done as part of this script, so the user gets the progress in the dialog window (default `0`)
+# Parameter 5: Jamf recon (if value is `1`) done as part of this script, so the user gets the progress in the dialog window (default `0`) Will be skipped if Installomator did not install anything.
 jamf_recon=${5:-"0"}
 
 
@@ -46,6 +46,12 @@ fi
 
 
 # MARK: Script
+
+# Go through dialog_command_file to figure out if it did not install anything
+if grep "Latest version already installed" "$dialog_command_file"; then
+	echo "$(date +%F\ %T) : No Installomator installation happened. No Jamf recon"
+    jamf_recon=0
+fi
 
 # doing jamf recon in script
 if [[ $jamf_recon -eq 1 ]]; then


### PR DESCRIPTION
This PR fixes the MDM scripts so that the call to SwiftDialog is done to the binary in `/usr/local/bin/dialog`.

The Jamf scripts have been testet, but not the other MDM scripts.