### PR TITLE
New label: realvncondemandassist

### DIFF
--- a/fragments/labels/realvnconedemandassist.sh
+++ b/fragments/labels/realvnconedemandassist.sh
@@ -1,0 +1,9 @@
+realvncondemandassist)
+    name="On-Demand-Assist-$(curl -sL "https://www.realvnc.help/" | awk -F'"' '/Mac/ && /\.zip/{print $2}' | sed -n 's:.*generic/\(.*\)/.*:\1:p')-MacOSX-universal"
+    type="zip"
+    downloadURL=$(curl -sL "https://www.realvnc.help/" | awk -F'"' '/Mac/ && /\.zip/{print $2}')
+    appNewVersion="$(echo $downloadURL | sed -n 's:.*generic/\(.*\)/.*:\1:p')"
+    expectedTeamID="ZNCQ8JEH7X"
+    blockingProcesses=( "On-Demand Assist" "$name" )
+    appCustomVersion() { echo "$(defaults read "/Applications/On-Demand-Assist-$(curl -sL "https://www.realvnc.help/" | awk -F'"' '/Mac/ && /\.zip/{print $2}' | sed -n 's:.*generic/\(.*\)/.*:\1:p')-MacOSX-universal.app/Contents/Info.plist" CFBundleShortVersionString)" | sed 's/ ([^)]*)//' ; }
+    ;;


### PR DESCRIPTION
Added a new label for realVNC On-Demand Assist

The vendor changes the name of the installed app to match the version number, i.e. for version **2.1.0** the app name becomes On-Demand-Assist-**2.1.0**-MacOSX-universal

In order for the label to work correctly, I need to dynamically set:

**name**: this is done by pulling the version number from the download page and inserting it into the app name. It's not ideal as if users have an older version installed, e.g. 2.0, it won't delete the old version when installing the new version. However if the user has the current version installed, it won't overwrite it, which is preferable to me. I can't read the name locally as we've got to account for first time install use cases, where there will be no app name to read from.

**downloadURL**: this is from the webpage https://www.realvnc.help/ and there's a download link that changes with the version number (e.g. for 2.1.0 the download link is https://static.realvnc.help/generic/2.1.0/On-Demand-Assist.zip), so the code gets the URL from that link for Mac

**appNewVersion**: this comes from the URL from the downloads page; the code grabs the download URL then extracts the version number from it

**appCustomVersion**: the CFBundleShortString includes extra characters (e.g. 2.1.0 is 2.1.0 (r49525)) so the code gets the name of the latest version of the app using the download URL, grabs the CFBundleShortString, then removes the extra characters

