### PR TITLE
Create Cherry Audio CR-78 label

### DIFF
--- a/fragments/labels/cherryaudiocr78.sh
+++ b/fragments/labels/cherryaudiocr78.sh
@@ -1,0 +1,9 @@
+cherryaudiocr78)
+    name="CR-78"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.CR-78Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/cr-78/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiocr78.sh
+++ b/fragments/labels/cherryaudiocr78.sh
@@ -2,7 +2,6 @@ cherryaudiocr78)
     name="CR-78"
     type="pkg"
     packageID="com.cherryaudio.pkg.CR-78Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/cr-78/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiocr78  
2024-09-02 15:04:57 : REQ   : cherryaudiocr78 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:04:57 : INFO  : cherryaudiocr78 : ################## Version: 10.7beta
2024-09-02 15:04:57 : INFO  : cherryaudiocr78 : ################## Date: 2024-09-02
2024-09-02 15:04:57 : INFO  : cherryaudiocr78 : ################## cherryaudiocr78
2024-09-02 15:04:57 : DEBUG : cherryaudiocr78 : DEBUG mode 1 enabled.
2024-09-02 15:04:57 : INFO  : cherryaudiocr78 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:04:57 : DEBUG : cherryaudiocr78 : name=CR-78
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : appName=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : type=pkg
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : archiveName=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : downloadURL=https://store.cherryaudio.com/downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : curlOptions=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : appNewVersion=1.0.11
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : appCustomVersion function: Not defined
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : versionKey=CFBundleShortVersionString
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : packageID=com.cherryaudio.pkg.CR-78Package-StandAlone
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : pkgName=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : choiceChangesXML=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : expectedTeamID=A2XFV22B2X
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : blockingProcesses=CR-78
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : installerTool=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : CLIInstaller=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : CLIArguments=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : updateTool=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : updateToolArguments=
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : updateToolRunAsCurrentUser=
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : NOTIFY=success
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : LOGGING=DEBUG
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : Label type: pkg
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : archiveName: CR-78.pkg
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : found packageID com.cherryaudio.pkg.CR-78Package-StandAlone installed, version 1.0.11
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : appversion: 1.0.11
2024-09-02 15:04:58 : INFO  : cherryaudiocr78 : Latest version of CR-78 is 1.0.11
2024-09-02 15:04:58 : WARN  : cherryaudiocr78 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:04:58 : REQ   : cherryaudiocr78 : Downloading https://store.cherryaudio.com/downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg to CR-78.pkg
2024-09-02 15:04:58 : DEBUG : cherryaudiocr78 : No Dialog connection, just download
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : File list: -rw-r--r--  1 gilburns  staff    68M Sep  2 15:05 CR-78.pkg
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : File type: CR-78.pkg: xar archive compressed TOC: 7166, SHA-1 checksum
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/cr-78-macos-installer?file=CR-78-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 71498104
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="CR-78-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:04:58 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IjdJR0I2cWQ5L3hSUWdDV3ZoYmVDcHc9PSIsInZhbHVlIjoiR3Fpb3RpczNlNXpFRVE2NkJrL1Z1ZW1KUTFGN3NJcVhzZStPSDVHN2k4cW9KUnV0eTlzeitOQng4U0tIdTIvR0VEV3EzUFVzVXhpd1NEdkE1bENzcWFvZ2JvY1h5UDdaT1VPRXE3anFWNk5EUEpBcXMyLzRCRW5zYzJoMDRnR0wiLCJtYWMiOiI3NGUxMjZmODlhYTdjMWI0OTc0N2QzYmE5ZjM3Y2JlODI5ZjczYjhjOWMxYTc1ZmZhOTc4NTA4NzQ3ZTBjOWFkIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:04:58 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IjVKZlFVYXdvbnB4RFZyYVZsaWFidGc9PSIsInZhbHVlIjoibWxndmgxMTBjU2x1MS8vVTgrc1JoU2kycmpZeXpsMXVXL2h6NGtyemw5ZERLRGF4VTVDNm9CbGY4aVJqVHFySmhpSUFSQlZ4Vk5GemRUZjdvNXBmRVhxRGYzL2JQQTZBaTZxZkN5OWVIUXpFS0t4djNxMm83MDUvUzNGM0JvZlQiLCJtYWMiOiJmZjY0ODY0MzZjMTMwMjc5OTQwNjRjYjRiMzE4MjRkOTcwYmUzNzJkMDZlYzUzMDAzMDEzZTI4ZDFiNmJmN2MwIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:04:58 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7013 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:05:07 : REQ   : cherryaudiocr78 : Installing CR-78
2024-09-02 15:05:07 : INFO  : cherryaudiocr78 : Verifying: CR-78.pkg
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : File list: -rw-r--r--  1 gilburns  staff    68M Sep  2 15:05 CR-78.pkg
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : File type: CR-78.pkg: xar archive compressed TOC: 7166, SHA-1 checksum
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : spctlOut is CR-78.pkg: accepted
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : source=Notarized Developer ID
2024-09-02 15:05:07 : DEBUG : cherryaudiocr78 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:05:07 : INFO  : cherryaudiocr78 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:05:07 : INFO  : cherryaudiocr78 : Checking package version.
2024-09-02 15:05:08 : INFO  : cherryaudiocr78 : Downloaded package com.cherryaudio.pkg.CR-78Package-StandAlone version 1.0.11
2024-09-02 15:05:08 : INFO  : cherryaudiocr78 : Downloaded version of CR-78 is the same as installed.
2024-09-02 15:05:08 : DEBUG : cherryaudiocr78 : DEBUG mode 1, not reopening anything
2024-09-02 15:05:08 : REQ   : cherryaudiocr78 : No new version to install
2024-09-02 15:05:08 : REQ   : cherryaudiocr78 : ################## End Installomator, exit code 0 
