### PR TITLE
Add the Whimsical label

### DIFF
--- a/fragments/labels/whimsical.sh
+++ b/fragments/labels/whimsical.sh
@@ -1,0 +1,15 @@
+whimsical)
+    name="Whimsical"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://desktop.whimsical.com/mac/dmg/arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://desktop.whimsical.app/mac/dmg/x64"
+    fi
+    appNewVersion=$(curl -sIkL $downloadURL | sed -r '/filename=/!d;s/.*filename=(.*)$/\1/' | awk '{print $2}')
+    expectedTeamID="2N6497CB83"
+    versionKey="CFBundleShortVersionString"
+    appName="Whimsical.app"
+    blockingProcesses=( "Whimsical" )
+    ;;
+    


### PR DESCRIPTION
Adds the new Whimsical desktop app: https://whimsical.com/download

Tested here, I think everything is working?

```
$ ./assemble.sh whimsical
2024-07-10 12:56:10 : REQ   : whimsical : ################## Start Installomator v. 10.6beta, date 2024-07-10
2024-07-10 12:56:10 : INFO  : whimsical : ################## Version: 10.6beta
2024-07-10 12:56:10 : INFO  : whimsical : ################## Date: 2024-07-10
2024-07-10 12:56:10 : INFO  : whimsical : ################## whimsical
2024-07-10 12:56:10 : DEBUG : whimsical : DEBUG mode 1 enabled.
2024-07-10 12:56:10 : INFO  : whimsical : SwiftDialog is not installed, clear cmd file var
 dnslookup: 0.003730 | connect: 0.032941 | appconnect: 0.107159 | pretransfer: 0.107251 | starttransfer: 0.147426 | total: 0.147442 | size: 0
2024-07-10 12:56:11 : DEBUG : whimsical : name=Whimsical
2024-07-10 12:56:11 : DEBUG : whimsical : appName=Whimsical.app
2024-07-10 12:56:11 : DEBUG : whimsical : type=dmg
2024-07-10 12:56:11 : DEBUG : whimsical : archiveName=
2024-07-10 12:56:11 : DEBUG : whimsical : downloadURL=https://desktop.whimsical.com/mac/dmg/arm64
2024-07-10 12:56:11 : DEBUG : whimsical : curlOptions=
2024-07-10 12:56:11 : DEBUG : whimsical : appNewVersion=
2024-07-10 12:56:11 : DEBUG : whimsical : appCustomVersion function: Not defined
2024-07-10 12:56:11 : DEBUG : whimsical : versionKey=CFBundleShortVersionString
2024-07-10 12:56:11 : DEBUG : whimsical : packageID=
2024-07-10 12:56:11 : DEBUG : whimsical : pkgName=
2024-07-10 12:56:11 : DEBUG : whimsical : choiceChangesXML=
2024-07-10 12:56:11 : DEBUG : whimsical : expectedTeamID=2N6497CB83
2024-07-10 12:56:11 : DEBUG : whimsical : blockingProcesses=Whimsical
2024-07-10 12:56:11 : DEBUG : whimsical : installerTool=
2024-07-10 12:56:11 : DEBUG : whimsical : CLIInstaller=
2024-07-10 12:56:11 : DEBUG : whimsical : CLIArguments=
2024-07-10 12:56:11 : DEBUG : whimsical : updateTool=
2024-07-10 12:56:11 : DEBUG : whimsical : updateToolArguments=
2024-07-10 12:56:11 : DEBUG : whimsical : updateToolRunAsCurrentUser=
2024-07-10 12:56:11 : INFO  : whimsical : BLOCKING_PROCESS_ACTION=tell_user
2024-07-10 12:56:11 : INFO  : whimsical : NOTIFY=success
2024-07-10 12:56:11 : INFO  : whimsical : LOGGING=DEBUG
2024-07-10 12:56:11 : INFO  : whimsical : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-10 12:56:11 : INFO  : whimsical : Label type: dmg
2024-07-10 12:56:11 : INFO  : whimsical : archiveName: Whimsical.dmg
2024-07-10 12:56:11 : DEBUG : whimsical : Changing directory to /Users/danielcompton/Developer/whimsical/Installomator/build
2024-07-10 12:56:11 : INFO  : whimsical : App(s) found: /Applications/Whimsical.app
2024-07-10 12:56:11 : INFO  : whimsical : found app at /Applications/Whimsical.app, version 0.1.36, on versionKey CFBundleShortVersionString
2024-07-10 12:56:11 : INFO  : whimsical : appversion: 0.1.36
2024-07-10 12:56:11 : INFO  : whimsical : Latest version not specified.
2024-07-10 12:56:11 : REQ   : whimsical : Downloading https://desktop.whimsical.com/mac/dmg/arm64 to Whimsical.dmg
2024-07-10 12:56:11 : DEBUG : whimsical : No Dialog connection, just download
2024-07-10 12:56:17 : DEBUG : whimsical : File list: -rw-r--r--  1 danielcompton  staff   101M 10 Jul 12:56 Whimsical.dmg
2024-07-10 12:56:17 : DEBUG : whimsical : File type: Whimsical.dmg: zlib compressed data
2024-07-10 12:56:17 : DEBUG : whimsical : curl output was:
*   Trying [2606:4700:3031::6815:4bad]:443...
* Connected to desktop.whimsical.com (2606:4700:3031::6815:4bad) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2535 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=desktop.whimsical.com
*  start date: Jun 24 01:00:49 2024 GMT
*  expire date: Sep 22 01:00:48 2024 GMT
*  subjectAltName: host "desktop.whimsical.com" matched cert's "desktop.whimsical.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://desktop.whimsical.com/mac/dmg/arm64
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: desktop.whimsical.com]
* [HTTP/2] [1] [:path: /mac/dmg/arm64]
* [HTTP/2] [1] [user-agent: curl/8.4.0]
* [HTTP/2] [1] [accept: */*]
> GET /mac/dmg/arm64 HTTP/2
> Host: desktop.whimsical.com
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/2 200
< date: Wed, 10 Jul 2024 00:56:13 GMT
< content-type: application/octet-stream
< content-length: 105681444
< accept-ranges: bytes
< cache-control: no-store
< content-disposition: attachment; filename="Whimsical 0.1.36 - arm64.dmg"
< etag: "0052245bf3f00d3944d3e1ada70e4072"
< last-modified: Tue, 09 Jul 2024 12:07:08 GMT
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=U80LvJCXhS2qs2r3ULRvE6cAQpsCj%2BQgCQnwUtn39saEMNTFkEgpOK1N5x%2BYDYAWOg63seQgL6GtizFqhpPiShBaYoJawIj%2Bi3WddsyUmIuHJ6bvxj%2F%2BQ44zsTXPxFGZhSuRumKRUSHCtC16xtgti0IlAys%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
< cf-ray: 8a0c97af8c9ca838-SYD
< alt-svc: h3=":443"; ma=86400
<
{ [20480 bytes data]
* Connection #0 to host desktop.whimsical.com left intact
dnslookup: 0.002353 | connect: 0.031919 | appconnect: 0.067629 | pretransfer: 0.067729 | starttransfer: 1.750148 | total: 5.776412 | size: 105681444

2024-07-10 12:56:17 : DEBUG : whimsical : DEBUG mode 1, not checking for blocking processes
2024-07-10 12:56:17 : REQ   : whimsical : Installing Whimsical
2024-07-10 12:56:17 : INFO  : whimsical : Mounting /Users/danielcompton/Developer/whimsical/Installomator/build/Whimsical.dmg
2024-07-10 12:56:19 : DEBUG : whimsical : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $FA9F001B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8F3FB577
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $03C09E29
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $03DEDC8C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $03C09E29
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $D8FBAFF7
verified   CRC32 $41B15671
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/Whimsical 0.1.36-arm64

2024-07-10 12:56:19 : INFO  : whimsical : Mounted: /Volumes/Whimsical 0.1.36-arm64
2024-07-10 12:56:19 : INFO  : whimsical : Verifying: /Volumes/Whimsical 0.1.36-arm64/Whimsical.app
2024-07-10 12:56:19 : DEBUG : whimsical : App size: 271M	/Volumes/Whimsical 0.1.36-arm64/Whimsical.app
2024-07-10 12:56:21 : DEBUG : whimsical : Debugging enabled, App Verification output was:
/Volumes/Whimsical 0.1.36-arm64/Whimsical.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Whimsical Incorporated (2N6497CB83)

2024-07-10 12:56:21 : INFO  : whimsical : Team ID matching: 2N6497CB83 (expected: 2N6497CB83 )
2024-07-10 12:56:21 : INFO  : whimsical : Downloaded version of Whimsical is 0.1.36 on versionKey CFBundleShortVersionString, same as installed.
2024-07-10 12:56:21 : DEBUG : whimsical : Unmounting /Volumes/Whimsical 0.1.36-arm64
2024-07-10 12:56:22 : DEBUG : whimsical : Debugging enabled, Unmounting output was:
"disk7" ejected.
2024-07-10 12:56:22 : DEBUG : whimsical : DEBUG mode 1, not reopening anything
2024-07-10 12:56:22 : REG   : whimsical : No new version to install
2024-07-10 12:56:22 : REQ   : whimsical : ################## End Installomator, exit code 0
```