### PR TITLE
joplin label

### DIFF
--- a/fragments/labels/joplin.sh
+++ b/fragments/labels/joplin.sh
@@ -1,0 +1,12 @@
+joplin)
+    name="Joplin"
+    type="dmg"
+	if [[ $(arch) == “arm64” ]]; then
+        archiveName="Joplin-[0-9.]*-arm64.DMG"
+    elif [[ $(arch) == “i386” ]]; then
+        archiveName="Joplin-[0-9.]*.dmg"
+    fi
+    downloadURL="$(downloadURLFromGit laurent22 joplin)"
+    appNewVersion="$(versionFromGit laurent22 joplin)"
+    expectedTeamID="A9BXAFS6CT"
+    ;;


### PR DESCRIPTION
./assemble.sh joplin
2024-04-30 14:37:27 : REQ   : joplin : ################## Start Installomator v. 10.6beta, date 2024-04-30
2024-04-30 14:37:27 : INFO  : joplin : ################## Version: 10.6beta
2024-04-30 14:37:27 : INFO  : joplin : ################## Date: 2024-04-30
2024-04-30 14:37:27 : INFO  : joplin : ################## joplin
2024-04-30 14:37:27 : DEBUG : joplin : DEBUG mode 1 enabled.
2024-04-30 14:37:29 : DEBUG : joplin : name=Joplin
2024-04-30 14:37:29 : DEBUG : joplin : appName=
2024-04-30 14:37:29 : DEBUG : joplin : type=dmg
2024-04-30 14:37:29 : DEBUG : joplin : archiveName=
2024-04-30 14:37:29 : DEBUG : joplin : downloadURL=https://github.com/laurent22/joplin/releases/download/v2.14.20/Joplin-2.14.20.dmg
2024-04-30 14:37:29 : DEBUG : joplin : curlOptions=
2024-04-30 14:37:29 : DEBUG : joplin : appNewVersion=2.14.20
2024-04-30 14:37:29 : DEBUG : joplin : appCustomVersion function: Not defined
2024-04-30 14:37:29 : DEBUG : joplin : versionKey=CFBundleShortVersionString
2024-04-30 14:37:29 : DEBUG : joplin : packageID=
2024-04-30 14:37:29 : DEBUG : joplin : pkgName=
2024-04-30 14:37:29 : DEBUG : joplin : choiceChangesXML=
2024-04-30 14:37:29 : DEBUG : joplin : expectedTeamID=A9BXAFS6CT
2024-04-30 14:37:29 : DEBUG : joplin : blockingProcesses=
2024-04-30 14:37:29 : DEBUG : joplin : installerTool=
2024-04-30 14:37:29 : DEBUG : joplin : CLIInstaller=
2024-04-30 14:37:29 : DEBUG : joplin : CLIArguments=
2024-04-30 14:37:29 : DEBUG : joplin : updateTool=
2024-04-30 14:37:29 : DEBUG : joplin : updateToolArguments=
2024-04-30 14:37:29 : DEBUG : joplin : updateToolRunAsCurrentUser=
2024-04-30 14:37:29 : INFO  : joplin : BLOCKING_PROCESS_ACTION=tell_user
2024-04-30 14:37:29 : INFO  : joplin : NOTIFY=success
2024-04-30 14:37:29 : INFO  : joplin : LOGGING=DEBUG
2024-04-30 14:37:29 : INFO  : joplin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-04-30 14:37:29 : INFO  : joplin : Label type: dmg
2024-04-30 14:37:29 : INFO  : joplin : archiveName: Joplin.dmg
2024-04-30 14:37:29 : INFO  : joplin : no blocking processes defined, using Joplin as default
2024-04-30 14:37:29 : DEBUG : joplin : Changing directory to /Users/user/Documents/GitHub/Installomator/build
2024-04-30 14:37:29 : INFO  : joplin : name: Joplin, appName: Joplin.app
2024-04-30 14:37:30.128 mdfind[64941:1720944] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-04-30 14:37:30.129 mdfind[64941:1720944] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-04-30 14:37:30.716 mdfind[64941:1720944] Couldn't determine the mapping between prefab keywords and predicates.
2024-04-30 14:37:30 : WARN  : joplin : No previous app found
2024-04-30 14:37:30 : WARN  : joplin : could not find Joplin.app
2024-04-30 14:37:30 : INFO  : joplin : appversion:
2024-04-30 14:37:30 : INFO  : joplin : Latest version of Joplin is 2.14.20
2024-04-30 14:37:30 : REQ   : joplin : Downloading https://github.com/laurent22/joplin/releases/download/v2.14.20/Joplin-2.14.20.dmg to Joplin.dmg
2024-04-30 14:37:30 : DEBUG : joplin : No Dialog connection, just download
2024-04-30 14:37:39 : DEBUG : joplin : File list: -rw-r--r--  1 user  staff   232M Apr 30 14:37 Joplin.dmg
2024-04-30 14:37:39 : DEBUG : joplin : File type: Joplin.dmg: zlib compressed data
2024-04-30 14:37:39 : DEBUG : joplin : curl output was:
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/laurent22/joplin/releases/download/v2.14.20/Joplin-2.14.20.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /laurent22/joplin/releases/download/v2.14.20/Joplin-2.14.20.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /laurent22/joplin/releases/download/v2.14.20/Joplin-2.14.20.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Tue, 30 Apr 2024 12:35:18 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/1101aa10-d480-4e57-b876-ed24ab419732?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240430%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240430T123518Z&X-Amz-Expires=300&X-Amz-Signature=1206aba649841d0d1ae8701c568bf72bcb9325a8b1d3f8ea266747dffa69b926&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=79162682&response-content-disposition=attachment%3B%20filename%3DJoplin-2.14.20.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: 28AD:7CC39:1193967F:11D56D3A:6630E586 <
{ [0 bytes data]
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/1101aa10-d480-4e57-b876-ed24ab419732?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240430%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240430T123518Z&X-Amz-Expires=300&X-Amz-Signature=1206aba649841d0d1ae8701c568bf72bcb9325a8b1d3f8ea266747dffa69b926&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=79162682&response-content-disposition=attachment%3B%20filename%3DJoplin-2.14.20.dmg&response-content-type=application%2Foctet-stream'
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/1101aa10-d480-4e57-b876-ed24ab419732?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240430%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240430T123518Z&X-Amz-Expires=300&X-Amz-Signature=1206aba649841d0d1ae8701c568bf72bcb9325a8b1d3f8ea266747dffa69b926&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=79162682&response-content-disposition=attachment%3B%20filename%3DJoplin-2.14.20.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/79162682/1101aa10-d480-4e57-b876-ed24ab419732?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240430%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240430T123518Z&X-Amz-Expires=300&X-Amz-Signature=1206aba649841d0d1ae8701c568bf72bcb9325a8b1d3f8ea266747dffa69b926&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=79162682&response-content-disposition=attachment%3B%20filename%3DJoplin-2.14.20.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/79162682/1101aa10-d480-4e57-b876-ed24ab419732?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240430%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240430T123518Z&X-Amz-Expires=300&X-Amz-Signature=1206aba649841d0d1ae8701c568bf72bcb9325a8b1d3f8ea266747dffa69b926&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=79162682&response-content-disposition=attachment%3B%20filename%3DJoplin-2.14.20.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< content-md5: j5SDs2xq5N0NUZgeq+jB7w==
< last-modified: Mon, 18 Mar 2024 16:24:10 GMT
< etag: "0x8DC4767D78ABBC3"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 0303e882-001e-0058-0556-79390a000000 < x-ms-version: 2020-10-02
< x-ms-creation-time: Mon, 18 Mar 2024 16:24:10 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Joplin-2.14.20.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 5357
< date: Tue, 30 Apr 2024 12:35:19 GMT
< x-served-by: cache-iad-kcgs7200037-IAD, cache-fra-eddf8230139-FRA < x-cache: HIT, HIT
< x-cache-hits: 8163, 0
< x-timer: S1714480519.951180,VS0,VE378
< content-length: 243413492
<
{ [8259 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-04-30 14:37:39 : DEBUG : joplin : DEBUG mode 1, not checking for blocking processes
2024-04-30 14:37:39 : REQ   : joplin : Installing Joplin
2024-04-30 14:37:39 : INFO  : joplin : Mounting /Users/user/Documents/GitHub/Installomator/build/Joplin.dmg
2024-04-30 14:37:45 : DEBUG : joplin : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $9227ED1C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $01E75EB7
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $309FD9D0
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $59B8A946
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $309FD9D0
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $BB59AF16
verified CRC32 $649F1535
/dev/disk3          	GUID_partition_scheme
/dev/disk3s1        	Apple_HFS                      	/Volumes/Joplin 2.14.20

2024-04-30 14:37:45 : INFO  : joplin : Mounted: /Volumes/Joplin 2.14.20 2024-04-30 14:37:45 : INFO  : joplin : Verifying: /Volumes/Joplin 2.14.20/Joplin.app 2024-04-30 14:37:45 : DEBUG : joplin : App size: 680M	/Volumes/Joplin 2.14.20/Joplin.app 2024-04-30 14:37:50 : DEBUG : joplin : Debugging enabled, App Verification output was: /Volumes/Joplin 2.14.20/Joplin.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Laurent Cozic (A9BXAFS6CT)

2024-04-30 14:37:50 : INFO  : joplin : Team ID matching: A9BXAFS6CT (expected: A9BXAFS6CT ) 2024-04-30 14:37:50 : INFO  : joplin : Installing Joplin version 2.14.20 on versionKey CFBundleShortVersionString. 2024-04-30 14:37:50 : INFO  : joplin : App has LSMinimumSystemVersion: 10.13 2024-04-30 14:37:50 : DEBUG : joplin : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-04-30 14:37:50 : INFO  : joplin : Finishing... 2024-04-30 14:37:53 : INFO  : joplin : name: Joplin, appName: Joplin.app 2024-04-30 14:37:53.730 mdfind[65064:1721530] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-04-30 14:37:53.731 mdfind[65064:1721530] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-04-30 14:37:54.076 mdfind[65064:1721530] Couldn't determine the mapping between prefab keywords and predicates. 2024-04-30 14:37:54 : WARN  : joplin : No previous app found 2024-04-30 14:37:54 : WARN  : joplin : could not find Joplin.app
2024-04-30 14:37:54 : REQ   : joplin : Installed Joplin, version 2.14.20
2024-04-30 14:37:54 : INFO  : joplin : notifying
2024-04-30 14:37:54 : DEBUG : joplin : Unmounting /Volumes/Joplin 2.14.20
2024-04-30 14:37:55 : DEBUG : joplin : Debugging enabled, Unmounting output was:
"disk3" ejected.
2024-04-30 14:37:55 : DEBUG : joplin : DEBUG mode 1, not reopening anything
2024-04-30 14:37:55 : REQ   : joplin : All done!
2024-04-30 14:37:55 : REQ   : joplin : ################## End Installomator, exit code 0