### PR TITLE
Update googlechromeenterprise.sh appNewVersion

### DIFF
--- a/fragments/labels/googlechromeenterprise.sh
+++ b/fragments/labels/googlechromeenterprise.sh
@@ -4,7 +4,7 @@ googlechromeenterprise)
     downloadURL="https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg"
     appNewVersion=$(curl -s https://omahaproxy.appspot.com/history | awk -F',' '/mac_arm64,stable/{print $3; exit}')
     expectedTeamID="EQHXZ8M8AV"
-    updateTool="/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent"
+    appNewVersion=$(getJSONValue "$(curl -fsL "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=fraction>0.01,endtime=none&order_by=version%20desc" )" "releases[0].version" )
     updateToolArguments=( -runMode oneshot -userInitiated YES )
     updateToolRunAsCurrentUser=1
     ;;


### PR DESCRIPTION
Use the same appNewVersion check as the googlechromepkg label.
````
sudo ./installomator.sh googlechromeenterprise BLOCKING_PROCESS_ACTION=prompt_user_loop NOTIFY=silent DEBUG=0
2024-06-21 14:09:39 : REQ   : googlechromeenterprise : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-06-21 14:09:39 : INFO  : googlechromeenterprise : ################## Version: 10.6beta
2024-06-21 14:09:39 : INFO  : googlechromeenterprise : ################## Date: 2024-04-23
2024-06-21 14:09:39 : INFO  : googlechromeenterprise : ################## googlechromeenterprise
2024-06-21 14:09:39 : DEBUG : googlechromeenterprise : DEBUG mode 1 enabled.
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : setting variable from argument NOTIFY=silent
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : setting variable from argument DEBUG=0
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : name=Google Chrome
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : appName=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : type=pkg
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : archiveName=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : downloadURL=https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : curlOptions=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : appNewVersion=126.0.6478.115
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : appCustomVersion function: Not defined
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : versionKey=CFBundleShortVersionString
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : packageID=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : pkgName=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : choiceChangesXML=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : expectedTeamID=EQHXZ8M8AV
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : blockingProcesses=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : installerTool=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : CLIInstaller=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : CLIArguments=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : updateTool=
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : updateToolArguments=-runMode oneshot -userInitiated YES
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : updateToolRunAsCurrentUser=1
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : BLOCKING_PROCESS_ACTION=prompt_user_loop
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : NOTIFY=silent
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : LOGGING=DEBUG
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : Label type: pkg
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : archiveName: Google Chrome.pkg
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : no blocking processes defined, using Google Chrome as default
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ULCcvpSxWD
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : App(s) found: /Applications/Google Chrome.app
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : found app at /Applications/Google Chrome.app, version 126.0.6478.115, on versionKey CFBundleShortVersionString
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : appversion: 126.0.6478.115
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : Latest version of Google Chrome is 126.0.6478.115
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : There is no newer version available.
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ULCcvpSxWD
2024-06-21 14:09:40 : DEBUG : googlechromeenterprise : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ULCcvpSxWD
2024-06-21 14:09:40 : INFO  : googlechromeenterprise : Installomator did not close any apps, so no need to reopen any apps.
2024-06-21 14:09:40 : REQ   : googlechromeenterprise : No newer version.
2024-06-21 14:09:40 : REQ   : googlechromeenterprise : ################## End Installomator, exit code 0 
````