### PR TITLE
Remove talkdeskcallbar label

### DIFF
--- a/fragments/labels/talkdeskcallbar.sh
+++ b/fragments/labels/talkdeskcallbar.sh
@@ -1,8 +1,0 @@
-talkdeskcallbar)
-    name="Callbar"
-    type="dmg"
-    talkdeskcallbarVersions=$(curl -fsL "https://downloadcallbar.talkdesk.com/release_metadata.json")
-    appNewVersion=$(getJSONValue "$talkdeskcallbarVersions" "version")
-    downloadURL=https://downloadcallbar.talkdesk.com/Callbar-${appNewVersion}.dmg
-    expectedTeamID="YGGJX44TB8"
-    ;;


### PR DESCRIPTION
Removing the label for `talkdeskcallbar`, as the Callbar app reached its end of life in September, 2023: https://support.talkdesk.com/hc/en-us/articles/6628805817115-Upgrading-to-Talkdesk-Workspace-FAQ#h_01HPSE50JMTPMBZRGKZ8DBRV8D

The `talkdeskcxcloud` label is available for the Talkdesk Workspace app, which is their recommended migration path.