### PR TITLE
Fix keyshot2024 label

### DIFF
--- a/fragments/labels/keyshot2024.sh
+++ b/fragments/labels/keyshot2024.sh
@@ -1,5 +1,6 @@
-keyshot12_2024)
-    name="KeyShot12"
+keyshot|\
+keyshot2024)
+    name="KeyShot"
     type="pkg"
     expectedTeamID="W7B24M74T3"
     downloadURL="https://www.keyshot.com/download/370762/"


### PR DESCRIPTION
App name was incorrect, and label was misleading - keyshot2024 is v13, not v12.