### PR TITLE
Update cryptomator.sh

### DIFF
--- a/fragments/labels/cryptomator.sh
+++ b/fragments/labels/cryptomator.sh
@@ -2,12 +2,10 @@ cryptomator)
     name="Cryptomator"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="Cryptomator-[0-9.]*-arm64.dmg"
-
+        downloadURL="$(curl -fs "https://cryptomator.org/downloads/mac-arm64/thanks/" | grep -oE "href=\"https:\/\/github.com\/cryptomator\/cryptomator\/releases\/download\/[0-9.]+/.*-arm64\.dmg\"" | cut -d '"' -f 2)"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="Cryptomator-[0-9.]*-x64.dmg"
+        downloadURL="$(curl -fs "https://cryptomator.org/downloads/mac/thanks/" | grep -oE "href=\"https:\/\/github.com\/cryptomator\/cryptomator\/releases\/download\/[0-9.]+/.*-x64\.dmg\"" | cut -d '"' -f 2)"
     fi
-    downloadURL=$(downloadURLFromGit cryptomator cryptomator)
-    appNewVersion=$(versionFromGit cryptomator cryptomator)
+    appNewVersion=$(echo "${downloadURL}" | awk -F'/' '{ print $(NF-1) }')
     expectedTeamID="YZQJQUHA3L"
     ;;


### PR DESCRIPTION
Using the functions `downloadURLFromGit` and `versionFromGit` proved to be not so reliable in this case since the developer recently released a [Windows only version](https://github.com/cryptomator/cryptomator/releases/tag/1.12.4) of Cryptomator. So I reworked the label to hopefully make it more reliable.

-----

2024-05-15 16:07:53 : REQ   : cryptomator : ################## Start Installomator v. 10.6beta, date 2024-05-15
2024-05-15 16:07:53 : INFO  : cryptomator : ################## Version: 10.6beta
2024-05-15 16:07:53 : INFO  : cryptomator : ################## Date: 2024-05-15
2024-05-15 16:07:53 : INFO  : cryptomator : ################## cryptomator
2024-05-15 16:07:53 : INFO  : cryptomator : SwiftDialog is not installed, clear cmd file var
2024-05-15 16:07:53 : INFO  : cryptomator : BLOCKING_PROCESS_ACTION=tell_user
2024-05-15 16:07:53 : INFO  : cryptomator : NOTIFY=success
2024-05-15 16:07:53 : INFO  : cryptomator : LOGGING=INFO
2024-05-15 16:07:53 : INFO  : cryptomator : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-15 16:07:53 : INFO  : cryptomator : Label type: dmg
2024-05-15 16:07:53 : INFO  : cryptomator : archiveName: Cryptomator.dmg
2024-05-15 16:07:53 : INFO  : cryptomator : no blocking processes defined, using Cryptomator as default
2024-05-15 16:07:53 : INFO  : cryptomator : name: Cryptomator, appName: Cryptomator.app
2024-05-15 16:07:53.734 mdfind[20418:6796658] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-05-15 16:07:53.735 mdfind[20418:6796658] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-05-15 16:07:54.038 mdfind[20418:6796658] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-15 16:07:54 : WARN  : cryptomator : No previous app found
2024-05-15 16:07:54 : WARN  : cryptomator : could not find Cryptomator.app
2024-05-15 16:07:54 : INFO  : cryptomator : appversion:
2024-05-15 16:07:54 : INFO  : cryptomator : Latest version of Cryptomator is 1.12.3
2024-05-15 16:07:54 : REQ   : cryptomator : Downloading https://github.com/cryptomator/cryptomator/releases/download/1.12.3/Cryptomator-1.12.3-arm64.dmg to Cryptomator.dmg
2024-05-15 16:07:55 : REQ   : cryptomator : no more blocking processes, continue with update
2024-05-15 16:07:55 : REQ   : cryptomator : Installing Cryptomator
2024-05-15 16:07:55 : INFO  : cryptomator : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XUIFi4syBb/Cryptomator.dmg
2024-05-15 16:08:00 : INFO  : cryptomator : Mounted: /Volumes/Cryptomator
2024-05-15 16:08:00 : INFO  : cryptomator : Verifying: /Volumes/Cryptomator/Cryptomator.app
2024-05-15 16:08:01 : INFO  : cryptomator : Team ID matching: YZQJQUHA3L (expected: YZQJQUHA3L )
2024-05-15 16:08:01 : INFO  : cryptomator : Installing Cryptomator version 1.12.3 on versionKey CFBundleShortVersionString.
2024-05-15 16:08:01 : INFO  : cryptomator : App has LSMinimumSystemVersion: 11
2024-05-15 16:08:01 : INFO  : cryptomator : Copy /Volumes/Cryptomator/Cryptomator.app to /Applications
2024-05-15 16:08:01 : WARN  : cryptomator : Changing owner to kryptonit
2024-05-15 16:08:01 : INFO  : cryptomator : Finishing...
2024-05-15 16:08:04 : INFO  : cryptomator : App(s) found: /Applications/Cryptomator.app
2024-05-15 16:08:04 : INFO  : cryptomator : found app at /Applications/Cryptomator.app, version 1.12.3, on versionKey CFBundleShortVersionString
2024-05-15 16:08:04 : REQ   : cryptomator : Installed Cryptomator, version 1.12.3
2024-05-15 16:08:04 : INFO  : cryptomator : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-05-15 16:08:04 : INFO  : cryptomator : Installomator did not close any apps, so no need to reopen any apps.
2024-05-15 16:08:05 : REQ   : cryptomator : All done!
2024-05-15 16:08:05 : REQ   : cryptomator : ################## End Installomator, exit code 0