### PR TITLE
Update snagit.sh

### DIFF
--- a/fragments/labels/snagit.sh
+++ b/fragments/labels/snagit.sh
@@ -3,6 +3,6 @@ snagit2024)
     name="Snagit 2024"
     type="dmg"
     downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2024" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2024" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2024" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/p>.*//')
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
The **appNewVersion** variable in the current **snagit/snagit2024** label outputs `2024.2.4</p>` instead of just `2024.2.4`. Please see below.

```
2024-04-25 13:33:02 : REQ   : snagit2024 : ################## Start Installomator v. 10.5, date 2023-10-15
2024-04-25 13:33:02 : INFO  : snagit2024 : ################## Version: 10.5
2024-04-25 13:33:02 : INFO  : snagit2024 : ################## Date: 2023-10-15
2024-04-25 13:33:02 : INFO  : snagit2024 : ################## snagit2024
2024-04-25 13:33:02 : INFO  : snagit2024 : SwiftDialog is not installed, clear cmd file var
2024-04-25 13:33:03 : INFO  : snagit2024 : BLOCKING_PROCESS_ACTION=tell_user
2024-04-25 13:33:03 : INFO  : snagit2024 : NOTIFY=silent
2024-04-25 13:33:03 : INFO  : snagit2024 : LOGGING=INFO
2024-04-25 13:33:03 : INFO  : snagit2024 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-25 13:33:03 : INFO  : snagit2024 : Label type: dmg
2024-04-25 13:33:03 : INFO  : snagit2024 : archiveName: Snagit 2024.dmg
2024-04-25 13:33:03 : INFO  : snagit2024 : no blocking processes defined, using Snagit 2024 as default
2024-04-25 13:33:03 : INFO  : snagit2024 : App(s) found: /Applications/Snagit 2024.app
2024-04-25 13:33:03 : INFO  : snagit2024 : found app at /Applications/Snagit 2024.app, version 2024.2.3, on versionKey CFBundleShortVersionString
2024-04-25 13:33:03 : INFO  : snagit2024 : appversion: 2024.2.3
2024-04-25 13:33:03 : INFO  : snagit2024 : Latest version of Snagit 2024 is 2024.2.4</p>
2024-04-25 13:33:03 : REQ   : snagit2024 : Downloading https://download.techsmith.com/snagitmac/releases/snagit.dmg to Snagit 2024.dmg
2024-04-25 13:33:14 : REQ   : snagit2024 : no more blocking processes, continue with update
2024-04-25 13:33:14 : REQ   : snagit2024 : Installing Snagit 2024
2024-04-25 13:33:14 : INFO  : snagit2024 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1CohSm1E1j/Snagit 2024.dmg
2024-04-25 13:33:15 : INFO  : snagit2024 : Mounted: /Volumes/Snagit
2024-04-25 13:33:15 : INFO  : snagit2024 : Verifying: /Volumes/Snagit/Snagit 2024.app
2024-04-25 13:33:19 : INFO  : snagit2024 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2024-04-25 13:33:19 : INFO  : snagit2024 : Downloaded version of Snagit 2024 is 2024.2.4 on versionKey CFBundleShortVersionString (replacing version 2024.2.3).
2024-04-25 13:33:19 : INFO  : snagit2024 : App has LSMinimumSystemVersion: 12.0
2024-04-25 13:33:19 : WARN  : snagit2024 : Removing existing /Applications/Snagit 2024.app
2024-04-25 13:33:20 : INFO  : snagit2024 : Copy /Volumes/Snagit/Snagit 2024.app to /Applications
2024-04-25 13:33:23 : WARN  : snagit2024 : Changing owner to kryptonit
2024-04-25 13:33:24 : INFO  : snagit2024 : Finishing...
2024-04-25 13:33:27 : INFO  : snagit2024 : App(s) found: /Applications/Snagit 2024.app
2024-04-25 13:33:27 : INFO  : snagit2024 : found app at /Applications/Snagit 2024.app, version 2024.2.4, on versionKey CFBundleShortVersionString
2024-04-25 13:33:27 : REQ   : snagit2024 : Installed Snagit 2024, version 2024.2.4
2024-04-25 13:33:27 : INFO  : snagit2024 : Installomator did not close any apps, so no need to reopen any apps.
2024-04-25 13:33:27 : REQ   : snagit2024 : All done!
2024-04-25 13:33:27 : REQ   : snagit2024 : ################## End Installomator, exit code 0
```

This change fixes that problem.