### PR TITLE
Update slack.sh

### DIFF
--- a/fragments/labels/slack.sh
+++ b/fragments/labels/slack.sh
@@ -6,6 +6,6 @@ slack)
     elif [[ $(arch) == arm64 ]]; then
        downloadURL="https://slack.com/ssb/download-osx-silicon"
     fi
-    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | cut -d "/" -f6 )
+    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | cut -d "/" -f7 )
     expectedTeamID="BQR82RBBHL"
     ;;


### PR DESCRIPTION
the appNewVersion was reporting "x64" for intel and "arm64" for Arm. Adjusting the field from 6 to 7 resulted in it properly pulling the new version so that installomator will no longer attempt unnecessary installs