### PR TITLE
New Label: blackhole

### DIFF
--- a/fragments/labels/blackhole.sh
+++ b/fragments/labels/blackhole.sh
@@ -1,0 +1,30 @@
+blackhole2ch)
+    name="BlackHole"
+    appName="BlackHole2ch.driver"
+    type="pkg"
+    packageID="audio.existential.BlackHole2ch"
+    targetDir="/Library/Audio/Plug-Ins/HAL"
+    downloadURL=$(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-2ch.json)" "url")
+    appNewVersion=$($(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-2ch.json)" "version"))
+    expectedTeamID="Q5C99V536K"
+    ;;
+blackhole16ch)
+    name="BlackHole"
+    appName="BlackHole16ch.driver"
+    type="pkg"
+    packageID="audio.existential.BlackHole16ch"
+    targetDir="/Library/Audio/Plug-Ins/HAL"
+    downloadURL=$(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-16ch.json)" "url")
+    appNewVersion=$($(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-16ch.json)" "version"))
+    expectedTeamID="Q5C99V536K"
+    ;;
+blackhole64ch)
+    name="BlackHole"
+    appName="BlackHole64ch.driver"
+    type="pkg"
+    packageID="audio.existential.BlackHole64ch"
+    targetDir="/Library/Audio/Plug-Ins/HAL"
+    downloadURL=$(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-64ch.json)" "url")
+    appNewVersion=$($(getJSONValue "$(curl -fsL https://formulae.brew.sh/api/cask/blackhole-64ch.json)" "version"))
+    expectedTeamID="Q5C99V536K"
+    ;;


### PR DESCRIPTION

