### PR TITLE
fix displaylinkmanager label

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -2,7 +2,7 @@ displaylinkmanager)
     name="DisplayLink Manager"
     type="pkg"
     #packageID="com.displaylink.displaylinkmanagerapp"
-    downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep 'class="download-link">Download' | sed -n '2p' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
-    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep "Release:" | sed -n '2p' | cut -d ' ' -f2)
+    downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 'class="download-link">Download' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
+    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 "Release:" | cut -d ' ' -f2)
     expectedTeamID="73YQY62QM3"
     ;;


### PR DESCRIPTION
original PR here from @sjurlohne in https://github.com/Installomator/Installomator/pull/1337

```
# sudo ./Installomator.sh displaylinkmanager DEBUG=0 NOTIFY=success INSTALL=force                                                                               
Password:
2024-03-12 13:53:48 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.6beta, date 2024-03-04
2024-03-12 13:53:48 : INFO  : displaylinkmanager : ################## Version: 10.6beta
2024-03-12 13:53:48 : INFO  : displaylinkmanager : ################## Date: 2024-03-04
2024-03-12 13:53:48 : INFO  : displaylinkmanager : ################## displaylinkmanager
2024-03-12 13:53:48 : DEBUG : displaylinkmanager : DEBUG mode 1 enabled.
2024-03-12 13:53:54 : INFO  : displaylinkmanager : setting variable from argument DEBUG=0
2024-03-12 13:53:54 : INFO  : displaylinkmanager : setting variable from argument NOTIFY=success
2024-03-12 13:53:54 : INFO  : displaylinkmanager : setting variable from argument INSTALL=force
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : name=DisplayLink Manager
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : appName=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : type=pkg
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : archiveName=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : downloadURL=https://www.synaptics.com/sites/default/files/exe_files/2024-03/DisplayLink%20Manager%20Graphics%20Connectivity1.10.1-EXE.pkg
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : curlOptions=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : appNewVersion=1.10.1
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : appCustomVersion function: Not defined
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : versionKey=CFBundleShortVersionString
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : packageID=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : pkgName=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : choiceChangesXML=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : expectedTeamID=73YQY62QM3
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : blockingProcesses=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : installerTool=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : CLIInstaller=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : CLIArguments=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : updateTool=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : updateToolArguments=
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : updateToolRunAsCurrentUser=
2024-03-12 13:53:54 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2024-03-12 13:53:54 : INFO  : displaylinkmanager : NOTIFY=success
2024-03-12 13:53:54 : INFO  : displaylinkmanager : LOGGING=DEBUG
2024-03-12 13:53:54 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-03-12 13:53:54 : INFO  : displaylinkmanager : Label type: pkg
2024-03-12 13:53:54 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.pkg
2024-03-12 13:53:54 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7
2024-03-12 13:53:54 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2024-03-12 13:53:54 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 1.10.0, on versionKey CFBundleShortVersionString
2024-03-12 13:53:54 : INFO  : displaylinkmanager : appversion: 1.10.0
2024-03-12 13:53:54 : INFO  : displaylinkmanager : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-03-12 13:53:54 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 1.10.1
2024-03-12 13:53:54 : REQ   : displaylinkmanager : Downloading https://www.synaptics.com/sites/default/files/exe_files/2024-03/DisplayLink%20Manager%20Graphics%20Connectivity1.10.1-EXE.pkg to DisplayLink Manager.pkg
2024-03-12 13:53:54 : DEBUG : displaylinkmanager : No Dialog connection, just download
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : File list: -rw-r--r--  1 root  wheel   6.9M Mar 12 13:53 DisplayLink Manager.pkg
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : File type: DisplayLink Manager.pkg: xar archive compressed TOC: 4997, SHA-1 checksum
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : curl output was:
*   Trying 54.245.106.105:443...
* Connected to www.synaptics.com (54.245.106.105) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3149 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Synaptics Inc.; CN=www.synaptics.com
*  start date: Dec  9 00:00:00 2023 GMT
*  expire date: Jan  8 23:59:59 2025 GMT
*  subjectAltName: host "www.synaptics.com" matched cert's "www.synaptics.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.synaptics.com/sites/default/files/exe_files/2024-03/DisplayLink%20Manager%20Graphics%20Connectivity1.10.1-EXE.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.synaptics.com]
* [HTTP/2] [1] [:path: /sites/default/files/exe_files/2024-03/DisplayLink%20Manager%20Graphics%20Connectivity1.10.1-EXE.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /sites/default/files/exe_files/2024-03/DisplayLink%20Manager%20Graphics%20Connectivity1.10.1-EXE.pkg HTTP/2
> Host: www.synaptics.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< server: nginx
< date: Tue, 12 Mar 2024 12:53:55 GMT
< content-length: 7267472
< x-content-type-options: nosniff
< last-modified: Mon, 11 Mar 2024 13:50:05 GMT
< accept-ranges: bytes
< cache-control: max-age=1209600
< expires: Tue, 26 Mar 2024 12:53:55 GMT
< x-request-id: v-95d561a2-e06f-11ee-98ac-733f6ed1d71f
< x-ah-environment: prod
< age: 0
< via: varnish
< x-cache: MISS
<
{ [22125 bytes data]
* Connection #0 to host www.synaptics.com left intact

2024-03-12 13:53:58 : REQ   : displaylinkmanager : no more blocking processes, continue with update
2024-03-12 13:53:58 : REQ   : displaylinkmanager : Installing DisplayLink Manager
2024-03-12 13:53:58 : INFO  : displaylinkmanager : Verifying: DisplayLink Manager.pkg
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : File list: -rw-r--r--  1 root  wheel   6.9M Mar 12 13:53 DisplayLink Manager.pkg
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : File type: DisplayLink Manager.pkg: xar archive compressed TOC: 4997, SHA-1 checksum
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : spctlOut is DisplayLink Manager.pkg: accepted
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : source=Notarized Developer ID
2024-03-12 13:53:58 : DEBUG : displaylinkmanager : origin=Developer ID Installer: DisplayLink Corp (73YQY62QM3)
2024-03-12 13:53:58 : INFO  : displaylinkmanager : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2024-03-12 13:53:58 : INFO  : displaylinkmanager : Installing DisplayLink Manager.pkg to /
2024-03-12 13:54:03 : DEBUG : displaylinkmanager : Debugging enabled, installer output was:
Mar 12 13:53:58  installer[97564] <Debug>: JS: No KEXT found, not requiring restart
Last Log repeated 2 times
Mar 12 13:53:58  installer[97564] <Debug>: JS: Found already installed DisplayLink driver
Mar 12 13:53:58  installer[97564] <Debug>: JS: DisplayLink previous installation found, build version:117
Mar 12 13:53:58  installer[97564] <Debug>: JS: DisplayLink previous installation found:1.10.0
Mar 12 13:53:58  installer[97564] <Debug>: JS: current version:1,10,1,93 bundle version:1,10,0,117
Mar 12 13:53:58  installer[97564] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink Manager.pkg trustLevel=350
Mar 12 13:53:58  installer[97564] <Debug>: External component packages (1) trustLevel=350
Mar 12 13:53:58  installer[97564] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Mar 12 13:53:58  installer[97564] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink%20Manager.pkg#DisplayLinkManagerApp.pkg
Mar 12 13:53:58  installer[97564] <Info>: Set authorization level to root for session
Mar 12 13:53:58  installer[97564] <Info>: Authorization is being checked, waiting until authorization arrives.
Mar 12 13:53:58  installer[97564] <Info>: Administrator authorization granted.
Mar 12 13:53:58  installer[97564] <Info>: Packages have been authorized for installation.
Mar 12 13:53:58  installer[97564] <Debug>: Will use PK session
Mar 12 13:53:58  installer[97564] <Debug>: Using authorization level of root for IFPKInstallElement
Mar 12 13:53:58  installer[97564] <Info>: Starting installation:
Mar 12 13:53:58  installer[97564] <Notice>: Configuring volume "Macintosh HD"
Mar 12 13:53:58  installer[97564] <Info>: Preparing disk for local booted install.
Mar 12 13:53:58  installer[97564] <Notice>: Free space on "Macintosh HD": 89.32 GB (89319845888 bytes).
Mar 12 13:53:58  installer[97564] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.975647xA68i"
Mar 12 13:53:58  installer[97564] <Notice>: IFPKInstallElement (1 packages)
Mar 12 13:53:59  installer[97564] <Info>: Current Path: /usr/sbin/installer
Mar 12 13:53:59  installer[97564] <Info>: Current Path: /bin/zsh
Mar 12 13:53:59  installer[97564] <Info>: Current Path: /usr/bin/sudo
Mar 12 13:53:59  installer[97564] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is DisplayLink Manager
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „DisplayLink Manager“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Mar 12 13:54:01  installer[97564] <Info>: PackageKit: Registered bundle file:///Applications/DisplayLink%20Manager.app/ for uid 0
Mar 12 13:54:01  installer[97564] <Info>: PackageKit: Registered bundle file:///Applications/DisplayLink%20Manager.app/Contents/Library/LoginItems/DisplayLinkLoginHelper.app/ for uid 0

installer: Paketskripte ausführen ….....
installer: Pakete überprüfen ….....
#Mar 12 13:54:02  installer[97564] <Notice>: Running install actions
Mar 12 13:54:02  installer[97564] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.975647xA68i"
Mar 12 13:54:02  installer[97564] <Notice>: Finalize disk "Macintosh HD"
Mar 12 13:54:02  installer[97564] <Notice>: Notifying system of updated components
Mar 12 13:54:02  installer[97564] <Notice>:
Mar 12 13:54:02  installer[97564] <Notice>: **** Summary Information ****
Mar 12 13:54:02  installer[97564] <Notice>:   Operation      Elapsed time
Mar 12 13:54:02  installer[97564] <Notice>: -----------------------------
Mar 12 13:54:02  installer[97564] <Notice>:        disk      0.00 seconds
Mar 12 13:54:02  installer[97564] <Notice>:      script      0.00 seconds
Mar 12 13:54:02  installer[97564] <Notice>:        zero      0.00 seconds
Mar 12 13:54:02  installer[97564] <Notice>:     install      3.13 seconds
Mar 12 13:54:02  installer[97564] <Notice>:     -total-      3.13 seconds
Mar 12 13:54:02  installer[97564] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-03-12 13:53:58+01 mac installer[97564]: JS: No KEXT found, not requiring restart
2024-03-12 13:53:58+01 mac installer[97564]: JS: No KEXT found, not requiring restart
2024-03-12 13:53:58+01 mac installer[97564]: JS: Found already installed DisplayLink driver
2024-03-12 13:53:58+01 mac installer[97564]: JS: DisplayLink previous installation found, build version:117
2024-03-12 13:53:58+01 mac installer[97564]: JS: DisplayLink previous installation found:1.10.0
2024-03-12 13:53:58+01 mac installer[97564]: JS: current version:1,10,1,93 bundle version:1,10,0,117
2024-03-12 13:53:58+01 mac installer[97564]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink Manager.pkg trustLevel=350
2024-03-12 13:53:58+01 mac installer[97564]: External component packages (1) trustLevel=350
2024-03-12 13:53:58+01 mac installer[97564]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-03-12 13:53:58+01 mac installer[97564]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink%20Manager.pkg#DisplayLinkManagerApp.pkg
2024-03-12 13:53:58+01 mac installer[97564]: Set authorization level to root for session
2024-03-12 13:53:58+01 mac installer[97564]: Authorization is being checked, waiting until authorization arrives.
2024-03-12 13:53:58+01 mac installer[97564]: Administrator authorization granted.
2024-03-12 13:53:58+01 mac installer[97564]: Packages have been authorized for installation.
2024-03-12 13:53:58+01 mac installer[97564]: Will use PK session
2024-03-12 13:53:58+01 mac installer[97564]: Using authorization level of root for IFPKInstallElement
2024-03-12 13:53:58+01 mac installer[97564]: Starting installation:
2024-03-12 13:53:58+01 mac installer[97564]: Configuring volume "Macintosh HD"
2024-03-12 13:53:58+01 mac installer[97564]: Preparing disk for local booted install.
2024-03-12 13:53:58+01 mac installer[97564]: Free space on "Macintosh HD": 89.32 GB (89319845888 bytes).
2024-03-12 13:53:58+01 mac installer[97564]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.975647xA68i"
2024-03-12 13:53:58+01 mac installer[97564]: IFPKInstallElement (1 packages)
2024-03-12 13:53:59+01 mac installer[97564]: Current Path: /usr/sbin/installer
2024-03-12 13:53:59+01 mac installer[97564]: Current Path: /bin/zsh
2024-03-12 13:53:59+01 mac installer[97564]: Current Path: /usr/bin/sudo
2024-03-12 13:53:59+01 mac installd[97565]: installd: Starting
2024-03-12 13:53:59+01 mac installd[97565]: installd: uid=0, euid=0
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Adding client PKInstallDaemonClient pid=97564, uid=0 (/usr/sbin/installer)
2024-03-12 13:53:59+01 mac installer[97564]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Set reponsibility for install to 60875
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Hosted team responsibility for install set to team:(73YQY62QM3)
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: ----- Begin install -----
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: packages=(
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/8E993B7F-92D0-4DB8-AA14-292F5FF29235.activeSandbox
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink%20Manager.pkg#DisplayLinkManagerApp.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/C6ECDCBD-EB50-417A-A4D1-6F4EDEA07783.activeSandbox/Root/Applications, uid=0)
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: prevent user idle system sleep
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: suspending backupd
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/C6ECDCBD-EB50-417A-A4D1-6F4EDEA07783.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/C6ECDCBD-EB50-417A-A4D1-6F4EDEA07783.activeSandbox
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/C6ECDCBD-EB50-417A-A4D1-6F4EDEA07783.activeSandbox/Root (1 items) to /
2024-03-12 13:53:59+01 mac installd[97565]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.RL0xkg/Scripts/com.displaylink.displaylinkmanagerapp.AHswA5
2024-03-12 13:53:59+01 mac package_script_service[97568]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.RL0xkg/Scripts/com.displaylink.displaylinkmanagerapp.AHswA5
2024-03-12 13:53:59+01 mac package_script_service[97568]: Set responsibility to pid: 60875, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2024-03-12 13:53:59+01 mac package_script_service[97568]: Hosted team responsibility for script set to team:(73YQY62QM3)
2024-03-12 13:53:59+01 mac package_script_service[97568]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.RL0xkg/Scripts/com.displaylink.displaylinkmanagerapp.AHswA5
2024-03-12 13:53:59+01 mac package_script_service[97568]: ./postinstall: DisplayLink uninstall script
2024-03-12 13:53:59+01 mac package_script_service[97568]: ./postinstall: > DisplayLink uninstaller running in "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink Manager.pkg" mode
2024-03-12 13:53:59+01 mac package_script_service[97568]: ./postinstall: > Removing DisplayLink user agents
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: > Removing DisplayLink daemon
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: All DisplayLink processes are finished
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Applications/DisplayLink not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/Application Support/DisplayLink not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/LaunchAgents/73YQY62QM3.com.displaylink.DisplayLinkAPServer.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/LaunchAgents/com.displaylink.useragent-prelogin.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/LaunchAgents/com.displaylink.useragent.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/LaunchDaemons/com.displaylink.displaylinkmanager.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/LaunchDaemons/com.displaylink.launchd.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/Preferences/com.displaylink.plist not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/PrivilegedHelperTools/DisplayLink not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/Receipts/DisplayLink Software Installer.pkg not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/StartupItems/DisplayLinkAgent not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkGA.plugin not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkGA_10.6.plugin not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /etc/asl/com.displaylink.windowserver not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /var/db/receipts/com.displaylink* not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /var/log/displaylink not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/Extensions/DisplayLinkDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /Library/Extensions/DisplayLinkEthernetDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkDriver0.9.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkEthernetDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkNcmDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: /System/Library/Extensions/DisplayLinkNullDriver.kext KEXT not found, skipping.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: > Remove plists from user directories
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: > DisplayLink uninstall script done.
2024-03-12 13:54:00+01 mac package_script_service[97568]: ./postinstall: Starting DisplayLinkManager.app
2024-03-12 13:54:00+01 mac package_script_service[97568]: PackageKit: Hosted team responsible for script has been cleared.
2024-03-12 13:54:00+01 mac package_script_service[97568]: Responsibility set back to self.
2024-03-12 13:54:00+01 mac installd[97565]: PackageKit: Writing receipt for com.displaylink.displaylinkmanagerapp to /
2024-03-12 13:54:00+01 mac installd[97565]: PackageKit: No Intel binaries to translate.
2024-03-12 13:54:00+01 mac installd[97565]: PackageKit: Touched bundle /Applications/DisplayLink Manager.app
2024-03-12 13:54:00+01 mac installd[97565]: PackageKit: Touched bundle /Applications/DisplayLink Manager.app/Contents/Library/LoginItems/DisplayLinkLoginHelper.app
2024-03-12 13:54:00+01 mac installd[97565]: Installed "DisplayLink Manager" (1.10.1.93)
2024-03-12 13:54:00+01 mac installd[97565]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: releasing backupd
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: allow user idle system sleep
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: ----- End install -----
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: 2.2s elapsed install time
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: Cleared responsibility for install from 97564.
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: Hosted team responsible for install has been cleared.
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: Running idle tasks
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: Done with sandbox removals
2024-03-12 13:54:01+01 mac installer[97564]: PackageKit: Registered bundle file:///Applications/DisplayLink%20Manager.app/ for uid 0
2024-03-12 13:54:01+01 mac installer[97564]: PackageKit: Registered bundle file:///Applications/DisplayLink%20Manager.app/Contents/Library/LoginItems/DisplayLinkLoginHelper.app/ for uid 0
2024-03-12 13:54:01+01 mac installd[97565]: PackageKit: Removing client PKInstallDaemonClient pid=97564, uid=0 (/usr/sbin/installer)
2024-03-12 13:54:02+01 mac installer[97564]: Running install actions
2024-03-12 13:54:02+01 mac installer[97564]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.975647xA68i"
2024-03-12 13:54:02+01 mac installer[97564]: Finalize disk "Macintosh HD"
2024-03-12 13:54:02+01 mac installer[97564]: Notifying system of updated components
2024-03-12 13:54:02+01 mac installer[97564]:
2024-03-12 13:54:02+01 mac installer[97564]: **** Summary Information ****
2024-03-12 13:54:02+01 mac installer[97564]:   Operation      Elapsed time
2024-03-12 13:54:02+01 mac installer[97564]: -----------------------------
2024-03-12 13:54:02+01 mac installer[97564]:        disk      0.00 seconds
2024-03-12 13:54:02+01 mac installer[97564]:      script      0.00 seconds
2024-03-12 13:54:02+01 mac installer[97564]:        zero      0.00 seconds
2024-03-12 13:54:02+01 mac installer[97564]:     install      3.13 seconds
2024-03-12 13:54:02+01 mac installer[97564]:     -total-      3.13 seconds
2024-03-12 13:54:02+01 mac installer[97564]:

2024-03-12 13:54:03 : INFO  : displaylinkmanager : Finishing...
2024-03-12 13:54:06 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2024-03-12 13:54:06 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 1.10.1, on versionKey CFBundleShortVersionString
2024-03-12 13:54:06 : REQ   : displaylinkmanager : Installed DisplayLink Manager, version 1.10.1
2024-03-12 13:54:06 : INFO  : displaylinkmanager : notifying
ERROR: Notifications are not allowed for this application
2024-03-12 13:54:06 : DEBUG : displaylinkmanager : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7
2024-03-12 13:54:06 : DEBUG : displaylinkmanager : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7/DisplayLink Manager.pkg
2024-03-12 13:54:06 : DEBUG : displaylinkmanager : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.klAfVClnK7
2024-03-12 13:54:06 : INFO  : displaylinkmanager : Installomator did not close any apps, so no need to reopen any apps.
2024-03-12 13:54:06 : REQ   : displaylinkmanager : All done!
2024-03-12 13:54:06 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0
```