### PR TITLE
Create Cherry Audio CA2600 label

### DIFF
--- a/fragments/labels/cherryaudioca2600.sh
+++ b/fragments/labels/cherryaudioca2600.sh
@@ -2,7 +2,6 @@ cherryaudioca2600)
     name="CA2600"
     type="pkg"
     packageID="com.cherryaudio.pkg.CA2600Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/ca2600/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudioca2600.sh
+++ b/fragments/labels/cherryaudioca2600.sh
@@ -1,0 +1,9 @@
+cherryaudioca2600)
+    name="CA2600"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.CA2600Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/ca2600/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudioca2600
2024-09-02 15:00:53 : REQ   : cherryaudioca2600 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:00:53 : INFO  : cherryaudioca2600 : ################## Version: 10.7beta
2024-09-02 15:00:53 : INFO  : cherryaudioca2600 : ################## Date: 2024-09-02
2024-09-02 15:00:53 : INFO  : cherryaudioca2600 : ################## cherryaudioca2600
2024-09-02 15:00:53 : DEBUG : cherryaudioca2600 : DEBUG mode 1 enabled.
2024-09-02 15:00:53 : INFO  : cherryaudioca2600 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : name=CA2600
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : appName=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : type=pkg
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : archiveName=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : downloadURL=https://store.cherryaudio.com/downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : curlOptions=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : appNewVersion=1.4.0
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : appCustomVersion function: Not defined
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : versionKey=CFBundleShortVersionString
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : packageID=com.cherryaudio.pkg.CA2600Package-StandAlone
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : pkgName=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : choiceChangesXML=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : expectedTeamID=A2XFV22B2X
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : blockingProcesses=CA2600
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : installerTool=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : CLIInstaller=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : CLIArguments=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : updateTool=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : updateToolArguments=
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : updateToolRunAsCurrentUser=
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : NOTIFY=success
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : LOGGING=DEBUG
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : Label type: pkg
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : archiveName: CA2600.pkg
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : found packageID com.cherryaudio.pkg.CA2600Package-StandAlone installed, version 1.4.0
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : appversion: 1.4.0
2024-09-02 15:00:54 : INFO  : cherryaudioca2600 : Latest version of CA2600 is 1.4.0
2024-09-02 15:00:54 : WARN  : cherryaudioca2600 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:00:54 : REQ   : cherryaudioca2600 : Downloading https://store.cherryaudio.com/downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg to CA2600.pkg
2024-09-02 15:00:54 : DEBUG : cherryaudioca2600 : No Dialog connection, just download
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:01 CA2600.pkg
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : File type: CA2600.pkg: xar archive compressed TOC: 6995, SHA-1 checksum
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/ca2600-macos-installer?file=CA2600-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 69075421
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="CA2600-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:00:54 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6ImkrRVN6bnpmUGRuR3h3OHp4QlZ4NXc9PSIsInZhbHVlIjoiY3J5L2RYem9rdklRc0UwbmtJVnBGU0s2SzBjR3YxNmc1bGhwcGIwdzVjdVlJM283RmZZUzJGbTJyT3YzZWY0bG9JSzBrTk01eTNEQkdQV2JPdHI5Qll0VllWYVQyQWIzbi9TcjNNWjRhR2hQQUEyK2dXa09IQ0tpQzQ1MHFKcmIiLCJtYWMiOiI1ZGQwYmEyNGM4NmNmOWM4YzQ5YWIzNDM1YTdlMjdkODc1OGQzMjI3ZmE0OWQzN2IwYmExMzE5NTY5MGI1OGEzIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:00:54 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IjZwN281UndXNGtKbDRXelFJeWV1ZGc9PSIsInZhbHVlIjoiRU1PdWhvQXFSVGNheVp0WGppV2g0amE5VWZzbWRhTU5NbWRFYUdOU201a3dWTU1RY0xXaWNGSmV4ekFRcjBPUGpMWGQ2VzFMQXpOY09PSXVHek81K2ovSERFQmtlZGgvVjZMT1l3dEdQZVFpRUxzbmZqWFg1dmE5RDJ2WkZtUkMiLCJtYWMiOiI5MDI0MzRlZjViNTZiNGM4ZDVkODA4YWE4YWJmMTZlMDRhODMwZThkYjZkZWM0NTVjMjVjOWYzNzg1MTFmZDZlIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:00:54 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7012 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:01:04 : REQ   : cherryaudioca2600 : Installing CA2600
2024-09-02 15:01:04 : INFO  : cherryaudioca2600 : Verifying: CA2600.pkg
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:01 CA2600.pkg
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : File type: CA2600.pkg: xar archive compressed TOC: 6995, SHA-1 checksum
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : spctlOut is CA2600.pkg: accepted
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : source=Notarized Developer ID
2024-09-02 15:01:04 : DEBUG : cherryaudioca2600 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:01:05 : INFO  : cherryaudioca2600 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:01:05 : INFO  : cherryaudioca2600 : Checking package version.
2024-09-02 15:01:05 : INFO  : cherryaudioca2600 : Downloaded package com.cherryaudio.pkg.CA2600Package-StandAlone version 1.4.0
2024-09-02 15:01:05 : INFO  : cherryaudioca2600 : Downloaded version of CA2600 is the same as installed.
2024-09-02 15:01:05 : DEBUG : cherryaudioca2600 : DEBUG mode 1, not reopening anything
2024-09-02 15:01:05 : REQ   : cherryaudioca2600 : No new version to install
2024-09-02 15:01:05 : REQ   : cherryaudioca2600 : ################## End Installomator, exit code 0 
