### PR TITLE
Update eclipsetemurin21.sh

### DIFF
--- a/fragments/labels/eclipsetemurin21.sh
+++ b/fragments/labels/eclipsetemurin21.sh
@@ -1,7 +1,11 @@
 eclipsetemurin21)
     name="Temurin 21"
     type="pkg"
-    packageID="net.temurin.21.jdk"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="OpenJDK21U-jdk_aarch64_mac_hotspot_[0-9._]+\.pkg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="OpenJDK21U-jdk_x64_mac_hotspot_[0-9._]+\.pkg"
+    fi
     downloadURL="$(downloadURLFromGit adoptium temurin21-binaries)"
     appNewVersion="$(downloadURLFromGit adoptium temurin21-binaries | grep -oE 'jdk-21(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"


### PR DESCRIPTION
Added logic for determining architecture (Apple Silicon or Intel).

Also removed the packageID variable since the appCustomVersion function is used to determine installed version.