```sh
$ ./utils/assemble.sh blackhole2ch
2024-05-04 01:47:47 : REQ   : blackhole2ch : ################## Start Installomator v. 10.5, date 2024-05-04
2024-05-04 01:47:47 : INFO  : blackhole2ch : ################## Version: 10.5
2024-05-04 01:47:47 : INFO  : blackhole2ch : ################## Date: 2024-05-04
2024-05-04 01:47:47 : INFO  : blackhole2ch : ################## blackhole2ch
2024-05-04 01:47:47 : DEBUG : blackhole2ch : DEBUG mode 1 enabled.
/Users/tadayuki/ghq/github.com/scriptingosx/Installomator/build/Installomator.sh:2294: command not found: 0.6.0
2024-05-04 01:47:48 : INFO  : blackhole2ch : setting variable from argument DEBUG=0
2024-05-04 01:47:48 : DEBUG : blackhole2ch : name=BlackHole 2ch
2024-05-04 01:47:48 : DEBUG : blackhole2ch : appName=BlackHole2ch.driver
2024-05-04 01:47:48 : DEBUG : blackhole2ch : type=pkg
2024-05-04 01:47:48 : DEBUG : blackhole2ch : archiveName=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : downloadURL=https://existential.audio/downloads/BlackHole2ch-0.6.0.pkg
2024-05-04 01:47:48 : DEBUG : blackhole2ch : curlOptions=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : appNewVersion=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : appCustomVersion function: Not defined
2024-05-04 01:47:48 : DEBUG : blackhole2ch : versionKey=CFBundleShortVersionString
2024-05-04 01:47:48 : DEBUG : blackhole2ch : packageID=audio.existential.BlackHole2ch
2024-05-04 01:47:48 : DEBUG : blackhole2ch : pkgName=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : choiceChangesXML=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : expectedTeamID=Q5C99V536K
2024-05-04 01:47:48 : DEBUG : blackhole2ch : blockingProcesses=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : installerTool=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : CLIInstaller=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : CLIArguments=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : updateTool=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : updateToolArguments=
2024-05-04 01:47:48 : DEBUG : blackhole2ch : updateToolRunAsCurrentUser=
2024-05-04 01:47:48 : INFO  : blackhole2ch : BLOCKING_PROCESS_ACTION=tell_user
2024-05-04 01:47:48 : INFO  : blackhole2ch : NOTIFY=success
2024-05-04 01:47:48 : INFO  : blackhole2ch : LOGGING=DEBUG
2024-05-04 01:47:48 : INFO  : blackhole2ch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-04 01:47:48 : INFO  : blackhole2ch : Label type: pkg
2024-05-04 01:47:48 : INFO  : blackhole2ch : archiveName: BlackHole 2ch.pkg
2024-05-04 01:47:48 : INFO  : blackhole2ch : no blocking processes defined, using BlackHole 2ch as default
2024-05-04 01:47:48 : DEBUG : blackhole2ch : Changing directory to /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.5iYmLMZq
2024-05-04 01:47:48 : INFO  : blackhole2ch : No version found using packageID audio.existential.BlackHole2ch
2024-05-04 01:47:48 : INFO  : blackhole2ch : name: BlackHole 2ch, appName: BlackHole2ch.driver
2024-05-04 01:47:48.576 mdfind[31794:274309] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:47:48.576 mdfind[31794:274309] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:47:48.707 mdfind[31794:274309] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:47:48 : WARN  : blackhole2ch : No previous app found
2024-05-04 01:47:48 : WARN  : blackhole2ch : could not find BlackHole2ch.driver
2024-05-04 01:47:48 : INFO  : blackhole2ch : appversion:
2024-05-04 01:47:48 : INFO  : blackhole2ch : Latest version not specified.
2024-05-04 01:47:48 : REQ   : blackhole2ch : Downloading https://existential.audio/downloads/BlackHole2ch-0.6.0.pkg to BlackHole 2ch.pkg
2024-05-04 01:47:48 : DEBUG : blackhole2ch : No Dialog connection, just download
2024-05-04 01:47:49 : DEBUG : blackhole2ch : File list: -rw-r--r--  1 tadayuki  staff    98K  5  4 01:47 BlackHole 2ch.pkg
2024-05-04 01:47:49 : DEBUG : blackhole2ch : File type: BlackHole 2ch.pkg: xar archive compressed TOC: 4801, SHA-1 checksum
2024-05-04 01:47:49 : DEBUG : blackhole2ch : curl output was:
*   Trying 162.241.218.190:443...
* Connected to existential.audio (162.241.218.190) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2927 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=existential-audio.donnaroth.com
*  start date: Mar 21 12:50:23 2024 GMT
*  expire date: Jun 19 12:50:22 2024 GMT
*  subjectAltName: host "existential.audio" matched cert's "existential.audio"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://existential.audio/downloads/BlackHole2ch-0.6.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: existential.audio]
* [HTTP/2] [1] [:path: /downloads/BlackHole2ch-0.6.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/BlackHole2ch-0.6.0.pkg HTTP/2
> Host: existential.audio
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< last-modified: Mon, 15 Apr 2024 23:11:47 GMT
< accept-ranges: bytes
< content-length: 100683
< host-header: c2hhcmVkLmJsdWVob3N0LmNvbQ==
< content-type: application/octet-stream
< date: Fri, 03 May 2024 16:47:49 GMT
< server: Apache
<
{ [16244 bytes data]
* Connection #0 to host existential.audio left intact

2024-05-04 01:47:49 : REQ   : blackhole2ch : no more blocking processes, continue with update
2024-05-04 01:47:49 : REQ   : blackhole2ch : Installing BlackHole 2ch
2024-05-04 01:47:49 : INFO  : blackhole2ch : Verifying: BlackHole 2ch.pkg
2024-05-04 01:47:49 : DEBUG : blackhole2ch : File list: -rw-r--r--  1 tadayuki  staff    98K  5  4 01:47 BlackHole 2ch.pkg
2024-05-04 01:47:49 : DEBUG : blackhole2ch : File type: BlackHole 2ch.pkg: xar archive compressed TOC: 4801, SHA-1 checksum
2024-05-04 01:47:49 : DEBUG : blackhole2ch : spctlOut is BlackHole 2ch.pkg: accepted
2024-05-04 01:47:49 : DEBUG : blackhole2ch : source=Notarized Developer ID
2024-05-04 01:47:49 : DEBUG : blackhole2ch : origin=Developer ID Installer: Existential Audio Inc. (Q5C99V536K)
2024-05-04 01:47:49 : INFO  : blackhole2ch : Team ID: Q5C99V536K (expected: Q5C99V536K )
2024-05-04 01:47:49 : INFO  : blackhole2ch : Installing BlackHole 2ch.pkg to /Library/Audio/Plug-Ins/HAL
2024-05-04 01:47:51 : DEBUG : blackhole2ch : Debugging enabled, installer output was:
installer: Must be run as root to install this package.
Output of /var/log/install.log below this line.----------------------------------------------------------

2024-05-04 01:47:51 : INFO  : blackhole2ch : Finishing...
2024-05-04 01:47:54 : INFO  : blackhole2ch : No version found using packageID audio.existential.BlackHole2ch
2024-05-04 01:47:54 : INFO  : blackhole2ch : name: BlackHole 2ch, appName: BlackHole2ch.driver
2024-05-04 01:47:54.591 mdfind[31907:274791] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:47:54.591 mdfind[31907:274791] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:47:54.708 mdfind[31907:274791] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:47:54 : WARN  : blackhole2ch : No previous app found
2024-05-04 01:47:54 : WARN  : blackhole2ch : could not find BlackHole2ch.driver
2024-05-04 01:47:54 : REQ   : blackhole2ch : Installed BlackHole 2ch
2024-05-04 01:47:54 : INFO  : blackhole2ch : notifying
Notifications are not available: Notifications are not allowed for this application
Check to see if Notifications for Dialog.app are enabled in notification center
2024-05-04 01:47:55 : DEBUG : blackhole2ch : Deleting /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.5iYmLMZq
2024-05-04 01:47:55 : DEBUG : blackhole2ch : Debugging enabled, Deleting tmpDir output was:
/var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.5iYmLMZq/BlackHole 2ch.pkg
2024-05-04 01:47:55 : DEBUG : blackhole2ch : /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.5iYmLMZq
2024-05-04 01:47:55 : INFO  : blackhole2ch : Installomator did not close any apps, so no need to reopen any apps.
2024-05-04 01:47:55 : REQ   : blackhole2ch : All done!
2024-05-04 01:47:55 : REQ   : blackhole2ch : ################## End Installomator, exit code 0
```

