### PR TITLE
Create Cherry Audio DCO-106 label

### DIFF
--- a/fragments/labels/cherryaudiodco106.sh
+++ b/fragments/labels/cherryaudiodco106.sh
@@ -1,0 +1,9 @@
+cherryaudiodco106)
+    name="DCO-106"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.DCO106Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/dco-106/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiodco106
2024-09-02 15:06:20 : REQ   : cherryaudiodco106 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:06:20 : INFO  : cherryaudiodco106 : ################## Version: 10.7beta
2024-09-02 15:06:20 : INFO  : cherryaudiodco106 : ################## Date: 2024-09-02
2024-09-02 15:06:20 : INFO  : cherryaudiodco106 : ################## cherryaudiodco106
2024-09-02 15:06:20 : DEBUG : cherryaudiodco106 : DEBUG mode 1 enabled.
2024-09-02 15:06:20 : INFO  : cherryaudiodco106 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : name=DCO-106
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : appName=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : type=pkg
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : archiveName=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : downloadURL=https://store.cherryaudio.com/downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : curlOptions=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : appNewVersion=1.4.0
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : appCustomVersion function: Not defined
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : versionKey=CFBundleShortVersionString
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : packageID=com.cherryaudio.pkg.DCO106Package-StandAlone
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : pkgName=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : choiceChangesXML=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : expectedTeamID=A2XFV22B2X
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : blockingProcesses=DCO-106
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : installerTool=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : CLIInstaller=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : CLIArguments=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : updateTool=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : updateToolArguments=
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : updateToolRunAsCurrentUser=
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : NOTIFY=success
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : LOGGING=DEBUG
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : Label type: pkg
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : archiveName: DCO-106.pkg
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : found packageID com.cherryaudio.pkg.DCO106Package-StandAlone installed, version 1.4.0
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : appversion: 1.4.0
2024-09-02 15:06:21 : INFO  : cherryaudiodco106 : Latest version of DCO-106 is 1.4.0
2024-09-02 15:06:21 : WARN  : cherryaudiodco106 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:06:21 : REQ   : cherryaudiodco106 : Downloading https://store.cherryaudio.com/downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg to DCO-106.pkg
2024-09-02 15:06:21 : DEBUG : cherryaudiodco106 : No Dialog connection, just download
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:06 DCO-106.pkg
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : File type: DCO-106.pkg: xar archive compressed TOC: 6935, SHA-1 checksum
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/dco-106-macos-installer?file=DCO-106-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38404484
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="DCO-106-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:06:21 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IlFHNVFMVlpCYVNaUU5YVXZuM2dWalE9PSIsInZhbHVlIjoiVVQ2dGFIL0xSS3NINS9uK2R6aHhXZitqQ0xPTzNXWHRpZ0pPUGp6M2d5QzZndTduZmtJajhTaEN2L01JcTlnMGZUTGMxQzJzaExPNnNlNytORHhESlJEU3NLVGJRVUx2Y1RBT2xsMU1VL0gwQVVZamYxTmlTRzRDRzIwbERoZkwiLCJtYWMiOiI1NjRmMjZhOGQ1MWUyZmJiMzdiMzM2MWJmNTMyOGE1MmE3MzNmMjZjY2UxNzA1NWJjZWVkMWI2YTQxMTNlNDIyIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:06:21 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IkQvQThkSzBXc01hc1V4WmVRWHFLVEE9PSIsInZhbHVlIjoibnM5SUcvaG9MSXVFUm5XR2d0NnJkcVJSd2cvTEFuMGN6R1dNTHNyaHVPS0xTOHZzb2lnaWtzVTdyalQ3WXVVcWsxVHYwc2xoeFpoa3Fmb3M2U05uVU81UHZFM2l0R3JhTDlLaldHQWJoOThONy9aUVltSUNOVFNnd0ZrQkQ5b2EiLCJtYWMiOiIxN2QxNGZhZWZjM2Q3MDhlYTY0MGMyNDA0MmJlZDdlNmIzNzRkN2FmNWM4YTgzOTEzZjYwNjgyYTVkM2Y1NzU5IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:06:21 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7011 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:06:27 : REQ   : cherryaudiodco106 : Installing DCO-106
2024-09-02 15:06:27 : INFO  : cherryaudiodco106 : Verifying: DCO-106.pkg
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:06 DCO-106.pkg
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : File type: DCO-106.pkg: xar archive compressed TOC: 6935, SHA-1 checksum
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : spctlOut is DCO-106.pkg: accepted
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : source=Notarized Developer ID
2024-09-02 15:06:27 : DEBUG : cherryaudiodco106 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:06:27 : INFO  : cherryaudiodco106 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:06:27 : INFO  : cherryaudiodco106 : Checking package version.
2024-09-02 15:06:28 : INFO  : cherryaudiodco106 : Downloaded package com.cherryaudio.pkg.DCO106Package-StandAlone version 1.4.0
2024-09-02 15:06:28 : INFO  : cherryaudiodco106 : Downloaded version of DCO-106 is the same as installed.
2024-09-02 15:06:28 : DEBUG : cherryaudiodco106 : DEBUG mode 1, not reopening anything
2024-09-02 15:06:28 : REQ   : cherryaudiodco106 : No new version to install
2024-09-02 15:06:28 : REQ   : cherryaudiodco106 : ################## End Installomator, exit code 0 
