### PR TITLE
Update to VLC Label

### DIFF
--- a/fragments/labels/vlc.sh
+++ b/fragments/labels/vlc.sh
@@ -1,11 +1,8 @@
 vlc)
+    # VLC is a versatile, open-source multimedia player that supports a wide range of audio, video, and streaming formats across multiple platforms
     name="VLC"
     type="dmg"
-    latestVersionURL="https://get.videolan.org/vlc/last/macosx/"
-    archiveName=$(curl -sf "$latestVersionURL" | grep -ioE 'vlc-[0-9]+\.[0-9]+\.[0-9]+-universal\.dmg' | uniq)
-    downloadURL="${latestVersionURL}${archiveName}"
-    appNewVersion=$(awk -F'[-.]' '{print $2"."$3"."$4}' <<< "$archiveName")
-    versionKey="CFBundleShortVersionString"
+    appNewVersion=$(curl -s https://www.videolan.org/vlc/#download | xmllint --html --xpath "//script[contains(text(),'var PLATFORMS')]" - 2>/dev/null | grep -o '"osx":{"name":"macOS[^}]*' | grep -o '"latestVersion":"[^"]*' | sed 's/"latestVersion":"//')
+    downloadURL="https://get.videolan.org/vlc/$appNewVersion/macosx/vlc-$appNewVersion-universal.dmg"
     expectedTeamID="75GAHG3SZQ"
     ;;
-


### PR DESCRIPTION
The previous VLC label ran into an issue where the VLC web developer forgot to update the page:

https://forum.videolan.org/viewtopic.php?f=10&t=164762&sid=68e382a3df0b6329d4cc06fbb11611ee

This might be a better method for download the latest release that is less forgettable:

output:

```
sudo Installomator/utils/assemble.sh vlc DEBUG=0
2024-07-03 16:23:07 : REQ   : vlc : ################## Start Installomator v. 10.6beta, date 2024-07-03
2024-07-03 16:23:07 : INFO  : vlc : ################## Version: 10.6beta
2024-07-03 16:23:07 : INFO  : vlc : ################## Date: 2024-07-03
2024-07-03 16:23:07 : INFO  : vlc : ################## vlc
2024-07-03 16:23:07 : DEBUG : vlc : DEBUG mode 1 enabled.
2024-07-03 16:23:08 : INFO  : vlc : setting variable from argument DEBUG=0
2024-07-03 16:23:08 : DEBUG : vlc : name=VLC
2024-07-03 16:23:08 : DEBUG : vlc : appName=
2024-07-03 16:23:08 : DEBUG : vlc : type=dmg
2024-07-03 16:23:08 : DEBUG : vlc : archiveName=
2024-07-03 16:23:08 : DEBUG : vlc : downloadURL=https://get.videolan.org/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg
2024-07-03 16:23:08 : DEBUG : vlc : curlOptions=
2024-07-03 16:23:08 : DEBUG : vlc : appNewVersion=3.0.21
2024-07-03 16:23:08 : DEBUG : vlc : appCustomVersion function: Not defined
2024-07-03 16:23:08 : DEBUG : vlc : versionKey=CFBundleShortVersionString
2024-07-03 16:23:08 : DEBUG : vlc : packageID=
2024-07-03 16:23:08 : DEBUG : vlc : pkgName=
2024-07-03 16:23:08 : DEBUG : vlc : choiceChangesXML=
2024-07-03 16:23:08 : DEBUG : vlc : expectedTeamID=75GAHG3SZQ
2024-07-03 16:23:08 : DEBUG : vlc : blockingProcesses=
2024-07-03 16:23:08 : DEBUG : vlc : installerTool=
2024-07-03 16:23:08 : DEBUG : vlc : CLIInstaller=
2024-07-03 16:23:08 : DEBUG : vlc : CLIArguments=
2024-07-03 16:23:08 : DEBUG : vlc : updateTool=
2024-07-03 16:23:08 : DEBUG : vlc : updateToolArguments=
2024-07-03 16:23:08 : DEBUG : vlc : updateToolRunAsCurrentUser=
2024-07-03 16:23:08 : INFO  : vlc : BLOCKING_PROCESS_ACTION=tell_user
2024-07-03 16:23:08 : INFO  : vlc : NOTIFY=success
2024-07-03 16:23:08 : INFO  : vlc : LOGGING=DEBUG
2024-07-03 16:23:08 : INFO  : vlc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-03 16:23:08 : INFO  : vlc : Label type: dmg
2024-07-03 16:23:08 : INFO  : vlc : archiveName: VLC.dmg
2024-07-03 16:23:08 : INFO  : vlc : no blocking processes defined, using VLC as default
2024-07-03 16:23:08 : DEBUG : vlc : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oMyCbHnxpH
2024-07-03 16:23:08 : INFO  : vlc : name: VLC, appName: VLC.app
2024-07-03 16:23:08.347 mdfind[12801:43679176] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-03 16:23:08.347 mdfind[12801:43679176] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-03 16:23:08.423 mdfind[12801:43679176] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-03 16:23:08 : WARN  : vlc : No previous app found
2024-07-03 16:23:08 : WARN  : vlc : could not find VLC.app
2024-07-03 16:23:08 : INFO  : vlc : appversion:
2024-07-03 16:23:08 : INFO  : vlc : Latest version of VLC is 3.0.21
2024-07-03 16:23:08 : REQ   : vlc : Downloading https://get.videolan.org/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg to VLC.dmg
2024-07-03 16:23:08 : DEBUG : vlc : No Dialog connection, just download
2024-07-03 16:23:13 : DEBUG : vlc : File list: -rw-r--r--  1 root  wheel    81M Jul  3 16:23 VLC.dmg
2024-07-03 16:23:13 : DEBUG : vlc : File type: VLC.dmg: bzip2 compressed data, block size = 100k
2024-07-03 16:23:13 : DEBUG : vlc : curl output was:
* Host get.videolan.org:443 was resolved.
* IPv6: (none)
* IPv4: 62.210.246.226
*   Trying 62.210.246.226:443...
* Connected to get.videolan.org (62.210.246.226) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2664 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=get-dc2.videolan.org
*  start date: Jun 25 01:12:07 2024 GMT
*  expire date: Sep 23 01:12:06 2024 GMT
*  subjectAltName: host "get.videolan.org" matched cert's "get.videolan.org"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://get.videolan.org/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: get.videolan.org]
* [HTTP/2] [1] [:path: /vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg HTTP/2
> Host: get.videolan.org
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 302
< server: nginx
< date: Wed, 03 Jul 2024 22:23:08 GMT
< content-type: text/html; charset=UTF-8
< location: https://opencolo.mm.fcix.net/videolan-ftp/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg
< alt-svc: h2=":443"
<
* Ignoring the response-body
* Connection #0 to host get.videolan.org left intact
* Issue another request to this URL: 'https://opencolo.mm.fcix.net/videolan-ftp/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg'
* Host opencolo.mm.fcix.net:443 was resolved.
* IPv6: (none)
* IPv4: 50.117.120.66
*   Trying 50.117.120.66:443...
* Connected to opencolo.mm.fcix.net (50.117.120.66) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2596 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=opencolo.mm.fcix.net
*  start date: May 25 07:20:48 2024 GMT
*  expire date: Aug 23 07:20:47 2024 GMT
*  subjectAltName: host "opencolo.mm.fcix.net" matched cert's "opencolo.mm.fcix.net"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /videolan-ftp/vlc/3.0.21/macosx/vlc-3.0.21-universal.dmg HTTP/1.1
> Host: opencolo.mm.fcix.net
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.20.1
< Date: Wed, 03 Jul 2024 22:23:10 GMT
< Content-Type: application/octet-stream
< Content-Length: 85154196
< Last-Modified: Sat, 08 Jun 2024 23:35:41 GMT
< Connection: keep-alive
< ETag: "6664eacd-5135994"
< Accept-Ranges: bytes
<
{ [16122 bytes data]
* Connection #1 to host opencolo.mm.fcix.net left intact

2024-07-03 16:23:13 : REQ   : vlc : no more blocking processes, continue with update
2024-07-03 16:23:13 : REQ   : vlc : Installing VLC
2024-07-03 16:23:13 : INFO  : vlc : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oMyCbHnxpH/VLC.dmg
2024-07-03 16:23:19 : DEBUG : vlc : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $5BE2429D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $BE85DA91
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5918B622
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $7FE76D49
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5918B622
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9DF495A7
verified   CRC32 $F0A94024
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/VLC media player

2024-07-03 16:23:19 : INFO  : vlc : Mounted: /Volumes/VLC media player
2024-07-03 16:23:19 : INFO  : vlc : Verifying: /Volumes/VLC media player/VLC.app
2024-07-03 16:23:19 : DEBUG : vlc : App size: 238M	/Volumes/VLC media player/VLC.app
2024-07-03 16:23:40 : DEBUG : vlc : Debugging enabled, App Verification output was:
/Volumes/VLC media player/VLC.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: VideoLAN (75GAHG3SZQ)

2024-07-03 16:23:40 : INFO  : vlc : Team ID matching: 75GAHG3SZQ (expected: 75GAHG3SZQ )
2024-07-03 16:23:40 : INFO  : vlc : Installing VLC version 3.0.21 on versionKey CFBundleShortVersionString.
2024-07-03 16:23:40 : INFO  : vlc : App has LSMinimumSystemVersion: 10.7.5
2024-07-03 16:23:40 : INFO  : vlc : Copy /Volumes/VLC media player/VLC.app to /Applications
2024-07-03 16:23:58 : DEBUG : vlc : Debugging enabled, App copy output was:
Copying /Volumes/VLC media player/VLC.app

2024-07-03 16:23:58 : WARN  : vlc : Changing owner to u0105821
2024-07-03 16:23:58 : INFO  : vlc : Finishing...
2024-07-03 16:24:01 : INFO  : vlc : App(s) found: /Applications/VLC.app
2024-07-03 16:24:01 : INFO  : vlc : found app at /Applications/VLC.app, version 3.0.21, on versionKey CFBundleShortVersionString
2024-07-03 16:24:01 : REQ   : vlc : Installed VLC, version 3.0.21
2024-07-03 16:24:01 : INFO  : vlc : notifying
2024-07-03 16:24:01 : DEBUG : vlc : Unmounting /Volumes/VLC media player
2024-07-03 16:24:01 : DEBUG : vlc : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-07-03 16:24:01 : DEBUG : vlc : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oMyCbHnxpH
2024-07-03 16:24:01 : DEBUG : vlc : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oMyCbHnxpH/VLC.dmg
2024-07-03 16:24:01 : DEBUG : vlc : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oMyCbHnxpH
2024-07-03 16:24:01 : INFO  : vlc : Installomator did not close any apps, so no need to reopen any apps.
2024-07-03 16:24:01 : REQ   : vlc : All done!
2024-07-03 16:24:01 : REQ   : vlc : ################## End Installomator, exit code 0
```