### PR TITLE
Fix GIMP download

### DIFF
--- a/fragments/labels/gimp.sh
+++ b/fragments/labels/gimp.sh
@@ -2,9 +2,9 @@ gimp)
     name="GIMP"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-arm64.dmg")
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-arm64.*\.dmg")
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-x86_64.dmg")
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-x86_64.*\.dmg")
     fi
     appNewVersion=$(echo $downloadURL | cut -d "-" -f 2)
     expectedTeamID="T25BQ8HSJF"

--- a/fragments/labels/gimp.sh
+++ b/fragments/labels/gimp.sh
@@ -2,9 +2,9 @@ gimp)
     name="GIMP"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-arm64.*\.dmg")
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o 'download\.gimp\.org\/gimp\/v[0-9\.]*\/macos\/gimp-[0-9\.]*-arm64.*\.dmg\"' | tr -d '"')
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-x86_64.*\.dmg")
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o 'download\.gimp\.org\/gimp\/v[0-9\.]*\/macos\/gimp-[0-9\.]*-x86_64.*\.dmg\"' | tr -d '"')
     fi
     appNewVersion=$(echo $downloadURL | cut -d "-" -f 2)
     expectedTeamID="T25BQ8HSJF"


### PR DESCRIPTION
Fixes https://github.com/Installomator/Installomator/issues/1676
```
sudo ./installomator.sh gimp BLOCKING_PROCESS_ACTION=prompt_user_loop NOTIFY=silent DEBUG=0

Password:
2024-05-31 14:29:41 : REQ   : gimp : ################## Start Installomator v. 10.5.1, date 2024-03-14
2024-05-31 14:29:41 : INFO  : gimp : ################## Version: 10.5.1
2024-05-31 14:29:41 : INFO  : gimp : ################## Date: 2024-03-14
2024-05-31 14:29:41 : INFO  : gimp : ################## gimp
2024-05-31 14:29:42 : INFO  : gimp : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-05-31 14:29:42 : INFO  : gimp : setting variable from argument NOTIFY=silent
2024-05-31 14:29:42 : INFO  : gimp : setting variable from argument DEBUG=0
2024-05-31 14:29:42 : INFO  : gimp : BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-05-31 14:29:42 : INFO  : gimp : NOTIFY=silent
2024-05-31 14:29:42 : INFO  : gimp : LOGGING=INFO
2024-05-31 14:29:42 : INFO  : gimp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-05-31 14:29:42 : INFO  : gimp : Label type: dmg
2024-05-31 14:29:42 : INFO  : gimp : archiveName: GIMP.dmg
2024-05-31 14:29:42 : INFO  : gimp : no blocking processes defined, using GIMP as default
2024-05-31 14:29:42 : INFO  : gimp : name: GIMP, appName: GIMP.app
2024-05-31 14:29:42.531 mdfind[56384:7580944] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-05-31 14:29:42.531 mdfind[56384:7580944] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-05-31 14:29:42.613 mdfind[56384:7580944] Couldn't determine the mapping between prefab keywords and predicates.
2024-05-31 14:29:42 : WARN  : gimp : No previous app found
2024-05-31 14:29:42 : WARN  : gimp : could not find GIMP.app
2024-05-31 14:29:42 : INFO  : gimp : appversion: 
2024-05-31 14:29:42 : INFO  : gimp : Latest version of GIMP is 2.10.38
2024-05-31 14:29:42 : REQ   : gimp : Downloading https://download.gimp.org/gimp/v2.10/macos/gimp-2.10.38-arm64-1.dmg to GIMP.dmg
2024-05-31 14:29:52 : REQ   : gimp : no more blocking processes, continue with update
2024-05-31 14:29:52 : REQ   : gimp : Installing GIMP
2024-05-31 14:29:52 : INFO  : gimp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.GJ9QOsQ3cp/GIMP.dmg
2024-05-31 14:29:55 : INFO  : gimp : Mounted: /Volumes/GIMP 2.10 Install
2024-05-31 14:29:55 : INFO  : gimp : Verifying: /Volumes/GIMP 2.10 Install/GIMP.app
2024-05-31 14:30:06 : INFO  : gimp : Team ID matching: T25BQ8HSJF (expected: T25BQ8HSJF )
2024-05-31 14:30:06 : INFO  : gimp : Installing GIMP version 2.10.38 on versionKey CFBundleShortVersionString.
2024-05-31 14:30:06 : INFO  : gimp : App has LSMinimumSystemVersion: 10.13
2024-05-31 14:30:06 : INFO  : gimp : Copy /Volumes/GIMP 2.10 Install/GIMP.app to /Applications
2024-05-31 14:30:22 : WARN  : gimp : Changing owner to maartenwijnants
2024-05-31 14:30:23 : INFO  : gimp : Finishing...
2024-05-31 14:30:26 : INFO  : gimp : App(s) found: /Applications/GIMP.app
2024-05-31 14:30:26 : INFO  : gimp : found app at /Applications/GIMP.app, version 2.10.38, on versionKey CFBundleShortVersionString
2024-05-31 14:30:26 : REQ   : gimp : Installed GIMP, version 2.10.38
2024-05-31 14:30:27 : INFO  : gimp : Installomator did not close any apps, so no need to reopen any apps.
2024-05-31 14:30:27 : REQ   : gimp : All done!
2024-05-31 14:30:27 : REQ   : gimp : ################## End Installomator, exit code 0
```