### PR TITLE
New Label: Sipgate CLINQ

### DIFF
--- a/fragments/labels/sipgateclinq.sh
+++ b/fragments/labels/sipgateclinq.sh
@@ -1,0 +1,8 @@
+sipgateclinq)
+    name="Sipgate CLINQ"
+    type="dmg"
+    appNewVersion=$(curl -fs -L https://desktop.download.sipgate.com/latest-mac.yml | sed -n 's/version: \(.*\)/\1/p')
+    downloadURL="https://desktop.download.sipgate.com/sipgate%20CLINQ-${appNewVersion}.dmg"
+    expectedTeamID="K4L4M6DD76"
+;;
+


### PR DESCRIPTION
New label for the App Sipgate CLINQ, a softphone client for sipgate.de.