### PR TITLE
Create Label unityhub.sh

### DIFF
--- a/fragments/labels/unityhub.sh
+++ b/fragments/labels/unityhub.sh
@@ -1,0 +1,7 @@
+unityhub)
+    name="Unity Hub"
+    type="dmg"
+    downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg"
+    appNewVersion=$(curl -s https://unity.com/unity-hub/release-notes | grep -oE '>[0-9]+\.[0-9]+\.[0-9]+<' | head -1 | tr -d '<>')
+    expectedTeamID="BVPN9UFA9B"
+    ;;


### PR DESCRIPTION
Created Label unityhub.sh

Software: https://docs.unity3d.com/hub/manual/InstallHub.html

Output:

```
Script result: 2024-07-30 20:49:48 : REQ   :  : shifting arguments for Jamf
2024-07-30 20:49:48 : REQ   : unityhub : ################## Start Installomator v. 10.6beta, date 2024-04-23
2024-07-30 20:49:48 : INFO  : unityhub : ################## Version: 10.6beta
2024-07-30 20:49:48 : INFO  : unityhub : ################## Date: 2024-04-23
2024-07-30 20:49:48 : INFO  : unityhub : ################## unityhub
2024-07-30 20:49:57 : INFO  : unityhub : BLOCKING_PROCESS_ACTION=tell_user_then_kill
2024-07-30 20:49:57 : INFO  : unityhub : NOTIFY=silent
2024-07-30 20:49:57 : INFO  : unityhub : LOGGING=INFO
2024-07-30 20:49:57 : INFO  : unityhub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-30 20:49:57 : INFO  : unityhub : Label type: dmg
2024-07-30 20:49:57 : INFO  : unityhub : archiveName: Unity Hub.dmg
2024-07-30 20:49:57 : INFO  : unityhub : no blocking processes defined, using Unity Hub as default
2024-07-30 20:49:57 : INFO  : unityhub : name: Unity Hub, appName: Unity Hub.app
2024-07-30 20:49:57.947 mdfind[86116:11349015] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-07-30 20:49:57.947 mdfind[86116:11349015] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-07-30 20:49:58.297 mdfind[86116:11349015] Couldn't determine the mapping between prefab keywords and predicates.
2024-07-30 20:49:58 : WARN  : unityhub : No previous app found
2024-07-30 20:49:58 : WARN  : unityhub : could not find Unity Hub.app
2024-07-30 20:49:58 : INFO  : unityhub : appversion:
2024-07-30 20:49:58 : INFO  : unityhub : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-07-30 20:49:58 : INFO  : unityhub : Latest version of Unity Hub is 3.8.0
2024-07-30 20:49:58 : REQ   : unityhub : Downloading https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg to Unity Hub.dmg
2024-07-30 20:50:00 : REQ   : unityhub : no more blocking processes, continue with update
2024-07-30 20:50:00 : REQ   : unityhub : Installing Unity Hub
2024-07-30 20:50:00 : INFO  : unityhub : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.sqlantaXEn/Unity Hub.dmg
2024-07-30 20:50:12 : INFO  : unityhub : Mounted: /Volumes/Unity Hub 3.8.0
2024-07-30 20:50:12 : INFO  : unityhub : Verifying: /Volumes/Unity Hub 3.8.0/Unity Hub.app
2024-07-30 20:50:33 : INFO  : unityhub : Team ID matching: BVPN9UFA9B (expected: BVPN9UFA9B )
2024-07-30 20:50:33 : INFO  : unityhub : Installing Unity Hub version 3.8.0 on versionKey CFBundleShortVersionString.
2024-07-30 20:50:33 : INFO  : unityhub : App has LSMinimumSystemVersion: 10.13
2024-07-30 20:50:33 : INFO  : unityhub : Copy /Volumes/Unity Hub 3.8.0/Unity Hub.app to /Applications
2024-07-30 20:50:50 : WARN  : unityhub : Changing owner to whiteb
2024-07-30 20:50:50 : INFO  : unityhub : Finishing...
2024-07-30 20:50:53 : INFO  : unityhub : App(s) found: /Applications/Unity Hub.app
2024-07-30 20:50:53 : INFO  : unityhub : found app at /Applications/Unity Hub.app, version 3.8.0, on versionKey CFBundleShortVersionString
2024-07-30 20:50:53 : REQ   : unityhub : Installed Unity Hub, version 3.8.0
2024-07-30 20:50:53 : INFO  : unityhub : Installomator did not close any apps, so no need to reopen any apps.
2024-07-30 20:50:53 : REQ   : unityhub : All done!
2024-07-30 20:50:53 : REQ   : unityhub : ################## End Installomator, exit code 0
```