### PR TITLE
Extended version checking, MAU availability and update package selection of select Microsoft labels

### DIFF
--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -99,6 +99,18 @@ if [[ ! -x $DIALOG_CMD ]]; then
     DIALOG_CMD_FILE=""
 fi
 
+# scot: moved here from main.sh to ensure all arguments are available before executing labels
+# MARK: finish reading the arguments:
+while [[ -n $1 ]]; do
+    if [[ $1 =~ ".*\=.*" ]]; then
+        # if an argument contains an = character, send it to eval
+        printlog "setting variable from argument $1" INFO
+        eval $1
+    fi
+    # shift to next argument
+    shift 1
+done
+
 # MARK: labels in case statement
 case $label in
 longversion)

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -638,7 +638,10 @@ installFromPKG() {
 
     deduplicatelogs "$spctlOut"
 
-    if [[ $spctlStatus -ne 0 ]] ; then
+# scot: Microsoft does not notarize their Delta update packages, added extra check to allow for this
+    if [[ $spctlStatus -eq 3 ]] && [[ $expectedTeamID == "UBF8T346G9" ]] && [[ $downloadURL =~ "Delta" ]]; then
+       printlog "Microsoft does not notarize Delta updaters...continuing."
+    elif [[ $spctlStatus -ne 0 ]] ; then
     #if ! spctlout=$(spctl -a -vv -t install "$archiveName" 2>&1 ); then
         cleanupAndExit 4 "Error verifying $archiveName error:\n$logoutput" ERROR
     fi

--- a/fragments/labels/microsoftcompanyportal.sh
+++ b/fragments/labels/microsoftcompanyportal.sh
@@ -1,14 +1,36 @@
 microsoftcompanyportal)
     name="Company Portal"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869655"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.intunecompanyportal.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/CompanyPortal_.*pkg" | cut -d "_" -f 2 | cut -d "-" -f 1)
+    appName="$name.app"
+    versionKey="CFBundleShortVersionString"
     expectedTeamID="UBF8T346G9"
+    msid="IMCP01"
+    linkid="869655"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing URL for updater"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | grep -i "Upgrade.pkg" | sed 's/^[[:space:]]*//' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps IMCP01 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    appNewVersion=$(echo $downloadURL | grep -o "/CompanyPortal_.*pkg" | awk -F'_' '{ print $2 }' | sed 's/-.*//')
+    
     ;;

--- a/fragments/labels/microsoftedge.sh
+++ b/fragments/labels/microsoftedge.sh
@@ -3,37 +3,14 @@ microsoftedgeconsumerstable|\
 microsoftedgeenterprisestable)
     name="Microsoft Edge"
     type="pkg"
-    appName="$name.app"
-    versionKey="CFBundleVersion"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=2093504"
+    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.edge"]/cfbundleversion' 2>/dev/null | sed -E 's/<cfbundleversion>([0-9.]*)<.*/\1/')
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/MicrosoftEdge.*pkg" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="UBF8T346G9"
-    msid="EDGE01"
-    linkid="2093504"
-    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
-    getAppVersion
-    if [[ $appversion && $INSTALL != "force" ]]; then
-        printlog "Grabbing updater URL for Delta update"
-        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "Update-"| tr -d '\n' | sed 's/pkg.*/pkg/')
-    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
-    else
-        toolOutput="99"
+        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
     fi
-    if [[ $toolOutput -eq 0 ]]; then
-        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
-        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-        updateToolArguments=( --install --apps ${msid} )
-    elif [[ $toolOutput -eq 99 ]]; then
-        printlog "force/debug set or msupdate unavailable, update tool not set"
-    elif [[ $toolOutput -ne 0 ]]; then
-        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
-    fi
-    if [[ $updaterURL && $INSTALL != "force" ]]; then
-        printlog "Setting downloadURL to updaterURL"
-        downloadURL="$updaterURL"
-    fi
-
-    appNewVersion=$(echo $downloadURL | grep -o "/Microsoft.*pkg" | cut -d "-" -f 2 | cut -d "." -f 1-4)
-
+    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+    updateToolArguments=( --install --apps EDGE01 )
     ;;

--- a/fragments/labels/microsoftedge.sh
+++ b/fragments/labels/microsoftedge.sh
@@ -3,14 +3,37 @@ microsoftedgeconsumerstable|\
 microsoftedgeenterprisestable)
     name="Microsoft Edge"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=2093504"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.edge"]/cfbundleversion' 2>/dev/null | sed -E 's/<cfbundleversion>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/MicrosoftEdge.*pkg" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="EDGE01"
