### PR TITLE
Create Cherry Audio Elka-X label

### DIFF
--- a/fragments/labels/cherryaudioelkax.sh
+++ b/fragments/labels/cherryaudioelkax.sh
@@ -2,7 +2,6 @@ cherryaudioelkax)
     name="Elka-X"
     type="pkg"
     packageID="com.cherryaudio.pkg.Elka-XPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/elka-x/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudioelkax.sh
+++ b/fragments/labels/cherryaudioelkax.sh
@@ -1,0 +1,9 @@
+cherryaudioelkax)
+    name="Elka-X"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Elka-XPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/elka-x/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudioelkax     
2024-09-02 15:10:33 : REQ   : cherryaudioelkax : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:10:33 : INFO  : cherryaudioelkax : ################## Version: 10.7beta
2024-09-02 15:10:33 : INFO  : cherryaudioelkax : ################## Date: 2024-09-02
2024-09-02 15:10:33 : INFO  : cherryaudioelkax : ################## cherryaudioelkax
2024-09-02 15:10:33 : DEBUG : cherryaudioelkax : DEBUG mode 1 enabled.
2024-09-02 15:10:33 : INFO  : cherryaudioelkax : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : name=Elka-X
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : appName=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : type=pkg
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : archiveName=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : downloadURL=https://store.cherryaudio.com/downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : curlOptions=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : appNewVersion=1.4.0
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : appCustomVersion function: Not defined
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : versionKey=CFBundleShortVersionString
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : packageID=com.cherryaudio.pkg.Elka-XPackage-StandAlone
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : pkgName=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : choiceChangesXML=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : expectedTeamID=A2XFV22B2X
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : blockingProcesses=Elka-X
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : installerTool=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : CLIInstaller=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : CLIArguments=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : updateTool=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : updateToolArguments=
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : updateToolRunAsCurrentUser=
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : NOTIFY=success
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : LOGGING=DEBUG
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : Label type: pkg
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : archiveName: Elka-X.pkg
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : found packageID com.cherryaudio.pkg.Elka-XPackage-StandAlone installed, version 1.4.0
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : appversion: 1.4.0
2024-09-02 15:10:34 : INFO  : cherryaudioelkax : Latest version of Elka-X is 1.4.0
2024-09-02 15:10:34 : WARN  : cherryaudioelkax : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:10:34 : REQ   : cherryaudioelkax : Downloading https://store.cherryaudio.com/downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg to Elka-X.pkg
2024-09-02 15:10:34 : DEBUG : cherryaudioelkax : No Dialog connection, just download
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:10 Elka-X.pkg
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : File type: Elka-X.pkg: xar archive compressed TOC: 6952, SHA-1 checksum, contains 
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : - OpenPGP Secret Key
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/elka-x-macos-installer?file=Elka-X-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38604004
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Elka-X-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:10:35 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6InR4bHArSHBZN05zdnJKaWxRU0IyZ2c9PSIsInZhbHVlIjoibFVLdGpOeEc3N3dUc2tQUWhnY1B4YVVJL000ZlBwRHBwbWpFQVdNRGhHUmJzRTk3NnZNR2dkdmNSZ0VlMDFxeDdtdHJySUV5UU5qWHoyd1dvRmFybFgwc29OWTNjQXB3M0xHbGlqcDMvcmFyM21FRDBYTU41eGlrK2hVaGgwV0IiLCJtYWMiOiIwZWQwMDkxMGMyYTg2NWQ3ZjFiY2FjYTY3ODc1MTE4ZWI5YTczMjRiN2IxMmQ5NjQ5MmIyMjBjY2YyM2I5MjQ4IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:10:35 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IkxTcTFLQSthV3IyRmU4OWQyM2lLTFE9PSIsInZhbHVlIjoiRTV6MTQ0VHlxVmxjbTduMU5UNFphZ0NpRG1XMzlOMkFOdG00MnAwS3duSVBTUmpFa21Ob1N0bzErd0FscmVyVWMvd2dPYnVtS3JMTkoxWDFmd3hhdHh5TWUyRmRCNTRKRjFqYm80MFNUcEJKc0JSc1hnbWtwM2N1dy9nTFhaT3EiLCJtYWMiOiI3MDA3NjYyZjQ1ZDQyYmVmMTUzYjVhMWZlZmI1MjBjN2ZjOTYxMzg5MGI3N2Y4ZjAwY2ZhNmUzN2Y0MWJlOTExIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:10:35 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7012 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:10:40 : REQ   : cherryaudioelkax : Installing Elka-X
2024-09-02 15:10:40 : INFO  : cherryaudioelkax : Verifying: Elka-X.pkg
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:10 Elka-X.pkg
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : File type: Elka-X.pkg: xar archive compressed TOC: 6952, SHA-1 checksum, contains 
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : - OpenPGP Secret Key
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : spctlOut is Elka-X.pkg: accepted
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : source=Notarized Developer ID
2024-09-02 15:10:40 : DEBUG : cherryaudioelkax : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:10:40 : INFO  : cherryaudioelkax : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:10:40 : INFO  : cherryaudioelkax : Checking package version.
2024-09-02 15:10:41 : INFO  : cherryaudioelkax : Downloaded package com.cherryaudio.pkg.Elka-XPackage-StandAlone version 1.4.0
2024-09-02 15:10:41 : INFO  : cherryaudioelkax : Downloaded version of Elka-X is the same as installed.
2024-09-02 15:10:41 : DEBUG : cherryaudioelkax : DEBUG mode 1, not reopening anything
2024-09-02 15:10:41 : REQ   : cherryaudioelkax : No new version to install
2024-09-02 15:10:41 : REQ   : cherryaudioelkax : ################## End Installomator, exit code 0 
