### PR TITLE
update-cmake

### DIFF
--- a/fragments/labels/cmake.sh
+++ b/fragments/labels/cmake.sh
@@ -1,5 +1,4 @@
 cmake)
-	# An open-source tool designed to manage the build process of software using a compiler-independent method
     name="CMake"
     type="dmg"
     downloadURL=$(downloadURLFromGit Kitware CMake)

--- a/fragments/labels/cmake.sh
+++ b/fragments/labels/cmake.sh
@@ -1,7 +1,8 @@
 cmake)
+	# An open-source tool designed to manage the build process of software using a compiler-independent method
     name="CMake"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://cmake.org/download" | awk -F'[()]' '/id="latest"/{print $2}')
-    downloadURL="https://github.com/Kitware/CMake/releases/download/v${appNewVersion}/cmake-${appNewVersion}-macos-universal.dmg"
+    downloadURL=$(downloadURLFromGit Kitware CMake)
+    appNewVersion=$(versionFromGit Kitware CMake)
     expectedTeamID="W38PE5Y733"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh cmake DEBUG=0
2024-07-09 16:37:34 : REQ   : cmake : ################## Start Installomator v. 10.6beta, date 2024-07-09
2024-07-09 16:37:34 : INFO  : cmake : ################## Version: 10.6beta
2024-07-09 16:37:34 : INFO  : cmake : ################## Date: 2024-07-09
2024-07-09 16:37:34 : INFO  : cmake : ################## cmake
2024-07-09 16:37:34 : DEBUG : cmake : DEBUG mode 1 enabled.
2024-07-09 16:37:35 : INFO  : cmake : setting variable from argument DEBUG=0
2024-07-09 16:37:35 : DEBUG : cmake : name=CMake
2024-07-09 16:37:35 : DEBUG : cmake : appName=
2024-07-09 16:37:35 : DEBUG : cmake : type=dmg
2024-07-09 16:37:35 : DEBUG : cmake : archiveName=
2024-07-09 16:37:35 : DEBUG : cmake : downloadURL=https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-macos-universal.dmg
2024-07-09 16:37:35 : DEBUG : cmake : curlOptions=
2024-07-09 16:37:35 : DEBUG : cmake : appNewVersion=3.30.0
2024-07-09 16:37:35 : DEBUG : cmake : appCustomVersion function: Not defined
2024-07-09 16:37:35 : DEBUG : cmake : versionKey=CFBundleShortVersionString
2024-07-09 16:37:35 : DEBUG : cmake : packageID=
2024-07-09 16:37:35 : DEBUG : cmake : pkgName=
2024-07-09 16:37:35 : DEBUG : cmake : choiceChangesXML=
2024-07-09 16:37:35 : DEBUG : cmake : expectedTeamID=W38PE5Y733
2024-07-09 16:37:35 : DEBUG : cmake : blockingProcesses=
2024-07-09 16:37:35 : DEBUG : cmake : installerTool=
2024-07-09 16:37:35 : DEBUG : cmake : CLIInstaller=
2024-07-09 16:37:35 : DEBUG : cmake : CLIArguments=
2024-07-09 16:37:35 : DEBUG : cmake : updateTool=
2024-07-09 16:37:35 : DEBUG : cmake : updateToolArguments=
2024-07-09 16:37:35 : DEBUG : cmake : updateToolRunAsCurrentUser=
2024-07-09 16:37:35 : INFO  : cmake : BLOCKING_PROCESS_ACTION=tell_user
2024-07-09 16:37:35 : INFO  : cmake : NOTIFY=success
2024-07-09 16:37:35 : INFO  : cmake : LOGGING=DEBUG
2024-07-09 16:37:35 : INFO  : cmake : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-09 16:37:35 : INFO  : cmake : Label type: dmg
2024-07-09 16:37:35 : INFO  : cmake : archiveName: CMake.dmg
2024-07-09 16:37:35 : INFO  : cmake : no blocking processes defined, using CMake as default
2024-07-09 16:37:35 : DEBUG : cmake : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hx3YOfO0R7
2024-07-09 16:37:35 : INFO  : cmake : name: CMake, appName: CMake.app
2024-07-09 16:37:35.663 mdfind[14371:48586717] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-09 16:37:35.663 mdfind[14371:48586717] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-09 16:37:35.713 mdfind[14371:48586717] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 16:37:35 : WARN  : cmake : No previous app found
2024-07-09 16:37:35 : WARN  : cmake : could not find CMake.app
2024-07-09 16:37:35 : INFO  : cmake : appversion:
2024-07-09 16:37:35 : INFO  : cmake : Latest version of CMake is 3.30.0
2024-07-09 16:37:35 : REQ   : cmake : Downloading https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-macos-universal.dmg to CMake.dmg
2024-07-09 16:37:35 : DEBUG : cmake : No Dialog connection, just download
2024-07-09 16:37:38 : DEBUG : cmake : File list: -rw-r--r--  1 root  wheel    77M Jul  9 16:37 CMake.dmg
2024-07-09 16:37:38 : DEBUG : cmake : File type: CMake.dmg: zlib compressed data
2024-07-09 16:37:38 : DEBUG : cmake : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.113.3
*   Trying 140.82.113.3:443...
* Connected to github.com (140.82.113.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-macos-universal.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-macos-universal.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-macos-universal.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Tue, 09 Jul 2024 22:37:16 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/537699/79aa8ee7-b130-48f6-8f78-7ccc57acacf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T223716Z&X-Amz-Expires=300&X-Amz-Signature=cce730b793788f212bd872ba6d2ac956966c6de365781b0fb1ea72fd845f8004&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=537699&response-content-disposition=attachment%3B%20filename%3Dcmake-3.30.0-macos-universal.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com/v1/engines/github-completion/completions *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: 249A:9EB2:12E7FE5:1A2A698:668DBBAF
<
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/537699/79aa8ee7-b130-48f6-8f78-7ccc57acacf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T223716Z&X-Amz-Expires=300&X-Amz-Signature=cce730b793788f212bd872ba6d2ac956966c6de365781b0fb1ea72fd845f8004&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=537699&response-content-disposition=attachment%3B%20filename%3Dcmake-3.30.0-macos-universal.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.111.133, 185.199.108.133, 185.199.109.133, 185.199.110.133
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/537699/79aa8ee7-b130-48f6-8f78-7ccc57acacf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T223716Z&X-Amz-Expires=300&X-Amz-Signature=cce730b793788f212bd872ba6d2ac956966c6de365781b0fb1ea72fd845f8004&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=537699&response-content-disposition=attachment%3B%20filename%3Dcmake-3.30.0-macos-universal.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/537699/79aa8ee7-b130-48f6-8f78-7ccc57acacf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T223716Z&X-Amz-Expires=300&X-Amz-Signature=cce730b793788f212bd872ba6d2ac956966c6de365781b0fb1ea72fd845f8004&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=537699&response-content-disposition=attachment%3B%20filename%3Dcmake-3.30.0-macos-universal.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/537699/79aa8ee7-b130-48f6-8f78-7ccc57acacf2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T223716Z&X-Amz-Expires=300&X-Amz-Signature=cce730b793788f212bd872ba6d2ac956966c6de365781b0fb1ea72fd845f8004&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=537699&response-content-disposition=attachment%3B%20filename%3Dcmake-3.30.0-macos-universal.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Tue, 02 Jul 2024 15:47:05 GMT
< etag: "0x8DC9AAE393847F6"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 20054ed6-501e-0037-7b99-cc33f9000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Tue, 02 Jul 2024 15:47:05 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=cmake-3.30.0-macos-universal.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< date: Tue, 09 Jul 2024 22:37:36 GMT
< age: 19
< x-served-by: cache-iad-kjyo7100127-IAD, cache-den8242-DEN
< x-cache: HIT, HIT
< x-cache-hits: 1568, 1
< x-timer: S1720564656.080984,VS0,VE221
< content-length: 80624375
<
{ [10518 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-07-09 16:37:38 : REQ   : cmake : no more blocking processes, continue with update
2024-07-09 16:37:38 : REQ   : cmake : Installing CMake
2024-07-09 16:37:38 : INFO  : cmake : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hx3YOfO0R7/CMake.dmg
2024-07-09 16:37:43 : DEBUG : cmake : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $08C7D0C7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F58A227C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $6DE87A21
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $557E6B54
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $6DE87A21
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9FCB9C28
verified   CRC32 $85D1B7AC
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/cmake-3.30.0-macos-universal

2024-07-09 16:37:43 : INFO  : cmake : Mounted: /Volumes/cmake-3.30.0-macos-universal
2024-07-09 16:37:43 : INFO  : cmake : Verifying: /Volumes/cmake-3.30.0-macos-universal/CMake.app
2024-07-09 16:37:43 : DEBUG : cmake : App size: 240M	/Volumes/cmake-3.30.0-macos-universal/CMake.app
2024-07-09 16:37:45 : DEBUG : cmake : Debugging enabled, App Verification output was:
/Volumes/cmake-3.30.0-macos-universal/CMake.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Kitware Inc. (W38PE5Y733)

2024-07-09 16:37:45 : INFO  : cmake : Team ID matching: W38PE5Y733 (expected: W38PE5Y733 )
2024-07-09 16:37:45 : INFO  : cmake : Installing CMake version 3.30.0 on versionKey CFBundleShortVersionString.
2024-07-09 16:37:45 : INFO  : cmake : Copy /Volumes/cmake-3.30.0-macos-universal/CMake.app to /Applications
2024-07-09 16:37:48 : DEBUG : cmake : Debugging enabled, App copy output was:
Copying /Volumes/cmake-3.30.0-macos-universal/CMake.app

2024-07-09 16:37:48 : WARN  : cmake : Changing owner to u0105821
2024-07-09 16:37:48 : INFO  : cmake : Finishing...
2024-07-09 16:37:51 : INFO  : cmake : App(s) found: /Applications/CMake.app
2024-07-09 16:37:51 : INFO  : cmake : found app at /Applications/CMake.app, version 3.30.0, on versionKey CFBundleShortVersionString
2024-07-09 16:37:51 : REQ   : cmake : Installed CMake, version 3.30.0
2024-07-09 16:37:51 : INFO  : cmake : notifying
2024-07-09 16:37:51 : DEBUG : cmake : Unmounting /Volumes/cmake-3.30.0-macos-universal
2024-07-09 16:37:52 : DEBUG : cmake : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-07-09 16:37:52 : DEBUG : cmake : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hx3YOfO0R7
2024-07-09 16:37:52 : DEBUG : cmake : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hx3YOfO0R7/CMake.dmg
2024-07-09 16:37:52 : DEBUG : cmake : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hx3YOfO0R7
2024-07-09 16:37:52 : INFO  : cmake : Installomator did not close any apps, so no need to reopen any apps.
2024-07-09 16:37:52 : REQ   : cmake : All done!
2024-07-09 16:37:52 : REQ   : cmake : ################## End Installomator, exit code 0
```