### PR TITLE
Update homebrew.sh label with new Team ID

### DIFF
--- a/fragments/labels/homebrew.sh
+++ b/fragments/labels/homebrew.sh
@@ -4,6 +4,6 @@ homebrew)
     packageID="sh.brew.homebrew"
     downloadURL="$(downloadURLFromGit Homebrew brew)"
     appNewVersion="$(versionFromGit Homebrew brew)"
-    expectedTeamID="6248TWFRH6"
+    expectedTeamID="927JGANW46"
     archiveName="Homebrew.pkg"
     ;;


### PR DESCRIPTION
The developer ID for Homebrew has changed. I have checked with the Brew team and it looks to be expected.