### PR TITLE
Update docker.sh

### DIFF
--- a/fragments/labels/docker.sh
+++ b/fragments/labels/docker.sh
@@ -1,13 +1,18 @@
 docker)
     name="Docker"
     type="dmg"
-    if [[ $(arch) == arm64 ]]; then
-     downloadURL="https://desktop.docker.com/mac/stable/arm64/Docker.dmg"
-     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/arm64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
-    elif [[ $(arch) == i386 ]]; then
-     downloadURL="https://desktop.docker.com/mac/stable/amd64/Docker.dmg"
-     appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
+    if [[ "$(arch)" == arm64 ]]; then
+        downloadURL="https://desktop.docker.com/mac/stable/arm64/Docker.dmg"
+        appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/arm64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
+    elif [[ "$(arch)" == i386 ]]; then
+        downloadURL="https://desktop.docker.com/mac/stable/amd64/Docker.dmg"
+        appNewVersion=$( curl -fs "https://desktop.docker.com/mac/main/amd64/appcast.xml" | xpath '(//rss/channel/item/enclosure/@sparkle:shortVersionString)[last()]' 2>/dev/null | cut -d '"' -f2 )
+    fi
+    CLIInstaller="Docker.app/Contents/MacOS/install"
+    CLIArguments=(--accept-license)
+    if [[ "${currentUser}" != "loginwindow" ]];then
+        CLIArguments+=(--user "${currentUser}")
     fi
     expectedTeamID="9BNSXJN65R"
-    blockingProcesses=( "Docker Desktop" "Docker" )
+    blockingProcesses=( "Docker Desktop" )
     ;;


