### PR TITLE
lable-mamp

### DIFF
--- a/fragments/labels/mamp.sh
+++ b/fragments/labels/mamp.sh
@@ -1,0 +1,7 @@
+mamp)
+    name="MAMP"
+    type="pkg"
+    downloadURL="$(curl -fsL 'https://www.mamp.info/en/downloads/' | grep -o 'https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-[^"]*.pkg' | head -1)"
+    appNewVersion="$(echo "${downloadURL}" | grep -o 'MAMP-MAMP-PRO-[0-9]*\.[0-9]*' | sed 's/MAMP-MAMP-PRO-//')"
+    expectedTeamID="5KCB5KHK77"
+    ;;


### PR DESCRIPTION
2024-07-18 14:56:31 : REQ   : mamp : ################## Start Installomator v. 10.6beta, date 2024-07-18
2024-07-18 14:56:31 : INFO  : mamp : ################## Version: 10.6beta
2024-07-18 14:56:31 : INFO  : mamp : ################## Date: 2024-07-18
2024-07-18 14:56:31 : INFO  : mamp : ################## mamp
2024-07-18 14:56:31 : DEBUG : mamp : DEBUG mode 1 enabled.
2024-07-18 14:56:31 : DEBUG : mamp : name=MAMP
2024-07-18 14:56:31 : DEBUG : mamp : appName=
2024-07-18 14:56:31 : DEBUG : mamp : type=pkg
2024-07-18 14:56:31 : DEBUG : mamp : archiveName=
2024-07-18 14:56:31 : DEBUG : mamp : downloadURL=https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.0-Apple-chip.pkg
2024-07-18 14:56:31 : DEBUG : mamp : curlOptions=
2024-07-18 14:56:31 : DEBUG : mamp : appNewVersion=7.0
2024-07-18 14:56:31 : DEBUG : mamp : appCustomVersion function: Not defined
2024-07-18 14:56:31 : DEBUG : mamp : versionKey=CFBundleShortVersionString
2024-07-18 14:56:31 : DEBUG : mamp : packageID=
2024-07-18 14:56:31 : DEBUG : mamp : pkgName=
2024-07-18 14:56:31 : DEBUG : mamp : choiceChangesXML=
2024-07-18 14:56:31 : DEBUG : mamp : expectedTeamID=5KCB5KHK77
2024-07-18 14:56:31 : DEBUG : mamp : blockingProcesses=
2024-07-18 14:56:31 : DEBUG : mamp : installerTool=
2024-07-18 14:56:31 : DEBUG : mamp : CLIInstaller=
2024-07-18 14:56:31 : DEBUG : mamp : CLIArguments=
2024-07-18 14:56:31 : DEBUG : mamp : updateTool=
2024-07-18 14:56:31 : DEBUG : mamp : updateToolArguments=
2024-07-18 14:56:31 : DEBUG : mamp : updateToolRunAsCurrentUser=
2024-07-18 14:56:31 : INFO  : mamp : BLOCKING_PROCESS_ACTION=tell_user
2024-07-18 14:56:31 : INFO  : mamp : NOTIFY=success
2024-07-18 14:56:31 : INFO  : mamp : LOGGING=DEBUG
2024-07-18 14:56:31 : INFO  : mamp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-18 14:56:31 : INFO  : mamp : Label type: pkg
2024-07-18 14:56:31 : INFO  : mamp : archiveName: MAMP.pkg
2024-07-18 14:56:31 : INFO  : mamp : no blocking processes defined, using MAMP as default
2024-07-18 14:56:31 : DEBUG : mamp : Changing directory to .
2024-07-18 14:56:31 : INFO  : mamp : name: MAMP, appName: MAMP.app
2024-07-18 14:56:31.823 mdfind[60688:716045] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-07-18 14:56:31.823 mdfind[60688:716045] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-07-18 14:56:32.016 mdfind[60688:716045] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-18 14:56:32 : WARN  : mamp : No previous app found
2024-07-18 14:56:32 : WARN  : mamp : could not find MAMP.app
2024-07-18 14:56:32 : INFO  : mamp : appversion:
2024-07-18 14:56:32 : INFO  : mamp : Latest version of MAMP is 7.0
2024-07-18 14:56:32 : REQ   : mamp : Downloading https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.0-Apple-chip.pkg to MAMP.pkg
2024-07-18 14:56:32 : DEBUG : mamp : No Dialog connection, just download
2024-07-18 14:57:41 : DEBUG : mamp : File list: -rw-r--r--  1 root  staff   644M 18 Jul 14:57 MAMP.pkg
2024-07-18 14:57:41 : DEBUG : mamp : File type: MAMP.pkg: xar archive compressed TOC: 7062, SHA-1 checksum
2024-07-18 14:57:41 : DEBUG : mamp : curl output was:
* Host downloads.mamp.info:443 was resolved.
* IPv6: (none)
* IPv4: 92.204.236.229
*   Trying 92.204.236.229:443...
* Connected to downloads.mamp.info (92.204.236.229) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4016 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.mamp.info
*  start date: Feb 13 09:07:57 2024 GMT
*  expire date: Mar  2 12:07:07 2025 GMT
*  subjectAltName: host "downloads.mamp.info" matched cert's "*.mamp.info"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=Starfield Technologies, Inc.; OU=http://certs.starfieldtech.com/repository/; CN=Starfield Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.0-Apple-chip.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.mamp.info]
* [HTTP/2] [1] [:path: /MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.0-Apple-chip.pkg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.0-Apple-chip.pkg HTTP/2
> Host: downloads.mamp.info
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< server: nginx
< date: Thu, 18 Jul 2024 12:56:32 GMT
< content-type: application/vnd.apple.installer+xml < content-length: 675717338
< cache-control: s-maxage=0, max-age=0, no-cache, no-store, must-revalidate < expires: Thu, 01 Jan 1970 00:00:00 GMT
< last-modified: Thu, 18 Jul 2024 11:13:07 GMT
< etag: "2846a0da-61d83a9cd76c0"
< x-cache-status: MISS
< accept-ranges: bytes
<
{ [16112 bytes data]
* Connection #0 to host downloads.mamp.info left intact

2024-07-18 14:57:41 : DEBUG : mamp : DEBUG mode 1, not checking for blocking processes
2024-07-18 14:57:41 : REQ   : mamp : Installing MAMP
2024-07-18 14:57:41 : INFO  : mamp : Verifying: MAMP.pkg
2024-07-18 14:57:41 : DEBUG : mamp : File list: -rw-r--r--  1 root  staff   644M 18 Jul 14:57 MAMP.pkg
2024-07-18 14:57:41 : DEBUG : mamp : File type: MAMP.pkg: xar archive compressed TOC: 7062, SHA-1 checksum
2024-07-18 14:57:41 : DEBUG : mamp : spctlOut is MAMP.pkg: accepted
2024-07-18 14:57:41 : DEBUG : mamp : source=Notarized Developer ID
2024-07-18 14:57:41 : DEBUG : mamp : origin=Developer ID Installer: MAMP GmbH (5KCB5KHK77)
2024-07-18 14:57:41 : INFO  : mamp : Team ID: 5KCB5KHK77 (expected: 5KCB5KHK77 )
2024-07-18 14:57:41 : DEBUG : mamp : DEBUG enabled, skipping installation
2024-07-18 14:57:41 : INFO  : mamp : Finishing...
2024-07-18 14:57:44 : INFO  : mamp : name: MAMP, appName: MAMP.app
2024-07-18 14:57:44.744 mdfind[60839:717561] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-07-18 14:57:44.745 mdfind[60839:717561] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-07-18 14:57:44.826 mdfind[60839:717561] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-18 14:57:44 : WARN  : mamp : No previous app found
2024-07-18 14:57:44 : WARN  : mamp : could not find MAMP.app
2024-07-18 14:57:44 : REQ   : mamp : Installed MAMP, version 7.0
2024-07-18 14:57:44 : INFO  : mamp : notifying
2024-07-18 14:57:45 : DEBUG : mamp : DEBUG mode 1, not reopening anything
2024-07-18 14:57:45 : REQ   : mamp : All done!
2024-07-18 14:57:45 : REQ   : mamp : ################## End Installomator, exit code 0