### PR TITLE
Add label for zenangst/Gray

### DIFF
--- a/fragments/labels/gray.sh
+++ b/fragments/labels/gray.sh
@@ -1,0 +1,7 @@
+gray)
+    name="Gray"
+    type="zip"
+    downloadURL=$(downloadURLFromGit zenangst Gray)
+    appNewVersion=$(versionFromGit zenangst Gray)
+    expectedTeamID=E23HUP39A3
+    archiveName=Gray.zip

--- a/fragments/labels/gray.sh
+++ b/fragments/labels/gray.sh
@@ -3,5 +3,5 @@ gray)
     type="zip"
     downloadURL=$(downloadURLFromGit zenangst Gray)
     appNewVersion=$(versionFromGit zenangst Gray)
-    expectedTeamID=E23HUP39A3
-    archiveName=Gray.zip
+    expectedTeamID="E23HUP39A3"
+    archiveName="Gray.zip"


### PR DESCRIPTION
Gray allows the end user to set light/dark mode on a per-application basis.