### PR TITLE
Create Cherry Audio Chroma label

### DIFF
--- a/fragments/labels/cherryaudiochroma.sh
+++ b/fragments/labels/cherryaudiochroma.sh
@@ -1,0 +1,9 @@
+cherryaudiochroma)
+    name="Chroma"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.ChromaPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/chroma/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiochroma.sh
+++ b/fragments/labels/cherryaudiochroma.sh
@@ -2,7 +2,6 @@ cherryaudiochroma)
     name="Chroma"
     type="pkg"
     packageID="com.cherryaudio.pkg.ChromaPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/chroma/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiochroma
2024-09-02 15:03:16 : REQ   : cherryaudiochroma : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:03:16 : INFO  : cherryaudiochroma : ################## Version: 10.7beta
2024-09-02 15:03:16 : INFO  : cherryaudiochroma : ################## Date: 2024-09-02
2024-09-02 15:03:16 : INFO  : cherryaudiochroma : ################## cherryaudiochroma
2024-09-02 15:03:16 : DEBUG : cherryaudiochroma : DEBUG mode 1 enabled.
2024-09-02 15:03:16 : INFO  : cherryaudiochroma : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : name=Chroma
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : appName=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : type=pkg
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : archiveName=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : downloadURL=https://store.cherryaudio.com/downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : curlOptions=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : appNewVersion=1.0.9
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : appCustomVersion function: Not defined
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : versionKey=CFBundleShortVersionString
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : packageID=com.cherryaudio.pkg.ChromaPackage-StandAlone
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : pkgName=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : choiceChangesXML=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : expectedTeamID=A2XFV22B2X
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : blockingProcesses=Chroma
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : installerTool=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : CLIInstaller=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : CLIArguments=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : updateTool=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : updateToolArguments=
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : updateToolRunAsCurrentUser=
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : NOTIFY=success
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : LOGGING=DEBUG
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : Label type: pkg
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : archiveName: Chroma.pkg
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : found packageID com.cherryaudio.pkg.ChromaPackage-StandAlone installed, version 1.0.9
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : appversion: 1.0.9
2024-09-02 15:03:17 : INFO  : cherryaudiochroma : Latest version of Chroma is 1.0.9
2024-09-02 15:03:17 : WARN  : cherryaudiochroma : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:03:17 : REQ   : cherryaudiochroma : Downloading https://store.cherryaudio.com/downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg to Chroma.pkg
2024-09-02 15:03:17 : DEBUG : cherryaudiochroma : No Dialog connection, just download
2024-09-02 15:03:22 : DEBUG : cherryaudiochroma : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:03 Chroma.pkg
2024-09-02 15:03:22 : DEBUG : cherryaudiochroma : File type: Chroma.pkg: xar archive compressed TOC: 7170, SHA-1 checksum
2024-09-02 15:03:22 : DEBUG : cherryaudiochroma : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/chroma-macos-installer?file=Chroma-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 39706562
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Chroma-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:03:18 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6ImpDRmJhZ3BXVWl3QmVRalpJRDExVFE9PSIsInZhbHVlIjoiYUFMTDBrb0Rvc3NDcUpDd1JkU3RPTnRXUnFUNDNlaG1iSG80VThRZVlrb0x0dXFtWDlYeWMyZ2FaMGJiZEN4cXlraTZhbUxwdnBDRTFkbFp4WHBKU2pnQTVmd01CZENZMzBadFBPam1YZ1AvSnh2Rzc3eEovY2V5Nk0xVU1XbFEiLCJtYWMiOiJkNWQ4MzI5MmM4ODRmZWM4OTkxMzU5N2ViNzE3NWM3ODBjYWIyMjYzYjVlOWVjN2VjY2E2MGMzZTk4ZGUwNDIxIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:03:18 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6ImlFQXhteVhsdm03VkJDdEpLR3ZNUUE9PSIsInZhbHVlIjoiVXM0S1V5VmhtODJhMFdqMktwdWJqejdZZzdNUm9BSm54WjdCMVJ5UWswUDJldFJ0bjA5MGkrMStmUjJHK1ZLejNPVnp1OENUR2o1T3IvQWNIUXBycnh2U0d5VCt2Y2VFMXFjTE1zTjQ3WlBQWlpxZXlUUVdET0hKOGswL0o1ZE4iLCJtYWMiOiJkYWM0ODBjNWYzMjgwZTFjMzY5MDc1NTczZjU1M2ZjNTgzZGRhMTE4ODkxNGIwNTk1ZWVjMTc5ZTE0ZTcwMzM1IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:03:18 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7012 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:03:22 : DEBUG : cherryaudiochroma : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:03:22 : REQ   : cherryaudiochroma : Installing Chroma
2024-09-02 15:03:22 : INFO  : cherryaudiochroma : Verifying: Chroma.pkg
2024-09-02 15:03:22 : DEBUG : cherryaudiochroma : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:03 Chroma.pkg
2024-09-02 15:03:23 : DEBUG : cherryaudiochroma : File type: Chroma.pkg: xar archive compressed TOC: 7170, SHA-1 checksum
2024-09-02 15:03:23 : DEBUG : cherryaudiochroma : spctlOut is Chroma.pkg: accepted
2024-09-02 15:03:23 : DEBUG : cherryaudiochroma : source=Notarized Developer ID
2024-09-02 15:03:23 : DEBUG : cherryaudiochroma : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:03:23 : INFO  : cherryaudiochroma : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:03:23 : INFO  : cherryaudiochroma : Checking package version.
2024-09-02 15:03:23 : INFO  : cherryaudiochroma : Downloaded package com.cherryaudio.pkg.ChromaPackage-StandAlone version 1.0.9
2024-09-02 15:03:23 : INFO  : cherryaudiochroma : Downloaded version of Chroma is the same as installed.
2024-09-02 15:03:23 : DEBUG : cherryaudiochroma : DEBUG mode 1, not reopening anything
2024-09-02 15:03:23 : REQ   : cherryaudiochroma : No new version to install
2024-09-02 15:03:23 : REQ   : cherryaudiochroma : ################## End Installomator, exit code 0 
