### PR TITLE
New label : Rhino 7

### DIFF
--- a/fragments/labels/rhino7.sh
+++ b/fragments/labels/rhino7.sh
@@ -1,0 +1,8 @@
+rhino7)
+    name="Rhino 7"
+    type="dmg"
+    sparkleFeed=$(curl -fs "https://files.mcneel.com/rhino/7/mac/updates/commercialUpdates.xml")
+    appNewVersion=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString[1]' 2>/dev/null | cut -d '"' -f 2 | cut -d ' ' -f 1)
+    downloadURL=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f 2)
+    expectedTeamID="D6XDM4N99E"
+    ;;


### PR DESCRIPTION
Output : 

```
2024-03-28 10:00:04 : REQ   : rhino7 : ################## Start Installomator v. 10.6beta, date 2024-03-28
2024-03-28 10:00:04 : INFO  : rhino7 : ################## Version: 10.6beta
2024-03-28 10:00:04 : INFO  : rhino7 : ################## Date: 2024-03-28
2024-03-28 10:00:04 : INFO  : rhino7 : ################## rhino7
2024-03-28 10:00:04 : DEBUG : rhino7 : DEBUG mode 1 enabled.
2024-03-28 10:00:05 : DEBUG : rhino7 : name=Rhino 7
2024-03-28 10:00:05 : DEBUG : rhino7 : appName=
2024-03-28 10:00:05 : DEBUG : rhino7 : type=dmg
2024-03-28 10:00:05 : DEBUG : rhino7 : archiveName=
2024-03-28 10:00:05 : DEBUG : rhino7 : downloadURL=https://files.mcneel.com/rhino/7/mac/releases/rhino_7.36.23346.16352.dmg
2024-03-28 10:00:05 : DEBUG : rhino7 : curlOptions=
2024-03-28 10:00:05 : DEBUG : rhino7 : appNewVersion=7.36.23346.16352
2024-03-28 10:00:05 : DEBUG : rhino7 : appCustomVersion function: Not defined
2024-03-28 10:00:05 : DEBUG : rhino7 : versionKey=CFBundleShortVersionString
2024-03-28 10:00:05 : DEBUG : rhino7 : packageID=
2024-03-28 10:00:05 : DEBUG : rhino7 : pkgName=
2024-03-28 10:00:05 : DEBUG : rhino7 : choiceChangesXML=
2024-03-28 10:00:05 : DEBUG : rhino7 : expectedTeamID=D6XDM4N99E
2024-03-28 10:00:05 : DEBUG : rhino7 : blockingProcesses=
2024-03-28 10:00:05 : DEBUG : rhino7 : installerTool=
2024-03-28 10:00:05 : DEBUG : rhino7 : CLIInstaller=
2024-03-28 10:00:05 : DEBUG : rhino7 : CLIArguments=
2024-03-28 10:00:05 : DEBUG : rhino7 : updateTool=
2024-03-28 10:00:05 : DEBUG : rhino7 : updateToolArguments=
2024-03-28 10:00:05 : DEBUG : rhino7 : updateToolRunAsCurrentUser=
2024-03-28 10:00:05 : INFO  : rhino7 : BLOCKING_PROCESS_ACTION=tell_user
2024-03-28 10:00:05 : INFO  : rhino7 : NOTIFY=success
2024-03-28 10:00:05 : INFO  : rhino7 : LOGGING=DEBUG
2024-03-28 10:00:05 : INFO  : rhino7 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-03-28 10:00:05 : INFO  : rhino7 : Label type: dmg
2024-03-28 10:00:05 : INFO  : rhino7 : archiveName: Rhino 7.dmg
2024-03-28 10:00:05 : INFO  : rhino7 : no blocking processes defined, using Rhino 7 as default
2024-03-28 10:00:05 : DEBUG : rhino7 : Changing directory to /Users/xxx/Developer/github.com/ci7rix/Installomator/build
2024-03-28 10:00:05 : INFO  : rhino7 : name: Rhino 7, appName: Rhino 7.app
2024-03-28 10:00:05.125 mdfind[7955:146286] [UserQueryParser] Loading keywords and predicates for locale "fr_CH"
2024-03-28 10:00:05.125 mdfind[7955:146286] [UserQueryParser] Loading keywords and predicates for locale "fr"
2024-03-28 10:00:05.170 mdfind[7955:146286] Couldn't determine the mapping between prefab keywords and predicates.
2024-03-28 10:00:05.170 mdfind[7955:146286] Couldn't determine the mapping between prefab keywords and predicates.
2024-03-28 10:00:05 : WARN  : rhino7 : No previous app found
2024-03-28 10:00:05 : WARN  : rhino7 : could not find Rhino 7.app
2024-03-28 10:00:05 : INFO  : rhino7 : appversion:
2024-03-28 10:00:05 : INFO  : rhino7 : Latest version of Rhino 7 is 7.36.23346.16352
2024-03-28 10:00:05 : REQ   : rhino7 : Downloading https://files.mcneel.com/rhino/7/mac/releases/rhino_7.36.23346.16352.dmg to Rhino 7.dmg
2024-03-28 10:00:05 : DEBUG : rhino7 : No Dialog connection, just download
2024-03-28 10:00:11 : DEBUG : rhino7 : File list: -rw-r--r--  1 xxx  staff   410M Mar 28 10:00 Rhino 7.dmg
2024-03-28 10:00:11 : DEBUG : rhino7 : File type: Rhino 7.dmg: bzip2 compressed data, block size = 100k
2024-03-28 10:00:11 : DEBUG : rhino7 : curl output was:
*   Trying 99.86.91.55:443...
* Connected to files.mcneel.com (99.86.91.55) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4950 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.mcneel.com
*  start date: Mar  8 00:00:00 2024 GMT
*  expire date: Apr  5 23:59:59 2025 GMT
*  subjectAltName: host "files.mcneel.com" matched cert's "*.mcneel.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /rhino/7/mac/releases/rhino_7.36.23346.16352.dmg HTTP/1.1
> Host: files.mcneel.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: binary/octet-stream
< Content-Length: 429626913
< Connection: keep-alive
< Date: Thu, 28 Mar 2024 08:48:57 GMT
< Last-Modified: Wed, 10 Jan 2024 01:08:56 GMT
< ETag: "f08ff628e75b16dfa2f15ee8c34b4410-52"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 0f8d42bdd4e806bc0112f0b6ba3f2334.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: CDG50-C1
< X-Amz-Cf-Id: 0qOD3yvyLbZLAWCDZlXxONRuAD3HQpDkpl8QJFjBrj3Xwe_Mpkl8GA==
< Age: 671
<
{ [16384 bytes data]
* Connection #0 to host files.mcneel.com left intact

2024-03-28 10:00:11 : DEBUG : rhino7 : DEBUG mode 1, not checking for blocking processes
2024-03-28 10:00:11 : REQ   : rhino7 : Installing Rhino 7
2024-03-28 10:00:11 : INFO  : rhino7 : Mounting /Users/xxx/Developer/github.com/ci7rix/Installomator/build/Rhino 7.dmg
2024-03-28 10:00:11 : DEBUG : rhino7 : Debugging enabled, dmgmount output was:
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/Rhinoceros

2024-03-28 10:00:11 : INFO  : rhino7 : Mounted: /Volumes/Rhinoceros
2024-03-28 10:00:11 : INFO  : rhino7 : Verifying: /Volumes/Rhinoceros/Rhino 7.app
2024-03-28 10:00:12 : DEBUG : rhino7 : App size: 1.2G   /Volumes/Rhinoceros/Rhino 7.app
2024-03-28 10:01:33 : DEBUG : rhino7 : Debugging enabled, App Verification output was:
/Volumes/Rhinoceros/Rhino 7.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Robert McNeel & Associates (D6XDM4N99E)

2024-03-28 10:01:33 : INFO  : rhino7 : Team ID matching: D6XDM4N99E (expected: D6XDM4N99E )
2024-03-28 10:01:33 : INFO  : rhino7 : Installing Rhino 7 version 7.36 on versionKey CFBundleShortVersionString.
2024-03-28 10:01:33 : INFO  : rhino7 : App has LSMinimumSystemVersion: 10.14
2024-03-28 10:01:33 : DEBUG : rhino7 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-03-28 10:01:33 : INFO  : rhino7 : Finishing...
2024-03-28 10:01:36 : INFO  : rhino7 : name: Rhino 7, appName: Rhino 7.app
2024-03-28 10:01:36.435 mdfind[8064:147573] [UserQueryParser] Loading keywords and predicates for locale "fr_CH"
2024-03-28 10:01:36.435 mdfind[8064:147573] [UserQueryParser] Loading keywords and predicates for locale "fr"
2024-03-28 10:01:36.510 mdfind[8064:147573] Couldn't determine the mapping between prefab keywords and predicates.
2024-03-28 10:01:36.510 mdfind[8064:147573] Couldn't determine the mapping between prefab keywords and predicates.
2024-03-28 10:01:36 : WARN  : rhino7 : No previous app found
2024-03-28 10:01:36 : WARN  : rhino7 : could not find Rhino 7.app
2024-03-28 10:01:36 : REQ   : rhino7 : Installed Rhino 7, version 7.36
2024-03-28 10:01:36 : INFO  : rhino7 : notifying
ERROR: Notifications are not allowed for this application
2024-03-28 10:01:36 : DEBUG : rhino7 : Unmounting /Volumes/Rhinoceros
2024-03-28 10:01:37 : DEBUG : rhino7 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-03-28 10:01:37 : DEBUG : rhino7 : DEBUG mode 1, not reopening anything
2024-03-28 10:01:37 : REQ   : rhino7 : All done!
2024-03-28 10:01:37 : REQ   : rhino7 : ################## End Installomator, exit code 0

```