### PR TITLE
Update arcbrowser.sh

### DIFF
--- a/fragments/labels/arcbrowser.sh
+++ b/fragments/labels/arcbrowser.sh
@@ -2,6 +2,6 @@ arcbrowser)
 name="Arc"
 type="dmg"
 downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
-appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*/\1/')"
+appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
 expectedTeamID="S6N382Y83G"
     ;;


### PR DESCRIPTION
Output:
Installomator/utils/assemble.sh arcbrowser
2024-04-03 11:32:14 : REQ   : arcbrowser : ################## Start Installomator v. 10.6beta, date 2024-04-03
2024-04-03 11:32:14 : INFO  : arcbrowser : ################## Version: 10.6beta
2024-04-03 11:32:14 : INFO  : arcbrowser : ################## Date: 2024-04-03
2024-04-03 11:32:14 : INFO  : arcbrowser : ################## arcbrowser
2024-04-03 11:32:14 : DEBUG : arcbrowser : DEBUG mode 1 enabled.
2024-04-03 11:32:15 : DEBUG : arcbrowser : name=Arc
2024-04-03 11:32:15 : DEBUG : arcbrowser : appName=
2024-04-03 11:32:15 : DEBUG : arcbrowser : type=dmg
2024-04-03 11:32:15 : DEBUG : arcbrowser : archiveName=
2024-04-03 11:32:15 : DEBUG : arcbrowser : downloadURL=https://releases.arc.net/release/Arc-latest.dmg
2024-04-03 11:32:15 : DEBUG : arcbrowser : curlOptions=
2024-04-03 11:32:15 : DEBUG : arcbrowser : appNewVersion=location: https://arc.net/release/Arc-latest.dmg
2024-04-03 11:32:15 : DEBUG : arcbrowser : 1.36.0
2024-04-03 11:32:15 : DEBUG : arcbrowser : appCustomVersion function: Not defined
2024-04-03 11:32:15 : DEBUG : arcbrowser : versionKey=CFBundleShortVersionString
2024-04-03 11:32:15 : DEBUG : arcbrowser : packageID=
2024-04-03 11:32:16 : DEBUG : arcbrowser : pkgName=
2024-04-03 11:32:16 : DEBUG : arcbrowser : choiceChangesXML=
2024-04-03 11:32:16 : DEBUG : arcbrowser : expectedTeamID=S6N382Y83G
2024-04-03 11:32:16 : DEBUG : arcbrowser : blockingProcesses=
2024-04-03 11:32:16 : DEBUG : arcbrowser : installerTool=
2024-04-03 11:32:16 : DEBUG : arcbrowser : CLIInstaller=
2024-04-03 11:32:16 : DEBUG : arcbrowser : CLIArguments=
2024-04-03 11:32:16 : DEBUG : arcbrowser : updateTool=
2024-04-03 11:32:16 : DEBUG : arcbrowser : updateToolArguments=
2024-04-03 11:32:16 : DEBUG : arcbrowser : updateToolRunAsCurrentUser=
2024-04-03 11:32:16 : INFO  : arcbrowser : BLOCKING_PROCESS_ACTION=tell_user
2024-04-03 11:32:16 : INFO  : arcbrowser : NOTIFY=success
2024-04-03 11:32:16 : INFO  : arcbrowser : LOGGING=DEBUG
2024-04-03 11:32:16 : INFO  : arcbrowser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-03 11:32:16 : INFO  : arcbrowser : Label type: dmg
2024-04-03 11:32:16 : INFO  : arcbrowser : archiveName: Arc.dmg
2024-04-03 11:32:16 : INFO  : arcbrowser : no blocking processes defined, using Arc as default
2024-04-03 11:32:16 : DEBUG : arcbrowser : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2024-04-03 11:32:16 : INFO  : arcbrowser : App(s) found: /Applications/Arc.app
2024-04-03 11:32:16 : INFO  : arcbrowser : found app at /Applications/Arc.app, version 1.36.0, on versionKey CFBundleShortVersionString
2024-04-03 11:32:16 : INFO  : arcbrowser : appversion: 1.36.0
2024-04-03 11:32:16 : INFO  : arcbrowser : Latest version of Arc is location: https://arc.net/release/Arc-latest.dmg
2024-04-03 11:32:16 : INFO  : arcbrowser : 1.36.0
2024-04-03 11:32:16 : INFO  : arcbrowser : Arc.dmg exists and DEBUG mode 1 enabled, skipping download
2024-04-03 11:32:16 : DEBUG : arcbrowser : DEBUG mode 1, not checking for blocking processes
2024-04-03 11:32:16 : REQ   : arcbrowser : Installing Arc
2024-04-03 11:32:16 : INFO  : arcbrowser : Mounting /Users/admin/Documents/GitHub/Installomator/build/Arc.dmg
2024-04-03 11:32:16 : DEBUG : arcbrowser : Debugging enabled, dmgmount output was:
expected   CRC32 $CD7596EE
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_HFSX                     	/Volumes/Arc

2024-04-03 11:32:16 : INFO  : arcbrowser : Mounted: /Volumes/Arc 2024-04-03 11:32:16 : INFO  : arcbrowser : Verifying: /Volumes/Arc/Arc.app 2024-04-03 11:32:16 : DEBUG : arcbrowser : App size: 764M	/Volumes/Arc/Arc.app 2024-04-03 11:32:20 : DEBUG : arcbrowser : Debugging enabled, App Verification output was: /Volumes/Arc/Arc.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G)

2024-04-03 11:32:20 : INFO  : arcbrowser : Team ID matching: S6N382Y83G (expected: S6N382Y83G ) 2024-04-03 11:32:20 : INFO  : arcbrowser : Downloaded version of Arc is 1.36.0 on versionKey CFBundleShortVersionString, same as installed. 2024-04-03 11:32:20 : DEBUG : arcbrowser : Unmounting /Volumes/Arc 2024-04-03 11:32:20 : DEBUG : arcbrowser : Debugging enabled, Unmounting output was: "disk6" ejected.
2024-04-03 11:32:20 : DEBUG : arcbrowser : DEBUG mode 1, not reopening anything
2024-04-03 11:32:20 : REG   : arcbrowser : No new version to install
2024-04-03 11:32:20 : REQ   : arcbrowser : ################## End Installomator, exit code 0