### PR TITLE
Update mendeleyreferencemanager.sh

### DIFF
--- a/fragments/labels/mendeleyreferencemanager.sh
+++ b/fragments/labels/mendeleyreferencemanager.sh
@@ -1,8 +1,8 @@
 mendeleyreferencemanager)
     name="Mendeley Reference Manager"
     type="dmg"
-    downloadURL=$(curl -fs "https://www.mendeley.com/download-reference-manager/macOS" | grep -E -o "https://static.mendeley.com/bin/desktop/.*?.dmg")
-    appNewVersion=$(curl -fs "https://www.mendeley.com/download-reference-manager/macOS" | grep -E -o "https://static.mendeley.com/bin/desktop/.*?.dmg" | awk -F'mendeley-reference-manager-' '{print $2}' | sed 's/.dmg//g')
+    downloadURL=$(curl -fs "https://www.mendeley.com/download-reference-manager/macOS" | grep -oE "https://static.mendeley.com/bin/desktop/.*?.dmg")
+    appNewVersion=$(curl -fs "https://www.mendeley.com/download-reference-manager/macOS" | grep -oE "https://static.mendeley.com/bin/desktop/.*?.dmg" | sed -n 's/.*mendeley-reference-manager-\([0-9.-]*\)-x64.dmg/\1/p')
     expectedTeamID="45K89Y5X9B"
     #Company="Elsevier Inc."
     ;;


### PR DESCRIPTION
The current appNewVersion variable returns the latest version in the format "2.110.2-x64" instead of just "2.110.2". This change fixes that problem.