### PR TITLE
Delete redeye.sh

### DIFF
--- a/fragments/labels/redeye.sh
+++ b/fragments/labels/redeye.sh
@@ -1,8 +1,0 @@
-redeye)
-    # credit: Drew Diver (@grumpydrew on MacAdmins Slack)
-    name="Red Eye"
-    type="zip"
-    downloadURL="https://www.hexedbits.com/downloads/redeye.zip"
-    appNewVersion=$( curl -fs "https://www.hexedbits.com/redeye/" | grep "Latest version" | sed -E 's/.*Latest version ([0-9.]*),.*/\1/g' )
-    expectedTeamID="5VRJU68BZ5"
-    ;;


### PR DESCRIPTION
Red Eye has moved behind a paywall, see https://www.hexedbits.com/redeye/ where you are directed to Gumroad for purchase.