### PR TITLE
Update marathon2.sh

### DIFF
--- a/fragments/labels/marathon2.sh
+++ b/fragments/labels/marathon2.sh
@@ -1,5 +1,5 @@
 marathon2)
-    name="Marathon 2"
+    name="Classic Marathon 2"
     type="dmg"
     archiveName="Marathon2-[0-9.]*-Mac.dmg"
     versionKey="CFBundleVersion"


### PR DESCRIPTION
Alephone changed the app name of Marathon 2 from Marathon 2.app to "Classic Marathon 2.app". This addresses #1496 

Log attached of the output of `sudo utils/assemble.sh marathon2 DEBUG=0`

[marathon2log.txt](https://github.com/Installomator/Installomator/files/14577525/marathon2log.txt)