Output:
```
zsh assemble.sh realvncondemandassist DEBUG=0
2024-02-29 12:15:25 : REQ   : realvncondemandassist : ################## Start Installomator v. 10.6beta, date 2024-02-29
2024-02-29 12:15:25 : INFO  : realvncondemandassist : ################## Version: 10.6beta
2024-02-29 12:15:25 : INFO  : realvncondemandassist : ################## Date: 2024-02-29
2024-02-29 12:15:25 : INFO  : realvncondemandassist : ################## realvncondemandassist
2024-02-29 12:15:25 : DEBUG : realvncondemandassist : DEBUG mode 1 enabled.
2024-02-29 12:15:26 : INFO  : realvncondemandassist : setting variable from argument DEBUG=0
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : name=On-Demand-Assist-2.1.0-MacOSX-universal
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : appName=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : type=zip
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : archiveName=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : downloadURL=https://static.realvnc.help/generic/2.1.0/On-Demand-Assist.zip
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : curlOptions=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : appNewVersion=2.1.0
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : appCustomVersion function: Defined.
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : versionKey=CFBundleShortVersionString
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : packageID=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : pkgName=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : choiceChangesXML=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : expectedTeamID=ZNCQ8JEH7X
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : blockingProcesses=On-Demand Assist On-Demand-Assist-2.1.0-MacOSX-universal
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : installerTool=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : CLIInstaller=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : CLIArguments=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : updateTool=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : updateToolArguments=
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : updateToolRunAsCurrentUser=
2024-02-29 12:15:26 : INFO  : realvncondemandassist : BLOCKING_PROCESS_ACTION=tell_user
2024-02-29 12:15:26 : INFO  : realvncondemandassist : NOTIFY=success
2024-02-29 12:15:26 : INFO  : realvncondemandassist : LOGGING=DEBUG
2024-02-29 12:15:26 : INFO  : realvncondemandassist : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-02-29 12:15:26 : INFO  : realvncondemandassist : Label type: zip
2024-02-29 12:15:26 : INFO  : realvncondemandassist : archiveName: On-Demand-Assist-2.1.0-MacOSX-universal.zip
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : Changing directory to /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy
2024-02-29 12:15:26.771 defaults[26136:1019769]
The domain/default pair of (/Applications/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2024-02-29 12:15:26 : INFO  : realvncondemandassist : Custom App Version detection is used, found
2024-02-29 12:15:26 : INFO  : realvncondemandassist : appversion:
2024-02-29 12:15:26 : INFO  : realvncondemandassist : Latest version of On-Demand-Assist-2.1.0-MacOSX-universal is 2.1.0
2024-02-29 12:15:26 : REQ   : realvncondemandassist : Downloading https://static.realvnc.help/generic/2.1.0/On-Demand-Assist.zip to On-Demand-Assist-2.1.0-MacOSX-universal.zip
2024-02-29 12:15:26 : DEBUG : realvncondemandassist : No Dialog connection, just download
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : File list: -rw-r--r--  1 adambutterwick  staff   4.7M 29 Feb 12:15 On-Demand-Assist-2.1.0-MacOSX-universal.zip
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : File type: On-Demand-Assist-2.1.0-MacOSX-universal.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : curl output was:
*   Trying 108.156.39.118:443...
* Connected to static.realvnc.help (108.156.39.118) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4964 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=static.realvnc.help
*  start date: Oct 19 00:00:00 2023 GMT
*  expire date: Nov 16 23:59:59 2024 GMT
*  subjectAltName: host "static.realvnc.help" matched cert's "static.realvnc.help"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /generic/2.1.0/On-Demand-Assist.zip HTTP/1.1
> Host: static.realvnc.help
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/zip
< Content-Length: 4877600
< Connection: keep-alive
< Date: Thu, 29 Feb 2024 10:30:30 GMT
< Last-Modified: Thu, 13 Apr 2023 08:05:09 GMT
< ETag: "2d9d3c891ff451bf12586f9b3f33d537"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 7309328e91f012108061822748228b68.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: LHR50-P1
< X-Amz-Cf-Id: GDYmxCEHR-60O34cef-cjBLjNvQxoBMZazNnxpaehkzSDohWJsSJJw==
< Age: 6298
<
{ [16384 bytes data]
* Connection #0 to host static.realvnc.help left intact

2024-02-29 12:15:27 : REQ   : realvncondemandassist : no more blocking processes, continue with update
2024-02-29 12:15:27 : REQ   : realvncondemandassist : Installing On-Demand-Assist-2.1.0-MacOSX-universal
2024-02-29 12:15:27 : INFO  : realvncondemandassist : Unzipping On-Demand-Assist-2.1.0-MacOSX-universal.zip
2024-02-29 12:15:27 : INFO  : realvncondemandassist : Verifying: /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : App size:  11M	/var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : Debugging enabled, App Verification output was:
/var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: RealVNC Limited (ZNCQ8JEH7X)

2024-02-29 12:15:27 : INFO  : realvncondemandassist : Team ID matching: ZNCQ8JEH7X (expected: ZNCQ8JEH7X )
2024-02-29 12:15:27 : INFO  : realvncondemandassist : Installing On-Demand-Assist-2.1.0-MacOSX-universal version 2.1.0 (r49525) on versionKey CFBundleShortVersionString.
2024-02-29 12:15:27 : INFO  : realvncondemandassist : Copy /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app to /Applications
2024-02-29 12:15:27 : DEBUG : realvncondemandassist : Debugging enabled, App copy output was:
Copying /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app

2024-02-29 12:15:27 : WARN  : realvncondemandassist : Changing owner to adambutterwick
2024-02-29 12:15:27 : INFO  : realvncondemandassist : Finishing...
2024-02-29 12:15:31 : INFO  : realvncondemandassist : Custom App Version detection is used, found 2.1.0
2024-02-29 12:15:31 : REQ   : realvncondemandassist : Installed On-Demand-Assist-2.1.0-MacOSX-universal, version 2.1.0 (r49525)
2024-02-29 12:15:31 : INFO  : realvncondemandassist : notifying
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : Deleting /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : Debugging enabled, Deleting tmpDir output was:
/var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/CodeResources
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/_CodeSignature/CodeResources
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/_CodeSignature
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/MacOS/odserver
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/MacOS
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/downArrow@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack06.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack07.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack05.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack11.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack10.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack04.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack00.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack01.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack03.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack02.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/bannerStatusQuestion@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/screenRecord@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/od_elevate.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/od_confirm_check@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/odserver.icns
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/CloudConfig.pkg
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/logo.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/rightArrow@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/stopRecord@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/od_server_unconnected@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack09.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/spinnerblack08.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/od_file_transfer.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources/od_server_connected@2x.png
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Resources
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents/Info.plist
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app/Contents
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.app
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy/On-Demand-Assist-2.1.0-MacOSX-universal.zip
2024-02-29 12:15:31 : DEBUG : realvncondemandassist : /var/folders/6s/t_m0n56s11v0v5x2tk7yk9rw0000gq/T/tmp.5TNPWSZnLy
2024-02-29 12:15:31 : INFO  : realvncondemandassist : Installomator did not close any apps, so no need to reopen any apps.
2024-02-29 12:15:31 : REQ   : realvncondemandassist : All done!
2024-02-29 12:15:31 : REQ   : realvncondemandassist : ################## End Installomator, exit code 0