### PR TITLE
Update sketchupviewer downloadURL

### DIFF
--- a/fragments/labels/sketchupviewer.sh
+++ b/fragments/labels/sketchupviewer.sh
@@ -1,6 +1,6 @@
 sketchupviewer)
     name="SketchUpViewer"
     type="dmg"
-    downloadURL="$(curl -fs https://www.sketchup.com/sketchup/SketchUpViewer-en-dmg | grep "<a href=" | sed 's/.*href="//' | sed 's/".*//')"
+    downloadURL="$(curl -Lfs https://www.sketchup.com/en/sketchup-viewer/downloads | grep -o 'https://download.sketchup.com/SketchUpViewer[0-9\-]*.dmg')"
     expectedTeamID="J8PVMCY7KL"
     ;;


### PR DESCRIPTION
Fixes the download for the sketchupviewer label.
````
sudo ./installomator.sh sketchupviewer BLOCKING_PROCESS_ACTION=prompt_user_loop NOTIFY=silent DEBUG=0
2024-06-14 10:03:45 : REQ   : sketchupviewer : ################## Start Installomator v. 10.5.2, date 2024-06-05
2024-06-14 10:03:45 : INFO  : sketchupviewer : ################## Version: 10.5.2
2024-06-14 10:03:45 : INFO  : sketchupviewer : ################## Date: 2024-06-05
2024-06-14 10:03:45 : INFO  : sketchupviewer : ################## sketchupviewer
2024-06-14 10:03:45 : DEBUG : sketchupviewer : DEBUG mode 1 enabled.
2024-06-14 10:04:06 : INFO  : sketchupviewer : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-14 10:04:06 : INFO  : sketchupviewer : setting variable from argument NOTIFY=silent
2024-06-14 10:04:06 : INFO  : sketchupviewer : setting variable from argument DEBUG=0
2024-06-14 10:04:06 : DEBUG : sketchupviewer : name=SketchUpViewer
2024-06-14 10:04:06 : DEBUG : sketchupviewer : appName=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : type=dmg
2024-06-14 10:04:06 : DEBUG : sketchupviewer : archiveName=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : downloadURL=https://download.sketchup.com/SketchUpViewer-2022-0-315-108.dmg
2024-06-14 10:04:06 : DEBUG : sketchupviewer : curlOptions=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : appNewVersion=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : appCustomVersion function: Not defined
2024-06-14 10:04:06 : DEBUG : sketchupviewer : versionKey=CFBundleShortVersionString
2024-06-14 10:04:06 : DEBUG : sketchupviewer : packageID=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : pkgName=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : choiceChangesXML=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : expectedTeamID=J8PVMCY7KL
2024-06-14 10:04:06 : DEBUG : sketchupviewer : blockingProcesses=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : installerTool=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : CLIInstaller=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : CLIArguments=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : updateTool=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : updateToolArguments=
2024-06-14 10:04:06 : DEBUG : sketchupviewer : updateToolRunAsCurrentUser=
2024-06-14 10:04:06 : INFO  : sketchupviewer : BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-14 10:04:06 : INFO  : sketchupviewer : NOTIFY=silent
2024-06-14 10:04:06 : INFO  : sketchupviewer : LOGGING=DEBUG
2024-06-14 10:04:06 : INFO  : sketchupviewer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-14 10:04:06 : INFO  : sketchupviewer : Label type: dmg
2024-06-14 10:04:06 : INFO  : sketchupviewer : archiveName: SketchUpViewer.dmg
2024-06-14 10:04:06 : INFO  : sketchupviewer : no blocking processes defined, using SketchUpViewer as default
2024-06-14 10:04:06 : DEBUG : sketchupviewer : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gxTwvZAwKl
2024-06-14 10:04:06 : INFO  : sketchupviewer : name: SketchUpViewer, appName: SketchUpViewer.app
2024-06-14 10:04:07.029 mdfind[54480:10841603] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-06-14 10:04:07.032 mdfind[54480:10841603] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-06-14 10:04:07.365 mdfind[54480:10841603] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-14 10:04:07 : WARN  : sketchupviewer : No previous app found
2024-06-14 10:04:07 : WARN  : sketchupviewer : could not find SketchUpViewer.app
2024-06-14 10:04:07 : INFO  : sketchupviewer : appversion: 
2024-06-14 10:04:07 : INFO  : sketchupviewer : Latest version not specified.
2024-06-14 10:04:07 : REQ   : sketchupviewer : Downloading https://download.sketchup.com/SketchUpViewer-2022-0-315-108.dmg to SketchUpViewer.dmg
2024-06-14 10:04:07 : DEBUG : sketchupviewer : No Dialog connection, just download
2024-06-14 10:04:25 : DEBUG : sketchupviewer : File list: -rw-r--r--  1 root  wheel   166M Jun 14 10:04 SketchUpViewer.dmg
2024-06-14 10:04:26 : DEBUG : sketchupviewer : File type: SketchUpViewer.dmg: bzip2 compressed data, block size = 100k
2024-06-14 10:04:26 : DEBUG : sketchupviewer : curl output was:
* Host download.sketchup.com:443 was resolved.
* IPv6: 2600:9000:274d:9400:11:52b4:fec0:93a1, 2600:9000:274d:da00:11:52b4:fec0:93a1, 2600:9000:274d:4400:11:52b4:fec0:93a1, 2600:9000:274d:a000:11:52b4:fec0:93a1, 2600:9000:274d:5400:11:52b4:fec0:93a1, 2600:9000:274d:8e00:11:52b4:fec0:93a1, 2600:9000:274d:8600:11:52b4:fec0:93a1, 2600:9000:274d:9200:11:52b4:fec0:93a1
* IPv4: 18.65.39.64, 18.65.39.110, 18.65.39.128, 18.65.39.7
*   Trying 18.65.39.64:443...
* Connected to download.sketchup.com (18.65.39.64) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4952 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.sketchup.com
*  start date: Feb 11 00:00:00 2024 GMT
*  expire date: Mar 12 23:59:59 2025 GMT
*  subjectAltName: host "download.sketchup.com" matched cert's "*.sketchup.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.sketchup.com/SketchUpViewer-2022-0-315-108.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.sketchup.com]
* [HTTP/2] [1] [:path: /SketchUpViewer-2022-0-315-108.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /SketchUpViewer-2022-0-315-108.dmg HTTP/2
> Host: download.sketchup.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: binary/octet-stream
< content-length: 174137329
< date: Fri, 14 Jun 2024 07:42:57 GMT
< last-modified: Mon, 24 Jan 2022 20:34:49 GMT
< etag: "39cb0478f9d0a91b573ae7e0bca6affd"
< x-amz-version-id: IGR45z6fTTW7RbaheBARQFtfzYlj1Pf5
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 6750d77433312fa1bf305e9ae7af80ae.cloudfront.net (CloudFront)
< x-amz-cf-pop: AMS1-P1
< x-amz-cf-id: iRo1QgZI2eN6E6vVhLuiQoklm5aUca37dkFaxPaaW64kMrtX9PHqdw==
< age: 1278
< 
{ [17898 bytes data]
* Connection #0 to host download.sketchup.com left intact

2024-06-14 10:04:26 : REQ   : sketchupviewer : no more blocking processes, continue with update
2024-06-14 10:04:26 : REQ   : sketchupviewer : Installing SketchUpViewer
2024-06-14 10:04:26 : INFO  : sketchupviewer : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gxTwvZAwKl/SketchUpViewer.dmg
2024-06-14 10:04:39 : DEBUG : sketchupviewer : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $A981DD3F
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $A6B7B62A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $3F9ED5DC
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $0CA1D194
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $3F9ED5DC
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $B6640587
verified CRC32 $917AA653
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/SketchUp Viewer

2024-06-14 10:04:39 : INFO  : sketchupviewer : Mounted: /Volumes/SketchUp Viewer
2024-06-14 10:04:39 : INFO  : sketchupviewer : Verifying: /Volumes/SketchUp Viewer/SketchUpViewer.app
2024-06-14 10:04:39 : DEBUG : sketchupviewer : App size: 437M   /Volumes/SketchUp Viewer/SketchUpViewer.app
2024-06-14 10:04:54 : DEBUG : sketchupviewer : Debugging enabled, App Verification output was:
/Volumes/SketchUp Viewer/SketchUpViewer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Trimble Navigation Limited (J8PVMCY7KL)

2024-06-14 10:04:54 : INFO  : sketchupviewer : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2024-06-14 10:04:54 : INFO  : sketchupviewer : Installing SketchUpViewer version 22.0 on versionKey CFBundleShortVersionString.
2024-06-14 10:04:54 : INFO  : sketchupviewer : App has LSMinimumSystemVersion: 10.14
2024-06-14 10:04:54 : INFO  : sketchupviewer : Copy /Volumes/SketchUp Viewer/SketchUpViewer.app to /Applications
2024-06-14 10:05:06 : DEBUG : sketchupviewer : Debugging enabled, App copy output was:
Copying /Volumes/SketchUp Viewer/SketchUpViewer.app

2024-06-14 10:05:06 : WARN  : sketchupviewer : Changing owner to maartenwijnants
2024-06-14 10:05:06 : INFO  : sketchupviewer : Finishing...
2024-06-14 10:05:09 : INFO  : sketchupviewer : App(s) found: /Applications/SketchUpViewer.app
2024-06-14 10:05:09 : INFO  : sketchupviewer : found app at /Applications/SketchUpViewer.app, version 22.0, on versionKey CFBundleShortVersionString
2024-06-14 10:05:09 : REQ   : sketchupviewer : Installed SketchUpViewer, version 22.0
2024-06-14 10:05:09 : DEBUG : sketchupviewer : Unmounting /Volumes/SketchUp Viewer
2024-06-14 10:05:09 : DEBUG : sketchupviewer : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-06-14 10:05:09 : DEBUG : sketchupviewer : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gxTwvZAwKl
2024-06-14 10:05:09 : DEBUG : sketchupviewer : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gxTwvZAwKl/SketchUpViewer.dmg
2024-06-14 10:05:09 : DEBUG : sketchupviewer : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gxTwvZAwKl
2024-06-14 10:05:09 : INFO  : sketchupviewer : Installomator did not close any apps, so no need to reopen any apps.
2024-06-14 10:05:09 : REQ   : sketchupviewer : All done!
2024-06-14 10:05:09 : REQ   : sketchupviewer : ################## End Installomator, exit code 0 
````
