### PR TITLE
Create microsoftteams-rollingout.sh

### DIFF
--- a/fragments/labels/microsoftteams-rollingout.sh
+++ b/fragments/labels/microsoftteams-rollingout.sh
@@ -1,4 +1,4 @@
-microsoftteamsrollingout)
+microsoftteams-rollingout)
     name="Microsoft Teams"
     type="pkg"
     packageID="com.microsoft.teams2"

--- a/fragments/labels/microsoftteamsrollingout.sh
+++ b/fragments/labels/microsoftteamsrollingout.sh
@@ -1,0 +1,21 @@
+microsoftteamsrollingout)
+    name="Microsoft Teams"
+    type="pkg"
+    packageID="com.microsoft.teams2"
+    # Fetch the latest version number from the Microsoft documentation page
+    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning |
+        awk '/<h4 id="mac-version-history">Mac version history<\/h4>/,/<\/table>/' |
+        grep -A 3 '(Rolling out)' |
+        grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' |
+        head -n 1)
+    downloadURL="https://statics.teams.cdn.office.net/production-osx/${appNewVersion}/MicrosoftTeams.pkg"
+    expectedTeamID="UBF8T346G9"
+    blockingProcesses=( Teams MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams WebView Helper" "Microsoft Teams Launcher" "Microsoft Teams (work preview)" "Microsoft Teams classic Helper" "com.microsoft.teams2.respawn")
+    # msupdate requires a PPPC profile pushed out from Jamf to work, https://github.com/pbowden-msft/MobileConfigs/tree/master/Jamf-MSUpdate
+    if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
+        printlog "Running msupdate --list"
+        "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" --list
+    fi
+    updateTool="/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate"
+    updateToolArguments=( --install --apps TEAMS21 ) # --wait 600
+    ;;

--- a/fragments/labels/microsoftteamsrollingout.sh
+++ b/fragments/labels/microsoftteamsrollingout.sh
@@ -3,11 +3,7 @@ microsoftteamsrollingout)
     type="pkg"
     packageID="com.microsoft.teams2"
     # Fetch the latest version number from the Microsoft documentation page
-    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning |
-        awk '/<h4 id="mac-version-history">Mac version history<\/h4>/,/<\/table>/' |
-        grep -A 3 '(Rolling out)' |
-        grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' |
-        head -n 1)
+    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning | awk '/<h4 id="mac-version-history">Mac version history<\/h4>/,/<\/table>/' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
     downloadURL="https://statics.teams.cdn.office.net/production-osx/${appNewVersion}/MicrosoftTeams.pkg"
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams WebView Helper" "Microsoft Teams Launcher" "Microsoft Teams (work preview)" "Microsoft Teams classic Helper" "com.microsoft.teams2.respawn")


### PR DESCRIPTION
label "microsoftteamsrollingout" label for the "rolling out" version of "Microsoft Teams.app" (post app binary name-changes) as listed on the Microsoft Learn page: [Teams App Versioning](https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning)


__________________________________-
OUTPUT of ./assemble.sh microsoftteamsrollingout