+    linkid="2093504"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "Update-"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps EDGE01 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+
+    appNewVersion=$(echo $downloadURL | grep -o "/Microsoft.*pkg" | cut -d "-" -f 2 | cut -d "." -f 1-4)
+
     ;;

--- a/fragments/labels/microsoftexcel.sh
+++ b/fragments/labels/microsoftexcel.sh
@@ -1,14 +1,45 @@
 microsoftexcel)
     name="Microsoft Excel"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=525135"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.excel.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="XCEL2019"
+    linkid="525135"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "${appversion}_to_" | grep -v "_to_${appversion}" | tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
+    if [[ ! $updaterURL && $appversion ]]; then
+        printlog "No Delta found...grabbing full updater URL"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='FullUpdaterLocation']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps XCEL2019 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    if [[ $(echo $downloadURL | grep '_to_') ]]; then
+        printlog "Setting appNewVersion to Delta version"
+        appNewVersion=$(echo $downloadURL | awk -F'_to_' '{ print $2 }' | sed 's/_.*//')
+    else
+        printlog "Setting appNewVersion to Installer/Updater version"
+        appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-3)
+    fi
     ;;

--- a/fragments/labels/microsoftonedrive.sh
+++ b/fragments/labels/microsoftonedrive.sh
@@ -3,9 +3,10 @@ microsoftonedrive)
     # https://support.microsoft.com/en-us/office/onedrive-release-notes-845dcf18-f921-435e-bf28-4e24b95e5fc0#OSVersion=Mac
     name="OneDrive"
     type="pkg"
+    versionKey="CFBundleVersion"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=823060"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.onedrive.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | cut -d "/" -f 6 | cut -d "." -f 1-3)
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | cut -d "/" -f 6 | cut -d "." -f 1-4)
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"

--- a/fragments/labels/microsoftonenote.sh
+++ b/fragments/labels/microsoftonenote.sh
@@ -1,14 +1,45 @@
 microsoftonenote)
     name="Microsoft OneNote"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=820886"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.onenote.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="ONMC2019"
+    linkid="820886"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "${appversion}_to_" | grep -v "_to_${appversion}" | tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
+    if [[ ! $updaterURL && $appversion ]]; then
+        printlog "No Delta found...grabbing full updater URL"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='FullUpdaterLocation']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps ONMC2019 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    if [[ $(echo $downloadURL | grep '_to_') ]]; then
+        printlog "Setting appNewVersion to Delta version"
+        appNewVersion=$(echo $downloadURL | awk -F'_to_' '{ print $2 }' | sed 's/_.*//')
+    else
+        printlog "Setting appNewVersion to Installer/Updater version"
+        appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-3)
+    fi
     ;;

--- a/fragments/labels/microsoftoutlook.sh
+++ b/fragments/labels/microsoftoutlook.sh
@@ -1,14 +1,45 @@
 microsoftoutlook)
     name="Microsoft Outlook"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=525137"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.outlook.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="OPIM2019"
+    linkid="525137"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "${appversion}_to_" | grep -v "_to_${appversion}" | tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
+    if [[ ! $updaterURL && $appversion ]]; then
+        printlog "No Delta found...grabbing full updater URL"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='FullUpdaterLocation']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps OPIM2019 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    if [[ $(echo $downloadURL | grep '_to_') ]]; then
+        printlog "Setting appNewVersion to Delta version"
+        appNewVersion=$(echo $downloadURL | awk -F'_to_' '{ print $2 }' | sed 's/_.*//')
+    else
+        printlog "Setting appNewVersion to Installer/Updater version"
+        appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-3)
+    fi
     ;;

--- a/fragments/labels/microsoftpowerpoint.sh
+++ b/fragments/labels/microsoftpowerpoint.sh
@@ -1,14 +1,45 @@
 microsoftpowerpoint)
     name="Microsoft PowerPoint"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=525136"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.powerpoint.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="PPT32019"
+    linkid="525136"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "${appversion}_to_" | grep -v "_to_${appversion}" | tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
+    if [[ ! $updaterURL && $appversion ]]; then
+        printlog "No Delta found...grabbing full updater URL"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='FullUpdaterLocation']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps PPT32019 )
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    if [[ $(echo $downloadURL | grep '_to_') ]]; then
+        printlog "Setting appNewVersion to Delta version"
+        appNewVersion=$(echo $downloadURL | awk -F'_to_' '{ print $2 }' | sed 's/_.*//')
+    else
+        printlog "Setting appNewVersion to Installer/Updater version"
+        appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-3)
+    fi
     ;;

