### PR TITLE
New label: Amazon Corretto 21 JDK

### DIFF
--- a/fragments/labels/amazoncorretto21jdk.sh
+++ b/fragments/labels/amazoncorretto21jdk.sh
@@ -1,0 +1,12 @@
+amazoncorretto21jdk)
+    name="Amazon Corretto 21 JDK"
+    type="pkg"
+    case $(arch) in
+        "arm64") cpu_arch="aarch64" ;;
+        "i386") cpu_arch="x64" ;;
+    esac
+    downloadURL="https://corretto.aws/downloads/latest/amazon-corretto-21-${cpu_arch}-macos-jdk.pkg"
+    appNewVersion="$(curl -fsIL $downloadURL | sed -nE 's/^[lL]ocation.*\/([0-9]+\.[0-9.]*[0-9]).*/\1/p')"
+    appCustomVersion(){ java -version 2>&1 | sed -nE 's/.*Runtime.*Corretto-([0-9]+\.[0-9.]*[0-9]).*/\1/p' }
+    expectedTeamID="94KV3E626L"
+    ;;


### PR DESCRIPTION
Output:

```
# ./assemble.sh amazoncorretto21jdk DEBUG=0
2024-04-18 10:35:14 : REQ   : amazoncorretto21jdk : ################## Start Installomator v. 10.6beta, date 2024-04-18
2024-04-18 10:35:14 : INFO  : amazoncorretto21jdk : ################## Version: 10.6beta
2024-04-18 10:35:14 : INFO  : amazoncorretto21jdk : ################## Date: 2024-04-18
2024-04-18 10:35:14 : INFO  : amazoncorretto21jdk : ################## amazoncorretto21jdk
2024-04-18 10:35:14 : DEBUG : amazoncorretto21jdk : DEBUG mode 1 enabled.
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : setting variable from argument DEBUG=0
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : name=Amazon Corretto 21 JDK
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : appName=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : type=pkg
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : archiveName=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : downloadURL=https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-macos-jdk.pkg
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : curlOptions=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : appNewVersion=21.0.3.9.1
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : appCustomVersion function: Defined.
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : versionKey=CFBundleShortVersionString
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : packageID=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : pkgName=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : choiceChangesXML=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : expectedTeamID=94KV3E626L
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : blockingProcesses=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : installerTool=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : CLIInstaller=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : CLIArguments=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : updateTool=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : updateToolArguments=
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : updateToolRunAsCurrentUser=
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : BLOCKING_PROCESS_ACTION=tell_user
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : NOTIFY=success
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : LOGGING=DEBUG
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : Label type: pkg
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : archiveName: Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : no blocking processes defined, using Amazon Corretto 21 JDK as default
2024-04-18 10:35:16 : DEBUG : amazoncorretto21jdk : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : Custom App Version detection is used, found
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : appversion:
2024-04-18 10:35:16 : INFO  : amazoncorretto21jdk : Latest version of Amazon Corretto 21 JDK is 21.0.3.9.1
2024-04-18 10:35:17 : REQ   : amazoncorretto21jdk : Downloading https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-macos-jdk.pkg to Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:17 : DEBUG : amazoncorretto21jdk : No Dialog connection, just download
2024-04-18 10:35:49 : DEBUG : amazoncorretto21jdk : File list: -rw-r--r--  1 root  wheel   192M Apr 18 10:35 Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:49 : DEBUG : amazoncorretto21jdk : File type: Amazon Corretto 21 JDK.pkg: xar archive compressed TOC: 4803, SHA-1 checksum
2024-04-18 10:35:49 : DEBUG : amazoncorretto21jdk : curl output was:
* Host corretto.aws:443 was resolved.
* IPv6: (none)
* IPv4: 18.238.4.72, 18.238.4.64, 18.238.4.60, 18.238.4.19
*   Trying 18.238.4.72:443...
* Connected to corretto.aws (18.238.4.72) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3470 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=corretto.aws
*  start date: Apr 16 00:00:00 2024 GMT
*  expire date: May 16 23:59:59 2025 GMT
*  subjectAltName: host "corretto.aws" matched cert's "corretto.aws"
*  issuer: O=Redacted; CN=Redacted
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /downloads/latest/amazon-corretto-21-aarch64-macos-jdk.pkg HTTP/1.1
> Host: corretto.aws
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 302 Moved Temporarily
< Content-Length: 0
< Connection: keep-alive
< Server: CloudFront
< Date: Thu, 18 Apr 2024 10:26:17 GMT
< Location: /downloads/resources/21.0.3.9.1/amazon-corretto-21.0.3.9.1-macosx-aarch64.pkg
< Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
< Content-Security-Policy: default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'
< X-Content-Type-Options: nosniff
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< Referrer-Policy: same-origin
< X-Cache: Hit from cloudfront
< Via: 1.1 7e50e11b37fc55ad87bf48e905b770a0.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: PHL51-P1
< X-Amz-Cf-Id: gQASxkmVwU6KTkUf3fSu7AHPZ71zRxLRbKRqEC_I6cCwzhc1KZgYwg==
< Age: 14940
<
* Ignoring the response-body
* Connection #0 to host corretto.aws left intact
* Issue another request to this URL: 'https://corretto.aws/downloads/resources/21.0.3.9.1/amazon-corretto-21.0.3.9.1-macosx-aarch64.pkg'
* Found bundle for host: 0x600003594060 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection with host corretto.aws
> GET /downloads/resources/21.0.3.9.1/amazon-corretto-21.0.3.9.1-macosx-aarch64.pkg HTTP/1.1
> Host: corretto.aws
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: binary/octet-stream
< Content-Length: 201214076
< Connection: keep-alive
< Date: Thu, 18 Apr 2024 14:22:21 GMT
< x-amz-replication-status: COMPLETED
< Last-Modified: Tue, 16 Apr 2024 17:37:42 GMT
< ETag: "cfa1b530185e9f0775f1bc2c3c9a685a"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: boJ10uL_eWVaU7H4ExElRYV5GUPom6PF
< Accept-Ranges: bytes
< Server: AmazonS3
< Strict-Transport-Security: max-age=63072000; includeSubdomains; preload
< Content-Security-Policy: default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'
< X-Content-Type-Options: nosniff
< X-Frame-Options: DENY
< X-XSS-Protection: 1; mode=block
< Referrer-Policy: same-origin
< X-Cache: Hit from cloudfront
< Via: 1.1 7e50e11b37fc55ad87bf48e905b770a0.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: PHL51-P1
< X-Amz-Cf-Id: szanjLHHxL0VKGCxZ_wrl1YSqFmpNO2nrXb7IApxYj_fzf8Py8udTg==
< Age: 777
<
{ [16384 bytes data]
* Connection #0 to host corretto.aws left intact

2024-04-18 10:35:49 : REQ   : amazoncorretto21jdk : no more blocking processes, continue with update
2024-04-18 10:35:49 : REQ   : amazoncorretto21jdk : Installing Amazon Corretto 21 JDK
2024-04-18 10:35:49 : INFO  : amazoncorretto21jdk : Verifying: Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:50 : DEBUG : amazoncorretto21jdk : File list: -rw-r--r--  1 root  wheel   192M Apr 18 10:35 Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:50 : DEBUG : amazoncorretto21jdk : File type: Amazon Corretto 21 JDK.pkg: xar archive compressed TOC: 4803, SHA-1 checksum
2024-04-18 10:35:50 : DEBUG : amazoncorretto21jdk : spctlOut is Amazon Corretto 21 JDK.pkg: accepted
2024-04-18 10:35:50 : DEBUG : amazoncorretto21jdk : source=Notarized Developer ID
2024-04-18 10:35:50 : DEBUG : amazoncorretto21jdk : origin=Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
2024-04-18 10:35:50 : INFO  : amazoncorretto21jdk : Team ID: 94KV3E626L (expected: 94KV3E626L )
2024-04-18 10:35:50 : INFO  : amazoncorretto21jdk : Installing Amazon Corretto 21 JDK.pkg to /
2024-04-18 10:35:56 : DEBUG : amazoncorretto21jdk : Debugging enabled, installer output was:
Apr 18 10:35:50  installer[12514] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon Corretto 21 JDK.pkg trustLevel=350
Apr 18 10:35:50  installer[12514] <Debug>: External component packages (1) trustLevel=350
Apr 18 10:35:50  installer[12514] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Apr 18 10:35:50  installer[12514] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon%20Corretto%2021%20JDK.pkg#amazon-corretto-21.jdk.pkg
Apr 18 10:35:50  installer[12514] <Info>: Set authorization level to root for session
Apr 18 10:35:50  installer[12514] <Info>: Authorization is being checked, waiting until authorization arrives.
Apr 18 10:35:50  installer[12514] <Info>: Administrator authorization granted.
Apr 18 10:35:50  installer[12514] <Info>: Packages have been authorized for installation.
Apr 18 10:35:50  installer[12514] <Debug>: Will use PK session
Apr 18 10:35:50  installer[12514] <Debug>: Using authorization level of root for IFPKInstallElement
Apr 18 10:35:50  installer[12514] <Info>: Starting installation:
Apr 18 10:35:50  installer[12514] <Notice>: Configuring volume "Macintosh HD"
Apr 18 10:35:50  installer[12514] <Info>: Preparing disk for local booted install.
Apr 18 10:35:50  installer[12514] <Notice>: Free space on "Macintosh HD": 453.77 GB (453765816320 bytes).
Apr 18 10:35:50  installer[12514] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12514NCJW5b"
Apr 18 10:35:50  installer[12514] <Notice>: IFPKInstallElement (1 packages)
Apr 18 10:35:50  installer[12514] <Info>: Current Path: /usr/sbin/installer
Apr 18 10:35:50  installer[12514] <Info>: Current Path: /bin/zsh
Last Log repeated 2 times
Apr 18 10:35:50  installer[12514] <Info>: Current Path: /usr/bin/sudo
Apr 18 10:35:50  installer[12514] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Amazon Corretto 21
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Amazon Corretto 21….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Moving items into place….....
installer: Validating packages….....
#Apr 18 10:35:54  installer[12514] <Notice>: Running install actions
Apr 18 10:35:54  installer[12514] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12514NCJW5b"
Apr 18 10:35:54  installer[12514] <Notice>: Finalize disk "Macintosh HD"
Apr 18 10:35:54  installer[12514] <Notice>: Notifying system of updated components
Apr 18 10:35:54  installer[12514] <Notice>:
Apr 18 10:35:54  installer[12514] <Notice>: **** Summary Information ****
Apr 18 10:35:54  installer[12514] <Notice>:   Operation      Elapsed time
Apr 18 10:35:54  installer[12514] <Notice>: -----------------------------
Apr 18 10:35:54  installer[12514] <Notice>:        disk      0.00 seconds
Apr 18 10:35:54  installer[12514] <Notice>:      script      0.00 seconds
Apr 18 10:35:54  installer[12514] <Notice>:        zero      0.00 seconds
Apr 18 10:35:54  installer[12514] <Notice>:     install      4.12 seconds
Apr 18 10:35:54  installer[12514] <Notice>:     -total-      4.13 seconds
Apr 18 10:35:54  installer[12514] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-04-18 10:35:50-04 redacted installer[12514]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon Corretto 21 JDK.pkg trustLevel=350
2024-04-18 10:35:50-04 redacted installer[12514]: External component packages (1) trustLevel=350
2024-04-18 10:35:50-04 redacted installer[12514]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-04-18 10:35:50-04 redacted installer[12514]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon%20Corretto%2021%20JDK.pkg#amazon-corretto-21.jdk.pkg
2024-04-18 10:35:50-04 redacted installer[12514]: Set authorization level to root for session
2024-04-18 10:35:50-04 redacted installer[12514]: Authorization is being checked, waiting until authorization arrives.
2024-04-18 10:35:50-04 redacted installer[12514]: Administrator authorization granted.
2024-04-18 10:35:50-04 redacted installer[12514]: Packages have been authorized for installation.
2024-04-18 10:35:50-04 redacted installer[12514]: Will use PK session
2024-04-18 10:35:50-04 redacted installer[12514]: Using authorization level of root for IFPKInstallElement
2024-04-18 10:35:50-04 redacted installer[12514]: Starting installation:
2024-04-18 10:35:50-04 redacted installer[12514]: Configuring volume "Macintosh HD"
2024-04-18 10:35:50-04 redacted installer[12514]: Preparing disk for local booted install.
2024-04-18 10:35:50-04 redacted installer[12514]: Free space on "Macintosh HD": 453.77 GB (453765816320 bytes).
2024-04-18 10:35:50-04 redacted installer[12514]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12514NCJW5b"
2024-04-18 10:35:50-04 redacted installer[12514]: IFPKInstallElement (1 packages)
2024-04-18 10:35:50-04 redacted installer[12514]: Current Path: /usr/sbin/installer
2024-04-18 10:35:50-04 redacted installer[12514]: Current Path: /bin/zsh
Last Log repeated 3 times
2024-04-18 10:35:50-04 redacted installer[12514]: Current Path: /usr/bin/sudo
2024-04-18 10:35:50-04 redacted installd[1453]: PackageKit: Adding client PKInstallDaemonClient pid=12514, uid=0 (/usr/sbin/installer)
2024-04-18 10:35:50-04 redacted installer[12514]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-04-18 10:35:50-04 redacted installd[1453]: PackageKit: Set reponsibility for install to 4795
2024-04-18 10:35:51-04 redacted installd[1453]: PackageKit: Hosted team responsibility for install set to team:(94KV3E626L)
2024-04-18 10:35:51-04 redacted installd[1453]: PackageKit: ----- Begin install -----
2024-04-18 10:35:51-04 redacted installd[1453]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-04-18 10:35:51-04 redacted installd[1453]: PackageKit: packages=(
2024-04-18 10:35:51-04 redacted installd[1453]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon%20Corretto%2021%20JDK.pkg#amazon-corretto-21.jdk.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/28584A5A-B5CC-4DEC-8497-2D4A095DE0C4.activeSandbox/Root/Library/Java/JavaVirtualMachines, uid=0)
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: prevent user idle system sleep
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: suspending backupd
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.fdYGUT/Scripts/com.amazon.corretto.21.4Jk4Ad
2024-04-18 10:35:53-04 redacted package_script_service[1850]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.fdYGUT/Scripts/com.amazon.corretto.21.4Jk4Ad
2024-04-18 10:35:53-04 redacted package_script_service[1850]: Set responsibility to pid: 4795, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-04-18 10:35:53-04 redacted package_script_service[1850]: Hosted team responsibility for script set to team:(94KV3E626L)
2024-04-18 10:35:53-04 redacted package_script_service[1850]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.fdYGUT/Scripts/com.amazon.corretto.21.4Jk4Ad
2024-04-18 10:35:53-04 redacted install_monitor[12520]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-04-18 10:35:53-04 redacted package_script_service[1850]: PackageKit: Hosted team responsible for script has been cleared.
2024-04-18 10:35:53-04 redacted package_script_service[1850]: Responsibility set back to self.
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/28584A5A-B5CC-4DEC-8497-2D4A095DE0C4.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/28584A5A-B5CC-4DEC-8497-2D4A095DE0C4.activeSandbox
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/28584A5A-B5CC-4DEC-8497-2D4A095DE0C4.activeSandbox/Root (1 items) to /
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Writing receipt for com.amazon.corretto.21 to /
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: No Intel binaries to translate.
2024-04-18 10:35:53-04 redacted installd[1453]: Installed "Amazon Corretto 21" (21.0.3.9.1)
2024-04-18 10:35:53-04 redacted installd[1453]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-04-18 10:35:53-04 redacted install_monitor[12520]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: releasing backupd
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: allow user idle system sleep
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: ----- End install -----
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: 2.4s elapsed install time
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Cleared responsibility for install from 12514.
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Hosted team responsible for install has been cleared.
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Running idle tasks
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Removing client PKInstallDaemonClient pid=12514, uid=0 (/usr/sbin/installer)
2024-04-18 10:35:53-04 redacted installd[1453]: PackageKit: Done with sandbox removals
2024-04-18 10:35:54-04 redacted installer[12514]: Running install actions
2024-04-18 10:35:54-04 redacted installer[12514]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12514NCJW5b"
2024-04-18 10:35:54-04 redacted installer[12514]: Finalize disk "Macintosh HD"
2024-04-18 10:35:54-04 redacted installer[12514]: Notifying system of updated components
2024-04-18 10:35:54-04 redacted installer[12514]:
2024-04-18 10:35:54-04 redacted installer[12514]: **** Summary Information ****
2024-04-18 10:35:54-04 redacted installer[12514]:   Operation      Elapsed time
2024-04-18 10:35:54-04 redacted installer[12514]: -----------------------------
2024-04-18 10:35:54-04 redacted installer[12514]:        disk      0.00 seconds
2024-04-18 10:35:54-04 redacted installer[12514]:      script      0.00 seconds
2024-04-18 10:35:54-04 redacted installer[12514]:        zero      0.00 seconds
2024-04-18 10:35:54-04 redacted installer[12514]:     install      4.12 seconds
2024-04-18 10:35:54-04 redacted installer[12514]:     -total-      4.13 seconds
2024-04-18 10:35:54-04 redacted installer[12514]:

2024-04-18 10:35:56 : INFO  : amazoncorretto21jdk : Finishing...
2024-04-18 10:35:59 : INFO  : amazoncorretto21jdk : Custom App Version detection is used, found 21.0.3.9.1
2024-04-18 10:35:59 : REQ   : amazoncorretto21jdk : Installed Amazon Corretto 21 JDK, version 21.0.3.9.1
2024-04-18 10:35:59 : INFO  : amazoncorretto21jdk : notifying
2024-04-18 10:35:59 : DEBUG : amazoncorretto21jdk : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl
2024-04-18 10:35:59 : DEBUG : amazoncorretto21jdk : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl/Amazon Corretto 21 JDK.pkg
2024-04-18 10:35:59 : DEBUG : amazoncorretto21jdk : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ajX7woozYl
2024-04-18 10:36:00 : INFO  : amazoncorretto21jdk : Installomator did not close any apps, so no need to reopen any apps.
2024-04-18 10:36:00 : REQ   : amazoncorretto21jdk : All done!
2024-04-18 10:36:00 : REQ   : amazoncorretto21jdk : ################## End Installomator, exit code 0

```