### PR TITLE
New Label: Cloudbrink

### DIFF
--- a/fragments/labels/cloudbrink.sh
+++ b/fragments/labels/cloudbrink.sh
@@ -1,0 +1,10 @@
+cloudbrink)
+  name="BrinkAgent"
+  type="pkg"
+  pkgName="BrinkAgent-latest.app"
+  appNewVersion=$(curl -sL "https://cloudbrink.com/brink-app-dl/release-notes.txt" | grep -i macos | awk '{print $3}')
+  downloadURL="https://cloudbrink.com/brink-app-dl/BrinkAgent-latest.pkg"
+  expectedTeamID="DG4B583484"
+  blockingProcesses=( "brinkagent" "BrinkAgent" "brinkwatchdog" )
+  forcefulQuit=YES
+  ;;


### PR DESCRIPTION
2024-03-17 16:12:42 : REQ   : cloudbrink : ################## Start Installomator v. 10.5, date 2023-10-15
2024-03-17 16:12:42 : INFO  : cloudbrink : ################## Version: 10.5
2024-03-17 16:12:42 : INFO  : cloudbrink : ################## Date: 2023-10-15
2024-03-17 16:12:42 : INFO  : cloudbrink : ################## cloudbrink
2024-03-17 16:12:42 : DEBUG : cloudbrink : DEBUG mode 1 enabled.
2024-03-17 16:12:42 : INFO  : cloudbrink : setting variable from argument NOTIFY=all
2024-03-17 16:12:42 : INFO  : cloudbrink : setting variable from argument DEBUG=0
2024-03-17 16:12:42 : INFO  : cloudbrink : setting variable from argument LOGO="jamf"
2024-03-17 16:12:42 : INFO  : cloudbrink : setting variable from argument REOPEN="yes"
2024-03-17 16:12:42 : INFO  : cloudbrink : setting variable from argument BLOCKING_PROCESS_ACTION=ignore
2024-03-17 16:12:42 : DEBUG : cloudbrink : name=BrinkAgent
2024-03-17 16:12:42 : DEBUG : cloudbrink : appName=
2024-03-17 16:12:42 : DEBUG : cloudbrink : type=pkg
2024-03-17 16:12:42 : DEBUG : cloudbrink : archiveName=
2024-03-17 16:12:43 : DEBUG : cloudbrink : downloadURL=https://cloudbrink.com/brink-app-dl/BrinkAgent-latest.pkg
2024-03-17 16:12:43 : DEBUG : cloudbrink : curlOptions=
2024-03-17 16:12:43 : DEBUG : cloudbrink : appNewVersion=13.2.148
2024-03-17 16:12:43 : DEBUG : cloudbrink : appCustomVersion function: Not defined
2024-03-17 16:12:43 : DEBUG : cloudbrink : versionKey=CFBundleShortVersionString
2024-03-17 16:12:43 : DEBUG : cloudbrink : packageID=
2024-03-17 16:12:43 : DEBUG : cloudbrink : pkgName=BrinkAgent-latest.app
2024-03-17 16:12:43 : DEBUG : cloudbrink : choiceChangesXML=
2024-03-17 16:12:43 : DEBUG : cloudbrink : expectedTeamID=DG4B583484
2024-03-17 16:12:43 : DEBUG : cloudbrink : blockingProcesses=brinkagent BrinkAgent brinkwatchdog
2024-03-17 16:12:43 : DEBUG : cloudbrink : installerTool=
2024-03-17 16:12:43 : DEBUG : cloudbrink : CLIInstaller=
2024-03-17 16:12:43 : DEBUG : cloudbrink : CLIArguments=
2024-03-17 16:12:43 : DEBUG : cloudbrink : updateTool=
2024-03-17 16:12:43 : DEBUG : cloudbrink : updateToolArguments=
2024-03-17 16:12:43 : DEBUG : cloudbrink : updateToolRunAsCurrentUser=
2024-03-17 16:12:43 : INFO  : cloudbrink : BLOCKING_PROCESS_ACTION=ignore
2024-03-17 16:12:43 : INFO  : cloudbrink : NOTIFY=all
2024-03-17 16:12:43 : INFO  : cloudbrink : LOGGING=DEBUG
2024-03-17 16:12:43 : INFO  : cloudbrink : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2024-03-17 16:12:43 : INFO  : cloudbrink : Label type: pkg
2024-03-17 16:12:43 : INFO  : cloudbrink : archiveName: BrinkAgent.pkg
2024-03-17 16:12:43 : DEBUG : cloudbrink : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO
2024-03-17 16:12:43 : INFO  : cloudbrink : App(s) found: /Applications/BrinkAgent.app
2024-03-17 16:12:43 : INFO  : cloudbrink : found app at /Applications/BrinkAgent.app, version 13.2.141, on versionKey CFBundleShortVersionString
2024-03-17 16:12:43 : INFO  : cloudbrink : appversion: 13.2.141
2024-03-17 16:12:43 : INFO  : cloudbrink : Latest version of BrinkAgent is 13.2.148
2024-03-17 16:12:43 : REQ   : cloudbrink : Downloading https://cloudbrink.com/brink-app-dl/BrinkAgent-latest.pkg to BrinkAgent.pkg
2024-03-17 16:12:43 : INFO  : cloudbrink : notifying
2024-03-17 16:12:43 : DEBUG : cloudbrink : No Dialog connection, just download
2024-03-17 16:12:45 : DEBUG : cloudbrink : File list: -rw-r--r--  1 root  wheel   115M Mar 17 16:12 BrinkAgent.pkg
2024-03-17 16:12:45 : DEBUG : cloudbrink : File type: BrinkAgent.pkg: xar archive compressed TOC: 4871, SHA-1 checksum
2024-03-17 16:12:45 : DEBUG : cloudbrink : curl output was:
*   Trying [2606:4700:20::681a:294]:443...
* Connected to cloudbrink.com (2606:4700:20::681a:294) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4143 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cloudbrink.com
*  start date: Feb 22 20:05:50 2024 GMT
*  expire date: May 22 20:05:49 2024 GMT
*  subjectAltName: host "cloudbrink.com" matched cert's "cloudbrink.com"
*  issuer: C=US; O=Let's Encrypt; CN=E1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cloudbrink.com/brink-app-dl/BrinkAgent-latest.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cloudbrink.com]
* [HTTP/2] [1] [:path: /brink-app-dl/BrinkAgent-latest.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /brink-app-dl/BrinkAgent-latest.pkg HTTP/2
> Host: cloudbrink.com
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/2 200 
< date: Sun, 17 Mar 2024 23:12:43 GMT
< content-type: application/octet-stream
< content-length: 120410687
< last-modified: Mon, 12 Feb 2024 17:39:54 GMT
< etag: "65ca57ea-72d523f"
< x-cacheable: SHORT
< vary: Accept-Encoding,Cookie
< cache-control: max-age=600, must-revalidate
< accept-ranges: bytes
< x-cache: HIT: 1
< x-cache-group: normal
< x-orig-cache-control: max-age=600, must-revalidate
< cf-cache-status: DYNAMIC
< set-cookie: __cf_bm=uqEii3OryJy.fvMd8.FcetN5XIK4xkG4UL_dqnTRZBM-1710717163-1.0.1.1-sHLKAN1ZPWRtHvI6c2..R_xM79923xJ9k5RvxbM2aVLi13hkhhsKM1PpZWbL7bcQkKX0bqSCH18lXTThHqoDoQ; path=/; expires=Sun, 17-Mar-24 23:42:43 GMT; domain=.cloudbrink.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8660ab5edc987c5b-LAX
< alt-svc: h3=":443"; ma=86400
< 
{ [32265 bytes data]
* Connection #0 to host cloudbrink.com left intact

2024-03-17 16:12:45 : INFO  : cloudbrink : ignoring blocking processes
2024-03-17 16:12:45 : REQ   : cloudbrink : Installing BrinkAgent
2024-03-17 16:12:45 : INFO  : cloudbrink : notifying
2024-03-17 16:12:46 : INFO  : cloudbrink : Verifying: BrinkAgent.pkg
2024-03-17 16:12:46 : DEBUG : cloudbrink : File list: -rw-r--r--  1 root  wheel   115M Mar 17 16:12 BrinkAgent.pkg
2024-03-17 16:12:46 : DEBUG : cloudbrink : File type: BrinkAgent.pkg: xar archive compressed TOC: 4871, SHA-1 checksum
2024-03-17 16:12:46 : DEBUG : cloudbrink : spctlOut is BrinkAgent.pkg: accepted
2024-03-17 16:12:46 : DEBUG : cloudbrink : source=Notarized Developer ID
2024-03-17 16:12:46 : DEBUG : cloudbrink : origin=Developer ID Installer: Cloudbrink Inc (DG4B583484)
2024-03-17 16:12:46 : INFO  : cloudbrink : Team ID: DG4B583484 (expected: DG4B583484 )
2024-03-17 16:12:46 : INFO  : cloudbrink : Installing BrinkAgent.pkg to /
2024-03-17 16:13:06 : DEBUG : cloudbrink : Debugging enabled, installer output was:
Mar 17 16:12:46  installer[13849] <Info>: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
Mar 17 16:12:46  installer[13849] <Warning>: Architecture Translation: Process is about to get executed as Intel.
installer: Warning - A previous installation of brinkagent exists. Installer will clean the existing brinkagent
Mar 17 16:12:46  installer[13849] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg trustLevel=350
Mar 17 16:12:46  installer[13849] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Mar 17 16:12:46  installer[13849] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg#BrinkAgent.pkg
Mar 17 16:12:46  installer[13849] <Info>: Set authorization level to root for session
Mar 17 16:12:46  installer[13849] <Info>: Authorization is being checked, waiting until authorization arrives.
Mar 17 16:12:46  installer[13849] <Info>: Administrator authorization granted.
Mar 17 16:12:46  installer[13849] <Info>: Packages have been authorized for installation.
Mar 17 16:12:46  installer[13849] <Debug>: Will use PK session
Mar 17 16:12:46  installer[13849] <Debug>: Using authorization level of root for IFPKInstallElement
Mar 17 16:12:46  installer[13849] <Info>: Install request is requesting Rosetta translation.
Mar 17 16:12:46  installer[13849] <Info>: Starting installation:
Mar 17 16:12:46  installer[13849] <Notice>: Configuring volume "Macintosh HD"
Mar 17 16:12:46  installer[13849] <Info>: Preparing disk for local booted install.
Mar 17 16:12:46  installer[13849] <Notice>: Free space on "Macintosh HD": 226.3 GB (226300596224 bytes).
Mar 17 16:12:46  installer[13849] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13849Sh9RRB"
Mar 17 16:12:46  installer[13849] <Notice>: IFPKInstallElement (1 packages)
Mar 17 16:12:46  installer[13849] <Info>: Current Path: /usr/sbin/installer
Mar 17 16:12:46  installer[13849] <Info>: Current Path: /bin/zsh
Mar 17 16:12:46  installer[13849] <Info>: Current Path: /bin/bash
Mar 17 16:12:46  installer[13849] <Info>: Current Path: /usr/local/jamf/bin/jamf
Mar 17 16:12:46  installer[13849] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is brinkagent
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing brinkagent….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
Last Log repeated 11 times
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
Last Log repeated 15 times
#
installer: Registering updated components….....
installer: Validating packages….....
#Mar 17 16:13:04  installer[13849] <Notice>: Running install actions
Mar 17 16:13:04  installer[13849] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13849Sh9RRB"
Mar 17 16:13:04  installer[13849] <Notice>: Finalize disk "Macintosh HD"
Mar 17 16:13:04  installer[13849] <Notice>: Notifying system of updated components
Mar 17 16:13:04  installer[13849] <Notice>:
Mar 17 16:13:04  installer[13849] <Notice>: **** Summary Information ****
Mar 17 16:13:04  installer[13849] <Notice>:   Operation      Elapsed time
Mar 17 16:13:04  installer[13849] <Notice>: -----------------------------
Mar 17 16:13:04  installer[13849] <Notice>:        disk      0.00 seconds
Mar 17 16:13:04  installer[13849] <Notice>:      script      0.00 seconds
Mar 17 16:13:04  installer[13849] <Notice>:        zero      0.00 seconds
Mar 17 16:13:04  installer[13849] <Notice>:     install      18.26 seconds
Mar 17 16:13:04  installer[13849] <Notice>:     -total-      18.26 seconds
Mar 17 16:13:04  installer[13849] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-03-17 16:12:46-07 kevin-test installer[13849]: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Architecture Translation: Process is about to get executed as Intel.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg trustLevel=350
2024-03-17 16:12:46-07 kevin-test installer[13849]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-03-17 16:12:46-07 kevin-test installer[13849]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg#BrinkAgent.pkg
2024-03-17 16:12:46-07 kevin-test installer[13849]: Set authorization level to root for session
2024-03-17 16:12:46-07 kevin-test installer[13849]: Authorization is being checked, waiting until authorization arrives.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Administrator authorization granted.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Packages have been authorized for installation.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Will use PK session
2024-03-17 16:12:46-07 kevin-test installer[13849]: Using authorization level of root for IFPKInstallElement
2024-03-17 16:12:46-07 kevin-test installer[13849]: Install request is requesting Rosetta translation.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Starting installation:
2024-03-17 16:12:46-07 kevin-test installer[13849]: Configuring volume "Macintosh HD"
2024-03-17 16:12:46-07 kevin-test installer[13849]: Preparing disk for local booted install.
2024-03-17 16:12:46-07 kevin-test installer[13849]: Free space on "Macintosh HD": 226.3 GB (226300596224 bytes).
2024-03-17 16:12:46-07 kevin-test installer[13849]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13849Sh9RRB"
2024-03-17 16:12:46-07 kevin-test installer[13849]: IFPKInstallElement (1 packages)
2024-03-17 16:12:46-07 kevin-test installer[13849]: Current Path: /usr/sbin/installer
2024-03-17 16:12:46-07 kevin-test installer[13849]: Current Path: /bin/zsh
2024-03-17 16:12:46-07 kevin-test installer[13849]: Current Path: /bin/bash
2024-03-17 16:12:46-07 kevin-test installer[13849]: Current Path: /usr/local/jamf/bin/jamf
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: Adding client PKInstallDaemonClient pid=13849, uid=0 (/usr/sbin/installer)
2024-03-17 16:12:46-07 kevin-test installer[13849]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: Set reponsibility for install to 13483
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: Hosted team responsibility for install set to team:(DG4B583484)
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: ----- Begin install -----
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: packages=(
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: Will do receipt-based obsoleting for package identifier com.cloudbrink.BrinkAgent (prefix path=/)
2024-03-17 16:12:46-07 kevin-test installd[2614]: PackageKit: Extracting file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg#BrinkAgent.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/11751B05-180A-4F21-B621-6BA3CA8ABACB.activeSandbox/Root, uid=0)
2024-03-17 16:12:47-07 kevin-test installd[2614]: PackageKit: prevent user idle system sleep
2024-03-17 16:12:47-07 kevin-test installd[2614]: PackageKit: suspending backupd
2024-03-17 16:12:47-07 kevin-test installd[2614]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: Set responsibility to pid: 13483, responsible_path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfManagementService.app/Contents/MacOS/JamfManagementService
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: Hosted team responsibility for script set to team:(DG4B583484)
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp/preinstall'
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:47-07 kevin-test install_monitor[13850]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: mv: /opt/BrinkAgent/iplist.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: mv: /opt/BrinkAgent/iplistgwif.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: mv: /opt/BrinkAgent/ip6list.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: mv: /opt/BrinkAgent/ip6listgwif.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: action is stop
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: brinkip is 192.168.9.9
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: utun_if is invalid
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: brinkip6 is fdc0::c0a8:0909
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: net.inet.ip.forwarding: 1 -> 1
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: net.inet6.ip6.forwarding: 1 -> 1
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: /opt/BrinkAgent/mac_rule.sh: line 146: : No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: resetting dns
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: cat: def_route_reset_dns.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: sh: def_route_reset_dns.txt: No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: DNS server restored
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: /opt/BrinkAgent/mac_rule.sh: line 146: : No such file or directory
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.254.8.202: not in table
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.254.44.25: not in table
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:47-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.181.128.111: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 54.177.122.145: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.220.19.76: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.220.6.88: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 44.224.104.242: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 15.181.19.207: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 44.206.193.86: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 54.237.18.61: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 3.208.224.216: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 52.71.172.116: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 34.195.181.19: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 52.2.96.5: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 34.72.189.22: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 52.206.166.86: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 34.235.30.177: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: route: writing to routing socket: not in table
2024-03-17 16:12:48-07 kevin-test package_script_service[2616]: ./preinstall: delete net 44.193.125.29: not in table
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: ./preinstall: Successfully uninstalled Brink Agent.
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: PackageKit: Hosted team responsible for script has been cleared.
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: Responsibility set back to self.
2024-03-17 16:12:54-07 kevin-test installd[2614]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/11751B05-180A-4F21-B621-6BA3CA8ABACB.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/11751B05-180A-4F21-B621-6BA3CA8ABACB.activeSandbox
2024-03-17 16:12:54-07 kevin-test installd[2614]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/11751B05-180A-4F21-B621-6BA3CA8ABACB.activeSandbox/Root (1 items) to /
2024-03-17 16:12:54-07 kevin-test installd[2614]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: Set responsibility to pid: 13483, responsible_path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfManagementService.app/Contents/MacOS/JamfManagementService
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: Hosted team responsibility for script set to team:(DG4B583484)
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp/postinstall'
2024-03-17 16:12:54-07 kevin-test package_script_service[2616]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.IuyJCd/Scripts/com.cloudbrink.BrinkAgent.kJVIfp
2024-03-17 16:12:57-07 kevin-test package_script_service[2616]: ./postinstall: 14039	0	com.cloudbrink.brinkagent
2024-03-17 16:13:03-07 kevin-test package_script_service[2616]: ./postinstall: -	0	com.cloudbrink.brinkGuiHelper
2024-03-17 16:13:03-07 kevin-test package_script_service[2616]: PackageKit: Hosted team responsible for script has been cleared.
2024-03-17 16:13:03-07 kevin-test package_script_service[2616]: Responsibility set back to self.
2024-03-17 16:13:03-07 kevin-test installd[2614]: PackageKit: Writing receipt for com.cloudbrink.BrinkAgent to /
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/agent
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/brinkagent
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/brinkwatchdog
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/lib/libevent-2.1.7.dylib
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/lib/libevent_core-2.1.7.dylib
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/lib/libevent_extra-2.1.7.dylib
2024-03-17 16:13:04-07 kevin-test installd[2614]: oahd translated /opt/BrinkAgent/lib/libevent_pthreads-2.1.7.dylib
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Translated 7 binaries.
2024-03-17 16:13:04-07 kevin-test installd[2614]: Installed "brinkagent" ()
2024-03-17 16:13:04-07 kevin-test installd[2614]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-03-17 16:13:04-07 kevin-test install_monitor[13850]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: releasing backupd
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: allow user idle system sleep
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: ----- End install -----
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: 18.1s elapsed install time
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Cleared responsibility for install from 13849.
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Hosted team responsible for install has been cleared.
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Running idle tasks
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Removing client PKInstallDaemonClient pid=13849, uid=0 (/usr/sbin/installer)
2024-03-17 16:13:04-07 kevin-test installd[2614]: PackageKit: Done with sandbox removals
2024-03-17 16:13:04-07 kevin-test installer[13849]: Running install actions
2024-03-17 16:13:04-07 kevin-test installer[13849]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13849Sh9RRB"
2024-03-17 16:13:04-07 kevin-test installer[13849]: Finalize disk "Macintosh HD"
2024-03-17 16:13:04-07 kevin-test installer[13849]: Notifying system of updated components
2024-03-17 16:13:04-07 kevin-test installer[13849]:
2024-03-17 16:13:04-07 kevin-test installer[13849]: **** Summary Information ****
2024-03-17 16:13:04-07 kevin-test installer[13849]:   Operation      Elapsed time
2024-03-17 16:13:04-07 kevin-test installer[13849]: -----------------------------
2024-03-17 16:13:04-07 kevin-test installer[13849]:        disk      0.00 seconds
2024-03-17 16:13:04-07 kevin-test installer[13849]:      script      0.00 seconds
2024-03-17 16:13:04-07 kevin-test installer[13849]:        zero      0.00 seconds
2024-03-17 16:13:04-07 kevin-test installer[13849]:     install      18.26 seconds
2024-03-17 16:13:04-07 kevin-test installer[13849]:     -total-      18.26 seconds
2024-03-17 16:13:04-07 kevin-test installer[13849]:

2024-03-17 16:13:06 : INFO  : cloudbrink : Finishing...
2024-03-17 16:13:09 : INFO  : cloudbrink : App(s) found: /Applications/BrinkAgent.app
2024-03-17 16:13:09 : INFO  : cloudbrink : found app at /Applications/BrinkAgent.app, version 13.2.148, on versionKey CFBundleShortVersionString
2024-03-17 16:13:09 : REQ   : cloudbrink : Installed BrinkAgent, version 13.2.148
2024-03-17 16:13:09 : INFO  : cloudbrink : notifying
2024-03-17 16:13:10 : DEBUG : cloudbrink : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO
2024-03-17 16:13:10 : DEBUG : cloudbrink : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO/BrinkAgent.pkg
2024-03-17 16:13:10 : DEBUG : cloudbrink : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Dam9TAppJO
2024-03-17 16:13:10 : INFO  : cloudbrink : Installomator did not close any apps, so no need to reopen any apps.
2024-03-17 16:13:10 : REQ   : cloudbrink : All done!
2024-03-17 16:13:10 : REQ   : cloudbrink : ################## End Installomator, exit code 0 