### PR TITLE
Update marathoninfinity.sh

### DIFF
--- a/fragments/labels/marathoninfinity.sh
+++ b/fragments/labels/marathoninfinity.sh
@@ -1,5 +1,5 @@
 marathoninfinity)
-    name="Marathon Infinity"
+    name="Classic Marathon Infinity"
     type="dmg"
     archiveName="MarathonInfinity-[0-9.]*-Mac.dmg"
     versionKey="CFBundleVersion"


### PR DESCRIPTION
Alephone changed the app name of Marathon Infinity from Marathon Infinity.app to "Classic Marathon Infinity.app". This addresses #1497 

Log attached of the output of `sudo utils/assemble.sh marathoninfinity DEBUG=0`

[marathoninfinitylog.txt](https://github.com/Installomator/Installomator/files/14577541/marathoninfinitylog.txt)
