### PR TITLE
Update blender.sh

### DIFF
--- a/fragments/labels/blender.sh
+++ b/fragments/labels/blender.sh
@@ -2,13 +2,15 @@ blender)
     name="Blender"
     type="dmg"
     versionKey="CFBundleShortVersionString"
-    appNewVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/ | grep -o 'Blender[0-9]\+\.[0-9]\+' | cut -d 'r' -f 2 | sort -V | tail -1)
+    baseVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/ | grep -o 'Blender[0-9]\+\.[0-9]\+' | cut -d 'r' -f 2 | sort -V | tail -1)
     if [[ $(arch) == "arm64" ]]; then
-        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/"| grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-arm64\.dmg' | sort -V | tail -1)
-        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/$archiveName"
+        appNewVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/ | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-arm64\.dmg' | sort -V | tail -1 | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' )
+        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/"| grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-arm64\.dmg' | sort -V | tail -1)
+        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/$archiveName"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/" | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-x64\.dmg' | sort -V | tail -1)
-        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$appNewVersion/$archiveName"
+        appNewVersion=$(curl -sf https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/ | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-x64\.dmg' | sort -V | tail -1 | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' )
+        archiveName=$(curl -sf "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/" | grep -o 'blender-[0-9]\+\.[0-9]\+\.[0-9]\+-macos-x64\.dmg' | sort -V | tail -1)
+        downloadURL="https://ftp.nluug.nl/pub/graphics/blender/release/Blender$baseVersion/$archiveName"
     fi
     expectedTeamID="68UA947AUU"
     ;;


### PR DESCRIPTION
Output:

Installomator/utils/assemble.sh blender
Password:
2024-04-03 16:43:02 : REQ   : blender : ################## Start Installomator v. 10.6beta, date 2024-04-03
2024-04-03 16:43:02 : INFO  : blender : ################## Version: 10.6beta
2024-04-03 16:43:02 : INFO  : blender : ################## Date: 2024-04-03
2024-04-03 16:43:02 : INFO  : blender : ################## blender
2024-04-03 16:43:02 : DEBUG : blender : DEBUG mode 1 enabled.
2024-04-03 16:43:04 : DEBUG : blender : name=Blender
2024-04-03 16:43:04 : DEBUG : blender : appName=
2024-04-03 16:43:04 : DEBUG : blender : type=dmg
2024-04-03 16:43:04 : DEBUG : blender : archiveName=blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:04 : DEBUG : blender : downloadURL=https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.1/blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:04 : DEBUG : blender : curlOptions=
2024-04-03 16:43:04 : DEBUG : blender : appNewVersion=4.1.0
2024-04-03 16:43:04 : DEBUG : blender : appCustomVersion function: Not defined
2024-04-03 16:43:04 : DEBUG : blender : versionKey=CFBundleShortVersionString
2024-04-03 16:43:04 : DEBUG : blender : packageID=
2024-04-03 16:43:04 : DEBUG : blender : pkgName=
2024-04-03 16:43:04 : DEBUG : blender : choiceChangesXML=
2024-04-03 16:43:04 : DEBUG : blender : expectedTeamID=68UA947AUU
2024-04-03 16:43:04 : DEBUG : blender : blockingProcesses=
2024-04-03 16:43:04 : DEBUG : blender : installerTool=
2024-04-03 16:43:04 : DEBUG : blender : CLIInstaller=
2024-04-03 16:43:04 : DEBUG : blender : CLIArguments=
2024-04-03 16:43:04 : DEBUG : blender : updateTool=
2024-04-03 16:43:04 : DEBUG : blender : updateToolArguments=
2024-04-03 16:43:04 : DEBUG : blender : updateToolRunAsCurrentUser=
2024-04-03 16:43:05 : INFO  : blender : BLOCKING_PROCESS_ACTION=tell_user
2024-04-03 16:43:05 : INFO  : blender : NOTIFY=success
2024-04-03 16:43:05 : INFO  : blender : LOGGING=DEBUG
2024-04-03 16:43:05 : INFO  : blender : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-03 16:43:05 : INFO  : blender : Label type: dmg
2024-04-03 16:43:05 : INFO  : blender : archiveName: blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:05 : INFO  : blender : no blocking processes defined, using Blender as default
2024-04-03 16:43:05 : DEBUG : blender : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2024-04-03 16:43:05 : INFO  : blender : App(s) found: /Applications/Blender.app
2024-04-03 16:43:05 : INFO  : blender : found app at /Applications/Blender.app, version 4.1.0, on versionKey CFBundleShortVersionString
2024-04-03 16:43:05 : INFO  : blender : appversion: 4.1.0
2024-04-03 16:43:05 : INFO  : blender : Latest version of Blender is 4.1.0
2024-04-03 16:43:05 : WARN  : blender : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-04-03 16:43:05 : REQ   : blender : Downloading https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.1/blender-4.1.0-macos-arm64.dmg to blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:05 : DEBUG : blender : No Dialog connection, just download
2024-04-03 16:43:35 : DEBUG : blender : File list: -rw-r--r--  1 root  staff   256M Apr  3 16:43 blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:35 : DEBUG : blender : File type: blender-4.1.0-macos-arm64.dmg: zlib compressed data
2024-04-03 16:43:35 : DEBUG : blender : curl output was:
*   Trying 145.220.21.40:443...
* Connected to ftp.nluug.nl (145.220.21.40) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2879 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=ftp.nluug.nl
*  start date: Feb 13 05:02:02 2024 GMT
*  expire date: May 13 05:02:01 2024 GMT
*  subjectAltName: host "ftp.nluug.nl" matched cert's "ftp.nluug.nl"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /pub/graphics/blender/release/Blender4.1/blender-4.1.0-macos-arm64.dmg HTTP/1.1
> Host: ftp.nluug.nl
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 03 Apr 2024 22:43:05 GMT
< Server: Apache/2.2.15 (CentOS)
< Last-Modified: Tue, 26 Mar 2024 10:57:01 GMT
< ETag: "24177fa88-10055bed-6148e26519d48"
< Accept-Ranges: bytes
< Content-Length: 268786669
< Content-Type: application/octet-stream
<
{ [8000 bytes data]
* Connection #0 to host ftp.nluug.nl left intact

2024-04-03 16:43:35 : DEBUG : blender : DEBUG mode 1, not checking for blocking processes
2024-04-03 16:43:35 : REQ   : blender : Installing Blender
2024-04-03 16:43:35 : INFO  : blender : Mounting /Users/admin/Documents/GitHub/Installomator/build/blender-4.1.0-macos-arm64.dmg
2024-04-03 16:43:39 : DEBUG : blender : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $90FFA9B0
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $C74B05F8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $C4A2872C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E8467CF3
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $C4A2872C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $801C92E5
verified   CRC32 $E871D410
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Blender

2024-04-03 16:43:39 : INFO  : blender : Mounted: /Volumes/Blender 2024-04-03 16:43:39 : INFO  : blender : Verifying: /Volumes/Blender/Blender.app 2024-04-03 16:43:39 : DEBUG : blender : App size: 753M	/Volumes/Blender/Blender.app 2024-04-03 16:43:43 : DEBUG : blender : Debugging enabled, App Verification output was: /Volumes/Blender/Blender.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Stichting Blender Foundation (68UA947AUU)

2024-04-03 16:43:43 : INFO  : blender : Team ID matching: 68UA947AUU (expected: 68UA947AUU ) 2024-04-03 16:43:43 : INFO  : blender : Downloaded version of Blender is 4.1.0 on versionKey CFBundleShortVersionString, same as installed. 2024-04-03 16:43:43 : DEBUG : blender : Unmounting /Volumes/Blender 2024-04-03 16:43:43 : DEBUG : blender : Debugging enabled, Unmounting output was: "disk6" ejected.
2024-04-03 16:43:43 : DEBUG : blender : DEBUG mode 1, not reopening anything
2024-04-03 16:43:43 : REG   : blender : No new version to install
2024-04-03 16:43:43 : REQ   : blender : ################## End Installomator, exit code 0