--- a/fragments/labels/microsoftremotedesktop.sh
+++ b/fragments/labels/microsoftremotedesktop.sh
@@ -1,14 +1,38 @@
 microsoftremotedesktop)
     name="Microsoft Remote Desktop"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=868963"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.remotedesktop.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_Remote_Desktop.*pkg" | cut -d "_" -f 4)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
+    msid="MSRD10"
+    linkid="868963"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for updater"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep -i "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps MSRD10 )
+    
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    
+    appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 4 | cut -d "." -f 1-3)
+
     ;;

--- a/fragments/labels/microsoftword.sh
+++ b/fragments/labels/microsoftword.sh
@@ -1,14 +1,45 @@
 microsoftword)
     name="Microsoft Word"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=525134"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.word.standalone.365"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-2)
+    appName="$name.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="UBF8T346G9"
-    if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" ]]; then
-        printlog "Running msupdate --list"
-        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+    msid="MSWD2019"
+    linkid="525134"
+    downloadURL=$(curl -fsIL "https://go.microsoft.com/fwlink/?linkid=${linkid}" | grep -i location: | awk -F': ' '{ print $2 }' | tr -d '\n' | sed 's/pkg.*/pkg/')
+    getAppVersion
+    if [[ $appversion && $INSTALL != "force" ]]; then
+        printlog "Grabbing updater URL for Delta update"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='Location']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "${appversion}_to_" | grep -v "_to_${appversion}" | tr -d '\n' | sed 's/pkg.*/pkg/')
     fi
