### PR TITLE
Camunda: Update label for arm64/x64

### DIFF
--- a/fragments/labels/camunda.sh
+++ b/fragments/labels/camunda.sh
@@ -1,7 +1,11 @@
 camunda)
     name="Camunda Modeler"
     type="dmg"
-    downloadURL=$(curl -s https://camunda.com/download/modeler/ | grep dmg | sed -n 's/.*href="\([^"]*\)".*/\1/p')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fs https://camunda.com/download/modeler/ |  sed -n 's/.*href="\([^"]*\)".*/\1/p' | grep arm64.dmg)
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fs https://camunda.com/download/modeler/ |  sed -n 's/.*href="\([^"]*\)".*/\1/p' | grep x64.dmg)
+    fi
     appNewVersion=$(echo "${downloadURL}" | sed 's/.*release\/camunda-modeler\/\([^\/]*\)\/camunda-modeler-.*/\1/')
     expectedTeamID="3JVGD57JQZ"
     ;;


### PR DESCRIPTION
```
2024-07-25 10:01:52 : REQ   : camunda : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-07-25 10:01:52 : INFO  : camunda : ################## Version: 10.6beta
2024-07-25 10:01:53 : INFO  : camunda : ################## Date: 2024-04-23
2024-07-25 10:01:53 : INFO  : camunda : ################## camunda
2024-07-25 10:01:53 : DEBUG : camunda : DEBUG mode 1 enabled.
2024-07-25 10:01:53 : INFO  : camunda : setting variable from argument DEBUG=0
2024-07-25 10:01:53 : INFO  : camunda : setting variable from argument NOTIFY=success
2024-07-25 10:01:53 : DEBUG : camunda : name=Camunda Modeler
2024-07-25 10:01:53 : DEBUG : camunda : appName=
2024-07-25 10:01:53 : DEBUG : camunda : type=dmg
2024-07-25 10:01:53 : DEBUG : camunda : archiveName=
2024-07-25 10:01:53 : DEBUG : camunda : downloadURL=https://downloads.camunda.cloud/release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg
2024-07-25 10:01:53 : DEBUG : camunda : curlOptions=
2024-07-25 10:01:53 : DEBUG : camunda : appNewVersion=5.25.0
2024-07-25 10:01:53 : DEBUG : camunda : appCustomVersion function: Not defined
2024-07-25 10:01:53 : DEBUG : camunda : versionKey=CFBundleShortVersionString
2024-07-25 10:01:53 : DEBUG : camunda : packageID=
2024-07-25 10:01:53 : DEBUG : camunda : pkgName=
2024-07-25 10:01:53 : DEBUG : camunda : choiceChangesXML=
2024-07-25 10:01:53 : DEBUG : camunda : expectedTeamID=3JVGD57JQZ
2024-07-25 10:01:53 : DEBUG : camunda : blockingProcesses=
2024-07-25 10:01:53 : DEBUG : camunda : installerTool=
2024-07-25 10:01:53 : DEBUG : camunda : CLIInstaller=
2024-07-25 10:01:53 : DEBUG : camunda : CLIArguments=
2024-07-25 10:01:53 : DEBUG : camunda : updateTool=
2024-07-25 10:01:53 : DEBUG : camunda : updateToolArguments=
2024-07-25 10:01:53 : DEBUG : camunda : updateToolRunAsCurrentUser=
2024-07-25 10:01:53 : INFO  : camunda : BLOCKING_PROCESS_ACTION=tell_user
2024-07-25 10:01:53 : INFO  : camunda : NOTIFY=success
2024-07-25 10:01:53 : INFO  : camunda : LOGGING=DEBUG
2024-07-25 10:01:53 : INFO  : camunda : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-25 10:01:53 : INFO  : camunda : Label type: dmg
2024-07-25 10:01:53 : INFO  : camunda : archiveName: Camunda Modeler.dmg
2024-07-25 10:01:53 : INFO  : camunda : no blocking processes defined, using Camunda Modeler as default
2024-07-25 10:01:53 : DEBUG : camunda : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n9Jz6U4zHQ
2024-07-25 10:01:53 : INFO  : camunda : App(s) found: /Applications/Camunda Modeler.app
2024-07-25 10:01:53 : INFO  : camunda : found app at /Applications/Camunda Modeler.app, version 5.24.0, on versionKey CFBundleShortVersionString
2024-07-25 10:01:53 : INFO  : camunda : appversion: 5.24.0
2024-07-25 10:01:53 : INFO  : camunda : Latest version of Camunda Modeler is 5.25.0
2024-07-25 10:01:53 : REQ   : camunda : Downloading https://downloads.camunda.cloud/release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg to Camunda Modeler.dmg
2024-07-25 10:01:53 : DEBUG : camunda : No Dialog connection, just download
2024-07-25 10:02:02 : DEBUG : camunda : File list: -rw-r--r--  1 root  wheel   107M 25 Jul 10:02 Camunda Modeler.dmg
2024-07-25 10:02:02 : DEBUG : camunda : File type: Camunda Modeler.dmg: zlib compressed data
2024-07-25 10:02:02 : DEBUG : camunda : curl output was:
* Host downloads.camunda.cloud:443 was resolved.
* IPv6: (none)
* IPv4: 104.155.1.97
*   Trying 104.155.1.97:443...
* Connected to downloads.camunda.cloud (104.155.1.97) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2590 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=downloads.camunda.cloud
*  start date: Jul 21 12:07:59 2024 GMT
*  expire date: Oct 19 12:07:58 2024 GMT
*  subjectAltName: host "downloads.camunda.cloud" matched cert's "downloads.camunda.cloud"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.camunda.cloud/release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.camunda.cloud]
* [HTTP/2] [1] [:path: /release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg HTTP/2
> Host: downloads.camunda.cloud
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 302
< date: Thu, 25 Jul 2024 08:01:54 GMT
< content-type: text/plain; charset=utf-8
< content-length: 716
< location: https://storage.googleapis.com/downloads-camunda-cloud-release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg?GoogleAccessId=download-center-reader%40camunda-public.iam.gserviceaccount.com&Expires=1721895414&Signature=DnZXX9sTz2jOO3Dt4tN0sjD0Gcbkb%2BKyCUr3y%2BrTGi0%2F4RsF9XEQtz9%2FCRAIc3HfA2zreWvHDxykqbydB6fTjyogip75SZZFXYY9fXjjTQIwYwGHW3Fy0y%2BZBclJYf4H43YsZzHxtzjoNdOkjR5zzTMUqzz7NhKLZvfYFt2IHjZFWnYdszhGoG4xBElxcALdOEAZpABH83JYtsVZlGc6C%2Bt1uhxNY0jIA07mOdWHYEFhQSvNmO9LCMNtqZNArbR9PVYniDmBIg3PIFjXiC9BnwH3v6NeUV8PX1W%2F1FSi7qzkvk1%2FFvUoyv3P5BfuzRcBCkBxQG1eto5vKAZA0gqdsg%3D%3D&response-content-disposition=attachment%3B%20filename%3D%22camunda-modeler-5.25.0-mac-arm64.dmg%22
< x-powered-by: Express
< vary: Accept
< strict-transport-security: max-age=63072000; includeSubDomains
<
* Ignoring the response-body
* Connection #0 to host downloads.camunda.cloud left intact
* Issue another request to this URL: 'https://storage.googleapis.com/downloads-camunda-cloud-release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg?GoogleAccessId=download-center-reader%40camunda-public.iam.gserviceaccount.com&Expires=1721895414&Signature=DnZXX9sTz2jOO3Dt4tN0sjD0Gcbkb%2BKyCUr3y%2BrTGi0%2F4RsF9XEQtz9%2FCRAIc3HfA2zreWvHDxykqbydB6fTjyogip75SZZFXYY9fXjjTQIwYwGHW3Fy0y%2BZBclJYf4H43YsZzHxtzjoNdOkjR5zzTMUqzz7NhKLZvfYFt2IHjZFWnYdszhGoG4xBElxcALdOEAZpABH83JYtsVZlGc6C%2Bt1uhxNY0jIA07mOdWHYEFhQSvNmO9LCMNtqZNArbR9PVYniDmBIg3PIFjXiC9BnwH3v6NeUV8PX1W%2F1FSi7qzkvk1%2FFvUoyv3P5BfuzRcBCkBxQG1eto5vKAZA0gqdsg%3D%3D&response-content-disposition=attachment%3B%20filename%3D%22camunda-modeler-5.25.0-mac-arm64.dmg%22'
* Host storage.googleapis.com:443 was resolved.
* IPv6: (none)
* IPv4: 142.251.209.155, 172.217.19.91, 142.250.181.219, 172.217.16.91
*   Trying 142.251.209.155:443...
* Connected to storage.googleapis.com (142.251.209.155) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3831 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=storage.googleapis.com
*  start date: Jun 24 07:57:50 2024 GMT
*  expire date: Sep 16 07:57:49 2024 GMT
*  subjectAltName: host "storage.googleapis.com" matched cert's "storage.googleapis.com"
*  issuer: C=US; O=Google Trust Services; CN=WR2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://storage.googleapis.com/downloads-camunda-cloud-release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg?GoogleAccessId=download-center-reader%40camunda-public.iam.gserviceaccount.com&Expires=1721895414&Signature=DnZXX9sTz2jOO3Dt4tN0sjD0Gcbkb%2BKyCUr3y%2BrTGi0%2F4RsF9XEQtz9%2FCRAIc3HfA2zreWvHDxykqbydB6fTjyogip75SZZFXYY9fXjjTQIwYwGHW3Fy0y%2BZBclJYf4H43YsZzHxtzjoNdOkjR5zzTMUqzz7NhKLZvfYFt2IHjZFWnYdszhGoG4xBElxcALdOEAZpABH83JYtsVZlGc6C%2Bt1uhxNY0jIA07mOdWHYEFhQSvNmO9LCMNtqZNArbR9PVYniDmBIg3PIFjXiC9BnwH3v6NeUV8PX1W%2F1FSi7qzkvk1%2FFvUoyv3P5BfuzRcBCkBxQG1eto5vKAZA0gqdsg%3D%3D&response-content-disposition=attachment%3B%20filename%3D%22camunda-modeler-5.25.0-mac-arm64.dmg%22
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: storage.googleapis.com]
* [HTTP/2] [1] [:path: /downloads-camunda-cloud-release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg?GoogleAccessId=download-center-reader%40camunda-public.iam.gserviceaccount.com&Expires=1721895414&Signature=DnZXX9sTz2jOO3Dt4tN0sjD0Gcbkb%2BKyCUr3y%2BrTGi0%2F4RsF9XEQtz9%2FCRAIc3HfA2zreWvHDxykqbydB6fTjyogip75SZZFXYY9fXjjTQIwYwGHW3Fy0y%2BZBclJYf4H43YsZzHxtzjoNdOkjR5zzTMUqzz7NhKLZvfYFt2IHjZFWnYdszhGoG4xBElxcALdOEAZpABH83JYtsVZlGc6C%2Bt1uhxNY0jIA07mOdWHYEFhQSvNmO9LCMNtqZNArbR9PVYniDmBIg3PIFjXiC9BnwH3v6NeUV8PX1W%2F1FSi7qzkvk1%2FFvUoyv3P5BfuzRcBCkBxQG1eto5vKAZA0gqdsg%3D%3D&response-content-disposition=attachment%3B%20filename%3D%22camunda-modeler-5.25.0-mac-arm64.dmg%22]
* [HTTP/2] [1] [user-agent: curl/8.6.0]
* [HTTP/2] [1] [accept: */*]
> GET /downloads-camunda-cloud-release/camunda-modeler/5.25.0/camunda-modeler-5.25.0-mac-arm64.dmg?GoogleAccessId=download-center-reader%40camunda-public.iam.gserviceaccount.com&Expires=1721895414&Signature=DnZXX9sTz2jOO3Dt4tN0sjD0Gcbkb%2BKyCUr3y%2BrTGi0%2F4RsF9XEQtz9%2FCRAIc3HfA2zreWvHDxykqbydB6fTjyogip75SZZFXYY9fXjjTQIwYwGHW3Fy0y%2BZBclJYf4H43YsZzHxtzjoNdOkjR5zzTMUqzz7NhKLZvfYFt2IHjZFWnYdszhGoG4xBElxcALdOEAZpABH83JYtsVZlGc6C%2Bt1uhxNY0jIA07mOdWHYEFhQSvNmO9LCMNtqZNArbR9PVYniDmBIg3PIFjXiC9BnwH3v6NeUV8PX1W%2F1FSi7qzkvk1%2FFvUoyv3P5BfuzRcBCkBxQG1eto5vKAZA0gqdsg%3D%3D&response-content-disposition=attachment%3B%20filename%3D%22camunda-modeler-5.25.0-mac-arm64.dmg%22 HTTP/2
> Host: storage.googleapis.com
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/2 200
< expires: Thu, 25 Jul 2024 08:01:54 GMT
< date: Thu, 25 Jul 2024 08:01:54 GMT
< cache-control: private, max-age=0
< last-modified: Wed, 26 Jun 2024 07:32:18 GMT
< etag: "de2b681907928f1c84d71fccbe14922a"
< x-goog-generation: 1719387138570313
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 111896943
< content-type: application/x-apple-diskimage
< content-disposition: attachment; filename="camunda-modeler-5.25.0-mac-arm64.dmg"
< x-goog-hash: crc32c=3vn3Iw==
< x-goog-hash: md5=3itoGQeSjxyE1x/MvhSSKg==
< x-goog-storage-class: MULTI_REGIONAL
< accept-ranges: bytes
< content-length: 111896943
< x-guploader-uploadid: AHxI1nMukVcq-EBn0IQgKwq1mLOonqJhKNbZPYBuuXI5947tueHoZ9qDPEQUbFIHexPgFvwphZ0dVmM7Kg
< server: UploadServer
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
<
{ [7011 bytes data]
* Connection #1 to host storage.googleapis.com left intact

2024-07-25 10:02:03 : REQ   : camunda : no more blocking processes, continue with update
2024-07-25 10:02:03 : REQ   : camunda : Installing Camunda Modeler
2024-07-25 10:02:03 : INFO  : camunda : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n9Jz6U4zHQ/Camunda Modeler.dmg
2024-07-25 10:02:09 : DEBUG : camunda : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $5A4BA21A
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $C5773341
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $46FAD5B8
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $E1C05852
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $46FAD5B8
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $49C0D3A0
Die überprüfte CRC32-Prüfsumme ist $C24497F6
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Camunda Modeler 5.25.0-arm64

2024-07-25 10:02:09 : INFO  : camunda : Mounted: /Volumes/Camunda Modeler 5.25.0-arm64
2024-07-25 10:02:09 : INFO  : camunda : Verifying: /Volumes/Camunda Modeler 5.25.0-arm64/Camunda Modeler.app
2024-07-25 10:02:09 : DEBUG : camunda : App size: 296M	/Volumes/Camunda Modeler 5.25.0-arm64/Camunda Modeler.app
2024-07-25 10:02:10 : DEBUG : camunda : Debugging enabled, App Verification output was:
/Volumes/Camunda Modeler 5.25.0-arm64/Camunda Modeler.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Camunda Services GmbH (3JVGD57JQZ)

2024-07-25 10:02:10 : INFO  : camunda : Team ID matching: 3JVGD57JQZ (expected: 3JVGD57JQZ )
2024-07-25 10:02:10 : INFO  : camunda : Downloaded version of Camunda Modeler is 5.25.0 on versionKey CFBundleShortVersionString (replacing version 5.24.0).
2024-07-25 10:02:10 : INFO  : camunda : App has LSMinimumSystemVersion: 10.15
2024-07-25 10:02:10 : WARN  : camunda : Removing existing /Applications/Camunda Modeler.app
2024-07-25 10:02:10 : DEBUG : camunda : Debugging enabled, App removing output was:
/Applications/Camunda Modeler.app/Contents/
Last Log repeated 269 times
/Applications/Camunda Modeler.app/Contents
/Applications/Camunda Modeler.app

2024-07-25 10:02:10 : INFO  : camunda : Copy /Volumes/Camunda Modeler 5.25.0-arm64/Camunda Modeler.app to /Applications
2024-07-25 10:02:11 : DEBUG : camunda : Debugging enabled, App copy output was:
Copying /Volumes/Camunda Modeler 5.25.0-arm64/Camunda Modeler.app

2024-07-25 10:02:11 : WARN  : camunda : Changing owner to mac
2024-07-25 10:02:11 : INFO  : camunda : Finishing...
2024-07-25 10:02:14 : INFO  : camunda : App(s) found: /Applications/Camunda Modeler.app
2024-07-25 10:02:14 : INFO  : camunda : found app at /Applications/Camunda Modeler.app, version 5.25.0, on versionKey CFBundleShortVersionString
2024-07-25 10:02:14 : REQ   : camunda : Installed Camunda Modeler, version 5.25.0
2024-07-25 10:02:14 : INFO  : camunda : notifying
2024-07-25 10:02:14 : DEBUG : camunda : Unmounting /Volumes/Camunda Modeler 5.25.0-arm64
2024-07-25 10:02:15 : DEBUG : camunda : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-07-25 10:02:15 : DEBUG : camunda : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n9Jz6U4zHQ
2024-07-25 10:02:15 : DEBUG : camunda : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n9Jz6U4zHQ/Camunda Modeler.dmg
2024-07-25 10:02:15 : DEBUG : camunda : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n9Jz6U4zHQ
2024-07-25 10:02:15 : INFO  : camunda : Installomator did not close any apps, so no need to reopen any apps.
2024-07-25 10:02:15 : REQ   : camunda : All done!
2024-07-25 10:02:15 : REQ   : camunda : ################## End Installomator, exit code 0
```