### PR TITLE
LaTeX labels (basictex, mactex, texliveutility, texshop, texshop-alternative)

### DIFF
--- a/fragments/labels/basictex.sh
+++ b/fragments/labels/basictex.sh
@@ -1,0 +1,7 @@
+basictex)
+    # Small LaTeX alternative to mactex
+    name="BasicTeX"
+    type="pkg"
+    downloadURL="https://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg"
+    expectedTeamID="RBGCY5RJWM"
+    ;;

--- a/fragments/labels/mactex.sh
+++ b/fragments/labels/mactex.sh
@@ -1,6 +1,8 @@
 mactex)
+    # Big LaTeX distribution. Small alternative is basictex
+    # Includes these apps (maybe in older version): texshop (texshop-alternative), texliveutility, latexit, bibdesk
+    # You might want to run those labels after this one to update apps fully
     name="MacTeX"
-    appName="TeX Live Utility.app"
     type="pkg"
     downloadURL="https://mirror.ctan.org/systems/mac/mactex/MacTeX.pkg"
     expectedTeamID="RBGCY5RJWM"

--- a/fragments/labels/texliveutility.sh
+++ b/fragments/labels/texliveutility.sh
@@ -1,0 +1,7 @@
+texliveutility)
+    name="TeX Live Utility"
+    type="zip"
+    downloadURL="$(downloadURLFromGit amaxwell tlutility)"
+    appNewVersion="$(versionFromGit amaxwell tlutility)"
+    expectedTeamID="966Z24PX4J"
+    ;;

--- a/fragments/labels/texshop-alternative.sh
+++ b/fragments/labels/texshop-alternative.sh
@@ -1,5 +1,5 @@
 texshop-alternative)
-    # This label is really an alternative to the original TeXShop, as it might not have the latest version and is not maintained by original author of TeXShop.
+    # This label is really an alternative to the original TeXShop, as it might not have the latest version and is not maintained by original developers of TeXShop.
     name="TeXShop"
     type="zip"
     downloadURL="$(downloadURLFromGit TeXShop TeXShop)"

--- a/fragments/labels/texshop-alternative.sh
+++ b/fragments/labels/texshop-alternative.sh
@@ -1,4 +1,5 @@
-texshop)
+texshop-alternative)
+    # This label is really an alternative to the original TeXShop, as it might not have the latest version and is not maintained by original author of TeXShop.
     name="TeXShop"
     type="zip"
     downloadURL="$(downloadURLFromGit TeXShop TeXShop)"

--- a/fragments/labels/texshop.sh
+++ b/fragments/labels/texshop.sh
@@ -1,0 +1,10 @@
+texshop)
+    # This is the original source of TeXShop, but it is often very slow to download.
+    # A label texshop-alternative exists that is hosted on GitHub, but might not have the latest version and is not maintained by the original developers.
+    # This app needs basictex or mactex for the LaTeX part.
+    name="TeXShop"
+    type="zip"
+    downloadURL="https://pages.uoregon.edu/koch/texshop/texshop-64/texshop.zip"
+    appNewVersion="$(curl -fs https://pages.uoregon.edu/koch/texshop/obtaining.html | xmllint --html --format - | grep "texshop-64/texshop.zip" | grep "Latest TeXShop" | sed -E 's/.*Version ([0-9.]*).*/\1/')"
+    expectedTeamID="RBGCY5RJWM"
+    ;;


### PR DESCRIPTION
So in #1486, it is being made clear that the `texshop` label is not really the developer source distribution, so that label was renamed to `texshop-alternative`.

So a new `texshop` was made, but be aware that it can be slow, but the alternative might not be the latest version.

In order to do anything LaTeX you need the underlying engine and tools. `basictex` is a small package of those tools, `mactex` is a full 5 GB release of them. The latter includes the apps `texshop` (`texshop-alternative`), `texliveutility`, `latexit`, `bibdesk`.

So it might be a good idea to run those labels after, in order to make sure the apps are the latest version.