### PR TITLE
Removed mistaken double `appNewVersion`

### DIFF
--- a/fragments/labels/whatsapp.sh
+++ b/fragments/labels/whatsapp.sh
@@ -4,5 +4,4 @@ whatsapp)
     downloadURL="https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release"
     appNewVersion=$(curl -fsLIXGET "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release" | grep -i "^location" | grep -m 1 -o "WhatsApp-.*dmg" | sed 's/.*WhatsApp-2.//g' | sed 's/.dmg//g')
     expectedTeamID="57T9237FN3"
-    appNewVersion=$(curl -s https://web.whatsapp.com/desktop/mac/releases | awk -F '"' '/"name"/ {print $4}')
     ;;


### PR DESCRIPTION
./utils/assemble.sh whatsapp
2024-08-20 10:05:56 : REQ   : whatsapp : ################## Start Installomator v. 10.6beta, date 2024-08-20
2024-08-20 10:05:56 : INFO  : whatsapp : ################## Version: 10.6beta
2024-08-20 10:05:56 : INFO  : whatsapp : ################## Date: 2024-08-20
2024-08-20 10:05:56 : INFO  : whatsapp : ################## whatsapp
2024-08-20 10:05:57 : DEBUG : whatsapp : DEBUG mode 1 enabled.
2024-08-20 10:06:00 : DEBUG : whatsapp : name=WhatsApp
2024-08-20 10:06:00 : DEBUG : whatsapp : appName=
2024-08-20 10:06:00 : DEBUG : whatsapp : type=dmg
2024-08-20 10:06:00 : DEBUG : whatsapp : archiveName=
2024-08-20 10:06:00 : DEBUG : whatsapp : downloadURL=https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release
2024-08-20 10:06:00 : DEBUG : whatsapp : curlOptions=
2024-08-20 10:06:00 : DEBUG : whatsapp : appNewVersion=24.15.80
2024-08-20 10:06:00 : DEBUG : whatsapp : appCustomVersion function: Not defined
2024-08-20 10:06:00 : DEBUG : whatsapp : versionKey=CFBundleShortVersionString
2024-08-20 10:06:00 : DEBUG : whatsapp : packageID=
2024-08-20 10:06:00 : DEBUG : whatsapp : pkgName=
2024-08-20 10:06:00 : DEBUG : whatsapp : choiceChangesXML=
2024-08-20 10:06:00 : DEBUG : whatsapp : expectedTeamID=57T9237FN3
2024-08-20 10:06:00 : DEBUG : whatsapp : blockingProcesses=
2024-08-20 10:06:00 : DEBUG : whatsapp : installerTool=
2024-08-20 10:06:00 : DEBUG : whatsapp : CLIInstaller=
2024-08-20 10:06:00 : DEBUG : whatsapp : CLIArguments=
2024-08-20 10:06:00 : DEBUG : whatsapp : updateTool=
2024-08-20 10:06:00 : DEBUG : whatsapp : updateToolArguments=
2024-08-20 10:06:00 : DEBUG : whatsapp : updateToolRunAsCurrentUser=
2024-08-20 10:06:00 : INFO  : whatsapp : BLOCKING_PROCESS_ACTION=tell_user
2024-08-20 10:06:00 : INFO  : whatsapp : NOTIFY=success
2024-08-20 10:06:00 : INFO  : whatsapp : LOGGING=DEBUG
2024-08-20 10:06:00 : INFO  : whatsapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-08-20 10:06:00 : INFO  : whatsapp : Label type: dmg
2024-08-20 10:06:00 : INFO  : whatsapp : archiveName: WhatsApp.dmg
2024-08-20 10:06:00 : INFO  : whatsapp : no blocking processes defined, using WhatsApp as default
2024-08-20 10:06:00 : DEBUG : whatsapp : Changing directory to /Users/bigmacadmin/Documents/GitHub/installomator/build
2024-08-20 10:06:00 : INFO  : whatsapp : name: WhatsApp, appName: WhatsApp.app
2024-08-20 10:06:00.405 mdfind[46574:12471839] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-08-20 10:06:00.406 mdfind[46574:12471839] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-08-20 10:06:00.590 mdfind[46574:12471839] Couldn't determine the mapping between prefab keywords and predicates.
2024-08-20 10:06:00 : WARN  : whatsapp : No previous app found
2024-08-20 10:06:00 : WARN  : whatsapp : could not find WhatsApp.app
2024-08-20 10:06:00 : INFO  : whatsapp : appversion:
2024-08-20 10:06:00 : INFO  : whatsapp : Latest version of WhatsApp is 24.15.80
2024-08-20 10:06:00 : REQ   : whatsapp : Downloading https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release to WhatsApp.dmg
2024-08-20 10:06:00 : DEBUG : whatsapp : No Dialog connection, just download
2024-08-20 10:06:04 : DEBUG : whatsapp : File list: -rw-r--r--  1 bigmacadmin  staff   120M Aug 20 10:06 WhatsApp.dmg
2024-08-20 10:06:04 : DEBUG : whatsapp : File type: WhatsApp.dmg: zlib compressed data
2024-08-20 10:06:04 : DEBUG : whatsapp : curl output was:
* Host web.whatsapp.com:443 was resolved.
* IPv6: (none)
* IPv4: 31.13.70.49
*   Trying 31.13.70.49:443...
* Connected to web.whatsapp.com (31.13.70.49) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2850 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Meta Platforms, Inc.; CN=*.whatsapp.net
*  start date: May 30 00:00:00 2024 GMT
*  expire date: Aug 28 23:59:59 2024 GMT
*  subjectAltName: host "web.whatsapp.com" matched cert's "*.whatsapp.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: web.whatsapp.com]
* [HTTP/2] [1] [:path: /desktop/mac_native/release/?configuration=Release]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /desktop/mac_native/release/?configuration=Release HTTP/2
> Host: web.whatsapp.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 302
< vary: Accept-Encoding
< location: https://scontent.xx.fbcdn.net/v/t39.16592-6/10000000_1667282317373046_6719061145006669018_n.dmg/WhatsApp-2.24.15.80.dmg?_nc_cat=100&ccb=1-7&_nc_sid=8f3826&_nc_ohc=bsNhsxOGjz4Q7kNvgGq7nqU&_nc_ht=scontent.xx&oh=00_AYD7bOQNiN18a4Yvptbj_Wd0rULcKX4NkXsv5VDtts2K4A&oe=66CAAE29 < reporting-endpoints: coop_report="https://www.facebook.com/browser_reporting/coop/?minimize=0", default="https://web.whatsapp.com/ajax/whatsapp_error_reports/?device_level=unknown", permissions_policy="https://www.whatsapp.com/whatsapp_browser_error_reports/" < report-to: {"max_age":2592000,"endpoints":[{"url":"https://www.facebook.com/browser_reporting/coop/?minimize=0"}],"group":"coop_report","include_subdomains":true}, {"max_age":259200,"endpoints":[{"url":"https://web.whatsapp.com/ajax/whatsapp_error_reports/?device_level=unknown"}]}, {"max_age":21600,"endpoints":[{"url":"https://www.whatsapp.com/whatsapp_browser_error_reports/"}],"group":"permissions_policy"} < content-security-policy-report-only: default-src 'self' blob: data:;script-src data: blob: 'self' 'unsafe-inline' 'report-sample' https://static.whatsapp.net https://*.youtube.com https://maps.googleapis.com https://maps.gstatic.com https://*.google-analytics.com;style-src data: blob: 'self' 'unsafe-inline' https://static.whatsapp.net https://fonts.googleapis.com;connect-src 'self' https://*.whatsapp.net https://www.facebook.com blob: https://crashlogs.whatsapp.net/wa_clb_data https://crashlogs.whatsapp.net/wa_fls_upload_check wss://*.web.whatsapp.com wss://web.whatsapp.com wss://web-fallback.whatsapp.com https://www.whatsapp.com https://dyn.web.whatsapp.com https://graph.whatsapp.com/graphql/ https://graph.facebook.com/graphql ws://web.whatsapp.com wss://web.whatsapp.com:5222 data: https://*.tenor.co https://*.giphy.com https://maps.googleapis.com https://*.google-analytics.com;font-src data: 'self' https://static.whatsapp.net https://fonts.gstatic.com;img-src 'self' data: blob: https://*.whatsapp.net https://*.fbcdn.net *.tenor.co *.tenor.com *.giphy.com https://*.ytimg.com *.youtube.com https://maps.googleapis.com/maps/api/staticmap https://*.google-analytics.com;media-src 'self' https://*.whatsapp.net https://*.cdninstagram.com https://*.fbcdn.net blob: mediastream: data: *.tenor.co *.tenor.com https://*.giphy.com;child-src 'self' blob: data:;frame-src 'self' blob: data: https://*.youtube.com;block-all-mixed-content;upgrade-insecure-requests;report-uri https://www.facebook.com/csp/reporting/?minimize=0; < document-policy: force-load-at-top
< permissions-policy: accelerometer=(), attribution-reporting=(), autoplay=(), battery=(self), bluetooth=(), camera=(), ch-device-memory=(), ch-downlink=(), ch-dpr=(), ch-ect=(), ch-rtt=(), ch-save-data=(), ch-ua-arch=(), ch-ua-bitness=(), ch-viewport-height=(), ch-viewport-width=(), ch-width=(), clipboard-read=(), clipboard-write=(), compute-pressure=(), display-capture=(), encrypted-media=(), fullscreen=(self), gamepad=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), keyboard-map=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), private-state-token-issuance=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), shared-storage=(), shared-storage-select-url=(), private-state-token-redemption=(), usb=(), usb-unrestricted=(), unload=(self), window-management=(), xr-spatial-tracking=();report-to="permissions_policy" < cross-origin-resource-policy: same-origin
< cross-origin-opener-policy: same-origin-allow-popups;report-to="coop_report" < pragma: no-cache
< cache-control: private, no-cache, no-store, must-revalidate < expires: Sat, 01 Jan 2000 00:00:00 GMT
< x-content-type-options: nosniff
< x-xss-protection: 0
< content-security-policy: frame-ancestors 'self'; < content-security-policy: default-src 'self' blob: data:;script-src data: blob: 'self' 'unsafe-inline' 'report-sample' https://static.whatsapp.net https://*.youtube.com https://maps.googleapis.com https://maps.gstatic.com https://*.google-analytics.com;style-src data: blob: 'self' 'unsafe-inline' https://static.whatsapp.net https://fonts.googleapis.com;connect-src 'self' https://*.whatsapp.net https://www.facebook.com blob: https://crashlogs.whatsapp.net/wa_clb_data https://crashlogs.whatsapp.net/wa_fls_upload_check wss://*.web.whatsapp.com wss://web.whatsapp.com wss://web-fallback.whatsapp.com https://www.whatsapp.com https://dyn.web.whatsapp.com https://graph.whatsapp.com/graphql/ https://graph.facebook.com/graphql ws://web.whatsapp.com wss://web.whatsapp.com:5222 data: https://*.tenor.co https://*.giphy.com https://maps.googleapis.com https://*.google-analytics.com;font-src data: 'self' https://static.whatsapp.net https://fonts.gstatic.com;img-src 'self' data: blob: https://*.whatsapp.net https://*.fbcdn.net *.tenor.co *.tenor.com *.giphy.com https://*.ytimg.com *.youtube.com https://maps.googleapis.com/maps/api/staticmap https://*.google-analytics.com;media-src 'self' https://*.whatsapp.net https://*.cdninstagram.com https://*.fbcdn.net blob: mediastream: data: *.tenor.co *.tenor.com https://*.giphy.com;child-src 'self' blob: data:;frame-src 'self' blob: data: https://*.youtube.com;block-all-mixed-content;upgrade-insecure-requests; < strict-transport-security: max-age=31536000; preload; includeSubDomains < content-type: text/html; charset="utf-8"
< x-fb-debug: 0TJRQPkUJmavLpn5Vow/WbLqMAuTJE08wlBZ1Kty6hX2GXYIuc8DD6WyFihYM3sV0g4+xlEH125CN78RyeOCoA== < x-fb-server-load: 52
< content-length: 0
< date: Tue, 20 Aug 2024 17:06:00 GMT
< x-fb-connection-quality: EXCELLENT; q=0.9, rtt=11, rtx=0, c=15, mss=1380, tbw=3298, tp=-1, tpl=-1, uplat=134, ullat=0 < alt-svc: h3=":443"; ma=86400
<
* Ignoring the response-body
* Connection #0 to host web.whatsapp.com left intact
* Issue another request to this URL: 'https://scontent.xx.fbcdn.net/v/t39.16592-6/10000000_1667282317373046_6719061145006669018_n.dmg/WhatsApp-2.24.15.80.dmg?_nc_cat=100&ccb=1-7&_nc_sid=8f3826&_nc_ohc=bsNhsxOGjz4Q7kNvgGq7nqU&_nc_ht=scontent.xx&oh=00_AYD7bOQNiN18a4Yvptbj_Wd0rULcKX4NkXsv5VDtts2K4A&oe=66CAAE29'
* Host scontent.xx.fbcdn.net:443 was resolved.
* IPv6: (none)
* IPv4: 157.240.11.22
*   Trying 157.240.11.22:443...
* Connected to scontent.xx.fbcdn.net (157.240.11.22) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2916 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=Menlo Park; O=Meta Platforms, Inc.; CN=*.facebook.com
*  start date: May 30 00:00:00 2024 GMT
*  expire date: Aug 28 23:59:59 2024 GMT
*  subjectAltName: host "scontent.xx.fbcdn.net" matched cert's "*.xx.fbcdn.net"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://scontent.xx.fbcdn.net/v/t39.16592-6/10000000_1667282317373046_6719061145006669018_n.dmg/WhatsApp-2.24.15.80.dmg?_nc_cat=100&ccb=1-7&_nc_sid=8f3826&_nc_ohc=bsNhsxOGjz4Q7kNvgGq7nqU&_nc_ht=scontent.xx&oh=00_AYD7bOQNiN18a4Yvptbj_Wd0rULcKX4NkXsv5VDtts2K4A&oe=66CAAE29
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: scontent.xx.fbcdn.net]
* [HTTP/2] [1] [:path: /v/t39.16592-6/10000000_1667282317373046_6719061145006669018_n.dmg/WhatsApp-2.24.15.80.dmg?_nc_cat=100&ccb=1-7&_nc_sid=8f3826&_nc_ohc=bsNhsxOGjz4Q7kNvgGq7nqU&_nc_ht=scontent.xx&oh=00_AYD7bOQNiN18a4Yvptbj_Wd0rULcKX4NkXsv5VDtts2K4A&oe=66CAAE29]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /v/t39.16592-6/10000000_1667282317373046_6719061145006669018_n.dmg/WhatsApp-2.24.15.80.dmg?_nc_cat=100&ccb=1-7&_nc_sid=8f3826&_nc_ohc=bsNhsxOGjz4Q7kNvgGq7nqU&_nc_ht=scontent.xx&oh=00_AYD7bOQNiN18a4Yvptbj_Wd0rULcKX4NkXsv5VDtts2K4A&oe=66CAAE29 HTTP/2
> Host: scontent.xx.fbcdn.net
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< x-additional-error-detail:
< last-modified: Thu, 01 Aug 2024 14:31:43 GMT
< content-type: application/octet-stream
< cross-origin-resource-policy: cross-origin
< timing-allow-origin: *
< access-control-allow-origin: *
< accept-ranges: bytes
< content-length: 125819766
< date: Tue, 20 Aug 2024 17:06:01 GMT
< cache-control: max-age=1209600, no-transform
< x-fb-connection-quality: EXCELLENT; q=0.9, rtt=18, rtx=0, c=13, mss=1380, tbw=3364, tp=-1, tpl=-1, uplat=0, ullat=-1 < alt-svc: h3=":443"; ma=86400
<
{ [1492 bytes data]
* Connection #1 to host scontent.xx.fbcdn.net left intact

2024-08-20 10:06:04 : DEBUG : whatsapp : DEBUG mode 1, not checking for blocking processes
2024-08-20 10:06:04 : REQ   : whatsapp : Installing WhatsApp
2024-08-20 10:06:04 : INFO  : whatsapp : Mounting /Users/bigmacadmin/Documents/GitHub/installomator/build/WhatsApp.dmg
2024-08-20 10:06:09 : DEBUG : whatsapp : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $CB8B09A5
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $35384FD6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CE725285
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $382DCF53
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CE725285
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $D6FC2282
verified   CRC32 $4A543C87
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/WhatsApp Installer

2024-08-20 10:06:09 : INFO  : whatsapp : Mounted: /Volumes/WhatsApp Installer 2024-08-20 10:06:09 : INFO  : whatsapp : Verifying: /Volumes/WhatsApp Installer/WhatsApp.app 2024-08-20 10:06:09 : DEBUG : whatsapp : App size: 388M	/Volumes/WhatsApp Installer/WhatsApp.app 2024-08-20 10:06:11 : DEBUG : whatsapp : Debugging enabled, App Verification output was: /Volumes/WhatsApp Installer/WhatsApp.app: accepted source=Notarized Developer ID
origin=Developer ID Application: WhatsApp Inc. (57T9237FN3)

2024-08-20 10:06:11 : INFO  : whatsapp : Team ID matching: 57T9237FN3 (expected: 57T9237FN3 ) 2024-08-20 10:06:11 : INFO  : whatsapp : Installing WhatsApp version 24.15.80 on versionKey CFBundleShortVersionString. 2024-08-20 10:06:11 : INFO  : whatsapp : App has LSMinimumSystemVersion: 11.0 2024-08-20 10:06:11 : DEBUG : whatsapp : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-08-20 10:06:11 : INFO  : whatsapp : Finishing... 2024-08-20 10:06:14 : INFO  : whatsapp : name: WhatsApp, appName: WhatsApp.app 2024-08-20 10:06:14.532 mdfind[46656:12472158] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-08-20 10:06:14.532 mdfind[46656:12472158] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-08-20 10:06:14.595 mdfind[46656:12472158] Couldn't determine the mapping between prefab keywords and predicates. 2024-08-20 10:06:14 : WARN  : whatsapp : No previous app found 2024-08-20 10:06:14 : WARN  : whatsapp : could not find WhatsApp.app
2024-08-20 10:06:14 : REQ   : whatsapp : Installed WhatsApp, version 24.15.80
2024-08-20 10:06:14 : INFO  : whatsapp : notifying
2024-08-20 10:06:15 : DEBUG : whatsapp : Unmounting /Volumes/WhatsApp Installer
2024-08-20 10:06:15 : DEBUG : whatsapp : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-08-20 10:06:15 : DEBUG : whatsapp : DEBUG mode 1, not reopening anything
2024-08-20 10:06:15 : REQ   : whatsapp : All done!
2024-08-20 10:06:15 : REQ   : whatsapp : ################## End Installomator, exit code 0