### PR TITLE
Create Label vernierspectralanalysis.sh

### DIFF
--- a/fragments/labels/vernierspectralanalysis.sh
+++ b/fragments/labels/vernierspectralanalysis.sh
@@ -1,0 +1,7 @@
+vernierspectralanalysis)
+    name="Vernier Spectral Analysis"
+    type="dmg"
+    appNewVersion=$(curl -s "https://apps.apple.com/us/app/vernier-spectral-analysis/id1323245536" | egrep -o 'Version [0-9]+\.[0-9]+' | sed 's/Version //' | head -1)
+    downloadURL="https://software-releases.graphicalanalysis.com/sa/mac/release/latest/Vernier-Spectral-Analysis.dmg"
+    expectedTeamID="75WN2B2WR8"
+    ;;


### PR DESCRIPTION
Created Label vernierspectralanalysis.sh

Software: https://www.vernier.com/product/spectral-analysis/

Output:

```
Script result: 2024-07-30 20:28:57 : REQ   :  : shifting arguments for Jamf
2024-07-30 20:28:57 : REQ   : vernierspectralanalysis : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-07-30 20:28:57 : INFO  : vernierspectralanalysis : ################## Version: 10.6beta
2024-07-30 20:28:57 : INFO  : vernierspectralanalysis : ################## Date: 2024-04-23
2024-07-30 20:28:57 : INFO  : vernierspectralanalysis : ################## vernierspectralanalysis
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : NOTIFY=silent
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : LOGGING=INFO
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : Label type: dmg
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : archiveName: Vernier Spectral Analysis.dmg
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : no blocking processes defined, using Vernier Spectral Analysis as default
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : name: Vernier Spectral Analysis, appName: Vernier Spectral Analysis.app
2024-07-30 20:28:58.265 mdfind[84447:11325923] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-30 20:28:58.266 mdfind[84447:11325923] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-30 20:28:58.680 mdfind[84447:11325923] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-30 20:28:58 : WARN  : vernierspectralanalysis : No previous app found
2024-07-30 20:28:58 : WARN  : vernierspectralanalysis : could not find Vernier Spectral Analysis.app
2024-07-30 20:28:58 : INFO  : vernierspectralanalysis : appversion:
2024-07-30 20:28:59 : INFO  : vernierspectralanalysis : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-07-30 20:28:59 : INFO  : vernierspectralanalysis : Latest version of Vernier Spectral Analysis is 4.12
2024-07-30 20:28:59 : REQ   : vernierspectralanalysis : Downloading https://software-releases.graphicalanalysis.com/sa/mac/release/latest/Vernier-Spectral-Analysis.dmg to Vernier Spectral Analysis.dmg
2024-07-30 20:29:05 : REQ   : vernierspectralanalysis : no more blocking processes, continue with update
2024-07-30 20:29:05 : REQ   : vernierspectralanalysis : Installing Vernier Spectral Analysis
2024-07-30 20:29:05 : INFO  : vernierspectralanalysis : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.USkWAUIOhM/Vernier Spectral Analysis.dmg
2024-07-30 20:29:12 : INFO  : vernierspectralanalysis : Mounted: /Volumes/Vernier Spectral Analysis 4.12.0-2240-universal
2024-07-30 20:29:12 : INFO  : vernierspectralanalysis : Verifying: /Volumes/Vernier Spectral Analysis 4.12.0-2240-universal/Vernier Spectral Analysis.app
2024-07-30 20:29:16 : INFO  : vernierspectralanalysis : Team ID matching: 75WN2B2WR8 (expected: 75WN2B2WR8 )
2024-07-30 20:29:16 : INFO  : vernierspectralanalysis : Installing Vernier Spectral Analysis version 4.12.0-2240 on versionKey CFBundleShortVersionString.
2024-07-30 20:29:16 : INFO  : vernierspectralanalysis : App has LSMinimumSystemVersion: 11.7
2024-07-30 20:29:16 : INFO  : vernierspectralanalysis : Copy /Volumes/Vernier Spectral Analysis 4.12.0-2240-universal/Vernier Spectral Analysis.app to /Applications
2024-07-30 20:29:24 : WARN  : vernierspectralanalysis : Changing owner to whiteb
2024-07-30 20:29:25 : INFO  : vernierspectralanalysis : Finishing...
2024-07-30 20:29:28 : INFO  : vernierspectralanalysis : App(s) found: /Applications/Vernier Spectral Analysis.app
2024-07-30 20:29:28 : INFO  : vernierspectralanalysis : found app at /Applications/Vernier Spectral Analysis.app, version 4.12.0-2240, on versionKey CFBundleShortVersionString
2024-07-30 20:29:28 : REQ   : vernierspectralanalysis : Installed Vernier Spectral Analysis, version 4.12.0-2240
2024-07-30 20:29:28 : INFO  : vernierspectralanalysis : Installomator did not close any apps, so no need to reopen any apps.
2024-07-30 20:29:29 : REQ   : vernierspectralanalysis : All done!
2024-07-30 20:29:29 : REQ   : vernierspectralanalysis : ################## End Installomator, exit code 0
```