### PR TITLE
Label fix: yubikeymanagerqt

### DIFF
--- a/fragments/labels/yubikeymanagerqt.sh
+++ b/fragments/labels/yubikeymanagerqt.sh
@@ -1,9 +1,8 @@
 yubikeymanagerqt)
-    # credit: Tadayuki Onishi (@kenchan0130)
     name="YubiKey Manager GUI"
     type="pkg"
-    downloadURL="https://developers.yubico.com/yubikey-manager-qt/Releases/$(curl -sfL https://api.github.com/repos/Yubico/yubikey-manager-qt/releases/latest | awk -F '"' '/"tag_name"/ { print $4 }')-mac.pkg"
-    #appNewVersion=$(curl -fs https://developers.yubico.com/yubikey-manager-qt/Releases/ | grep mac.pkg | head -1 | sed -E "s/.*-([0-9.]*)-mac.*/\1/") # does not work
-    appNewVersion=$(versionFromGit Yubico yubikey-manager-qt)
+    baseURL="https://developers.yubico.com/yubikey-manager-qt/Releases"
+    downloadURL="$baseURL/$(curl -sfL "$baseURL" | grep -oE 'yubikey[^"]*.pkg' | head -1)"
+    appNewVersion=$(grep -oE '\d+\.[0-9.]*\d' <<< "$downloadURL")
     expectedTeamID="LQA3CS5MM7"
     ;;


### PR DESCRIPTION
The current label for YubiKey Manager GUI (yubikeymanagerqt) breaks when the latest version is not for macOS. For example, on 4/4/2024 the vendor released version 1.2.6 as a Windows-only security fix. In this instance, the old label tries to download a non-existent 1.2.6 Mac version.

