### PR TITLE
Update clevershare2.sh - Fix downloadURL and TeamID

### DIFF
--- a/fragments/labels/clevershare2.sh
+++ b/fragments/labels/clevershare2.sh
@@ -2,7 +2,7 @@ clevershare2)
     name="Clevershare"
     type="dmg"
     printlog "Label for $name broken in test" ERROR
-    downloadURL=$(curl -fs https://www.clevertouch.com/eu/clevershare2g | grep -i -o -E "https.*notarized.*\.dmg")
+    downloadURL=$(curl -fs https://www.clevertouch.com/uk/clevershare2g | grep -i -o -E "https.*validated.*\.dmg")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/([0-9.]*)\/[0-9]*\/.*\.dmg$/\1/')
-    expectedTeamID="P76M9BE8DQ"
+    expectedTeamID="LHZP4ZQ39M"
     ;;


### PR DESCRIPTION
Previous clevershare2.sh label hasn't been updated since a long time
There's a new downloadURL and TeamID : 

```
clevershare2)
    name="Clevershare"
    type="dmg"
    printlog "Label for $name broken in test" ERROR
    downloadURL=$(curl -fs https://www.clevertouch.com/uk/clevershare2g | grep -i -o -E "https.*validated.*\.dmg")
    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/([0-9.]*)\/[0-9]*\/.*\.dmg$/\1/')
    expectedTeamID="LHZP4ZQ39M"
    ;;
```

Output :
```
2024-06-27 16:08:32 : REQ   :  : shifting arguments for Jamf
2024-06-27 16:08:32 : REQ   : clevershare2 : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-06-27 16:08:32 : INFO  : clevershare2 : ################## Version: 10.6beta
2024-06-27 16:08:32 : INFO  : clevershare2 : ################## Date: 2024-04-23
2024-06-27 16:08:32 : INFO  : clevershare2 : ################## clevershare2
2024-06-27 16:08:32 : DEBUG : clevershare2 : DEBUG mode 1 enabled.
2024-06-27 16:08:32 : INFO  : clevershare2 : SwiftDialog is not installed, clear cmd file var
2024-06-27 16:08:32 : ERROR : clevershare2 : Label for Clevershare broken in test
2024-06-27 16:08:33 : INFO  : clevershare2 : setting variable from argument DEBUG=0
2024-06-27 16:08:33 : INFO  : clevershare2 : setting variable from argument NOTIFY=silent
2024-06-27 16:08:33 : INFO  : clevershare2 : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user
2024-06-27 16:08:33 : INFO  : clevershare2 : setting variable from argument SYSTEMOWNER=1
2024-06-27 16:08:33 : DEBUG : clevershare2 : name=Clevershare
2024-06-27 16:08:33 : DEBUG : clevershare2 : appName=
2024-06-27 16:08:33 : DEBUG : clevershare2 : type=dmg
2024-06-27 16:08:33 : DEBUG : clevershare2 : archiveName=
2024-06-27 16:08:33 : DEBUG : clevershare2 : downloadURL=https://saharaplc.s3.eu-west-2.amazonaws.com/Clevershare+5/Clients/5.7/MacOS+-+New/Clevershare-5.7.1.7015-validated.dmg
2024-06-27 16:08:33 : DEBUG : clevershare2 : curlOptions=
2024-06-27 16:08:33 : DEBUG : clevershare2 : appNewVersion=https://saharaplc.s3.eu-west-2.amazonaws.com/Clevershare+5/Clients/5.7/MacOS+-+New/Clevershare-5.7.1.7015-validated.dmg
2024-06-27 16:08:33 : DEBUG : clevershare2 : appCustomVersion function: Not defined
2024-06-27 16:08:33 : DEBUG : clevershare2 : versionKey=CFBundleShortVersionString
2024-06-27 16:08:33 : DEBUG : clevershare2 : packageID=
2024-06-27 16:08:33 : DEBUG : clevershare2 : pkgName=
2024-06-27 16:08:33 : DEBUG : clevershare2 : choiceChangesXML=
2024-06-27 16:08:33 : DEBUG : clevershare2 : expectedTeamID=LHZP4ZQ39M
2024-06-27 16:08:33 : DEBUG : clevershare2 : blockingProcesses=
2024-06-27 16:08:33 : DEBUG : clevershare2 : installerTool=
2024-06-27 16:08:33 : DEBUG : clevershare2 : CLIInstaller=
2024-06-27 16:08:33 : DEBUG : clevershare2 : CLIArguments=
2024-06-27 16:08:33 : DEBUG : clevershare2 : updateTool=
2024-06-27 16:08:33 : DEBUG : clevershare2 : updateToolArguments=
2024-06-27 16:08:33 : DEBUG : clevershare2 : updateToolRunAsCurrentUser=
2024-06-27 16:08:33 : INFO  : clevershare2 : BLOCKING_PROCESS_ACTION=prompt_user
2024-06-27 16:08:33 : INFO  : clevershare2 : NOTIFY=silent
2024-06-27 16:08:33 : INFO  : clevershare2 : LOGGING=DEBUG
2024-06-27 16:08:33 : INFO  : clevershare2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-06-27 16:08:33 : INFO  : clevershare2 : Label type: dmg
2024-06-27 16:08:33 : INFO  : clevershare2 : archiveName: Clevershare.dmg
2024-06-27 16:08:33 : INFO  : clevershare2 : no blocking processes defined, using Clevershare as default
2024-06-27 16:08:33 : DEBUG : clevershare2 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.P34PDjziUR
2024-06-27 16:08:33 : INFO  : clevershare2 : name: Clevershare, appName: Clevershare.app
2024-06-27 16:08:33.215 mdfind[12774:123442] [UserQueryParser] Loading keywords and predicates for locale "fr_FR"
2024-06-27 16:08:33.215 mdfind[12774:123442] [UserQueryParser] Loading keywords and predicates for locale "fr"
2024-06-27 16:08:33.263 mdfind[12774:123442] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-27 16:08:33.263 mdfind[12774:123442] Couldn't determine the mapping between prefab keywords and predicates.
2024-06-27 16:08:33 : WARN  : clevershare2 : No previous app found
2024-06-27 16:08:33 : WARN  : clevershare2 : could not find Clevershare.app
2024-06-27 16:08:33 : INFO  : clevershare2 : appversion: 
2024-06-27 16:08:33 : INFO  : clevershare2 : Latest version of Clevershare is https://saharaplc.s3.eu-west-2.amazonaws.com/Clevershare+5/Clients/5.7/MacOS+-+New/Clevershare-5.7.1.7015-validated.dmg
2024-06-27 16:08:33 : REQ   : clevershare2 : Downloading https://saharaplc.s3.eu-west-2.amazonaws.com/Clevershare+5/Clients/5.7/MacOS+-+New/Clevershare-5.7.1.7015-validated.dmg to Clevershare.dmg
2024-06-27 16:08:33 : DEBUG : clevershare2 : No Dialog connection, just download
2024-06-27 16:08:38 : DEBUG : clevershare2 : File list: -rw-r--r--  1 root  wheel    10M Jun 27 16:08 Clevershare.dmg
2024-06-27 16:08:38 : DEBUG : clevershare2 : File type: Clevershare.dmg: bzip2 compressed data, block size = 100k
2024-06-27 16:08:38 : DEBUG : clevershare2 : curl output was:
*   Trying 52.95.142.98:443...
* Connected to saharaplc.s3.eu-west-2.amazonaws.com (52.95.142.98) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [341 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [106 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5506 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.eu-west-2.amazonaws.com
*  start date: Apr 25 00:00:00 2024 GMT
*  expire date: Apr 21 23:59:59 2025 GMT
*  subjectAltName: host "saharaplc.s3.eu-west-2.amazonaws.com" matched cert's "*.s3.eu-west-2.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.1
> GET /Clevershare+5/Clients/5.7/MacOS+-+New/Clevershare-5.7.1.7015-validated.dmg HTTP/1.1

> Host: saharaplc.s3.eu-west-2.amazonaws.com

> User-Agent: curl/8.1.2

> Accept: */*

> 

< HTTP/1.1 200 OK

< x-amz-id-2: 6wfiZc/Y4zDKc5qhsYMVY/4gLK92fZhsjfyj1NACAb6wPfXjQQi8DiGEFFfGs9e1UldchWEgyuU=

< x-amz-request-id: 915AEBD74AQGZ089

< Date: Thu, 27 Jun 2024 14:08:34 GMT

< Last-Modified: Mon, 23 Oct 2023 07:39:01 GMT

< ETag: "59a19f84da2c3adfb54c3ada4656c0f3"

< x-amz-server-side-encryption: AES256

< x-amz-version-id: 5AjOx4vqTB6.gT2xSziOFDEWGMd1MMnZ

< Accept-Ranges: bytes

< Content-Type: application/x-apple-diskimage

< Server: AmazonS3

< Content-Length: 10761990

< 

{ [16384 bytes data]
* Connection #0 to host saharaplc.s3.eu-west-2.amazonaws.com left intact

2024-06-27 16:08:38 : REQ   : clevershare2 : no more blocking processes, continue with update
2024-06-27 16:08:38 : REQ   : clevershare2 : Installing Clevershare
2024-06-27 16:08:38 : INFO  : clevershare2 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.P34PDjziUR/Clevershare.dmg
2024-06-27 16:08:40 : DEBUG : clevershare2 : Debugging enabled, dmgmount output was:
Calcul de la somme de contrôle de Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR : : vérifiée   CRC32 $9CB19831
Calcul de la somme de contrôle de GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1) : vérifiée   CRC32 $F74F34F9
Calcul de la somme de contrôle de GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl : vérifiée   CRC32 $814155F5
Calcul de la somme de contrôle de  (Apple_Free : 3)…
(Apple_Free : 3) : vérifiée   CRC32 $00000000
Calcul de la somme de contrôle de disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4) : vérifiée   CRC32 $00EC57B7
Calcul de la somme de contrôle de GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table : vérifiée   CRC32 $814155F5
Calcul de la somme de contrôle de GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6) : vérifiée   CRC32 $C8B5BDEC
vérifiée   CRC32 $700A1317
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Clevershare

2024-06-27 16:08:40 : INFO  : clevershare2 : Mounted: /Volumes/Clevershare
2024-06-27 16:08:40 : INFO  : clevershare2 : Verifying: /Volumes/Clevershare/Clevershare.app
2024-06-27 16:08:40 : DEBUG : clevershare2 : App size:  19M	/Volumes/Clevershare/Clevershare.app
2024-06-27 16:08:41 : DEBUG : clevershare2 : Debugging enabled, App Verification output was:
/Volumes/Clevershare/Clevershare.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Sahara Presentation Systems PLC (LHZP4ZQ39M)

2024-06-27 16:08:41 : INFO  : clevershare2 : Team ID matching: LHZP4ZQ39M (expected: LHZP4ZQ39M )
2024-06-27 16:08:41 : INFO  : clevershare2 : Installing Clevershare version 5.7.1 on versionKey CFBundleShortVersionString.
2024-06-27 16:08:41 : INFO  : clevershare2 : App has LSMinimumSystemVersion: 10.11
2024-06-27 16:08:41 : INFO  : clevershare2 : Copy /Volumes/Clevershare/Clevershare.app to /Applications
2024-06-27 16:08:42 : DEBUG : clevershare2 : Debugging enabled, App copy output was:
Copying /Volumes/Clevershare/Clevershare.app

2024-06-27 16:08:42 : WARN  : clevershare2 : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2024-06-27 16:08:42 : INFO  : clevershare2 : Finishing...
2024-06-27 16:08:45 : INFO  : clevershare2 : App(s) found: /Applications/Clevershare.app
2024-06-27 16:08:45 : INFO  : clevershare2 : found app at /Applications/Clevershare.app, version 5.7.1, on versionKey CFBundleShortVersionString
2024-06-27 16:08:45 : REQ   : clevershare2 : Installed Clevershare, version 5.7.1
2024-06-27 16:08:45 : DEBUG : clevershare2 : Unmounting /Volumes/Clevershare
2024-06-27 16:08:45 : DEBUG : clevershare2 : Debugging enabled, Unmounting output was:
"disk5" ejected.
2024-06-27 16:08:45 : DEBUG : clevershare2 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.P34PDjziUR
2024-06-27 16:08:45 : DEBUG : clevershare2 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.P34PDjziUR/Clevershare.dmg
2024-06-27 16:08:45 : DEBUG : clevershare2 : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.P34PDjziUR
2024-06-27 16:08:45 : INFO  : clevershare2 : Installomator did not close any apps, so no need to reopen any apps.
2024-06-27 16:08:45 : REQ   : clevershare2 : All done!
2024-06-27 16:08:45 : REQ   : clevershare2 : ################## End Installomator, exit code 0
```