### PR TITLE
Update download URLs for vmwarehorizonclient

### DIFF
--- a/fragments/labels/vmwarehorizonclient.sh
+++ b/fragments/labels/vmwarehorizonclient.sh
@@ -1,9 +1,9 @@
 vmwarehorizonclient)
     name="VMware Horizon Client"
     type="pkgInDmg"
-    downloadGroup=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY" | grep -o '[^"]*_MAC_[^"]*')
-    fileName=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&dlgType=PRODUCT_BINARY&downloadGroup=${downloadGroup}" | grep -o '"fileName":"[^"]*"' | cut -d: -f2 | sed 's/"//g')
-    downloadURL="https://download3.vmware.com/software/$downloadGroup/${fileName}"
-    appNewVersion=$(curl -fsL "https://my.vmware.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=${downloadGroup}" | grep -o '[^"]*\.dmg[^"]*' | sed 's/.*-\(.*\)-.*/\1/')
+    downloadGroup=$(curl -fsL "https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY" | grep -o '[^"]*_MAC_[^"]*')
+    fileName=$(curl -fsL "https://customerconnect.omnissa.com/channel/public/api/v1.0/dlg/details?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&dlgType=PRODUCT_BINARY&downloadGroup=${downloadGroup}" | grep -o '"fileName":"[^"]*"' | cut -d: -f2 | sed 's/"//g')
+    downloadURL="https://download3.omnissa.com/software/${downloadGroup}/${fileName}"
+    appNewVersion=$(curl -fsL "https://customerconnect.omnissa.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=${downloadGroup}" | grep -o '[^"]*\.dmg[^"]*' | sed 's/.*-\(.*\)-.*/\1/')
     expectedTeamID="EG7KH642X6"
     ;;


### PR DESCRIPTION
work was done by @DanielBahr2 and @spikehed in https://github.com/Installomator/Installomator/issues/1658

this pr fixes https://github.com/Installomator/Installomator/issues/1658


```
sudo ./Installomator.sh vmwarehorizonclient DEBUG=0 NOTIFY=success                                                                                                                                                                                                           1 ✘
Password:
2024-06-06 13:30:33 : REQ   : vmwarehorizonclient : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-06-06 13:30:33 : INFO  : vmwarehorizonclient : ################## Version: 10.6beta
2024-06-06 13:30:33 : INFO  : vmwarehorizonclient : ################## Date: 2024-04-23
2024-06-06 13:30:33 : INFO  : vmwarehorizonclient : ################## vmwarehorizonclient
2024-06-06 13:30:33 : DEBUG : vmwarehorizonclient : DEBUG mode 1 enabled.
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : setting variable from argument DEBUG=0
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : setting variable from argument NOTIFY=success
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : name=VMware Horizon Client
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : appName=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : type=pkgInDmg
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : archiveName=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : downloadURL=https://download3.omnissa.com/software/CART25FQ1_MAC_2312.1/VMware-Horizon-Client-2312.1-8.12.1-23531248.dmg
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : curlOptions=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : appNewVersion=8.12.1
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : appCustomVersion function: Not defined
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : versionKey=CFBundleShortVersionString
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : packageID=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : pkgName=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : choiceChangesXML=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : expectedTeamID=EG7KH642X6
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : blockingProcesses=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : installerTool=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : CLIInstaller=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : CLIArguments=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : updateTool=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : updateToolArguments=
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : updateToolRunAsCurrentUser=
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : BLOCKING_PROCESS_ACTION=tell_user
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : NOTIFY=success
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : LOGGING=DEBUG
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : Label type: pkgInDmg
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : archiveName: VMware Horizon Client.dmg
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : no blocking processes defined, using VMware Horizon Client as default
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k7rLp6gF7f
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : name: VMware Horizon Client, appName: VMware Horizon Client.app
2024-06-06 13:30:35.783 mdfind[41679:12026678] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-06-06 13:30:35.784 mdfind[41679:12026678] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-06-06 13:30:35.842 mdfind[41679:12026678] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-06 13:30:35 : WARN  : vmwarehorizonclient : No previous app found
2024-06-06 13:30:35 : WARN  : vmwarehorizonclient : could not find VMware Horizon Client.app
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : appversion:
2024-06-06 13:30:35 : INFO  : vmwarehorizonclient : Latest version of VMware Horizon Client is 8.12.1
2024-06-06 13:30:35 : REQ   : vmwarehorizonclient : Downloading https://download3.omnissa.com/software/CART25FQ1_MAC_2312.1/VMware-Horizon-Client-2312.1-8.12.1-23531248.dmg to VMware Horizon Client.dmg
2024-06-06 13:30:35 : DEBUG : vmwarehorizonclient : No Dialog connection, just download
2024-06-06 13:30:44 : DEBUG : vmwarehorizonclient : File list: -rw-r--r--  1 root  wheel   158M  6 Jun 13:30 VMware Horizon Client.dmg
2024-06-06 13:30:44 : DEBUG : vmwarehorizonclient : File type: VMware Horizon Client.dmg: zlib compressed data
2024-06-06 13:30:44 : DEBUG : vmwarehorizonclient : curl output was:
* Host download3.omnissa.com:443 was resolved.
* IPv6: (none)
* IPv4: 2.16.206.215, 2.16.206.209
*   Trying 2.16.206.215:443...
* Connected to download3.omnissa.com (2.16.206.215) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2962 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=Palo Alto; O=VMware LLC; CN=*.omnissa.com
*  start date: Apr  3 00:00:00 2024 GMT
*  expire date: Apr  2 23:59:59 2025 GMT
*  subjectAltName: host "download3.omnissa.com" matched cert's "*.omnissa.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /software/CART25FQ1_MAC_2312.1/VMware-Horizon-Client-2312.1-8.12.1-23531248.dmg HTTP/1.1
> Host: download3.omnissa.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< x-amz-id-2: 6bNxDtkbqHEoP2UuHXlbeZOVIw46MBiV/Ena1srAjhISYu5OJzndJGojDsSOEg7aXiAQQt0iFkY=
< x-amz-request-id: P7W95GNRFB6740PA
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Content-Type: binary/octet-stream
< Server: AmazonS3
< Last-Modified: Wed, 10 Apr 2024 00:03:00 GMT
< ETag: "8b075682525d0b9cfad35bb858b07c86-20"
< Content-Length: 165845464
< Cache-Control: max-age=1238926
< Expires: Thu, 20 Jun 2024 19:39:22 GMT
< Date: Thu, 06 Jun 2024 11:30:36 GMT
< Alt-Svc: h3=":443"; ma=93600
< Connection: keep-alive
<
{ [15845 bytes data]
* Connection #0 to host download3.omnissa.com left intact

2024-06-06 13:30:44 : REQ   : vmwarehorizonclient : no more blocking processes, continue with update
2024-06-06 13:30:44 : REQ   : vmwarehorizonclient : Installing VMware Horizon Client
2024-06-06 13:30:44 : INFO  : vmwarehorizonclient : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k7rLp6gF7f/VMware Horizon Client.dmg
2024-06-06 13:30:47 : DEBUG : vmwarehorizonclient : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $E6D3E22B
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $D2576326
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $C52EF049
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $7949BB39
Prüfsumme für GPT Partition Data (Backup GPT Table : 5) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $C52EF049
Prüfsumme für GPT Header (Backup GPT Header : 6) berechnen …
GPT Header (Backup GPT Header : 6): Die überprüfte CRC32-Prüfsumme ist $CAB2EBDB
Die überprüfte CRC32-Prüfsumme ist $3758A253
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/VMware Horizon Client

2024-06-06 13:30:47 : INFO  : vmwarehorizonclient : Mounted: /Volumes/VMware Horizon Client
2024-06-06 13:30:47 : DEBUG : vmwarehorizonclient : Found pkg(s):
/Volumes/VMware Horizon Client/VMware Horizon Client.pkg
2024-06-06 13:30:47 : INFO  : vmwarehorizonclient : found pkg: /Volumes/VMware Horizon Client/VMware Horizon Client.pkg
2024-06-06 13:30:47 : INFO  : vmwarehorizonclient : Verifying: /Volumes/VMware Horizon Client/VMware Horizon Client.pkg
2024-06-06 13:30:47 : DEBUG : vmwarehorizonclient : File list: -rw-r--r--@ 1 201  _guest   157M 22 Mär 19:54 /Volumes/VMware Horizon Client/VMware Horizon Client.pkg
2024-06-06 13:30:47 : DEBUG : vmwarehorizonclient : File type: /Volumes/VMware Horizon Client/VMware Horizon Client.pkg: xar archive compressed TOC: 5893, SHA-1 checksum
2024-06-06 13:30:48 : DEBUG : vmwarehorizonclient : spctlOut is /Volumes/VMware Horizon Client/VMware Horizon Client.pkg: accepted
2024-06-06 13:30:48 : DEBUG : vmwarehorizonclient : source=Notarized Developer ID
2024-06-06 13:30:48 : DEBUG : vmwarehorizonclient : origin=Developer ID Installer: VMware, Inc. (EG7KH642X6)
2024-06-06 13:30:48 : INFO  : vmwarehorizonclient : Team ID: EG7KH642X6 (expected: EG7KH642X6 )
2024-06-06 13:30:48 : INFO  : vmwarehorizonclient : Installing /Volumes/VMware Horizon Client/VMware Horizon Client.pkg to /
2024-06-06 13:30:57 : DEBUG : vmwarehorizonclient : Debugging enabled, installer output was:
Jun  6 13:30:48  installer[41816] <Debug>: Product archive /Volumes/VMware Horizon Client/VMware Horizon Client.pkg trustLevel=350
Jun  6 13:30:48  installer[41816] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Jun  6 13:30:48  installer[41816] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Horizon.Client.pkg
Jun  6 13:30:48  installer[41816] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Deem.InstallerHelper.pkg
Jun  6 13:30:48  installer[41816] <Info>: Set authorization level to root for session
Jun  6 13:30:48  installer[41816] <Info>: Authorization is being checked, waiting until authorization arrives.
Jun  6 13:30:48  installer[41816] <Info>: Administrator authorization granted.
Jun  6 13:30:48  installer[41816] <Info>: Packages have been authorized for installation.
Jun  6 13:30:48  installer[41816] <Debug>: Will use PK session
Jun  6 13:30:48  installer[41816] <Debug>: Using authorization level of root for IFPKInstallElement
Jun  6 13:30:48  installer[41816] <Info>: Starting installation:
Jun  6 13:30:48  installer[41816] <Notice>: Configuring volume "Macintosh HD"
Jun  6 13:30:48  installer[41816] <Info>: Preparing disk for local booted install.
Jun  6 13:30:48  installer[41816] <Notice>: Free space on "Macintosh HD": 32.02 GB (32020819968 bytes).
Jun  6 13:30:48  installer[41816] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41816fYChns"
Jun  6 13:30:48  installer[41816] <Notice>: IFPKInstallElement (2 packages)
Jun  6 13:30:48  installer[41816] <Info>: Current Path: /usr/sbin/installer
Jun  6 13:30:48  installer[41816] <Info>: Current Path: /bin/zsh
Jun  6 13:30:48  installer[41816] <Info>: Current Path: /usr/bin/sudo
Jun  6 13:30:48  installer[41816] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is VMware Horizon Client
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „VMware Horizon Client“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Jun  6 13:30:55  installer[41816] <Info>: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/Contents/Resources/VMware%20RemoteMKS.app/ for uid 0
Jun  6 13:30:55  installer[41816] <Info>: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/Contents/Resources/Uninstall%20VMware%20Horizon%20Client.app/ for uid 0
Jun  6 13:30:55  installer[41816] <Info>: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/ for uid 0

installer: Paketskripte ausführen ….....
Last Log repeated 3 times
installer: Pakete überprüfen ….....
#Jun  6 13:30:55  installer[41816] <Notice>: Running install actions
Jun  6 13:30:55  installer[41816] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41816fYChns"
Jun  6 13:30:55  installer[41816] <Notice>: Finalize disk "Macintosh HD"
Jun  6 13:30:55  installer[41816] <Notice>: Notifying system of updated components
Jun  6 13:30:55  installer[41816] <Notice>:
Jun  6 13:30:55  installer[41816] <Notice>: **** Summary Information ****
Jun  6 13:30:55  installer[41816] <Notice>:   Operation      Elapsed time
Jun  6 13:30:55  installer[41816] <Notice>: -----------------------------
Jun  6 13:30:55  installer[41816] <Notice>:        disk      0.01 seconds
Jun  6 13:30:55  installer[41816] <Notice>:      script      0.00 seconds
Jun  6 13:30:55  installer[41816] <Notice>:        zero      0.00 seconds
Jun  6 13:30:55  installer[41816] <Notice>:     install      7.13 seconds
Jun  6 13:30:55  installer[41816] <Notice>:     -total-      7.13 seconds
Jun  6 13:30:55  installer[41816] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUPreferenceManager: Service connection interrupted.
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUAppStoreUpdateController: Service connection interrupted.
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: Releasing connection 0x11f636b30
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUOSUUpdateController: softwareupdated: Service connection interrupted!
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUOSUUpdateController: Service connection interrupted w/ scheduler!
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUOSUShimController: Connection interrupted with softwareupdated
2024-06-06 13:30:46+02 mac SoftwareUpdateNotificationManager[30803]: SUAppStoreUpdateController: Observing SUSoftwareUpdateDaemonStarted
2024-06-06 13:30:46+02 mac suhelperd[30410]: DISPATCH_MACH_NO_SENDERS for client port.
2024-06-06 13:30:46+02 mac suhelperd[30410]: DISPATCH_MACH_DISCONNECTED for client port.
2024-06-06 13:30:46+02 mac suhelperd[30410]: Client(pid:30392) has disconnected.
2024-06-06 13:30:48+02 mac installer[41816]: Product archive /Volumes/VMware Horizon Client/VMware Horizon Client.pkg trustLevel=350
2024-06-06 13:30:48+02 mac installer[41816]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-06-06 13:30:48+02 mac installer[41816]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Horizon.Client.pkg
2024-06-06 13:30:48+02 mac installer[41816]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Deem.InstallerHelper.pkg
2024-06-06 13:30:48+02 mac installer[41816]: Set authorization level to root for session
2024-06-06 13:30:48+02 mac installer[41816]: Authorization is being checked, waiting until authorization arrives.
2024-06-06 13:30:48+02 mac installer[41816]: Administrator authorization granted.
2024-06-06 13:30:48+02 mac installer[41816]: Packages have been authorized for installation.
2024-06-06 13:30:48+02 mac installer[41816]: Will use PK session
2024-06-06 13:30:48+02 mac installer[41816]: Using authorization level of root for IFPKInstallElement
2024-06-06 13:30:48+02 mac installer[41816]: Starting installation:
2024-06-06 13:30:48+02 mac installer[41816]: Configuring volume "Macintosh HD"
2024-06-06 13:30:48+02 mac installer[41816]: Preparing disk for local booted install.
2024-06-06 13:30:48+02 mac installer[41816]: Free space on "Macintosh HD": 32.02 GB (32020819968 bytes).
2024-06-06 13:30:48+02 mac installer[41816]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41816fYChns"
2024-06-06 13:30:48+02 mac installer[41816]: IFPKInstallElement (2 packages)
2024-06-06 13:30:48+02 mac installer[41816]: Current Path: /usr/sbin/installer
2024-06-06 13:30:48+02 mac installer[41816]: Current Path: /bin/zsh
2024-06-06 13:30:48+02 mac installer[41816]: Current Path: /usr/bin/sudo
2024-06-06 13:30:48+02 mac installd[41820]: installd: Starting
2024-06-06 13:30:48+02 mac installd[41820]: installd: uid=0, euid=0
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: Adding client PKInstallDaemonClient pid=41816, uid=0 (/usr/sbin/installer)
2024-06-06 13:30:48+02 mac installer[41816]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: Set reponsibility for install to 41816
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: Hosted team responsibility for install set to team:(EG7KH642X6)
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: ----- Begin install -----
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: packages=(
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: Will do receipt-based obsoleting for package identifier com.vmware.VMware.Deem.InstallerHelper (prefix path=private/var/tmp/VMware/)
2024-06-06 13:30:48+02 mac installd[41820]: PackageKit: Extracting file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Horizon.Client.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/85493387-CBD8-4C37-BAEE-6D82EF254426.activeSandbox/Root/Applications, uid=0)
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit: Extracting file://localhost/Volumes/VMware%20Horizon%20Client/VMware%20Horizon%20Client.pkg#VMware.Deem.InstallerHelper.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/85493387-CBD8-4C37-BAEE-6D82EF254426.activeSandbox/Root/private/var/tmp/VMware, uid=0)
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit: prevent user idle system sleep
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit: suspending backupd
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:50+02 mac package_script_service[41822]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:50+02 mac package_script_service[41822]: Set responsibility to pid: 41816, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2024-06-06 13:30:50+02 mac package_script_service[41822]: Hosted team responsibility for script set to team:(EG7KH642X6)
2024-06-06 13:30:50+02 mac package_script_service[41822]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:50+02 mac package_script_service[41822]: ./preinstall: Running preinstall script of Telemetry Installer Helper.
2024-06-06 13:30:50+02 mac package_script_service[41822]: PackageKit: Hosted team responsible for script has been cleared.
2024-06-06 13:30:50+02 mac package_script_service[41822]: Responsibility set back to self.
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/85493387-CBD8-4C37-BAEE-6D82EF254426.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/85493387-CBD8-4C37-BAEE-6D82EF254426.activeSandbox
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/85493387-CBD8-4C37-BAEE-6D82EF254426.activeSandbox/Root (2 items) to /
2024-06-06 13:30:50+02 mac installd[41820]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.horizon.KSibO6
2024-06-06 13:30:50+02 mac package_script_service[41822]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.horizon.KSibO6
2024-06-06 13:30:50+02 mac package_script_service[41822]: Set responsibility to pid: 41816, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2024-06-06 13:30:50+02 mac package_script_service[41822]: Hosted team responsibility for script set to team:(EG7KH642X6)
2024-06-06 13:30:50+02 mac package_script_service[41822]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.horizon.KSibO6
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + export PATH=/bin:/sbin:/usr/bin:/usr/sbin
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + PATH=/bin:/sbin:/usr/bin:/usr/sbin
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + umask 022
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + DESTINATION=/Applications
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + APP='/Applications/VMware Horizon Client.app'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + LIBDIR='/Applications/VMware Horizon Client.app/Contents/Library'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + HELPER_DIR=/Library/PrivilegedHelperTools
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + HELPERPLIST_DIR=/Library/LaunchDaemons
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + UNINSTALLER='/Applications/VMware Horizon Client.app/Contents/Resources/uninstall.sh'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + SUPPORTDIR='/Library/Application Support/VMware/VMware Horizon View'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + startPrivilegedHelper com.vmware.horizon.CDSHelper
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + local helper=com.vmware.horizon.CDSHelper
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + '[' -d /Library/PrivilegedHelperTools ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + '[' -d /Library/LaunchDaemons ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + cp -f -- '/Applications/VMware Horizon Client.app/Contents/Library/LaunchServices/com.vmware.horizon.CDSHelper' /Library/PrivilegedHelperTools/com.vmware.horizon.CDSHelper
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + chmod 544 /Library/PrivilegedHelperTools/com.vmware.horizon.CDSHelper
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + cp -f -- '/Applications/VMware Horizon Client.app/Contents/Library/LaunchServices/com.vmware.horizon.CDSHelper.plist' /Library/LaunchDaemons/com.vmware.horizon.CDSHelper.plist
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + chmod 644 /Library/LaunchDaemons/com.vmware.horizon.CDSHelper.plist
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + launchctl load /Library/LaunchDaemons/com.vmware.horizon.CDSHelper.plist
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: Load failed: 5: Input/output error
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: Try running `launchctl bootstrap` as root for richer errors.
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + initUSBServices
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + local 'usbScript=/Applications/VMware Horizon Client.app/Contents/Library/InitUsbServices.tool'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: + source '/Applications/VMware Horizon Client.app/Contents/Library/InitUsbServices.tool' '/Applications/VMware Horizon Client.app/Contents/Library'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ export PATH=/bin:/sbin:/usr/bin:/usr/sbin
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ PATH=/bin:/sbin:/usr/bin:/usr/sbin
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' 0 -ne 0 ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ echo 41825
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: 41825
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ LOGDIR='/Library/Logs/VMware/VMware Horizon Client'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ mkdir -p '/Library/Logs/VMware/VMware Horizon Client'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ LOG='/Library/Logs/VMware/VMware Horizon Client/vmware-view-usb-init.log'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ rm -f '/Library/Logs/VMware/VMware Horizon Client/vmware-view-usb-init.log'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ echo 'Initializing USB Remote Desktop Services'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ SUPPORT_DIR='/Library/Application Support/VMware'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ ensureDir '/Library/Application Support/VMware'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ local 'path=/Library/Application Support/VMware'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' -d '/Library/Application Support/VMware' ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ echo '*** Setting permissions on /Library/Application Support/VMware...'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: *** Setting permissions on /Library/Application Support/VMware...
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chown -- root:wheel '/Library/Application Support/VMware'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chmod -- 755 '/Library/Application Support/VMware'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ ensureDir '/Library/Application Support/VMware/VMware Horizon View'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ local 'path=/Library/Application Support/VMware/VMware Horizon View'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' -d '/Library/Application Support/VMware/VMware Horizon View' ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ echo '*** Setting permissions on /Library/Application Support/VMware/VMware Horizon View...'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: *** Setting permissions on /Library/Application Support/VMware/VMware Horizon View...
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chown -- root:wheel '/Library/Application Support/VMware/VMware Horizon View'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chmod -- 755 '/Library/Application Support/VMware/VMware Horizon View'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ LIBDIR=
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' 1 -eq 1 ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' -d '/Applications/VMware Horizon Client.app/Contents/Library' ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ LIBDIR='/Applications/VMware Horizon Client.app/Contents/Library'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ echo 'Using the new pkg install mode'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ '[' '!' -z '/Applications/VMware Horizon Client.app/Contents/Library' ']'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chown -R root:wheel '/Applications/VMware Horizon Client.app/Contents/Library/Open VMware View Client Services' '/Applications/VMware Horizon Client.app/Contents/Library/VMware View Client Services' '/Applications/VMware Horizon Client.app/Contents/Library/services.sh' '/Applications/VMware Horizon Client.app/Contents/Library/vmware-usbarbitrator'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chmod 4755 '/Applications/VMware Horizon Client.app/Contents/Library/Open VMware View Client Services'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ chmod 755 '/Applications/VMware Horizon Client.app/Contents/Library/VMware View Client Services' '/Applications/VMware Horizon Client.app/Contents/Library/services.sh' '/Applications/VMware Horizon Client.app/Contents/Library/vmware-usbarbitrator'
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: ++ defaults -currentHost write /Library/Preferences/com.vmware.horizon promptedUSBServicesInstall -bool YES
2024-06-06 13:30:51+02 mac package_script_service[41822]: PackageKit: Hosted team responsible for script has been cleared.
2024-06-06 13:30:51+02 mac package_script_service[41822]: Responsibility set back to self.
2024-06-06 13:30:51+02 mac installd[41820]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:51+02 mac package_script_service[41822]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:51+02 mac package_script_service[41822]: Set responsibility to pid: 41816, responsible_path: /Applications/iTerm.app/Contents/MacOS/iTerm2
2024-06-06 13:30:51+02 mac package_script_service[41822]: Hosted team responsibility for script set to team:(EG7KH642X6)
2024-06-06 13:30:51+02 mac package_script_service[41822]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.WgYbSs/Scripts/com.vmware.VMware.Deem.InstallerHelper.CqbuIy
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: Running Telemetry Installer Helper postinstall script.
2024-06-06 13:30:51+02 mac package_script_service[41822]: ./postinstall: Running DEEMD installation script.
2024-06-06 13:30:51+02 mac installer[41846]: Product archive /private/var/tmp/vmware/VMware.Deem.Service.universal.pkg trustLevel=350
2024-06-06 13:30:51+02 mac installer[41846]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-06-06 13:30:51+02 mac installer[41846]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/tmp/vmware/VMware.Deem.Service.universal.pkg#VMware.Deem.pkg
2024-06-06 13:30:51+02 mac installer[41846]: Set authorization level to root for session
2024-06-06 13:30:51+02 mac installer[41846]: Authorization is being checked, waiting until authorization arrives.
2024-06-06 13:30:51+02 mac installer[41846]: Administrator authorization granted.
2024-06-06 13:30:51+02 mac installer[41846]: Packages have been authorized for installation.
2024-06-06 13:30:51+02 mac installer[41846]: Will use PK session
2024-06-06 13:30:51+02 mac installer[41846]: Using authorization level of root for IFPKInstallElement
2024-06-06 13:30:51+02 mac installer[41846]: Starting installation:
2024-06-06 13:30:51+02 mac installer[41846]: Configuring volume "Macintosh HD"
2024-06-06 13:30:51+02 mac installer[41846]: Preparing disk for local booted install.
2024-06-06 13:30:51+02 mac installer[41846]: Free space on "Macintosh HD": 31.66 GB (31659937792 bytes).
2024-06-06 13:30:51+02 mac installer[41846]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41846v1RWrA"
2024-06-06 13:30:51+02 mac installer[41846]: IFPKInstallElement (1 packages)
2024-06-06 13:30:51+02 mac installer[41846]: Current Path: /usr/sbin/installer
2024-06-06 13:30:51+02 mac installer[41846]: Current Path: /bin/bash
2024-06-06 13:30:51+02 mac installer[41846]: Current Path: /System/Library/PrivateFrameworks/PackageKit.framework/Versions/A/XPCServices/package_script_service.xpc/Contents/MacOS/package_script_service
2024-06-06 13:30:51+02 mac installer[41846]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: Failed to set hosted team responsibility for install to team:(S2ZMFGQM93)
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: ----- Begin install -----
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: packages=(
2024-06-06 13:30:52+02 mac suhelperd[30410]: Exiting Daemon SUHelperExitCodeNoSenders
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: Will do receipt-based obsoleting for package identifier com.vmware.VMware.Deem (prefix path=Library/Application Support/VMware/)
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: Extracting file://localhost/private/var/tmp/vmware/VMware.Deem.Service.universal.pkg#VMware.Deem.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/42F4B1C9-8F6F-462B-8447-16722EC5F851.activeSandbox/Root/Library/Application Support/VMware, uid=0)
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: Package name is VMware.Deem
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: Upgrading at base path /
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: Installation vorbereiten ….....
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: Volume vorbereiten ….....
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: „VMware.Deem“ vorbereiten ….....
2024-06-06 13:30:52+02 mac package_script_service[41822]: ./postinstall: installer: Warten, bis andere Installationen abgeschlossen werden ….....
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: Executing script "./preinstall" in /private/tmp/PKInstallSandbox.P5g4Kx/Scripts/com.vmware.VMware.Deem.8VB21F
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: DEEMD pre installation process started.
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: No postfix DEEM version found, get the version number of it.
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: deemd version is:23.11.00.18
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: DEEMD already installed and all files are set.
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: No postfix DEEM version found, get the version number of it.
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: Current version 23.11.00.18 and install version 23.11.00.18 are the same.
2024-06-06 13:30:52+02 mac installer[41846]: ./preinstall: Skip the version downgrade of the TLM Service.
2024-06-06 13:30:52+02 mac installer[41846]: PackageKit: Install Failed: Error Domain=PKInstallErrorDomain Code=112 "Beim Ausführen der Skripts aus dem Paket „VMware.Deem.Service.universal.pkg“ ist ein Fehler aufgetreten." UserInfo={NSFilePath=./preinstall, NSURL=#VMware.Deem.pkg -- file://localhost/private/var/tmp/vmware/VMware.Deem.Service.universal.pkg, PKInstallPackageIdentifier=com.vmware.VMware.Deem, NSLocalizedDescription=Beim Ausführen der Skripts aus dem Paket „VMware.Deem.Service.universal.pkg“ ist ein Fehler aufgetreten.} {
2024-06-06 13:30:52+02 mac installer[41846]: install:didFailWithError:Error Domain=PKInstallErrorDomain Code=112 "Beim Ausführen der Skripts aus dem Paket „VMware.Deem.Service.universal.pkg“ ist ein Fehler aufgetreten." UserInfo={NSFilePath=./preinstall, NSURL=#VMware.Deem.pkg -- file://localhost/private/var/tmp/vmware/VMware.Deem.Service.universal.pkg, PKInstallPackageIdentifier=com.vmware.VMware.Deem, NSLocalizedDescription=Beim Ausführen der Skripts aus dem Paket „VMware.Deem.Service.universal.pkg“ ist ein Fehler aufgetreten.}
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: #
2024-06-06 13:30:53+02 mac installer[41846]: Install failed: Die Installation ist aufgrund eines Fehlers fehlgeschlagen. Wende dich an den Hersteller der Software.
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: installer: Dateien schreiben ….....
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: #
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: installer: The upgrade failed. (Die Installation ist aufgrund eines Fehlers fehlgeschlagen. Wende dich an den Hersteller der Software. Beim Ausführen der Skripts aus dem Paket „VMware.Deem.Service.universal.pkg“ ist ein Fehler aufgetreten.)
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: Removing temp DEEMD installation files.
2024-06-06 13:30:53+02 mac package_script_service[41822]: ./postinstall: Running TLM installation script.
2024-06-06 13:30:53+02 mac installer[41872]: Product archive /private/var/tmp/vmware/VMware.EndpointTelemetryService-universal.pkg trustLevel=350
2024-06-06 13:30:53+02 mac installer[41872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-06-06 13:30:53+02 mac installer[41872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/tmp/vmware/VMware.EndpointTelemetryService-universal.pkg#VMware.EndpointTelemetryService.pkg
2024-06-06 13:30:53+02 mac installer[41872]: Set authorization level to root for session
2024-06-06 13:30:53+02 mac installer[41872]: Authorization is being checked, waiting until authorization arrives.
2024-06-06 13:30:53+02 mac installer[41872]: Administrator authorization granted.
2024-06-06 13:30:53+02 mac installer[41872]: Packages have been authorized for installation.
2024-06-06 13:30:53+02 mac installer[41872]: Will use PK session
2024-06-06 13:30:53+02 mac installer[41872]: Using authorization level of root for IFPKInstallElement
2024-06-06 13:30:53+02 mac installer[41872]: Starting installation:
2024-06-06 13:30:53+02 mac installer[41872]: Configuring volume "Macintosh HD"
2024-06-06 13:30:53+02 mac installer[41872]: Preparing disk for local booted install.
2024-06-06 13:30:53+02 mac installer[41872]: Free space on "Macintosh HD": 31.7 GB (31696019456 bytes).
2024-06-06 13:30:53+02 mac installer[41872]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41872KZ6SIZ"
2024-06-06 13:30:53+02 mac installer[41872]: IFPKInstallElement (1 packages)
2024-06-06 13:30:53+02 mac installer[41872]: Current Path: /usr/sbin/installer
2024-06-06 13:30:53+02 mac installer[41872]: Current Path: /bin/bash
2024-06-06 13:30:53+02 mac installer[41872]: Current Path: /System/Library/PrivateFrameworks/PackageKit.framework/Versions/A/XPCServices/package_script_service.xpc/Contents/MacOS/package_script_service
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: Failed to set hosted team responsibility for install to team:(S2ZMFGQM93)
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: ----- Begin install -----
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: packages=(
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: Extracting file://localhost/private/var/tmp/vmware/VMware.EndpointTelemetryService-universal.pkg#VMware.EndpointTelemetryService.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/13759625-8389-4DA2-8989-354DF1B3A901.activeSandbox/Root/Library/Application Support/VMware, uid=0)
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: Executing script "./preinstall" in /private/tmp/PKInstallSandbox.ocYRob/Scripts/com.vmware.VMware.EndpointTelemetryService.aeJPX7
2024-06-06 13:30:53+02 mac installer[41872]: ./preinstall: Pre installation process started
2024-06-06 13:30:53+02 mac installer[41872]: ./preinstall: TLM already installed and all files are set.
2024-06-06 13:30:53+02 mac installer[41872]: ./preinstall: Current version 23.11.0.16 and install version 23.11.0.16 are the same.
2024-06-06 13:30:53+02 mac installer[41872]: ./preinstall: Skip the version downgrade of the TLM Service, the Install Helper will update the installation config file.
2024-06-06 13:30:53+02 mac installer[41872]: PackageKit: Install Failed: Error Domain=PKInstallErrorDomain Code=112 "Beim Ausführen der Skripts aus dem Paket „VMware.EndpointTelemetryService-universal.pkg“ ist ein Fehler aufgetreten." UserInfo={NSFilePath=./preinstall, NSURL=#VMware.EndpointTelemetryService.pkg -- file://localhost/private/var/tmp/vmware/VMware.EndpointTelemetryService-universal.pkg, PKInstallPackageIdentifier=com.vmware.VMware.EndpointTelemetryService, NSLocalizedDescription=Beim Ausführen der Skripts aus dem Paket „VMware.EndpointTelemetryService-universal.pkg“ ist ein Fehler aufgetreten.} {
2024-06-06 13:30:53+02 mac installer[41872]: install:didFailWithError:Error Domain=PKInstallErrorDomain Code=112 "Beim Ausführen der Skripts aus dem Paket „VMware.EndpointTelemetryService-universal.pkg“ ist ein Fehler aufgetreten." UserInfo={NSFilePath=./preinstall, NSURL=#VMware.EndpointTelemetryService.pkg -- file://localhost/private/var/tmp/vmware/VMware.EndpointTelemetryService-universal.pkg, PKInstallPackageIdentifier=com.vmware.VMware.EndpointTelemetryService, NSLocalizedDescription=Beim Ausführen der Skripts aus dem Paket „VMware.EndpointTelemetryService-universal.pkg“ ist ein Fehler aufgetreten.}
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: Package name is VMware.EndpointTelemetryService
2024-06-06 13:30:54+02 mac installer[41872]: Install failed: Die Installation ist aufgrund eines Fehlers fehlgeschlagen. Wende dich an den Hersteller der Software.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: Upgrading at base path /
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: Installation vorbereiten ….....
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: Volume vorbereiten ….....
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: „VMware.EndpointTelemetryService“ vorbereiten ….....
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: Warten, bis andere Installationen abgeschlossen werden ….....
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: #
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: installer: The upgrade failed. (Die Installation ist aufgrund eines Fehlers fehlgeschlagen. Wende dich an den Hersteller der Software. Beim Ausführen der Skripts aus dem Paket „VMware.EndpointTelemetryService-universal.pkg“ ist ein Fehler aufgetreten.)
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: Removing temp TLM installation files.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: Removing Telemetry installation files.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: Telemetry Installer Helper postinstall script finished.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: The installer name is: VMware Horizon Client.pkg
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: VMware Horizon Client.pkg contains VMware Horizon Client, it's a Horizon Client installer.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: Installation item alreay exists, no need to update the installation config file.
2024-06-06 13:30:54+02 mac package_script_service[41822]: ./postinstall: The installer name is: VMware Horizon Client.pkg
2024-06-06 13:30:54+02 mac package_script_service[41822]: PackageKit: Hosted team responsible for script has been cleared.
2024-06-06 13:30:54+02 mac package_script_service[41822]: Responsibility set back to self.
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: Writing receipt for com.vmware.horizon to /
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: Writing receipt for com.vmware.VMware.Deem.InstallerHelper to /
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: No Intel binaries to translate.
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: Touched bundle /Applications/VMware Horizon Client.app/Contents/Resources/VMware RemoteMKS.app
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: Touched bundle /Applications/VMware Horizon Client.app/Contents/Resources/Uninstall VMware Horizon Client.app
2024-06-06 13:30:54+02 mac installd[41820]: PackageKit: Touched bundle /Applications/VMware Horizon Client.app
2024-06-06 13:30:54+02 mac installd[41820]: Installed "VMware Horizon Client" ()
2024-06-06 13:30:54+02 mac installd[41820]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: releasing backupd
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: allow user idle system sleep
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: ----- End install -----
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: 6.7s elapsed install time
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Cleared responsibility for install from 41816.
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Cleared permissions on Installer.app
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Hosted team responsible for install has been cleared.
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Running idle tasks
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Done with sandbox removals
2024-06-06 13:30:55+02 mac installer[41816]: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/Contents/Resources/VMware%20RemoteMKS.app/ for uid 0
2024-06-06 13:30:55+02 mac installer[41816]: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/Contents/Resources/Uninstall%20VMware%20Horizon%20Client.app/ for uid 0
2024-06-06 13:30:55+02 mac installer[41816]: PackageKit: Registered bundle file:///Applications/VMware%20Horizon%20Client.app/ for uid 0
2024-06-06 13:30:55+02 mac installd[41820]: PackageKit: Removing client PKInstallDaemonClient pid=41816, uid=0 (/usr/sbin/installer)
2024-06-06 13:30:55+02 mac installer[41816]: Running install actions
2024-06-06 13:30:55+02 mac installer[41816]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.41816fYChns"
2024-06-06 13:30:55+02 mac installer[41816]: Finalize disk "Macintosh HD"
2024-06-06 13:30:55+02 mac installer[41816]: Notifying system of updated components
2024-06-06 13:30:55+02 mac installer[41816]:
2024-06-06 13:30:55+02 mac installer[41816]: **** Summary Information ****
2024-06-06 13:30:55+02 mac installer[41816]:   Operation      Elapsed time
2024-06-06 13:30:55+02 mac installer[41816]: -----------------------------
2024-06-06 13:30:55+02 mac installer[41816]:        disk      0.01 seconds
2024-06-06 13:30:55+02 mac installer[41816]:      script      0.00 seconds
2024-06-06 13:30:55+02 mac installer[41816]:        zero      0.00 seconds
2024-06-06 13:30:55+02 mac installer[41816]:     install      7.13 seconds
2024-06-06 13:30:55+02 mac installer[41816]:     -total-      7.13 seconds
2024-06-06 13:30:55+02 mac installer[41816]:

2024-06-06 13:30:57 : INFO  : vmwarehorizonclient : Finishing...
2024-06-06 13:31:00 : INFO  : vmwarehorizonclient : App(s) found: /Applications/VMware Horizon Client.app
2024-06-06 13:31:00 : INFO  : vmwarehorizonclient : found app at /Applications/VMware Horizon Client.app, version 8.12.1, on versionKey CFBundleShortVersionString
2024-06-06 13:31:00 : REQ   : vmwarehorizonclient : Installed VMware Horizon Client, version 8.12.1
2024-06-06 13:31:00 : INFO  : vmwarehorizonclient : notifying
2024-06-06 13:31:01 : DEBUG : vmwarehorizonclient : Unmounting /Volumes/VMware Horizon Client
2024-06-06 13:31:01 : DEBUG : vmwarehorizonclient : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-06-06 13:31:01 : DEBUG : vmwarehorizonclient : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k7rLp6gF7f
2024-06-06 13:31:01 : DEBUG : vmwarehorizonclient : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k7rLp6gF7f/VMware Horizon Client.dmg
2024-06-06 13:31:01 : DEBUG : vmwarehorizonclient : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k7rLp6gF7f
2024-06-06 13:31:01 : INFO  : vmwarehorizonclient : Installomator did not close any apps, so no need to reopen any apps.
2024-06-06 13:31:01 : REQ   : vmwarehorizonclient : All done!
2024-06-06 13:31:01 : REQ   : vmwarehorizonclient : ################## End Installomator, exit code 0
```