### PR TITLE
New Label: Freeplane

### DIFF
--- a/fragments/labels/freeplane.sh
+++ b/fragments/labels/freeplane.sh
@@ -1,0 +1,11 @@
+freeplane)
+    name="Freeplane"
+    type="dmg"
+    appNewVersion=$(curl -fsL "https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable/archive" | xpath '//rss/channel/item[1]/title' 2>/dev/null | awk -F'/' '{ print $(NF-2) }')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fsL "https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable/archive/${appNewVersion}" | grep -oE '<link>(.*-apple.dmg/download)</link>' | tail -1 | sed 's/<link>//;s/<\/link>//')
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fsL "https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable/archive/${appNewVersion}" | grep -oE '<link>(.*-intel.dmg/download)</link>' | tail -1 | sed 's/<link>//;s/<\/link>//')
+    fi
+    expectedTeamID="CSHVD99Y7K"
+    ;;


### PR DESCRIPTION
2024-02-16 11:46:15 : REQ   : freeplane : ################## Start Installomator v. 10.6beta, date 2024-02-16
2024-02-16 11:46:15 : INFO  : freeplane : ################## Version: 10.6beta
2024-02-16 11:46:15 : INFO  : freeplane : ################## Date: 2024-02-16
2024-02-16 11:46:15 : INFO  : freeplane : ################## freeplane
2024-02-16 11:46:15 : INFO  : freeplane : SwiftDialog is not installed, clear cmd file var
2024-02-16 11:46:17 : INFO  : freeplane : BLOCKING_PROCESS_ACTION=tell_user
2024-02-16 11:46:17 : INFO  : freeplane : NOTIFY=success
2024-02-16 11:46:17 : INFO  : freeplane : LOGGING=INFO
2024-02-16 11:46:17 : INFO  : freeplane : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-16 11:46:17 : INFO  : freeplane : Label type: dmg
2024-02-16 11:46:17 : INFO  : freeplane : archiveName: Freeplane.dmg
2024-02-16 11:46:17 : INFO  : freeplane : no blocking processes defined, using Freeplane as default
2024-02-16 11:46:17 : INFO  : freeplane : name: Freeplane, appName: Freeplane.app
2024-02-16 11:46:17.170 mdfind[16345:187125] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-16 11:46:17.170 mdfind[16345:187125] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-16 11:46:17.278 mdfind[16345:187125] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-16 11:46:17 : WARN  : freeplane : No previous app found
2024-02-16 11:46:17 : WARN  : freeplane : could not find Freeplane.app
2024-02-16 11:46:17 : INFO  : freeplane : appversion:
2024-02-16 11:46:17 : INFO  : freeplane : Latest version of Freeplane is 1.11.10
2024-02-16 11:46:17 : REQ   : freeplane : Downloading https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.11.10/Freeplane-1.11.10-apple.dmg/download to Freeplane.dmg
2024-02-16 11:47:17 : REQ   : freeplane : no more blocking processes, continue with update
2024-02-16 11:47:17 : REQ   : freeplane : Installing Freeplane
2024-02-16 11:47:17 : INFO  : freeplane : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.LzXocRVgRh/Freeplane.dmg
2024-02-16 11:47:22 : INFO  : freeplane : Mounted: /Volumes/Freeplane
2024-02-16 11:47:22 : INFO  : freeplane : Verifying: /Volumes/Freeplane/Freeplane.app
2024-02-16 11:47:23 : INFO  : freeplane : Team ID matching: CSHVD99Y7K (expected: CSHVD99Y7K )
2024-02-16 11:47:23 : INFO  : freeplane : Installing Freeplane version 1.11.10 on versionKey CFBundleShortVersionString.
2024-02-16 11:47:23 : INFO  : freeplane : App has LSMinimumSystemVersion: 10.11
2024-02-16 11:47:23 : INFO  : freeplane : Copy /Volumes/Freeplane/Freeplane.app to /Applications
2024-02-16 11:47:23 : WARN  : freeplane : Changing owner to kryptonit
2024-02-16 11:47:23 : INFO  : freeplane : Finishing...
2024-02-16 11:47:26 : INFO  : freeplane : App(s) found: /Applications/Freeplane.app
2024-02-16 11:47:26 : INFO  : freeplane : found app at /Applications/Freeplane.app, version 1.11.10, on versionKey CFBundleShortVersionString
2024-02-16 11:47:27 : REQ   : freeplane : Installed Freeplane, version 1.11.10
2024-02-16 11:47:27 : INFO  : freeplane : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-16 11:47:27 : INFO  : freeplane : Installomator did not close any apps, so no need to reopen any apps.
2024-02-16 11:47:27 : REQ   : freeplane : All done!
2024-02-16 11:47:27 : REQ   : freeplane : ################## End Installomator, exit code 0