### PR TITLE
Create displaynote label

### DIFF
--- a/fragments/labels/displaynote.sh
+++ b/fragments/labels/displaynote.sh
@@ -1,0 +1,8 @@
+displaynote)
+name="displaynote"
+type="pkg"
+packageID="com.displaynote.DisplayNoteApp"
+downloadURL="https://montage-updates.displaynote.com/api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac"
+appNewVersion="$(curl -fsIL "https://montage-updates.displaynote.com/api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac" | grep -i ^Content-Disposition | sed -n 's/.*displaynote-mac-\([0-9.]*\)-released\.pkg.*/\1/p')"
+expectedTeamID="Q3ML87W6WF"
+;;


### PR DESCRIPTION
./assemble.sh displaynote
2024-04-25 09:52:51 : REQ   : displaynote : ################## Start Installomator v. 10.6beta, date 2024-04-25
2024-04-25 09:52:51 : INFO  : displaynote : ################## Version: 10.6beta
2024-04-25 09:52:51 : INFO  : displaynote : ################## Date: 2024-04-25
2024-04-25 09:52:51 : INFO  : displaynote : ################## displaynote
2024-04-25 09:52:51 : DEBUG : displaynote : DEBUG mode 1 enabled.
2024-04-25 09:52:53 : DEBUG : displaynote : name=displaynote
2024-04-25 09:52:53 : DEBUG : displaynote : appName=
2024-04-25 09:52:53 : DEBUG : displaynote : type=pkg
2024-04-25 09:52:53 : DEBUG : displaynote : archiveName=
2024-04-25 09:52:53 : DEBUG : displaynote : downloadURL=https://montage-updates.displaynote.com/api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac
2024-04-25 09:52:53 : DEBUG : displaynote : curlOptions=
2024-04-25 09:52:53 : DEBUG : displaynote : appNewVersion=2.31.0.31904
2024-04-25 09:52:54 : DEBUG : displaynote : appCustomVersion function: Not defined
2024-04-25 09:52:54 : DEBUG : displaynote : versionKey=CFBundleShortVersionString
2024-04-25 09:52:54 : DEBUG : displaynote : packageID=com.displaynote.DisplayNoteApp
2024-04-25 09:52:54 : DEBUG : displaynote : pkgName=
2024-04-25 09:52:54 : DEBUG : displaynote : choiceChangesXML=
2024-04-25 09:52:54 : DEBUG : displaynote : expectedTeamID=Q3ML87W6WF
2024-04-25 09:52:54 : DEBUG : displaynote : blockingProcesses=
2024-04-25 09:52:54 : DEBUG : displaynote : installerTool=
2024-04-25 09:52:54 : DEBUG : displaynote : CLIInstaller=
2024-04-25 09:52:54 : DEBUG : displaynote : CLIArguments=
2024-04-25 09:52:54 : DEBUG : displaynote : updateTool=
2024-04-25 09:52:54 : DEBUG : displaynote : updateToolArguments=
2024-04-25 09:52:54 : DEBUG : displaynote : updateToolRunAsCurrentUser=
2024-04-25 09:52:54 : INFO  : displaynote : BLOCKING_PROCESS_ACTION=tell_user
2024-04-25 09:52:54 : INFO  : displaynote : NOTIFY=success
2024-04-25 09:52:54 : INFO  : displaynote : LOGGING=DEBUG
2024-04-25 09:52:54 : INFO  : displaynote : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-25 09:52:54 : INFO  : displaynote : Label type: pkg
2024-04-25 09:52:54 : INFO  : displaynote : archiveName: displaynote.pkg
2024-04-25 09:52:54 : INFO  : displaynote : no blocking processes defined, using displaynote as default
2024-04-25 09:52:54 : DEBUG : displaynote : Changing directory to /Users/naschenbrenner/Documents/GitHub/Installomator/build
2024-04-25 09:52:54 : INFO  : displaynote : No version found using packageID com.displaynote.DisplayNoteApp
2024-04-25 09:52:54 : INFO  : displaynote : name: displaynote, appName: displaynote.app
2024-04-25 09:52:54.470 mdfind[61797:2433078] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-25 09:52:54.471 mdfind[61797:2433078] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-25 09:52:54.573 mdfind[61797:2433078] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-25 09:52:54 : WARN  : displaynote : No previous app found
2024-04-25 09:52:54 : WARN  : displaynote : could not find displaynote.app
2024-04-25 09:52:54 : INFO  : displaynote : appversion:
2024-04-25 09:52:54 : INFO  : displaynote : Latest version of displaynote is 2.31.0.31904
2024-04-25 09:52:54 : REQ   : displaynote : Downloading https://montage-updates.displaynote.com/api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac to displaynote.pkg
2024-04-25 09:52:54 : DEBUG : displaynote : No Dialog connection, just download
2024-04-25 09:53:08 : DEBUG : displaynote : File list: -rw-r--r--@ 1 naschenbrenner  staff   137M Apr 25 09:53 displaynote.pkg
2024-04-25 09:53:09 : DEBUG : displaynote : File type: displaynote.pkg: xar archive compressed TOC: 4949, SHA-1 checksum
2024-04-25 09:53:09 : DEBUG : displaynote : curl output was:
*   Trying 52.232.7.72:443...
* Connected to montage-updates.displaynote.com (52.232.7.72) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [336 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3696 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.displaynote.com
*  start date: Apr 17 00:00:00 2024 GMT
*  expire date: May 18 23:59:59 2025 GMT
*  subjectAltName: host "montage-updates.displaynote.com" matched cert's "*.displaynote.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=GeoTrust TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac HTTP/1.1
> Host: montage-updates.displaynote.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.18.0 (Ubuntu)
< Date: Thu, 25 Apr 2024 14:52:55 GMT
< Content-Type: application/octet-stream
< Content-Length: 144088564
< Connection: keep-alive
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< Content-Disposition: attachment; filename=displaynote-mac-2.31.0.31904-released.pkg; size=144088564 <
{ [16016 bytes data]
* Connection #0 to host montage-updates.displaynote.com left intact

2024-04-25 09:53:09 : DEBUG : displaynote : DEBUG mode 1, not checking for blocking processes
2024-04-25 09:53:09 : REQ   : displaynote : Installing displaynote
2024-04-25 09:53:09 : INFO  : displaynote : Verifying: displaynote.pkg
2024-04-25 09:53:09 : DEBUG : displaynote : File list: -rw-r--r--@ 1 naschenbrenner  staff   137M Apr 25 09:53 displaynote.pkg
2024-04-25 09:53:09 : DEBUG : displaynote : File type: displaynote.pkg: xar archive compressed TOC: 4949, SHA-1 checksum
2024-04-25 09:53:09 : DEBUG : displaynote : spctlOut is displaynote.pkg: accepted
2024-04-25 09:53:09 : DEBUG : displaynote : source=Notarized Developer ID
2024-04-25 09:53:09 : DEBUG : displaynote : origin=Developer ID Installer: DisplayNote Technologies Ltd (Q3ML87W6WF)
2024-04-25 09:53:09 : INFO  : displaynote : Team ID: Q3ML87W6WF (expected: Q3ML87W6WF )
2024-04-25 09:53:09 : DEBUG : displaynote : DEBUG enabled, skipping installation
2024-04-25 09:53:09 : INFO  : displaynote : Finishing...
2024-04-25 09:53:12 : INFO  : displaynote : No version found using packageID com.displaynote.DisplayNoteApp
2024-04-25 09:53:12 : INFO  : displaynote : name: displaynote, appName: displaynote.app
2024-04-25 09:53:12.466 mdfind[61873:2433604] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-25 09:53:12.466 mdfind[61873:2433604] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-25 09:53:12.525 mdfind[61873:2433604] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-25 09:53:12 : WARN  : displaynote : No previous app found
2024-04-25 09:53:12 : WARN  : displaynote : could not find displaynote.app
2024-04-25 09:53:12 : REQ   : displaynote : Installed displaynote, version 2.31.0.31904
2024-04-25 09:53:12 : INFO  : displaynote : notifying
2024-04-25 09:53:13 : DEBUG : displaynote : DEBUG mode 1, not reopening anything
2024-04-25 09:53:13 : REQ   : displaynote : All done!
2024-04-25 09:53:13 : REQ   : displaynote : ################## End Installomator, exit code 0


Another note I'd like to add is that the string in the download url looks random but is in fact static, I have a download from November and December of different versions that show the download URL as https://montage-updates.displaynote.com/api/download/f10632d2-9fbf-11e8-8999-ff918fb3468a/vanilla/released/last?app_name=displaynote-mac