### PR TITLE
Updated Label for NetNewsWire

### DIFF
--- a/fragments/labels/netnewswire.sh
+++ b/fragments/labels/netnewswire.sh
@@ -1,5 +1,4 @@
 netnewswire)
-    # NetNewsWire is a free, open-source RSS reader for macOS that allows users to efficiently follow and manage their favorite websites and blogs
     name="NetNewsWire"
     type="zip"
     downloadURL="$(curl -fs https://ranchero.com/downloads/netnewswire-release.xml | xmllint --xpath 'string(//item[1]/enclosure/@url)' -)"

--- a/fragments/labels/netnewswire.sh
+++ b/fragments/labels/netnewswire.sh
@@ -1,8 +1,8 @@
 netnewswire)
+    # NetNewsWire is a free, open-source RSS reader for macOS that allows users to efficiently follow and manage their favorite websites and blogs
     name="NetNewsWire"
     type="zip"
-    downloadURL=$(curl -fs https://ranchero.com/downloads/netnewswire-release.xml \
-        | xpath '//rss/channel/item[1]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2)
-    appNewVersion=$(curl -fs https://ranchero.com/downloads/netnewswire-release.xml | xpath '//rss/channel/item[1]/enclosure/@sparkle:shortVersionString' 2>/dev/null | cut -d '"' -f 2)
+    downloadURL="$(curl -fs https://ranchero.com/downloads/netnewswire-release.xml | xmllint --xpath 'string(//item[1]/enclosure/@url)' -)"
+    appNewVersion="$(curl -fs https://ranchero.com/downloads/netnewswire-release.xml | xmllint --xpath 'string(//*[local-name()="item"][1]/*[local-name()="enclosure"]/@*[local-name()="shortVersionString"])' -)"
     expectedTeamID="M8L2WTLA8W"
     ;;


### PR DESCRIPTION
Output:

```
# sudo Installomator/utils/assemble.sh netnewswire DEBUG=0
2024-07-08 17:05:35 : REQ   : netnewswire : ################## Start Installomator v. 10.6beta, date 2024-07-08
2024-07-08 17:05:35 : INFO  : netnewswire : ################## Version: 10.6beta
2024-07-08 17:05:35 : INFO  : netnewswire : ################## Date: 2024-07-08
2024-07-08 17:05:35 : INFO  : netnewswire : ################## netnewswire
2024-07-08 17:05:35 : DEBUG : netnewswire : DEBUG mode 1 enabled.
2024-07-08 17:05:35 : INFO  : netnewswire : setting variable from argument DEBUG=0
2024-07-08 17:05:35 : DEBUG : netnewswire : name=NetNewsWire
2024-07-08 17:05:35 : DEBUG : netnewswire : appName=
2024-07-08 17:05:35 : DEBUG : netnewswire : type=zip
2024-07-08 17:05:35 : DEBUG : netnewswire : archiveName=
2024-07-08 17:05:35 : DEBUG : netnewswire : downloadURL=https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-6.1.4/NetNewsWire6.1.4.zip
2024-07-08 17:05:35 : DEBUG : netnewswire : curlOptions=
2024-07-08 17:05:35 : DEBUG : netnewswire : appNewVersion=6.1.4
2024-07-08 17:05:35 : DEBUG : netnewswire : appCustomVersion function: Not defined
2024-07-08 17:05:35 : DEBUG : netnewswire : versionKey=CFBundleShortVersionString
2024-07-08 17:05:35 : DEBUG : netnewswire : packageID=
2024-07-08 17:05:35 : DEBUG : netnewswire : pkgName=
2024-07-08 17:05:36 : DEBUG : netnewswire : choiceChangesXML=
2024-07-08 17:05:36 : DEBUG : netnewswire : expectedTeamID=M8L2WTLA8W
2024-07-08 17:05:36 : DEBUG : netnewswire : blockingProcesses=
2024-07-08 17:05:36 : DEBUG : netnewswire : installerTool=
2024-07-08 17:05:36 : DEBUG : netnewswire : CLIInstaller=
2024-07-08 17:05:36 : DEBUG : netnewswire : CLIArguments=
2024-07-08 17:05:36 : DEBUG : netnewswire : updateTool=
2024-07-08 17:05:36 : DEBUG : netnewswire : updateToolArguments=
2024-07-08 17:05:36 : DEBUG : netnewswire : updateToolRunAsCurrentUser=
2024-07-08 17:05:36 : INFO  : netnewswire : BLOCKING_PROCESS_ACTION=tell_user
2024-07-08 17:05:36 : INFO  : netnewswire : NOTIFY=success
2024-07-08 17:05:36 : INFO  : netnewswire : LOGGING=DEBUG
2024-07-08 17:05:36 : INFO  : netnewswire : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-08 17:05:36 : INFO  : netnewswire : Label type: zip
2024-07-08 17:05:36 : INFO  : netnewswire : archiveName: NetNewsWire.zip
2024-07-08 17:05:36 : INFO  : netnewswire : no blocking processes defined, using NetNewsWire as default
2024-07-08 17:05:36 : DEBUG : netnewswire : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Fi86AzfUGX
2024-07-08 17:05:36 : INFO  : netnewswire : name: NetNewsWire, appName: NetNewsWire.app
2024-07-08 17:05:36.155 mdfind[27633:47436811] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-08 17:05:36.155 mdfind[27633:47436811] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-08 17:05:36.206 mdfind[27633:47436811] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-08 17:05:36 : INFO  : netnewswire : App(s) found: /Users/u0105821/git/github/Installomator/build/NetNewsWire.app/Applications/Internet/NetNewsWire.app
2024-07-08 17:05:36 : INFO  : netnewswire : found app at /Applications/Internet/NetNewsWire.app, version 6.1.4, on versionKey CFBundleShortVersionString
2024-07-08 17:05:36 : INFO  : netnewswire : appversion: 6.1.4
2024-07-08 17:05:36 : INFO  : netnewswire : Latest version of NetNewsWire is 6.1.4
2024-07-08 17:05:36 : INFO  : netnewswire : There is no newer version available.
2024-07-08 17:05:36 : DEBUG : netnewswire : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Fi86AzfUGX
2024-07-08 17:05:36 : DEBUG : netnewswire : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Fi86AzfUGX
2024-07-08 17:05:36 : INFO  : netnewswire : Installomator did not close any apps, so no need to reopen any apps.
2024-07-08 17:05:36 : REQ   : netnewswire : No newer version.
2024-07-08 17:05:36 : REQ   : netnewswire : ################## End Installomator, exit code 0
```