### PR TITLE
Update surfdrive.sh

### DIFF
--- a/fragments/labels/surfdrive.sh
+++ b/fragments/labels/surfdrive.sh
@@ -1,9 +1,14 @@
 surfdrive)
     name="SURFdrive"
     type="pkg"
-    downloadURL="https://surfdrive.surf.nl/downloads/surfdrive-latest-x86_64.pkg"
+	if [[ $(arch) == "arm64" ]]; then
+		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm64)
+		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm |cut -d- -f2)
+    elif [[ $(arch) == "i386" ]]; then
+		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86)
+		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86 |cut -d- -f2)
+	fi
     expectedTeamID="4AP2STM4H5"
-    appNewVersion=$(curl -fs https://wiki.surfnet.nl/display/SURFdrive/Downloads+voor+SURFdrive|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg|cut -d- -f2)
     appName="surfdrive.app"
     blockingProcesses=( "surfdrive" )
-    ;;
+	;;


### PR DESCRIPTION
URL changed; added arm64 version.

Output:
````
./Installomator/utils/assemble.sh surfdrive
2024-07-12 13:11:48 : REQ   : surfdrive : ################## Start Installomator v. 10.6beta, date 2024-07-12
2024-07-12 13:11:48 : INFO  : surfdrive : ################## Version: 10.6beta
2024-07-12 13:11:48 : INFO  : surfdrive : ################## Date: 2024-07-12
2024-07-12 13:11:48 : INFO  : surfdrive : ################## surfdrive
2024-07-12 13:11:48 : DEBUG : surfdrive : DEBUG mode 1 enabled.
2024-07-12 13:11:49 : DEBUG : surfdrive : name=SURFdrive
2024-07-12 13:11:49 : DEBUG : surfdrive : appName=surfdrive.app
2024-07-12 13:11:49 : DEBUG : surfdrive : type=pkg
2024-07-12 13:11:49 : DEBUG : surfdrive : archiveName=
2024-07-12 13:11:49 : DEBUG : surfdrive : downloadURL=https://surfdrive.surf.nl/downloads/surfdrive-5.3.1.14097-x86_64.pkg
2024-07-12 13:11:49 : DEBUG : surfdrive : curlOptions=
2024-07-12 13:11:49 : DEBUG : surfdrive : appNewVersion=5.3.1.14097
2024-07-12 13:11:49 : DEBUG : surfdrive : appCustomVersion function: Not defined
2024-07-12 13:11:49 : DEBUG : surfdrive : versionKey=CFBundleShortVersionString
2024-07-12 13:11:49 : DEBUG : surfdrive : packageID=
2024-07-12 13:11:49 : DEBUG : surfdrive : pkgName=
2024-07-12 13:11:49 : DEBUG : surfdrive : choiceChangesXML=
2024-07-12 13:11:49 : DEBUG : surfdrive : expectedTeamID=4AP2STM4H5
2024-07-12 13:11:49 : DEBUG : surfdrive : blockingProcesses=surfdrive
2024-07-12 13:11:49 : DEBUG : surfdrive : installerTool=
2024-07-12 13:11:49 : DEBUG : surfdrive : CLIInstaller=
2024-07-12 13:11:49 : DEBUG : surfdrive : CLIArguments=
2024-07-12 13:11:49 : DEBUG : surfdrive : updateTool=
2024-07-12 13:11:49 : DEBUG : surfdrive : updateToolArguments=
2024-07-12 13:11:49 : DEBUG : surfdrive : updateToolRunAsCurrentUser=
2024-07-12 13:11:49 : INFO  : surfdrive : BLOCKING_PROCESS_ACTION=tell_user
2024-07-12 13:11:49 : INFO  : surfdrive : NOTIFY=success
2024-07-12 13:11:49 : INFO  : surfdrive : LOGGING=DEBUG
2024-07-12 13:11:49 : INFO  : surfdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-12 13:11:49 : INFO  : surfdrive : Label type: pkg
2024-07-12 13:11:49 : INFO  : surfdrive : archiveName: SURFdrive.pkg
2024-07-12 13:11:49 : DEBUG : surfdrive : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2024-07-12 13:11:49 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2024-07-12 13:11:50 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 5.2.1.13274, on versionKey CFBundleShortVersionString
2024-07-12 13:11:50 : INFO  : surfdrive : appversion: 5.2.1.13274
2024-07-12 13:11:50 : INFO  : surfdrive : Latest version of SURFdrive is 5.3.1.14097
2024-07-12 13:11:50 : REQ   : surfdrive : Downloading https://surfdrive.surf.nl/downloads/surfdrive-5.3.1.14097-x86_64.pkg to SURFdrive.pkg
2024-07-12 13:11:50 : DEBUG : surfdrive : No Dialog connection, just download
2024-07-12 13:11:55 : DEBUG : surfdrive : File list: -rw-r--r--  1 h.lans  2094862921    30M Jul 12 13:11 SURFdrive.pkg
2024-07-12 13:11:55 : DEBUG : surfdrive : File type: SURFdrive.pkg: xar archive compressed TOC: 5328, SHA-1 checksum
2024-07-12 13:11:55 : DEBUG : surfdrive : curl output was:
*   Trying 145.107.56.140:443...
* Connected to surfdrive.surf.nl (145.107.56.140) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [6418 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=NL; ST=Utrecht; O=SURF B.V.; CN=surfdrive.surf.nl
*  start date: Jan 30 00:00:00 2024 GMT
*  expire date: Jan 29 23:59:59 2025 GMT
*  subjectAltName: host "surfdrive.surf.nl" matched cert's "surfdrive.surf.nl"
*  issuer: C=NL; O=GEANT Vereniging; CN=GEANT OV RSA CA 4
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /downloads/surfdrive-5.3.1.14097-x86_64.pkg HTTP/1.1
> Host: surfdrive.surf.nl
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< date: Fri, 12 Jul 2024 11:11:50 GMT
< server: Apache
< x-frame-options: SAMEORIGIN
< last-modified: Tue, 02 Jul 2024 13:39:37 GMT
< etag: "1e596b5-61c43d8443840"
< accept-ranges: bytes
< content-length: 31823541
< content-type: application/vnd.apple.installer+xml
< strict-transport-security: max-age=31536000; includeSubDomains;
< set-cookie: app_cookie=web-b-12; path=/; HttpOnly; Secure
< cache-control: private
<
{ [14964 bytes data]
* Connection #0 to host surfdrive.surf.nl left intact

2024-07-12 13:11:55 : DEBUG : surfdrive : DEBUG mode 1, not checking for blocking processes
2024-07-12 13:11:55 : REQ   : surfdrive : Installing SURFdrive
2024-07-12 13:11:55 : INFO  : surfdrive : Verifying: SURFdrive.pkg
2024-07-12 13:11:55 : DEBUG : surfdrive : File list: -rw-r--r--  1 h.lans  2094862921    30M Jul 12 13:11 SURFdrive.pkg
2024-07-12 13:11:55 : DEBUG : surfdrive : File type: SURFdrive.pkg: xar archive compressed TOC: 5328, SHA-1 checksum
2024-07-12 13:11:55 : DEBUG : surfdrive : spctlOut is SURFdrive.pkg: accepted
2024-07-12 13:11:55 : DEBUG : surfdrive : source=Notarized Developer ID
2024-07-12 13:11:55 : DEBUG : surfdrive : origin=Developer ID Installer: ownCloud GmbH (4AP2STM4H5)
2024-07-12 13:11:55 : INFO  : surfdrive : Team ID: 4AP2STM4H5 (expected: 4AP2STM4H5 )
2024-07-12 13:11:55 : DEBUG : surfdrive : DEBUG enabled, skipping installation
2024-07-12 13:11:55 : INFO  : surfdrive : Finishing...
2024-07-12 13:11:58 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2024-07-12 13:11:58 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 5.2.1.13274, on versionKey CFBundleShortVersionString
2024-07-12 13:11:58 : REQ   : surfdrive : Installed SURFdrive, version 5.3.1.14097
2024-07-12 13:11:58 : INFO  : surfdrive : notifying
2024-07-12 13:11:59 : DEBUG : surfdrive : DEBUG mode 1, not reopening anything
2024-07-12 13:11:59 : REQ   : surfdrive : All done!
2024-07-12 13:11:59 : REQ   : surfdrive : ################## End Installomator, exit code 0
````