### PR TITLE
Update flstudiomac.sh

### DIFF
--- a/fragments/labels/flstudiomac.sh
+++ b/fragments/labels/flstudiomac.sh
@@ -1,8 +1,15 @@
 flstudiomac)
-    name="flstudio_mac"
+    name="flstudiomac"
     type="pkgInDmg"
-    packageID="com.Image-Line.pkg.FL21.2ONLINE"
-    downloadURL="https://install.image-line.com/flstudio/flstudio_mac_21.2.2.3470.dmg"
-    appNewVersion="$(getJSONValue $(curl -fsL "https://support.image-line.com/api.php?call=get_version_info&callback=il_get_version") "prod.741.mac.version")"
+    packageID="com.Image-Line.pkg.flcloud.plugins
+com.Image-Line.pkg.24ONLINE"
+    downloadURL="https://support.image-line.com/redirect/flstudio_mac_installer"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" )
+    appNewVersion=$(curl -fsL "https://support.image-line.com/api.php?call=get_version_info&callback=il_get_version_info_cb&prod_type=undefined" | \
+        sed 's/var get_version_info_res;get_version_info_res = il_get_version_info_cb(//;s/);$//' | \
+        sed 's/\\//g' | \
+        grep -o '"os":"mac","version":"[0-9.]*"' | \
+        sed 's/.*"version":"\([0-9.]*\)".*/\1/')
     expectedTeamID="N68WEP5ZZZ"
     ;;
+    


### PR DESCRIPTION
Fixed downloadURL and appNewVersion