### PR DESCRIPTION
The current installation method is inconvenient because the flow requires end users to have separate administrative privileges.
Since a [command line installation method is officially provided](https://docs.docker.com/desktop/install/mac-install/#install-and-run-docker-desktop-on-mac), I have changed to use this method.


```sh
$ ./utils/assemble.sh docker DEBUG=0 INSTALL=force BLOCKING_PROCESS_ACTION=kill
2024-05-31 15:33:50 : REQ   : docker : ################## Start Installomator v. 10.6beta, date 2024-05-31
2024-05-31 15:33:50 : INFO  : docker : ################## Version: 10.6beta
2024-05-31 15:33:50 : INFO  : docker : ################## Date: 2024-05-31
2024-05-31 15:33:50 : INFO  : docker : ################## docker
2024-05-31 15:33:50 : DEBUG : docker : DEBUG mode 1 enabled.
2024-05-31 15:33:50 : INFO  : docker : setting variable from argument DEBUG=0
2024-05-31 15:33:50 : INFO  : docker : setting variable from argument INSTALL=force
2024-05-31 15:33:50 : INFO  : docker : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2024-05-31 15:33:50 : DEBUG : docker : name=Docker
2024-05-31 15:33:50 : DEBUG : docker : appName=
2024-05-31 15:33:50 : DEBUG : docker : type=dmg
2024-05-31 15:33:50 : DEBUG : docker : archiveName=
2024-05-31 15:33:50 : DEBUG : docker : downloadURL=https://desktop.docker.com/mac/stable/arm64/Docker.dmg
2024-05-31 15:33:50 : DEBUG : docker : curlOptions=
2024-05-31 15:33:50 : DEBUG : docker : appNewVersion=4.30.0
2024-05-31 15:33:50 : DEBUG : docker : appCustomVersion function: Not defined
2024-05-31 15:33:50 : DEBUG : docker : versionKey=CFBundleShortVersionString
2024-05-31 15:33:50 : DEBUG : docker : packageID=
2024-05-31 15:33:50 : DEBUG : docker : pkgName=
2024-05-31 15:33:50 : DEBUG : docker : choiceChangesXML=
2024-05-31 15:33:50 : DEBUG : docker : expectedTeamID=9BNSXJN65R
2024-05-31 15:33:50 : DEBUG : docker : blockingProcesses=Docker Desktop
2024-05-31 15:33:50 : DEBUG : docker : installerTool=
2024-05-31 15:33:50 : DEBUG : docker : CLIInstaller=Docker.app/Contents/MacOS/install
2024-05-31 15:33:50 : DEBUG : docker : CLIArguments=--accept-license --user kenchan0130
2024-05-31 15:33:50 : DEBUG : docker : updateTool=
2024-05-31 15:33:50 : DEBUG : docker : updateToolArguments=
2024-05-31 15:33:50 : DEBUG : docker : updateToolRunAsCurrentUser=
2024-05-31 15:33:50 : INFO  : docker : BLOCKING_PROCESS_ACTION=kill
2024-05-31 15:33:50 : INFO  : docker : NOTIFY=success
2024-05-31 15:33:50 : INFO  : docker : LOGGING=DEBUG
2024-05-31 15:33:50 : INFO  : docker : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-31 15:33:50 : INFO  : docker : Label type: dmg
2024-05-31 15:33:50 : INFO  : docker : archiveName: Docker.dmg
2024-05-31 15:33:50 : DEBUG : docker : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DqeyCoMV
2024-05-31 15:33:50 : INFO  : docker : App(s) found: /Applications/Docker.app
2024-05-31 15:33:50 : INFO  : docker : found app at /Applications/Docker.app, version 4.30.0, on versionKey CFBundleShortVersionString
2024-05-31 15:33:50 : INFO  : docker : appversion: 4.30.0
2024-05-31 15:33:50 : INFO  : docker : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-05-31 15:33:50 : INFO  : docker : Latest version of Docker is 4.30.0
2024-05-31 15:33:50 : INFO  : docker : There is no newer version available.
2024-05-31 15:33:50 : REQ   : docker : Downloading https://desktop.docker.com/mac/stable/arm64/Docker.dmg to Docker.dmg
2024-05-31 15:33:50 : DEBUG : docker : No Dialog connection, just download
2024-05-31 15:34:01 : DEBUG : docker : File list: -rw-r--r--  1 root  wheel   411M  5 31 15:34 Docker.dmg
2024-05-31 15:34:01 : DEBUG : docker : File type: Docker.dmg: XZ compressed data, checksum NONE
2024-05-31 15:34:01 : DEBUG : docker : curl output was:
*   Trying 54.239.168.78:443...
* Connected to desktop.docker.com (54.239.168.78) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5104 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.docker.com
*  start date: Oct  2 00:00:00 2023 GMT
*  expire date: Oct 31 23:59:59 2024 GMT
*  subjectAltName: host "desktop.docker.com" matched cert's "*.docker.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://desktop.docker.com/mac/stable/arm64/Docker.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: desktop.docker.com]
* [HTTP/2] [1] [:path: /mac/stable/arm64/Docker.dmg]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mac/stable/arm64/Docker.dmg HTTP/2
> Host: desktop.docker.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 301
< content-length: 0
< location: https://desktop.docker.com/mac/main/arm64/Docker.dmg
< date: Fri, 31 May 2024 02:38:38 GMT
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 3c3be6aa0993c54a165cc8a390c3ccc2.cloudfront.net (CloudFront)
< x-amz-cf-pop: KIX56-C2
< x-amz-cf-id: VUki0KxqFCe-9EK-PK3u4-3hgA4QL9o1L7goMnlqNXu9pf9ngaWw2A==
< age: 14113
<
{ [0 bytes data]
* Connection #0 to host desktop.docker.com left intact
* Issue another request to this URL: 'https://desktop.docker.com/mac/main/arm64/Docker.dmg'
* Found bundle for host: 0x600003dd4450 [can multiplex]
* Re-using existing connection with host desktop.docker.com
* [HTTP/2] [3] OPENED stream for https://desktop.docker.com/mac/main/arm64/Docker.dmg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: desktop.docker.com]
* [HTTP/2] [3] [:path: /mac/main/arm64/Docker.dmg]
* [HTTP/2] [3] [user-agent: curl/8.4.0]
* [HTTP/2] [3] [accept: */*]
> GET /mac/main/arm64/Docker.dmg HTTP/2
> Host: desktop.docker.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< content-length: 431147839
< last-modified: Fri, 17 May 2024 16:03:16 GMT
< x-amz-version-id: 9Z_bdf2jadbkZBmYr_ISgMmvD.nrW0dt
< server: AmazonS3
< date: Fri, 31 May 2024 01:52:58 GMT
< etag: "a90611aa271a17b8bfb8a1e9519cad68"
< vary: Accept-Encoding
< x-cache: Hit from cloudfront
< via: 1.1 3c3be6aa0993c54a165cc8a390c3ccc2.cloudfront.net (CloudFront)
< x-amz-cf-pop: KIX56-C2
< x-amz-cf-id: uVlYIe8Cwj9KlHIiAVDiSgXtjC8Thuv3iSQYlK2r5alVYEZN9n0Xqw==
< age: 20057
<
{ [16020 bytes data]
* Connection #0 to host desktop.docker.com left intact

2024-05-31 15:34:01 : REQ   : docker : no more blocking processes, continue with update
2024-05-31 15:34:01 : REQ   : docker : Installing Docker
2024-05-31 15:34:01 : INFO  : docker : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DqeyCoMV/Docker.dmg
2024-05-31 15:34:23 : DEBUG : docker : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $BBCF6169
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $1354C779
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $86DEEACF
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)のチェックサムを計算中…
EFI System Partition (C12A7328-F81F-: 検証済み CRC32 $B54B659C
disk image (Apple_HFS : 5)のチェックサムを計算中…
disk image (Apple_HFS : 5): 検証済み CRC32 $391414F4
(Apple_Free : 6)のチェックサムを計算中…
(Apple_Free : 6): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 7)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $86DEEACF
GPT Header (Backup GPT Header : 8)のチェックサムを計算中…
GPT Header (Backup GPT Header : 8): 検証済み CRC32 $950C28F4
検証済み CRC32 $2473DCCD
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Docker

2024-05-31 15:34:23 : INFO  : docker : Mounted: /Volumes/Docker
2024-05-31 15:34:23 : INFO  : docker : Verifying: /Volumes/Docker/Docker.app
2024-05-31 15:34:23 : DEBUG : docker : App size: 1.6G	/Volumes/Docker/Docker.app
2024-05-31 15:34:48 : DEBUG : docker : Debugging enabled, App Verification output was:
/Volumes/Docker/Docker.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Docker Inc (9BNSXJN65R)

2024-05-31 15:34:48 : INFO  : docker : Team ID matching: 9BNSXJN65R (expected: 9BNSXJN65R )
2024-05-31 15:34:48 : INFO  : docker : Downloaded version of Docker is 4.30.0 on versionKey CFBundleShortVersionString, same as installed.
2024-05-31 15:34:48 : INFO  : docker : Using force to install anyway.
2024-05-31 15:34:48 : INFO  : docker : App has LSMinimumSystemVersion: 11.0
2024-05-31 15:34:48 : INFO  : docker : CLIInstaller exists, running installer command /Volumes/Docker/Docker.app/Contents/MacOS/install --accept-license --user kenchan0130
2024-05-31 15:35:06 : INFO  : docker : Succesfully ran /Volumes/Docker/Docker.app/Contents/MacOS/install --accept-license --user kenchan0130
2024-05-31 15:35:06 : DEBUG : docker : Debugging enabled, update tool output was:
Log

2024-05-31 15:35:06 : INFO  : docker : Finishing...
2024-05-31 15:35:09 : INFO  : docker : App(s) found: /Applications/Docker.app
2024-05-31 15:35:09 : INFO  : docker : found app at /Applications/Docker.app, version 4.30.0, on versionKey CFBundleShortVersionString
2024-05-31 15:35:09 : REQ   : docker : Installed Docker, version 4.30.0
2024-05-31 15:35:09 : INFO  : docker : notifying
2024-05-31 15:35:10 : DEBUG : docker : Unmounting /Volumes/Docker
2024-05-31 15:35:10 : DEBUG : docker : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-05-31 15:35:10 : DEBUG : docker : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DqeyCoMV
2024-05-31 15:35:10 : DEBUG : docker : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DqeyCoMV/Docker.dmg
2024-05-31 15:35:10 : DEBUG : docker : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DqeyCoMV
2024-05-31 15:35:10 : INFO  : docker : Installomator did not close any apps, so no need to reopen any apps.
2024-05-31 15:35:10 : REQ   : docker : All done!
2024-05-31 15:35:10 : REQ   : docker : ################## End Installomator, exit code 0
```