### PR TITLE
Update marathon.sh

### DIFF
--- a/fragments/labels/marathon.sh
+++ b/fragments/labels/marathon.sh
@@ -1,5 +1,5 @@
 marathon)
-    name="Marathon"
+    name="Classic Marathon"
     type="dmg"
     archiveName="Marathon-[0-9.]*-Mac.dmg"
     versionKey="CFBundleVersion"


### PR DESCRIPTION
Alephone changed the app name of Marathon from Marathon.app to "Classic Marathon.app". This addresses #1495 

Log attached of the output of `sudo utils/assemble.sh marathon DEBUG=0`

[marathonlog.txt](https://github.com/Installomator/Installomator/files/14577469/marathonlog.txt)
