### PR TITLE
Label Fix: Snagit 2024

### DIFF
--- a/fragments/labels/snagit.sh
+++ b/fragments/labels/snagit.sh
@@ -2,7 +2,8 @@ snagit|\
 snagit2024)
     name="Snagit 2024"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Snagit (Mac) 2024" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Snagit (Mac) 2024" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL 'https://www.techsmith.com/redirect.asp?target=sufeedurl&product=snagitmac&ver=2024.0.0&lang=enu&os=mac')
+    appNewVersion=$( <<<"$sparkleData" xpath 'string(//item/sparkle:shortVersionString)' )
+    downloadURL=$( <<<"$sparkleData" xpath 'string(//item/enclosure/@url)' )
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
This label has stopped working because the "Download-Links" page is now returning a "403 Forbidden" error. This PR updates the label to use the Sparkle feed instead.

Output:

```
# ./assemble.sh snagit2024 DEBUG=0 SYSTEMOWNER=1
2024-05-10 11:51:16 : REQ   : snagit2024 : ################## Start Installomator v. 10.6beta, date 2024-05-10
2024-05-10 11:51:16 : INFO  : snagit2024 : ################## Version: 10.6beta
2024-05-10 11:51:16 : INFO  : snagit2024 : ################## Date: 2024-05-10
2024-05-10 11:51:16 : INFO  : snagit2024 : ################## snagit2024
2024-05-10 11:51:16 : DEBUG : snagit2024 : DEBUG mode 1 enabled.
2024-05-10 11:51:17 : INFO  : snagit2024 : setting variable from argument DEBUG=0
2024-05-10 11:51:17 : INFO  : snagit2024 : setting variable from argument SYSTEMOWNER=1
2024-05-10 11:51:17 : DEBUG : snagit2024 : name=Snagit 2024
2024-05-10 11:51:17 : DEBUG : snagit2024 : appName=
2024-05-10 11:51:17 : DEBUG : snagit2024 : type=dmg
2024-05-10 11:51:17 : DEBUG : snagit2024 : archiveName=
2024-05-10 11:51:17 : DEBUG : snagit2024 : downloadURL=https://download.techsmith.com/snagitmac/releases/snagit.dmg
2024-05-10 11:51:17 : DEBUG : snagit2024 : curlOptions=
2024-05-10 11:51:17 : DEBUG : snagit2024 : appNewVersion=2024.2.4</p>
2024-05-10 11:51:17 : DEBUG : snagit2024 : appCustomVersion function: Not defined
2024-05-10 11:51:17 : DEBUG : snagit2024 : versionKey=CFBundleShortVersionString
2024-05-10 11:51:17 : DEBUG : snagit2024 : packageID=
2024-05-10 11:51:17 : DEBUG : snagit2024 : pkgName=
2024-05-10 11:51:18 : DEBUG : snagit2024 : choiceChangesXML=
2024-05-10 11:51:18 : DEBUG : snagit2024 : expectedTeamID=7TQL462TU8
2024-05-10 11:51:18 : DEBUG : snagit2024 : blockingProcesses=
2024-05-10 11:51:18 : DEBUG : snagit2024 : installerTool=
2024-05-10 11:51:18 : DEBUG : snagit2024 : CLIInstaller=
2024-05-10 11:51:18 : DEBUG : snagit2024 : CLIArguments=
2024-05-10 11:51:18 : DEBUG : snagit2024 : updateTool=
2024-05-10 11:51:18 : DEBUG : snagit2024 : updateToolArguments=
2024-05-10 11:51:18 : DEBUG : snagit2024 : updateToolRunAsCurrentUser=
2024-05-10 11:51:18 : INFO  : snagit2024 : BLOCKING_PROCESS_ACTION=tell_user
2024-05-10 11:51:18 : INFO  : snagit2024 : NOTIFY=success
2024-05-10 11:51:18 : INFO  : snagit2024 : LOGGING=DEBUG
2024-05-10 11:51:18 : INFO  : snagit2024 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-10 11:51:18 : INFO  : snagit2024 : Label type: dmg
2024-05-10 11:51:18 : INFO  : snagit2024 : archiveName: Snagit 2024.dmg
2024-05-10 11:51:18 : INFO  : snagit2024 : no blocking processes defined, using Snagit 2024 as default
2024-05-10 11:51:18 : DEBUG : snagit2024 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JoxvH5yqWI
2024-05-10 11:51:18 : INFO  : snagit2024 : name: Snagit 2024, appName: Snagit 2024.app
2024-05-10 11:51:18.923 mdfind[68089:1507093] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-05-10 11:51:18.923 mdfind[68089:1507093] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-05-10 11:51:19.027 mdfind[68089:1507093] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-10 11:51:19 : WARN  : snagit2024 : No previous app found
2024-05-10 11:51:19 : WARN  : snagit2024 : could not find Snagit 2024.app
2024-05-10 11:51:19 : INFO  : snagit2024 : appversion:
2024-05-10 11:51:19 : INFO  : snagit2024 : Latest version of Snagit 2024 is 2024.2.4</p>
2024-05-10 11:51:19 : REQ   : snagit2024 : Downloading https://download.techsmith.com/snagitmac/releases/snagit.dmg to Snagit 2024.dmg
2024-05-10 11:51:19 : DEBUG : snagit2024 : No Dialog connection, just download
2024-05-10 11:51:27 : DEBUG : snagit2024 : File list: -rw-r--r--  1 root  wheel   256M May 10 11:51 Snagit 2024.dmg
2024-05-10 11:51:27 : DEBUG : snagit2024 : File type: Snagit 2024.dmg: zlib compressed data
2024-05-10 11:51:27 : DEBUG : snagit2024 : curl output was:
* Host download.techsmith.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.62.113.134
*   Trying 23.62.113.134:443...
* Connected to download.techsmith.com (23.62.113.134) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3076 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Michigan; L=East Lansing; O=TechSmith Corporation; CN=download.techsmith.com
*  start date: Aug 15 00:00:00 2023 GMT
*  expire date: Aug 19 23:59:59 2024 GMT
*  subjectAltName: host "download.techsmith.com" matched cert's "download.techsmith.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.techsmith.com/snagitmac/releases/snagit.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.techsmith.com]
* [HTTP/2] [1] [:path: /snagitmac/releases/snagit.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /snagitmac/releases/snagit.dmg HTTP/2
> Host: download.techsmith.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Thu, 04 Apr 2024 15:03:50 GMT
< accept-ranges: bytes
< etag: "c61bfc4ca186da1:0"
< server: Microsoft-IIS/8.5
< content-length: 267965208
< cache-control: max-age=13186
< date: Fri, 10 May 2024 15:51:19 GMT
< akamai-request-bc: [a=23.54.64.201,b=996540935,c=g,n=US_NJ_PISCATAWAY,o=20940]
<
{ [16384 bytes data]
* Connection #0 to host download.techsmith.com left intact

2024-05-10 11:51:27 : REQ   : snagit2024 : no more blocking processes, continue with update
2024-05-10 11:51:27 : REQ   : snagit2024 : Installing Snagit 2024
2024-05-10 11:51:27 : INFO  : snagit2024 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JoxvH5yqWI/Snagit 2024.dmg
2024-05-10 11:51:28 : DEBUG : snagit2024 : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $7B09A448
verified   CRC32 $20C77341
/dev/disk4          	                               	/Volumes/Snagit

2024-05-10 11:51:29 : INFO  : snagit2024 : Mounted: /Volumes/Snagit
2024-05-10 11:51:29 : INFO  : snagit2024 : Verifying: /Volumes/Snagit/Snagit 2024.app
2024-05-10 11:51:29 : DEBUG : snagit2024 : App size: 581M	/Volumes/Snagit/Snagit 2024.app
2024-05-10 11:51:33 : DEBUG : snagit2024 : Debugging enabled, App Verification output was:
/Volumes/Snagit/Snagit 2024.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2024-05-10 11:51:33 : INFO  : snagit2024 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2024-05-10 11:51:33 : INFO  : snagit2024 : Installing Snagit 2024 version 2024.2.4 on versionKey CFBundleShortVersionString.
2024-05-10 11:51:33 : INFO  : snagit2024 : App has LSMinimumSystemVersion: 12.0
2024-05-10 11:51:33 : INFO  : snagit2024 : Copy /Volumes/Snagit/Snagit 2024.app to /Applications
2024-05-10 11:51:36 : DEBUG : snagit2024 : Debugging enabled, App copy output was:
Copying /Volumes/Snagit/Snagit 2024.app

2024-05-10 11:51:36 : WARN  : snagit2024 : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2024-05-10 11:51:37 : INFO  : snagit2024 : Finishing...
2024-05-10 11:51:40 : INFO  : snagit2024 : App(s) found: /Applications/Snagit 2024.app
2024-05-10 11:51:40 : INFO  : snagit2024 : found app at /Applications/Snagit 2024.app, version 2024.2.4, on versionKey CFBundleShortVersionString
2024-05-10 11:51:40 : REQ   : snagit2024 : Installed Snagit 2024, version 2024.2.4
2024-05-10 11:51:40 : INFO  : snagit2024 : notifying
2024-05-10 11:51:40 : DEBUG : snagit2024 : Unmounting /Volumes/Snagit
2024-05-10 11:51:41 : DEBUG : snagit2024 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-05-10 11:51:41 : DEBUG : snagit2024 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JoxvH5yqWI
2024-05-10 11:51:41 : DEBUG : snagit2024 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JoxvH5yqWI/Snagit 2024.dmg
2024-05-10 11:51:41 : DEBUG : snagit2024 : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JoxvH5yqWI
2024-05-10 11:51:41 : INFO  : snagit2024 : Installomator did not close any apps, so no need to reopen any apps.
2024-05-10 11:51:41 : REQ   : snagit2024 : All done!
2024-05-10 11:51:41 : REQ   : snagit2024 : ################## End Installomator, exit code 0

```