### PR TITLE
new-busycal

### DIFF
--- a/fragments/labels/busycal.sh
+++ b/fragments/labels/busycal.sh
@@ -1,0 +1,8 @@
+busycal)
+	# A powerful calendar app for macOS and iOS that offers customizable views, integrated task management, and seamless cloud sync
+    name="BusyCal"
+    type="dmg"
+    downloadURL=$(curl -fs https://www.busymac.com/busycal/releasenotes.html | grep -o 'https://www.busymac.com/download/bcl-\S*\.dmg' | sort -V | tail -n 1)
+    appNewVersion=$(curl -fs https://www.busymac.com/busycal/releasenotes.html | awk -F 'BusyCal ' '/BusyCal [0-9]+\.[0-9]+\.[0-9]+/{print $2}' | sort -V | tail -n 1)
+    expectedTeamID="N4RA379GBW"
+    ;;


### PR DESCRIPTION
output:
```
sudo Installomator/utils/assemble.sh busycal DEBUG=0
2024-07-09 17:33:30 : REQ   : busycal : ################## Start Installomator v. 10.6beta, date 2024-07-09
2024-07-09 17:33:30 : INFO  : busycal : ################## Version: 10.6beta
2024-07-09 17:33:30 : INFO  : busycal : ################## Date: 2024-07-09
2024-07-09 17:33:31 : INFO  : busycal : ################## busycal
2024-07-09 17:33:31 : DEBUG : busycal : DEBUG mode 1 enabled.
2024-07-09 17:33:32 : INFO  : busycal : setting variable from argument DEBUG=0
2024-07-09 17:33:32 : DEBUG : busycal : name=BusyCal
2024-07-09 17:33:32 : DEBUG : busycal : appName=
2024-07-09 17:33:32 : DEBUG : busycal : type=dmg
2024-07-09 17:33:32 : DEBUG : busycal : archiveName=
2024-07-09 17:33:32 : DEBUG : busycal : downloadURL=https://www.busymac.com/download/bcl-2024.3.2.dmg
2024-07-09 17:33:32 : DEBUG : busycal : curlOptions=
2024-07-09 17:33:32 : DEBUG : busycal : appNewVersion=2024.3.2
2024-07-09 17:33:32 : DEBUG : busycal : appCustomVersion function: Not defined
2024-07-09 17:33:32 : DEBUG : busycal : versionKey=CFBundleShortVersionString
2024-07-09 17:33:32 : DEBUG : busycal : packageID=
2024-07-09 17:33:32 : DEBUG : busycal : pkgName=
2024-07-09 17:33:32 : DEBUG : busycal : choiceChangesXML=
2024-07-09 17:33:32 : DEBUG : busycal : expectedTeamID=N4RA379GBW
2024-07-09 17:33:32 : DEBUG : busycal : blockingProcesses=
2024-07-09 17:33:32 : DEBUG : busycal : installerTool=
2024-07-09 17:33:32 : DEBUG : busycal : CLIInstaller=
2024-07-09 17:33:32 : DEBUG : busycal : CLIArguments=
2024-07-09 17:33:32 : DEBUG : busycal : updateTool=
2024-07-09 17:33:32 : DEBUG : busycal : updateToolArguments=
2024-07-09 17:33:32 : DEBUG : busycal : updateToolRunAsCurrentUser=
2024-07-09 17:33:32 : INFO  : busycal : BLOCKING_PROCESS_ACTION=tell_user
2024-07-09 17:33:32 : INFO  : busycal : NOTIFY=success
2024-07-09 17:33:32 : INFO  : busycal : LOGGING=DEBUG
2024-07-09 17:33:32 : INFO  : busycal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-09 17:33:32 : INFO  : busycal : Label type: dmg
2024-07-09 17:33:32 : INFO  : busycal : archiveName: BusyCal.dmg
2024-07-09 17:33:32 : INFO  : busycal : no blocking processes defined, using BusyCal as default
2024-07-09 17:33:32 : DEBUG : busycal : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.cgJbZSX4RY
2024-07-09 17:33:32 : INFO  : busycal : name: BusyCal, appName: BusyCal.app
2024-07-09 17:33:32.281 mdfind[46638:48699569] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-09 17:33:32.281 mdfind[46638:48699569] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-09 17:33:32.332 mdfind[46638:48699569] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-09 17:33:32 : INFO  : busycal : App(s) found: /Applications/Utilities/Staff/BusyCal.app
2024-07-09 17:33:32 : INFO  : busycal : found app at /Applications/Utilities/Staff/BusyCal.app, version 2024.3.2, on versionKey CFBundleShortVersionString
2024-07-09 17:33:32 : INFO  : busycal : appversion: 2024.3.2
2024-07-09 17:33:32 : INFO  : busycal : Latest version of BusyCal is 2024.3.2
2024-07-09 17:33:32 : REQ   : busycal : Downloading https://www.busymac.com/download/bcl-2024.3.2.dmg to BusyCal.dmg
2024-07-09 17:33:32 : DEBUG : busycal : No Dialog connection, just download
2024-07-09 17:33:33 : DEBUG : busycal : File list: -rw-r--r--  1 root  wheel    62M Jul  9 17:33 BusyCal.dmg
2024-07-09 17:33:33 : DEBUG : busycal : File type: BusyCal.dmg: zlib compressed data
2024-07-09 17:33:33 : DEBUG : busycal : curl output was:
* Host www.busymac.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.215.228.206
*   Trying 18.215.228.206:443...
* Connected to www.busymac.com (18.215.228.206) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3697 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=busymac.com
*  start date: Feb 21 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "www.busymac.com" matched cert's "www.busymac.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=Thawte TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /download/bcl-2024.3.2.dmg HTTP/1.1
> Host: www.busymac.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 302 Found
< Date: Tue, 09 Jul 2024 23:33:32 GMT
< Server: Apache/2.4.58 (Ubuntu)
< Location: https://downloads.busymac.com/bcl-2024.3.2-2024-06-28-23-50.dmg
< Content-Length: 329
< Content-Type: text/html; charset=iso-8859-1
<
* Ignoring the response-body
* Connection #0 to host www.busymac.com left intact
* Issue another request to this URL: 'https://downloads.busymac.com/bcl-2024.3.2-2024-06-28-23-50.dmg'
* Host downloads.busymac.com:443 was resolved.
* IPv6: (none)
* IPv4: 13.249.205.96, 13.249.205.64, 13.249.205.126, 13.249.205.119
*   Trying 13.249.205.96:443...
* Connected to downloads.busymac.com (13.249.205.96) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4967 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=downloads.busymac.com
*  start date: Jun 12 00:00:00 2024 GMT
*  expire date: Jul 12 23:59:59 2025 GMT
*  subjectAltName: host "downloads.busymac.com" matched cert's "downloads.busymac.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.busymac.com/bcl-2024.3.2-2024-06-28-23-50.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.busymac.com]
* [HTTP/2] [1] [:path: /bcl-2024.3.2-2024-06-28-23-50.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /bcl-2024.3.2-2024-06-28-23-50.dmg HTTP/2
> Host: downloads.busymac.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 64994349
< date: Tue, 09 Jul 2024 11:06:50 GMT
< last-modified: Fri, 28 Jun 2024 21:51:18 GMT
< etag: "d103c9db473879a22bccae888ade4027-8"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 c28e90c09fe72af9ef5e45a1bf85f0fc.cloudfront.net (CloudFront)
< x-amz-cf-pop: SLC50-C1
< x-amz-cf-id: e76lpsAwpqxVO7YrItQ-unhp183-xy5ugw_cPIvIwt_hnEYpi6bIcw==
< age: 44803
<
{ [16012 bytes data]
* Connection #1 to host downloads.busymac.com left intact

2024-07-09 17:33:34 : INFO  : busycal : found blocking process BusyCal
2024-07-09 17:33:41 : INFO  : busycal : telling app BusyCal to quit
2024-07-09 17:33:42 : INFO  : busycal : waiting 30 seconds for processes to quit
2024-07-09 17:34:12 : REQ   : busycal : no more blocking processes, continue with update
2024-07-09 17:34:12 : REQ   : busycal : Installing BusyCal
2024-07-09 17:34:12 : INFO  : busycal : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.cgJbZSX4RY/BusyCal.dmg
2024-07-09 17:34:15 : DEBUG : busycal : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3B0484F2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3BA1F28C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DA4A08CF
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $97290A4B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DA4A08CF
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $4AB93E31
verified   CRC32 $7BBE431E
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_HFS                      	/Volumes/BusyCal

2024-07-09 17:34:15 : INFO  : busycal : Mounted: /Volumes/BusyCal
2024-07-09 17:34:15 : INFO  : busycal : Verifying: /Volumes/BusyCal/BusyCal.app
2024-07-09 17:34:15 : DEBUG : busycal : App size: 143M	/Volumes/BusyCal/BusyCal.app
2024-07-09 17:34:16 : DEBUG : busycal : Debugging enabled, App Verification output was:
/Volumes/BusyCal/BusyCal.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Busy Apps FZE (N4RA379GBW)

2024-07-09 17:34:16 : INFO  : busycal : Team ID matching: N4RA379GBW (expected: N4RA379GBW )
2024-07-09 17:34:16 : INFO  : busycal : Downloaded version of BusyCal is 2024.3.2 on versionKey CFBundleShortVersionString, same as installed.
2024-07-09 17:34:16 : DEBUG : busycal : Unmounting /Volumes/BusyCal
2024-07-09 17:34:16 : DEBUG : busycal : Debugging enabled, Unmounting output was:
"disk13" ejected.
2024-07-09 17:34:16 : DEBUG : busycal : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.cgJbZSX4RY
2024-07-09 17:34:16 : DEBUG : busycal : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.cgJbZSX4RY/BusyCal.dmg
2024-07-09 17:34:16 : DEBUG : busycal : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.cgJbZSX4RY
2024-07-09 17:34:16 : INFO  : busycal : Telling app BusyCal.app to open
2024-07-09 17:34:17 : INFO  : busycal : Reopened BusyCal.app as u0105821
2024-07-09 17:34:17 : INFO  : busycal : u0105821
2024-07-09 17:34:17 : REG   : busycal : No new version to install
2024-07-09 17:34:17 : REQ   : busycal : ################## End Installomator, exit code 0
```