Output:
```
# ./assemble.sh yubikeymanagerqt DEBUG=0
2024-04-04 17:08:01 : REQ   : yubikeymanagerqt : ################## Start Installomator v. 10.6beta, date 2024-04-04
2024-04-04 17:08:01 : INFO  : yubikeymanagerqt : ################## Version: 10.6beta
2024-04-04 17:08:01 : INFO  : yubikeymanagerqt : ################## Date: 2024-04-04
2024-04-04 17:08:01 : INFO  : yubikeymanagerqt : ################## yubikeymanagerqt
2024-04-04 17:08:01 : DEBUG : yubikeymanagerqt : DEBUG mode 1 enabled.
2024-04-04 17:08:02 : INFO  : yubikeymanagerqt : setting variable from argument DEBUG=0
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : name=YubiKey Manager GUI
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : appName=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : type=pkg
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : archiveName=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : downloadURL=https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.5-mac.pkg
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : curlOptions=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : appNewVersion=1.2.5
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : appCustomVersion function: Not defined
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : versionKey=CFBundleShortVersionString
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : packageID=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : pkgName=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : choiceChangesXML=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : expectedTeamID=LQA3CS5MM7
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : blockingProcesses=
2024-04-04 17:08:02 : DEBUG : yubikeymanagerqt : installerTool=
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : CLIInstaller=
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : CLIArguments=
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : updateTool=
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : updateToolArguments=
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : updateToolRunAsCurrentUser=
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : BLOCKING_PROCESS_ACTION=tell_user
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : NOTIFY=success
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : LOGGING=DEBUG
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : Label type: pkg
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : archiveName: YubiKey Manager GUI.pkg
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : no blocking processes defined, using YubiKey Manager GUI as default
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : name: YubiKey Manager GUI, appName: YubiKey Manager GUI.app
2024-04-04 17:08:03.361 mdfind[57324:238183] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-04 17:08:03.361 mdfind[57324:238183] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-04 17:08:03.470 mdfind[57324:238183] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-04 17:08:03 : WARN  : yubikeymanagerqt : No previous app found
2024-04-04 17:08:03 : WARN  : yubikeymanagerqt : could not find YubiKey Manager GUI.app
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : appversion:
2024-04-04 17:08:03 : INFO  : yubikeymanagerqt : Latest version of YubiKey Manager GUI is 1.2.5
2024-04-04 17:08:03 : REQ   : yubikeymanagerqt : Downloading https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.5-mac.pkg to YubiKey Manager GUI.pkg
2024-04-04 17:08:03 : DEBUG : yubikeymanagerqt : No Dialog connection, just download
2024-04-04 17:08:12 : DEBUG : yubikeymanagerqt : File list: -rw-r--r--  1 root  wheel    70M Apr  4 17:08 YubiKey Manager GUI.pkg
2024-04-04 17:08:12 : DEBUG : yubikeymanagerqt : File type: YubiKey Manager GUI.pkg: xar archive compressed TOC: 4357, SHA-1 checksum
2024-04-04 17:08:12 : DEBUG : yubikeymanagerqt : curl output was:
* Host developers.yubico.com:443 was resolved.
* IPv6: (none)
* IPv4: 151.101.194.114, 151.101.2.114, 151.101.66.114, 151.101.130.114
*   Trying 151.101.194.114:443...
* Connected to developers.yubico.com (151.101.194.114) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3606 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=yubico.com
*  start date: Oct 31 19:38:44 2023 GMT
*  expire date: Dec  1 19:38:43 2024 GMT
*  subjectAltName: host "developers.yubico.com" matched cert's "developers.yubico.com"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.5-mac.pkg HTTP/1.1
> Host: developers.yubico.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Connection: keep-alive
< Content-Length: 73251304
< X-GUploader-UploadID: ABPtcPqTFpac-IwQc_QKvs4UmLEpHUsaF9Dj-XdZLja5m40i86rPJcLrzvk28Id9QuaAWweI5lk
< Expires: Thu, 04 Apr 2024 21:08:03 GMT
< Cache-Control: private, max-age=0
< Last-Modified: Thu, 04 Apr 2024 13:39:10 GMT
< ETag: "5c595d4303659b479426de81f124e04b"
< x-goog-generation: 1712237950340739
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 73251304
< x-amz-meta-goog-reserved-file-mtime: 1712237826
< Content-Type: application/vnd.apple.installer+xml
< x-goog-hash: crc32c=lHAgPA==
< x-goog-hash: md5=XFldQwNlm0eUJt6B8STgSw==
< x-amz-checksum-crc32c: lHAgPA==
< x-goog-storage-class: STANDARD
< Accept-Ranges: bytes
< Server: UploadServer
< Date: Thu, 04 Apr 2024 21:08:03 GMT
< Via: 1.1 varnish
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< X-Served-By: cache-ewr18175-EWR
< X-Cache: MISS
< X-Cache-Hits: 0
< X-Timer: S1712264884.805053,VS0,VE90
<
{ [8268 bytes data]
* Connection #0 to host developers.yubico.com left intact

2024-04-04 17:08:12 : REQ   : yubikeymanagerqt : no more blocking processes, continue with update
2024-04-04 17:08:12 : REQ   : yubikeymanagerqt : Installing YubiKey Manager GUI
2024-04-04 17:08:12 : INFO  : yubikeymanagerqt : Verifying: YubiKey Manager GUI.pkg
2024-04-04 17:08:12 : DEBUG : yubikeymanagerqt : File list: -rw-r--r--  1 root  wheel    70M Apr  4 17:08 YubiKey Manager GUI.pkg
2024-04-04 17:08:12 : DEBUG : yubikeymanagerqt : File type: YubiKey Manager GUI.pkg: xar archive compressed TOC: 4357, SHA-1 checksum
2024-04-04 17:08:13 : DEBUG : yubikeymanagerqt : spctlOut is YubiKey Manager GUI.pkg: accepted
2024-04-04 17:08:13 : DEBUG : yubikeymanagerqt : source=Notarized Developer ID
2024-04-04 17:08:13 : DEBUG : yubikeymanagerqt : origin=Developer ID Installer: Yubico Limited (LQA3CS5MM7)
2024-04-04 17:08:13 : INFO  : yubikeymanagerqt : Team ID: LQA3CS5MM7 (expected: LQA3CS5MM7 )
2024-04-04 17:08:13 : INFO  : yubikeymanagerqt : Installing YubiKey Manager GUI.pkg to /
2024-04-04 17:09:04 : DEBUG : yubikeymanagerqt : Debugging enabled, installer output was:
Apr  4 17:08:13  installer[57424] <Info>: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
Apr  4 17:08:13  installer[57424] <Warning>: Architecture Translation: Process is about to get executed as Intel.
Apr  4 17:08:13  installer[57424] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey Manager GUI.pkg trustLevel=350
Apr  4 17:08:13  installer[57424] <Debug>: External component packages (1) trustLevel=350
Apr  4 17:08:13  installer[57424] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Apr  4 17:08:13  installer[57424] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey%20Manager%20GUI.pkg#com.yubico.ykman.pkg
Apr  4 17:08:13  installer[57424] <Info>: Set authorization level to root for session
Apr  4 17:08:13  installer[57424] <Info>: Authorization is being checked, waiting until authorization arrives.
Apr  4 17:08:13  installer[57424] <Info>: Administrator authorization granted.
Apr  4 17:08:13  installer[57424] <Info>: Packages have been authorized for installation.
Apr  4 17:08:13  installer[57424] <Debug>: Will use PK session
Apr  4 17:08:13  installer[57424] <Debug>: Using authorization level of root for IFPKInstallElement
Apr  4 17:08:13  installer[57424] <Info>: Install request is requesting Rosetta translation.
Apr  4 17:08:13  installer[57424] <Info>: Starting installation:
Apr  4 17:08:13  installer[57424] <Notice>: Configuring volume "Macintosh HD"
Apr  4 17:08:13  installer[57424] <Info>: Preparing disk for local booted install.
Apr  4 17:08:13  installer[57424] <Notice>: Free space on "Macintosh HD": 457.61 GB (457606639616 bytes).
Apr  4 17:08:13  installer[57424] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.57424w5qxOn"
Apr  4 17:08:13  installer[57424] <Notice>: IFPKInstallElement (1 packages)
Apr  4 17:08:14  installer[57424] <Info>: Current Path: /usr/sbin/installer
Apr  4 17:08:14  installer[57424] <Info>: Current Path: /bin/zsh
Last Log repeated 2 times
Apr  4 17:08:14  installer[57424] <Info>: Current Path: /usr/bin/sudo
Apr  4 17:08:14  installer[57424] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is YubiKey Manager
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing YubiKey Manager….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Validating packages….....
#
installer: Writing files….....
#
installer: Writing files….....
Last Log repeated 2 times
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
Last Log repeated 2 times
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
Last Log repeated 2 times
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing package receipts….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#Apr  4 17:09:02  installer[57424] <Info>: PackageKit: Registered bundle file:///Applications/YubiKey%20Manager.app/ for uid 0
Apr  4 17:09:02  installer[57424] <Info>: PackageKit: Registered bundle file:///Applications/YubiKey%20Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/ for uid 0

installer: Registering updated components….....
Last Log repeated 47 times
installer: Validating packages….....
#Apr  4 17:09:03  installer[57424] <Notice>: Running install actions
Apr  4 17:09:03  installer[57424] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.57424w5qxOn"
Apr  4 17:09:03  installer[57424] <Notice>: Finalize disk "Macintosh HD"
Apr  4 17:09:03  installer[57424] <Notice>: Notifying system of updated components
Apr  4 17:09:03  installer[57424] <Notice>:
Apr  4 17:09:03  installer[57424] <Notice>: **** Summary Information ****
Apr  4 17:09:03  installer[57424] <Notice>:   Operation      Elapsed time
Apr  4 17:09:03  installer[57424] <Notice>: -----------------------------
Apr  4 17:09:03  installer[57424] <Notice>:        disk      0.00 seconds
Apr  4 17:09:03  installer[57424] <Notice>:      script      0.00 seconds
Apr  4 17:09:03  installer[57424] <Notice>:        zero      0.00 seconds
Apr  4 17:09:03  installer[57424] <Notice>:     install      49.32 seconds
Apr  4 17:09:03  installer[57424] <Notice>:     -total-      49.33 seconds
Apr  4 17:09:03  installer[57424] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The install was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-04-04 17:08:13-04 redacted installer[57424]: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
2024-04-04 17:08:13-04 redacted installer[57424]: Architecture Translation: Process is about to get executed as Intel.
2024-04-04 17:08:13-04 redacted installer[57424]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey Manager GUI.pkg trustLevel=350
2024-04-04 17:08:13-04 redacted installer[57424]: External component packages (1) trustLevel=350
2024-04-04 17:08:13-04 redacted installer[57424]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-04-04 17:08:13-04 redacted installer[57424]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey%20Manager%20GUI.pkg#com.yubico.ykman.pkg
2024-04-04 17:08:13-04 redacted installer[57424]: Set authorization level to root for session
2024-04-04 17:08:13-04 redacted installer[57424]: Authorization is being checked, waiting until authorization arrives.
2024-04-04 17:08:13-04 redacted installer[57424]: Administrator authorization granted.
2024-04-04 17:08:13-04 redacted installer[57424]: Packages have been authorized for installation.
2024-04-04 17:08:13-04 redacted installer[57424]: Will use PK session
2024-04-04 17:08:13-04 redacted installer[57424]: Using authorization level of root for IFPKInstallElement
2024-04-04 17:08:13-04 redacted installer[57424]: Install request is requesting Rosetta translation.
2024-04-04 17:08:13-04 redacted installer[57424]: Starting installation:
2024-04-04 17:08:13-04 redacted installer[57424]: Configuring volume "Macintosh HD"
2024-04-04 17:08:13-04 redacted installer[57424]: Preparing disk for local booted install.
2024-04-04 17:08:13-04 redacted installer[57424]: Free space on "Macintosh HD": 457.61 GB (457606639616 bytes).
2024-04-04 17:08:13-04 redacted installer[57424]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.57424w5qxOn"
2024-04-04 17:08:13-04 redacted installer[57424]: IFPKInstallElement (1 packages)
2024-04-04 17:08:14-04 redacted installer[57424]: Current Path: /usr/sbin/installer
2024-04-04 17:08:14-04 redacted installer[57424]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-04-04 17:08:14-04 redacted installer[57424]: Current Path: /usr/bin/sudo
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: Adding client PKInstallDaemonClient pid=57424, uid=0 (/usr/sbin/installer)
2024-04-04 17:08:14-04 redacted installer[57424]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: Set reponsibility for install to 56787
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: Hosted team responsibility for install set to team:(LQA3CS5MM7)
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: ----- Begin install -----
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-04-04 17:08:14-04 redacted installd[5480]: PackageKit: packages=(
2024-04-04 17:08:15-04 redacted installd[5480]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey%20Manager%20GUI.pkg#com.yubico.ykman.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/A898E5E9-453F-4B74-9013-A1E705DAEBB6.activeSandbox/Root/Applications, uid=0)
2024-04-04 17:08:25-04 redacted installd[5480]: PackageKit: prevent user idle system sleep
2024-04-04 17:08:25-04 redacted installd[5480]: PackageKit: suspending backupd
2024-04-04 17:08:25-04 redacted installd[5480]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/A898E5E9-453F-4B74-9013-A1E705DAEBB6.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/A898E5E9-453F-4B74-9013-A1E705DAEBB6.activeSandbox
2024-04-04 17:08:25-04 redacted install_monitor[57435]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-04-04 17:08:25-04 redacted installd[5480]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/A898E5E9-453F-4B74-9013-A1E705DAEBB6.activeSandbox/Root (1 items) to /
2024-04-04 17:08:26-04 redacted installd[5480]: PackageKit: Writing receipt for com.yubico.ykman to /
2024-04-04 17:08:26-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/Python
2024-04-04 17:08:26-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/Contents/MacOS/Python
2024-04-04 17:08:26-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/bin/python3.11
2024-04-04 17:08:26-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/bin/python3.11-intel64
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_asyncio.cpython-311-darwin.so
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_bisect.cpython-311-darwin.so
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_blake2.cpython-311-darwin.so
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_bz2.cpython-311-darwin.so
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_cn.cpython-311-darwin.so
2024-04-04 17:08:27-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_hk.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_iso2022.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_jp.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_kr.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_codecs_tw.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_contextvars.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_crypt.cpython-311-darwin.so
2024-04-04 17:08:28-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_csv.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_ctypes.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_ctypes_test.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_curses.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_curses_panel.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_datetime.cpython-311-darwin.so
2024-04-04 17:08:29-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_dbm.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_decimal.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_elementtree.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_gdbm.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_hashlib.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_heapq.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_json.cpython-311-darwin.so
2024-04-04 17:08:30-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_lsprof.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_lzma.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_md5.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_multibytecodec.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_multiprocessing.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_opcode.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_pickle.cpython-311-darwin.so
2024-04-04 17:08:31-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_posixshmem.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_posixsubprocess.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_queue.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_random.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_scproxy.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_sha1.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_sha256.cpython-311-darwin.so
2024-04-04 17:08:32-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_sha3.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_sha512.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_socket.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_sqlite3.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_ssl.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_statistics.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_struct.cpython-311-darwin.so
2024-04-04 17:08:33-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_testbuffer.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_testcapi.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_testimportmultiple.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_testinternalcapi.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_testmultiphase.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_typing.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_uuid.cpython-311-darwin.so
2024-04-04 17:08:34-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_xxsubinterpreters.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_xxtestfuzz.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/_zoneinfo.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/array.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/audioop.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/binascii.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/cmath.cpython-311-darwin.so
2024-04-04 17:08:35-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/fcntl.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/grp.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/math.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/mmap.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/nis.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/pyexpat.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/readline.cpython-311-darwin.so
2024-04-04 17:08:36-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/resource.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/select.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/syslog.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/termios.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/unicodedata.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/xxlimited.cpython-311-darwin.so
2024-04-04 17:08:37-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/xxlimited_35.cpython-311-darwin.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload/zlib.cpython-311-darwin.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_ARC4.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_Salsa20.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_chacha20.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_pkcs1_decode.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_aes.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_aesni.abi3.so
2024-04-04 17:08:38-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_arc2.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_blowfish.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_cast.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_cbc.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_cfb.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_ctr.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_des.abi3.so
2024-04-04 17:08:39-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_des3.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_ecb.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_eksblowfish.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_ocb.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Cipher/_raw_ofb.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_BLAKE2b.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_BLAKE2s.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_MD2.abi3.so
2024-04-04 17:08:40-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_MD4.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_MD5.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_RIPEMD160.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_SHA1.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_SHA224.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_SHA256.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_SHA384.abi3.so
2024-04-04 17:08:41-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_SHA512.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_ghash_clmul.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_ghash_portable.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_keccak.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Hash/_poly1305.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Math/_modexp.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Protocol/_scrypt.abi3.so
2024-04-04 17:08:42-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/PublicKey/_ec_ws.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/PublicKey/_ed25519.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/PublicKey/_ed448.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/PublicKey/_x25519.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Util/_cpuid_c.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/Cryptodome/Util/_strxor.abi3.so
2024-04-04 17:08:43-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/_brotli.cpython-311-darwin.so
2024-04-04 17:08:44-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/_cffi_backend.cpython-311-darwin.so
2024-04-04 17:08:44-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/charset_normalizer/md.cpython-311-darwin.so
2024-04-04 17:08:44-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/charset_normalizer/md__mypyc.cpython-311-darwin.so
2024-04-04 17:08:45-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so
2024-04-04 17:08:46-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/cryptography/hazmat/bindings/_rust.abi3.so
2024-04-04 17:08:46-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyppmd/c/_ppmd.cpython-311-darwin.so
2024-04-04 17:08:46-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/smartcard/scard/_scard.cpython-311-darwin.so
2024-04-04 17:08:47-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtCore.framework/Versions/5/QtCore
2024-04-04 17:08:47-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtDBus.framework/Versions/5/QtDBus
2024-04-04 17:08:49-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtGui.framework/Versions/5/QtGui
2024-04-04 17:08:49-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtNetwork.framework/Versions/5/QtNetwork
2024-04-04 17:08:50-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
2024-04-04 17:08:51-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQml.framework/Versions/5/QtQml
2024-04-04 17:08:51-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQmlModels.framework/Versions/5/QtQmlModels
2024-04-04 17:08:51-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQmlWorkerScript.framework/Versions/5/QtQmlWorkerScript
2024-04-04 17:08:51-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQuick.framework/Versions/5/QtQuick
2024-04-04 17:08:52-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQuickControls2.framework/Versions/5/QtQuickControls2
2024-04-04 17:08:52-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtQuickTemplates2.framework/Versions/5/QtQuickTemplates2
2024-04-04 17:08:52-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtRemoteObjects.framework/Versions/5/QtRemoteObjects
2024-04-04 17:08:52-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtSvg.framework/Versions/5/QtSvg
2024-04-04 17:08:53-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/QtWidgets.framework/Versions/5/QtWidgets
2024-04-04 17:08:53-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/capi.dylib
2024-04-04 17:08:53-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/libcrypto.1.1.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/libcrypto.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/libssl.1.1.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/libssl.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/Frameworks/padlock.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/MacOS/ykman
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/MacOS/ykman-gui
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/bearer/libqgenericbearer.dylib
2024-04-04 17:08:54-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/iconengines/libqsvgicon.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqgif.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqicns.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqico.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqjpeg.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqmacheif.dylib
2024-04-04 17:08:55-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqmacjp2.dylib
2024-04-04 17:08:56-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqsvg.dylib
2024-04-04 17:08:56-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqtga.dylib
2024-04-04 17:08:56-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqtiff.dylib
2024-04-04 17:08:56-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqwbmp.dylib
2024-04-04 17:08:56-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/imageformats/libqwebp.dylib
2024-04-04 17:08:57-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/platforms/libqcocoa.dylib
2024-04-04 17:08:57-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/printsupport/libcocoaprintersupport.dylib
2024-04-04 17:08:57-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libdialogplugin.dylib
2024-04-04 17:08:57-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libdialogsprivateplugin.dylib
2024-04-04 17:08:57-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libmodelsplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libpyothersideplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqmlfolderlistmodelplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqmlplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqmlsettingsplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqquicklayoutsplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtgraphicaleffectsplugin.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtgraphicaleffectsprivate.dylib
2024-04-04 17:08:58-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtlabscalendarplugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtlabsplatformplugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtqmlremoteobjects.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtqmlstatemachine.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquick2plugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrols2fusionstyleplugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrols2imaginestyleplugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrols2materialstyleplugin.dylib
2024-04-04 17:08:59-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrols2plugin.dylib
2024-04-04 17:09:00-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrols2universalstyleplugin.dylib
2024-04-04 17:09:00-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickcontrolsplugin.dylib
2024-04-04 17:09:00-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickextrasflatplugin.dylib
2024-04-04 17:09:00-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquickextrasplugin.dylib
2024-04-04 17:09:00-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libqtquicktemplates2plugin.dylib
2024-04-04 17:09:01-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libwidgetsplugin.dylib
2024-04-04 17:09:01-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libwindowplugin.dylib
2024-04-04 17:09:01-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/quick/libworkerscriptplugin.dylib
2024-04-04 17:09:01-04 redacted installd[5480]: oahd translated /Applications/YubiKey Manager.app/Contents/PlugIns/styles/libqmacstyle.dylib
2024-04-04 17:09:01-04 redacted installd[5480]: PackageKit: Translated 193 binaries.
2024-04-04 17:09:01-04 redacted installd[5480]: PackageKit: Touched bundle /Applications/YubiKey Manager.app
2024-04-04 17:09:01-04 redacted installd[5480]: PackageKit: Touched bundle /Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/Resources/Python.app
2024-04-04 17:09:01-04 redacted installd[5480]: Installed "YubiKey Manager" (1.2.5)
2024-04-04 17:09:01-04 redacted installd[5480]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-04-04 17:09:01-04 redacted install_monitor[57435]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: releasing backupd
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: allow user idle system sleep
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: ----- End install -----
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: 47.3s elapsed install time
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: Cleared responsibility for install from 57424.
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: Hosted team responsible for install has been cleared.
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: Running idle tasks
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: Done with sandbox removals
2024-04-04 17:09:02-04 redacted installer[57424]: PackageKit: Registered bundle file:///Applications/YubiKey%20Manager.app/ for uid 0
2024-04-04 17:09:02-04 redacted installer[57424]: PackageKit: Registered bundle file:///Applications/YubiKey%20Manager.app/Contents/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/ for uid 0
2024-04-04 17:09:02-04 redacted installd[5480]: PackageKit: Removing client PKInstallDaemonClient pid=57424, uid=0 (/usr/sbin/installer)
2024-04-04 17:09:03-04 redacted installer[57424]: Running install actions
2024-04-04 17:09:03-04 redacted installer[57424]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.57424w5qxOn"
2024-04-04 17:09:03-04 redacted installer[57424]: Finalize disk "Macintosh HD"
2024-04-04 17:09:03-04 redacted installer[57424]: Notifying system of updated components
2024-04-04 17:09:03-04 redacted installer[57424]:
2024-04-04 17:09:03-04 redacted installer[57424]: **** Summary Information ****
2024-04-04 17:09:03-04 redacted installer[57424]:   Operation      Elapsed time
2024-04-04 17:09:03-04 redacted installer[57424]: -----------------------------
2024-04-04 17:09:03-04 redacted installer[57424]:        disk      0.00 seconds
2024-04-04 17:09:03-04 redacted installer[57424]:      script      0.00 seconds
2024-04-04 17:09:03-04 redacted installer[57424]:        zero      0.00 seconds
2024-04-04 17:09:03-04 redacted installer[57424]:     install      49.32 seconds
2024-04-04 17:09:03-04 redacted installer[57424]:     -total-      49.33 seconds
2024-04-04 17:09:03-04 redacted installer[57424]:

2024-04-04 17:09:04 : INFO  : yubikeymanagerqt : Finishing...
2024-04-04 17:09:07 : INFO  : yubikeymanagerqt : name: YubiKey Manager GUI, appName: YubiKey Manager GUI.app
2024-04-04 17:09:07.610 mdfind[57774:240892] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-04 17:09:07.610 mdfind[57774:240892] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-04 17:09:07.694 mdfind[57774:240892] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-04 17:09:07 : WARN  : yubikeymanagerqt : No previous app found
2024-04-04 17:09:07 : WARN  : yubikeymanagerqt : could not find YubiKey Manager GUI.app
2024-04-04 17:09:07 : REQ   : yubikeymanagerqt : Installed YubiKey Manager GUI, version 1.2.5
2024-04-04 17:09:07 : INFO  : yubikeymanagerqt : notifying
2024-04-04 17:09:08 : DEBUG : yubikeymanagerqt : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm
2024-04-04 17:09:08 : DEBUG : yubikeymanagerqt : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm/YubiKey Manager GUI.pkg
2024-04-04 17:09:08 : DEBUG : yubikeymanagerqt : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aPljMXdvsm
2024-04-04 17:09:08 : INFO  : yubikeymanagerqt : Installomator did not close any apps, so no need to reopen any apps.
2024-04-04 17:09:08 : REQ   : yubikeymanagerqt : All done!
2024-04-04 17:09:08 : REQ   : yubikeymanagerqt : ################## End Installomator, exit code 0

```