### PR TITLE
New Label: Arduino IDE

### DIFF
--- a/fragments/labels/arduinoide.sh
+++ b/fragments/labels/arduinoide.sh
@@ -1,0 +1,13 @@
+arduinoide)
+    name="Arduino IDE"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="arduino-ide_[0-9.]*_macOS_arm64.dmg"
+
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="arduino-ide_[0-9.]*_macOS_64bit.dmg"
+    fi
+    downloadURL="$(downloadURLFromGit arduino arduino-ide)"
+    appNewVersion="$(versionFromGit arduino arduino-ide)"
+    expectedTeamID="7KT7ZWMCJT"
+    ;;


### PR DESCRIPTION
2024-02-21 11:04:07 : REQ   : arduinoide : ################## Start Installomator v. 10.6beta, date 2024-02-21
2024-02-21 11:04:07 : INFO  : arduinoide : ################## Version: 10.6beta
2024-02-21 11:04:07 : INFO  : arduinoide : ################## Date: 2024-02-21
2024-02-21 11:04:07 : INFO  : arduinoide : ################## arduinoide
2024-02-21 11:04:07 : INFO  : arduinoide : SwiftDialog is not installed, clear cmd file var
2024-02-21 11:04:08 : INFO  : arduinoide : BLOCKING_PROCESS_ACTION=tell_user
2024-02-21 11:04:08 : INFO  : arduinoide : NOTIFY=success
2024-02-21 11:04:08 : INFO  : arduinoide : LOGGING=INFO
2024-02-21 11:04:08 : INFO  : arduinoide : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-21 11:04:08 : INFO  : arduinoide : Label type: dmg
2024-02-21 11:04:08 : INFO  : arduinoide : archiveName: arduino-ide_[0-9.]*_macOS_arm64.dmg
2024-02-21 11:04:08 : INFO  : arduinoide : no blocking processes defined, using Arduino IDE as default
2024-02-21 11:04:08 : INFO  : arduinoide : name: Arduino IDE, appName: Arduino IDE.app
2024-02-21 11:04:08.140 mdfind[60408:2291187] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-21 11:04:08.140 mdfind[60408:2291187] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-21 11:04:08.194 mdfind[60408:2291187] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-21 11:04:08 : WARN  : arduinoide : No previous app found
2024-02-21 11:04:08 : WARN  : arduinoide : could not find Arduino IDE.app
2024-02-21 11:04:08 : INFO  : arduinoide : appversion:
2024-02-21 11:04:08 : INFO  : arduinoide : Latest version of Arduino IDE is 2.3.2
2024-02-21 11:04:08 : REQ   : arduinoide : Downloading https://github.com/arduino/arduino-ide/releases/download/2.3.2/arduino-ide_2.3.2_macOS_arm64.dmg to arduino-ide_[0-9.]*_macOS_arm64.dmg
2024-02-21 11:04:10 : REQ   : arduinoide : no more blocking processes, continue with update
2024-02-21 11:04:10 : REQ   : arduinoide : Installing Arduino IDE
2024-02-21 11:04:10 : INFO  : arduinoide : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mnk6g5PEeg/arduino-ide_[0-9.]*_macOS_arm64.dmg
2024-02-21 11:04:15 : INFO  : arduinoide : Mounted: /Volumes/Arduino IDE 2.3.2-arm64 1
2024-02-21 11:04:15 : INFO  : arduinoide : Verifying: /Volumes/Arduino IDE 2.3.2-arm64 1/Arduino IDE.app
2024-02-21 11:04:18 : INFO  : arduinoide : Team ID matching: 7KT7ZWMCJT (expected: 7KT7ZWMCJT )
2024-02-21 11:04:18 : INFO  : arduinoide : Installing Arduino IDE version 2.3.2 on versionKey CFBundleShortVersionString.
2024-02-21 11:04:18 : INFO  : arduinoide : App has LSMinimumSystemVersion: 10.15
2024-02-21 11:04:18 : INFO  : arduinoide : Copy /Volumes/Arduino IDE 2.3.2-arm64 1/Arduino IDE.app to /Applications
2024-02-21 11:04:21 : WARN  : arduinoide : Changing owner to kryptonit
2024-02-21 11:04:21 : INFO  : arduinoide : Finishing...
2024-02-21 11:04:24 : INFO  : arduinoide : App(s) found: /Applications/Arduino IDE.app
2024-02-21 11:04:24 : INFO  : arduinoide : found app at /Applications/Arduino IDE.app, version 2.3.2, on versionKey CFBundleShortVersionString
2024-02-21 11:04:24 : REQ   : arduinoide : Installed Arduino IDE, version 2.3.2
2024-02-21 11:04:24 : INFO  : arduinoide : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-02-21 11:04:25 : INFO  : arduinoide : Installomator did not close any apps, so no need to reopen any apps.
2024-02-21 11:04:25 : REQ   : arduinoide : All done!
2024-02-21 11:04:25 : REQ   : arduinoide : ################## End Installomator, exit code 0