### PR TITLE
Create Korg Software Pass label

### DIFF
--- a/fragments/labels/korgsoftwarepass.sh
+++ b/fragments/labels/korgsoftwarepass.sh
@@ -2,7 +2,6 @@ korgsoftwarepass)
     name="Korg Software Pass"
     type="pkgInDmg"
     packageID="jp.co.korg.pkg.korgsoftwarepass"
-    blockingProcesses=( "$name" )
     downloadVersion="$(curl -fs "https://id.korg.com/static_pages/3" | grep -E ".KORG_Software_Pass_([0-9]+(_[0-9]+)+)\.dmg" | cut -d\" -f4 | cut -d_ -f5-7 | cut -d. -f1 | xargs)"
     appNewVersion="$(echo "$downloadVersion" | tr '_' '.')"
     downloadURL="https://storage.korg.com/korgms/korg_collection/mac/KORG_Software_Pass_${downloadVersion}.dmg"

--- a/fragments/labels/korgsoftwarepass.sh
+++ b/fragments/labels/korgsoftwarepass.sh
@@ -1,0 +1,10 @@
+korgsoftwarepass)
+    name="Korg Software Pass"
+    type="pkgInDmg"
+    packageID="jp.co.korg.pkg.korgsoftwarepass"
+    blockingProcesses=( "$name" )
+    downloadVersion="$(curl -fs "https://id.korg.com/static_pages/3" | grep -E ".KORG_Software_Pass_([0-9]+(_[0-9]+)+)\.dmg" | cut -d\" -f4 | cut -d_ -f5-7 | cut -d. -f1 | xargs)"
+    appNewVersion="$(echo "$downloadVersion" | tr '_' '.')"
+    downloadURL="https://storage.korg.com/korgms/korg_collection/mac/KORG_Software_Pass_${downloadVersion}.dmg"
+    expectedTeamID="9H3HFX7NG2"
+    ;;


