### PR TITLE
Create movavivideosuite.sh

### DIFF
--- a/fragments/labels/movavivideosuite.sh
+++ b/fragments/labels/movavivideosuite.sh
@@ -1,0 +1,7 @@
+movavivideosuite)
+    name="Movavi Video Suite"
+    type="dmg"
+    downloadURL="https://xdn.movavi.com/x64/MovaviVideoSuiteSetup.dmg"
+    appNewVersion=""
+    expectedTeamID="U8KD48QDBK"
+    ;;


### PR DESCRIPTION
2024-04-16 07:46:52 : REQ   : movavivideosuite : ################## Start Installomator v. 10.6beta, date 2024-04-16
2024-04-16 07:46:52 : INFO  : movavivideosuite : ################## Version: 10.6beta
2024-04-16 07:46:52 : INFO  : movavivideosuite : ################## Date: 2024-04-16
2024-04-16 07:46:52 : INFO  : movavivideosuite : ################## movavivideosuite
2024-04-16 07:46:52 : DEBUG : movavivideosuite : DEBUG mode 1 enabled.
2024-04-16 07:46:52 : DEBUG : movavivideosuite : name=Movavi Video Suite
2024-04-16 07:46:52 : DEBUG : movavivideosuite : appName=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : type=dmg
2024-04-16 07:46:52 : DEBUG : movavivideosuite : archiveName=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : downloadURL=https://xdn.movavi.com/x64/MovaviVideoSuiteSetup.dmg
2024-04-16 07:46:52 : DEBUG : movavivideosuite : curlOptions=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : appNewVersion=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : appCustomVersion function: Not defined
2024-04-16 07:46:52 : DEBUG : movavivideosuite : versionKey=CFBundleShortVersionString
2024-04-16 07:46:52 : DEBUG : movavivideosuite : packageID=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : pkgName=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : choiceChangesXML=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : expectedTeamID=U8KD48QDBK
2024-04-16 07:46:52 : DEBUG : movavivideosuite : blockingProcesses=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : installerTool=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : CLIInstaller=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : CLIArguments=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : updateTool=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : updateToolArguments=
2024-04-16 07:46:52 : DEBUG : movavivideosuite : updateToolRunAsCurrentUser=
2024-04-16 07:46:52 : INFO  : movavivideosuite : BLOCKING_PROCESS_ACTION=tell_user
2024-04-16 07:46:52 : INFO  : movavivideosuite : NOTIFY=success
2024-04-16 07:46:52 : INFO  : movavivideosuite : LOGGING=DEBUG
2024-04-16 07:46:52 : INFO  : movavivideosuite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-16 07:46:52 : INFO  : movavivideosuite : Label type: dmg
2024-04-16 07:46:52 : INFO  : movavivideosuite : archiveName: Movavi Video Suite.dmg
2024-04-16 07:46:52 : INFO  : movavivideosuite : no blocking processes defined, using Movavi Video Suite as default
2024-04-16 07:46:52 : DEBUG : movavivideosuite : Changing directory to /Users/kxg2535/Library/CloudStorage/OneDrive-Yum!Brands,Inc/Documents/GitHub/Installomator/build
2024-04-16 07:46:52 : INFO  : movavivideosuite : name: Movavi Video Suite, appName: Movavi Video Suite.app
2024-04-16 07:46:52.456 mdfind[8778:10030728] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-16 07:46:52.456 mdfind[8778:10030728] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-16 07:46:52.534 mdfind[8778:10030728] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-16 07:46:52 : WARN  : movavivideosuite : No previous app found
2024-04-16 07:46:52 : WARN  : movavivideosuite : could not find Movavi Video Suite.app
2024-04-16 07:46:52 : INFO  : movavivideosuite : appversion:
2024-04-16 07:46:52 : INFO  : movavivideosuite : Latest version not specified.
2024-04-16 07:46:52 : REQ   : movavivideosuite : Downloading https://xdn.movavi.com/x64/MovaviVideoSuiteSetup.dmg to Movavi Video Suite.dmg
2024-04-16 07:46:52 : DEBUG : movavivideosuite : No Dialog connection, just download
2024-04-16 07:46:52 : DEBUG : movavivideosuite : File list: -rw-r--r--  1 root  staff   2.9M Apr 16 07:46 Movavi Video Suite.dmg
2024-04-16 07:46:52 : DEBUG : movavivideosuite : File type: Movavi Video Suite.dmg: bzip2 compressed data, block size = 100k
2024-04-16 07:46:52 : DEBUG : movavivideosuite : curl output was:
*   Trying 23.47.51.81:443...
* Connected to xdn.movavi.com (23.47.51.81) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2764 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=s1.movavi.com
*  start date: Apr 11 01:19:38 2024 GMT
*  expire date: Jul 10 01:19:37 2024 GMT
*  subjectAltName: host "xdn.movavi.com" matched cert's "xdn.movavi.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://xdn.movavi.com/x64/MovaviVideoSuiteSetup.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: xdn.movavi.com]
* [HTTP/2] [1] [:path: /x64/MovaviVideoSuiteSetup.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /x64/MovaviVideoSuiteSetup.dmg HTTP/2
> Host: xdn.movavi.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-length: 3051368
< last-modified: Tue, 05 Mar 2024 05:54:29 GMT
< etag: "65e6b395-2e8f68"
< x-content-type-options: nosniff
< referrer-policy: strict-origin-when-cross-origin < access-control-expose-headers: Cache-Control,Content-Disposition,Content-Length,Content-Type,Date,Expires,Pragma,Server < access-control-allow-headers: Access-Control-Allow-Origin < content-disposition: attachment; filename="MovaviVideoSuiteSetup.dmg" < accept-ranges: bytes
< cache-control: no-cache
< expires: Tue, 16 Apr 2024 12:46:52 GMT
< date: Tue, 16 Apr 2024 12:46:52 GMT
< strict-transport-security: max-age=86400 ; includeSubDomains <
{ [49152 bytes data]
* Connection #0 to host xdn.movavi.com left intact

2024-04-16 07:46:52 : DEBUG : movavivideosuite : DEBUG mode 1, not checking for blocking processes
2024-04-16 07:46:52 : REQ   : movavivideosuite : Installing Movavi Video Suite
2024-04-16 07:46:52 : INFO  : movavivideosuite : Mounting /Users/kxg2535/Library/CloudStorage/OneDrive-Yum!Brands,Inc/Documents/GitHub/Installomator/build/Movavi Video Suite.dmg
2024-04-16 07:46:53 : DEBUG : movavivideosuite : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $C2690752
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $BDF0BAA9
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $24253174
verified   CRC32 $3DA3607A
/dev/disk5          	Apple_partition_scheme
/dev/disk5s1        	Apple_partition_map
/dev/disk5s2        	Apple_HFS                      	/Volumes/Movavi Video Suite Installer

2024-04-16 07:46:53 : INFO  : movavivideosuite : Mounted: /Volumes/Movavi Video Suite Installer 2024-04-16 07:46:53 : INFO  : movavivideosuite : Verifying: /Volumes/Movavi Video Suite Installer/Movavi Video Suite.app 2024-04-16 07:46:53 : DEBUG : movavivideosuite : App size: 9.1M	/Volumes/Movavi Video Suite Installer/Movavi Video Suite.app 2024-04-16 07:46:53 : DEBUG : movavivideosuite : Debugging enabled, App Verification output was: /Volumes/Movavi Video Suite Installer/Movavi Video Suite.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Movavi Software Inc. (U8KD48QDBK)

2024-04-16 07:46:53 : INFO  : movavivideosuite : Team ID matching: U8KD48QDBK (expected: U8KD48QDBK ) 2024-04-16 07:46:53 : INFO  : movavivideosuite : Installing Movavi Video Suite version 1.6.0 on versionKey CFBundleShortVersionString. 2024-04-16 07:46:53 : INFO  : movavivideosuite : App has LSMinimumSystemVersion: 10.15 2024-04-16 07:46:53 : DEBUG : movavivideosuite : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-04-16 07:46:53 : INFO  : movavivideosuite : Finishing... 2024-04-16 07:46:56 : INFO  : movavivideosuite : name: Movavi Video Suite, appName: Movavi Video Suite.app 2024-04-16 07:46:56.678 mdfind[8919:10031214] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-04-16 07:46:56.678 mdfind[8919:10031214] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-04-16 07:46:56.730 mdfind[8919:10031214] Couldn't determine the mapping between prefab keywords and predicates. 2024-04-16 07:46:56 : WARN  : movavivideosuite : No previous app found 2024-04-16 07:46:56 : WARN  : movavivideosuite : could not find Movavi Video Suite.app
2024-04-16 07:46:56 : REQ   : movavivideosuite : Installed Movavi Video Suite, version 1.6.0
2024-04-16 07:46:56 : INFO  : movavivideosuite : notifying
2024-04-16 07:46:57 : DEBUG : movavivideosuite : Unmounting /Volumes/Movavi Video Suite Installer
2024-04-16 07:46:57 : DEBUG : movavivideosuite : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-04-16 07:46:57 : DEBUG : movavivideosuite : DEBUG mode 1, not reopening anything
2024-04-16 07:46:57 : REQ   : movavivideosuite : All done!
2024-04-16 07:46:57 : REQ   : movavivideosuite : ################## End Installomator, exit code 0