### PR TITLE
Update obs.sh

### DIFF
--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -1,15 +1,12 @@
 obs)
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="OBS-Studio-[0-9.]*-macOS-Apple.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="OBS-Studio-[0-9.]*-macOS-Intel.dmg"
+    fi
     name="OBS"
     type="dmg"
-    if [[ $(arch) == "arm64" ]]; then
-        SUFeedURL="https://obsproject.com/osx_update/updates_arm64_v2.xml"
-    elif [[ $(arch) == "i386" ]]; then
-        SUFeedURL="https://obsproject.com/osx_update/updates_x86_64_v2.xml"
-    fi
-    appNewVersion=$(curl -fs "$SUFeedURL" | xpath '(//rss/channel/item[sparkle:channel="stable"]/sparkle:shortVersionString/text())[1]' 2>/dev/null)
-    downloadURL=$(curl -fs "$SUFeedURL" | xpath 'string(//rss/channel/item[sparkle:channel="stable"]/enclosure/@url[1])' 2>/dev/null)
-    archiveName=$(basename "$downloadURL")   
-    versionKey="CFBundleShortVersionString"
-    blockingProcesses=( "OBS Studio" )
+    downloadURL="$(downloadURLFromGit obsproject obs-studio)"
+    appNewVersion="$(versionFromGit obsproject obs-studio)"
     expectedTeamID="2MMRE5MTB8"
     ;;

--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -1,11 +1,11 @@
 obs)
+    name="OBS"
+    type="dmg"
     if [[ $(arch) == "arm64" ]]; then
         archiveName="OBS-Studio-[0-9.]*-macOS-Apple.dmg"
     elif [[ $(arch) == "i386" ]]; then
         archiveName="OBS-Studio-[0-9.]*-macOS-Intel.dmg"
     fi
-    name="OBS"
-    type="dmg"
     downloadURL="$(downloadURLFromGit obsproject obs-studio)"
     appNewVersion="$(versionFromGit obsproject obs-studio)"
     expectedTeamID="2MMRE5MTB8"


