### PR TITLE
Update microsoftdefender appNewVersion

### DIFF
--- a/fragments/labels/microsoftdefender.sh
+++ b/fragments/labels/microsoftdefender.sh
@@ -3,7 +3,7 @@ microsoftdefenderatp)
     name="Microsoft Defender"
     type="pkg"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=2097502"
-    appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.defender.standalone"]/version' 2>/dev/null | sed -E 's/<version>([0-9.]*) .*/\1/')
+    appNewVersion=$(curl -fs https://raw.githubusercontent.com/MicrosoftDocs/defender-docs/public/defender-endpoint/mac-whatsnew.md | grep -m 1 -o "Build: [0-9\.]*" | awk '{print $2}')
     # No version number in download url
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then


### PR DESCRIPTION
Updated appNewVersion for the Microsoft Defender label as macadmins.software is currently not being updated.
```
sudo ./installomator.sh microsoftdefender BLOCKING_PROCESS_ACTION=prompt_user_loop NOTIFY=silent DEBUG=0

2024-06-05 11:30:57 : REQ   : microsoftdefender : ################## Start Installomator v. 10.5.1, date 2024-03-14
2024-06-05 11:30:57 : INFO  : microsoftdefender : ################## Version: 10.5.1
2024-06-05 11:30:57 : INFO  : microsoftdefender : ################## Date: 2024-03-14
2024-06-05 11:30:57 : INFO  : microsoftdefender : ################## microsoftdefender
2024-06-05 11:30:57 : INFO  : microsoftdefender : Running msupdate --list

Updates available:
  MSWD2019  Microsoft Word Update 16.85.2 (24052614)

2024-06-05 11:31:10 : INFO  : microsoftdefender : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-05 11:31:10 : INFO  : microsoftdefender : setting variable from argument NOTIFY=silent
2024-06-05 11:31:10 : INFO  : microsoftdefender : setting variable from argument DEBUG=0
2024-06-05 11:31:10 : INFO  : microsoftdefender : BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-05 11:31:10 : INFO  : microsoftdefender : NOTIFY=silent
2024-06-05 11:31:10 : INFO  : microsoftdefender : LOGGING=INFO
2024-06-05 11:31:10 : INFO  : microsoftdefender : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-05 11:31:10 : INFO  : microsoftdefender : Label type: pkg
2024-06-05 11:31:10 : INFO  : microsoftdefender : archiveName: Microsoft Defender.pkg
2024-06-05 11:31:10 : INFO  : microsoftdefender : no blocking processes defined, using Microsoft Defender as default
2024-06-05 11:31:10 : INFO  : microsoftdefender : App(s) found: /Applications/Microsoft Defender.app
2024-06-05 11:31:10 : INFO  : microsoftdefender : found app at /Applications/Microsoft Defender.app, version 101.24042.0008, on versionKey CFBundleShortVersionString
2024-06-05 11:31:10 : INFO  : microsoftdefender : appversion: 101.24042.0008
2024-06-05 11:31:10 : INFO  : microsoftdefender : Latest version of Microsoft Defender is 101.24042.0008
2024-06-05 11:31:10 : INFO  : microsoftdefender : There is no newer version available.
2024-06-05 11:31:10 : INFO  : microsoftdefender : Installomator did not close any apps, so no need to reopen any apps.
2024-06-05 11:31:10 : REQ   : microsoftdefender : No newer version.
2024-06-05 11:31:10 : REQ   : microsoftdefender : ################## End Installomator, exit code 0
```