```sh
$ ./utils/assemble.sh blackhole16ch
2024-05-04 01:48:26 : REQ   : blackhole16ch : ################## Start Installomator v. 10.5, date 2024-05-04
2024-05-04 01:48:26 : INFO  : blackhole16ch : ################## Version: 10.5
2024-05-04 01:48:26 : INFO  : blackhole16ch : ################## Date: 2024-05-04
2024-05-04 01:48:26 : INFO  : blackhole16ch : ################## blackhole16ch
2024-05-04 01:48:26 : DEBUG : blackhole16ch : DEBUG mode 1 enabled.
/Users/tadayuki/ghq/github.com/scriptingosx/Installomator/build/Installomator.sh:2304: command not found: 0.6.0
2024-05-04 01:48:27 : INFO  : blackhole16ch : setting variable from argument DEBUG=0
2024-05-04 01:48:27 : DEBUG : blackhole16ch : name=BlackHole 16ch
2024-05-04 01:48:27 : DEBUG : blackhole16ch : appName=BlackHole16ch.driver
2024-05-04 01:48:27 : DEBUG : blackhole16ch : type=pkg
2024-05-04 01:48:27 : DEBUG : blackhole16ch : archiveName=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : downloadURL=https://existential.audio/downloads/BlackHole16ch-0.6.0.pkg
2024-05-04 01:48:27 : DEBUG : blackhole16ch : curlOptions=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : appNewVersion=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : appCustomVersion function: Not defined
2024-05-04 01:48:27 : DEBUG : blackhole16ch : versionKey=CFBundleShortVersionString
2024-05-04 01:48:27 : DEBUG : blackhole16ch : packageID=audio.existential.BlackHole16ch
2024-05-04 01:48:27 : DEBUG : blackhole16ch : pkgName=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : choiceChangesXML=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : expectedTeamID=Q5C99V536K
2024-05-04 01:48:27 : DEBUG : blackhole16ch : blockingProcesses=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : installerTool=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : CLIInstaller=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : CLIArguments=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : updateTool=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : updateToolArguments=
2024-05-04 01:48:27 : DEBUG : blackhole16ch : updateToolRunAsCurrentUser=
2024-05-04 01:48:27 : INFO  : blackhole16ch : BLOCKING_PROCESS_ACTION=tell_user
2024-05-04 01:48:27 : INFO  : blackhole16ch : NOTIFY=success
2024-05-04 01:48:27 : INFO  : blackhole16ch : LOGGING=DEBUG
2024-05-04 01:48:27 : INFO  : blackhole16ch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-04 01:48:27 : INFO  : blackhole16ch : Label type: pkg
2024-05-04 01:48:27 : INFO  : blackhole16ch : archiveName: BlackHole 16ch.pkg
2024-05-04 01:48:27 : INFO  : blackhole16ch : no blocking processes defined, using BlackHole 16ch as default
2024-05-04 01:48:27 : DEBUG : blackhole16ch : Changing directory to /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.VzIH2aYT
2024-05-04 01:48:27 : INFO  : blackhole16ch : No version found using packageID audio.existential.BlackHole16ch
2024-05-04 01:48:27 : INFO  : blackhole16ch : name: BlackHole 16ch, appName: BlackHole16ch.driver
2024-05-04 01:48:27.790 mdfind[32300:276813] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:48:27.791 mdfind[32300:276813] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:48:27.914 mdfind[32300:276813] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:48:27 : WARN  : blackhole16ch : No previous app found
2024-05-04 01:48:27 : WARN  : blackhole16ch : could not find BlackHole16ch.driver
2024-05-04 01:48:27 : INFO  : blackhole16ch : appversion:
2024-05-04 01:48:27 : INFO  : blackhole16ch : Latest version not specified.
2024-05-04 01:48:27 : REQ   : blackhole16ch : Downloading https://existential.audio/downloads/BlackHole16ch-0.6.0.pkg to BlackHole 16ch.pkg
2024-05-04 01:48:27 : DEBUG : blackhole16ch : No Dialog connection, just download
2024-05-04 01:48:28 : DEBUG : blackhole16ch : File list: -rw-r--r--  1 tadayuki  staff   100K  5  4 01:48 BlackHole 16ch.pkg
2024-05-04 01:48:28 : DEBUG : blackhole16ch : File type: BlackHole 16ch.pkg: xar archive compressed TOC: 4807, SHA-1 checksum
2024-05-04 01:48:28 : DEBUG : blackhole16ch : curl output was:
*   Trying 162.241.218.190:443...
* Connected to existential.audio (162.241.218.190) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2927 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=existential-audio.donnaroth.com
*  start date: Mar 21 12:50:23 2024 GMT
*  expire date: Jun 19 12:50:22 2024 GMT
*  subjectAltName: host "existential.audio" matched cert's "existential.audio"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://existential.audio/downloads/BlackHole16ch-0.6.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: existential.audio]
* [HTTP/2] [1] [:path: /downloads/BlackHole16ch-0.6.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/BlackHole16ch-0.6.0.pkg HTTP/2
> Host: existential.audio
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< last-modified: Mon, 15 Apr 2024 23:11:46 GMT
< accept-ranges: bytes
< content-length: 102404
< host-header: c2hhcmVkLmJsdWVob3N0LmNvbQ==
< content-type: application/octet-stream
< date: Fri, 03 May 2024 16:48:28 GMT
< server: Apache
<
{ [16246 bytes data]
* Connection #0 to host existential.audio left intact

2024-05-04 01:48:28 : REQ   : blackhole16ch : no more blocking processes, continue with update
2024-05-04 01:48:28 : REQ   : blackhole16ch : Installing BlackHole 16ch
2024-05-04 01:48:28 : INFO  : blackhole16ch : Verifying: BlackHole 16ch.pkg
2024-05-04 01:48:29 : DEBUG : blackhole16ch : File list: -rw-r--r--  1 tadayuki  staff   100K  5  4 01:48 BlackHole 16ch.pkg
2024-05-04 01:48:29 : DEBUG : blackhole16ch : File type: BlackHole 16ch.pkg: xar archive compressed TOC: 4807, SHA-1 checksum
2024-05-04 01:48:29 : DEBUG : blackhole16ch : spctlOut is BlackHole 16ch.pkg: accepted
2024-05-04 01:48:29 : DEBUG : blackhole16ch : source=Notarized Developer ID
2024-05-04 01:48:29 : DEBUG : blackhole16ch : origin=Developer ID Installer: Existential Audio Inc. (Q5C99V536K)
2024-05-04 01:48:29 : INFO  : blackhole16ch : Team ID: Q5C99V536K (expected: Q5C99V536K )
2024-05-04 01:48:29 : INFO  : blackhole16ch : Installing BlackHole 16ch.pkg to /Library/Audio/Plug-Ins/HAL
2024-05-04 01:48:30 : DEBUG : blackhole16ch : Debugging enabled, installer output was:
installer: Must be run as root to install this package.
Output of /var/log/install.log below this line.----------------------------------------------------------

2024-05-04 01:48:30 : INFO  : blackhole16ch : Finishing...
2024-05-04 01:48:33 : INFO  : blackhole16ch : No version found using packageID audio.existential.BlackHole16ch
2024-05-04 01:48:33 : INFO  : blackhole16ch : name: BlackHole 16ch, appName: BlackHole16ch.driver
2024-05-04 01:48:33.790 mdfind[32402:277216] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:48:33.791 mdfind[32402:277216] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:48:33.933 mdfind[32402:277216] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:48:33 : WARN  : blackhole16ch : No previous app found
2024-05-04 01:48:33 : WARN  : blackhole16ch : could not find BlackHole16ch.driver
2024-05-04 01:48:33 : REQ   : blackhole16ch : Installed BlackHole 16ch
2024-05-04 01:48:33 : INFO  : blackhole16ch : notifying
Notifications are not available: Notifications are not allowed for this application
Check to see if Notifications for Dialog.app are enabled in notification center
2024-05-04 01:48:34 : DEBUG : blackhole16ch : Deleting /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.VzIH2aYT
2024-05-04 01:48:34 : DEBUG : blackhole16ch : Debugging enabled, Deleting tmpDir output was:
/var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.VzIH2aYT/BlackHole 16ch.pkg
2024-05-04 01:48:34 : DEBUG : blackhole16ch : /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.VzIH2aYT
2024-05-04 01:48:34 : INFO  : blackhole16ch : Installomator did not close any apps, so no need to reopen any apps.
2024-05-04 01:48:34 : REQ   : blackhole16ch : All done!
2024-05-04 01:48:34 : REQ   : blackhole16ch : ################## End Installomator, exit code 0
```

