### PR TITLE
Update Label:  perimeter 81 download url changed

### DIFF
--- a/fragments/labels/perimeter81.sh
+++ b/fragments/labels/perimeter81.sh
@@ -1,7 +1,8 @@
 perimeter81)
     name="Perimeter 81"
     type="pkg"
-    downloadURL="https://static.perimeter81.com/agents/mac/snapshot/latest/Perimeter81.pkg"
+    pkgURL=$(curl -sL https://support.perimeter81.com/docs/downloading-the-agent | grep -o "Perimeter81.*.pkg")
+    downloadURL="https://static.perimeter81.com/agents/mac/$pkgURL"
     appNewVersion="$(curl -fsIL "${downloadURL}" | grep -i ^x-amz-meta-version | sed -E 's/x-amz-meta-version: //' | cut -d"." -f1-3)"
     expectedTeamID="924635PD62"
     ;;


### PR DESCRIPTION
```
sudo ./Installomator.sh Perimeter81 DEBUG=0
Password:
2024-02-21 12:51:07 : REQ   : perimeter81 : ################## Start Installomator v. 10.6beta, date 2024-02-21
2024-02-21 12:51:07 : INFO  : perimeter81 : ################## Version: 10.6beta
2024-02-21 12:51:07 : INFO  : perimeter81 : ################## Date: 2024-02-21
2024-02-21 12:51:07 : INFO  : perimeter81 : ################## perimeter81
2024-02-21 12:51:07 : DEBUG : perimeter81 : DEBUG mode 1 enabled.
2024-02-21 12:51:07 : INFO  : perimeter81 : setting variable from argument DEBUG=0
2024-02-21 12:51:07 : DEBUG : perimeter81 : name=Perimeter 81
2024-02-21 12:51:07 : DEBUG : perimeter81 : appName=
2024-02-21 12:51:07 : DEBUG : perimeter81 : type=pkg
2024-02-21 12:51:07 : DEBUG : perimeter81 : archiveName=
2024-02-21 12:51:07 : DEBUG : perimeter81 : downloadURL=https://static.perimeter81.com/agents/mac/Perimeter81_10.4.2.1198.pkg
2024-02-21 12:51:07 : DEBUG : perimeter81 : curlOptions=
2024-02-21 12:51:07 : DEBUG : perimeter81 : appNewVersion=10.4.2
2024-02-21 12:51:07 : DEBUG : perimeter81 : appCustomVersion function: Not defined
2024-02-21 12:51:07 : DEBUG : perimeter81 : versionKey=CFBundleShortVersionString
2024-02-21 12:51:07 : DEBUG : perimeter81 : packageID=
2024-02-21 12:51:07 : DEBUG : perimeter81 : pkgName=
2024-02-21 12:51:07 : DEBUG : perimeter81 : choiceChangesXML=
2024-02-21 12:51:07 : DEBUG : perimeter81 : expectedTeamID=924635PD62
2024-02-21 12:51:07 : DEBUG : perimeter81 : blockingProcesses=
2024-02-21 12:51:07 : DEBUG : perimeter81 : installerTool=
2024-02-21 12:51:08 : DEBUG : perimeter81 : CLIInstaller=
2024-02-21 12:51:08 : DEBUG : perimeter81 : CLIArguments=
2024-02-21 12:51:08 : DEBUG : perimeter81 : updateTool=
2024-02-21 12:51:08 : DEBUG : perimeter81 : updateToolArguments=
2024-02-21 12:51:08 : DEBUG : perimeter81 : updateToolRunAsCurrentUser=
2024-02-21 12:51:08 : INFO  : perimeter81 : BLOCKING_PROCESS_ACTION=tell_user
2024-02-21 12:51:08 : INFO  : perimeter81 : NOTIFY=success
2024-02-21 12:51:08 : INFO  : perimeter81 : LOGGING=DEBUG
2024-02-21 12:51:08 : INFO  : perimeter81 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-21 12:51:08 : INFO  : perimeter81 : Label type: pkg
2024-02-21 12:51:08 : INFO  : perimeter81 : archiveName: Perimeter 81.pkg
2024-02-21 12:51:08 : INFO  : perimeter81 : no blocking processes defined, using Perimeter 81 as default
2024-02-21 12:51:08 : DEBUG : perimeter81 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z
2024-02-21 12:51:08 : INFO  : perimeter81 : name: Perimeter 81, appName: Perimeter 81.app
2024-02-21 12:51:08.129 mdfind[87148:4054604] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-02-21 12:51:08.129 mdfind[87148:4054604] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-02-21 12:51:08.213 mdfind[87148:4054604] Couldn't determine the mapping between prefab keywords and predicates.
2024-02-21 12:51:08 : WARN  : perimeter81 : No previous app found
2024-02-21 12:51:08 : WARN  : perimeter81 : could not find Perimeter 81.app
2024-02-21 12:51:08 : INFO  : perimeter81 : appversion:
2024-02-21 12:51:08 : INFO  : perimeter81 : Latest version of Perimeter 81 is 10.4.2
2024-02-21 12:51:08 : REQ   : perimeter81 : Downloading https://static.perimeter81.com/agents/mac/Perimeter81_10.4.2.1198.pkg to Perimeter 81.pkg
2024-02-21 12:51:08 : DEBUG : perimeter81 : No Dialog connection, just download
2024-02-21 12:51:11 : DEBUG : perimeter81 : File list: -rw-r--r--@ 1 root  wheel   177M Feb 21 12:51 Perimeter 81.pkg
2024-02-21 12:51:11 : DEBUG : perimeter81 : File type: Perimeter 81.pkg: xar archive compressed TOC: 4704, SHA-1 checksum
2024-02-21 12:51:11 : DEBUG : perimeter81 : curl output was:
*   Trying 18.173.219.80:443...
* Connected to static.perimeter81.com (18.173.219.80) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4986 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=static.safervpn.com
*  start date: Sep  2 00:00:00 2023 GMT
*  expire date: Sep 30 23:59:59 2024 GMT
*  subjectAltName: host "static.perimeter81.com" matched cert's "static.perimeter81.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://static.perimeter81.com/agents/mac/Perimeter81_10.4.2.1198.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: static.perimeter81.com]
* [HTTP/2] [1] [:path: /agents/mac/Perimeter81_10.4.2.1198.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /agents/mac/Perimeter81_10.4.2.1198.pkg HTTP/2
> Host: static.perimeter81.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 185468278
< date: Wed, 21 Feb 2024 15:14:24 GMT
< last-modified: Sun, 28 Jan 2024 09:46:13 GMT
< etag: "ca4373d9a789126672928d51f8e2f954"
< x-amz-server-side-encryption: AES256
< x-amz-meta-version: 10.4.2.1198
< x-amz-meta-platform: macos
< x-amz-meta-filetype: pkg
< x-amz-meta-signature: fc8f897197c0157067a4e3368a5c6a90a24bf113736afecd3a9be4ceb90b7f11
< x-amz-meta-arch: x86
< x-amz-version-id: AcSXc99U9SxwuAZ1O5SozRNeyL_8dIeV
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 a3cc1cfce2f0f18de36e3834e18556b8.cloudfront.net (CloudFront)
< x-amz-cf-pop: JFK52-P1
< x-amz-cf-id: X6a2f_mSF9LJ48GkH3EyRGGROqS1I6m2crh9QGnoSSOF_Mtdf8a6Eg==
< age: 9405
<
{ [32196 bytes data]
* Connection #0 to host static.perimeter81.com left intact

2024-02-21 12:51:11 : REQ   : perimeter81 : no more blocking processes, continue with update
2024-02-21 12:51:11 : REQ   : perimeter81 : Installing Perimeter 81
2024-02-21 12:51:11 : INFO  : perimeter81 : Verifying: Perimeter 81.pkg
2024-02-21 12:51:11 : DEBUG : perimeter81 : File list: -rw-r--r--@ 1 root  wheel   177M Feb 21 12:51 Perimeter 81.pkg
2024-02-21 12:51:11 : DEBUG : perimeter81 : File type: Perimeter 81.pkg: xar archive compressed TOC: 4704, SHA-1 checksum
2024-02-21 12:51:11 : DEBUG : perimeter81 : spctlOut is Perimeter 81.pkg: accepted
2024-02-21 12:51:11 : DEBUG : perimeter81 : source=Notarized Developer ID
2024-02-21 12:51:11 : DEBUG : perimeter81 : origin=Developer ID Installer: Perimeter 81 LTD (924635PD62)
2024-02-21 12:51:11 : INFO  : perimeter81 : Team ID: 924635PD62 (expected: 924635PD62 )
2024-02-21 12:51:11 : INFO  : perimeter81 : Installing Perimeter 81.pkg to /
2024-02-21 12:51:27 : DEBUG : perimeter81 : Debugging enabled, installer output was:
Feb 21 12:51:11  installer[87242] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z/Perimeter 81.pkg trustLevel=350
Feb 21 12:51:11  installer[87242] <Debug>: External component packages (1) trustLevel=350
Feb 21 12:51:11  installer[87242] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Feb 21 12:51:11  installer[87242] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z/Perimeter%2081.pkg#Perimeter%2081_unsigned.pkg
Feb 21 12:51:11  installer[87242] <Info>: Set authorization level to root for session
Feb 21 12:51:11  installer[87242] <Info>: Authorization is being checked, waiting until authorization arrives.
Feb 21 12:51:11  installer[87242] <Info>: Administrator authorization granted.
Feb 21 12:51:11  installer[87242] <Info>: Packages have been authorized for installation.
Feb 21 12:51:11  installer[87242] <Debug>: Will use PK session
Feb 21 12:51:11  installer[87242] <Debug>: Using authorization level of root for IFPKInstallElement
Feb 21 12:51:11  installer[87242] <Info>: Starting installation:
Feb 21 12:51:11  installer[87242] <Notice>: Configuring volume "Macintosh HD"
Feb 21 12:51:11  installer[87242] <Info>: Preparing disk for local booted install.
Feb 21 12:51:11  installer[87242] <Notice>: Free space on "Macintosh HD": 58.97 GB (58967973888 bytes).
Feb 21 12:51:11  installer[87242] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.872422uw35S"
Feb 21 12:51:11  installer[87242] <Notice>: IFPKInstallElement (1 packages)
Feb 21 12:51:11  installer[87242] <Info>: Current Path: /usr/sbin/installer
Feb 21 12:51:11  installer[87242] <Info>: Current Path: /bin/zsh
Feb 21 12:51:11  installer[87242] <Info>: Current Path: /usr/bin/sudo
Feb 21 12:51:12  installer[87242] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing ….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
Last Log repeated 2 times
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
Last Log repeated 13 times
installer: Validating packages….....
#Feb 21 12:51:25  installer[87242] <Info>: PackageKit: Registered bundle file:///Applications/Perimeter%2081.app/ for uid 0
Feb 21 12:51:25  installer[87242] <Info>: PackageKit: Registered bundle file:///Applications/Perimeter%2081.app/Contents/Library/LaunchServices/com.perimeter81d.app/ for uid 0

installer: Registering updated applications….....
#Feb 21 12:51:26  installer[87242] <Notice>: Running install actions
Feb 21 12:51:26  installer[87242] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.872422uw35S"
Feb 21 12:51:26  installer[87242] <Notice>: Finalize disk "Macintosh HD"
Feb 21 12:51:26  installer[87242] <Notice>: Notifying system of updated components
Feb 21 12:51:26  installer[87242] <Notice>:
Feb 21 12:51:26  installer[87242] <Notice>: **** Summary Information ****
Feb 21 12:51:26  installer[87242] <Notice>:   Operation      Elapsed time
Feb 21 12:51:26  installer[87242] <Notice>: -----------------------------
Feb 21 12:51:26  installer[87242] <Notice>:        disk      0.01 seconds
Feb 21 12:51:26  installer[87242] <Notice>:      script      0.00 seconds
Feb 21 12:51:26  installer[87242] <Notice>:        zero      0.00 seconds
Feb 21 12:51:26  installer[87242] <Notice>:     install      14.20 seconds
Feb 21 12:51:26  installer[87242] <Notice>:     -total-      14.21 seconds
Feb 21 12:51:26  installer[87242] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The install was successful

2024-02-21 12:51:27 : INFO  : perimeter81 : Finishing...
2024-02-21 12:51:30 : INFO  : perimeter81 : App(s) found: /Applications/Perimeter 81.app
2024-02-21 12:51:30 : INFO  : perimeter81 : found app at /Applications/Perimeter 81.app, version 10.4.2, on versionKey CFBundleShortVersionString
2024-02-21 12:51:30 : REQ   : perimeter81 : Installed Perimeter 81, version 10.4.2
2024-02-21 12:51:30 : INFO  : perimeter81 : notifying
ERROR: Notifications are not allowed for this application
2024-02-21 12:51:31 : DEBUG : perimeter81 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z
2024-02-21 12:51:31 : DEBUG : perimeter81 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z/Perimeter 81.pkg
2024-02-21 12:51:31 : DEBUG : perimeter81 : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YvTvq6AR2z
2024-02-21 12:51:31 : INFO  : perimeter81 : Installomator did not close any apps, so no need to reopen any apps.
2024-02-21 12:51:31 : REQ   : perimeter81 : All done!
2024-02-21 12:51:31 : REQ   : perimeter81 : ################## End Installomator, exit code 0
```