### PR TITLE
New Label: determinate

### DIFF
--- a/fragments/labels/determinate.sh
+++ b/fragments/labels/determinate.sh
@@ -2,9 +2,6 @@ determinate)
     name="Determinate"
     type="pkg"
     packageID="systems.determinate.Determinate"
-    # Note: https://install.determinate.systems/determinate-pkg/stable/Universal may return different URLs if a deploy is in progress.
-    # Fetching https://install.determinate.systems/determinate-pkg/stable/Universal and capturing the redirect target ensures the
-    # version printed is the version that will actually be installed.
     downloadUrl=$(curl -w "%{url_effective}\n" -I -L -s -S https://install.determinate.systems/determinate-pkg/stable/Universal -o /dev/null)
     appNewVersion=$(echo "$downloadUrl" | cut -d/ -f4)
     expectedTeamID="X3JQ4VPJZ6"

--- a/fragments/labels/determinate.sh
+++ b/fragments/labels/determinate.sh
@@ -5,7 +5,7 @@ determinate)
     # Note: https://install.determinate.systems/determinate-pkg/stable/Universal may return different URLs if a deploy is in progress.
     # Fetching https://install.determinate.systems/determinate-pkg/stable/Universal and capturing the redirect target ensures the
     # version printed is the version that will actually be installed.
