### PR TITLE
Create teladocproviderinstaller.sh

### DIFF
--- a/fragments/labels/teladocproviderinstaller.sh
+++ b/fragments/labels/teladocproviderinstaller.sh
@@ -1,0 +1,8 @@
+teladocproviderinstaller)
+    name="TeladocProviderInstaller"
+    type="pkg"
+    downloadURL="https://update.intouchreports.com/cdn/prod/ida/provider/mac/x64/manual/TeladocProviderInstaller.pkg"
+    appNewVersion=$(curl -fsL "https://update.intouchreports.com/cdn/prod/ida/provider/mac/x64/manual/latest-mac.yml" | grep -E 'version: ' | sed -E 's/version: \"?([0-9.]*)\"?/\1/')
+    packageID="com.intouchhealth.ith-provider"
+    expectedTeamID="TXR7NRCG98"
+    ;;


### PR DESCRIPTION
Creating a new label for the Teladoc Provider Installer

Here is my terminal output after successfully installing the software.

`daniel.ross@Daniel Ross LY6TPXJGT9 ~ % sudo /Users/daniel.ross/GitHub/Installomator/assemble.sh teladocproviderinstaller DEBUG=0
2024-08-13 18:36:10 : REQ   : teladocproviderinstaller : ################## Start Installomator v. 10.6beta, date 2024-08-13
2024-08-13 18:36:10 : INFO  : teladocproviderinstaller : ################## Version: 10.6beta
2024-08-13 18:36:10 : INFO  : teladocproviderinstaller : ################## Date: 2024-08-13
2024-08-13 18:36:10 : INFO  : teladocproviderinstaller : ################## teladocproviderinstaller
2024-08-13 18:36:10 : DEBUG : teladocproviderinstaller : DEBUG mode 1 enabled.
2024-08-13 18:36:10 : INFO  : teladocproviderinstaller : setting variable from argument DEBUG=0
2024-08-13 18:36:10 : DEBUG : teladocproviderinstaller : name=TeladocProviderInstaller
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : appName=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : type=pkg
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : archiveName=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : downloadURL=https://update.intouchreports.com/cdn/prod/ida/provider/mac/x64/manual/TeladocProviderInstaller.pkg
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : curlOptions=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : appNewVersion=1.6.5
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : appCustomVersion function: Not defined
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : versionKey=CFBundleShortVersionString
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : packageID=com.intouchhealth.ith-provider
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : pkgName=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : choiceChangesXML=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : expectedTeamID=TXR7NRCG98
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : blockingProcesses=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : installerTool=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : CLIInstaller=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : CLIArguments=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : updateTool=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : updateToolArguments=
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : updateToolRunAsCurrentUser=
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : BLOCKING_PROCESS_ACTION=tell_user
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : NOTIFY=success
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : LOGGING=DEBUG
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : Label type: pkg
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : archiveName: TeladocProviderInstaller.pkg
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : no blocking processes defined, using TeladocProviderInstaller as default
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tdho7QGE9Y
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : found packageID com.intouchhealth.ith-provider installed, version 1.6.5
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : appversion: 1.6.5
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : Latest version of TeladocProviderInstaller is 1.6.5
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : There is no newer version available.
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tdho7QGE9Y
2024-08-13 18:36:11 : DEBUG : teladocproviderinstaller : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.tdho7QGE9Y
2024-08-13 18:36:11 : INFO  : teladocproviderinstaller : Installomator did not close any apps, so no need to reopen any apps.
2024-08-13 18:36:11 : REQ   : teladocproviderinstaller : No newer version.
2024-08-13 18:36:11 : REQ   : teladocproviderinstaller : ################## End Installomator, exit code 0 `