### PR TITLE
New label :  Network Share Mounter

### DIFF
--- a/fragments/labels/networksharemounter.sh
+++ b/fragments/labels/networksharemounter.sh
@@ -1,0 +1,8 @@
+networksharemounter)
+    name="NetworkShareMounter"
+    type="pkg"
+    packageID="de.fau.rrze.NetworkShareMounter"
+    appNewVersion=$(curl -sfL https://gitlab.rrze.fau.de/api/v4/projects/506/releases | grep -o 'release-[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n 1)
+    downloadURL=$(curl -sfL "https://gitlab.rrze.fau.de/api/v4/projects/506/releases/release-$appNewVersion/assets/links/" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_%:-]*.pkg' | head -n 1)
+    expectedTeamID="C8F68RFW4L"
+    ;;


### PR DESCRIPTION
App to mount network shares at login or on network state changes.

```
./assemble.sh:108: no matches found: /Users/mro/Documents/InstallomatorLabels//*.sh
2024-02-14 15:02:53 : REQ   : networksharemounter : ################## Start Installomator v. 10.6beta, date 2024-02-14
2024-02-14 15:02:53 : INFO  : networksharemounter : ################## Version: 10.6beta
2024-02-14 15:02:53 : INFO  : networksharemounter : ################## Date: 2024-02-14
2024-02-14 15:02:53 : INFO  : networksharemounter : ################## networksharemounter
2024-02-14 15:02:53 : DEBUG : networksharemounter : DEBUG mode 1 enabled.
2024-02-14 15:02:53 : INFO  : networksharemounter : SwiftDialog is not installed, clear cmd file var
2024-02-14 15:02:53 : INFO  : networksharemounter : setting variable from argument NOTIFY=silent
2024-02-14 15:02:53 : INFO  : networksharemounter : setting variable from argument DEBUG=0
2024-02-14 15:02:53 : DEBUG : networksharemounter : name=NetworkShareMounter
2024-02-14 15:02:53 : DEBUG : networksharemounter : appName=
2024-02-14 15:02:53 : DEBUG : networksharemounter : type=pkg
2024-02-14 15:02:53 : DEBUG : networksharemounter : archiveName=
2024-02-14 15:02:53 : DEBUG : networksharemounter : downloadURL=https://gitlab.rrze.fau.de/api/v4/projects/506/packages/generic/networksharemounter/release-3.0.2/NetworkShareMounter-3.0.2.pkg
2024-02-14 15:02:53 : DEBUG : networksharemounter : curlOptions=
2024-02-14 15:02:53 : DEBUG : networksharemounter : appNewVersion=3.0.2
2024-02-14 15:02:53 : DEBUG : networksharemounter : appCustomVersion function: Not defined
2024-02-14 15:02:53 : DEBUG : networksharemounter : versionKey=CFBundleShortVersionString
2024-02-14 15:02:53 : DEBUG : networksharemounter : packageID=de.fau.rrze.NetworkShareMounter
2024-02-14 15:02:53 : DEBUG : networksharemounter : pkgName=
2024-02-14 15:02:53 : DEBUG : networksharemounter : choiceChangesXML=
2024-02-14 15:02:53 : DEBUG : networksharemounter : expectedTeamID=C8F68RFW4L
2024-02-14 15:02:53 : DEBUG : networksharemounter : blockingProcesses=
2024-02-14 15:02:53 : DEBUG : networksharemounter : installerTool=
2024-02-14 15:02:53 : DEBUG : networksharemounter : CLIInstaller=
2024-02-14 15:02:53 : DEBUG : networksharemounter : CLIArguments=
2024-02-14 15:02:53 : DEBUG : networksharemounter : updateTool=
2024-02-14 15:02:53 : DEBUG : networksharemounter : updateToolArguments=
2024-02-14 15:02:53 : DEBUG : networksharemounter : updateToolRunAsCurrentUser=
2024-02-14 15:02:54 : INFO  : networksharemounter : BLOCKING_PROCESS_ACTION=tell_user
2024-02-14 15:02:54 : INFO  : networksharemounter : NOTIFY=silent
2024-02-14 15:02:54 : INFO  : networksharemounter : LOGGING=DEBUG
2024-02-14 15:02:54 : INFO  : networksharemounter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-14 15:02:54 : INFO  : networksharemounter : Label type: pkg
2024-02-14 15:02:54 : INFO  : networksharemounter : archiveName: NetworkShareMounter.pkg
2024-02-14 15:02:54 : INFO  : networksharemounter : no blocking processes defined, using NetworkShareMounter as default
2024-02-14 15:02:54 : DEBUG : networksharemounter : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ
2024-02-14 15:02:54 : INFO  : networksharemounter : No version found using packageID de.fau.rrze.NetworkShareMounter
2024-02-14 15:02:54 : INFO  : networksharemounter : name: NetworkShareMounter, appName: NetworkShareMounter.app
2024-02-14 15:02:54.184 mdfind[77020:525709] [UserQueryParser] Loading keywords and predicates for locale "fr_CH"
2024-02-14 15:02:54.186 mdfind[77020:525709] [UserQueryParser] Loading keywords and predicates for locale "fr"
2024-02-14 15:02:54.260 mdfind[77020:525709] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-14 15:02:54.260 mdfind[77020:525709] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-14 15:02:54 : WARN  : networksharemounter : No previous app found
2024-02-14 15:02:54 : WARN  : networksharemounter : could not find NetworkShareMounter.app
2024-02-14 15:02:54 : INFO  : networksharemounter : appversion:
2024-02-14 15:02:54 : INFO  : networksharemounter : Latest version of NetworkShareMounter is 3.0.2
2024-02-14 15:02:54 : REQ   : networksharemounter : Downloading https://gitlab.rrze.fau.de/api/v4/projects/506/packages/generic/networksharemounter/release-3.0.2/NetworkShareMounter-3.0.2.pkg to NetworkShareMounter.pkg
2024-02-14 15:02:54 : DEBUG : networksharemounter : No Dialog connection, just download
2024-02-14 15:02:54 : DEBUG : networksharemounter : File list: -rw-r--r--  1 root  wheel   1.7M Feb 14 15:02 NetworkShareMounter.pkg
2024-02-14 15:02:54 : DEBUG : networksharemounter : File type: NetworkShareMounter.pkg: xar archive compressed TOC: 4535, SHA-1 checksum
2024-02-14 15:02:54 : DEBUG : networksharemounter : curl output was:
*   Trying 131.188.3.147:443...
* Connected to gitlab.rrze.fau.de (131.188.3.147) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5397 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: C=DE; ST=Bayern; O=Friedrich-Alexander-Universitt Erlangen-Nrnberg; CN=gitlab.rrze.fau.de
*  start date: Sep 30 00:00:00 2023 GMT
*  expire date: Sep 29 23:59:59 2024 GMT
*  subjectAltName: host "gitlab.rrze.fau.de" matched cert's "gitlab.rrze.fau.de"
*  issuer: C=NL; O=GEANT Vereniging; CN=GEANT OV RSA CA 4
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: gitlab.rrze.fau.de]
* h2 [:path: /api/v4/projects/506/packages/generic/networksharemounter/release-3.0.2/NetworkShareMounter-3.0.2.pkg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7fbb7900a800)
> GET /api/v4/projects/506/packages/generic/networksharemounter/release-3.0.2/NetworkShareMounter-3.0.2.pkg HTTP/2
> Host: gitlab.rrze.fau.de
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< server: nginx
< date: Wed, 14 Feb 2024 14:02:54 GMT
< content-type: application/octet-stream
< content-length: 1821228
< accept-ranges: bytes
< cache-control: max-age=0, private, must-revalidate
< content-disposition: attachment; filename="NetworkShareMounter-3.0.2.pkg"; filename*=UTF-8''NetworkShareMounter-3.0.2.pkg
< content-transfer-encoding: binary
< etag: W/"12ae32cb1ec02d01eda3581b127c1fee"
< last-modified: Tue, 13 Feb 2024 11:32:08 GMT
< vary: Origin
< x-content-type-options: nosniff
< x-frame-options: SAMEORIGIN
< x-gitlab-meta: {"correlation_id":"01HPKYTY2H8K3XYGACS3RCE7QE","version":"1"}
< x-request-id: 01HPKYTY2H8K3XYGACS3RCE7QE
< x-runtime: 0.045243
< strict-transport-security: max-age=63072000
< referrer-policy: strict-origin-when-cross-origin
<
{ [11586 bytes data]
* Connection #0 to host gitlab.rrze.fau.de left intact

2024-02-14 15:02:54 : REQ   : networksharemounter : no more blocking processes, continue with update
2024-02-14 15:02:54 : REQ   : networksharemounter : Installing NetworkShareMounter
2024-02-14 15:02:54 : INFO  : networksharemounter : Verifying: NetworkShareMounter.pkg
2024-02-14 15:02:54 : DEBUG : networksharemounter : File list: -rw-r--r--  1 root  wheel   1.7M Feb 14 15:02 NetworkShareMounter.pkg
2024-02-14 15:02:54 : DEBUG : networksharemounter : File type: NetworkShareMounter.pkg: xar archive compressed TOC: 4535, SHA-1 checksum
2024-02-14 15:02:54 : DEBUG : networksharemounter : spctlOut is NetworkShareMounter.pkg: accepted
2024-02-14 15:02:54 : DEBUG : networksharemounter : source=Notarized Developer ID
2024-02-14 15:02:54 : DEBUG : networksharemounter : origin=Developer ID Installer: Universitaet Erlangen-Nuernberg RRZE (C8F68RFW4L)
2024-02-14 15:02:55 : INFO  : networksharemounter : Team ID: C8F68RFW4L (expected: C8F68RFW4L )
2024-02-14 15:02:55 : INFO  : networksharemounter : Installing NetworkShareMounter.pkg to /
2024-02-14 15:02:58 : DEBUG : networksharemounter : Debugging enabled, installer output was:
Feb 14 15:02:55  installer[77111] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg trustLevel=350
Feb 14 15:02:55  installer[77111] <Debug>: External component packages (1) trustLevel=350
Feb 14 15:02:55  installer[77111] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Feb 14 15:02:55  installer[77111] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg#de.fau.rrze.NetworkShareMounter.pkg
Feb 14 15:02:55  installer[77111] <Info>: Set authorization level to root for session
Feb 14 15:02:55  installer[77111] <Info>: Authorization is being checked, waiting until authorization arrives.
Feb 14 15:02:55  installer[77111] <Info>: Administrator authorization granted.
Feb 14 15:02:55  installer[77111] <Info>: Packages have been authorized for installation.
Feb 14 15:02:55  installer[77111] <Debug>: Will use PK session
Feb 14 15:02:55  installer[77111] <Debug>: Using authorization level of root for IFPKInstallElement
Feb 14 15:02:55  installer[77111] <Info>: Starting installation:
Feb 14 15:02:55  installer[77111] <Notice>: Configuring volume "Macintosh HD"
Feb 14 15:02:55  installer[77111] <Info>: Preparing disk for local booted install.
Feb 14 15:02:55  installer[77111] <Notice>: Free space on "Macintosh HD": 471.76 Go (471756570624 bytes).
Feb 14 15:02:55  installer[77111] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.77111O3tHUZ"
Feb 14 15:02:55  installer[77111] <Notice>: IFPKInstallElement (1 packages)
Feb 14 15:02:55  installer[77111] <Info>: Current Path: /usr/sbin/installer
Feb 14 15:02:55  installer[77111] <Info>: Current Path: /bin/zsh
Feb 14 15:02:55  installer[77111] <Info>: Current Path: /usr/bin/sudo
Feb 14 15:02:55  installer[77111] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Network Share Mounter
installer: Installing at base path /
installer: Préparation à l’installation….....
installer: Préparation du disque….....
installer: Préparation de Network Share Mounter….....
installer: Attente de la fin des autres installations….....
installer: Configuration de l’installation….....
installer:
#Feb 14 15:02:56  installer[77111] <Info>: PackageKit: Registered bundle file:///Applications/Network%20Share%20Mounter.app/ for uid 0
Feb 14 15:02:56  installer[77111] <Info>: PackageKit: Registered bundle file:///Applications/Network%20Share%20Mounter.app/Contents/Library/LoginItems/LaunchAtLoginHelper.app/ for uid 0

installer: Validation des paquets….....
#Feb 14 15:02:56  installer[77111] <Notice>: Running install actions
Feb 14 15:02:56  installer[77111] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.77111O3tHUZ"
Feb 14 15:02:56  installer[77111] <Notice>: Finalize disk "Macintosh HD"
Feb 14 15:02:56  installer[77111] <Notice>: Notifying system of updated components
Feb 14 15:02:56  installer[77111] <Notice>:
Feb 14 15:02:56  installer[77111] <Notice>: **** Summary Information ****
Feb 14 15:02:56  installer[77111] <Notice>:   Operation      Elapsed time
Feb 14 15:02:56  installer[77111] <Notice>: -----------------------------
Feb 14 15:02:56  installer[77111] <Notice>:        disk      0.02 seconds
Feb 14 15:02:56  installer[77111] <Notice>:      script      0.00 seconds
Feb 14 15:02:56  installer[77111] <Notice>:        zero      0.00 seconds
Feb 14 15:02:56  installer[77111] <Notice>:     install      1.09 seconds
Feb 14 15:02:56  installer[77111] <Notice>:     -total-      1.11 seconds
Feb 14 15:02:56  installer[77111] <Notice>:

installer:      Exécution des actions du programme d’installation…
installer:
installer: Fin de l’installation….....
installer:
#
installer: Le logiciel a été installé avec succès......
installer: The install was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg trustLevel=350
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: External component packages (1) trustLevel=350
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg#de.fau.rrze.NetworkShareMounter.pkg
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Set authorization level to root for session
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Authorization is being checked, waiting until authorization arrives.
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Administrator authorization granted.
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Packages have been authorized for installation.
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Will use PK session
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Using authorization level of root for IFPKInstallElement
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Starting installation:
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Configuring volume "Macintosh HD"
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Preparing disk for local booted install.
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Free space on "Macintosh HD": 471.76 Go (471756570624 bytes).
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.77111O3tHUZ"
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: IFPKInstallElement (1 packages)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Current Path: /usr/sbin/installer
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: Current Path: /usr/bin/sudo
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Adding client PKInstallDaemonClient pid=77111, uid=0 (/usr/sbin/installer)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installer[77111]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Set reponsibility for install to 77111
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Hosted team responsibility for install set to team:(C8F68RFW4L)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: ----- Begin install -----
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: packages=(
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg#de.fau.rrze.NetworkShareMounter.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/578F817B-049A-44FB-8950-282B85444F59.activeSandbox/Root/Applications, uid=0)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: prevent user idle system sleep
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: suspending backupd
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/578F817B-049A-44FB-8950-282B85444F59.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/578F817B-049A-44FB-8950-282B85444F59.activeSandbox
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q install_monitor[77112]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/578F817B-049A-44FB-8950-282B85444F59.activeSandbox/Root (1 items) to /
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Writing receipt for de.fau.rrze.NetworkShareMounter to /
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Touched bundle /Applications/Network Share Mounter.app
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Touched bundle /Applications/Network Share Mounter.app/Contents/Library/LoginItems/LaunchAtLoginHelper.app
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: Installed "Network Share Mounter" (3.0.2)
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q installd[594]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-02-14 15:02:55+01 MacBookPro-C02VM269HV2Q install_monitor[77112]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: releasing backupd
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: allow user idle system sleep
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: ----- End install -----
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: 0.8s elapsed install time
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Cleared responsibility for install from 77111.
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Cleared permissions on Installer.app
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Hosted team responsible for install has been cleared.
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Running idle tasks
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Done with sandbox removals
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: PackageKit: Registered bundle file:///Applications/Network%20Share%20Mounter.app/ for uid 0
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: PackageKit: Registered bundle file:///Applications/Network%20Share%20Mounter.app/Contents/Library/LoginItems/LaunchAtLoginHelper.app/ for uid 0
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installd[594]: PackageKit: Removing client PKInstallDaemonClient pid=77111, uid=0 (/usr/sbin/installer)
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: Running install actions
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.77111O3tHUZ"
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: Finalize disk "Macintosh HD"
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: Notifying system of updated components
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: **** Summary Information ****
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:   Operation      Elapsed time
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]: -----------------------------
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:        disk      0.02 seconds
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:      script      0.00 seconds
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:        zero      0.00 seconds
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:     install      1.09 seconds
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:     -total-      1.11 seconds
2024-02-14 15:02:56+01 MacBookPro-C02VM269HV2Q installer[77111]:

2024-02-14 15:02:58 : INFO  : networksharemounter : Finishing...
2024-02-14 15:03:01 : INFO  : networksharemounter : found packageID de.fau.rrze.NetworkShareMounter installed, version 3.0.2
2024-02-14 15:03:01 : REQ   : networksharemounter : Installed NetworkShareMounter, version 3.0.2
2024-02-14 15:03:01 : DEBUG : networksharemounter : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ
2024-02-14 15:03:01 : DEBUG : networksharemounter : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ/NetworkShareMounter.pkg
2024-02-14 15:03:01 : DEBUG : networksharemounter : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6Iu8AjEZ
2024-02-14 15:03:01 : INFO  : networksharemounter : Installomator did not close any apps, so no need to reopen any apps.
2024-02-14 15:03:01 : REQ   : networksharemounter : All done!
2024-02-14 15:03:01 : REQ   : networksharemounter : ################## End Installomator, exit code 0

```