### PR TITLE
microsoftcompanyportal: Updated downloadURL to v5.2406.0

### DIFF
--- a/fragments/labels/microsoftcompanyportal.sh
+++ b/fragments/labels/microsoftcompanyportal.sh
@@ -1,7 +1,7 @@
 microsoftcompanyportal)
     name="Company Portal"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869655"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=853070"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.intunecompanyportal.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/CompanyPortal_.*pkg" | cut -d "_" -f 2 | cut -d "-" -f 1)
     expectedTeamID="UBF8T346G9"


### PR DESCRIPTION
Updated downloadURL to v5.2406.0. Sourced downloadURL from [Learn / Microsoft Intune / Intune service / Intune user help / Enroll your macOS device using the Company Portal app](https://learn.microsoft.com/en-us/mem/intune/user-help/enroll-your-device-in-intune-macos-cp).

