### PR TITLE
New Label for DrRacket (or racket)

### DIFF
--- a/fragments/labels/drracket.sh
+++ b/fragments/labels/drracket.sh
@@ -1,0 +1,14 @@
+drracket)
+	# DrRacket (or racket) offers a versatile programming environment for various platforms
+    name="DrRacket"
+    type="dmg"
+	appNewVersion=$(curl -fs https://racket-lang.org/download/ | grep -o 'racket-[0-9.]*-aarch64-macosx-cs\.dmg' | head -n 1 | sed 's/racket-\(.*\)-aarch64-macosx-cs\.dmg/\1/')
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(echo "https://download.racket-lang.org/installers/${appNewVersion}/"$(curl -fs https://racket-lang.org/download/ | grep -o 'racket-[0-9.]*-aarch64-macosx-cs\.dmg' | head -n 1))
+    else
+        downloadURL=$(echo "https://download.racket-lang.org/installers/${appNewVersion}/"$(curl -fs https://racket-lang.org/download/ | grep -o 'racket-[0-9.]*-x86_64-macosx-cs\.dmg' | head -n 1))
+    fi
+    folderName="Racket v${appNewVersion}"
+    appName="${folderName}/DrRacket.app"
+    expectedTeamID="MHDH6AFHDR"
+    ;;


### PR DESCRIPTION
output:
```
sudo Installomator/utils/assemble.sh drracket DEBUG=0
2024-07-03 17:21:47 : REQ   : drracket : ################## Start Installomator v. 10.6beta, date 2024-07-03
2024-07-03 17:21:47 : INFO  : drracket : ################## Version: 10.6beta
2024-07-03 17:21:47 : INFO  : drracket : ################## Date: 2024-07-03
2024-07-03 17:21:47 : INFO  : drracket : ################## drracket
2024-07-03 17:21:47 : DEBUG : drracket : DEBUG mode 1 enabled.
2024-07-03 17:21:48 : INFO  : drracket : setting variable from argument DEBUG=0
2024-07-03 17:21:48 : DEBUG : drracket : name=DrRacket
2024-07-03 17:21:48 : DEBUG : drracket : appName=Racket v8.13/DrRacket.app
2024-07-03 17:21:48 : DEBUG : drracket : type=dmg
2024-07-03 17:21:48 : DEBUG : drracket : archiveName=
2024-07-03 17:21:48 : DEBUG : drracket : downloadURL=https://download.racket-lang.org/installers/8.13/racket-8.13-aarch64-macosx-cs.dmg
2024-07-03 17:21:48 : DEBUG : drracket : curlOptions=
2024-07-03 17:21:48 : DEBUG : drracket : appNewVersion=8.13
2024-07-03 17:21:48 : DEBUG : drracket : appCustomVersion function: Not defined
2024-07-03 17:21:48 : DEBUG : drracket : versionKey=CFBundleShortVersionString
2024-07-03 17:21:48 : DEBUG : drracket : packageID=
2024-07-03 17:21:48 : DEBUG : drracket : pkgName=
2024-07-03 17:21:48 : DEBUG : drracket : choiceChangesXML=
2024-07-03 17:21:48 : DEBUG : drracket : expectedTeamID=MHDH6AFHDR
2024-07-03 17:21:48 : DEBUG : drracket : blockingProcesses=
2024-07-03 17:21:48 : DEBUG : drracket : installerTool=
2024-07-03 17:21:48 : DEBUG : drracket : CLIInstaller=
2024-07-03 17:21:48 : DEBUG : drracket : CLIArguments=
2024-07-03 17:21:48 : DEBUG : drracket : updateTool=
2024-07-03 17:21:48 : DEBUG : drracket : updateToolArguments=
2024-07-03 17:21:48 : DEBUG : drracket : updateToolRunAsCurrentUser=
2024-07-03 17:21:48 : INFO  : drracket : BLOCKING_PROCESS_ACTION=tell_user
2024-07-03 17:21:48 : INFO  : drracket : NOTIFY=success
2024-07-03 17:21:48 : INFO  : drracket : LOGGING=DEBUG
2024-07-03 17:21:48 : INFO  : drracket : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-03 17:21:48 : INFO  : drracket : Label type: dmg
2024-07-03 17:21:48 : INFO  : drracket : archiveName: DrRacket.dmg
2024-07-03 17:21:48 : INFO  : drracket : no blocking processes defined, using DrRacket as default
2024-07-03 17:21:48 : DEBUG : drracket : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AeDZz6frWA
2024-07-03 17:21:48 : INFO  : drracket : name: DrRacket, appName: Racket v8.13/DrRacket.app
2024-07-03 17:21:48.470 mdfind[46200:43796816] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-03 17:21:48.471 mdfind[46200:43796816] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-03 17:21:48.521 mdfind[46200:43796816] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-03 17:21:48 : WARN  : drracket : No previous app found
2024-07-03 17:21:48 : WARN  : drracket : could not find Racket v8.13/DrRacket.app
2024-07-03 17:21:48 : INFO  : drracket : appversion:
2024-07-03 17:21:48 : INFO  : drracket : Latest version of DrRacket is 8.13
2024-07-03 17:21:48 : REQ   : drracket : Downloading https://download.racket-lang.org/installers/8.13/racket-8.13-aarch64-macosx-cs.dmg to DrRacket.dmg
2024-07-03 17:21:48 : DEBUG : drracket : No Dialog connection, just download
2024-07-03 17:22:23 : DEBUG : drracket : File list: -rw-r--r--  1 root  wheel   251M Jul  3 17:22 DrRacket.dmg
2024-07-03 17:22:23 : DEBUG : drracket : File type: DrRacket.dmg: bzip2 compressed data, block size = 100k
2024-07-03 17:22:23 : DEBUG : drracket : curl output was:
* Host download.racket-lang.org:443 was resolved.
* IPv6: (none)
* IPv4: 172.67.188.90, 104.21.48.235
*   Trying 172.67.188.90:443...
* Connected to download.racket-lang.org (172.67.188.90) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4163 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=racket-lang.org
*  start date: May 29 11:09:04 2024 GMT
*  expire date: Aug 27 11:09:03 2024 GMT
*  subjectAltName: host "download.racket-lang.org" matched cert's "*.racket-lang.org"
*  issuer: C=US; O=Let's Encrypt; CN=E1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.racket-lang.org/installers/8.13/racket-8.13-aarch64-macosx-cs.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.racket-lang.org]
* [HTTP/2] [1] [:path: /installers/8.13/racket-8.13-aarch64-macosx-cs.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /installers/8.13/racket-8.13-aarch64-macosx-cs.dmg HTTP/2
> Host: download.racket-lang.org
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 302
< date: Wed, 03 Jul 2024 23:21:48 GMT
< content-length: 0
< location: https://mirror.racket-lang.org/installers/8.13/racket-8.13-aarch64-macosx-cs.dmg
< x-amz-id-2: 2ZqzOXWIaiAlipgHtO1NWYpIHEcP6QvONp/VEkX8q/HkQSALL5Rth02tTVd8qRqZj+iI7l074MIOHKr0w+YplA==
< x-amz-request-id: 1JJWDZV6S6Y1KMBJ
< cf-cache-status: BYPASS
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=o0OhLVB9O39yPn9vlIWzT24dTw33quyV4C1qtGxCEyxm3jfo9M9lkdirrTgohblF%2F8zyYDfCk3rPxhZFcEhiBzbm8FSFxWKtVo%2BRSenjcJ7tmDvdxTSKclGyx2MU2vNV7QGTlKMIry57Lt8%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
< cf-ray: 89da9d2f2d151f4c-DEN
< alt-svc: h3=":443"; ma=86400
<
* Ignoring the response-body
* Connection #0 to host download.racket-lang.org left intact
* Issue another request to this URL: 'https://mirror.racket-lang.org/installers/8.13/racket-8.13-aarch64-macosx-cs.dmg'
* Host mirror.racket-lang.org:443 was resolved.
* IPv6: (none)
* IPv4: 129.10.116.85
*   Trying 129.10.116.85:443...
* Connected to mirror.racket-lang.org (129.10.116.85) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2597 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=mirror.racket-lang.org
*  start date: May  8 16:36:28 2024 GMT
*  expire date: Aug  6 16:36:27 2024 GMT
*  subjectAltName: host "mirror.racket-lang.org" matched cert's "mirror.racket-lang.org"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /installers/8.13/racket-8.13-aarch64-macosx-cs.dmg HTTP/1.1
> Host: mirror.racket-lang.org
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 03 Jul 2024 23:21:49 GMT
< Server: Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips
< Last-Modified: Tue, 14 May 2024 09:34:04 GMT
< ETag: "facbc50-61866b3e31b00"
< Accept-Ranges: bytes
< Content-Length: 262978640
<
{ [16384 bytes data]
* Connection #1 to host mirror.racket-lang.org left intact

2024-07-03 17:22:23 : REQ   : drracket : no more blocking processes, continue with update
2024-07-03 17:22:23 : REQ   : drracket : Installing DrRacket
2024-07-03 17:22:23 : INFO  : drracket : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AeDZz6frWA/DrRacket.dmg
2024-07-03 17:22:41 : DEBUG : drracket : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $861C58DF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $93677240
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D6BE6078
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $9759BCE9
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D6BE6078
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $410CDE27
verified   CRC32 $32243E9C
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/Racket v8.13

2024-07-03 17:22:41 : INFO  : drracket : Mounted: /Volumes/Racket v8.13
2024-07-03 17:22:41 : INFO  : drracket : Verifying: /Volumes/Racket v8.13/Racket v8.13/DrRacket.app
2024-07-03 17:22:41 : DEBUG : drracket : App size:  47M	/Volumes/Racket v8.13/Racket v8.13/DrRacket.app
2024-07-03 17:22:42 : DEBUG : drracket : Debugging enabled, App Verification output was:
/Volumes/Racket v8.13/Racket v8.13/DrRacket.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Matthew FLATT (MHDH6AFHDR)

2024-07-03 17:22:42 : INFO  : drracket : Team ID matching: MHDH6AFHDR (expected: MHDH6AFHDR )
2024-07-03 17:22:42 : INFO  : drracket : Installing DrRacket version 8.13 on versionKey CFBundleShortVersionString.
2024-07-03 17:22:42 : INFO  : drracket : Copy /Volumes/Racket v8.13/Racket v8.13/DrRacket.app to /Applications
2024-07-03 17:24:04 : DEBUG : drracket : Debugging enabled, App copy output was:
Copying /Volumes/Racket v8.13/Racket v8.13

2024-07-03 17:24:04 : WARN  : drracket : Changing owner to u0105821
2024-07-03 17:24:04 : INFO  : drracket : Finishing...
2024-07-03 17:24:07 : INFO  : drracket : App(s) found: /Applications/Racket v8.13/DrRacket.app
2024-07-03 17:24:07 : INFO  : drracket : found app at /Applications/Racket v8.13/DrRacket.app, version 8.13, on versionKey CFBundleShortVersionString
2024-07-03 17:24:07 : REQ   : drracket : Installed DrRacket, version 8.13
2024-07-03 17:24:07 : INFO  : drracket : notifying
2024-07-03 17:24:07 : DEBUG : drracket : Unmounting /Volumes/Racket v8.13
2024-07-03 17:24:08 : DEBUG : drracket : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-07-03 17:24:08 : DEBUG : drracket : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AeDZz6frWA
2024-07-03 17:24:08 : DEBUG : drracket : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AeDZz6frWA/DrRacket.dmg
2024-07-03 17:24:08 : DEBUG : drracket : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AeDZz6frWA
2024-07-03 17:24:09 : INFO  : drracket : Installomator did not close any apps, so no need to reopen any apps.
2024-07-03 17:24:09 : REQ   : drracket : All done!
2024-07-03 17:24:09 : REQ   : drracket : ################## End Installomator, exit code 0
```