### PR TITLE
New Label: CMake

### DIFF
--- a/fragments/labels/cmake.sh
+++ b/fragments/labels/cmake.sh
@@ -1,0 +1,7 @@
+cmake)
+    name="CMake"
+    type="dmg"
+    appNewVersion=$(curl -fsL "https://cmake.org/download" | awk -F'[()]' '/id="latest"/{print $2}')
+    downloadURL="https://github.com/Kitware/CMake/releases/download/v${appNewVersion}/cmake-${appNewVersion}-macos-universal.dmg"
+    expectedTeamID="W38PE5Y733"
+    ;;


### PR DESCRIPTION
2024-02-19 16:22:43 : REQ   : cmake : ################## Start Installomator v. 10.6beta, date 2024-02-19
2024-02-19 16:22:43 : INFO  : cmake : ################## Version: 10.6beta
2024-02-19 16:22:43 : INFO  : cmake : ################## Date: 2024-02-19
2024-02-19 16:22:43 : INFO  : cmake : ################## cmake
2024-02-19 16:22:43 : INFO  : cmake : SwiftDialog is not installed, clear cmd file var
2024-02-19 16:22:44 : INFO  : cmake : BLOCKING_PROCESS_ACTION=tell_user
2024-02-19 16:22:44 : INFO  : cmake : NOTIFY=success
2024-02-19 16:22:44 : INFO  : cmake : LOGGING=INFO
2024-02-19 16:22:44 : INFO  : cmake : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-19 16:22:44 : INFO  : cmake : Label type: dmg
2024-02-19 16:22:44 : INFO  : cmake : archiveName: CMake.dmg
2024-02-19 16:22:44 : INFO  : cmake : no blocking processes defined, using CMake as default
2024-02-19 16:22:44 : INFO  : cmake : name: CMake, appName: CMake.app
2024-02-19 16:22:44.504 mdfind[98013:1383638] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-19 16:22:44.504 mdfind[98013:1383638] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-19 16:22:44.561 mdfind[98013:1383638] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-19 16:22:44 : WARN  : cmake : No previous app found
2024-02-19 16:22:44 : WARN  : cmake : could not find CMake.app
2024-02-19 16:22:44 : INFO  : cmake : appversion:
2024-02-19 16:22:44 : INFO  : cmake : Latest version of CMake is 3.28.3
2024-02-19 16:22:44 : REQ   : cmake : Downloading https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-macos-universal.dmg to CMake.dmg
2024-02-19 16:22:47 : REQ   : cmake : no more blocking processes, continue with update
2024-02-19 16:22:47 : REQ   : cmake : Installing CMake
2024-02-19 16:22:47 : INFO  : cmake : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.pPfgePmO76/CMake.dmg
2024-02-19 16:22:50 : INFO  : cmake : Mounted: /Volumes/cmake-3.28.3-macos-universal
2024-02-19 16:22:50 : INFO  : cmake : Verifying: /Volumes/cmake-3.28.3-macos-universal/CMake.app
2024-02-19 16:22:52 : INFO  : cmake : Team ID matching: W38PE5Y733 (expected: W38PE5Y733 )
2024-02-19 16:22:52 : INFO  : cmake : Installing CMake version 3.28.3 on versionKey CFBundleShortVersionString.
2024-02-19 16:22:52 : INFO  : cmake : Copy /Volumes/cmake-3.28.3-macos-universal/CMake.app to /Applications
2024-02-19 16:22:55 : WARN  : cmake : Changing owner to kryptonit
2024-02-19 16:22:55 : INFO  : cmake : Finishing...
2024-02-19 16:22:58 : INFO  : cmake : App(s) found: /Applications/CMake.app
2024-02-19 16:22:58 : INFO  : cmake : found app at /Applications/CMake.app, version 3.28.3, on versionKey CFBundleShortVersionString
2024-02-19 16:22:58 : REQ   : cmake : Installed CMake, version 3.28.3
2024-02-19 16:22:58 : INFO  : cmake : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-19 16:22:58 : INFO  : cmake : Installomator did not close any apps, so no need to reopen any apps.
2024-02-19 16:22:58 : REQ   : cmake : All done!
2024-02-19 16:22:58 : REQ   : cmake : ################## End Installomator, exit code 0