### PR TITLE
New Label: starface81x

### DIFF
--- a/fragments/labels/starface81x.sh
+++ b/fragments/labels/starface81x.sh
@@ -1,0 +1,9 @@
+starface81x)
+    name="STARFACE"
+    # Downloads the latest 8.1.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
+    type="dmg"
+    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure' | grep -m 1 "8.1" | sed 's/.*url\(.*\).dmg/\1/' | cut -d '"' -f 2)
+    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure' | grep -m 1 "8.1" | sed 's/.*sparkle:version\(.*\) type/\1/' | cut -d '"' -f 2)
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
Downloads the latest 8.1.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation

"The STARFACE app for Windows and macOS serves as the desktop user interface for your VoIP phone system. Make calls using your choice of desk or DECT telephone. Besides a powerful call manager, the STARFACE app integrates an SIP client for use of an appropriate headset"

sudo ./assemble.sh -l /Users/savvas/Desktop/Mosyle/Resources/InstallomatorLabels starface81x DEBUG=0
2024-05-02 13:36:26 : REQ   : starface81x : ################## Start Installomator v. 10.5, date 2024-05-02
2024-05-02 13:36:26 : INFO  : starface81x : ################## Version: 10.5
2024-05-02 13:36:26 : INFO  : starface81x : ################## Date: 2024-05-02
2024-05-02 13:36:26 : INFO  : starface81x : ################## starface81x
2024-05-02 13:36:26 : DEBUG : starface81x : DEBUG mode 1 enabled.
2024-05-02 13:36:26 : INFO  : starface81x : setting variable from argument DEBUG=0
2024-05-02 13:36:26 : DEBUG : starface81x : name=STARFACE
2024-05-02 13:36:26 : DEBUG : starface81x : appName=
2024-05-02 13:36:26 : DEBUG : starface81x : type=dmg
2024-05-02 13:36:26 : DEBUG : starface81x : archiveName=
2024-05-02 13:36:26 : DEBUG : starface81x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.0_887_889da59
2024-05-02 13:36:26 : DEBUG : starface81x : curlOptions=
2024-05-02 13:36:26 : DEBUG : starface81x : appNewVersion=887
2024-05-02 13:36:26 : DEBUG : starface81x : appCustomVersion function: Not defined
2024-05-02 13:36:26 : DEBUG : starface81x : versionKey=CFBundleVersion
2024-05-02 13:36:26 : DEBUG : starface81x : packageID=
2024-05-02 13:36:26 : DEBUG : starface81x : pkgName=
2024-05-02 13:36:26 : DEBUG : starface81x : choiceChangesXML=
2024-05-02 13:36:26 : DEBUG : starface81x : expectedTeamID=Q965D3UXEW
2024-05-02 13:36:26 : DEBUG : starface81x : blockingProcesses=
2024-05-02 13:36:26 : DEBUG : starface81x : installerTool=
2024-05-02 13:36:26 : DEBUG : starface81x : CLIInstaller=
2024-05-02 13:36:26 : DEBUG : starface81x : CLIArguments=
2024-05-02 13:36:26 : DEBUG : starface81x : updateTool=
2024-05-02 13:36:26 : DEBUG : starface81x : updateToolArguments=
2024-05-02 13:36:26 : DEBUG : starface81x : updateToolRunAsCurrentUser=
2024-05-02 13:36:26 : INFO  : starface81x : BLOCKING_PROCESS_ACTION=tell_user
2024-05-02 13:36:26 : INFO  : starface81x : NOTIFY=success
2024-05-02 13:36:26 : INFO  : starface81x : LOGGING=DEBUG
2024-05-02 13:36:26 : INFO  : starface81x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-02 13:36:26 : INFO  : starface81x : Label type: dmg
2024-05-02 13:36:26 : INFO  : starface81x : archiveName: STARFACE.dmg
2024-05-02 13:36:26 : INFO  : starface81x : no blocking processes defined, using STARFACE as default
2024-05-02 13:36:26 : DEBUG : starface81x : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tVDX5GTS
2024-05-02 13:36:26 : INFO  : starface81x : App(s) found: /Applications/STARFACE.app
2024-05-02 13:36:26 : INFO  : starface81x : found app at /Applications/STARFACE.app, version 493, on versionKey CFBundleVersion
2024-05-02 13:36:26 : INFO  : starface81x : appversion: 493
2024-05-02 13:36:26 : INFO  : starface81x : Latest version of STARFACE is 887
2024-05-02 13:36:26 : REQ   : starface81x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.0_887_889da59 to STARFACE.dmg
2024-05-02 13:36:26 : DEBUG : starface81x : No Dialog connection, just download
2024-05-02 13:36:33 : DEBUG : starface81x : File list: -rw-r--r--  1 root  wheel   196M  2 Mai 13:36 STARFACE.dmg
2024-05-02 13:36:33 : DEBUG : starface81x : File type: STARFACE.dmg: zlib compressed data
2024-05-02 13:36:33 : DEBUG : starface81x : curl output was:
*   Trying 217.160.0.241:443...
* Connected to www.starface-cdn.de (217.160.0.241) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [70 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2762 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.starface-cdn.de
*  start date: Oct  2 00:00:00 2023 GMT
*  expire date: Oct 16 23:59:59 2024 GMT
*  subjectAltName: host "www.starface-cdn.de" matched cert's "*.starface-cdn.de"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Encryption Everywhere DV TLS CA - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.starface-cdn.de/starface/clients/mac/STARFACE_8.1.0_887_889da59
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.starface-cdn.de]
* [HTTP/2] [1] [:path: /starface/clients/mac/STARFACE_8.1.0_887_889da59]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /starface/clients/mac/STARFACE_8.1.0_887_889da59 HTTP/2
> Host: www.starface-cdn.de
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 205146459
< date: Thu, 02 May 2024 11:36:27 GMT
< server: Apache
< content-location: STARFACE_8.1.0_887_889da59.dmg < vary: negotiate
< tcn: choice
< last-modified: Mon, 29 Apr 2024 06:52:14 GMT
< etag: "c3a495b-61736b181a380;61736b2668540
< accept-ranges: bytes
<
{ [16139 bytes data]
* Connection #0 to host www.starface-cdn.de left intact

2024-05-02 13:36:33 : REQ   : starface81x : no more blocking processes, continue with update
2024-05-02 13:36:33 : REQ   : starface81x : Installing STARFACE
2024-05-02 13:36:33 : INFO  : starface81x : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tVDX5GTS/STARFACE.dmg
2024-05-02 13:36:35 : DEBUG : starface81x : Debugging enabled, dmgmount output was:
Prüfsumme für Driver Descriptor Map (DDM : 0) berechnen …
Driver Descriptor Map (DDM : 0): Die überprüfte CRC32-Prüfsumme ist $121C0759
Prüfsumme für Apple (Apple_partition_map : 1) berechnen …
Apple (Apple_partition_map : 1): Die überprüfte CRC32-Prüfsumme ist $EA51D313
Prüfsumme für DiscRecording 9.0.3d5 (Apple_HFS : 2) berechnen …
DiscRecording 9.0.3d5 (Apple_HFS : 2: Die überprüfte CRC32-Prüfsumme ist $174143DF
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Die überprüfte CRC32-Prüfsumme ist $4BEB847C
/dev/disk10         	Apple_partition_scheme
/dev/disk10s1       	Apple_partition_map
/dev/disk10s2       	Apple_HFS                      	/Volumes/STARFACE Installer 1

2024-05-02 13:36:35 : INFO  : starface81x : Mounted: /Volumes/STARFACE Installer 1 2024-05-02 13:36:35 : INFO  : starface81x : Verifying: /Volumes/STARFACE Installer 1/STARFACE.app 2024-05-02 13:36:35 : DEBUG : starface81x : App size: 469M	/Volumes/STARFACE Installer 1/STARFACE.app 2024-05-02 13:36:38 : DEBUG : starface81x : Debugging enabled, App Verification output was: /Volumes/STARFACE Installer 1/STARFACE.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2024-05-02 13:36:38 : INFO  : starface81x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW ) 2024-05-02 13:36:38 : INFO  : starface81x : Downloaded version of STARFACE is 887 on versionKey CFBundleVersion (replacing version 493). 2024-05-02 13:36:38 : INFO  : starface81x : App has LSMinimumSystemVersion: 11.0 2024-05-02 13:36:38 : WARN  : starface81x : Removing existing /Applications/STARFACE.app 2024-05-02 13:36:38 : DEBUG : starface81x : Debugging enabled, App removing output was: /Applications/STARFACE.app/Contents/
Last Log repeated 965 times
/Applications/STARFACE.app/Contents
/Applications/STARFACE.app

2024-05-02 13:36:38 : INFO  : starface81x : Copy /Volumes/STARFACE Installer 1/STARFACE.app to /Applications 2024-05-02 13:36:39 : DEBUG : starface81x : Debugging enabled, App copy output was: Copying /Volumes/STARFACE Installer 1/STARFACE.app

2024-05-02 13:36:39 : WARN  : starface81x : Changing owner to savvas 2024-05-02 13:36:39 : INFO  : starface81x : Finishing... 2024-05-02 13:36:42 : INFO  : starface81x : App(s) found: /Applications/STARFACE.app 2024-05-02 13:36:42 : INFO  : starface81x : found app at /Applications/STARFACE.app, version 887, on versionKey CFBundleVersion
2024-05-02 13:36:42 : REQ   : starface81x : Installed STARFACE, version 887
2024-05-02 13:36:42 : INFO  : starface81x : notifying
Notifications are not available: Notifications are not allowed for this application
2024-05-02 13:36:42 : DEBUG : starface81x : Unmounting /Volumes/STARFACE Installer 1
2024-05-02 13:36:42 : DEBUG : starface81x : Debugging enabled, Unmounting output was:
"disk10" ejected.
2024-05-02 13:36:42 : DEBUG : starface81x : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tVDX5GTS
2024-05-02 13:36:42 : DEBUG : starface81x : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tVDX5GTS/STARFACE.dmg
2024-05-02 13:36:42 : DEBUG : starface81x : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tVDX5GTS
2024-05-02 13:36:42 : INFO  : starface81x : Installomator did not close any apps, so no need to reopen any apps.
2024-05-02 13:36:42 : REQ   : starface81x : All done!
2024-05-02 13:36:42 : REQ   : starface81x : ################## End Installomator, exit code 0