### PR TITLE
Microsoftcompanyportal downloadURL and appNewVersion change to get latest on NEW installs

### DIFF
--- a/fragments/labels/microsoftcompanyportal.sh
+++ b/fragments/labels/microsoftcompanyportal.sh
@@ -2,6 +2,7 @@ microsoftcompanyportal)
     name="Company Portal"
     type="pkg"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=853070"
+    appNewVersion=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409IMCP01.xml | xmllint --format --xpath "//*/array/dict[1]" - | awk -F'<key>Title</key>' '{ print $2 }' | awk -F'</string>' '{ print $1 }' | sed 's/<string>//' | rev | cut -d' ' -f1 | rev | tr -d "\n")
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"


### PR DESCRIPTION
Trying to address the specific issue expressed in #1600 of NOT LATEST version of `Microsoft Company Portal` being downloaded and installed by `installomator` on a NEW install of the app, I modified the `downloadURL` (to get the latest full installer) and `appNewVersion` (to get the version from the MAU XML feed schema pointed out on #897)

There appears to be a deeper thought process in #1490 of how to address this across all office apps but in the short term I wanted to use a URL that actually did grab the latest and was also used in the past by Autopkg maintainers (https://github.com/autopkg/rtrouton-recipes/blob/master/MicrosoftIntuneCompanyPortal/MicrosoftIntuneCompanyPortal.download.recipe).

In using this URL, the version details were not in the name of the PKG as per the previous URL so I used the inspiration on #897 to create a `curl` command that could get the version cleanly in the title field (as version does not have its own pref key in the XML)

Old values are left commented out

```
microsoftcompanyportal)
    name="Company Portal"
    type="pkg"
    #downloadURL="https://go.microsoft.com/fwlink/?linkid=869655"
    downloadURL="https://go.microsoft.com/fwlink/?linkid=853070"
    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.intunecompanyportal.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
    #appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/CompanyPortal_.*pkg" | cut -d "_" -f 2 | cut -d "-" -f 1)
    appNewVersion=$(curl -s https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409IMCP01.xml | xmllint --format --xpath "//*/array/dict[1]" - | awk -F'<key>Title</key>' '{ print $2 }' | awk -F'</string>' '{ print $1 }' | sed 's/<string>//' | rev | cut -d' ' -f1 | rev | tr -d "\n")
    expectedTeamID="UBF8T346G9"
    if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
        printlog "Running msupdate --list"
        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
    fi
    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
    updateToolArguments=( --install --apps IMCP01 )
    ;;
```

Output of the assemble:

```
installomator/utils/assemble.sh microsoftcompanyportal        
2024-05-10 02:44:22 : REQ   : microsoftcompanyportal : ################## Start Installomator v. 10.6beta, date 2024-05-10
2024-05-10 02:44:22 : INFO  : microsoftcompanyportal : ################## Version: 10.6beta
2024-05-10 02:44:22 : INFO  : microsoftcompanyportal : ################## Date: 2024-05-10
2024-05-10 02:44:22 : INFO  : microsoftcompanyportal : ################## microsoftcompanyportal
2024-05-10 02:44:22 : DEBUG : microsoftcompanyportal : DEBUG mode 1 enabled.
2024-05-10 02:44:22 : INFO  : microsoftcompanyportal : SwiftDialog is not installed, clear cmd file var
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : name=Company Portal
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : appName=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : type=pkg
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : archiveName=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : downloadURL=https://go.microsoft.com/fwlink/?linkid=853070
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : curlOptions=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : appNewVersion=5.2404.0
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : appCustomVersion function: Not defined
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : versionKey=CFBundleShortVersionString
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : packageID=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : pkgName=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : choiceChangesXML=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : expectedTeamID=UBF8T346G9
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : blockingProcesses=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : installerTool=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : CLIInstaller=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : CLIArguments=
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : updateToolArguments=--install --apps IMCP01
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : updateToolRunAsCurrentUser=
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : BLOCKING_PROCESS_ACTION=tell_user
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : NOTIFY=success
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : LOGGING=DEBUG
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : Label type: pkg
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : archiveName: Company Portal.pkg
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : no blocking processes defined, using Company Portal as default
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : Changing directory to /Users/aaron.polley/Documents/GitHub/installomator/build
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : App(s) found: /Applications/Company Portal.app
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : found app at /Applications/Company Portal.app, version 5.2404.0, on versionKey CFBundleShortVersionString
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : appversion: 5.2404.0
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : Latest version of Company Portal is 5.2404.0
2024-05-10 02:44:23 : WARN  : microsoftcompanyportal : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : App needs to be updated and uses /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2024-05-10 02:44:23 : WARN  : microsoftcompanyportal : DEBUG mode 1 enabled, not running update tool
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : Company Portal.pkg exists and DEBUG mode 1 enabled, skipping download
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : DEBUG mode 1, not checking for blocking processes
2024-05-10 02:44:23 : REQ   : microsoftcompanyportal : Installing Company Portal
2024-05-10 02:44:23 : INFO  : microsoftcompanyportal : Verifying: Company Portal.pkg
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : File list: -rw-r--r--@ 1 aaron.polley  staff    60M 10 May 02:13 Company Portal.pkg
2024-05-10 02:44:23 : DEBUG : microsoftcompanyportal : File type: Company Portal.pkg: xar archive compressed TOC: 7278, SHA-1 checksum
2024-05-10 02:44:24 : DEBUG : microsoftcompanyportal : spctlOut is Company Portal.pkg: accepted
2024-05-10 02:44:24 : DEBUG : microsoftcompanyportal : source=Notarized Developer ID
2024-05-10 02:44:24 : DEBUG : microsoftcompanyportal : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2024-05-10 02:44:24 : INFO  : microsoftcompanyportal : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2024-05-10 02:44:24 : DEBUG : microsoftcompanyportal : DEBUG enabled, skipping installation
2024-05-10 02:44:24 : INFO  : microsoftcompanyportal : Finishing...
2024-05-10 02:44:27 : INFO  : microsoftcompanyportal : App(s) found: /Applications/Company Portal.app
2024-05-10 02:44:27 : INFO  : microsoftcompanyportal : found app at /Applications/Company Portal.app, version 5.2404.0, on versionKey CFBundleShortVersionString
2024-05-10 02:44:27 : REQ   : microsoftcompanyportal : Installed Company Portal, version 5.2404.0
2024-05-10 02:44:27 : INFO  : microsoftcompanyportal : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-05-10 02:44:27 : DEBUG : microsoftcompanyportal : DEBUG mode 1, not reopening anything
2024-05-10 02:44:27 : REQ   : microsoftcompanyportal : All done!
2024-05-10 02:44:27 : REQ   : microsoftcompanyportal : ################## End Installomator, exit code 0 
```