### PR TITLE
add orbstack label

### DIFF
--- a/fragments/labels/orbstack.sh
+++ b/fragments/labels/orbstack.sh
@@ -1,0 +1,11 @@
+orbstack)
+    name="OrbStack"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://orbstack.dev/download/stable/latest/arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=https://orbstack.dev/download/stable/latest/amd64
+    fi
+    appNewVersion=$( curl --fail --silent --head $downloadURL | grep "location:" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' )
+    expectedTeamID="HUAQ24HBR6"
+    ;;


### PR DESCRIPTION
```shell
# ./assemble.sh orbstack INSTALL=force
2024-06-02 10:26:08 : REQ   : orbstack : ################## Start Installomator v. 10.6beta, date 2024-06-02
2024-06-02 10:26:08 : INFO  : orbstack : ################## Version: 10.6beta
2024-06-02 10:26:08 : INFO  : orbstack : ################## Date: 2024-06-02
2024-06-02 10:26:08 : INFO  : orbstack : ################## orbstack
2024-06-02 10:26:08 : DEBUG : orbstack : DEBUG mode 1 enabled.
2024-06-02 10:26:09 : INFO  : orbstack : setting variable from argument INSTALL=force
2024-06-02 10:26:09 : DEBUG : orbstack : name=OrbStack
2024-06-02 10:26:09 : DEBUG : orbstack : appName=
2024-06-02 10:26:09 : DEBUG : orbstack : type=dmg
2024-06-02 10:26:09 : DEBUG : orbstack : archiveName=
2024-06-02 10:26:09 : DEBUG : orbstack : downloadURL=https://orbstack.dev/download/stable/latest/arm64
2024-06-02 10:26:09 : DEBUG : orbstack : curlOptions=
2024-06-02 10:26:09 : DEBUG : orbstack : appNewVersion=1.6.1
2024-06-02 10:26:09 : DEBUG : orbstack : appCustomVersion function: Not defined
2024-06-02 10:26:09 : DEBUG : orbstack : versionKey=CFBundleShortVersionString
2024-06-02 10:26:09 : DEBUG : orbstack : packageID=
2024-06-02 10:26:09 : DEBUG : orbstack : pkgName=
2024-06-02 10:26:09 : DEBUG : orbstack : choiceChangesXML=
2024-06-02 10:26:09 : DEBUG : orbstack : expectedTeamID=HUAQ24HBR6
2024-06-02 10:26:09 : DEBUG : orbstack : blockingProcesses=
2024-06-02 10:26:09 : DEBUG : orbstack : installerTool=
2024-06-02 10:26:09 : DEBUG : orbstack : CLIInstaller=
2024-06-02 10:26:09 : DEBUG : orbstack : CLIArguments=
2024-06-02 10:26:09 : DEBUG : orbstack : updateTool=
2024-06-02 10:26:09 : DEBUG : orbstack : updateToolArguments=
2024-06-02 10:26:09 : DEBUG : orbstack : updateToolRunAsCurrentUser=
2024-06-02 10:26:09 : INFO  : orbstack : BLOCKING_PROCESS_ACTION=tell_user
2024-06-02 10:26:09 : INFO  : orbstack : NOTIFY=success
2024-06-02 10:26:09 : INFO  : orbstack : LOGGING=DEBUG
2024-06-02 10:26:09 : INFO  : orbstack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-02 10:26:09 : INFO  : orbstack : Label type: dmg
2024-06-02 10:26:09 : INFO  : orbstack : archiveName: OrbStack.dmg
2024-06-02 10:26:09 : INFO  : orbstack : no blocking processes defined, using OrbStack as default
2024-06-02 10:26:09 : DEBUG : orbstack : Changing directory to /Users/patrick/Developer/Installomator/build
2024-06-02 10:26:09 : INFO  : orbstack : App(s) found: /Applications/OrbStack.app
2024-06-02 10:26:09 : INFO  : orbstack : found app at /Applications/OrbStack.app, version 1.6.1, on versionKey CFBundleShortVersionString
2024-06-02 10:26:09 : INFO  : orbstack : appversion: 1.6.1
2024-06-02 10:26:09 : INFO  : orbstack : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-06-02 10:26:09 : INFO  : orbstack : Latest version of OrbStack is 1.6.1
2024-06-02 10:26:09 : WARN  : orbstack : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-06-02 10:26:09 : REQ   : orbstack : Downloading https://orbstack.dev/download/stable/latest/arm64 to OrbStack.dmg
2024-06-02 10:26:09 : DEBUG : orbstack : No Dialog connection, just download
2024-06-02 10:26:13 : DEBUG : orbstack : File list: -rw-r--r--  1 patrick  staff   415M  2 Jun 10:26 OrbStack.dmg
2024-06-02 10:26:13 : DEBUG : orbstack : File type: OrbStack.dmg: lzfse encoded, lzvn compressed
2024-06-02 10:26:13 : DEBUG : orbstack : curl output was:
* Host orbstack.dev:443 was resolved.
* IPv6: (none)
* IPv4: 76.76.21.142, 76.76.21.9
*   Trying 76.76.21.142:443...
* Connected to orbstack.dev (76.76.21.142) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2580 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=orbstack.dev
*  start date: Apr  3 03:44:12 2024 GMT
*  expire date: Jul  2 03:44:11 2024 GMT
*  subjectAltName: host "orbstack.dev" matched cert's "orbstack.dev"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://orbstack.dev/download/stable/latest/arm64
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: orbstack.dev]
* [HTTP/2] [1] [:path: /download/stable/latest/arm64]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /download/stable/latest/arm64 HTTP/2
> Host: orbstack.dev
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 307 
< access-control-allow-origin: https://docs.orbstack.dev
< cache-control: public, max-age=0, must-revalidate
< content-type: text/plain
< date: Sun, 02 Jun 2024 00:26:09 GMT
< location: https://cdn-updates.orbstack.dev/arm64/OrbStack_v1.6.1_17010_arm64.dmg
< permissions-policy: camera=(), microphone=(), geolocation=(), browsing-topics=()
< referrer-policy: same-origin
< server: Vercel
< strict-transport-security: max-age=63072000
< x-content-type-options: nosniff
< x-dns-prefetch-control: on
< x-frame-options: SAMEORIGIN
< x-vercel-id: syd1::djxhz-1717287969430-9d5faa9a4ccf
< x-xss-protection: 1; mode=block
< 
* Ignoring the response-body
* Connection #0 to host orbstack.dev left intact
* Issue another request to this URL: 'https://cdn-updates.orbstack.dev/arm64/OrbStack_v1.6.1_17010_arm64.dmg'
* Host cdn-updates.orbstack.dev:443 was resolved.
* IPv6: 2606:4700:20::681a:e93, 2606:4700:20::ac43:4588, 2606:4700:20::681a:f93
* IPv4: 172.67.69.136, 104.26.14.147, 104.26.15.147
*   Trying 172.67.69.136:443...
* Connected to cdn-updates.orbstack.dev (172.67.69.136) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2308 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=cdn-updates.orbstack.dev
*  start date: Jan 15 00:00:00 2024 GMT
*  expire date: Dec 31 23:59:59 2024 GMT
*  subjectAltName: host "cdn-updates.orbstack.dev" matched cert's "cdn-updates.orbstack.dev"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /arm64/OrbStack_v1.6.1_17010_arm64.dmg HTTP/1.1
> Host: cdn-updates.orbstack.dev
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Sun, 02 Jun 2024 00:26:09 GMT
< Content-Type: application/x-apple-diskimage
< Content-Length: 435495393
< Connection: keep-alive
< ETag: "b50ef2656194f67db879c496c4ef996d-84"
< Last-Modified: Wed, 29 May 2024 02:02:19 GMT
< Vary: Accept-Encoding
< Cache-Control: max-age=14400
< CF-Cache-Status: HIT
< Age: 4998
< Accept-Ranges: bytes
< Report-To: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=IstQrKsESPhDRwn2ezO0kXJtaSeZ5ScpL9PQbALFJywSKsZnvvEBrjhVIshpnOhZ4WwgXEcLIvBZGyFlQfzUbvS1g%2BwXsZsNhr922DEJ7EQtCCP93%2FiYpDBVyk7CxTHFLfp0aIOJ%2FdPzUw%3D%3D"}],"group":"cf-nel","max_age":604800}
< NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< Server: cloudflare
< CF-RAY: 88d34f713fd5555d-SYD
< 
{ [45628 bytes data]
* Connection #1 to host cdn-updates.orbstack.dev left intact

2024-06-02 10:26:13 : DEBUG : orbstack : DEBUG mode 1, not checking for blocking processes
2024-06-02 10:26:13 : REQ   : orbstack : Installing OrbStack
2024-06-02 10:26:13 : INFO  : orbstack : Mounting /Users/patrick/Developer/Installomator/build/OrbStack.dmg
2024-06-02 10:26:17 : DEBUG : orbstack : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C42F7C4C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $993EAFFF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $03E6782D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $96D195EC
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $03E6782D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9FF069FA
verified   CRC32 $E5D8F950
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_APFS
/dev/disk13         	EF57347C-0000-11AA-AA11-0030654
/dev/disk13s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Install OrbStack v1.6.1

2024-06-02 10:26:17 : INFO  : orbstack : Mounted: /Volumes/Install OrbStack v1.6.1
2024-06-02 10:26:17 : INFO  : orbstack : Verifying: /Volumes/Install OrbStack v1.6.1/OrbStack.app
2024-06-02 10:26:17 : DEBUG : orbstack : App size: 720M	/Volumes/Install OrbStack v1.6.1/OrbStack.app
2024-06-02 10:26:19 : DEBUG : orbstack : Debugging enabled, App Verification output was:
/Volumes/Install OrbStack v1.6.1/OrbStack.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Orbital Labs, LLC (U.S.) (HUAQ24HBR6)

2024-06-02 10:26:19 : INFO  : orbstack : Team ID matching: HUAQ24HBR6 (expected: HUAQ24HBR6 )
2024-06-02 10:26:19 : INFO  : orbstack : Downloaded version of OrbStack is 1.6.1 on versionKey CFBundleShortVersionString, same as installed.
2024-06-02 10:26:19 : INFO  : orbstack : Using force to install anyway.
2024-06-02 10:26:19 : INFO  : orbstack : App has LSMinimumSystemVersion: 12.3
2024-06-02 10:26:19 : DEBUG : orbstack : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-06-02 10:26:19 : INFO  : orbstack : Finishing...
2024-06-02 10:26:22 : INFO  : orbstack : App(s) found: /Applications/OrbStack.app
2024-06-02 10:26:22 : INFO  : orbstack : found app at /Applications/OrbStack.app, version 1.6.1, on versionKey CFBundleShortVersionString
2024-06-02 10:26:22 : REQ   : orbstack : Installed OrbStack, version 1.6.1
2024-06-02 10:26:22 : INFO  : orbstack : notifying
2024-06-02 10:26:22 : DEBUG : orbstack : Unmounting /Volumes/Install OrbStack v1.6.1
2024-06-02 10:26:22 : DEBUG : orbstack : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-06-02 10:26:22 : DEBUG : orbstack : DEBUG mode 1, not reopening anything
2024-06-02 10:26:22 : REQ   : orbstack : All done!
2024-06-02 10:26:22 : REQ   : orbstack : ################## End Installomator, exit code 0 
```