### PR TITLE
fixed package version extraction

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -581,7 +581,9 @@ getAppVersion() {
 
     # pkgs contains a version number, then we don't have to search for an app
     if [[ $packageID != "" ]]; then
-        appversion="$(pkgutil --pkg-info-plist ${packageID} 2>/dev/null | grep -A 1 pkg-version | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g')"
+        appversion="$(/usr/sbin/pkgutil --pkg-info-plist "${packageID}" 2>/dev/null |\
+            /usr/bin/xmllint --nonet --nowarning --nocatalogs \
+            --xpath '//key[.="pkg-version"]/following-sibling::*[1]/text()' - 2>/dev/null)"
         if [[ $appversion != "" ]]; then
             printlog "found packageID $packageID installed, version $appversion"
             updateDetected="YES"


### PR DESCRIPTION
The method to extract the pkg version from pkgutil failed in my testing for zulujdk:

> 2024-07-11 10:45:50 : INFO  : zulujdk17 : appversion: 	<string>17.50+19</string>

This PR uses `pkgutil --pkg-info-plist` and `xmllint` for robust parsing of the output, and will return the correct package version number:

> 2024-07-11 11:12:31 : INFO  : zulujdk17 : appversion: 17.50+19
