### PR TITLE
fix appNewVersion regex to account for beta versions

### DIFF
--- a/fragments/labels/1passwordcli.sh
+++ b/fragments/labels/1passwordcli.sh
@@ -3,7 +3,7 @@
     type="pkg"
     #packageID="com.1password.op"
     downloadURL=$(curl -fs https://app-updates.agilebits.com/product_history/CLI2 | grep -m 1 -i op_apple_universal | cut -d'"' -f 2)
-    appNewVersion=$(echo $downloadURL | sed -E 's/.*\/[a-zA-Z_]*([0-9.]*)\..*/\1/g')
+    appNewVersion=$(echo $downloadURL | sed -E 's/.*\/[a-zA-Z_]*([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)\.pkg.*/\1/g')
     appCustomVersion(){ /usr/local/bin/op -v }
     expectedTeamID="2BUA8C4S2C"
     ;;


### PR DESCRIPTION
This PR fixes issue #1687 

The regex should work for standard versions and beta versions, but please double check.

assemble.sh output:
```
❯ ./assemble.sh 1passwordcli DEBUG=0                                                                                                                                          ─╯
2024-06-05 21:53:22 : REQ   : 1passwordcli : ################## Start Installomator v. 10.6beta, date 2024-06-05
2024-06-05 21:53:22 : INFO  : 1passwordcli : ################## Version: 10.6beta
2024-06-05 21:53:22 : INFO  : 1passwordcli : ################## Date: 2024-06-05
2024-06-05 21:53:22 : INFO  : 1passwordcli : ################## 1passwordcli
2024-06-05 21:53:22 : DEBUG : 1passwordcli : DEBUG mode 1 enabled.
2024-06-05 21:53:22 : INFO  : 1passwordcli : SwiftDialog is not installed, clear cmd file var
2024-06-05 21:53:23 : INFO  : 1passwordcli : setting variable from argument DEBUG=0
2024-06-05 21:53:23 : DEBUG : 1passwordcli : name=1Password CLI
2024-06-05 21:53:23 : DEBUG : 1passwordcli : appName=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : type=pkg
2024-06-05 21:53:23 : DEBUG : 1passwordcli : archiveName=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : downloadURL=https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.0-beta.02/op_apple_universal_v2.30.0-beta.02.pkg
2024-06-05 21:53:23 : DEBUG : 1passwordcli : curlOptions=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : appNewVersion=2.30.0-beta.02
2024-06-05 21:53:23 : DEBUG : 1passwordcli : appCustomVersion function: Defined. 
2024-06-05 21:53:23 : DEBUG : 1passwordcli : versionKey=CFBundleShortVersionString
2024-06-05 21:53:23 : DEBUG : 1passwordcli : packageID=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : pkgName=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : choiceChangesXML=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : expectedTeamID=2BUA8C4S2C
2024-06-05 21:53:23 : DEBUG : 1passwordcli : blockingProcesses=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : installerTool=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : CLIInstaller=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : CLIArguments=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : updateTool=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : updateToolArguments=
2024-06-05 21:53:23 : DEBUG : 1passwordcli : updateToolRunAsCurrentUser=
2024-06-05 21:53:23 : INFO  : 1passwordcli : BLOCKING_PROCESS_ACTION=tell_user
2024-06-05 21:53:23 : INFO  : 1passwordcli : NOTIFY=success
2024-06-05 21:53:23 : INFO  : 1passwordcli : LOGGING=DEBUG
2024-06-05 21:53:23 : INFO  : 1passwordcli : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-05 21:53:23 : INFO  : 1passwordcli : Label type: pkg
2024-06-05 21:53:23 : INFO  : 1passwordcli : archiveName: 1Password CLI.pkg
2024-06-05 21:53:23 : INFO  : 1passwordcli : no blocking processes defined, using 1Password CLI as default
2024-06-05 21:53:23 : DEBUG : 1passwordcli : Changing directory to /var/folders/wb/2rymk3_14s303601cphvz0xr0000gp/T/tmp.z9DihYWNbv
2024-06-05 21:53:23 : INFO  : 1passwordcli : Custom App Version detection is used, found 2.30.0-beta.02
2024-06-05 21:53:23 : INFO  : 1passwordcli : appversion: 2.30.0-beta.02
2024-06-05 21:53:23 : INFO  : 1passwordcli : Latest version of 1Password CLI is 2.30.0-beta.02
2024-06-05 21:53:23 : INFO  : 1passwordcli : There is no newer version available.
2024-06-05 21:53:23 : DEBUG : 1passwordcli : Deleting /var/folders/wb/2rymk3_14s303601cphvz0xr0000gp/T/tmp.z9DihYWNbv
2024-06-05 21:53:23 : DEBUG : 1passwordcli : Debugging enabled, Deleting tmpDir output was:
/var/folders/wb/2rymk3_14s303601cphvz0xr0000gp/T/tmp.z9DihYWNbv
2024-06-05 21:53:23 : INFO  : 1passwordcli : Installomator did not close any apps, so no need to reopen any apps.
2024-06-05 21:53:23 : REQ   : 1passwordcli : No newer version.
2024-06-05 21:53:23 : REQ   : 1passwordcli : ################## End Installomator, exit code 0 
```

Manual regex testing:

```
$ downloadURL=$(curl -fs https://app-updates.agilebits.com/product_history/CLI2 | grep -m 1 -i op_apple_universal | cut -d'"' -f 2)                                                 
$ appNewVersion=$(echo $downloadURL | sed -E 's/.*\/[a-zA-Z_]*([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)\.pkg.*/\1/g')                                                                
$ echo $appNewVersion                                                                                                                                                                ─
2.30.0-beta.02


$ downloadURL=https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.0/op_apple_universal_v2.31.0.pkg                                                                                     
$ appNewVersion=$(echo $downloadURL | sed -E 's/.*\/[a-zA-Z_]*([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)\.pkg.*/\1/g')                                                                
$ echo $appNewVersion                                                                                                                                                                ─
2.31.0
```