### PR TITLE
Create deezer.sh

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -173,6 +173,7 @@ dbeaverce
 debookee
 dedoose
 deepl
+deezer
 defaultfolderx
 depnotify
 desktoppr

--- a/fragments/labels/deezer.sh
+++ b/fragments/labels/deezer.sh
@@ -1,0 +1,8 @@
+deezer)
+    name="Deezer"
+    type="dmg"
+    # There is no arm/universal binary. Need rosetta2 to run it on apple silicon
+    downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64"
+    appNewVersion=""
+    expectedTeamID="7QLUP2K45C"
+    ;;

--- a/fragments/labels/deezer.sh
+++ b/fragments/labels/deezer.sh
@@ -3,6 +3,6 @@ deezer)
     type="dmg"
     # There is no arm/universal binary. Need rosetta2 to run it on apple silicon
     downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64"
-    appNewVersion=""
+    appNewVersion=$(curl -fsLI "$downloadURL" | grep -o "DeezerDesktop_[0-9]*\.[0-9]*\.[0-9]*" | cut -d'_' -f2)
     expectedTeamID="7QLUP2K45C"
     ;;


### PR DESCRIPTION
There is only x86 binary.
We will have to update this label when there is new arm/universal binary.

```bash
./assemble.sh deezer
2024-05-21 16:39:50 : REQ   : deezer : ################## Start Installomator v. 10.6beta, date 2024-05-21
2024-05-21 16:39:50 : INFO  : deezer : ################## Version: 10.6beta
2024-05-21 16:39:50 : INFO  : deezer : ################## Date: 2024-05-21
2024-05-21 16:39:50 : INFO  : deezer : ################## deezer
2024-05-21 16:39:50 : DEBUG : deezer : DEBUG mode 1 enabled.
2024-05-21 16:39:50 : INFO  : deezer : SwiftDialog is not installed, clear cmd file var
2024-05-21 16:39:51 : DEBUG : deezer : name=Deezer
2024-05-21 16:39:51 : DEBUG : deezer : appName=
2024-05-21 16:39:51 : DEBUG : deezer : type=dmg
2024-05-21 16:39:51 : DEBUG : deezer : archiveName=
2024-05-21 16:39:51 : DEBUG : deezer : downloadURL=https://www.deezer.com/desktop/download?platform=darwin&architecture=x64
2024-05-21 16:39:51 : DEBUG : deezer : curlOptions=
2024-05-21 16:39:51 : DEBUG : deezer : appNewVersion=
2024-05-21 16:39:51 : DEBUG : deezer : appCustomVersion function: Not defined
2024-05-21 16:39:51 : DEBUG : deezer : versionKey=CFBundleShortVersionString
2024-05-21 16:39:51 : DEBUG : deezer : packageID=
2024-05-21 16:39:51 : DEBUG : deezer : pkgName=
2024-05-21 16:39:51 : DEBUG : deezer : choiceChangesXML=
2024-05-21 16:39:51 : DEBUG : deezer : expectedTeamID=7QLUP2K45C
2024-05-21 16:39:51 : DEBUG : deezer : blockingProcesses=
2024-05-21 16:39:51 : DEBUG : deezer : installerTool=
2024-05-21 16:39:51 : DEBUG : deezer : CLIInstaller=
2024-05-21 16:39:51 : DEBUG : deezer : CLIArguments=
2024-05-21 16:39:51 : DEBUG : deezer : updateTool=
2024-05-21 16:39:51 : DEBUG : deezer : updateToolArguments=
2024-05-21 16:39:51 : DEBUG : deezer : updateToolRunAsCurrentUser=
2024-05-21 16:39:51 : INFO  : deezer : BLOCKING_PROCESS_ACTION=tell_user
2024-05-21 16:39:51 : INFO  : deezer : NOTIFY=success
2024-05-21 16:39:51 : INFO  : deezer : LOGGING=DEBUG
2024-05-21 16:39:51 : INFO  : deezer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-21 16:39:51 : INFO  : deezer : Label type: dmg
2024-05-21 16:39:51 : INFO  : deezer : archiveName: Deezer.dmg
2024-05-21 16:39:51 : INFO  : deezer : no blocking processes defined, using Deezer as default
2024-05-21 16:39:51 : DEBUG : deezer : Changing directory to /Users/alexis/DEV/installomator-alexis/build
2024-05-21 16:39:51 : INFO  : deezer : App(s) found: /Applications/Deezer.app
2024-05-21 16:39:51 : INFO  : deezer : found app at /Applications/Deezer.app, version 6.0.130, on versionKey CFBundleShortVersionString
2024-05-21 16:39:51 : INFO  : deezer : appversion: 6.0.130
2024-05-21 16:39:51 : INFO  : deezer : Latest version not specified.
2024-05-21 16:39:51 : REQ   : deezer : Downloading https://www.deezer.com/desktop/download?platform=darwin&architecture=x64 to Deezer.dmg
2024-05-21 16:39:51 : DEBUG : deezer : No Dialog connection, just download
2024-05-21 16:39:53 : DEBUG : deezer : File list: -rw-r--r--  1 alexis  staff    85M May 21 16:39 Deezer.dmg
2024-05-21 16:39:53 : DEBUG : deezer : File type: Deezer.dmg: zlib compressed data
2024-05-21 16:39:53 : DEBUG : deezer : curl output was:
* Host www.deezer.com:443 was resolved.
* IPv6: (none)
* IPv4: 2.16.165.156, 2.16.11.67, 2.16.11.74
*   Trying 2.16.165.156:443...
* Connected to www.deezer.com (2.16.165.156) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3303 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.deezer.com
*  start date: Apr 11 00:00:00 2024 GMT
*  expire date: Apr 11 23:59:59 2025 GMT
*  subjectAltName: host "www.deezer.com" matched cert's "*.deezer.com"
*  issuer: C=FR; O=Gandi; CN=Gandi RSA Domain Validation Secure Server CA 3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.deezer.com/desktop/download?platform=darwin&architecture=x64
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.deezer.com]
* [HTTP/2] [1] [:path: /desktop/download?platform=darwin&architecture=x64]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /desktop/download?platform=darwin&architecture=x64 HTTP/2
> Host: www.deezer.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 302 
< server: Apache
< expires: Thu, 19 Nov 1981 08:52:00 GMT
< cache-control: no-store, no-cache, must-revalidate
< pragma: no-cache
< p3p: policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
< x-frame-options: SAMEORIGIN
< content-security-policy-report-only: upgrade-insecure-requests ; report-uri /csp-report
< content-security-policy-report-only: block-all-mixed-content ; report-uri /csp-report
< location: https://www.deezer.com/desktop/download/artifact/darwin/x64/6.0.130
< x-host: blm-web-45
< x-ua-compatible: IE=edge,chrome=1,requiresActiveX=true
< x-content-type-options: nosniff
< content-length: 0
< content-type: text/html; charset=utf-8
< strict-transport-security: max-age=31536000; includeSubDomains
< date: Tue, 21 May 2024 14:39:51 GMT
< set-cookie: sid=fr13018633b7692c628c5349967f38d55f1c5907; path=/; domain=.deezer.com; secure; HttpOnly; SameSite=None
< set-cookie: dzr_uniq_id=dzr_uniq_id_fraad7ec4edb5af98c266dbf5aad7d4304ea68c0; expires=Sun, 17-Nov-2024 14:39:51 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure; SameSite=None
< x-org: FR
< set-cookie: _abck=F9BDEF2D16D00740EC0DD88350D5BC7B~-1~YAAQmKUQAk/r1FGPAQAA5imYmwu0rVM6JbVWczkJFb/gV5wKif0d9d8fmTY7QSphNAtf69z+F7RAvlBhf238PYNAcIL4Ajm7On39ksj7ZaeLRpqavCpvi0GHCvJuIyife0sboFErGK1IyBrZD8uQMlm9J5ZAO/+lHx9U+sUG8KXYLoQmgnR1sD97NUUe01Zm8WRV6Zln10VY0MFstXoQFF32CCysxj2R11kIINaMNA6v+MeXwmavU2eQNQD14NyJ2NJTQ5CyPLRzc+C7RnoaKMDRCEZIMAEWBIvnX5FEj6nS6iXQxljH+aTMk4Ucg7sdadW8DMZ3879+L8V+V9WYBBt1pQkNHH2WNvIv53dE8Fq6deHi0u0UdAM=~-1~-1~-1; Domain=.deezer.com; Path=/; Expires=Wed, 21 May 2025 14:39:51 GMT; Max-Age=31536000; SameSite=None; Secure
< set-cookie: bm_sz=839149EDF1023123CE31AEF6D721C1C1~YAAQmKUQAlDr1FGPAQAA5imYmxdEySAhqPQXdhcoBcKbwvS4KS39ltnGV0AY9jWg3NV8fwI9iR9NDN+085n5/mo8VQgq+KOB4vcCP5XSm6uGqhdh3lpBTfLnT6daHiD0TEEBq2OE7dIjIMOX7j/GZ524qdBCndzj4PaQ2Rm4KMCW6B7U+v633q3PeGlRFSXwo5cUg/S0v/CGyXOUGl4d62dwNH6JkwRWuPA2xB6wfZZbhSWjxg1fG0KCCkNPp7JeBCheDusC40DGpAwXfA2gSUAH/HFJ2kVJ5vjvf2s/IXSQljGZowVtdPPA8awDrlZXf6UsiAAROH/SLtdrvDxQ5P2zIUBKCA+h21xOGap3QSB/py7C6wLx~3556659~3748918; Domain=.deezer.com; Path=/; Expires=Tue, 21 May 2024 18:39:51 GMT; Max-Age=14400; SameSite=None; Secure
< 
* Ignoring the response-body
* Connection #0 to host www.deezer.com left intact
* Issue another request to this URL: 'https://www.deezer.com/desktop/download/artifact/darwin/x64/6.0.130'
* Found bundle for host: 0x600003e64930 [can multiplex]
* Re-using existing connection with host www.deezer.com
* [HTTP/2] [3] OPENED stream for https://www.deezer.com/desktop/download/artifact/darwin/x64/6.0.130
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: www.deezer.com]
* [HTTP/2] [3] [:path: /desktop/download/artifact/darwin/x64/6.0.130]
* [HTTP/2] [3] [user-agent: curl/8.6.0]
* [HTTP/2] [3] [accept: */*]
> GET /desktop/download/artifact/darwin/x64/6.0.130 HTTP/2
> Host: www.deezer.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 302 
< server: Apache
< expires: Thu, 19 Nov 1981 08:52:00 GMT
< cache-control: no-store, no-cache, must-revalidate
< pragma: no-cache
< p3p: policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
< x-frame-options: SAMEORIGIN
< content-security-policy-report-only: upgrade-insecure-requests ; report-uri /csp-report
< content-security-policy-report-only: block-all-mixed-content ; report-uri /csp-report
< location: https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/6.0.130/DeezerDesktop_6.0.130.dmg
< x-host: blm-web-93
< x-ua-compatible: IE=edge,chrome=1,requiresActiveX=true
< x-content-type-options: nosniff
< content-length: 0
< content-type: text/html; charset=utf-8
< strict-transport-security: max-age=31536000; includeSubDomains
< date: Tue, 21 May 2024 14:39:51 GMT
< set-cookie: sid=fre9e0aaa2d11f1829bd8284f8f126157d7d0035; path=/; domain=.deezer.com; secure; HttpOnly; SameSite=None
< set-cookie: dzr_uniq_id=dzr_uniq_id_fr3b21358303e057f593f71f999c089bc37652b7; expires=Sun, 17-Nov-2024 14:39:51 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure; SameSite=None
< x-org: FR
< set-cookie: _abck=5017720B8CF8037455FEB42BAF827BF9~-1~YAAQmKUQAlPr1FGPAQAADSqYmwv9HV88R/7aWy626zlBlY7cCy2e9rROBYPWXvpJ4STZz/v5a2uWAeTw7Pk3sZd37Ylft0azbEJdYcuvLmjHirkUyM0xCG8EONaGFgNkLlB+FrTofaInibxTc8jTUFOqC8qbHFQ4ValX4DEXqaW3H3fhkshe2qM3a3pqIFW6PMQLJ3hudavD8fIwSs5FfbSemY36/vci/F+cQtN8iSp0rY9SgIRNkdhsWHifJGfyCJZK0ORPzcoFIZ3npxr3JO/GmbXJ8nuFQKQ+vbIaQwD556cErnPtOwcCnkmZHU6QEgQXY0m2suu+AjhJicoiQND2Ir3hjOzciUnjhcGatHmq4+DbmGU3d0s=~-1~-1~-1; Domain=.deezer.com; Path=/; Expires=Wed, 21 May 2025 14:39:51 GMT; Max-Age=31536000; SameSite=None; Secure
< set-cookie: bm_sz=D0A082A451C89909601E7EB77B5AAD2F~YAAQmKUQAlTr1FGPAQAADSqYmxfthIYLIfH6Q/9gLBnJaWamKO9Bte/tt6+zXoIBqZZsZkQqUTjsC8QQ5lL7ZmDNf4OL2nbbaDMj2MkziHnvN8XBpllXK6opLttpwCO0tjH6HArO8unaLb+x35rxekZHCyte8g1+7uIhn/sXv0zNUu+EKgPNV/2rvMhYYc+kd1sM6ItfoojrF4Kwl9/0nmkVkWyXzE2nyNPhuOAn1XTH90bpoILQkONRWnpxf1w0vNU6ddVBHBq+/tJCklYzaGs8DED28EXjQ/r0ncTPy0CRPBgG0Qq7nsDTHAZxxjxL7QrAoJboN+wfPL9tzxB5KLa4IbhSTXca8O3Mnt0BZ2gZPDYg1PIX~3556659~3748918; Domain=.deezer.com; Path=/; Expires=Tue, 21 May 2024 18:39:51 GMT; Max-Age=14400; SameSite=None; Secure
< 
* Ignoring the response-body
* Connection #0 to host www.deezer.com left intact
* Issue another request to this URL: 'https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/6.0.130/DeezerDesktop_6.0.130.dmg'
* Host e-cdn-content.dzcdn.net:443 was resolved.
* IPv6: (none)
* IPv4: 192.229.133.15
*   Trying 192.229.133.15:443...
* Connected to e-cdn-content.dzcdn.net (192.229.133.15) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [361 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [155 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3010 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Arizona; L=Tempe; O=Edgio, Inc.; CN=*.dzcdn.net
*  start date: May 17 00:00:00 2024 GMT
*  expire date: Jun 17 23:59:59 2025 GMT
*  subjectAltName: host "e-cdn-content.dzcdn.net" matched cert's "*.dzcdn.net"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://e-cdn-content.dzcdn.net/builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/6.0.130/DeezerDesktop_6.0.130.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: e-cdn-content.dzcdn.net]
* [HTTP/2] [1] [:path: /builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/6.0.130/DeezerDesktop_6.0.130.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /builds/deezer-desktop/8cF2rAuKxLcU1oMDmCYm8Uiqe19Ql0HTySLssdzLkQ9ZWHuDTp2JBtQOvdrFzWPA/darwin/x64/6.0.130/DeezerDesktop_6.0.130.dmg HTTP/2
> Host: e-cdn-content.dzcdn.net
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< accept-ranges: bytes
< access-control-expose-headers: x-deezer-client-ip, content-length, content-range
< age: 364027
< content-type: application/x-apple-diskimage
< date: Tue, 21 May 2024 14:39:51 GMT
< etag: "54aee74-617c521149031"
< last-modified: Mon, 06 May 2024 08:48:11 GMT
< server: ECS (pab/6F8E)
< strict-transport-security: max-age=31536000; includeSubDomains
< x-cache: HIT
< x-deezer-client-ip: 82.66.221.105
< x-host: blm-upload-02
< content-length: 88796788
< 
{ [32768 bytes data]
* Connection #1 to host e-cdn-content.dzcdn.net left intact

2024-05-21 16:39:53 : DEBUG : deezer : DEBUG mode 1, not checking for blocking processes
2024-05-21 16:39:53 : REQ   : deezer : Installing Deezer
2024-05-21 16:39:53 : INFO  : deezer : Mounting /Users/alexis/DEV/installomator-alexis/build/Deezer.dmg
2024-05-21 16:39:56 : DEBUG : deezer : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $2A945277
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $BAD379CC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $66EDBE28
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $3DE3919A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $66EDBE28
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $34DC164F
verified   CRC32 $B2022E1E
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Deezer 6.0.130

2024-05-21 16:39:56 : INFO  : deezer : Mounted: /Volumes/Deezer 6.0.130
2024-05-21 16:39:56 : INFO  : deezer : Verifying: /Volumes/Deezer 6.0.130/Deezer.app
2024-05-21 16:39:56 : DEBUG : deezer : App size: 196M	/Volumes/Deezer 6.0.130/Deezer.app
2024-05-21 16:39:58 : DEBUG : deezer : Debugging enabled, App Verification output was:
/Volumes/Deezer 6.0.130/Deezer.app: accepted
source=Developer ID
origin=Developer ID Application: DEEZER SA (7QLUP2K45C)

2024-05-21 16:39:58 : INFO  : deezer : Team ID matching: 7QLUP2K45C (expected: 7QLUP2K45C )
2024-05-21 16:39:58 : INFO  : deezer : Downloaded version of Deezer is 6.0.130 on versionKey CFBundleShortVersionString, same as installed.
2024-05-21 16:39:58 : DEBUG : deezer : Unmounting /Volumes/Deezer 6.0.130
2024-05-21 16:39:58 : DEBUG : deezer : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-05-21 16:39:58 : DEBUG : deezer : DEBUG mode 1, not reopening anything
2024-05-21 16:39:58 : REG   : deezer : No new version to install
2024-05-21 16:39:58 : REQ   : deezer : ################## End Installomator, exit code 0
```