### PR TITLE
Repeat failed attempts

### DIFF
--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -99,6 +99,14 @@ if [[ ! -x $DIALOG_CMD ]]; then
     DIALOG_CMD_FILE=""
 fi
 
+# Default value of MAXDOWNLOADATTEMPTS if set too low
+if [[ $MAXDOWNLOADATTEMPTS -lt 1 ]]; then
+  MAXDOWNLOADATTEMPTS=6
+fi
+
+# Alias curl to make it stubborn for grabbing the download URL and version
+alias curl='stubbornlyAttempt curl'
+
 # MARK: labels in case statement
 case $label in
 longversion)

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -243,7 +243,7 @@ stubbornlyAttempt() {
     if (( $command_status == 0 )); then
       break
     fi
-    $((current_attempt++))
+    ((current_attempt++))
     sleep 1
   done
 

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -228,6 +228,29 @@ getJSONValue() {
 		-e 'if (typeof value === "object") { JSON.stringify(value, null, 4) } else { value }'
 }
 
+# Calling this function with 'stubbornlyAttempt curl' will make it try several times if something failes
+stubbornlyAttempt() {
+  local -ar command_to_run=("command" "${@[1]}")
+  local -ar arguments=("${@[2,-1]}")
+  local -r MAX_ATTEMPTS=10
+  local current_attempt=0
+  local command_status=-1
+  local output=""
+
+  while (( $current_attempt < $MAX_ATTEMPTS )); do
+    output=$("${command_to_run[@]}" "${arguments[@]}")
+    command_status=$?
+    if (( $command_status == 0 )); then
+      break
+    fi
+    $((current_attempt++))
+    sleep 1
+  done
+
+  printf "%s" "${output}"
+  return $command_status
+}
+
 getAppVersion() {
     # modified by: Søren Theilgaard (@theilgaard) and Isaac Ordonez
 

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -149,6 +149,10 @@ IGNORE_DND_APPS=""
 # example that will ignore browsers when evaluating DND:
 # IGNORE_DND_APPS="firefox,Google Chrome,Safari,Microsoft Edge,Opera,Amphetamine,caffeinate"
 
+# Download attempts
+MAXDOWNLOADATTEMPTS=6
+# This variable decides how many times a download attempt is tried out, if it fails
+
 
 # Swift Dialog integration
 

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -297,7 +297,7 @@ else
 
     else
         printlog "No Dialog connection, just download" DEBUG
-        if [[ $downloadattempt -eq 0 ]]; then
+        if [[ $downloadattempt -eq 1 ]]; then
             printlog "1st download arguments: $ipversion -fsL --show-error --retry 5 --fail ${curlArgs[*]} ${curlOptions}"
             curldownload=$(curl -v $ipversion -fsL --show-error --retry 5 --fail ${curlArgs[@]} ${curlOptions} "$downloadURL" -o "$archiveName" 2>&1)
         else
@@ -317,7 +317,7 @@ else
     fi
     printlog "curlDownloadStatus: $curlDownloadStatus, attempt: $downloadattempt" DEBUG
     deduplicatelogs "$curlDownload"
-    if [[ $curldownloadstatus -ne 0 && $downloadattempt -ge 3 ]] ; then
+    if [[ $curldownloadstatus -ne 0 && $downloadattempt -ge 4 ]] ; then
         printlog "Setting download to IPv4 only" WARN
         ipversion="-4"
     fi
@@ -340,9 +340,9 @@ else
         printlog "File type: $(file "$archiveName")" ERROR
         cleanupAndExit 2 "Error downloading $downloadURL error:\n$logoutput" ERROR
     elif [[ $curldownloadstatus -eq 0 ]] ; then
+        printlog "Download successful" DEBUG
         printlog "File list: $(ls -lh "$archiveName")" DEBUG
         printlog "File type: $(file "$archiveName")" DEBUG
-        printlog "Download successful" DEBUG
         printlog "curl output was: $logoutput" DEBUG
         break
     fi

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -262,8 +262,8 @@ downloadattempt=0
 ipversion=""
 
 while [[ $downloadattempt -lt $MAXDOWNLOADATTEMPTS ]]; do
-$((downloadattempt++))
-printlog "${downloadattempt}. attempt of ${MAXDOWNLOADATTEMPTS} download attempts."
+((downloadattempt++))
+printlog "${downloadattempt}. download attempt of ${MAXDOWNLOADATTEMPTS} attempts."
 if [ -f "$archiveName" ] && [ "$DEBUG" -eq 1 ]; then
     printlog "$archiveName exists and DEBUG mode 1 enabled, skipping download"
 else
@@ -323,7 +323,7 @@ else
     fi
     if [[ $curldownloadstatus -ne 0 ]] && (( $downloadattempt < $MAXDOWNLOADATTEMPTS )); then
         printlog "RETRYING... Error downloading $downloadURL error: $logoutput" WARN
-        downloadattempt=$((downloadattempt++))
+        #((downloadattempt++))
         sleep 15
     elif [[ $curldownloadstatus -ne 0 ]] && (( $downloadattempt >= $MAXDOWNLOADATTEMPTS )); then
         printlog "error downloading $downloadURL" ERROR
@@ -336,8 +336,8 @@ else
                 displaynotification "$message" "Error installing $name"
             fi
         fi
-        printlog "File list: $(ls -lh "$archiveName")" ERROR
-        printlog "File type: $(file "$archiveName")" ERROR
+        printlog "File list: $(ls -lh "$archiveName")" DEBUG
+        printlog "File type: $(file "$archiveName")" DEBUG
         cleanupAndExit 2 "Error downloading $downloadURL error:\n$logoutput" ERROR
     elif [[ $curldownloadstatus -eq 0 ]] ; then
         printlog "Download successful" DEBUG
@@ -346,9 +346,7 @@ else
         printlog "curl output was: $logoutput" DEBUG
         break
     fi
-    printlog "File list: $(ls -lh "$archiveName")" DEBUG
-    printlog "File type: $(file "$archiveName")" DEBUG
-    printlog "curl output was:\n$logoutput" DEBUG
+    #printlog "curl output was:\n$logoutput" DEBUG
 fi
 done
 

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -304,10 +304,8 @@ else
             printlog "Subsequent download attempt: ${downloadattempt}: $ipversion -fsL --show-error -C - --fail --retry 5 ${curlArgs[*]} ${curlOptions}"
             curldownload=$(curl -v $ipversion -fsL --show-error -C - --fail --retry 5 ${curlArgs[@]} ${curlOptions} "$downloadURL" -o "$archiveName" 2>&1)
         fi
-        curlDownloadStatus=$(echo $?)
-        printlog "$curlDownload" DEBUG
-#         curldownloadstatus=$?
-#         curlDownload=$(curl -v -fsL --show-error ${curlOptions} "$downloadURL" -o "$archiveName" 2>&1)
+        curldownloadstatus=$?
+        printlog "Status: $curlDownloadStatus \n$curlDownload" DEBUG
     fi
     printlog "curlDownloadStatus: $curlDownloadStatus" DEBUG
     alternateError=$(printf '%s' "${curldownload}" | tail -n1 | grep -Eo 'errno [[:digit:]]+' | awk '{print $2}')
@@ -321,11 +319,11 @@ else
         printlog "Setting download to IPv4 only" WARN
         ipversion="-4"
     fi
-    if [[ $curldownloadstatus -ne 0 ]] && (( $downloadattempt < $MAXDOWNLOADATTEMPTS )); then
+    if [[ $curldownloadstatus -ne 0 ]] && [[ $downloadattempt -lt $MAXDOWNLOADATTEMPTS ]]; then
         printlog "RETRYING... Error downloading $downloadURL error: $logoutput" WARN
         #((downloadattempt++))
         sleep 15
-    elif [[ $curldownloadstatus -ne 0 ]] && (( $downloadattempt >= $MAXDOWNLOADATTEMPTS )); then
+    elif [[ $curldownloadstatus -ne 0 ]] && [[ $downloadattempt -ge $MAXDOWNLOADATTEMPTS ]]; then
         printlog "error downloading $downloadURL" ERROR
         message="$name update/installation failed. This will be logged, so IT can follow up."
         if [[ $currentUser != "loginwindow" && $NOTIFY == "all" ]]; then


### PR DESCRIPTION
Will `stubbornlyAttempt` to use `curl` in label definitions, and will repeat `MAXDOWNLOADATTEMPTS` times at download.

Most work by @isaacatmann but adapted by me, and changed a bit.