### PR TITLE
Update Cloudflare WARP download link and install type

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -2799,9 +2799,9 @@ closeio)
     ;;
 cloudflarewarp)
     name="Cloudflare_WARP"
-    type="pkgInZip"
+    type="pkg"
     packageID="com.cloudflare.1dot1dot1dot1.macos"
-    downloadURL="https://1111-releases.cloudflareclient.com/mac/Cloudflare_WARP.zip"
+    downloadURL="https://1111-releases.cloudflareclient.com/mac/latest"
     appNewVersion=""
     expectedTeamID="68WVV388M8"
     ;;


### PR DESCRIPTION
Cloudflare seems to have changed their download URL for WARP, where the old URL now returns a 500 error. This adaptation changes the URL and downloads the pkg directly.