### PR TITLE
new-postgresapp

### DIFF
--- a/fragments/labels/postgresapp.sh
+++ b/fragments/labels/postgresapp.sh
@@ -1,0 +1,9 @@
+postgresapp)
+	#  A full-featured PostgreSQL installation for macOS that includes PostGIS, a user-friendly interface, a convenient menu bar item, and automatic updates
+    name="Postgres"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit PostgresApp PostgresApp)
+    appNewVersion=$(versionFromGit PostgresApp PostgresApp)
+    archiveName="Postgres-$appNewVersion.dmg"
+    expectedTeamID="ZF84SJ5A3G"
+    ;;


### PR DESCRIPTION
output:
```
sudo Installomator/utils/assemble.sh postgresapp DEBUG=0
2024-07-09 17:07:53 : REQ   : postgresapp : ################## Start Installomator v. 10.6beta, date 2024-07-09
2024-07-09 17:07:53 : INFO  : postgresapp : ################## Version: 10.6beta
2024-07-09 17:07:53 : INFO  : postgresapp : ################## Date: 2024-07-09
2024-07-09 17:07:53 : INFO  : postgresapp : ################## postgresapp
2024-07-09 17:07:53 : DEBUG : postgresapp : DEBUG mode 1 enabled.
2024-07-09 17:07:54 : INFO  : postgresapp : setting variable from argument DEBUG=0
2024-07-09 17:07:54 : DEBUG : postgresapp : name=Postgres
2024-07-09 17:07:54 : DEBUG : postgresapp : appName=
2024-07-09 17:07:54 : DEBUG : postgresapp : type=dmg
2024-07-09 17:07:54 : DEBUG : postgresapp : archiveName=Postgres-2.7.3.dmg
2024-07-09 17:07:54 : DEBUG : postgresapp : downloadURL=https://github.com/PostgresApp/PostgresApp/releases/download/v2.7.3/Postgres-2.7.3-12-13-14-15-16.dmg
2024-07-09 17:07:54 : DEBUG : postgresapp : curlOptions=
2024-07-09 17:07:54 : DEBUG : postgresapp : appNewVersion=2.7.3
2024-07-09 17:07:54 : DEBUG : postgresapp : appCustomVersion function: Not defined
2024-07-09 17:07:54 : DEBUG : postgresapp : versionKey=CFBundleShortVersionString
2024-07-09 17:07:54 : DEBUG : postgresapp : packageID=
2024-07-09 17:07:54 : DEBUG : postgresapp : pkgName=
2024-07-09 17:07:54 : DEBUG : postgresapp : choiceChangesXML=
2024-07-09 17:07:54 : DEBUG : postgresapp : expectedTeamID=ZF84SJ5A3G
2024-07-09 17:07:54 : DEBUG : postgresapp : blockingProcesses=
2024-07-09 17:07:54 : DEBUG : postgresapp : installerTool=
2024-07-09 17:07:54 : DEBUG : postgresapp : CLIInstaller=
2024-07-09 17:07:54 : DEBUG : postgresapp : CLIArguments=
2024-07-09 17:07:54 : DEBUG : postgresapp : updateTool=
2024-07-09 17:07:54 : DEBUG : postgresapp : updateToolArguments=
2024-07-09 17:07:54 : DEBUG : postgresapp : updateToolRunAsCurrentUser=
2024-07-09 17:07:54 : INFO  : postgresapp : BLOCKING_PROCESS_ACTION=tell_user
2024-07-09 17:07:54 : INFO  : postgresapp : NOTIFY=success
2024-07-09 17:07:54 : INFO  : postgresapp : LOGGING=DEBUG
2024-07-09 17:07:54 : INFO  : postgresapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-09 17:07:54 : INFO  : postgresapp : Label type: dmg
2024-07-09 17:07:54 : INFO  : postgresapp : archiveName: Postgres-2.7.3.dmg
2024-07-09 17:07:54 : INFO  : postgresapp : no blocking processes defined, using Postgres as default
2024-07-09 17:07:54 : DEBUG : postgresapp : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lEIxcvYNFR
2024-07-09 17:07:54 : INFO  : postgresapp : name: Postgres, appName: Postgres.app
2024-07-09 17:07:54.778 mdfind[32852:48648912] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-09 17:07:54.778 mdfind[32852:48648912] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-09 17:07:54.828 mdfind[32852:48648912] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 17:07:54 : WARN  : postgresapp : No previous app found
2024-07-09 17:07:54 : WARN  : postgresapp : could not find Postgres.app
2024-07-09 17:07:54 : INFO  : postgresapp : appversion:
2024-07-09 17:07:54 : INFO  : postgresapp : Latest version of Postgres is 2.7.3
2024-07-09 17:07:54 : REQ   : postgresapp : Downloading https://github.com/PostgresApp/PostgresApp/releases/download/v2.7.3/Postgres-2.7.3-12-13-14-15-16.dmg to Postgres-2.7.3.dmg
2024-07-09 17:07:54 : DEBUG : postgresapp : No Dialog connection, just download
2024-07-09 17:09:18 : DEBUG : postgresapp : File list: -rw-r--r--  1 root  wheel   374M Jul  9 17:09 Postgres-2.7.3.dmg
2024-07-09 17:09:18 : DEBUG : postgresapp : File type: Postgres-2.7.3.dmg: zlib compressed data
2024-07-09 17:09:18 : DEBUG : postgresapp : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.113.3
*   Trying 140.82.113.3:443...
* Connected to github.com (140.82.113.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/PostgresApp/PostgresApp/releases/download/v2.7.3/Postgres-2.7.3-12-13-14-15-16.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /PostgresApp/PostgresApp/releases/download/v2.7.3/Postgres-2.7.3-12-13-14-15-16.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /PostgresApp/PostgresApp/releases/download/v2.7.3/Postgres-2.7.3-12-13-14-15-16.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 302
< server: GitHub.com
< date: Tue, 09 Jul 2024 23:07:06 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/3946572/4059f0fa-8bf9-4c06-b18a-d299ac90aee9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T230706Z&X-Amz-Expires=300&X-Amz-Signature=bfe67b3d916689b9b999faa9f2acba8a97359c9a0f9f09fc0caba7ca5c6ce528&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=3946572&response-content-disposition=attachment%3B%20filename%3DPostgres-2.7.3-12-13-14-15-16.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com/v1/engines/github-completion/completions *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: 1426:1E0150:14DE579:1CB12A7:668DC2CB
<
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/3946572/4059f0fa-8bf9-4c06-b18a-d299ac90aee9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T230706Z&X-Amz-Expires=300&X-Amz-Signature=bfe67b3d916689b9b999faa9f2acba8a97359c9a0f9f09fc0caba7ca5c6ce528&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=3946572&response-content-disposition=attachment%3B%20filename%3DPostgres-2.7.3-12-13-14-15-16.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.108.133, 185.199.109.133, 185.199.110.133, 185.199.111.133
*   Trying 185.199.108.133:443...
* connect to 185.199.108.133 port 443 from 10.128.69.171 port 52106 failed: Operation timed out
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/3946572/4059f0fa-8bf9-4c06-b18a-d299ac90aee9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T230706Z&X-Amz-Expires=300&X-Amz-Signature=bfe67b3d916689b9b999faa9f2acba8a97359c9a0f9f09fc0caba7ca5c6ce528&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=3946572&response-content-disposition=attachment%3B%20filename%3DPostgres-2.7.3-12-13-14-15-16.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/3946572/4059f0fa-8bf9-4c06-b18a-d299ac90aee9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T230706Z&X-Amz-Expires=300&X-Amz-Signature=bfe67b3d916689b9b999faa9f2acba8a97359c9a0f9f09fc0caba7ca5c6ce528&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=3946572&response-content-disposition=attachment%3B%20filename%3DPostgres-2.7.3-12-13-14-15-16.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/3946572/4059f0fa-8bf9-4c06-b18a-d299ac90aee9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240709%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240709T230706Z&X-Amz-Expires=300&X-Amz-Signature=bfe67b3d916689b9b999faa9f2acba8a97359c9a0f9f09fc0caba7ca5c6ce528&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=3946572&response-content-disposition=attachment%3B%20filename%3DPostgres-2.7.3-12-13-14-15-16.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Thu, 09 May 2024 07:59:07 GMT
< etag: "0x8DC6FFDE76B7A65"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 337ff94c-301e-0043-450d-c20709000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Thu, 09 May 2024 07:59:07 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Postgres-2.7.3-12-13-14-15-16.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 123
< date: Tue, 09 Jul 2024 23:09:10 GMT
< x-served-by: cache-iad-kjyo7100164-IAD, cache-den8272-DEN
< x-cache: HIT, HIT
< x-cache-hits: 861, 0
< x-timer: S1720566550.206964,VS0,VE224
< content-length: 392043944
<
{ [7396 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-07-09 17:09:18 : REQ   : postgresapp : no more blocking processes, continue with update
2024-07-09 17:09:18 : REQ   : postgresapp : Installing Postgres
2024-07-09 17:09:18 : INFO  : postgresapp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lEIxcvYNFR/Postgres-2.7.3.dmg
2024-07-09 17:09:22 : DEBUG : postgresapp : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $75B2F1D2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F3A8756B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $3AE0EE98
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $13A5369B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $3AE0EE98
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9CC8BEC9
verified   CRC32 $94C8981F
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/Postgres-2.7.3-12-13-14-15-16

2024-07-09 17:09:22 : INFO  : postgresapp : Mounted: /Volumes/Postgres-2.7.3-12-13-14-15-16
2024-07-09 17:09:22 : INFO  : postgresapp : Verifying: /Volumes/Postgres-2.7.3-12-13-14-15-16/Postgres.app
2024-07-09 17:09:22 : DEBUG : postgresapp : App size: 1.3G	/Volumes/Postgres-2.7.3-12-13-14-15-16/Postgres.app
2024-07-09 17:09:36 : DEBUG : postgresapp : Debugging enabled, App Verification output was:
/Volumes/Postgres-2.7.3-12-13-14-15-16/Postgres.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Jakob Egger (ZF84SJ5A3G)

2024-07-09 17:09:36 : INFO  : postgresapp : Team ID matching: ZF84SJ5A3G (expected: ZF84SJ5A3G )
2024-07-09 17:09:36 : INFO  : postgresapp : Installing Postgres version 2.7.3 on versionKey CFBundleShortVersionString.
2024-07-09 17:09:36 : INFO  : postgresapp : App has LSMinimumSystemVersion: 10.13
2024-07-09 17:09:36 : INFO  : postgresapp : Copy /Volumes/Postgres-2.7.3-12-13-14-15-16/Postgres.app to /Applications
2024-07-09 17:09:57 : DEBUG : postgresapp : Debugging enabled, App copy output was:
Copying /Volumes/Postgres-2.7.3-12-13-14-15-16/Postgres.app

2024-07-09 17:09:57 : WARN  : postgresapp : Changing owner to u0105821
2024-07-09 17:09:58 : INFO  : postgresapp : Finishing...
2024-07-09 17:10:01 : INFO  : postgresapp : App(s) found: /Applications/Postgres.app
2024-07-09 17:10:01 : INFO  : postgresapp : found app at /Applications/Postgres.app, version 2.7.3, on versionKey CFBundleShortVersionString
2024-07-09 17:10:01 : REQ   : postgresapp : Installed Postgres, version 2.7.3
2024-07-09 17:10:01 : INFO  : postgresapp : notifying
2024-07-09 17:10:01 : DEBUG : postgresapp : Unmounting /Volumes/Postgres-2.7.3-12-13-14-15-16
2024-07-09 17:10:02 : DEBUG : postgresapp : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-07-09 17:10:02 : DEBUG : postgresapp : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lEIxcvYNFR
2024-07-09 17:10:02 : DEBUG : postgresapp : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lEIxcvYNFR/Postgres-2.7.3.dmg
2024-07-09 17:10:02 : DEBUG : postgresapp : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lEIxcvYNFR
2024-07-09 17:10:02 : INFO  : postgresapp : Installomator did not close any apps, so no need to reopen any apps.
2024-07-09 17:10:02 : REQ   : postgresapp : All done!
2024-07-09 17:10:02 : REQ   : postgresapp : ################## End Installomator, exit code 0
```