### PR TITLE
Create busycontacts.sh

### DIFF
--- a/fragments/labels/busycontacts.sh
+++ b/fragments/labels/busycontacts.sh
@@ -1,0 +1,9 @@
+busycontacts)
+    name="BusyContacts"
+    type="dmg"
+    downloadURL="https://www.busymac.com/download/BusyContacts.dmg"
+    appNewVersion=$( curl -ILs "https://www.busymac.com/download/BusyContacts.dmg" | grep -m 1 -i '^location' | sed 's/.*bct-//' | sed 's/.dmg//' )
+    expectedTeamID="N4RA379GBW"
+    appName="BusyContacts.app"
+    blockingProcesses=( "BusyContacts" )
+    ;;


### PR DESCRIPTION
./assemble.sh busycontacts
2024-06-19 13:11:53 : REQ   : busycontacts : ################## Start Installomator v. 10.6beta, date 2024-06-19
2024-06-19 13:11:53 : INFO  : busycontacts : ################## Version: 10.6beta
2024-06-19 13:11:53 : INFO  : busycontacts : ################## Date: 2024-06-19
2024-06-19 13:11:53 : INFO  : busycontacts : ################## busycontacts
2024-06-19 13:11:53 : DEBUG : busycontacts : DEBUG mode 1 enabled.
2024-06-19 13:11:54 : DEBUG : busycontacts : name=BusyContacts
2024-06-19 13:11:54 : DEBUG : busycontacts : appName=BusyContacts.app
2024-06-19 13:11:54 : DEBUG : busycontacts : type=dmg
2024-06-19 13:11:54 : DEBUG : busycontacts : archiveName=
2024-06-19 13:11:54 : DEBUG : busycontacts : downloadURL=https://www.busymac.com/download/BusyContacts.dmg
2024-06-19 13:11:54 : DEBUG : busycontacts : curlOptions=
2024-06-19 13:11:54 : DEBUG : busycontacts : appNewVersion=2024.1.2
2024-06-19 13:11:54 : DEBUG : busycontacts : appCustomVersion function: Not defined
2024-06-19 13:11:54 : DEBUG : busycontacts : versionKey=CFBundleShortVersionString
2024-06-19 13:11:54 : DEBUG : busycontacts : packageID=
2024-06-19 13:11:54 : DEBUG : busycontacts : pkgName=
2024-06-19 13:11:54 : DEBUG : busycontacts : choiceChangesXML=
2024-06-19 13:11:54 : DEBUG : busycontacts : expectedTeamID=N4RA379GBW
2024-06-19 13:11:54 : DEBUG : busycontacts : blockingProcesses=BusyContacts
2024-06-19 13:11:54 : DEBUG : busycontacts : installerTool=
2024-06-19 13:11:55 : DEBUG : busycontacts : CLIInstaller=
2024-06-19 13:11:55 : DEBUG : busycontacts : CLIArguments=
2024-06-19 13:11:55 : DEBUG : busycontacts : updateTool=
2024-06-19 13:11:55 : DEBUG : busycontacts : updateToolArguments=
2024-06-19 13:11:55 : DEBUG : busycontacts : updateToolRunAsCurrentUser=
2024-06-19 13:11:55 : INFO  : busycontacts : BLOCKING_PROCESS_ACTION=tell_user
2024-06-19 13:11:55 : INFO  : busycontacts : NOTIFY=success
2024-06-19 13:11:55 : INFO  : busycontacts : LOGGING=DEBUG
2024-06-19 13:11:55 : INFO  : busycontacts : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-19 13:11:55 : INFO  : busycontacts : Label type: dmg
2024-06-19 13:11:55 : INFO  : busycontacts : archiveName: BusyContacts.dmg
2024-06-19 13:11:55 : DEBUG : busycontacts : Changing directory to /Users/mgoodman/Documents/GitHub/Installomator/build
2024-06-19 13:11:55 : INFO  : busycontacts : name: BusyContacts, appName: BusyContacts.app
2024-06-19 13:11:55.305 mdfind[4455:40198] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-06-19 13:11:55.306 mdfind[4455:40198] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-06-19 13:11:55.379 mdfind[4455:40198] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-19 13:11:55 : INFO  : busycontacts : App(s) found: /Users/mgoodman/Downloads/BusyContacts.app
2024-06-19 13:11:55 : WARN  : busycontacts : could not determine location of BusyContacts.app
2024-06-19 13:11:55 : INFO  : busycontacts : appversion: 
2024-06-19 13:11:55 : INFO  : busycontacts : Latest version of BusyContacts is 2024.1.2
2024-06-19 13:11:55 : REQ   : busycontacts : Downloading https://www.busymac.com/download/BusyContacts.dmg to BusyContacts.dmg
2024-06-19 13:11:55 : DEBUG : busycontacts : No Dialog connection, just download
2024-06-19 13:11:56 : DEBUG : busycontacts : File list: -rw-r--r--  1 mgoodman  staff    24M Jun 19 13:11 BusyContacts.dmg
2024-06-19 13:11:56 : DEBUG : busycontacts : File type: BusyContacts.dmg: zlib compressed data
2024-06-19 13:11:56 : DEBUG : busycontacts : curl output was:
* Host www.busymac.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.215.228.206
*   Trying 18.215.228.206:443...
* Connected to www.busymac.com (18.215.228.206) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3697 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=busymac.com
*  start date: Feb 21 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "www.busymac.com" matched cert's "www.busymac.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Thawte TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /download/BusyContacts.dmg HTTP/1.1
> Host: www.busymac.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/1.1 307 Temporary Redirect
< Date: Wed, 19 Jun 2024 20:11:56 GMT
< Server: Apache/2.4.58 (Ubuntu)
< Location: https://www.busymac.com/download/bct-2024.1.2.dmg
< Content-Length: 341
< Content-Type: text/html; charset=iso-8859-1
< 
* Ignoring the response-body
* Connection #0 to host www.busymac.com left intact
* Issue another request to this URL: 'https://www.busymac.com/download/bct-2024.1.2.dmg'
* Found bundle for host: 0x14490a680 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection with host www.busymac.com
> GET /download/bct-2024.1.2.dmg HTTP/1.1
> Host: www.busymac.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/1.1 302 Found
< Date: Wed, 19 Jun 2024 20:11:56 GMT
< Server: Apache/2.4.58 (Ubuntu)
< Location: https://downloads.busymac.com/bct-2024.1.2.dmg
< Content-Length: 312
< Content-Type: text/html; charset=iso-8859-1
< 
* Ignoring the response-body
* Connection #0 to host www.busymac.com left intact
* Issue another request to this URL: 'https://downloads.busymac.com/bct-2024.1.2.dmg'
* Host downloads.busymac.com:443 was resolved.
* IPv6: (none)
* IPv4: 216.137.39.62, 216.137.39.119, 216.137.39.110, 216.137.39.92
*   Trying 216.137.39.62:443...
* Connected to downloads.busymac.com (216.137.39.62) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4967 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=downloads.busymac.com
*  start date: Jun 12 00:00:00 2024 GMT
*  expire date: Jul 12 23:59:59 2025 GMT
*  subjectAltName: host "downloads.busymac.com" matched cert's "downloads.busymac.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.busymac.com/bct-2024.1.2.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.busymac.com]
* [HTTP/2] [1] [:path: /bct-2024.1.2.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /bct-2024.1.2.dmg HTTP/2
> Host: downloads.busymac.com
> User-Agent: curl/8.6.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/x-apple-diskimage
< content-length: 24715462
< date: Tue, 18 Jun 2024 23:30:24 GMT
< last-modified: Wed, 12 Jun 2024 00:33:46 GMT
< etag: "44848349052012f8529099c5dd7f78a5-2"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 f781ef6ca1647978bf98d972dc06ed4a.cloudfront.net (CloudFront)
< x-amz-cf-pop: LAX50-P2
< x-amz-cf-id: HFScSwJN7i9R9FnxGTQlPgS-NTH2BQd2JTYBmmPxouA4wt4M3V0B2w==
< age: 74493
< 
{ [32376 bytes data]
* Connection #1 to host downloads.busymac.com left intact

2024-06-19 13:11:56 : DEBUG : busycontacts : DEBUG mode 1, not checking for blocking processes
2024-06-19 13:11:56 : REQ   : busycontacts : Installing BusyContacts
2024-06-19 13:11:56 : INFO  : busycontacts : Mounting /Users/mgoodman/Documents/GitHub/Installomator/build/BusyContacts.dmg
2024-06-19 13:11:58 : DEBUG : busycontacts : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3B0484F2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $06B6CC53
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2F9194D2
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $7A430DC4
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2F9194D2
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $77AE00EE
verified   CRC32 $A3458D03
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/BusyContacts

2024-06-19 13:11:58 : INFO  : busycontacts : Mounted: /Volumes/BusyContacts
2024-06-19 13:11:58 : INFO  : busycontacts : Verifying: /Volumes/BusyContacts/BusyContacts.app
2024-06-19 13:11:58 : DEBUG : busycontacts : App size:  61M     /Volumes/BusyContacts/BusyContacts.app
2024-06-19 13:11:59 : DEBUG : busycontacts : Debugging enabled, App Verification output was:
/Volumes/BusyContacts/BusyContacts.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Busy Apps FZE (N4RA379GBW)

2024-06-19 13:11:59 : INFO  : busycontacts : Team ID matching: N4RA379GBW (expected: N4RA379GBW )
2024-06-19 13:11:59 : INFO  : busycontacts : Installing BusyContacts version 2024.1.2 on versionKey CFBundleShortVersionString.
2024-06-19 13:11:59 : INFO  : busycontacts : App has LSMinimumSystemVersion: 10.15
2024-06-19 13:11:59 : DEBUG : busycontacts : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-06-19 13:11:59 : INFO  : busycontacts : Finishing...
2024-06-19 13:12:02 : INFO  : busycontacts : name: BusyContacts, appName: BusyContacts.app
2024-06-19 13:12:02.643 mdfind[4612:41077] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-06-19 13:12:02.645 mdfind[4612:41077] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-06-19 13:12:02.750 mdfind[4612:41077] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-19 13:12:02 : INFO  : busycontacts : App(s) found: /Users/mgoodman/Downloads/BusyContacts.app
2024-06-19 13:12:02 : WARN  : busycontacts : could not determine location of BusyContacts.app
2024-06-19 13:12:02 : REQ   : busycontacts : Installed BusyContacts, version 2024.1.2
2024-06-19 13:12:02 : INFO  : busycontacts : notifying
2024-06-19 13:12:03 : DEBUG : busycontacts : Unmounting /Volumes/BusyContacts
2024-06-19 13:12:04 : DEBUG : busycontacts : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-06-19 13:12:04 : DEBUG : busycontacts : DEBUG mode 1, not reopening anything
2024-06-19 13:12:04 : REQ   : busycontacts : All done!
2024-06-19 13:12:04 : REQ   : busycontacts : ################## End Installomator, exit code 0 