### PR DESCRIPTION
Output:
Installomator/utils/assemble.sh obs
2024-04-03 09:33:44 : REQ   : obs : ################## Start Installomator v. 10.6beta, date 2024-04-03
2024-04-03 09:33:44 : INFO  : obs : ################## Version: 10.6beta
2024-04-03 09:33:44 : INFO  : obs : ################## Date: 2024-04-03
2024-04-03 09:33:44 : INFO  : obs : ################## obs
2024-04-03 09:33:44 : DEBUG : obs : DEBUG mode 1 enabled.
2024-04-03 09:33:46 : DEBUG : obs : name=OBS
2024-04-03 09:33:46 : DEBUG : obs : appName=
2024-04-03 09:33:46 : DEBUG : obs : type=dmg
2024-04-03 09:33:46 : DEBUG : obs : archiveName=OBS-Studio-[0-9.]*-macOS-Apple.dmg
2024-04-03 09:33:46 : DEBUG : obs : downloadURL=https://github.com/obsproject/obs-studio/releases/download/30.1.1/OBS-Studio-30.1.1-macOS-Apple.dmg
2024-04-03 09:33:46 : DEBUG : obs : curlOptions=
2024-04-03 09:33:46 : DEBUG : obs : appNewVersion=30.1.1
2024-04-03 09:33:46 : DEBUG : obs : appCustomVersion function: Not defined
2024-04-03 09:33:46 : DEBUG : obs : versionKey=CFBundleShortVersionString
2024-04-03 09:33:46 : DEBUG : obs : packageID=
2024-04-03 09:33:46 : DEBUG : obs : pkgName=
2024-04-03 09:33:46 : DEBUG : obs : choiceChangesXML=
2024-04-03 09:33:46 : DEBUG : obs : expectedTeamID=2MMRE5MTB8
2024-04-03 09:33:46 : DEBUG : obs : blockingProcesses=
2024-04-03 09:33:46 : DEBUG : obs : installerTool=
2024-04-03 09:33:46 : DEBUG : obs : CLIInstaller=
2024-04-03 09:33:46 : DEBUG : obs : CLIArguments=
2024-04-03 09:33:46 : DEBUG : obs : updateTool=
2024-04-03 09:33:46 : DEBUG : obs : updateToolArguments=
2024-04-03 09:33:46 : DEBUG : obs : updateToolRunAsCurrentUser=
2024-04-03 09:33:46 : INFO  : obs : BLOCKING_PROCESS_ACTION=tell_user
2024-04-03 09:33:46 : INFO  : obs : NOTIFY=success
2024-04-03 09:33:46 : INFO  : obs : LOGGING=DEBUG
2024-04-03 09:33:46 : INFO  : obs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-03 09:33:46 : INFO  : obs : Label type: dmg
2024-04-03 09:33:46 : INFO  : obs : archiveName: OBS-Studio-[0-9.]*-macOS-Apple.dmg
2024-04-03 09:33:46 : INFO  : obs : no blocking processes defined, using OBS as default
2024-04-03 09:33:46 : DEBUG : obs : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2024-04-03 09:33:46 : INFO  : obs : App(s) found: /Applications/OBS.app
2024-04-03 09:33:46 : INFO  : obs : found app at /Applications/OBS.app, version 30.1.0, on versionKey CFBundleShortVersionString
2024-04-03 09:33:46 : INFO  : obs : appversion: 30.1.0
2024-04-03 09:33:46 : INFO  : obs : Latest version of OBS is 30.1.1
2024-04-03 09:33:46 : REQ   : obs : Downloading https://github.com/obsproject/obs-studio/releases/download/30.1.1/OBS-Studio-30.1.1-macOS-Apple.dmg to OBS-Studio-[0-9.]*-macOS-Apple.dmg
2024-04-03 09:33:46 : DEBUG : obs : No Dialog connection, just download
2024-04-03 09:33:52 : DEBUG : obs : File list: -rw-r--r--  1 root  staff   160M Apr  3 09:33 OBS-Studio-[0-9.]*-macOS-Apple.dmg
2024-04-03 09:33:52 : DEBUG : obs : File type: OBS-Studio-[0-9.]*-macOS-Apple.dmg: lzfse encoded, lzvn compressed
2024-04-03 09:33:52 : DEBUG : obs : curl output was:
*   Trying 140.82.112.3:443...
* Connected to github.com (140.82.112.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/obsproject/obs-studio/releases/download/30.1.1/OBS-Studio-30.1.1-macOS-Apple.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /obsproject/obs-studio/releases/download/30.1.1/OBS-Studio-30.1.1-macOS-Apple.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /obsproject/obs-studio/releases/download/30.1.1/OBS-Studio-30.1.1-macOS-Apple.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Wed, 03 Apr 2024 15:33:46 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/286acb20-3343-48f0-8fec-c12b9bc831a4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240403%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240403T153346Z&X-Amz-Expires=300&X-Amz-Signature=e97a60ac0bf5453ea217e05c0c446c842db9b991d6ed87d9ed33a914ad7ea2f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.1.1-macOS-Apple.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: E133:BD292:1298DC9:1B4ECB7:660D76DA <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/286acb20-3343-48f0-8fec-c12b9bc831a4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240403%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240403T153346Z&X-Amz-Expires=300&X-Amz-Signature=e97a60ac0bf5453ea217e05c0c446c842db9b991d6ed87d9ed33a914ad7ea2f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.1.1-macOS-Apple.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/13233158/286acb20-3343-48f0-8fec-c12b9bc831a4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240403%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240403T153346Z&X-Amz-Expires=300&X-Amz-Signature=e97a60ac0bf5453ea217e05c0c446c842db9b991d6ed87d9ed33a914ad7ea2f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.1.1-macOS-Apple.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/13233158/286acb20-3343-48f0-8fec-c12b9bc831a4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240403%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240403T153346Z&X-Amz-Expires=300&X-Amz-Signature=e97a60ac0bf5453ea217e05c0c446c842db9b991d6ed87d9ed33a914ad7ea2f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.1.1-macOS-Apple.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/13233158/286acb20-3343-48f0-8fec-c12b9bc831a4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240403%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240403T153346Z&X-Amz-Expires=300&X-Amz-Signature=e97a60ac0bf5453ea217e05c0c446c842db9b991d6ed87d9ed33a914ad7ea2f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=13233158&response-content-disposition=attachment%3B%20filename%3DOBS-Studio-30.1.1-macOS-Apple.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: 1lIbZeIICifmeBkPm0D2SQ==
< last-modified: Sat, 23 Mar 2024 20:43:04 GMT
< etag: "0x8DC4B79D6D7EF4B"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 2cbdd072-f01e-005c-40d1-83b40d000000 < x-ms-version: 2020-10-02
< x-ms-creation-time: Sat, 23 Mar 2024 20:43:04 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=OBS-Studio-30.1.1-macOS-Apple.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 226
< date: Wed, 03 Apr 2024 15:33:47 GMT
< x-served-by: cache-iad-kiad7000027-IAD, cache-bfi-krnt7300046-BFI < x-cache: HIT, HIT
< x-cache-hits: 248, 0
< x-timer: S1712158427.810982,VS0,VE241
< content-length: 168018899
<
{ [11015 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-04-03 09:33:52 : DEBUG : obs : DEBUG mode 1, not checking for blocking processes
2024-04-03 09:33:52 : REQ   : obs : Installing OBS
2024-04-03 09:33:52 : INFO  : obs : Mounting /Users/admin/Documents/GitHub/Installomator/build/OBS-Studio-[0-9.]*-macOS-Apple.dmg
2024-04-03 09:33:54 : DEBUG : obs : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $18A22071
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3F1D714E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $90C57F20
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $1E4087F3
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $90C57F20
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $5B456E37
verified   CRC32 $7B3C5C59
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/OBS Studio 30.1.1 (Apple)

2024-04-03 09:33:54 : INFO  : obs : Mounted: /Volumes/OBS Studio 30.1.1 (Apple) 2024-04-03 09:33:54 : INFO  : obs : Verifying: /Volumes/OBS Studio 30.1.1 (Apple)/OBS.app 2024-04-03 09:33:54 : DEBUG : obs : App size: 395M	/Volumes/OBS Studio 30.1.1 (Apple)/OBS.app 2024-04-03 09:33:57 : DEBUG : obs : Debugging enabled, App Verification output was: /Volumes/OBS Studio 30.1.1 (Apple)/OBS.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Wizards of OBS LLC (2MMRE5MTB8)

2024-04-03 09:33:57 : INFO  : obs : Team ID matching: 2MMRE5MTB8 (expected: 2MMRE5MTB8 ) 2024-04-03 09:33:57 : INFO  : obs : Downloaded version of OBS is 30.1.1 on versionKey CFBundleShortVersionString (replacing version 30.1.0). 2024-04-03 09:33:57 : INFO  : obs : App has LSMinimumSystemVersion: 11.0 2024-04-03 09:33:57 : DEBUG : obs : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-04-03 09:33:57 : INFO  : obs : Finishing...
2024-04-03 09:34:00 : INFO  : obs : App(s) found: /Applications/OBS.app 2024-04-03 09:34:00 : INFO  : obs : found app at /Applications/OBS.app, version 30.1.0, on versionKey CFBundleShortVersionString
2024-04-03 09:34:00 : REQ   : obs : Installed OBS, version 30.1.1
2024-04-03 09:34:00 : INFO  : obs : notifying
2024-04-03 09:34:00 : DEBUG : obs : Unmounting /Volumes/OBS Studio 30.1.1 (Apple)
2024-04-03 09:34:00 : DEBUG : obs : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-04-03 09:34:00 : DEBUG : obs : DEBUG mode 1, not reopening anything
2024-04-03 09:34:00 : REQ   : obs : All done!
2024-04-03 09:34:00 : REQ   : obs : ################## End Installomator, exit code 0