### PR TITLE
New label expressvpn

### DIFF
--- a/fragments/labels/expressvpn.sh
+++ b/fragments/labels/expressvpn.sh
@@ -1,0 +1,9 @@
+expressvpn)
+    name="ExpressVPN"
+    type="pkg"
+    packageID="com.expressvpn.ExpressVPN"
+    downloadURL="https://www.expressvpn.com/clients/latest/mac"
+    appNewVersion="$(curl -fsIL https://www.expressvpn.com/clients/latest/mac | grep -i ^location | sed -n -e 's/^\(.*\)\(_release\)\(.*\)$/\3\2\1/p' | sed -n -e 's/^.*mac_//p')"
+    expectedTeamID="VMES9GFUQJ"
+    blockingProcesses=( "ExpressVPN" )
+    ;;

--- a/fragments/labels/expressvpn.sh
+++ b/fragments/labels/expressvpn.sh
@@ -5,5 +5,4 @@ expressvpn)
     downloadURL="https://www.expressvpn.com/clients/latest/mac"
     appNewVersion="$(curl -fsIL https://www.expressvpn.com/clients/latest/mac | grep -i ^location | sed -n -e 's/^\(.*\)\(_release\)\(.*\)$/\3\2\1/p' | sed -n -e 's/^.*mac_//p')"
     expectedTeamID="VMES9GFUQJ"
-    blockingProcesses=( "ExpressVPN" )
     ;;


### PR DESCRIPTION
Output of: Installomator/utils/assemble.sh expressvpn DEBUG=0