```
2024-08-17 22:45:04 : REQ   : flstudiomac : ################## Start Installomator v. 10.6beta, date 2024-08-17
2024-08-17 22:45:04 : INFO  : flstudiomac : ################## Version: 10.6beta
2024-08-17 22:45:04 : INFO  : flstudiomac : ################## Date: 2024-08-17
2024-08-17 22:45:04 : INFO  : flstudiomac : ################## flstudiomac
2024-08-17 22:45:04 : DEBUG : flstudiomac : DEBUG mode 1 enabled.
2024-08-17 22:45:04 : INFO  : flstudiomac : SwiftDialog is not installed, clear cmd file var
2024-08-17 22:45:05 : DEBUG : flstudiomac : name=flstudio_mac_24.1.1.3936
2024-08-17 22:45:05 : DEBUG : flstudiomac : appName=
2024-08-17 22:45:05 : DEBUG : flstudiomac : type=pkgInDmg
2024-08-17 22:45:05 : DEBUG : flstudiomac : archiveName=
2024-08-17 22:45:05 : DEBUG : flstudiomac : downloadURL=https://support.image-line.com/redirect/flstudio_mac_installer
2024-08-17 22:45:05 : DEBUG : flstudiomac : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
2024-08-17 22:45:05 : DEBUG : flstudiomac : appNewVersion=24.1.1.3936
2024-08-17 22:45:05 : DEBUG : flstudiomac : appCustomVersion function: Not defined
2024-08-17 22:45:05 : DEBUG : flstudiomac : versionKey=CFBundleShortVersionString
2024-08-17 22:45:05 : DEBUG : flstudiomac : packageID=com.Image-Line.pkg.flcloud.plugins
2024-08-17 22:45:05 : DEBUG : flstudiomac : com.Image-Line.pkg.24ONLINE
2024-08-17 22:45:05 : DEBUG : flstudiomac : pkgName=
2024-08-17 22:45:05 : DEBUG : flstudiomac : choiceChangesXML=
2024-08-17 22:45:05 : DEBUG : flstudiomac : expectedTeamID=N68WEP5ZZZ
2024-08-17 22:45:05 : DEBUG : flstudiomac : blockingProcesses=
2024-08-17 22:45:05 : DEBUG : flstudiomac : installerTool=
2024-08-17 22:45:05 : DEBUG : flstudiomac : CLIInstaller=
2024-08-17 22:45:05 : DEBUG : flstudiomac : CLIArguments=
2024-08-17 22:45:05 : DEBUG : flstudiomac : updateTool=
2024-08-17 22:45:05 : DEBUG : flstudiomac : updateToolArguments=
2024-08-17 22:45:05 : DEBUG : flstudiomac : updateToolRunAsCurrentUser=
2024-08-17 22:45:05 : INFO  : flstudiomac : BLOCKING_PROCESS_ACTION=tell_user
2024-08-17 22:45:05 : INFO  : flstudiomac : NOTIFY=success
2024-08-17 22:45:05 : INFO  : flstudiomac : LOGGING=DEBUG
2024-08-17 22:45:05 : INFO  : flstudiomac : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-08-17 22:45:05 : INFO  : flstudiomac : Label type: pkgInDmg
2024-08-17 22:45:05 : INFO  : flstudiomac : archiveName: flstudio_mac_24.1.1.3936.dmg
2024-08-17 22:45:05 : INFO  : flstudiomac : no blocking processes defined, using flstudio_mac_24.1.1.3936 as default
2024-08-17 22:45:05 : DEBUG : flstudiomac : Changing directory to /Users/lowyiyuan/Documents/Scripts/Installomator/build
2024-08-17 22:45:05 : INFO  : flstudiomac : No version found using packageID com.Image-Line.pkg.flcloud.plugins
2024-08-17 22:45:05 : INFO  : flstudiomac : com.Image-Line.pkg.24ONLINE
2024-08-17 22:45:05 : INFO  : flstudiomac : name: flstudio_mac_24.1.1.3936, appName: flstudio_mac_24.1.1.3936.app
2024-08-17 22:45:05.640 mdfind[24967:312212] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2024-08-17 22:45:05.769 mdfind[24967:312212] Couldn't determine the mapping between prefab keywords and predicates.
2024-08-17 22:45:05 : WARN  : flstudiomac : No previous app found
2024-08-17 22:45:05 : WARN  : flstudiomac : could not find flstudio_mac_24.1.1.3936.app
2024-08-17 22:45:05 : INFO  : flstudiomac : appversion: 
2024-08-17 22:45:05 : INFO  : flstudiomac : Latest version of flstudio_mac_24.1.1.3936 is 24.1.1.3936
2024-08-17 22:45:05 : REQ   : flstudiomac : Downloading https://support.image-line.com/redirect/flstudio_mac_installer to flstudio_mac_24.1.1.3936.dmg
2024-08-17 22:45:05 : DEBUG : flstudiomac : No Dialog connection, just download

2024-08-17 22:55:56 : DEBUG : flstudiomac : File list: -rw-r--r--  1 lowyiyuan  staff   1.2G 17 Aug 22:55 flstudio_mac_24.1.1.3936.dmg
2024-08-17 22:55:56 : DEBUG : flstudiomac : File type: flstudio_mac_24.1.1.3936.dmg: zlib compressed data
2024-08-17 22:55:56 : DEBUG : flstudiomac : curl output was:
*   Trying 104.16.95.54:443...
* Connected to support.image-line.com (104.16.95.54) port 443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2539 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=image-line.com
*  start date: Jul 28 02:28:56 2024 GMT
*  expire date: Oct 26 02:28:55 2024 GMT
*  subjectAltName: host "support.image-line.com" matched cert's "*.image-line.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: support.image-line.com]
* h2 [:path: /redirect/flstudio_mac_installer]
* h2 [accept: */*]
* h2 [user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15]
* Using Stream ID: 1 (easy handle 0x7fe8f000a800)
> GET /redirect/flstudio_mac_installer HTTP/2
> Host: support.image-line.com
> Accept: */*
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
> 
< HTTP/2 302 
< date: Sat, 17 Aug 2024 14:45:06 GMT
< content-type: text/html; charset=UTF-8
< location: https://install.image-line.com/flstudio/flstudio_mac_24.1.1.3936.dmg
< content-security-policy: frame-ancestors 'self'
< cache-control: public
< expires: Sat, 17 Aug 2024 14:50:06 GMT
< authorization: -
< pragma: no-cache
< cf-cache-status: DYNAMIC
< set-cookie: _cfuvid=X_hzwyZPmQ0KZugK5CpkmrfRldGjCr2RGuczAVZsdn8-1723905906832-0.0.1.1-604800000; path=/; domain=.image-line.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8b4a722b5afc7380-PER
< 
{ [0 bytes data]
* Connection #0 to host support.image-line.com left intact
* Issue another request to this URL: 'https://install.image-line.com/flstudio/flstudio_mac_24.1.1.3936.dmg'
*   Trying 104.16.96.54:443...
* Connected to install.image-line.com (104.16.96.54) port 443 (#1)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3431 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=install.image-line.com
*  start date: Jul  6 13:01:10 2024 GMT
*  expire date: Oct  4 13:01:09 2024 GMT
*  subjectAltName: host "install.image-line.com" matched cert's "install.image-line.com"
*  issuer: C=US; O=Let's Encrypt; CN=E5
*  SSL certificate verify ok.
* using HTTP/2
* h2 [:method: GET]
* h2 [:scheme: https]
* h2 [:authority: install.image-line.com]
* h2 [:path: /flstudio/flstudio_mac_24.1.1.3936.dmg]
* h2 [accept: */*]
* h2 [user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15]
* Using Stream ID: 1 (easy handle 0x7fe8f000a800)
> GET /flstudio/flstudio_mac_24.1.1.3936.dmg HTTP/2
> Host: install.image-line.com
> Accept: */*
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
> 
< HTTP/2 200 
< date: Sat, 17 Aug 2024 14:45:07 GMT
< content-type: application/octet-stream
< content-length: 1268033610
< etag: "1e75f8c6dbcce40efced547b50638556"
< last-modified: Tue, 06 Aug 2024 11:54:02 GMT
< vary: Accept-Encoding
< cf-cache-status: HIT
< age: 4139
< expires: Sat, 17 Aug 2024 16:45:07 GMT
< cache-control: public, max-age=7200
< accept-ranges: bytes
< set-cookie: _cfuvid=eldWTv.6eOEIM99yNr21Bnznk60uORqUJkhxciMtjfQ-1723905907038-0.0.1.1-604800000; path=/; domain=.image-line.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8b4a722eedc78aca-PER
< 
{ [1360 bytes data]
* Connection #1 to host install.image-line.com left intact

2024-08-17 22:55:56 : DEBUG : flstudiomac : DEBUG mode 1, not checking for blocking processes
2024-08-17 22:55:56 : REQ   : flstudiomac : Installing flstudio_mac_24.1.1.3936
2024-08-17 22:55:56 : INFO  : flstudiomac : Mounting /Users/lowyiyuan/Documents/Scripts/Installomator/build/flstudio_mac_24.1.1.3936.dmg
2024-08-17 22:56:00 : DEBUG : flstudiomac : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $E2C227F1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $851B97F3
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $6918CD76
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $E5385519
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $6918CD76
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $AC43F2F4
verified CRC32 $6B809D6E
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/FL Studio

2024-08-17 22:56:00 : INFO  : flstudiomac : Mounted: /Volumes/FL Studio
2024-08-17 22:56:00 : DEBUG : flstudiomac : Found pkg(s):
/Volumes/FL Studio/Install FL Studio.pkg
2024-08-17 22:56:00 : INFO  : flstudiomac : found pkg: /Volumes/FL Studio/Install FL Studio.pkg
2024-08-17 22:56:00 : INFO  : flstudiomac : Verifying: /Volumes/FL Studio/Install FL Studio.pkg
2024-08-17 22:56:00 : DEBUG : flstudiomac : File list: -rw-r--r--  1 lowyiyuan  staff   1.2G  5 Aug 16:27 /Volumes/FL Studio/Install FL Studio.pkg
2024-08-17 22:56:00 : DEBUG : flstudiomac : File type: /Volumes/FL Studio/Install FL Studio.pkg: xar archive compressed TOC: 7516, SHA-1 checksum
2024-08-17 22:56:00 : DEBUG : flstudiomac : spctlOut is /Volumes/FL Studio/Install FL Studio.pkg: accepted
2024-08-17 22:56:00 : DEBUG : flstudiomac : source=Notarized Developer ID
2024-08-17 22:56:00 : DEBUG : flstudiomac : origin=Developer ID Installer: image-line (N68WEP5ZZZ)
2024-08-17 22:56:00 : INFO  : flstudiomac : Team ID: N68WEP5ZZZ (expected: N68WEP5ZZZ )
2024-08-17 22:56:00 : DEBUG : flstudiomac : DEBUG enabled, skipping installation
2024-08-17 22:56:00 : INFO  : flstudiomac : Finishing...
2024-08-17 22:56:04 : INFO  : flstudiomac : No version found using packageID com.Image-Line.pkg.flcloud.plugins
2024-08-17 22:56:04 : INFO  : flstudiomac : com.Image-Line.pkg.24ONLINE
2024-08-17 22:56:04 : INFO  : flstudiomac : name: flstudio_mac_24.1.1.3936, appName: flstudio_mac_24.1.1.3936.app
2024-08-17 22:56:04.116 mdfind[25644:322047] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2024-08-17 22:56:04.264 mdfind[25644:322047] Couldn't determine the mapping between prefab keywords and predicates.
2024-08-17 22:56:04 : WARN  : flstudiomac : No previous app found
2024-08-17 22:56:04 : WARN  : flstudiomac : could not find flstudio_mac_24.1.1.3936.app
2024-08-17 22:56:04 : REQ   : flstudiomac : Installed flstudio_mac_24.1.1.3936, version 24.1.1.3936
2024-08-17 22:56:04 : INFO  : flstudiomac : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-08-17 22:56:04 : DEBUG : flstudiomac : Unmounting /Volumes/FL Studio
2024-08-17 22:56:05 : DEBUG : flstudiomac : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-08-17 22:56:05 : DEBUG : flstudiomac : DEBUG mode 1, not reopening anything
2024-08-17 22:56:05 : REQ   : flstudiomac : All done!
2024-08-17 22:56:05 : REQ   : flstudiomac : ################## End Installomator, exit code 0 
```