### PR TITLE
Add blockingProcesses to garminexpress

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -1,5 +1,6 @@
 garminexpress)
     name="Garmin Express"
+    blockingProcesses=( "Garmin Express" "Garmin Express Service" )
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
     garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')


### PR DESCRIPTION
Apparently Garmin Express also has a Service process, which I forgot in min initial PR.
Installing the pkg with Installomator doesn't seem to quit the service process, so it needs to be quit before installation.