### PR TITLE
Fix microsoftautoupdate version check

### DIFF
--- a/fragments/labels/microsoftautoupdate.sh
+++ b/fragments/labels/microsoftautoupdate.sh
@@ -2,8 +2,8 @@ microsoftautoupdate)
     name="Microsoft AutoUpdate"
     type="pkg"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=830196"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.autoupdate.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "Microsoft_AutoUpdate.*pkg" | sed -E 's/[a-zA-Z_]*_([0-9.]*)_.*/\1/g' | cut -d "." -f 1-2)
+    versionKey="CFBundleVersion"
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "Microsoft_AutoUpdate.*pkg" | sed -E 's/[a-zA-Z_]*_([0-9.]*)_.*/\1/g')
     expectedTeamID="UBF8T346G9"
     # commented the updatetool for MSAutoupdate, because when Autoupdate is really
     # old or broken, you want to force a new install


### PR DESCRIPTION
The microsoftautoupdate label latest version check was cut of at the second dot.

```
2024-02-17 12:22:56 : INFO  : microsoftautoupdate : appversion: 4.68.1
2024-02-17 12:22:56 : INFO  : microsoftautoupdate : Latest version of Microsoft AutoUpdate is 4.68
```

Now the label uses the full version.

```
2024-02-19 14:51:45 : REQ   : microsoftautoupdate : ################## Start Installomator v. 10.6beta, date 2024-02-19
2024-02-19 14:51:45 : INFO  : microsoftautoupdate : ################## Version: 10.6beta
2024-02-19 14:51:45 : INFO  : microsoftautoupdate : ################## Date: 2024-02-19
2024-02-19 14:51:45 : INFO  : microsoftautoupdate : ################## microsoftautoupdate
2024-02-19 14:51:45 : DEBUG : microsoftautoupdate : DEBUG mode 1 enabled.
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : name=Microsoft AutoUpdate
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : appName=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : type=pkg
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : archiveName=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : downloadURL=https://go.microsoft.com/fwlink/?linkid=830196
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : curlOptions=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : appNewVersion=4.68.24021416
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : appCustomVersion function: Not defined
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : versionKey=CFBundleVersion
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : packageID=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : pkgName=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : choiceChangesXML=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : expectedTeamID=UBF8T346G9
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : blockingProcesses=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : installerTool=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : CLIInstaller=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : CLIArguments=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : updateTool=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : updateToolArguments=
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : updateToolRunAsCurrentUser=
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : BLOCKING_PROCESS_ACTION=tell_user
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : NOTIFY=success
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : LOGGING=DEBUG
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Label type: pkg
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : archiveName: Microsoft AutoUpdate.pkg
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : no blocking processes defined, using Microsoft AutoUpdate as default
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : Changing directory to .
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : name: Microsoft AutoUpdate, appName: Microsoft AutoUpdate.app
2024-02-19 14:51:46.371 mdfind[88782:1389900] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-19 14:51:46.371 mdfind[88782:1389900] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-19 14:51:46.442 mdfind[88782:1389900] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : App(s) found: /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : found app at /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app, version 4.68.24021416, on versionKey CFBundleVersion
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : appversion: 4.68.24021416
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Latest version of Microsoft AutoUpdate is 4.68.24021416
2024-02-19 14:51:46 : WARN  : microsoftautoupdate : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Microsoft AutoUpdate.pkg exists and DEBUG mode 1 enabled, skipping download
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : DEBUG mode 1, not checking for blocking processes
2024-02-19 14:51:46 : REQ   : microsoftautoupdate : Installing Microsoft AutoUpdate
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Verifying: Microsoft AutoUpdate.pkg
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : File list: -rw-r--r--  1 maartenwijnants  staff   5.0M Feb 19 14:43 Microsoft AutoUpdate.pkg
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : File type: Microsoft AutoUpdate.pkg: xar archive compressed TOC: 7175, SHA-1 checksum
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : spctlOut is Microsoft AutoUpdate.pkg: accepted
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : source=Notarized Developer ID
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2024-02-19 14:51:46 : DEBUG : microsoftautoupdate : DEBUG enabled, skipping installation
2024-02-19 14:51:46 : INFO  : microsoftautoupdate : Finishing...
2024-02-19 14:51:49 : INFO  : microsoftautoupdate : name: Microsoft AutoUpdate, appName: Microsoft AutoUpdate.app
2024-02-19 14:51:49.906 mdfind[88834:1390075] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-19 14:51:49.907 mdfind[88834:1390075] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-19 14:51:49.972 mdfind[88834:1390075] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-19 14:51:50 : INFO  : microsoftautoupdate : App(s) found: /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app
2024-02-19 14:51:50 : INFO  : microsoftautoupdate : found app at /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app, version 4.68.24021416, on versionKey CFBundleVersion
2024-02-19 14:51:50 : REQ   : microsoftautoupdate : Installed Microsoft AutoUpdate, version 4.68.24021416
2024-02-19 14:51:50 : INFO  : microsoftautoupdate : notifying
ERROR: Notifications are not available: Notifications are not allowed for this application
ERROR: Check to see if Notifications for Dialog.app are enabled in notification center
2024-02-19 14:51:50 : DEBUG : microsoftautoupdate : DEBUG mode 1, not reopening anything
2024-02-19 14:51:50 : REQ   : microsoftautoupdate : All done!
2024-02-19 14:51:50 : REQ   : microsoftautoupdate : ################## End Installomator, exit code 0 
```