### PR DESCRIPTION
assemble.sh korgsoftwarepass
2024-09-02 14:53:58 : REQ   : korgsoftwarepass : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 14:53:58 : INFO  : korgsoftwarepass : ################## Version: 10.7beta
2024-09-02 14:53:58 : INFO  : korgsoftwarepass : ################## Date: 2024-09-02
2024-09-02 14:53:58 : INFO  : korgsoftwarepass : ################## korgsoftwarepass
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : DEBUG mode 1 enabled.
2024-09-02 14:53:58 : INFO  : korgsoftwarepass : SwiftDialog is not installed, clear cmd file var
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : name=Korg Software Pass
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : appName=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : type=pkgInDmg
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : archiveName=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : downloadURL=https://storage.korg.com/korgms/korg_collection/mac/KORG_Software_Pass_1_2_17.dmg
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : curlOptions=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : appNewVersion=1.2.17
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : appCustomVersion function: Not defined
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : versionKey=CFBundleShortVersionString
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : packageID=jp.co.korg.pkg.korgsoftwarepass
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : pkgName=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : choiceChangesXML=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : expectedTeamID=9H3HFX7NG2
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : blockingProcesses=Korg Software Pass
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : installerTool=
2024-09-02 14:53:58 : DEBUG : korgsoftwarepass : CLIInstaller=
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : CLIArguments=
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : updateTool=
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : updateToolArguments=
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : updateToolRunAsCurrentUser=
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : NOTIFY=success
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : LOGGING=DEBUG
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : Label type: pkgInDmg
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : archiveName: Korg Software Pass.dmg
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : found packageID jp.co.korg.pkg.korgsoftwarepass installed, version 1.2.17
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : appversion: 1.2.17
2024-09-02 14:53:59 : INFO  : korgsoftwarepass : Latest version of Korg Software Pass is 1.2.17
2024-09-02 14:53:59 : WARN  : korgsoftwarepass : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 14:53:59 : REQ   : korgsoftwarepass : Downloading https://storage.korg.com/korgms/korg_collection/mac/KORG_Software_Pass_1_2_17.dmg to Korg Software Pass.dmg
2024-09-02 14:53:59 : DEBUG : korgsoftwarepass : No Dialog connection, just download
2024-09-02 14:54:02 : DEBUG : korgsoftwarepass : File list: -rw-r--r--  1 gilburns  staff    28M Sep  2 14:54 Korg Software Pass.dmg
2024-09-02 14:54:02 : DEBUG : korgsoftwarepass : File type: Korg Software Pass.dmg: zlib compressed data
2024-09-02 14:54:02 : DEBUG : korgsoftwarepass : curl output was:
* Host storage.korg.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.160.225.54, 18.160.225.20, 18.160.225.92, 18.160.225.78
*   Trying 18.160.225.54:443...
* Connected to storage.korg.com (18.160.225.54) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4955 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=korg.com
*  start date: Nov 21 00:00:00 2023 GMT
*  expire date: Dec 19 23:59:59 2024 GMT
*  subjectAltName: host "storage.korg.com" matched cert's "*.korg.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /korgms/korg_collection/mac/KORG_Software_Pass_1_2_17.dmg HTTP/1.1
> Host: storage.korg.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 29875646
< Connection: keep-alive
< Last-Modified: Mon, 22 Jul 2024 03:26:31 GMT
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< Date: Mon, 02 Sep 2024 01:26:46 GMT
< ETag: "fb428d020ec5b2dd1adeb7f33008a45c"
< X-Cache: Hit from cloudfront
< Via: 1.1 b183cbc6d63456cc1757c3885f9fbd9a.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD58-P4
< X-Amz-Cf-Id: iukEuKsCplNQ4CpM1rOyJ-yj6YhPIUb1kUSFdkNqHdSDQQMuxFp4qQ==
< Age: 66434
< 
{ [16384 bytes data]
* Connection #0 to host storage.korg.com left intact

2024-09-02 14:54:02 : DEBUG : korgsoftwarepass : DEBUG mode 1, not checking for blocking processes
2024-09-02 14:54:02 : REQ   : korgsoftwarepass : Installing Korg Software Pass
2024-09-02 14:54:02 : INFO  : korgsoftwarepass : Mounting /Users/gilburns/GitHub/Installomator/build/Korg Software Pass.dmg
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $25516AA1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1C0490BA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $17710658
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E714605D
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $17710658
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $340B90D7
verified   CRC32 $8A07B2A1
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/KORG_Software_Pass

2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Mounted: /Volumes/KORG_Software_Pass
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : Found pkg(s):
/Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : found pkg: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Verifying: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : File list: -rw-r--r--  1 gilburns  staff    27M Jul 21 21:25 /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : File type: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg: xar archive compressed TOC: 4963, SHA-1 checksum
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : spctlOut is /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg: accepted
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : source=Notarized Developer ID
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : origin=Developer ID Installer: KORG INC. (9H3HFX7NG2)
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Team ID: 9H3HFX7NG2 (expected: 9H3HFX7NG2 )
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Checking package version.
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Downloaded package jp.co.korg.pkg.korgsoftwarepass version 1.2.17
2024-09-02 14:54:06 : INFO  : korgsoftwarepass : Downloaded version of Korg Software Pass is the same as installed.
2024-09-02 14:54:06 : DEBUG : korgsoftwarepass : Unmounting /Volumes/KORG_Software_Pass
2024-09-02 14:54:07 : DEBUG : korgsoftwarepass : Debugging enabled, Unmounting output was:
"disk7" ejected.
2024-09-02 14:54:07 : DEBUG : korgsoftwarepass : DEBUG mode 1, not reopening anything
2024-09-02 14:54:07 : REQ   : korgsoftwarepass : No new version to install
2024-09-02 14:54:07 : REQ   : korgsoftwarepass : ################## End Installomator, exit code 0 