-    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
-    updateToolArguments=( --install --apps MSWD2019 )
+    if [[ ! $updaterURL && $appversion ]]; then
+        printlog "No Delta found...grabbing full updater URL"
+        updaterURL=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409${msid}.xml | xmllint --format --xpath ".//*/key[text()='FullUpdaterLocation']/following-sibling::*[1]" - | awk -F'<string>' '{ print $2 }' | sed 's/<.*//' | grep "_Updater"| tr -d '\n' | sed 's/pkg.*/pkg/')
+    fi
+    if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
+        printlog "Running msupdate --list"
+        toolOutput=$("/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list | grep -c 'XPC Connection to updater invalidated')
+    else
+        toolOutput="99"
+    fi
+    if [[ $toolOutput -eq 0 ]]; then
+        printlog "XPC Connection to msupdate succesfull, setting msupdate as update tool"
+        updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+        updateToolArguments=( --install --apps ${msid} )
+    elif [[ $toolOutput -eq 99 ]]; then
+        printlog "force/debug set or msupdate unavailable, update tool not set"
+    elif [[ $toolOutput -ne 0 ]]; then
+        printlog "XPC Connection to updater invalidated or otherwise failed, update tool not set"
+    fi
+    if [[ $updaterURL && $INSTALL != "force" ]]; then
+        printlog "Setting downloadURL to updaterURL"
+        downloadURL="$updaterURL"
+    fi
+    if [[ $(echo $downloadURL | grep '_to_') ]]; then
+        printlog "Setting appNewVersion to Delta version"
+        appNewVersion=$(echo $downloadURL | awk -F'_to_' '{ print $2 }' | sed 's/_.*//')
+    else
+        printlog "Setting appNewVersion to Installer/Updater version"
+        appNewVersion=$(echo $downloadURL | grep -o "/Microsoft_.*pkg" | cut -d "_" -f 3 | cut -d "." -f 1-3)
+    fi
     ;;

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -5,17 +5,6 @@
     ;;
 esac
 
-# MARK: finish reading the arguments:
-while [[ -n $1 ]]; do
-    if [[ $1 =~ ".*\=.*" ]]; then
-        # if an argument contains an = character, send it to eval
-        printlog "setting variable from argument $1" INFO
-        eval $1
-    fi
-    # shift to next argument
-    shift 1
-done
-
 # verify we have everything we need
 if [[ -z $name ]]; then
     printlog "need to provide 'name'" ERROR
@@ -204,7 +193,7 @@ if ! cd "$tmpDir"; then
 fi
 
 # MARK: get installed version
-getAppVersion
+[[ ! $appversion ]] && getAppVersion
 printlog "appversion: $appversion"
 
 # NOTE: Exit if new version is the same as installed version (appNewVersion specified)
@@ -227,7 +216,15 @@ if [[ -n $appNewVersion ]]; then
                     updateDialog "complete" "Latest version already installed..."
                     sleep 2
                 fi
-                cleanupAndExit 0 "No newer version." REQ
+                if [[ $DEBUG -ge 2 ]]; then
+                    printlog "appversion: $appversion"
+                    printlog "appNewVersion: $appNewVersion"
+                    printlog "appName: $name"
+                    cleanupAndExit 0 "DEBUG mode 2 enabled, just report app versions and exit." REQ
+                else
+                    cleanupAndExit 0 "No newer version." REQ
+                fi
+                
             fi
         else
             printlog "DEBUG mode 1 enabled, not exiting, but there is no new version of app." WARN
@@ -236,6 +233,16 @@ if [[ -n $appNewVersion ]]; then
 else
     printlog "Latest version not specified."
 fi
+
+if [[ $DEBUG -ge 2 ]]; then
+    printlog "appversion: $appversion"
+    printlog "appNewVersion: $appNewVersion"
+    printlog "appName: $name"
+    cleanupAndExit 0 "DEBUG mode 2 enabled, just report app versions and exit." REQ
+                
+fi
+
+
 
 # MARK: check if this is an Update and we can use updateTool
 if [[ (-n $appversion && -n "$updateTool") || "$type" == "updateronly" ]]; then

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -216,15 +216,7 @@ if [[ -n $appNewVersion ]]; then
                     updateDialog "complete" "Latest version already installed..."
                     sleep 2
                 fi
-                if [[ $DEBUG -ge 2 ]]; then
-                    printlog "appversion: $appversion"
-                    printlog "appNewVersion: $appNewVersion"
-                    printlog "appName: $name"
-                    cleanupAndExit 0 "DEBUG mode 2 enabled, just report app versions and exit." REQ
-                else
-                    cleanupAndExit 0 "No newer version." REQ
-                fi
-                
+                cleanupAndExit 0 "No newer version." REQ
             fi
         else
             printlog "DEBUG mode 1 enabled, not exiting, but there is no new version of app." WARN
@@ -233,16 +225,6 @@ if [[ -n $appNewVersion ]]; then
 else
     printlog "Latest version not specified."
 fi
-
-if [[ $DEBUG -ge 2 ]]; then
-    printlog "appversion: $appversion"
-    printlog "appNewVersion: $appNewVersion"
-    printlog "appName: $name"
-    cleanupAndExit 0 "DEBUG mode 2 enabled, just report app versions and exit." REQ
-                
-fi
-
-
 
 # MARK: check if this is an Update and we can use updateTool
 if [[ (-n $appversion && -n "$updateTool") || "$type" == "updateronly" ]]; then


### PR DESCRIPTION
Altered the behavior of select `microsoft` labels to check for full version numbers and compare them against both full installer package versions and update (full or delta) package versions. Update packages are often more current than the full installer packages available at any given time. This will prevent repeated attempts to update apps that are already at a version above what is provided by the installer. This can be the case when the app has previously been updated by Microsoft Auto Updater (MAU) or by other means.

Here is a real world example example of the version differences (between installer and updater packages) for Outlook from earlier this month:
Latest version parsed from the installer (default Installomator behavior):
```
https://go.microsoft.com/fwlink/?linkid=525137 ->
https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.81.24011420_Installer.pkg
appNewVersion=16.81.24011420
```
If latest version is parsed from the MAU XML file (new behavior):
```
https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409OPIM2019.xml ->
# updater
https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.81.24012814_Updater.pkg
appNewVersion=16.81.24012814

# delta updater
https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Outlook_16.81.24011420_to_16.81.24012814_Delta.pkg
appNewVersion=16.81.24012814
```

In this case, when using current Installomator behavior:
If `appversion=16.81.24012814` (because it has already been updated by MAU or by other means) Installomator will keep trying to update it again and again because `appversion != appNewVersion`
OR
if `appversion=16.81.24011420` Installomator will report that it is current because `appversion == appNewVersion` even though the newest available version is actually 16.81.24012814

A true representation of an apps current version can be obtained by using a combination of the two data sources. This method has the additional benefit of grabbing the updater package URL (or delta update package URL) when an update is appropriate (based on the standard logic used by Installomator), possibly decreasing the download/install time.

I've also added logic that will check if MAU is available and functional before selecting `updateTool` as the update method. If MAU is unavailable, the update/install will continue using the downloadURL.