### PR TITLE
Update pgadmin4.sh to support arm64 arch

### DIFF
--- a/fragments/labels/pgadmin4.sh
+++ b/fragments/labels/pgadmin4.sh
@@ -1,8 +1,13 @@
 pgadmin4)
     name="pgAdmin 4"
     type="dmg"
-    downloadParent="https://www.postgresql.org/ftp/pgadmin/pgadmin4/"
-    appNewVersion=$(curl -fs "${downloadParent}" | grep -oE 'v[0-9]+.[0-9]+' | sort -V | tail -n 1 | sed 's/v//g')
-    downloadURL="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v$appNewVersion/macos/pgadmin4-$appNewVersion-x86_64.dmg"
+    downloadParent="https://ftp.postgresql.org/pub/pgadmin/pgadmin4/"
+    appNewVersion=$(curl -fs "${downloadParent}" | grep -oE 'v\d+\.\d+' | sort --version-sort | tail -n 1 | sed 's/v//g')
+    if [[ $(arch) == "arm64" ]]; then
+        archLabel="arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        archLabel="x86_64"
+    fi
+    downloadURL="${downloadParent}v${appNewVersion}/macos/pgadmin4-${appNewVersion}-${archLabel}.dmg"
     expectedTeamID="TCHGL2R7C5"
     ;;


### PR DESCRIPTION
The current `pgadmin4.sh` label default to `x86_64` when a `arm64` version is also available.

I also introduces those other changes:
* downloadParent url updated to use the same between version fetching and dmg fetching
* update regex to use `\d` instead of `[0-9]`
* update `sort` param from `-V` to `--sort-version` to be more explicit

This is my first PR - please let me know if this is the correct way to fix this issue.

Tested on my local (arm64)