### PR TITLE
Update camtasia2023.sh

### DIFF
--- a/fragments/labels/camtasia2023.sh
+++ b/fragments/labels/camtasia2023.sh
@@ -2,7 +2,8 @@ camtasia|\
 camtasia2023)
     name="Camtasia 2023"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Camtasia (Mac) 2023" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Camtasia (Mac) 2023" | sed -e 's/.*Camtasia (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL 'https://sparkle.cloud.techsmith.com/api/v1/AppcastManifest/?version=23.0.0&utm_source=product&utm_medium=cmac&utm_campaign=cm23&ipc_item_name=cmac&ipc_platform=macos')
+    appNewVersion=$( <<<"$sparkleData" xpath 'string(//item/sparkle:shortVersionString)' )
+    downloadURL=$( <<<"$sparkleData" xpath 'string(//item/enclosure/@url)' )
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
This label has stopped working because the "Download-Links" page is now returning a "403 Forbidden" error. This PR updates the label to use the Sparkle feed instead.

Output:

```
 # ./assemble.sh camtasia2023 DEBUG=0 SYSTEMOWNER=1
2024-05-10 10:47:13 : REQ   : camtasia2023 : ################## Start Installomator v. 10.6beta, date 2024-05-10
2024-05-10 10:47:13 : INFO  : camtasia2023 : ################## Version: 10.6beta
2024-05-10 10:47:13 : INFO  : camtasia2023 : ################## Date: 2024-05-10
2024-05-10 10:47:13 : INFO  : camtasia2023 : ################## camtasia2023
2024-05-10 10:47:13 : DEBUG : camtasia2023 : DEBUG mode 1 enabled.
Query didn't return a nodeset. Value: Query didn't return a nodeset. Value: 2024-05-10 10:47:13 : INFO  : camtasia2023 : setting variable from argument DEBUG=0
2024-05-10 10:47:13 : INFO  : camtasia2023 : setting variable from argument SYSTEMOWNER=1
2024-05-10 10:47:13 : DEBUG : camtasia2023 : name=Camtasia 2023
2024-05-10 10:47:14 : DEBUG : camtasia2023 : appName=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : type=dmg
2024-05-10 10:47:14 : DEBUG : camtasia2023 : archiveName=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : downloadURL=https://download.techsmith.com//camtasiamac/releases/23314/Camtasia.dmg
2024-05-10 10:47:14 : DEBUG : camtasia2023 : curlOptions=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : appNewVersion=2023.3.14
2024-05-10 10:47:14 : DEBUG : camtasia2023 : appCustomVersion function: Not defined
2024-05-10 10:47:14 : DEBUG : camtasia2023 : versionKey=CFBundleShortVersionString
2024-05-10 10:47:14 : DEBUG : camtasia2023 : packageID=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : pkgName=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : choiceChangesXML=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : expectedTeamID=7TQL462TU8
2024-05-10 10:47:14 : DEBUG : camtasia2023 : blockingProcesses=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : installerTool=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : CLIInstaller=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : CLIArguments=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : updateTool=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : updateToolArguments=
2024-05-10 10:47:14 : DEBUG : camtasia2023 : updateToolRunAsCurrentUser=
2024-05-10 10:47:14 : INFO  : camtasia2023 : BLOCKING_PROCESS_ACTION=tell_user
2024-05-10 10:47:14 : INFO  : camtasia2023 : NOTIFY=success
2024-05-10 10:47:14 : INFO  : camtasia2023 : LOGGING=DEBUG
2024-05-10 10:47:14 : INFO  : camtasia2023 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-10 10:47:15 : INFO  : camtasia2023 : Label type: dmg
2024-05-10 10:47:15 : INFO  : camtasia2023 : archiveName: Camtasia 2023.dmg
2024-05-10 10:47:15 : INFO  : camtasia2023 : no blocking processes defined, using Camtasia 2023 as default
2024-05-10 10:47:15 : DEBUG : camtasia2023 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YpSbp7xTqR
2024-05-10 10:47:15 : INFO  : camtasia2023 : name: Camtasia 2023, appName: Camtasia 2023.app
2024-05-10 10:47:15.258 mdfind[59601:1435317] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-05-10 10:47:15.258 mdfind[59601:1435317] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-05-10 10:47:15.338 mdfind[59601:1435317] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-10 10:47:15 : WARN  : camtasia2023 : No previous app found
2024-05-10 10:47:15 : WARN  : camtasia2023 : could not find Camtasia 2023.app
2024-05-10 10:47:15 : INFO  : camtasia2023 : appversion:
2024-05-10 10:47:15 : INFO  : camtasia2023 : Latest version of Camtasia 2023 is 2023.3.14
2024-05-10 10:47:15 : REQ   : camtasia2023 : Downloading https://download.techsmith.com//camtasiamac/releases/23314/Camtasia.dmg to Camtasia 2023.dmg
2024-05-10 10:47:15 : DEBUG : camtasia2023 : No Dialog connection, just download
2024-05-10 10:48:45 : DEBUG : camtasia2023 : File list: -rw-r--r--  1 root  wheel   427M May 10 10:48 Camtasia 2023.dmg
2024-05-10 10:48:45 : DEBUG : camtasia2023 : File type: Camtasia 2023.dmg: data
2024-05-10 10:48:45 : DEBUG : camtasia2023 : curl output was:
* Host download.techsmith.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.14.154.6
*   Trying 23.14.154.6:443...
* Connected to download.techsmith.com (23.14.154.6) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [66 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3612 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Michigan; L=East Lansing; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 15 00:00:00 2023 GMT
*  expire date: Aug 19 23:59:59 2024 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: O=Leidos; CN=Leidos Perimeter FW CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET //camtasiamac/releases/23314/Camtasia.dmg HTTP/1.1
> Host: download.techsmith.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/octet-stream
< Last-Modified: Mon, 22 Apr 2024 15:31:38 GMT
< Accept-Ranges: bytes
< ETag: "e161df2aca94da1:0"
< Server: Microsoft-IIS/8.5
< Content-Length: 447891745
< Cache-Control: max-age=3726
< Date: Fri, 10 May 2024 14:47:15 GMT
< Connection: keep-alive
< Akamai-Request-BC: [a=184.25.117.172,b=91563880,c=g,n=US_NY_NEWYORK,o=20940]
<
{ [16008 bytes data]
* Connection #0 to host download.techsmith.com left intact

2024-05-10 10:48:45 : REQ   : camtasia2023 : no more blocking processes, continue with update
2024-05-10 10:48:45 : REQ   : camtasia2023 : Installing Camtasia 2023
2024-05-10 10:48:45 : INFO  : camtasia2023 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YpSbp7xTqR/Camtasia 2023.dmg
2024-05-10 10:48:47 : DEBUG : camtasia2023 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $9CFA0E85
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $067A4AE6
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $D066910B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $D4DCE4D9
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/Camtasia

2024-05-10 10:48:47 : INFO  : camtasia2023 : Mounted: /Volumes/Camtasia
2024-05-10 10:48:47 : INFO  : camtasia2023 : Verifying: /Volumes/Camtasia/Camtasia 2023.app
2024-05-10 10:48:47 : DEBUG : camtasia2023 : App size: 742M	/Volumes/Camtasia/Camtasia 2023.app
2024-05-10 10:48:52 : DEBUG : camtasia2023 : Debugging enabled, App Verification output was:
/Volumes/Camtasia/Camtasia 2023.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2024-05-10 10:48:52 : INFO  : camtasia2023 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2024-05-10 10:48:52 : INFO  : camtasia2023 : Installing Camtasia 2023 version 2023.3.14 on versionKey CFBundleShortVersionString.
2024-05-10 10:48:52 : INFO  : camtasia2023 : App has LSMinimumSystemVersion: 11.0
2024-05-10 10:48:52 : INFO  : camtasia2023 : Copy /Volumes/Camtasia/Camtasia 2023.app to /Applications
2024-05-10 10:48:59 : DEBUG : camtasia2023 : Debugging enabled, App copy output was:
Copying /Volumes/Camtasia/Camtasia 2023.app

2024-05-10 10:48:59 : WARN  : camtasia2023 : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2024-05-10 10:49:00 : INFO  : camtasia2023 : Finishing...
2024-05-10 10:49:03 : INFO  : camtasia2023 : App(s) found: /Applications/Camtasia 2023.app
2024-05-10 10:49:03 : INFO  : camtasia2023 : found app at /Applications/Camtasia 2023.app, version 2023.3.14, on versionKey CFBundleShortVersionString
2024-05-10 10:49:03 : REQ   : camtasia2023 : Installed Camtasia 2023, version 2023.3.14
2024-05-10 10:49:03 : INFO  : camtasia2023 : notifying
2024-05-10 10:49:03 : DEBUG : camtasia2023 : Unmounting /Volumes/Camtasia
2024-05-10 10:49:04 : DEBUG : camtasia2023 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-05-10 10:49:05 : DEBUG : camtasia2023 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YpSbp7xTqR
2024-05-10 10:49:05 : DEBUG : camtasia2023 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YpSbp7xTqR/Camtasia 2023.dmg
2024-05-10 10:49:05 : DEBUG : camtasia2023 : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YpSbp7xTqR
2024-05-10 10:49:05 : INFO  : camtasia2023 : Installomator did not close any apps, so no need to reopen any apps.
2024-05-10 10:49:05 : REQ   : camtasia2023 : All done!
2024-05-10 10:49:05 : REQ   : camtasia2023 : ################## End Installomator, exit code 0

```