### PR TITLE
Added New Label chatgpt

### DIFF
--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -1,0 +1,7 @@
+chatgpt)
+	 # ChatGPT Mac client developed by OpenAI for general users offers an intuitive platform for accessing AI-powered assistance and support on macOS devices
+     name="ChatGPT"
+     type="dmg"
+     downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
+     expectedTeamID="2DC432GLL2"
+     ;;


### PR DESCRIPTION
Output:
```
Installomator/utils/assemble.sh chatgpt DEBUG=0
2024-07-03 15:30:30 : REQ   : chatgpt : ################## Start Installomator v. 10.6beta, date 2024-07-03
2024-07-03 15:30:30 : INFO  : chatgpt : ################## Version: 10.6beta
2024-07-03 15:30:30 : INFO  : chatgpt : ################## Date: 2024-07-03
2024-07-03 15:30:30 : INFO  : chatgpt : ################## chatgpt
2024-07-03 15:30:30 : DEBUG : chatgpt : DEBUG mode 1 enabled.
2024-07-03 15:30:30 : INFO  : chatgpt : setting variable from argument DEBUG=0
2024-07-03 15:30:30 : DEBUG : chatgpt : name=ChatGPT
2024-07-03 15:30:30 : DEBUG : chatgpt : appName=
2024-07-03 15:30:30 : DEBUG : chatgpt : type=dmg
2024-07-03 15:30:30 : DEBUG : chatgpt : archiveName=
2024-07-03 15:30:30 : DEBUG : chatgpt : downloadURL=https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg
2024-07-03 15:30:30 : DEBUG : chatgpt : curlOptions=
2024-07-03 15:30:30 : DEBUG : chatgpt : appNewVersion=
2024-07-03 15:30:30 : DEBUG : chatgpt : appCustomVersion function: Not defined
2024-07-03 15:30:30 : DEBUG : chatgpt : versionKey=CFBundleShortVersionString
2024-07-03 15:30:30 : DEBUG : chatgpt : packageID=
2024-07-03 15:30:30 : DEBUG : chatgpt : pkgName=
2024-07-03 15:30:30 : DEBUG : chatgpt : choiceChangesXML=
2024-07-03 15:30:30 : DEBUG : chatgpt : expectedTeamID=2DC432GLL2
2024-07-03 15:30:30 : DEBUG : chatgpt : blockingProcesses=
2024-07-03 15:30:30 : DEBUG : chatgpt : installerTool=
2024-07-03 15:30:30 : DEBUG : chatgpt : CLIInstaller=
2024-07-03 15:30:30 : DEBUG : chatgpt : CLIArguments=
2024-07-03 15:30:30 : DEBUG : chatgpt : updateTool=
2024-07-03 15:30:30 : DEBUG : chatgpt : updateToolArguments=
2024-07-03 15:30:30 : DEBUG : chatgpt : updateToolRunAsCurrentUser=
2024-07-03 15:30:30 : INFO  : chatgpt : BLOCKING_PROCESS_ACTION=tell_user
2024-07-03 15:30:30 : INFO  : chatgpt : NOTIFY=success
2024-07-03 15:30:30 : INFO  : chatgpt : LOGGING=DEBUG
2024-07-03 15:30:30 : INFO  : chatgpt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-03 15:30:30 : INFO  : chatgpt : Label type: dmg
2024-07-03 15:30:30 : INFO  : chatgpt : archiveName: ChatGPT.dmg
2024-07-03 15:30:30 : INFO  : chatgpt : no blocking processes defined, using ChatGPT as default
2024-07-03 15:30:30 : DEBUG : chatgpt : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.eNY9oEX9iA
2024-07-03 15:30:30 : INFO  : chatgpt : name: ChatGPT, appName: ChatGPT.app
2024-07-03 15:30:30.543 mdfind[75998:43567595] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-03 15:30:30.543 mdfind[75998:43567595] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-03 15:30:30.596 mdfind[75998:43567595] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-03 15:30:30 : WARN  : chatgpt : No previous app found
2024-07-03 15:30:30 : WARN  : chatgpt : could not find ChatGPT.app
2024-07-03 15:30:30 : INFO  : chatgpt : appversion:
2024-07-03 15:30:30 : INFO  : chatgpt : Latest version not specified.
2024-07-03 15:30:30 : REQ   : chatgpt : Downloading https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg to ChatGPT.dmg
2024-07-03 15:30:30 : DEBUG : chatgpt : No Dialog connection, just download
2024-07-03 15:30:33 : DEBUG : chatgpt : File list: -rw-r--r--  1 root  wheel    46M Jul  3 15:30 ChatGPT.dmg
2024-07-03 15:30:33 : DEBUG : chatgpt : File type: ChatGPT.dmg: zlib compressed data
2024-07-03 15:30:33 : DEBUG : chatgpt : curl output was:
* Host persistent.oaistatic.com:443 was resolved.
* IPv6: (none)
* IPv4: 104.18.12.201, 104.18.13.201
*   Trying 104.18.12.201:443...
* Connected to persistent.oaistatic.com (104.18.12.201) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3437 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=persistent.oaistatic.com
*  start date: Jun 25 20:41:19 2024 GMT
*  expire date: Sep 23 20:41:18 2024 GMT
*  subjectAltName: host "persistent.oaistatic.com" matched cert's "persistent.oaistatic.com"
*  issuer: C=US; O=Let's Encrypt; CN=E6
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: persistent.oaistatic.com]
* [HTTP/2] [1] [:path: /sidekick/public/ChatGPT_Desktop_public_latest.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /sidekick/public/ChatGPT_Desktop_public_latest.dmg HTTP/2
> Host: persistent.oaistatic.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< date: Wed, 03 Jul 2024 21:30:31 GMT
< content-type: application/x-apple-diskimage
< content-length: 48519669
< cache-control: max-age=300
< content-md5: OegrDUOmOJd+gOuWvKkBEw==
< last-modified: Wed, 03 Jul 2024 18:02:20 GMT
< etag: 0x8DC9B8A48562083
< x-ms-request-id: 424b97ce-e01e-0073-1573-cd9c51000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< access-control-expose-headers: content-length
< access-control-allow-origin: *
< cf-cache-status: HIT
< accept-ranges: bytes
< set-cookie: __cf_bm=FDu_3OiWSqu3adfrmFnQzLBbtY4GNT5vjMdipSgfrPY-1720042231-1.0.1.1-3C5T4DU3PH.cEols_ZzI9JiQmY6Vfn6hiRd.g1PPgHm4NIDh9bLjgF.hrrIo0NyTpDN1YWCogkG5bY9O6j2_PQ; path=/; expires=Wed, 03-Jul-24 22:00:31 GMT; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< set-cookie: _cfuvid=869hxE1hZ2rZ3KSaBE2v4WwWqx1C2itzOlDzXWBeTv0-1720042231902-0.0.1.1-604800000; path=/; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 89d9fa2cef44faec-SJC
< alt-svc: h3=":443"; ma=86400
<
{ [1360 bytes data]
* Connection #0 to host persistent.oaistatic.com left intact

2024-07-03 15:30:33 : REQ   : chatgpt : no more blocking processes, continue with update
2024-07-03 15:30:33 : REQ   : chatgpt : Installing ChatGPT
2024-07-03 15:30:33 : INFO  : chatgpt : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.eNY9oEX9iA/ChatGPT.dmg
2024-07-03 15:30:37 : DEBUG : chatgpt : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $E14B5432
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D378FA74
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $B345CF1D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $C14F67FF
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $B345CF1D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $B086A371
verified   CRC32 $145767E1
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/ChatGPT Installer

2024-07-03 15:30:37 : INFO  : chatgpt : Mounted: /Volumes/ChatGPT Installer
2024-07-03 15:30:37 : INFO  : chatgpt : Verifying: /Volumes/ChatGPT Installer/ChatGPT.app
2024-07-03 15:30:37 : DEBUG : chatgpt : App size: 138M	/Volumes/ChatGPT Installer/ChatGPT.app
2024-07-03 15:30:39 : DEBUG : chatgpt : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Installer/ChatGPT.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI, L.L.C. (2DC432GLL2)

2024-07-03 15:30:39 : INFO  : chatgpt : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2024-07-03 15:30:39 : INFO  : chatgpt : Installing ChatGPT version 1.2024.171 on versionKey CFBundleShortVersionString.
2024-07-03 15:30:39 : INFO  : chatgpt : App has LSMinimumSystemVersion: 14.0
2024-07-03 15:30:39 : INFO  : chatgpt : Copy /Volumes/ChatGPT Installer/ChatGPT.app to /Applications
2024-07-03 15:30:41 : DEBUG : chatgpt : Debugging enabled, App copy output was:
Copying /Volumes/ChatGPT Installer/ChatGPT.app

2024-07-03 15:30:41 : WARN  : chatgpt : Changing owner to u0105821
2024-07-03 15:30:42 : INFO  : chatgpt : Finishing...
2024-07-03 15:30:45 : INFO  : chatgpt : App(s) found: /Applications/ChatGPT.app
2024-07-03 15:30:45 : INFO  : chatgpt : found app at /Applications/ChatGPT.app, version 1.2024.171, on versionKey CFBundleShortVersionString
2024-07-03 15:30:45 : REQ   : chatgpt : Installed ChatGPT, version 1.2024.171
2024-07-03 15:30:45 : INFO  : chatgpt : notifying
2024-07-03 15:30:45 : DEBUG : chatgpt : Unmounting /Volumes/ChatGPT Installer
2024-07-03 15:30:45 : DEBUG : chatgpt : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-07-03 15:30:45 : DEBUG : chatgpt : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.eNY9oEX9iA
2024-07-03 15:30:45 : DEBUG : chatgpt : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.eNY9oEX9iA/ChatGPT.dmg
2024-07-03 15:30:45 : DEBUG : chatgpt : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.eNY9oEX9iA
2024-07-03 15:30:45 : INFO  : chatgpt : Installomator did not close any apps, so no need to reopen any apps.
2024-07-03 15:30:45 : REQ   : chatgpt : All done!
2024-07-03 15:30:45 : REQ   : chatgpt : ################## End Installomator, exit code 0

```