-    downloadUrl=$(curl -sfI https://install.determinate.systems/determinate-pkg/stable/Universal  | awk -F' ' '/location: /{print $2}')
+    downloadUrl=$(curl -w "%{url_effective}\n" -I -L -s -S https://install.determinate.systems/determinate-pkg/stable/Universal -o /dev/null)
     appNewVersion=$(echo "$downloadUrl" | cut -d/ -f4)
     expectedTeamID="X3JQ4VPJZ6"
     ;;

--- a/fragments/labels/determinate.sh
+++ b/fragments/labels/determinate.sh
@@ -2,7 +2,10 @@ determinate)
     name="Determinate"
     type="pkg"
     packageID="systems.determinate.Determinate"
-    downloadURL="https://install.determinate.systems/determinate-pkg/stable/Universal"
-    appNewVersion=$(curl -sfI "${downloadURL}"  | awk -F'/' '/location: /{print $4}')
+    # Note: https://install.determinate.systems/determinate-pkg/stable/Universal may return different URLs if a deploy is in progress.
+    # Fetching https://install.determinate.systems/determinate-pkg/stable/Universal and capturing the redirect target ensures the
+    # version printed is the version that will actually be installed.
+    downloadUrl=$(curl -sfI https://install.determinate.systems/determinate-pkg/stable/Universal  | awk -F' ' '/location: /{print $2}')
+    appNewVersion=$(echo "$downloadUrl" | cut -d/ -f4)
     expectedTeamID="X3JQ4VPJZ6"
     ;;

--- a/fragments/labels/determinate.sh
+++ b/fragments/labels/determinate.sh
@@ -1,0 +1,8 @@
+determinate)
+    name="Determinate"
+    type="pkg"
+    packageID="systems.determinate.Determinate"
+    downloadURL="https://install.determinate.systems/determinate-pkg/stable/Universal"
+    appNewVersion=$(curl -sfI "${downloadURL}"  | awk -F'/' '/location: /{print $4}')
+    expectedTeamID="X3JQ4VPJZ6"
+    ;;


### PR DESCRIPTION
Determinate provides Nix via Determinate Systems.

See: https://determinate.systems/nix/

    2024-08-26 19:06:21 : REQ   : determinate : ################## Start Installomator v. 10.6beta, date 2024-08-26
    2024-08-26 19:06:22 : INFO  : determinate : ################## Version: 10.6beta
    2024-08-26 19:06:22 : INFO  : determinate : ################## Date: 2024-08-26
    2024-08-26 19:06:22 : INFO  : determinate : ################## determinate
    2024-08-26 19:06:22 : DEBUG : determinate : DEBUG mode 1 enabled.
    2024-08-26 19:06:22 : INFO  : determinate : SwiftDialog is not installed, clear cmd file var
    2024-08-26 19:06:22 : DEBUG : determinate : name=Determinate
    2024-08-26 19:06:22 : DEBUG : determinate : appName=
    2024-08-26 19:06:22 : DEBUG : determinate : type=pkg
    2024-08-26 19:06:22 : DEBUG : determinate : archiveName=
    2024-08-26 19:06:22 : DEBUG : determinate : downloadURL=https://install.determinate.systems/determinate-pkg/stable/Universal
    2024-08-26 19:06:22 : DEBUG : determinate : curlOptions=
    2024-08-26 19:06:22 : DEBUG : determinate : appNewVersion=v0.1.1
    2024-08-26 19:06:22 : DEBUG : determinate : appCustomVersion function: Not defined
    2024-08-26 19:06:22 : DEBUG : determinate : versionKey=CFBundleShortVersionString
    2024-08-26 19:06:22 : DEBUG : determinate : packageID=systems.determinate.Determinate
    2024-08-26 19:06:22 : DEBUG : determinate : pkgName=
    2024-08-26 19:06:22 : DEBUG : determinate : choiceChangesXML=
    2024-08-26 19:06:22 : DEBUG : determinate : expectedTeamID=X3JQ4VPJZ6
    2024-08-26 19:06:22 : DEBUG : determinate : blockingProcesses=
    2024-08-26 19:06:22 : DEBUG : determinate : installerTool=
    2024-08-26 19:06:22 : DEBUG : determinate : CLIInstaller=
    2024-08-26 19:06:22 : DEBUG : determinate : CLIArguments=
    2024-08-26 19:06:22 : DEBUG : determinate : updateTool=
    2024-08-26 19:06:22 : DEBUG : determinate : updateToolArguments=
    2024-08-26 19:06:22 : DEBUG : determinate : updateToolRunAsCurrentUser=
    2024-08-26 19:06:22 : INFO  : determinate : BLOCKING_PROCESS_ACTION=tell_user
    2024-08-26 19:06:22 : INFO  : determinate : NOTIFY=success
    2024-08-26 19:06:22 : INFO  : determinate : LOGGING=DEBUG
    2024-08-26 19:06:22 : INFO  : determinate : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
    2024-08-26 19:06:22 : INFO  : determinate : Label type: pkg
    2024-08-26 19:06:22 : INFO  : determinate : archiveName: Determinate.pkg
    2024-08-26 19:06:22 : INFO  : determinate : no blocking processes defined, using Determinate as default
    2024-08-26 19:06:22 : DEBUG : determinate : Changing directory to /Users/grahamchristensen/src/github.com/Installomator/Installomator/build
    2024-08-26 19:06:22 : INFO  : determinate : found packageID systems.determinate.Determinate installed, version  <string>v0.1.1</string>
    2024-08-26 19:06:22 : INFO  : determinate : appversion:         <string>v0.1.1</string>
    2024-08-26 19:06:22 : INFO  : determinate : Latest version of Determinate is v0.1.1
    2024-08-26 19:06:22 : REQ   : determinate : Downloading https://install.determinate.systems/determinate-pkg/stable/Universal to Determinate.pkg
    2024-08-26 19:06:22 : DEBUG : determinate : No Dialog connection, just download
    2024-08-26 19:07:07 : DEBUG : determinate : File list: -rw-r--r--  1 grahamchristensen  staff    78M Aug 26 19:07 Determinate.pkg
    2024-08-26 19:07:07 : DEBUG : determinate : File type: Determinate.pkg: xar archive compressed TOC: 5668, SHA-1 checksum
    2024-08-26 19:07:07 : DEBUG : determinate : curl output was:
    * Host install.determinate.systems:443 was resolved.
    * IPv6: 2a09:8280:1::a705
    * IPv4: 149.248.218.82
    *   Trying [2a09:8280:1::a705]:443...
    * Connected to install.determinate.systems (2a09:8280:1::a705) port 443
    * ALPN: curl offers h2,http/1.1
    * (304) (OUT), TLS handshake, Client hello (1):
    } [332 bytes data]
    *  CAfile: /etc/ssl/cert.pem
    *  CApath: none
    * (304) (IN), TLS handshake, Server hello (2):
    { [122 bytes data]
    * (304) (IN), TLS handshake, Unknown (8):
    { [19 bytes data]
    * (304) (IN), TLS handshake, Certificate (11):
    { [2056 bytes data]
    * (304) (IN), TLS handshake, CERT verify (15):
    { [78 bytes data]
    * (304) (IN), TLS handshake, Finished (20):
    { [36 bytes data]
    * (304) (OUT), TLS handshake, Finished (20):
    } [36 bytes data]
    * SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
    * ALPN: server accepted h2
    * Server certificate:
    *  subject: CN=install.determinate.systems
    *  start date: Jul 21 23:35:57 2024 GMT
    *  expire date: Oct 19 23:35:56 2024 GMT
    *  subjectAltName: host "install.determinate.systems" matched cert's "install.determinate.systems"
    *  issuer: C=US; O=Let's Encrypt; CN=E6
    *  SSL certificate verify ok.
    * using HTTP/2
    * [HTTP/2] [1] OPENED stream for https://install.determinate.systems/determinate-pkg/stable/Universal
    * [HTTP/2] [1] [:method: GET]
    * [HTTP/2] [1] [:scheme: https]
    * [HTTP/2] [1] [:authority: install.determinate.systems]
    * [HTTP/2] [1] [:path: /determinate-pkg/stable/Universal]
    * [HTTP/2] [1] [user-agent: curl/8.6.0]
    * [HTTP/2] [1] [accept: */*]
    > GET /determinate-pkg/stable/Universal HTTP/2
    > Host: install.determinate.systems
    > User-Agent: curl/8.6.0
    > Accept: */*
    >
    < HTTP/2 307
    < location: https://determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com/v0.1.1/Determinate.pkg-Universal
    < content-length: 0
    < date: Mon, 26 Aug 2024 23:06:22 GMT
    < server: Fly/8e58ca40b (2024-08-26)
    < via: 2 fly.io
    < fly-request-id: 01J68F1G2GXG69T2PWAYAJC4KE-iad
    <
    * Ignoring the response-body
    * Connection #0 to host install.determinate.systems left intact
    * Issue another request to this URL: 'https://determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com/v0.1.1/Determinate.pkg-Universal'
    * Host determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com:443 was resolved.
    * IPv6: 2600:1fa0:602f:85c0:34db:5d22::, 2600:1fa0:606f:8b41:34db:b38a::, 2600:1fa0:6048:281:34db:651b::, 2600:1fa0:606f:8c90:34db:e4c2::, 2600:1fa0:60c8:208:34db:68a0::, 2600:1fa0:60af:8cc9:34db:e9ba::, 2600:1fa0:602f:8990:34db:5f22::, 2600:1fa0:602f:8949:34db:5e2a::
    * IPv4: 52.219.109.210, 3.5.130.39, 16.12.65.82, 3.5.131.133, 52.219.98.170, 52.219.111.50, 52.219.92.98, 3.5.132.162
    *   Trying [2600:1fa0:602f:85c0:34db:5d22::]:443...
    * Connected to determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com (2600:1fa0:602f:85c0:34db:5d22::) port 443
    * ALPN: curl offers h2,http/1.1
    * (304) (OUT), TLS handshake, Client hello (1):
    } [383 bytes data]
    * (304) (IN), TLS handshake, Server hello (2):
    { [122 bytes data]
    * (304) (IN), TLS handshake, Unknown (8):
    { [25 bytes data]
    * (304) (IN), TLS handshake, Certificate (11):
    { [5512 bytes data]
    * (304) (IN), TLS handshake, CERT verify (15):
    { [264 bytes data]
    * (304) (IN), TLS handshake, Finished (20):
    { [36 bytes data]
    * (304) (OUT), TLS handshake, Finished (20):
    } [36 bytes data]
    * SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
    * ALPN: server accepted http/1.1
    * Server certificate:
    *  subject: CN=*.s3.us-east-2.amazonaws.com
    *  start date: Feb 29 00:00:00 2024 GMT
    *  expire date: Feb 12 23:59:59 2025 GMT
    *  subjectAltName: host "determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com" matched cert's "*.s3.dualstack.us-east-2.amazonaws.com"
    *  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
    *  SSL certificate verify ok.
    * using HTTP/1.x
    > GET /v0.1.1/Determinate.pkg-Universal HTTP/1.1
    > Host: determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com
    > User-Agent: curl/8.6.0
    > Accept: */*
    >
    < HTTP/1.1 200 OK
    < x-amz-id-2: ExsYGwG5utI+ojT9l0LRyjFpjdj/TfwL6gdMjE3i0pMgYe6aziL8inQalJ4cYKPgyH333aa0iYE=
    < x-amz-request-id: A304ZMTTM71CEQ6Y
    < Date: Mon, 26 Aug 2024 23:06:23 GMT
    < Last-Modified: Mon, 26 Aug 2024 22:31:05 GMT
    < ETag: "066e7e365cf0e7a7a9f312fbe5347e40-10"
    < x-amz-server-side-encryption: AES256
    < Content-Disposition: attachment; filename="Determinate.pkg"
    < x-amz-version-id: VmM5pUG3BIb1zGLOSi7L4_kAslaaZCUb
    < Accept-Ranges: bytes
    < Content-Type: binary/octet-stream
    < Server: AmazonS3
    < Content-Length: 81831912
    <
    { [18822 bytes data]
    * Connection #1 to host determinate-pkg20240826203520431200000001.s3.dualstack.us-east-2.amazonaws.com left intact

    2024-08-26 19:07:07 : DEBUG : determinate : DEBUG mode 1, not checking for blocking processes
    2024-08-26 19:07:07 : REQ   : determinate : Installing Determinate
    2024-08-26 19:07:07 : INFO  : determinate : Verifying: Determinate.pkg
    2024-08-26 19:07:07 : DEBUG : determinate : File list: -rw-r--r--  1 grahamchristensen  staff    78M Aug 26 19:07 Determinate.pkg
    2024-08-26 19:07:07 : DEBUG : determinate : File type: Determinate.pkg: xar archive compressed TOC: 5668, SHA-1 checksum
    2024-08-26 19:07:07 : DEBUG : determinate : spctlOut is Determinate.pkg: accepted
    2024-08-26 19:07:07 : DEBUG : determinate : source=Notarized Developer ID
    2024-08-26 19:07:07 : DEBUG : determinate : origin=Developer ID Installer: Determinate Systems, Inc. (X3JQ4VPJZ6)
    2024-08-26 19:07:07 : INFO  : determinate : Team ID: X3JQ4VPJZ6 (expected: X3JQ4VPJZ6 )
    2024-08-26 19:07:07 : INFO  : determinate : Checking package version.
    2024-08-26 19:07:07 : INFO  : determinate : Downloaded package systems.determinate.Determinate version v0.1.1
    2024-08-26 19:07:07 : DEBUG : determinate : DEBUG enabled, skipping installation
    2024-08-26 19:07:07 : INFO  : determinate : Finishing...
    2024-08-26 19:07:10 : INFO  : determinate : found packageID systems.determinate.Determinate installed, version  <string>v0.1.1</string>
    2024-08-26 19:07:10 : REQ   : determinate : Installed Determinate, version v0.1.1
    2024-08-26 19:07:10 : INFO  : determinate : notifying
    displaynotification:7: no such file or directory: /usr/local/bin/dialog
    displaynotification:13: no such file or directory: /usr/local/bin/dialog
    2024-08-26 19:07:10 : DEBUG : determinate : DEBUG mode 1, not reopening anything
    2024-08-26 19:07:10 : REQ   : determinate : All done!
    2024-08-26 19:07:10 : REQ   : determinate : ################## End Installomator, exit code 0