### PR TITLE
update slack label

### DIFF
--- a/fragments/labels/slack.sh
+++ b/fragments/labels/slack.sh
@@ -1,11 +1,7 @@
 slack)
     name="Slack"
     type="dmg"
-    if [[ $(arch) == i386 ]]; then
-       downloadURL="https://slack.com/ssb/download-osx"
-    elif [[ $(arch) == arm64 ]]; then
-       downloadURL="https://slack.com/ssb/download-osx-silicon"
-    fi
+    downloadURL="https://slack.com/ssb/download-osx-universal"
     appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | cut -d "/" -f7 )
     expectedTeamID="BQR82RBBHL"
     ;;


### PR DESCRIPTION
Slack now has a universal binary, so I updated the labels' download URL

```bash
./assemble.sh slack
2024-05-21 16:07:20 : REQ   : slack : ################## Start Installomator v. 10.6beta, date 2024-05-21
2024-05-21 16:07:20 : INFO  : slack : ################## Version: 10.6beta
2024-05-21 16:07:20 : INFO  : slack : ################## Date: 2024-05-21
2024-05-21 16:07:20 : INFO  : slack : ################## slack
2024-05-21 16:07:20 : DEBUG : slack : DEBUG mode 1 enabled.
2024-05-21 16:07:20 : INFO  : slack : SwiftDialog is not installed, clear cmd file var
2024-05-21 16:07:21 : DEBUG : slack : name=Slack
2024-05-21 16:07:21 : DEBUG : slack : appName=
2024-05-21 16:07:21 : DEBUG : slack : type=dmg
2024-05-21 16:07:21 : DEBUG : slack : archiveName=
2024-05-21 16:07:21 : DEBUG : slack : downloadURL=https://slack.com/ssb/download-osx-universal
2024-05-21 16:07:21 : DEBUG : slack : curlOptions=
2024-05-21 16:07:21 : DEBUG : slack : appNewVersion=4.38.125
2024-05-21 16:07:21 : DEBUG : slack : appCustomVersion function: Not defined
2024-05-21 16:07:21 : DEBUG : slack : versionKey=CFBundleShortVersionString
2024-05-21 16:07:21 : DEBUG : slack : packageID=
2024-05-21 16:07:21 : DEBUG : slack : pkgName=
2024-05-21 16:07:21 : DEBUG : slack : choiceChangesXML=
2024-05-21 16:07:21 : DEBUG : slack : expectedTeamID=BQR82RBBHL
2024-05-21 16:07:21 : DEBUG : slack : blockingProcesses=
2024-05-21 16:07:21 : DEBUG : slack : installerTool=
2024-05-21 16:07:21 : DEBUG : slack : CLIInstaller=
2024-05-21 16:07:21 : DEBUG : slack : CLIArguments=
2024-05-21 16:07:21 : DEBUG : slack : updateTool=
2024-05-21 16:07:21 : DEBUG : slack : updateToolArguments=
2024-05-21 16:07:21 : DEBUG : slack : updateToolRunAsCurrentUser=
2024-05-21 16:07:21 : INFO  : slack : BLOCKING_PROCESS_ACTION=tell_user
2024-05-21 16:07:21 : INFO  : slack : NOTIFY=success
2024-05-21 16:07:21 : INFO  : slack : LOGGING=DEBUG
2024-05-21 16:07:21 : INFO  : slack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-21 16:07:21 : INFO  : slack : Label type: dmg
2024-05-21 16:07:21 : INFO  : slack : archiveName: Slack.dmg
2024-05-21 16:07:21 : INFO  : slack : no blocking processes defined, using Slack as default
2024-05-21 16:07:21 : DEBUG : slack : Changing directory to /Users/alexis/DEV/installomator-alexis/build
2024-05-21 16:07:21 : INFO  : slack : App(s) found: /Applications/Slack.app
2024-05-21 16:07:21 : INFO  : slack : found app at /Applications/Slack.app, version 4.38.125, on versionKey CFBundleShortVersionString
2024-05-21 16:07:21 : INFO  : slack : appversion: 4.38.125
2024-05-21 16:07:21 : INFO  : slack : Latest version of Slack is 4.38.125
2024-05-21 16:07:21 : WARN  : slack : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-05-21 16:07:21 : REQ   : slack : Downloading https://slack.com/ssb/download-osx-universal to Slack.dmg
2024-05-21 16:07:21 : DEBUG : slack : No Dialog connection, just download
2024-05-21 16:07:24 : DEBUG : slack : File list: -rw-r--r--  1 alexis  staff   167M May 21 16:07 Slack.dmg
2024-05-21 16:07:24 : DEBUG : slack : File type: Slack.dmg: bzip2 compressed data, block size = 100k
2024-05-21 16:07:24 : DEBUG : slack : curl output was:
* Host slack.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.168.172.238, 18.169.61.189, 18.134.215.41, 18.169.120.191
*   Trying 18.168.172.238:443...
* Connected to slack.com (18.168.172.238) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [314 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3973 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=slack.com
*  start date: Mar 20 18:03:03 2024 GMT
*  expire date: Jun 18 18:03:02 2024 GMT
*  subjectAltName: host "slack.com" matched cert's "slack.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://slack.com/ssb/download-osx-universal
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: slack.com]
* [HTTP/2] [1] [:path: /ssb/download-osx-universal]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /ssb/download-osx-universal HTTP/2
> Host: slack.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 302 
< date: Tue, 21 May 2024 14:07:21 GMT
< server: Apache
< vary: Accept-Encoding
< location: https://downloads.slack-edge.com/desktop-releases/mac/universal/4.38.125/Slack-4.38.125-macOS.dmg
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< referrer-policy: no-referrer
< x-slack-unique-id: Zkyqmfa45viyIMpMa4cdvwAAEDE
< x-slack-backend: r
< x-frame-options: SAMEORIGIN
< content-type: text/html
< content-length: 0
< set-cookie: b=bc803ac1f7165d1e0a1a6fb7bfac4f7e; expires=Sun, 21-May-2034 14:07:21 GMT; Max-Age=315532800; path=/; domain=.slack.com; secure; SameSite=None
< set-cookie: x=bc803ac1f7165d1e0a1a6fb7bfac4f7e.1716300441; expires=Tue, 21-May-2024 14:22:21 GMT; Max-Age=900; path=/; domain=.slack.com; secure; SameSite=None
< via: 1.1 slack-prod.tinyspeck.com, envoy-www-iad-zvopmcun, envoy-edge-lhr-astfczpp
< x-envoy-attempt-count: 1
< x-envoy-upstream-service-time: 125
< x-backend: main_normal main_canary_with_overflow main_control_with_overflow
< x-server: slack-www-hhvm-main-iad-hhdo
< x-slack-shared-secret-outcome: no-match
< x-edge-backend: envoy-www
< x-slack-edge-shared-secret-outcome: no-match
< 
* Ignoring the response-body
* Connection #0 to host slack.com left intact
* Issue another request to this URL: 'https://downloads.slack-edge.com/desktop-releases/mac/universal/4.38.125/Slack-4.38.125-macOS.dmg'
* Host downloads.slack-edge.com:443 was resolved.
* IPv6: (none)
* IPv4: 108.156.22.108, 108.156.22.102, 108.156.22.65, 108.156.22.2
*   Trying 108.156.22.108:443...
* Connected to downloads.slack-edge.com (108.156.22.108) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3989 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=slack-edge.com
*  start date: Apr  2 12:51:15 2024 GMT
*  expire date: Jul  1 12:51:14 2024 GMT
*  subjectAltName: host "downloads.slack-edge.com" matched cert's "*.slack-edge.com"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.slack-edge.com/desktop-releases/mac/universal/4.38.125/Slack-4.38.125-macOS.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.slack-edge.com]
* [HTTP/2] [1] [:path: /desktop-releases/mac/universal/4.38.125/Slack-4.38.125-macOS.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /desktop-releases/mac/universal/4.38.125/Slack-4.38.125-macOS.dmg HTTP/2
> Host: downloads.slack-edge.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 175414223
< last-modified: Wed, 15 May 2024 19:47:56 GMT
< x-amz-server-side-encryption: AES256
< content-encoding: 
< accept-ranges: bytes
< server: AmazonS3
< date: Tue, 21 May 2024 12:01:37 GMT
< cache-control: max-age=14400
< etag: "96121f0a382476d5ee1f9768972d415c"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 e3d7e26a5df51c85de01773b18b95a58.cloudfront.net (CloudFront)
< x-amz-cf-pop: HEL51-P1
< x-amz-cf-id: 0fBkjpKolforheJI2Ywb-LOrcGpOvWB9vv5maFBqF7kELJE-eEuU1w==
< age: 7546
< 
{ [15962 bytes data]
* Connection #1 to host downloads.slack-edge.com left intact

2024-05-21 16:07:24 : DEBUG : slack : DEBUG mode 1, not checking for blocking processes
2024-05-21 16:07:24 : REQ   : slack : Installing Slack
2024-05-21 16:07:24 : INFO  : slack : Mounting /Users/alexis/DEV/installomator-alexis/build/Slack.dmg
2024-05-21 16:07:42 : DEBUG : slack : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3334E7B9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $6382356E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $545C2448
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $FB8EFA50
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $545C2448
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $71D6DE0B
verified   CRC32 $7CCA09BB
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Slack

2024-05-21 16:07:42 : INFO  : slack : Mounted: /Volumes/Slack
2024-05-21 16:07:42 : INFO  : slack : Verifying: /Volumes/Slack/Slack.app
2024-05-21 16:07:42 : DEBUG : slack : App size: 458M	/Volumes/Slack/Slack.app
2024-05-21 16:08:04 : DEBUG : slack : Debugging enabled, App Verification output was:
/Volumes/Slack/Slack.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Slack Technologies, Inc. (BQR82RBBHL)

2024-05-21 16:08:04 : INFO  : slack : Team ID matching: BQR82RBBHL (expected: BQR82RBBHL )
2024-05-21 16:08:04 : INFO  : slack : Downloaded version of Slack is 4.38.125 on versionKey CFBundleShortVersionString, same as installed.
2024-05-21 16:08:04 : DEBUG : slack : Unmounting /Volumes/Slack
2024-05-21 16:08:05 : DEBUG : slack : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-05-21 16:08:05 : DEBUG : slack : DEBUG mode 1, not reopening anything
2024-05-21 16:08:05 : REG   : slack : No new version to install
2024-05-21 16:08:05 : REQ   : slack : ################## End Installomator, exit code 0
```