### PR TITLE
new-eclipseideforjavadevelopers

### DIFF
--- a/fragments/labels/eclipseideforjavadevelopers.sh
+++ b/fragments/labels/eclipseideforjavadevelopers.sh
@@ -1,0 +1,13 @@
+eclipseideforjavadevelopers)
+    # A feature-rich integrated development environment that supports Java development with tools for coding, debugging, and build automation
+    name="Eclipse"
+    type="dmg"
+    alphaChar=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o 'eclipse-java-[0-9]\{4\}-[0-9]\{2\}-[A-Za-z0-9]\+-macosx-cocoa-x86_64\.dmg' | awk -F'-' '{print $5}')
+    yearMonth=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o "eclipse-java-[0-9]\{4\}-[0-9]\{2\}-$alphaChar-macosx-cocoa-x86_64.dmg" | sed -E 's/.*eclipse-java-([0-9]{4}-[0-9]{2})-R.*/\1/')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-aarch64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-x86_64.dmg"
+    fi
+    expectedTeamID="JCDTMS22B4"
+    ;;


### PR DESCRIPTION
output:
```
 # Installomator/utils/assemble.sh eclipseideforjavadevelopers DEBUG=0
2024-07-18 13:26:09 : REQ   : eclipseideforjavadevelopers : ################## Start Installomator v. 10.6beta, date 2024-07-18
2024-07-18 13:26:09 : INFO  : eclipseideforjavadevelopers : ################## Version: 10.6beta
2024-07-18 13:26:09 : INFO  : eclipseideforjavadevelopers : ################## Date: 2024-07-18
2024-07-18 13:26:09 : INFO  : eclipseideforjavadevelopers : ################## eclipseideforjavadevelopers
2024-07-18 13:26:09 : DEBUG : eclipseideforjavadevelopers : DEBUG mode 1 enabled.
2024-07-18 13:26:10 : INFO  : eclipseideforjavadevelopers : setting variable from argument DEBUG=0
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : name=Eclipse
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : appName=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : type=dmg
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : archiveName=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : downloadURL=https://download.eclipse.org/technology/epp/downloads/release/2024-06/R/eclipse-java-2024-06-R-macosx-cocoa-aarch64.dmg
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : curlOptions=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : appNewVersion=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : appCustomVersion function: Not defined
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : versionKey=CFBundleShortVersionString
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : packageID=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : pkgName=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : choiceChangesXML=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : expectedTeamID=JCDTMS22B4
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : blockingProcesses=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : installerTool=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : CLIInstaller=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : CLIArguments=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : updateTool=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : updateToolArguments=
2024-07-18 13:26:10 : DEBUG : eclipseideforjavadevelopers : updateToolRunAsCurrentUser=
2024-07-18 13:26:10 : INFO  : eclipseideforjavadevelopers : BLOCKING_PROCESS_ACTION=tell_user
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : NOTIFY=success
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : LOGGING=DEBUG
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : Label type: dmg
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : archiveName: Eclipse.dmg
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : no blocking processes defined, using Eclipse as default
2024-07-18 13:26:11 : DEBUG : eclipseideforjavadevelopers : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Mm5st89Gmw
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : name: Eclipse, appName: Eclipse.app
2024-07-18 13:26:11.077 mdfind[99607:59277838] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-18 13:26:11.077 mdfind[99607:59277838] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-18 13:26:11.175 mdfind[99607:59277838] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-18 13:26:11 : WARN  : eclipseideforjavadevelopers : No previous app found
2024-07-18 13:26:11 : WARN  : eclipseideforjavadevelopers : could not find Eclipse.app
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : appversion:
2024-07-18 13:26:11 : INFO  : eclipseideforjavadevelopers : Latest version not specified.
2024-07-18 13:26:11 : REQ   : eclipseideforjavadevelopers : Downloading https://download.eclipse.org/technology/epp/downloads/release/2024-06/R/eclipse-java-2024-06-R-macosx-cocoa-aarch64.dmg to Eclipse.dmg
2024-07-18 13:26:11 : DEBUG : eclipseideforjavadevelopers : No Dialog connection, just download
2024-07-18 13:26:29 : DEBUG : eclipseideforjavadevelopers : File list: -rw-r--r--  1 root  wheel   329M Jul 18 13:26 Eclipse.dmg
2024-07-18 13:26:29 : DEBUG : eclipseideforjavadevelopers : File type: Eclipse.dmg: zlib compressed data
2024-07-18 13:26:29 : DEBUG : eclipseideforjavadevelopers : curl output was:
* Host download.eclipse.org:443 was resolved.
* IPv6: (none)
* IPv4: 198.41.30.199
*   Trying 198.41.30.199:443...
* Connected to download.eclipse.org (198.41.30.199) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3227 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [589 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=CA; ST=Ontario; L=Ottawa; O=Eclipse.org Foundation, Inc.; CN=*.eclipse.org
*  start date: Jul 15 00:00:00 2024 GMT
*  expire date: Apr  4 23:59:59 2025 GMT
*  subjectAltName: host "download.eclipse.org" matched cert's "*.eclipse.org"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.eclipse.org/technology/epp/downloads/release/2024-06/R/eclipse-java-2024-06-R-macosx-cocoa-aarch64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.eclipse.org]
* [HTTP/2] [1] [:path: /technology/epp/downloads/release/2024-06/R/eclipse-java-2024-06-R-macosx-cocoa-aarch64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /technology/epp/downloads/release/2024-06/R/eclipse-java-2024-06-R-macosx-cocoa-aarch64.dmg HTTP/2
> Host: download.eclipse.org
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< server: nginx
< date: Thu, 18 Jul 2024 19:24:48 GMT
< content-type: application/x-apple-diskimage
< content-length: 344782139
< last-modified: Tue, 11 Jun 2024 01:54:15 GMT
< etag: "148cf53b-61a938b1027ef"
< x-nodeid: download2
< content-security-policy: frame-ancestors 'self'
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< strict-transport-security: max-age=63072000; includeSubDomains; preload
< cache-control: private, max-age=8m, no-transform
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< x-proxy-cache: MISS
< accept-ranges: bytes
<
{ [7451 bytes data]
* Connection #0 to host download.eclipse.org left intact

2024-07-18 13:26:29 : REQ   : eclipseideforjavadevelopers : no more blocking processes, continue with update
2024-07-18 13:26:29 : REQ   : eclipseideforjavadevelopers : Installing Eclipse
2024-07-18 13:26:29 : INFO  : eclipseideforjavadevelopers : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Mm5st89Gmw/Eclipse.dmg
2024-07-18 13:26:33 : DEBUG : eclipseideforjavadevelopers : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $01024443
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $02AF1947
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7CCCF56B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $424F47B8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7CCCF56B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $38372142
verified   CRC32 $E68A4F4D
/dev/disk14         	GUID_partition_scheme
/dev/disk14s1       	Apple_HFS                      	/Volumes/Eclipse 1

2024-07-18 13:26:33 : INFO  : eclipseideforjavadevelopers : Mounted: /Volumes/Eclipse 1
2024-07-18 13:26:33 : INFO  : eclipseideforjavadevelopers : Verifying: /Volumes/Eclipse 1/Eclipse.app
2024-07-18 13:26:33 : DEBUG : eclipseideforjavadevelopers : App size: 387M	/Volumes/Eclipse 1/Eclipse.app
2024-07-18 13:26:36 : DEBUG : eclipseideforjavadevelopers : Debugging enabled, App Verification output was:
/Volumes/Eclipse 1/Eclipse.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Eclipse Foundation, Inc. (JCDTMS22B4)

2024-07-18 13:26:36 : INFO  : eclipseideforjavadevelopers : Team ID matching: JCDTMS22B4 (expected: JCDTMS22B4 )
2024-07-18 13:26:36 : INFO  : eclipseideforjavadevelopers : Installing Eclipse version 4.32.0 on versionKey CFBundleShortVersionString.
2024-07-18 13:26:36 : INFO  : eclipseideforjavadevelopers : Copy /Volumes/Eclipse 1/Eclipse.app to /Applications
2024-07-18 13:26:37 : DEBUG : eclipseideforjavadevelopers : Debugging enabled, App copy output was:
Copying /Volumes/Eclipse 1/Eclipse.app

2024-07-18 13:26:37 : WARN  : eclipseideforjavadevelopers : Changing owner to u0105821
2024-07-18 13:26:37 : INFO  : eclipseideforjavadevelopers : Finishing...
2024-07-18 13:26:40 : INFO  : eclipseideforjavadevelopers : App(s) found: /Applications/Eclipse.app
2024-07-18 13:26:40 : INFO  : eclipseideforjavadevelopers : found app at /Applications/Eclipse.app, version 4.32.0, on versionKey CFBundleShortVersionString
2024-07-18 13:26:40 : REQ   : eclipseideforjavadevelopers : Installed Eclipse, version 4.32.0
2024-07-18 13:26:40 : INFO  : eclipseideforjavadevelopers : notifying
2024-07-18 13:26:40 : DEBUG : eclipseideforjavadevelopers : Unmounting /Volumes/Eclipse 1
2024-07-18 13:26:40 : DEBUG : eclipseideforjavadevelopers : Debugging enabled, Unmounting output was:
"disk14" ejected.
2024-07-18 13:26:40 : DEBUG : eclipseideforjavadevelopers : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Mm5st89Gmw
2024-07-18 13:26:40 : DEBUG : eclipseideforjavadevelopers : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Mm5st89Gmw/Eclipse.dmg
2024-07-18 13:26:40 : DEBUG : eclipseideforjavadevelopers : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Mm5st89Gmw
2024-07-18 13:26:40 : INFO  : eclipseideforjavadevelopers : Installomator did not close any apps, so no need to reopen any apps.
2024-07-18 13:26:40 : REQ   : eclipseideforjavadevelopers : All done!
2024-07-18 13:26:40 : REQ   : eclipseideforjavadevelopers : ################## End Installomator, exit code 0
```