```sh
$ ./utils/assemble.sh blackhole64ch
2024-05-04 01:48:54 : REQ   : blackhole64ch : ################## Start Installomator v. 10.5, date 2024-05-04
2024-05-04 01:48:54 : INFO  : blackhole64ch : ################## Version: 10.5
2024-05-04 01:48:54 : INFO  : blackhole64ch : ################## Date: 2024-05-04
2024-05-04 01:48:54 : INFO  : blackhole64ch : ################## blackhole64ch
2024-05-04 01:48:54 : DEBUG : blackhole64ch : DEBUG mode 1 enabled.
/Users/tadayuki/ghq/github.com/scriptingosx/Installomator/build/Installomator.sh:2314: command not found: 0.6.0
2024-05-04 01:48:55 : INFO  : blackhole64ch : setting variable from argument DEBUG=0
2024-05-04 01:48:55 : DEBUG : blackhole64ch : name=BlackHole 64ch
2024-05-04 01:48:55 : DEBUG : blackhole64ch : appName=BlackHole64ch.driver
2024-05-04 01:48:55 : DEBUG : blackhole64ch : type=pkg
2024-05-04 01:48:55 : DEBUG : blackhole64ch : archiveName=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : downloadURL=https://existential.audio/downloads/BlackHole64ch-0.6.0.pkg
2024-05-04 01:48:55 : DEBUG : blackhole64ch : curlOptions=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : appNewVersion=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : appCustomVersion function: Not defined
2024-05-04 01:48:55 : DEBUG : blackhole64ch : versionKey=CFBundleShortVersionString
2024-05-04 01:48:55 : DEBUG : blackhole64ch : packageID=audio.existential.BlackHole64ch
2024-05-04 01:48:55 : DEBUG : blackhole64ch : pkgName=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : choiceChangesXML=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : expectedTeamID=Q5C99V536K
2024-05-04 01:48:55 : DEBUG : blackhole64ch : blockingProcesses=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : installerTool=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : CLIInstaller=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : CLIArguments=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : updateTool=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : updateToolArguments=
2024-05-04 01:48:55 : DEBUG : blackhole64ch : updateToolRunAsCurrentUser=
2024-05-04 01:48:55 : INFO  : blackhole64ch : BLOCKING_PROCESS_ACTION=tell_user
2024-05-04 01:48:55 : INFO  : blackhole64ch : NOTIFY=success
2024-05-04 01:48:55 : INFO  : blackhole64ch : LOGGING=DEBUG
2024-05-04 01:48:55 : INFO  : blackhole64ch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-04 01:48:55 : INFO  : blackhole64ch : Label type: pkg
2024-05-04 01:48:55 : INFO  : blackhole64ch : archiveName: BlackHole 64ch.pkg
2024-05-04 01:48:55 : INFO  : blackhole64ch : no blocking processes defined, using BlackHole 64ch as default
2024-05-04 01:48:55 : DEBUG : blackhole64ch : Changing directory to /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.bliXlB9Q
2024-05-04 01:48:55 : INFO  : blackhole64ch : No version found using packageID audio.existential.BlackHole64ch
2024-05-04 01:48:55 : INFO  : blackhole64ch : name: BlackHole 64ch, appName: BlackHole64ch.driver
2024-05-04 01:48:55.508 mdfind[32738:278834] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:48:55.508 mdfind[32738:278834] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:48:55.634 mdfind[32738:278834] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:48:55 : WARN  : blackhole64ch : No previous app found
2024-05-04 01:48:55 : WARN  : blackhole64ch : could not find BlackHole64ch.driver
2024-05-04 01:48:55 : INFO  : blackhole64ch : appversion:
2024-05-04 01:48:55 : INFO  : blackhole64ch : Latest version not specified.
2024-05-04 01:48:55 : REQ   : blackhole64ch : Downloading https://existential.audio/downloads/BlackHole64ch-0.6.0.pkg to BlackHole 64ch.pkg
2024-05-04 01:48:55 : DEBUG : blackhole64ch : No Dialog connection, just download
2024-05-04 01:48:56 : DEBUG : blackhole64ch : File list: -rw-r--r--  1 tadayuki  staff   100K  5  4 01:48 BlackHole 64ch.pkg
2024-05-04 01:48:56 : DEBUG : blackhole64ch : File type: BlackHole 64ch.pkg: xar archive compressed TOC: 4823, SHA-1 checksum
2024-05-04 01:48:56 : DEBUG : blackhole64ch : curl output was:
*   Trying 162.241.218.190:443...
* Connected to existential.audio (162.241.218.190) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2927 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=existential-audio.donnaroth.com
*  start date: Mar 21 12:50:23 2024 GMT
*  expire date: Jun 19 12:50:22 2024 GMT
*  subjectAltName: host "existential.audio" matched cert's "existential.audio"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://existential.audio/downloads/BlackHole64ch-0.6.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: existential.audio]
* [HTTP/2] [1] [:path: /downloads/BlackHole64ch-0.6.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/BlackHole64ch-0.6.0.pkg HTTP/2
> Host: existential.audio
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< last-modified: Mon, 15 Apr 2024 23:11:47 GMT
< accept-ranges: bytes
< content-length: 102340
< host-header: c2hhcmVkLmJsdWVob3N0LmNvbQ==
< content-type: application/octet-stream
< date: Fri, 03 May 2024 16:48:56 GMT
< server: Apache
<
{ [16245 bytes data]
* Connection #0 to host existential.audio left intact

2024-05-04 01:48:56 : REQ   : blackhole64ch : no more blocking processes, continue with update
2024-05-04 01:48:56 : REQ   : blackhole64ch : Installing BlackHole 64ch
2024-05-04 01:48:56 : INFO  : blackhole64ch : Verifying: BlackHole 64ch.pkg
2024-05-04 01:48:56 : DEBUG : blackhole64ch : File list: -rw-r--r--  1 tadayuki  staff   100K  5  4 01:48 BlackHole 64ch.pkg
2024-05-04 01:48:56 : DEBUG : blackhole64ch : File type: BlackHole 64ch.pkg: xar archive compressed TOC: 4823, SHA-1 checksum
2024-05-04 01:48:56 : DEBUG : blackhole64ch : spctlOut is BlackHole 64ch.pkg: accepted
2024-05-04 01:48:56 : DEBUG : blackhole64ch : source=Notarized Developer ID
2024-05-04 01:48:56 : DEBUG : blackhole64ch : origin=Developer ID Installer: Existential Audio Inc. (Q5C99V536K)
2024-05-04 01:48:56 : INFO  : blackhole64ch : Team ID: Q5C99V536K (expected: Q5C99V536K )
2024-05-04 01:48:56 : INFO  : blackhole64ch : Installing BlackHole 64ch.pkg to /Library/Audio/Plug-Ins/HAL
2024-05-04 01:48:58 : DEBUG : blackhole64ch : Debugging enabled, installer output was:
installer: Must be run as root to install this package.
Output of /var/log/install.log below this line.----------------------------------------------------------

2024-05-04 01:48:58 : INFO  : blackhole64ch : Finishing...
2024-05-04 01:49:01 : INFO  : blackhole64ch : No version found using packageID audio.existential.BlackHole64ch
2024-05-04 01:49:01 : INFO  : blackhole64ch : name: BlackHole 64ch, appName: BlackHole64ch.driver
2024-05-04 01:49:01.551 mdfind[32850:279261] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2024-05-04 01:49:01.552 mdfind[32850:279261] [UserQueryParser] Loading keywords and predicates for locale "ja"
2024-05-04 01:49:01.671 mdfind[32850:279261] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-04 01:49:01 : WARN  : blackhole64ch : No previous app found
2024-05-04 01:49:01 : WARN  : blackhole64ch : could not find BlackHole64ch.driver
2024-05-04 01:49:01 : REQ   : blackhole64ch : Installed BlackHole 64ch
2024-05-04 01:49:01 : INFO  : blackhole64ch : notifying
Notifications are not available: Notifications are not allowed for this application
Check to see if Notifications for Dialog.app are enabled in notification center
2024-05-04 01:49:02 : DEBUG : blackhole64ch : Deleting /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.bliXlB9Q
2024-05-04 01:49:02 : DEBUG : blackhole64ch : Debugging enabled, Deleting tmpDir output was:
/var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.bliXlB9Q/BlackHole 64ch.pkg
2024-05-04 01:49:02 : DEBUG : blackhole64ch : /var/folders/kp/r1dzsf0n42150d5l9ngjx9s00000gn/T/tmp.bliXlB9Q
2024-05-04 01:49:02 : INFO  : blackhole64ch : Installomator did not close any apps, so no need to reopen any apps.
2024-05-04 01:49:02 : REQ   : blackhole64ch : All done!
2024-05-04 01:49:02 : REQ   : blackhole64ch : ################## End Installomator, exit code 0
```