### PR TITLE
Update autodeskfusion360admininstall.sh

### DIFF
--- a/fragments/labels/autodeskfusion360admininstall.sh
+++ b/fragments/labels/autodeskfusion360admininstall.sh
@@ -2,7 +2,7 @@ autodeskfusion360admininstall)
     name="Autodesk Fusion 360 Admin Install"
     type="pkg"
     packageID="com.autodesk.edu.fusion360"
-    downloadURL="https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20360%20Admin%20Install.pkg"
+    downloadURL="https://dl.appstreaming.autodesk.com/production/installers/Autodesk%20Fusion%20Admin%20Install.pkg"
     appNewVersion=$(curl -fs "https://dl.appstreaming.autodesk.com/production/97e6dd95735340d6ad6e222a520454db/73e72ada57b7480280f7a6f4a289729f/full.json" | sed -E 's/.*build-version":"([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+).*/\1/g')
     expectedTeamID="XXKJ396S2Y"
     appName="Autodesk Fusion 360.app"


### PR DESCRIPTION
Update Fusion 360 Admin Install - The previous URL was redirecting to the Fusion 360 Client Install.

Verified appNewVersion is still correct.

In regards to #1460 