```
utils % ./assemble.sh microsoftteamsrollingout        
2024-05-23 18:15:40 : REQ   : microsoftteamsrollingout : ################## Start Installomator v. 10.6beta, date 2024-05-23
2024-05-23 18:15:40 : INFO  : microsoftteamsrollingout : ################## Version: 10.6beta
2024-05-23 18:15:40 : INFO  : microsoftteamsrollingout : ################## Date: 2024-05-23
2024-05-23 18:15:40 : INFO  : microsoftteamsrollingout : ################## microsoftteamsrollingout
2024-05-23 18:15:40 : DEBUG : microsoftteamsrollingout : DEBUG mode 1 enabled.
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : name=Microsoft Teams
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : appName=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : type=pkg
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : archiveName=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : downloadURL=https://statics.teams.cdn.office.net/production-osx/24102.2214.2869.7475/MicrosoftTeams.pkg
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : curlOptions=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : appNewVersion=24102.2214.2869.7475
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : appCustomVersion function: Not defined
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : versionKey=CFBundleShortVersionString
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : packageID=com.microsoft.teams2
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : pkgName=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : choiceChangesXML=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : expectedTeamID=UBF8T346G9
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : blockingProcesses=Teams MSTeams Microsoft Teams Microsoft Teams WebView Microsoft Teams WebView Helper Microsoft Teams Launcher Microsoft Teams (work preview) Microsoft Teams classic Helper com.microsoft.teams2.respawn
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : installerTool=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : CLIInstaller=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : CLIArguments=
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : updateToolArguments=--install --apps TEAMS21
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : updateToolRunAsCurrentUser=
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : BLOCKING_PROCESS_ACTION=tell_user
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : NOTIFY=success
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : LOGGING=DEBUG
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : Label type: pkg
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : archiveName: Microsoft Teams.pkg
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : Changing directory to /Users/Shared/Installomator/Installomator/build
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : found packageID com.microsoft.teams2 installed, version 24102.2214.2869.7475
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : appversion: 24102.2214.2869.7475
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : Latest version of Microsoft Teams is 24102.2214.2869.7475
2024-05-23 18:15:41 : WARN  : microsoftteamsrollingout : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : App needs to be updated and uses /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2024-05-23 18:15:41 : WARN  : microsoftteamsrollingout : DEBUG mode 1 enabled, not running update tool
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : Microsoft Teams.pkg exists and DEBUG mode 1 enabled, skipping download
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : DEBUG mode 1, not checking for blocking processes
2024-05-23 18:15:41 : REQ   : microsoftteamsrollingout : Installing Microsoft Teams
2024-05-23 18:15:41 : INFO  : microsoftteamsrollingout : Verifying: Microsoft Teams.pkg
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : File list: -rw-r--r--  1 gknackstedt  wheel   288M May 23 14:40 Microsoft Teams.pkg
2024-05-23 18:15:41 : DEBUG : microsoftteamsrollingout : File type: Microsoft Teams.pkg: xar archive compressed TOC: 5394, SHA-1 checksum
2024-05-23 18:15:42 : DEBUG : microsoftteamsrollingout : spctlOut is Microsoft Teams.pkg: accepted
2024-05-23 18:15:42 : DEBUG : microsoftteamsrollingout : source=Notarized Developer ID
2024-05-23 18:15:42 : DEBUG : microsoftteamsrollingout : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2024-05-23 18:15:42 : INFO  : microsoftteamsrollingout : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2024-05-23 18:15:42 : INFO  : microsoftteamsrollingout : Checking package version.
2024-05-23 18:15:42 : INFO  : microsoftteamsrollingout : Downloaded package com.microsoft.teams2 version 24102.2214.2869.7475
2024-05-23 18:15:42 : INFO  : microsoftteamsrollingout : Downloaded version of Microsoft Teams is the same as installed.
2024-05-23 18:15:42 : DEBUG : microsoftteamsrollingout : DEBUG mode 1, not reopening anything
2024-05-23 18:15:42 : REQ   : microsoftteamsrollingout : No new version to install
2024-05-23 18:15:42 : REQ   : microsoftteamsrollingout : ################## End Installomator, exit code 0 

__________________________________________
OUTPUT of ./assemble.sh microsoftteamsrollingout DEBUG=0

```
./assemble.sh microsoftteamsrollingout DEBUG=0
2024-05-23 18:14:33 : REQ   : microsoftteamsrollingout : ################## Start Installomator v. 10.6beta, date 2024-05-23
2024-05-23 18:14:33 : INFO  : microsoftteamsrollingout : ################## Version: 10.6beta
2024-05-23 18:14:33 : INFO  : microsoftteamsrollingout : ################## Date: 2024-05-23
2024-05-23 18:14:33 : INFO  : microsoftteamsrollingout : ################## microsoftteamsrollingout
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : DEBUG mode 1 enabled.
2024-05-23 18:14:33 : INFO  : microsoftteamsrollingout : setting variable from argument DEBUG=0
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : name=Microsoft Teams
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : appName=
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : type=pkg
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : archiveName=
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : downloadURL=https://statics.teams.cdn.office.net/production-osx/24102.2214.2869.7475/MicrosoftTeams.pkg
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : curlOptions=
2024-05-23 18:14:33 : DEBUG : microsoftteamsrollingout : appNewVersion=24102.2214.2869.7475
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : appCustomVersion function: Not defined
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : versionKey=CFBundleShortVersionString
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : packageID=com.microsoft.teams2
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : pkgName=
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : choiceChangesXML=
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : expectedTeamID=UBF8T346G9
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : blockingProcesses=Teams MSTeams Microsoft Teams Microsoft Teams WebView Microsoft Teams WebView Helper Microsoft Teams Launcher Microsoft Teams (work preview) Microsoft Teams classic Helper com.microsoft.teams2.respawn
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : installerTool=
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : CLIInstaller=
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : CLIArguments=
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : updateToolArguments=--install --apps TEAMS21
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : updateToolRunAsCurrentUser=
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : BLOCKING_PROCESS_ACTION=tell_user
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : NOTIFY=success
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : LOGGING=DEBUG
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : Label type: pkg
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : archiveName: Microsoft Teams.pkg
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : Changing directory to /var/folders/7n/9mn01rf93n38hn7564ydmsv80000gq/T/tmp.z6fUUui9iQ
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : found packageID com.microsoft.teams2 installed, version 24102.2214.2869.7475
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : appversion: 24102.2214.2869.7475
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : Latest version of Microsoft Teams is 24102.2214.2869.7475
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : There is no newer version available.
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : Deleting /var/folders/7n/9mn01rf93n38hn7564ydmsv80000gq/T/tmp.z6fUUui9iQ
2024-05-23 18:14:34 : DEBUG : microsoftteamsrollingout : Debugging enabled, Deleting tmpDir output was:
/var/folders/7n/9mn01rf93n38hn7564ydmsv80000gq/T/tmp.z6fUUui9iQ
2024-05-23 18:14:34 : INFO  : microsoftteamsrollingout : Installomator did not close any apps, so no need to reopen any apps.
2024-05-23 18:14:34 : REQ   : microsoftteamsrollingout : No newer version.
2024-05-23 18:14:34 : REQ   : microsoftteamsrollingout : ################## End Installomator, exit code 0 
```