### PR TITLE
New Label: podmandesktopairgap

### DIFF
--- a/fragments/labels/podmandesktopairgap.sh
+++ b/fragments/labels/podmandesktopairgap.sh
@@ -1,0 +1,12 @@
+podmandesktopairgap)
+    name="Podman Desktop"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit containers podman-desktop)
+    appNewVersion=$(versionFromGit containers podman-desktop)
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="podman-desktop-airgap-$appNewVersion-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="podman-desktop-airgap-$appNewVersion-x64.dmg"
+    fi
+    expectedTeamID="HYSCB8KRL2"
+    ;;


### PR DESCRIPTION
The podmandesktop label already exists in this repository.
However, it does not support an **airgap** version for installation in restricted environments.

Therefore I have added a new label.

https://github.com/containers/podman-desktop

```sh
$ ./utils/assemble.sh podmandesktopairgap
2024-07-31 14:37:03 : REQ   : podmandesktopairgap : ################## Start Installomator v. 10.6beta, date 2024-07-31
2024-07-31 14:37:03 : INFO  : podmandesktopairgap : ################## Version: 10.6beta
2024-07-31 14:37:03 : INFO  : podmandesktopairgap : ################## Date: 2024-07-31
2024-07-31 14:37:03 : INFO  : podmandesktopairgap : ################## podmandesktopairgap
2024-07-31 14:37:03 : DEBUG : podmandesktopairgap : DEBUG mode 1 enabled.
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : name=Podman Desktop
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : appName=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : type=dmg
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : archiveName=podman-desktop-airgap-1.11.1-arm64.dmg
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : downloadURL=https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-arm64.dmg
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : curlOptions=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : appNewVersion=1.11.1
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : appCustomVersion function: Not defined
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : versionKey=CFBundleShortVersionString
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : packageID=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : pkgName=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : choiceChangesXML=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : expectedTeamID=HYSCB8KRL2
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : blockingProcesses=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : installerTool=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : CLIInstaller=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : CLIArguments=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : updateTool=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : updateToolArguments=
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : updateToolRunAsCurrentUser=
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : BLOCKING_PROCESS_ACTION=tell_user
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : NOTIFY=success
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : LOGGING=DEBUG
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : Label type: dmg
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : archiveName: podman-desktop-airgap-1.11.1-arm64.dmg
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : no blocking processes defined, using Podman Desktop as default
2024-07-31 14:37:05 : DEBUG : podmandesktopairgap : Changing directory to /Users/tonishi/ghq/github.com/Installomator/Installomator/build
2024-07-31 14:37:05 : INFO  : podmandesktopairgap : name: Podman Desktop, appName: Podman Desktop.app
2024-07-31 14:37:06 : WARN  : podmandesktopairgap : No previous app found
2024-07-31 14:37:06 : WARN  : podmandesktopairgap : could not find Podman Desktop.app
2024-07-31 14:37:06 : INFO  : podmandesktopairgap : appversion:
2024-07-31 14:37:06 : INFO  : podmandesktopairgap : Latest version of Podman Desktop is 1.11.1
2024-07-31 14:37:06 : REQ   : podmandesktopairgap : Downloading https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-arm64.dmg to podman-desktop-airgap-1.11.1-arm64.dmg
2024-07-31 14:37:06 : DEBUG : podmandesktopairgap : No Dialog connection, just download
2024-07-31 14:37:12 : DEBUG : podmandesktopairgap : File list: -rw-r--r--  1 tonishi  staff   160M  7 31 14:37 podman-desktop-airgap-1.11.1-arm64.dmg
2024-07-31 14:37:12 : DEBUG : podmandesktopairgap : File type: podman-desktop-airgap-1.11.1-arm64.dmg: zlib compressed data
2024-07-31 14:37:12 : DEBUG : podmandesktopairgap : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 20.200.245.247
*   Trying 20.200.245.247:443...
* Connected to github.com (20.200.245.247) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-arm64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-arm64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /containers/podman-desktop/releases/download/v1.11.1/podman-desktop-1.11.1-arm64.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 302
< server: GitHub.com
< date: Wed, 31 Jul 2024 05:37:06 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/465844859/36c4bf47-83ff-43c1-a51f-7814e0884b23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240731T053706Z&X-Amz-Expires=300&X-Amz-Signature=787ddab652926c2b6b8bcaabbaa74a77cc634f9e1c5e89f0f5c41d7ace1109d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=465844859&response-content-disposition=attachment%3B%20filename%3Dpodman-desktop-1.11.1-arm64.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com api.githubcopilot.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com/v1/engines/github-completion/completions proxy.enterprise.githubcopilot.com/v1/engines/github-completion/completions *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: F8D1:1ADC11:2B530E:2FF552:66A9CD82
<
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/465844859/36c4bf47-83ff-43c1-a51f-7814e0884b23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240731T053706Z&X-Amz-Expires=300&X-Amz-Signature=787ddab652926c2b6b8bcaabbaa74a77cc634f9e1c5e89f0f5c41d7ace1109d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=465844859&response-content-disposition=attachment%3B%20filename%3Dpodman-desktop-1.11.1-arm64.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.109.133, 185.199.110.133, 185.199.111.133, 185.199.108.133
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/465844859/36c4bf47-83ff-43c1-a51f-7814e0884b23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240731T053706Z&X-Amz-Expires=300&X-Amz-Signature=787ddab652926c2b6b8bcaabbaa74a77cc634f9e1c5e89f0f5c41d7ace1109d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=465844859&response-content-disposition=attachment%3B%20filename%3Dpodman-desktop-1.11.1-arm64.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/465844859/36c4bf47-83ff-43c1-a51f-7814e0884b23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240731T053706Z&X-Amz-Expires=300&X-Amz-Signature=787ddab652926c2b6b8bcaabbaa74a77cc634f9e1c5e89f0f5c41d7ace1109d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=465844859&response-content-disposition=attachment%3B%20filename%3Dpodman-desktop-1.11.1-arm64.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/465844859/36c4bf47-83ff-43c1-a51f-7814e0884b23?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240731%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240731T053706Z&X-Amz-Expires=300&X-Amz-Signature=787ddab652926c2b6b8bcaabbaa74a77cc634f9e1c5e89f0f5c41d7ace1109d9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=465844859&response-content-disposition=attachment%3B%20filename%3Dpodman-desktop-1.11.1-arm64.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Mon, 24 Jun 2024 15:02:31 GMT
< etag: "0x8DC945EABD33806"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: f6caaec7-001e-0058-51e9-cf390a000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Mon, 24 Jun 2024 15:02:31 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=podman-desktop-1.11.1-arm64.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< age: 0
< date: Wed, 31 Jul 2024 05:37:07 GMT
< x-served-by: cache-iad-kcgs7200177-IAD, cache-icn1450044-ICN
< x-cache: HIT, HIT
< x-cache-hits: 252, 0
< x-timer: S1722404227.983360,VS0,VE969
< content-length: 167657837
<
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-07-31 14:37:12 : DEBUG : podmandesktopairgap : DEBUG mode 1, not checking for blocking processes
2024-07-31 14:37:12 : REQ   : podmandesktopairgap : Installing Podman Desktop
2024-07-31 14:37:12 : INFO  : podmandesktopairgap : Mounting /Users/tonishi/ghq/github.com/Installomator/Installomator/build/podman-desktop-airgap-1.11.1-arm64.dmg
2024-07-31 14:37:15 : DEBUG : podmandesktopairgap : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $4AA4D912
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $D1B614F8
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $9F080D9D
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
disk image (Apple_APFS : 4)のチェックサムを計算中…
disk image (Apple_APFS : 4): 検証済み CRC32 $66559202
(Apple_Free : 5)のチェックサムを計算中…
(Apple_Free : 5): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 6)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $9F080D9D
GPT Header (Backup GPT Header : 7)のチェックサムを計算中…
GPT Header (Backup GPT Header : 7): 検証済み CRC32 $B84ED122
検証済み CRC32 $49411055
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Podman Desktop 1.11.1-arm64

2024-07-31 14:37:15 : INFO  : podmandesktopairgap : Mounted: /Volumes/Podman Desktop 1.11.1-arm64
2024-07-31 14:37:15 : INFO  : podmandesktopairgap : Verifying: /Volumes/Podman Desktop 1.11.1-arm64/Podman Desktop.app
2024-07-31 14:37:15 : DEBUG : podmandesktopairgap : App size: 359M	/Volumes/Podman Desktop 1.11.1-arm64/Podman Desktop.app
2024-07-31 14:37:18 : DEBUG : podmandesktopairgap : Debugging enabled, App Verification output was:
/Volumes/Podman Desktop 1.11.1-arm64/Podman Desktop.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Red Hat, Inc. (HYSCB8KRL2)

2024-07-31 14:37:18 : INFO  : podmandesktopairgap : Team ID matching: HYSCB8KRL2 (expected: HYSCB8KRL2 )
2024-07-31 14:37:18 : INFO  : podmandesktopairgap : Installing Podman Desktop version 1.11.1 on versionKey CFBundleShortVersionString.
2024-07-31 14:37:19 : INFO  : podmandesktopairgap : App has LSMinimumSystemVersion: 10.15
2024-07-31 14:37:19 : DEBUG : podmandesktopairgap : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-07-31 14:37:19 : INFO  : podmandesktopairgap : Finishing...
2024-07-31 14:37:22 : INFO  : podmandesktopairgap : name: Podman Desktop, appName: Podman Desktop.app
2024-07-31 14:37:22 : WARN  : podmandesktopairgap : No previous app found
2024-07-31 14:37:22 : WARN  : podmandesktopairgap : could not find Podman Desktop.app
2024-07-31 14:37:22 : REQ   : podmandesktopairgap : Installed Podman Desktop, version 1.11.1
2024-07-31 14:37:22 : INFO  : podmandesktopairgap : notifying
2024-07-31 14:37:22 : DEBUG : podmandesktopairgap : Unmounting /Volumes/Podman Desktop 1.11.1-arm64
2024-07-31 14:37:22 : DEBUG : podmandesktopairgap : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-07-31 14:37:22 : DEBUG : podmandesktopairgap : DEBUG mode 1, not reopening anything
2024-07-31 14:37:22 : REQ   : podmandesktopairgap : All done!
2024-07-31 14:37:22 : REQ   : podmandesktopairgap : ################## End Installomator, exit code 0
```