2024-02-14 10:46:13 : REQ   : expressvpn : ################## Start Installomator v. 10.6beta, date 2024-02-14
2024-02-14 10:46:13 : INFO  : expressvpn : ################## Version: 10.6beta
2024-02-14 10:46:13 : INFO  : expressvpn : ################## Date: 2024-02-14
2024-02-14 10:46:13 : INFO  : expressvpn : ################## expressvpn
2024-02-14 10:46:13 : DEBUG : expressvpn : DEBUG mode 1 enabled.
2024-02-14 10:46:13 : INFO  : expressvpn : SwiftDialog is not installed, clear cmd file var
2024-02-14 10:46:14 : INFO  : expressvpn : setting variable from argument DEBUG=0
2024-02-14 10:46:14 : DEBUG : expressvpn : name=ExpressVPN
2024-02-14 10:46:14 : DEBUG : expressvpn : appName=
2024-02-14 10:46:14 : DEBUG : expressvpn : type=pkg
2024-02-14 10:46:14 : DEBUG : expressvpn : archiveName=
2024-02-14 10:46:14 : DEBUG : expressvpn : downloadURL=https://www.expressvpn.com/clients/latest/mac
2024-02-14 10:46:14 : DEBUG : expressvpn : curlOptions=
2024-02-14 10:46:14 : DEBUG : expressvpn : appNewVersion=11.51.0.80076
2024-02-14 10:46:14 : DEBUG : expressvpn : appCustomVersion function: Not defined
2024-02-14 10:46:14 : DEBUG : expressvpn : versionKey=CFBundleShortVersionString
2024-02-14 10:46:14 : DEBUG : expressvpn : packageID=com.expressvpn.ExpressVPN
2024-02-14 10:46:14 : DEBUG : expressvpn : pkgName=
2024-02-14 10:46:14 : DEBUG : expressvpn : choiceChangesXML=
2024-02-14 10:46:14 : DEBUG : expressvpn : expectedTeamID=VMES9GFUQJ
2024-02-14 10:46:14 : DEBUG : expressvpn : blockingProcesses=ExpressVPN
2024-02-14 10:46:14 : DEBUG : expressvpn : installerTool=
2024-02-14 10:46:14 : DEBUG : expressvpn : CLIInstaller=
2024-02-14 10:46:14 : DEBUG : expressvpn : CLIArguments=
2024-02-14 10:46:14 : DEBUG : expressvpn : updateTool=
2024-02-14 10:46:14 : DEBUG : expressvpn : updateToolArguments=
2024-02-14 10:46:15 : DEBUG : expressvpn : updateToolRunAsCurrentUser=
2024-02-14 10:46:15 : INFO  : expressvpn : BLOCKING_PROCESS_ACTION=tell_user
2024-02-14 10:46:15 : INFO  : expressvpn : NOTIFY=success
2024-02-14 10:46:15 : INFO  : expressvpn : LOGGING=DEBUG
2024-02-14 10:46:15 : INFO  : expressvpn : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-14 10:46:15 : INFO  : expressvpn : Label type: pkg
2024-02-14 10:46:15 : INFO  : expressvpn : archiveName: ExpressVPN.pkg
2024-02-14 10:46:15 : DEBUG : expressvpn : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD
2024-02-14 10:46:15 : INFO  : expressvpn : found packageID com.expressvpn.ExpressVPN installed, version 	<string>11.51.0 (80076)</string>
2024-02-14 10:46:15 : INFO  : expressvpn : appversion: 	<string>11.51.0 (80076)</string>
2024-02-14 10:46:15 : INFO  : expressvpn : Latest version of ExpressVPN is 11.51.0.80076
2024-02-14 10:46:15 : REQ   : expressvpn : Downloading https://www.expressvpn.com/clients/latest/mac to ExpressVPN.pkg
2024-02-14 10:46:15 : DEBUG : expressvpn : No Dialog connection, just download
2024-02-14 10:46:24 : DEBUG : expressvpn : File list: -rw-r--r--  1 root  wheel    62M Feb 14 10:46 ExpressVPN.pkg
2024-02-14 10:46:24 : DEBUG : expressvpn : File type: ExpressVPN.pkg: xar archive compressed TOC: 11489, SHA-1 checksum
2024-02-14 10:46:24 : DEBUG : expressvpn : curl output was:
*   Trying 65.9.55.122:443...
* Connected to www.expressvpn.com (65.9.55.122) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4975 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=expressvpn.com
*  start date: Nov 12 00:00:00 2023 GMT
*  expire date: Dec 11 23:59:59 2024 GMT
*  subjectAltName: host "www.expressvpn.com" matched cert's "www.expressvpn.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.expressvpn.com/clients/latest/mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.expressvpn.com]
* [HTTP/2] [1] [:path: /clients/latest/mac]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /clients/latest/mac HTTP/2
> Host: www.expressvpn.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< content-type: text/html; charset=utf-8
< location: https://www.expressvpn.works/clients/mac/expressvpn_mac_11.51.0.80076_release.pkg < date: Wed, 14 Feb 2024 09:46:16 GMT
< server: nginx
< cache-control: no-cache
< set-cookie: landing_page=https%3A%2F%2Fwww.expressvpn.com%2Fclients%2Flatest%2Fmac; path=/; expires=Fri, 14 Feb 2025 09:46:16 -0000; secure; HttpOnly; SameSite=Lax < set-cookie: xvid=WeBh0ZKHo0ZpyfJVJ_1aHiuiy2SbwiA8eJboAElB-Eg%3D; path=/; expires=Fri, 14 Feb 2025 09:46:16 -0000; secure; SameSite=Lax < set-cookie: xvgtm=%7B%22location%22%3A%22SE%22%2C%22logged_in%22%3Afalse%2C%22report_aid_to_ga%22%3Afalse%7D; path=/; secure; SameSite=Lax < x-request-id: d74a3284-d6c8-4af4-8e4a-b96a8342066c < x-runtime: 0.014491
< strict-transport-security: max-age=31536000; includeSubDomains; preload < x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< referrer-policy: no-referrer-when-downgrade
< x-frame-options: SAMEORIGIN
< x-cache: Miss from cloudfront
< via: 1.1 d30a7800f939c215cded21c657c43fc8.cloudfront.net (CloudFront) < x-amz-cf-pop: ARN54-C1
< x-amz-cf-id: LhdVm73TgCeQ8eG34VwraLdHzTrHujC8ybYBu8rPwGSx3etseM9Fcw== <
* Ignoring the response-body { [147 bytes data]
* Connection #0 to host www.expressvpn.com left intact
* Issue another request to this URL: 'https://www.expressvpn.works/clients/mac/expressvpn_mac_11.51.0.80076_release.pkg'
*   Trying 108.157.229.40:443...
* Connected to www.expressvpn.works (108.157.229.40) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4978 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=expressvpn.works
*  start date: Nov 12 00:00:00 2023 GMT
*  expire date: Dec 11 23:59:59 2024 GMT
*  subjectAltName: host "www.expressvpn.works" matched cert's "www.expressvpn.works"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.expressvpn.works/clients/mac/expressvpn_mac_11.51.0.80076_release.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.expressvpn.works]
* [HTTP/2] [1] [:path: /clients/mac/expressvpn_mac_11.51.0.80076_release.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /clients/mac/expressvpn_mac_11.51.0.80076_release.pkg HTTP/2
> Host: www.expressvpn.works
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/x-newton-compatible-pkg < content-length: 65218757
< date: Wed, 14 Feb 2024 09:46:17 GMT
< last-modified: Thu, 08 Feb 2024 02:14:40 GMT
< etag: "609aeea92b2056ae0ac2aab1fcd60c21"
< x-amz-server-side-encryption: AES256
< x-amz-meta-md5: 609aeea92b2056ae0ac2aab1fcd60c21 < x-amz-meta-sha256: 74889c5b9dcb9636a5f085761c6e6f609b59d6351c5642c5e8cf35438fae1806 < content-disposition: attachment
< x-amz-version-id: K9USzV1ZmX6nRVEg2N1h75hS5dERYhl0 < accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 917c6054ae6e10a98fc566c655129e8a.cloudfront.net (CloudFront) < x-amz-cf-pop: ARN56-P2
< x-amz-cf-id: -4qr_PMqqhlwFKi_jacWCv0yFpm2Za8Rjfu3Rb5mT6a6hiyuN0Svvg== <
{ [1262 bytes data]
* Connection #1 to host www.expressvpn.works left intact
2024-02-14 10:46:25 : REQ   : expressvpn : no more blocking processes, continue with update
2024-02-14 10:46:25 : REQ   : expressvpn : Installing ExpressVPN
2024-02-14 10:46:25 : INFO  : expressvpn : Verifying: ExpressVPN.pkg
2024-02-14 10:46:25 : DEBUG : expressvpn : File list: -rw-r--r--  1 root  wheel    62M Feb 14 10:46 ExpressVPN.pkg
2024-02-14 10:46:25 : DEBUG : expressvpn : File type: ExpressVPN.pkg: xar archive compressed TOC: 11489, SHA-1 checksum
2024-02-14 10:46:25 : DEBUG : expressvpn : spctlOut is ExpressVPN.pkg: accepted
2024-02-14 10:46:25 : DEBUG : expressvpn : source=Notarized Developer ID
2024-02-14 10:46:25 : DEBUG : expressvpn : origin=Developer ID Installer: ExprsVPN LLC (VMES9GFUQJ)
2024-02-14 10:46:25 : INFO  : expressvpn : Team ID: VMES9GFUQJ (expected: VMES9GFUQJ )
2024-02-14 10:46:25 : INFO  : expressvpn : Checking package version.
2024-02-14 10:46:26 : INFO  : expressvpn : Downloaded package com.expressvpn.ExpressVPN version 11.51.0 (80076)
2024-02-14 10:46:26 : INFO  : expressvpn : Installing ExpressVPN.pkg to /
2024-02-14 10:46:39 : DEBUG : expressvpn : Debugging enabled, installer output was:
Feb 14 10:46:26  installer[7871] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg trustLevel=350
Feb 14 10:46:27  installer[7871] <Debug>: External component packages (1) trustLevel=350
Feb 14 10:46:27  installer[7871] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Feb 14 10:46:27  installer[7871] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg#ExpressVPN.pkg
Feb 14 10:46:27  installer[7871] <Info>: Set authorization level to root for session
Feb 14 10:46:27  installer[7871] <Info>: Authorization is being checked, waiting until authorization arrives.
Feb 14 10:46:27  installer[7871] <Info>: Administrator authorization granted.
Feb 14 10:46:27  installer[7871] <Info>: Packages have been authorized for installation.
Feb 14 10:46:27  installer[7871] <Debug>: Will use PK session
Feb 14 10:46:27  installer[7871] <Debug>: Using authorization level of root for IFPKInstallElement
Feb 14 10:46:27  installer[7871] <Info>: Starting installation:
Feb 14 10:46:27  installer[7871] <Notice>: Configuring volume "Macintosh HD"
Feb 14 10:46:27  installer[7871] <Info>: Preparing disk for local booted install.
Feb 14 10:46:27  installer[7871] <Notice>: Free space on "Macintosh HD": 203,37 GB (203368292352 bytes).
Feb 14 10:46:27  installer[7871] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.7871BORyGj"
Feb 14 10:46:27  installer[7871] <Notice>: IFPKInstallElement (1 packages)
Feb 14 10:46:27  installer[7871] <Info>: Current Path: /usr/sbin/installer
Feb 14 10:46:27  installer[7871] <Info>: Current Path: /bin/zsh
Feb 14 10:46:27  installer[7871] <Info>: Current Path: /usr/bin/sudo
Feb 14 10:46:27  installer[7871] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is ExpressVPN
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing ExpressVPN….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#Feb 14 10:46:38  installer[7871] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN%20Launcher.app/ for uid 0
Feb 14 10:46:38  installer[7871] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN%20IKEv2.app/ for uid 0
Feb 14 10:46:38  installer[7871] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/ for uid 0
installer: Running package scripts….....
Last Log repeated 13 times
installer: Validating packages….....
#Feb 14 10:46:38  installer[7871] <Notice>: Running install actions
Feb 14 10:46:38  installer[7871] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.7871BORyGj"
Feb 14 10:46:38  installer[7871] <Notice>: Finalize disk "Macintosh HD"
Feb 14 10:46:38  installer[7871] <Notice>: Notifying system of updated components
Feb 14 10:46:38  installer[7871] <Notice>:
Feb 14 10:46:38  installer[7871] <Notice>: **** Summary Information ****
Feb 14 10:46:38  installer[7871] <Notice>:   Operation      Elapsed time
Feb 14 10:46:38  installer[7871] <Notice>: -----------------------------
Feb 14 10:46:38  installer[7871] <Notice>:        disk      0.01 seconds
Feb 14 10:46:38  installer[7871] <Notice>:      script      0.00 seconds
Feb 14 10:46:38  installer[7871] <Notice>:        zero      0.00 seconds
Feb 14 10:46:38  installer[7871] <Notice>:     install      11.16 seconds
Feb 14 10:46:38  installer[7871] <Notice>:     -total-      11.18 seconds
Feb 14 10:46:38  installer[7871] <Notice>:
installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-02-14 10:46:26+01 C02DRJ2FML7H installer[7871]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg trustLevel=350
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: External component packages (1) trustLevel=350
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg#ExpressVPN.pkg
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Set authorization level to root for session
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Authorization is being checked, waiting until authorization arrives.
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Administrator authorization granted.
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Packages have been authorized for installation.
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Will use PK session
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Using authorization level of root for IFPKInstallElement
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Starting installation:
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Configuring volume "Macintosh HD"
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Preparing disk for local booted install.
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Free space on "Macintosh HD": 203,37 GB (203368292352 bytes).
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.7871BORyGj"
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: IFPKInstallElement (1 packages)
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Current Path: /usr/sbin/installer
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Current Path: /bin/zsh
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: Current Path: /usr/bin/sudo
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: Adding client PKInstallDaemonClient pid=7871, uid=0 (/usr/sbin/installer)
2024-02-14 10:46:27+01 C02DRJ2FML7H installer[7871]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: Set reponsibility for install to 7322
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: Hosted team responsibility for install set to team:(VMES9GFUQJ)
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: ----- Begin install -----
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: packages=(
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: Will do receipt-based obsoleting for package identifier com.expressvpn.ExpressVPN (prefix path=Applications)
2024-02-14 10:46:27+01 C02DRJ2FML7H installd[1031]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg#ExpressVPN.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/655368B2-E643-4243-A44A-58C8B3313734.activeSandbox/Root/Applications, uid=0)
2024-02-14 10:46:29+01 C02DRJ2FML7H installd[1031]: PackageKit: prevent user idle system sleep
2024-02-14 10:46:29+01 C02DRJ2FML7H installd[1031]: PackageKit: suspending backupd
2024-02-14 10:46:29+01 C02DRJ2FML7H installd[1031]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:29+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:29+01 C02DRJ2FML7H package_script_service[18479]: Set responsibility to pid: 7322, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-02-14 10:46:29+01 C02DRJ2FML7H package_script_service[18479]: Hosted team responsibility for script set to team:(VMES9GFUQJ)
2024-02-14 10:46:29+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:29+01 C02DRJ2FML7H install_monitor[7872]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Hosted team responsible for script has been cleared.
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: Responsibility set back to self.
2024-02-14 10:46:30+01 C02DRJ2FML7H installd[1031]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/655368B2-E643-4243-A44A-58C8B3313734.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/655368B2-E643-4243-A44A-58C8B3313734.activeSandbox
2024-02-14 10:46:30+01 C02DRJ2FML7H installd[1031]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/655368B2-E643-4243-A44A-58C8B3313734.activeSandbox/Root (1 items) to /
2024-02-14 10:46:30+01 C02DRJ2FML7H installd[1031]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: Set responsibility to pid: 7322, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: Hosted team responsibility for script set to team:(VMES9GFUQJ)
2024-02-14 10:46:30+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.z8kCzr/Scripts/com.expressvpn.ExpressVPN.B15BCy
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Lightway: 1.43.1
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: library versions:
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall:   Lightway Core: 1.16.1
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall:   WolfSSL: 5.6.6
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall:   Balloon: 1.23.1
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Copyright (C) 2009-2024 ExpressVPN. All rights reserved.
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: OpenVPN 2.4.7 [git:production/72431482784367ad] x86_64-apple-darwin21.4.0 [SSL (OpenSSL)] [MH/RECVDA] [AEAD] built on Feb  8 2023
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: library versions: OpenSSL 1.1.1t  7 Feb 2023
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Originally developed by James Yonan
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Copyright (C) 2002-2018 OpenVPN Inc <sales@openvpn.net>
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Compile time defines: enable_async_push=no enable_comp_stub=no enable_crypto=yes enable_crypto_ofb_cfb=yes enable_debug=no enable_def_auth=yes enable_dependency_tracking=no enable_dlopen=unknown enable_dlopen_self=unknown enable_dlopen_self_static=unknown enable_fast_install=needless enable_fragment=yes enable_iproute2=no enable_libtool_lock=yes enable_lz4=no enable_lzo=no enable_management=yes enable_multihome=yes enable_pam_dlopen=no enable_pedantic=no enable_pf=no enable_pkcs11=no enable_plugin_auth_pam=no enable_plugin_down_root=no enable_plugins=no enable_port_share=yes enable_selinux=no enable_server=no enable_shared=no enable_shared_with_static_runtimes=no enable_small=no enable_static=yes enable_strict=no enable_strict_options=no enable_systemd=no enable_werror=no enable_win32_dll=yes enable_x509_alt_username=no with_aix_soname=aix with_crypto_library=openssl with_gnu_ld=no with_mem_check=no with_sysroot=no
2024-02-14 10:46:36+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: The application is already a part of the firewall
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Incoming connection to the application is permitted
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: The application is already a part of the firewall
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Incoming connection to the application is permitted
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: The application is already a part of the firewall
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: Incoming connection to the application is permitted
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: 2024-02-14 10:46:37.310 defaults[7998:1172435]
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: The domain/default pair of (com.expressvpn.ExpressVPN, enableXVCA) does not exist
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: 2024-02-14 10:46:37.347 defaults[8000:1172441]
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: ./postinstall: The domain/default pair of (com.expressvpn.ExpressVPN, launchOnStartup) does not exist
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: PackageKit: Hosted team responsible for script has been cleared.
2024-02-14 10:46:37+01 C02DRJ2FML7H package_script_service[18479]: Responsibility set back to self.
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Writing receipt for com.expressvpn.ExpressVPN to /
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Touched bundle /Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN Launcher.app
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Touched bundle /Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN IKEv2.app
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Touched bundle /Applications/ExpressVPN.app
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: Installed "ExpressVPN" ()
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-02-14 10:46:37+01 C02DRJ2FML7H install_monitor[7872]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: releasing backupd
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: allow user idle system sleep
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: ----- End install -----
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: 10.6s elapsed install time
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Cleared responsibility for install from 7871.
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Hosted team responsible for install has been cleared.
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Running idle tasks
2024-02-14 10:46:37+01 C02DRJ2FML7H installd[1031]: PackageKit: Done with sandbox removals
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN%20Launcher.app/ for uid 0
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN%20IKEv2.app/ for uid 0
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/ for uid 0
2024-02-14 10:46:38+01 C02DRJ2FML7H installd[1031]: PackageKit: Removing client PKInstallDaemonClient pid=7871, uid=0 (/usr/sbin/installer)
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: Running install actions
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.7871BORyGj"
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: Finalize disk "Macintosh HD"
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: Notifying system of updated components
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: **** Summary Information ****
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:   Operation      Elapsed time
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]: -----------------------------
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:        disk      0.01 seconds
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:      script      0.00 seconds
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:        zero      0.00 seconds
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:     install      11.16 seconds
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:     -total-      11.18 seconds
2024-02-14 10:46:38+01 C02DRJ2FML7H installer[7871]:
2024-02-14 10:46:39 : INFO  : expressvpn : Finishing...
2024-02-14 10:46:42 : INFO  : expressvpn : found packageID com.expressvpn.ExpressVPN installed, version 	<string>11.51.0 (80076)</string>
2024-02-14 10:46:43 : REQ   : expressvpn : Installed ExpressVPN, version 11.51.0 (80076)
2024-02-14 10:46:43 : INFO  : expressvpn : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-14 10:46:43 : DEBUG : expressvpn : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD
2024-02-14 10:46:43 : DEBUG : expressvpn : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD/ExpressVPN.pkg
2024-02-14 10:46:43 : DEBUG : expressvpn : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NmtS5YdPdD
2024-02-14 10:46:43 : INFO  : expressvpn : Installomator did not close any apps, so no need to reopen any apps.
2024-02-14 10:46:43 : REQ   : expressvpn : All done!
2024-02-14 10:46:43 : REQ   : expressvpn : ################## End Installomator, exit code 0