### PR TITLE
Update dymoconnectdesktop.sh

### DIFF
--- a/fragments/labels/dymoconnectdesktop
+++ b/fragments/labels/dymoconnectdesktop
@@ -1,0 +1,9 @@
+dymoconnectdesktop)
+    name="DYMO Connect"
+    type="pkg"
+    appNewVersion=$(curl -s https://formulae.brew.sh/cask/dymo-label | grep -o 'Current version:.*[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
+    archiveName="DCDMac${appNewVersion}.pkg"
+    downloadURL="https://download.dymo.com/dymo/Software/Mac/DCDMac${appNewVersion}.pkg"
+    expectedTeamID="N3S6676K3E"
+    blockingProcesses="DYMO Connect"
+    ;;

--- a/fragments/labels/dymoconnectdesktop
+++ b/fragments/labels/dymoconnectdesktop
@@ -1,9 +1,0 @@
-dymoconnectdesktop)
-    name="DYMO Connect"
-    type="pkg"
-    appNewVersion=$(curl -s https://formulae.brew.sh/cask/dymo-label | grep -o 'Current version:.*[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
-    archiveName="DCDMac${appNewVersion}.pkg"
-    downloadURL="https://download.dymo.com/dymo/Software/Mac/DCDMac${appNewVersion}.pkg"
-    expectedTeamID="N3S6676K3E"
-    blockingProcesses="DYMO Connect"
-    ;;

--- a/fragments/labels/dymoconnectdesktop.sh
+++ b/fragments/labels/dymoconnectdesktop.sh
@@ -5,5 +5,4 @@ dymoconnectdesktop)
     archiveName="DCDMac${appNewVersion}.pkg"
     downloadURL="https://download.dymo.com/dymo/Software/Mac/DCDMac${appNewVersion}.pkg"
     expectedTeamID="N3S6676K3E"
-    blockingProcesses="DYMO Connect"
     ;;

--- a/fragments/labels/dymoconnectdesktop.sh
+++ b/fragments/labels/dymoconnectdesktop.sh
@@ -1,8 +1,9 @@
 dymoconnectdesktop)
     name="DYMO Connect"
     type="pkg"
-    downloadURL=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | sort -rV | head -n 1| sort -rV | head -n 1)
-    appNewVersion=$(curl -fs -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" "https://www.dymo.com/compatibility-chart.html" | grep -oE 'https?://[^"]+\.pkg' | awk -F/ '{print $NF}' | sed 's/DCDMac\([0-9\.]*\)\.pkg/\1.pkg/' | cut -d"." -f1-4 | sort -rV | head -n 1)
+    appNewVersion=$(curl -s https://formulae.brew.sh/cask/dymo-label | grep -o 'Current version:.*[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
+    archiveName="DCDMac${appNewVersion}.pkg"
+    downloadURL="https://download.dymo.com/dymo/Software/Mac/DCDMac${appNewVersion}.pkg"
     expectedTeamID="N3S6676K3E"
     blockingProcesses="DYMO Connect"
     ;;


### PR DESCRIPTION
Previous version of label was untouched since 3/21/23.

This change addresses this issue: #1760

Output:

```
Script result: 2024-07-30 17:55:40 : REQ   :  : shifting arguments for Jamf
2024-07-30 17:55:41 : REQ   : dymoconnectdesktop : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : ################## Version: 10.6beta
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : ################## Date: 2024-04-23
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : ################## dymoconnectdesktop
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : NOTIFY=silent
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : LOGGING=INFO
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : Label type: pkg
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : archiveName: DCDMac1.4.6.60.pkg
2024-07-30 17:55:41 : INFO  : dymoconnectdesktop : name: DYMO Connect, appName: DYMO Connect.app
2024-07-30 17:55:41.961 mdfind[73140:11155527] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-30 17:55:41.962 mdfind[73140:11155527] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-30 17:55:42.107 mdfind[73140:11155527] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-30 17:55:42 : WARN  : dymoconnectdesktop : No previous app found
2024-07-30 17:55:42 : WARN  : dymoconnectdesktop : could not find DYMO Connect.app
2024-07-30 17:55:42 : INFO  : dymoconnectdesktop : appversion:
2024-07-30 17:55:42 : INFO  : dymoconnectdesktop : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-07-30 17:55:42 : INFO  : dymoconnectdesktop : Latest version of DYMO Connect is 1.4.6.60
2024-07-30 17:55:42 : REQ   : dymoconnectdesktop : Downloading https://download.dymo.com/dymo/Software/Mac/DCDMac1.4.6.60.pkg to DCDMac1.4.6.60.pkg
2024-07-30 17:55:44 : REQ   : dymoconnectdesktop : no more blocking processes, continue with update
2024-07-30 17:55:44 : REQ   : dymoconnectdesktop : Installing DYMO Connect
2024-07-30 17:55:44 : INFO  : dymoconnectdesktop : Verifying: DCDMac1.4.6.60.pkg
2024-07-30 17:55:44 : INFO  : dymoconnectdesktop : Team ID: N3S6676K3E (expected: N3S6676K3E )
2024-07-30 17:55:44 : INFO  : dymoconnectdesktop : Installing DCDMac1.4.6.60.pkg to /
2024-07-30 17:56:12 : INFO  : dymoconnectdesktop : Finishing...
2024-07-30 17:56:16 : INFO  : dymoconnectdesktop : App(s) found: /Applications/DYMO Connect.app
2024-07-30 17:56:16 : INFO  : dymoconnectdesktop : found app at /Applications/DYMO Connect.app, version 1.4.6.60, on versionKey CFBundleShortVersionString
2024-07-30 17:56:16 : REQ   : dymoconnectdesktop : Installed DYMO Connect, version 1.4.6.60
2024-07-30 17:56:16 : INFO  : dymoconnectdesktop : Installomator did not close any apps, so no need to reopen any apps.
2024-07-30 17:56:16 : REQ   : dymoconnectdesktop : All done!
2024-07-30 17:56:16 : REQ   : dymoconnectdesktop : ################## End Installomator, exit code 0
```