### PR TITLE
Update firefoxpkg_intl.sh

### DIFF
--- a/fragments/labels/firefoxpkg_intl.sh
+++ b/fragments/labels/firefoxpkg_intl.sh
@@ -3,7 +3,7 @@ firefoxpkg_intl)
     # and install corrosponding version of Firefox ESR
     name="Firefox"
     type="pkg"
-    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-')
+    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-' | cut -f1 -d"@")
     # userLanguage="sv-SE" #for tests without international language setup
     printlog "Found language $userLanguage to be used for Firefox." WARN
     releaseURL="https://ftp.mozilla.org/pub/firefox/releases/latest/README.txt"


### PR DESCRIPTION
If the system language and region setting are different, the output of AppleLocale has a trailing @rg=auzzzz at the end. For example; the Language is English (UK) but the Region is set to New Zealand then this causes the result of userLanguage to be en-GB@rg=auzzzz which then fails to find a match and the en-US version of Firefox is installed.
![Matching Language Region](https://github.com/Installomator/Installomator/assets/14327101/0176f06e-367a-4d49-a943-889c3fd6ba9f)

If the system language and region settings match for example English UK as the language and "United Kingdom" as the region, the output does not have the trailing @rg=auzzzz.
![Mismatched Language Region](https://github.com/Installomator/Installomator/assets/14327101/68a2ffba-3149-4465-a22d-fcec82ca0679)

I have updated userLanguage to include | cut -f1 -d"@" so that it handles this better.

OUTPUT with the change (system language was UK and region was NZ:
2024-04-22 09:08:17 : REQ   : firefoxpkg_intl : ################## Start Installomator v. 10.6beta, date 2024-04-14
2024-04-22 09:08:17 : INFO  : firefoxpkg_intl : ################## Version: 10.6beta
2024-04-22 09:08:17 : INFO  : firefoxpkg_intl : ################## Date: 2024-04-14
2024-04-22 09:08:17 : INFO  : firefoxpkg_intl : ################## firefoxpkg_intl
2024-04-22 09:08:17 : DEBUG : firefoxpkg_intl : DEBUG mode 1 enabled.
2024-04-22 09:08:17 : WARN  : firefoxpkg_intl : Found language en-GB to be used for Firefox.
2024-04-22 09:08:17 : WARN  : firefoxpkg_intl : Using language en-GB for download.
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : setting variable from argument DEBUG=0
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : name=Firefox
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : appName=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : type=pkg
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : archiveName=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : downloadURL=https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang=en-GB
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : curlOptions=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : appNewVersion=125.0.1
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : appCustomVersion function: Not defined
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : versionKey=CFBundleShortVersionString
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : packageID=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : pkgName=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : choiceChangesXML=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : expectedTeamID=43AQ936H96
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : blockingProcesses=firefox
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : installerTool=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : CLIInstaller=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : CLIArguments=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : updateTool=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : updateToolArguments=
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : updateToolRunAsCurrentUser=
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : BLOCKING_PROCESS_ACTION=tell_user
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : NOTIFY=success
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : LOGGING=DEBUG
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : Label type: pkg
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : archiveName: Firefox.pkg
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : Changing directory to /var/folders/_r/fxgqtg2x1739gzr9jdgklrsc0000gn/T/tmp.bmflCoFJ04
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : name: Firefox, appName: Firefox.app
2024-04-22 09:08:18.821 mdfind[1840:15285] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2024-04-22 09:08:18.880 mdfind[1840:15285] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-22 09:08:18 : WARN  : firefoxpkg_intl : No previous app found
2024-04-22 09:08:18 : WARN  : firefoxpkg_intl : could not find Firefox.app
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : appversion:
2024-04-22 09:08:18 : INFO  : firefoxpkg_intl : Latest version of Firefox is 125.0.1
2024-04-22 09:08:18 : REQ   : firefoxpkg_intl : Downloading https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang=en-GB to Firefox.pkg
2024-04-22 09:08:18 : DEBUG : firefoxpkg_intl : No Dialog connection, just download
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : File list: -rw-r--r--  1 phill  staff   142M 22 Apr 09:08 Firefox.pkg
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : File type: Firefox.pkg: xar archive compressed TOC: 4451, SHA-1 checksum
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : curl output was:
*   Trying 44.241.58.201:443...
* Connected to download.mozilla.org (44.241.58.201) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3052 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Mozilla Corporation; CN=download.mozilla.org
*  start date: Feb 22 00:00:00 2024 GMT
*  expire date: Mar 11 23:59:59 2025 GMT
*  subjectAltName: host "download.mozilla.org" matched cert's "download.mozilla.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /?product=firefox-pkg-latest-ssl&os=osx&lang=en-GB HTTP/1.1
> Host: download.mozilla.org
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 302 Found
< Cache-Control: max-age=60
< Content-Type: text/html; charset=utf-8
< Date: Sun, 21 Apr 2024 21:08:19 GMT
< Location: https://download-installer.cdn.mozilla.net/pub/firefox/releases/125.0.1/mac/en-GB/Firefox%20125.0.1.pkg < Content-Length: 126
< Connection: keep-alive
<
* Ignoring the response-body { [126 bytes data]
* Connection #0 to host download.mozilla.org left intact
* Issue another request to this URL: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/125.0.1/mac/en-GB/Firefox%20125.0.1.pkg'
*   Trying 34.117.35.28:443...
* Connected to download-installer.cdn.mozilla.net (34.117.35.28) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [339 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2626 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download-installer.cdn.mozilla.net
*  start date: Feb 25 21:19:52 2024 GMT
*  expire date: May 25 21:19:51 2024 GMT
*  subjectAltName: host "download-installer.cdn.mozilla.net" matched cert's "download-installer.cdn.mozilla.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: download-installer.cdn.mozilla.net]
* h2 [:path: /pub/firefox/releases/125.0.1/mac/en-GB/Firefox%20125.0.1.pkg]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x143812e00)
> GET /pub/firefox/releases/125.0.1/mac/en-GB/Firefox%20125.0.1.pkg HTTP/2
> Host: download-installer.cdn.mozilla.net
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/2 200
< server: nginx
< x-guploader-uploadid: ABPtcPoZZ9cRo_PiCHNlEbKUQDmrf7VejO6g-ctSY4empr65ZN6CZfMqGzeguDkuOKPeD_nlH5RTrBRgwg < x-goog-generation: 1713276879710735
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 148890817
< x-goog-hash: crc32c=0wFcBw==
< x-goog-hash: md5=VvKP8BFuq0YUTQEdEMJw5Q==
< x-goog-storage-class: STANDARD
< accept-ranges: bytes
< strict-transport-security: max-age=31536000
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000 < alt-svc: clear
< via: 1.1 google, 1.1 google
< date: Sun, 21 Apr 2024 20:27:38 GMT
< expires: Mon, 22 Apr 2024 00:27:38 GMT
< cache-control: max-age=14400
< age: 2441
< last-modified: Tue, 16 Apr 2024 14:14:39 GMT
< etag: "56f28ff0116eab46144d011d10c270e5"
< content-type: application/x-newton-compatible-pkg < vary: Origin
< content-length: 148890817
<
{ [8259 bytes data]
* Connection #1 to host download-installer.cdn.mozilla.net left intact

2024-04-22 09:08:26 : REQ   : firefoxpkg_intl : no more blocking processes, continue with update
2024-04-22 09:08:26 : REQ   : firefoxpkg_intl : Installing Firefox
2024-04-22 09:08:26 : INFO  : firefoxpkg_intl : Verifying: Firefox.pkg
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : File list: -rw-r--r--  1 phill  staff   142M 22 Apr 09:08 Firefox.pkg
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : File type: Firefox.pkg: xar archive compressed TOC: 4451, SHA-1 checksum
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : spctlOut is Firefox.pkg: accepted
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : source=Notarized Developer ID
2024-04-22 09:08:26 : DEBUG : firefoxpkg_intl : origin=Developer ID Installer: Mozilla Corporation (43AQ936H96)
2024-04-22 09:08:26 : INFO  : firefoxpkg_intl : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2024-04-22 09:08:26 : INFO  : firefoxpkg_intl : Installing Firefox.pkg to /
2024-04-22 09:08:28 : DEBUG : firefoxpkg_intl : Debugging enabled, installer output was:
installer: Must be run as root to install this package.
Output of /var/log/install.log below this line.----------------------------------------------------------

2024-04-22 09:08:28 : INFO  : firefoxpkg_intl : Finishing... 2024-04-22 09:08:31 : INFO  : firefoxpkg_intl : name: Firefox, appName: Firefox.app 2024-04-22 09:08:31.118 mdfind[1909:15484] [UserQueryParser] Loading keywords and predicates for locale "en_GB" 2024-04-22 09:08:31.177 mdfind[1909:15484] Couldn't determine the mapping between prefab keywords and predicates. 2024-04-22 09:08:31 : WARN  : firefoxpkg_intl : No previous app found 2024-04-22 09:08:31 : WARN  : firefoxpkg_intl : could not find Firefox.app
2024-04-22 09:08:31 : REQ   : firefoxpkg_intl : Installed Firefox, version 125.0.1
2024-04-22 09:08:31 : INFO  : firefoxpkg_intl : notifying
2024-04-22 09:08:31 : DEBUG : firefoxpkg_intl : Deleting /var/folders/_r/fxgqtg2x1739gzr9jdgklrsc0000gn/T/tmp.bmflCoFJ04
2024-04-22 09:08:31 : DEBUG : firefoxpkg_intl : Debugging enabled, Deleting tmpDir output was:
/var/folders/_r/fxgqtg2x1739gzr9jdgklrsc0000gn/T/tmp.bmflCoFJ04/Firefox.pkg
2024-04-22 09:08:31 : DEBUG : firefoxpkg_intl : /var/folders/_r/fxgqtg2x1739gzr9jdgklrsc0000gn/T/tmp.bmflCoFJ04
2024-04-22 09:08:31 : INFO  : firefoxpkg_intl : Installomator did not close any apps, so no need to reopen any apps.
2024-04-22 09:08:31 : REQ   : firefoxpkg_intl : All done!
2024-04-22 09:08:31 : REQ   : firefoxpkg_intl : ################## End Installomator, exit code 0