### PR TITLE
Select pgAdmin download based on architecture

### DIFF
--- a/fragments/labels/pgadmin4.sh
+++ b/fragments/labels/pgadmin4.sh
@@ -3,6 +3,10 @@ pgadmin4)
     type="dmg"
     downloadParent="https://www.postgresql.org/ftp/pgadmin/pgadmin4/"
     appNewVersion=$(curl -fs "${downloadParent}" | grep -oE 'v[0-9]+.[0-9]+' | sort -V | tail -n 1 | sed 's/v//g')
-    downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion-x86_64.dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion-arm64.dmg"
+    else
+        downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion-x86_64.dmg"
+    fi
     expectedTeamID="TCHGL2R7C5"
     ;;


### PR DESCRIPTION
Output:
```
% utils/assemble.sh pgadmin4
2024-04-16 08:43:22 : REQ   : pgadmin4 : ################## Start Installomator v. 10.6beta, date 2024-04-16
2024-04-16 08:43:22 : INFO  : pgadmin4 : ################## Version: 10.6beta
2024-04-16 08:43:22 : INFO  : pgadmin4 : ################## Date: 2024-04-16
2024-04-16 08:43:22 : INFO  : pgadmin4 : ################## pgadmin4
2024-04-16 08:43:22 : DEBUG : pgadmin4 : DEBUG mode 1 enabled.
2024-04-16 08:43:23 : DEBUG : pgadmin4 : name=pgAdmin 4
2024-04-16 08:43:23 : DEBUG : pgadmin4 : appName=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : type=dmg
2024-04-16 08:43:23 : DEBUG : pgadmin4 : archiveName=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : downloadURL=https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v8.5/macos/pgadmin4-8.5-arm64.dmg
2024-04-16 08:43:23 : DEBUG : pgadmin4 : curlOptions=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : appNewVersion=8.5
2024-04-16 08:43:23 : DEBUG : pgadmin4 : appCustomVersion function: Not defined
2024-04-16 08:43:23 : DEBUG : pgadmin4 : versionKey=CFBundleShortVersionString
2024-04-16 08:43:23 : DEBUG : pgadmin4 : packageID=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : pkgName=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : choiceChangesXML=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : expectedTeamID=TCHGL2R7C5
2024-04-16 08:43:23 : DEBUG : pgadmin4 : blockingProcesses=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : installerTool=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : CLIInstaller=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : CLIArguments=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : updateTool=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : updateToolArguments=
2024-04-16 08:43:23 : DEBUG : pgadmin4 : updateToolRunAsCurrentUser=
2024-04-16 08:43:23 : INFO  : pgadmin4 : BLOCKING_PROCESS_ACTION=tell_user
2024-04-16 08:43:23 : INFO  : pgadmin4 : NOTIFY=success
2024-04-16 08:43:23 : INFO  : pgadmin4 : LOGGING=DEBUG
2024-04-16 08:43:23 : INFO  : pgadmin4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-16 08:43:23 : INFO  : pgadmin4 : Label type: dmg
2024-04-16 08:43:23 : INFO  : pgadmin4 : archiveName: pgAdmin 4.dmg
2024-04-16 08:43:23 : INFO  : pgadmin4 : no blocking processes defined, using pgAdmin 4 as default
2024-04-16 08:43:23 : DEBUG : pgadmin4 : Changing directory to /Users/hessf/Git/Installomator/build
2024-04-16 08:43:23 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app
2024-04-16 08:43:23.945 mdfind[41472:7482857] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-16 08:43:23.945 mdfind[41472:7482857] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-16 08:43:24.073 mdfind[41472:7482857] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-16 08:43:24 : WARN  : pgadmin4 : No previous app found
2024-04-16 08:43:24 : WARN  : pgadmin4 : could not find pgAdmin 4.app
2024-04-16 08:43:24 : INFO  : pgadmin4 : appversion:
2024-04-16 08:43:24 : INFO  : pgadmin4 : Latest version of pgAdmin 4 is 8.5
2024-04-16 08:43:24 : REQ   : pgadmin4 : Downloading https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v8.5/macos/pgadmin4-8.5-arm64.dmg to pgAdmin 4.dmg
2024-04-16 08:43:24 : DEBUG : pgadmin4 : No Dialog connection, just download
2024-04-16 08:43:40 : DEBUG : pgadmin4 : File list: -rw-r--r--@ 1 hessf  staff   210M Apr 16 08:43 pgAdmin 4.dmg
2024-04-16 08:43:40 : DEBUG : pgadmin4 : File type: pgAdmin 4.dmg: bzip2 compressed data, block size = 900k
2024-04-16 08:43:40 : DEBUG : pgadmin4 : curl output was:
* Host ftp.postgresql.org:443 was resolved.
* IPv6: (none)
* IPv4: 217.196.149.55, 72.32.157.246, 87.238.57.227, 147.75.85.69
*   Trying 217.196.149.55:443...
* Connected to ftp.postgresql.org (217.196.149.55) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [6 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3286 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.postgresql.org
*  start date: Mar 17 14:30:25 2024 GMT
*  expire date: Apr 16 14:30:25 2025 GMT
*  subjectAltName: host "ftp.postgresql.org" matched cert's "*.postgresql.org"
*  issuer: C=US; ST=CO; L=Denver; O=Pinnacol Assurance; OU=deff624896835b1e68d49e88950204c0; CN=ca.pinnacol.goskope.com; emailAddress=certadmin@netskope.com
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /pub/pgadmin/pgadmin4/v8.5/macos/pgadmin4-8.5-arm64.dmg HTTP/1.1
> Host: ftp.postgresql.org
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx
< Date: Tue, 16 Apr 2024 14:43:24 GMT
< Content-Type: application/octet-stream
< Last-Modified: Thu, 04 Apr 2024 10:11:07 GMT
< Connection: keep-alive
< ETag: "660e7cbb-d245adc"
< Strict-Transport-Security: max-age=31536000
< Accept-Ranges: bytes
< Content-Length: 220486364
<
{ [32467 bytes data]
* Connection #0 to host ftp.postgresql.org left intact

2024-04-16 08:43:40 : DEBUG : pgadmin4 : DEBUG mode 1, not checking for blocking processes
2024-04-16 08:43:40 : REQ   : pgadmin4 : Installing pgAdmin 4
2024-04-16 08:43:40 : INFO  : pgadmin4 : Mounting /Users/hessf/Git/Installomator/build/pgAdmin 4.dmg
2024-04-16 08:43:55 : DEBUG : pgadmin4 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D48054F1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $A84A3E2B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $27EA034D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $1D585DA6
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $27EA034D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $82EA222B
verified   CRC32 $23AA89D2
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/pgAdmin 4

2024-04-16 08:43:55 : INFO  : pgadmin4 : Mounted: /Volumes/pgAdmin 4
2024-04-16 08:43:55 : INFO  : pgadmin4 : Verifying: /Volumes/pgAdmin 4/pgAdmin 4.app
2024-04-16 08:43:56 : DEBUG : pgadmin4 : App size: 704M	/Volumes/pgAdmin 4/pgAdmin 4.app
2024-04-16 08:45:06 : DEBUG : pgadmin4 : Debugging enabled, App Verification output was:
/Volumes/pgAdmin 4/pgAdmin 4.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: David Page (TCHGL2R7C5)

2024-04-16 08:45:06 : INFO  : pgadmin4 : Team ID matching: TCHGL2R7C5 (expected: TCHGL2R7C5 )
2024-04-16 08:45:06 : INFO  : pgadmin4 : Installing pgAdmin 4 version 8.5 on versionKey CFBundleShortVersionString.
2024-04-16 08:45:06 : INFO  : pgadmin4 : App has LSMinimumSystemVersion: 10.10.0
2024-04-16 08:45:06 : DEBUG : pgadmin4 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-04-16 08:45:06 : INFO  : pgadmin4 : Finishing...
2024-04-16 08:45:09 : INFO  : pgadmin4 : name: pgAdmin 4, appName: pgAdmin 4.app
2024-04-16 08:45:09.449 mdfind[41665:7484414] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-16 08:45:09.450 mdfind[41665:7484414] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-16 08:45:09.517 mdfind[41665:7484414] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-16 08:45:09 : WARN  : pgadmin4 : No previous app found
2024-04-16 08:45:09 : WARN  : pgadmin4 : could not find pgAdmin 4.app
2024-04-16 08:45:09 : REQ   : pgadmin4 : Installed pgAdmin 4, version 8.5
2024-04-16 08:45:09 : INFO  : pgadmin4 : notifying
2024-04-16 08:45:10 : DEBUG : pgadmin4 : Unmounting /Volumes/pgAdmin 4
2024-04-16 08:45:10 : DEBUG : pgadmin4 : Debugging enabled, Unmounting output was:
"disk8" ejected.
2024-04-16 08:45:10 : DEBUG : pgadmin4 : DEBUG mode 1, not reopening anything
2024-04-16 08:45:10 : REQ   : pgadmin4 : All done!
2024-04-16 08:45:10 : REQ   : pgadmin4 : ################## End Installomator, exit code 0```