### PR TITLE
Added new NOTIFY variable, "all_if_available"

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -511,6 +511,11 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
         printlog "Downloaded version of $name is $appNewVersion on versionKey $versionKey (replacing version $appversion)."
     fi
 
+  #The above notification is all we care about skipping for if $NOTIFY==all_if_available. Switching notify to "all" now so all logic doesn't need to be updated
+  if [[ $NOTIFY == "all_if_available" ]]; then
+    NOTIFY="all"
+  fi
+
     # macOS versioncheck
     minimumOSversion=$(defaults read $appPath/Contents/Info.plist LSMinimumSystemVersion 2>/dev/null )
     if [[ -n $minimumOSversion && $minimumOSversion =~ '[0-9.]*' ]]; then
@@ -681,6 +686,11 @@ installFromPKG() {
             fi
         fi
     fi
+
+      #The above notification is all we care about skipping for if $NOTIFY==all_if_available. Switching notify to "all" now so all logic doesn't need to be updated
+      if [[ $NOTIFY == "all_if_available" ]]; then
+        NOTIFY="all"
+      fi
 
     # skip install for DEBUG 1
     if [ "$DEBUG" -eq 1 ]; then

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -30,9 +30,10 @@ DEBUG=1
 # notify behavior
 NOTIFY=success
 # options:
-#   - success      notify the user on success
-#   - silent       no notifications
-#   - all          all notifications (great for Self Service installation)
+#   - success              notify the user on success
+#   - silent               no notifications
+#   - all                  all notifications (great for Self Service installation)
+#   - all_if_available     all notifications if there is a new version is available - otherwise, no notifications
 
 # time in seconds to wait for a prompt to be answered before exiting the script
 PROMPT_TIMEOUT=86400

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -237,6 +237,11 @@ else
     printlog "Latest version not specified."
 fi
 
+#The above notification is all we care about skipping for if $NOTIFY==all_if_available. Switching notify to "all" now so all logic doesn't need to be updated
+if [[ $NOTIFY == "all_if_available" ]]; then
+    NOTIFY="all"
+fi
+
 # MARK: check if this is an Update and we can use updateTool
 if [[ (-n $appversion && -n "$updateTool") || "$type" == "updateronly" ]]; then
     printlog "App needs to be updated and uses $updateTool. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now."


### PR DESCRIPTION
Some apps take a while to install and my users think it's not working without NOTIFY set to "all". That being said, users in my environment don't really care to get a notification saying "x app is up to date!". So this new variable, "all_if_available", will act the exact same as the NOTIFY variable of "all" (in fact, it switches itself to all after the first use case) with the exclusion of, it will act as if NOTIFY is set to "silent" if there are no new updates available.

When installomator is used for patching and keeps apps up to date on the latest version available, I could see this being useful for all labels.

Example output of Slack when it is on the latest version (slack is running at the start of this example):

```
./utils/assemble.sh slack DEBUG=0 NOTIFY=all_if_available
2024-03-19 13:15:38 : REQ   : slack : ################## Start Installomator v. 10.6beta, date 2024-03-19
2024-03-19 13:15:38 : INFO  : slack : ################## Version: 10.6beta
2024-03-19 13:15:38 : INFO  : slack : ################## Date: 2024-03-19
2024-03-19 13:15:38 : INFO  : slack : ################## slack
2024-03-19 13:15:38 : DEBUG : slack : DEBUG mode 1 enabled.
2024-03-19 13:15:38 : INFO  : slack : SwiftDialog is not installed, clear cmd file var
2024-03-19 13:15:39 : INFO  : slack : setting variable from argument DEBUG=0
2024-03-19 13:15:39 : INFO  : slack : setting variable from argument NOTIFY=all_if_available
2024-03-19 13:15:39 : DEBUG : slack : name=Slack
2024-03-19 13:15:39 : DEBUG : slack : appName=
2024-03-19 13:15:39 : DEBUG : slack : type=dmg
2024-03-19 13:15:39 : DEBUG : slack : archiveName=
2024-03-19 13:15:39 : DEBUG : slack : downloadURL=https://slack.com/ssb/download-osx-silicon
2024-03-19 13:15:39 : DEBUG : slack : curlOptions=
2024-03-19 13:15:39 : DEBUG : slack : appNewVersion=4.37.94
2024-03-19 13:15:39 : DEBUG : slack : appCustomVersion function: Not defined
2024-03-19 13:15:39 : DEBUG : slack : versionKey=CFBundleShortVersionString
2024-03-19 13:15:39 : DEBUG : slack : packageID=
2024-03-19 13:15:39 : DEBUG : slack : pkgName=
2024-03-19 13:15:39 : DEBUG : slack : choiceChangesXML=
2024-03-19 13:15:39 : DEBUG : slack : expectedTeamID=BQR82RBBHL
2024-03-19 13:15:39 : DEBUG : slack : blockingProcesses=
2024-03-19 13:15:39 : DEBUG : slack : installerTool=
2024-03-19 13:15:39 : DEBUG : slack : CLIInstaller=
2024-03-19 13:15:39 : DEBUG : slack : CLIArguments=
2024-03-19 13:15:39 : DEBUG : slack : updateTool=
2024-03-19 13:15:39 : DEBUG : slack : updateToolArguments=
2024-03-19 13:15:39 : DEBUG : slack : updateToolRunAsCurrentUser=
2024-03-19 13:15:39 : INFO  : slack : BLOCKING_PROCESS_ACTION=tell_user
2024-03-19 13:15:39 : INFO  : slack : NOTIFY=all_if_available
2024-03-19 13:15:39 : INFO  : slack : LOGGING=DEBUG
2024-03-19 13:15:39 : INFO  : slack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-03-19 13:15:39 : INFO  : slack : Label type: dmg
2024-03-19 13:15:39 : INFO  : slack : archiveName: Slack.dmg
2024-03-19 13:15:39 : INFO  : slack : no blocking processes defined, using Slack as default
2024-03-19 13:15:39 : DEBUG : slack : Changing directory to /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.TQhmqkfjIF
2024-03-19 13:15:39 : INFO  : slack : App(s) found: /Applications/Slack.app
2024-03-19 13:15:39 : INFO  : slack : found app at /Applications/Slack.app, version 4.37.94, on versionKey CFBundleShortVersionString
2024-03-19 13:15:39 : INFO  : slack : appversion: 4.37.94
2024-03-19 13:15:39 : INFO  : slack : Latest version of Slack is 4.37.94
2024-03-19 13:15:39 : INFO  : slack : There is no newer version available.
2024-03-19 13:15:39 : DEBUG : slack : Deleting /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.TQhmqkfjIF
2024-03-19 13:15:39 : DEBUG : slack : Debugging enabled, Deleting tmpDir output was:
/var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.TQhmqkfjIF
2024-03-19 13:15:39 : INFO  : slack : Installomator did not close any apps, so no need to reopen any apps.
2024-03-19 13:15:39 : REQ   : slack : No newer version.
2024-03-19 13:15:39 : REQ   : slack : ################## End Installomator, exit code 0
```

Example output of slack when it is not on the latest version (slack is running at the start of this example as well):

```
./utils/assemble.sh slack DEBUG=0 NOTIFY=all_if_available
2024-03-19 13:17:33 : REQ   : slack : ################## Start Installomator v. 10.6beta, date 2024-03-19
2024-03-19 13:17:33 : INFO  : slack : ################## Version: 10.6beta
2024-03-19 13:17:33 : INFO  : slack : ################## Date: 2024-03-19
2024-03-19 13:17:33 : INFO  : slack : ################## slack
2024-03-19 13:17:33 : DEBUG : slack : DEBUG mode 1 enabled.
2024-03-19 13:17:33 : INFO  : slack : SwiftDialog is not installed, clear cmd file var
2024-03-19 13:17:34 : INFO  : slack : setting variable from argument DEBUG=0
2024-03-19 13:17:34 : INFO  : slack : setting variable from argument NOTIFY=all_if_available
2024-03-19 13:17:34 : DEBUG : slack : name=Slack
2024-03-19 13:17:34 : DEBUG : slack : appName=
2024-03-19 13:17:34 : DEBUG : slack : type=dmg
2024-03-19 13:17:34 : DEBUG : slack : archiveName=
2024-03-19 13:17:34 : DEBUG : slack : downloadURL=https://slack.com/ssb/download-osx-silicon
2024-03-19 13:17:34 : DEBUG : slack : curlOptions=
2024-03-19 13:17:34 : DEBUG : slack : appNewVersion=4.37.94
2024-03-19 13:17:34 : DEBUG : slack : appCustomVersion function: Not defined
2024-03-19 13:17:34 : DEBUG : slack : versionKey=CFBundleShortVersionString
2024-03-19 13:17:34 : DEBUG : slack : packageID=
2024-03-19 13:17:34 : DEBUG : slack : pkgName=
2024-03-19 13:17:34 : DEBUG : slack : choiceChangesXML=
2024-03-19 13:17:34 : DEBUG : slack : expectedTeamID=BQR82RBBHL
2024-03-19 13:17:34 : DEBUG : slack : blockingProcesses=
2024-03-19 13:17:34 : DEBUG : slack : installerTool=
2024-03-19 13:17:34 : DEBUG : slack : CLIInstaller=
2024-03-19 13:17:34 : DEBUG : slack : CLIArguments=
2024-03-19 13:17:34 : DEBUG : slack : updateTool=
2024-03-19 13:17:34 : DEBUG : slack : updateToolArguments=
2024-03-19 13:17:34 : DEBUG : slack : updateToolRunAsCurrentUser=
2024-03-19 13:17:34 : INFO  : slack : BLOCKING_PROCESS_ACTION=tell_user
2024-03-19 13:17:34 : INFO  : slack : NOTIFY=all_if_available
2024-03-19 13:17:34 : INFO  : slack : LOGGING=DEBUG
2024-03-19 13:17:34 : INFO  : slack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-03-19 13:17:34 : INFO  : slack : Label type: dmg
2024-03-19 13:17:34 : INFO  : slack : archiveName: Slack.dmg
2024-03-19 13:17:34 : INFO  : slack : no blocking processes defined, using Slack as default
2024-03-19 13:17:34 : DEBUG : slack : Changing directory to /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.lqefWecTN2
2024-03-19 13:17:34 : INFO  : slack : App(s) found: /Applications/Slack.app
2024-03-19 13:17:34 : INFO  : slack : found app at /Applications/Slack.app, version 4.34.119, on versionKey CFBundleShortVersionString
2024-03-19 13:17:34 : INFO  : slack : appversion: 4.34.119
2024-03-19 13:17:34 : INFO  : slack : Latest version of Slack is 4.37.94
2024-03-19 13:17:34 : REQ   : slack : Downloading https://slack.com/ssb/download-osx-silicon to Slack.dmg
2024-03-19 13:17:34 : INFO  : slack : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-03-19 13:17:34 : DEBUG : slack : No Dialog connection, just download
2024-03-19 13:17:40 : DEBUG : slack : File list: -rw-r--r--  1 karson.fitzgerald  staff    91M Mar 19 13:17 Slack.dmg
2024-03-19 13:17:40 : DEBUG : slack : File type: Slack.dmg: bzip2 compressed data, block size = 100k
2024-03-19 13:17:40 : DEBUG : slack : curl output was:
*   Trying 54.71.95.193:443...
* Connected to slack.com (54.71.95.193) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [314 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3973 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=slack.com
*  start date: Jan 18 02:29:19 2024 GMT
*  expire date: Apr 17 02:29:18 2024 GMT
*  subjectAltName: host "slack.com" matched cert's "slack.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://slack.com/ssb/download-osx-silicon
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: slack.com]
* [HTTP/2] [1] [:path: /ssb/download-osx-silicon]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /ssb/download-osx-silicon HTTP/2
> Host: slack.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< date: Tue, 19 Mar 2024 19:17:35 GMT
< server: Apache
< vary: Accept-Encoding
< location: https://downloads.slack-edge.com/desktop-releases/mac/arm64/4.37.94/Slack-4.37.94-macOS.dmg
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< referrer-policy: no-referrer
< x-slack-unique-id: Zfnkz4k4ULm1nEp7Sf4lrAAAEAM
< x-slack-backend: r
< x-frame-options: SAMEORIGIN
< content-type: text/html
< content-length: 0
< set-cookie: b=bd25f82c5127274a38fe6abe0c5d9a82; expires=Sun, 19-Mar-2034 19:17:35 GMT; Max-Age=315532800; path=/; domain=.slack.com; secure; SameSite=None
< set-cookie: x=bd25f82c5127274a38fe6abe0c5d9a82.1710875855; expires=Tue, 19-Mar-2024 19:32:35 GMT; Max-Age=900; path=/; domain=.slack.com; secure; SameSite=None
< via: 1.1 slack-prod.tinyspeck.com, envoy-www-iad-cddwlvrn, envoy-edge-pdx-lcxojqcc
< x-envoy-attempt-count: 1
< x-envoy-upstream-service-time: 125
< x-backend: main_normal main_canary_with_overflow main_control_with_overflow
< x-server: slack-www-hhvm-main-iad-naxm
< x-slack-shared-secret-outcome: no-match
< x-edge-backend: envoy-www
< x-slack-edge-shared-secret-outcome: no-match
<
{ [0 bytes data]
* Connection #0 to host slack.com left intact
* Issue another request to this URL: 'https://downloads.slack-edge.com/desktop-releases/mac/arm64/4.37.94/Slack-4.37.94-macOS.dmg'
*   Trying 13.33.252.57:443...
* Connected to downloads.slack-edge.com (13.33.252.57) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2603 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=slack-edge.com
*  start date: Feb 20 14:46:53 2024 GMT
*  expire date: May 20 14:46:52 2024 GMT
*  subjectAltName: host "downloads.slack-edge.com" matched cert's "*.slack-edge.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.slack-edge.com/desktop-releases/mac/arm64/4.37.94/Slack-4.37.94-macOS.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.slack-edge.com]
* [HTTP/2] [1] [:path: /desktop-releases/mac/arm64/4.37.94/Slack-4.37.94-macOS.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /desktop-releases/mac/arm64/4.37.94/Slack-4.37.94-macOS.dmg HTTP/2
> Host: downloads.slack-edge.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 94968580
< last-modified: Mon, 18 Mar 2024 19:22:43 GMT
< x-amz-server-side-encryption: AES256
< content-encoding:
< accept-ranges: bytes
< server: AmazonS3
< date: Tue, 19 Mar 2024 15:27:58 GMT
< cache-control: max-age=14400
< etag: "38af40ffba880980810a39fce1ed5bed"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 bcf64c48b9c8b91e813eb6d256fda774.cloudfront.net (CloudFront)
< x-amz-cf-pop: DEN50-C1
< x-amz-cf-id: NGvPxSh338UcPhxGDjPKdz2gqDh0hPY2Q_vv1H3nK58RBTKXVIYL5A==
< age: 13887
<
{ [15962 bytes data]
* Connection #1 to host downloads.slack-edge.com left intact

2024-03-19 13:17:40 : INFO  : slack : found blocking process Slack
2024-03-19 13:17:42 : INFO  : slack : telling app Slack to quit
2024-03-19 13:17:42 : INFO  : slack : waiting 30 seconds for processes to quit
2024-03-19 13:18:12 : REQ   : slack : no more blocking processes, continue with update
2024-03-19 13:18:12 : REQ   : slack : Installing Slack
2024-03-19 13:18:12 : INFO  : slack : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-03-19 13:18:12 : INFO  : slack : Mounting /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.lqefWecTN2/Slack.dmg
2024-03-19 13:18:18 : DEBUG : slack : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $976D7413
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9C177450
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $777012D6
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E467A247
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $777012D6
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $89907B24
verified   CRC32 $DD02FA4A
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/Slack

2024-03-19 13:18:18 : INFO  : slack : Mounted: /Volumes/Slack
2024-03-19 13:18:18 : INFO  : slack : Verifying: /Volumes/Slack/Slack.app
2024-03-19 13:18:18 : DEBUG : slack : App size: 259M	/Volumes/Slack/Slack.app
2024-03-19 13:18:25 : DEBUG : slack : Debugging enabled, App Verification output was:
/Volumes/Slack/Slack.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Slack Technologies, Inc. (BQR82RBBHL)

2024-03-19 13:18:25 : INFO  : slack : Team ID matching: BQR82RBBHL (expected: BQR82RBBHL )
2024-03-19 13:18:25 : INFO  : slack : Downloaded version of Slack is 4.37.94 on versionKey CFBundleShortVersionString (replacing version 4.34.119).
2024-03-19 13:18:25 : INFO  : slack : App has LSMinimumSystemVersion: 11.0
2024-03-19 13:18:25 : WARN  : slack : Removing existing /Applications/Slack.app
2024-03-19 13:18:25 : DEBUG : slack : Debugging enabled, App removing output was:
/Applications/Slack.app/Contents/
Last Log repeated 634 times
/Applications/Slack.app/Contents
/Applications/Slack.app

2024-03-19 13:18:25 : INFO  : slack : Copy /Volumes/Slack/Slack.app to /Applications
2024-03-19 13:18:29 : DEBUG : slack : Debugging enabled, App copy output was:
Copying /Volumes/Slack/Slack.app

2024-03-19 13:18:29 : WARN  : slack : Changing owner to karson.fitzgerald
2024-03-19 13:18:29 : INFO  : slack : Finishing...
2024-03-19 13:18:32 : INFO  : slack : App(s) found: /Applications/Slack.app
2024-03-19 13:18:32 : INFO  : slack : found app at /Applications/Slack.app, version 4.37.94, on versionKey CFBundleShortVersionString
2024-03-19 13:18:32 : REQ   : slack : Installed Slack, version 4.37.94
2024-03-19 13:18:32 : INFO  : slack : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-03-19 13:18:32 : DEBUG : slack : Unmounting /Volumes/Slack
2024-03-19 13:18:32 : DEBUG : slack : Debugging enabled, Unmounting output was:
"disk7" ejected.
2024-03-19 13:18:32 : DEBUG : slack : Deleting /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.lqefWecTN2
2024-03-19 13:18:32 : DEBUG : slack : Debugging enabled, Deleting tmpDir output was:
/var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.lqefWecTN2/Slack.dmg
2024-03-19 13:18:32 : DEBUG : slack : /var/folders/pf/z2q3lm1n3nx0qnv8fkf8gq840000gp/T/tmp.lqefWecTN2
2024-03-19 13:18:32 : INFO  : slack : Telling app Slack.app to open
Password:
2024-03-19 13:18:40 : INFO  : slack : Reopened Slack.app as karson.fitzgerald
2024-03-19 13:18:40 : REQ   : slack : All done!
2024-03-19 13:18:40 : REQ   : slack : ################## End Installomator, exit code 0

```