### PR TITLE
Update macadminspython Team ID

### DIFF
--- a/fragments/labels/macadminspython.sh
+++ b/fragments/labels/macadminspython.sh
@@ -4,6 +4,6 @@ macadminspython)
     packageID="org.macadmins.python.recommended"
     downloadURL=$(curl --silent --fail "https://api.github.com/repos/macadmins/python/releases/latest" | awk -F '"' "/browser_download_url/ && /python_recommended_signed/ { print \$4; exit }")
     appNewVersion=$(grep -o -E '\d+\.\d+\.\d+\.\d+' <<< $downloadURL | head -n 1)
-    expectedTeamID="9GQZ7KUFR6"
+    expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
The team ID of the macadminspython package is incorrect and causes Installomator to fail.