### PR TITLE
Create Cherry Audio Galactic Reverb label

### DIFF
--- a/fragments/labels/cherryaudiogalacticreverb.sh
+++ b/fragments/labels/cherryaudiogalacticreverb.sh
@@ -1,0 +1,9 @@
+cherryaudiogalacticreverb)
+    name="Galactic Reverb"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.GalacticPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/galactic-reverb/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiogalacticreverb.sh
+++ b/fragments/labels/cherryaudiogalacticreverb.sh
@@ -2,7 +2,6 @@ cherryaudiogalacticreverb)
     name="Galactic Reverb"
     type="pkg"
     packageID="com.cherryaudio.pkg.GalacticPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/galactic-reverb/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiogalacticreverb
2024-09-02 15:12:12 : REQ   : cherryaudiogalacticreverb : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:12:12 : INFO  : cherryaudiogalacticreverb : ################## Version: 10.7beta
2024-09-02 15:12:12 : INFO  : cherryaudiogalacticreverb : ################## Date: 2024-09-02
2024-09-02 15:12:12 : INFO  : cherryaudiogalacticreverb : ################## cherryaudiogalacticreverb
2024-09-02 15:12:12 : DEBUG : cherryaudiogalacticreverb : DEBUG mode 1 enabled.
2024-09-02 15:12:12 : INFO  : cherryaudiogalacticreverb : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : name=Galactic Reverb
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : appName=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : type=pkg
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : archiveName=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : downloadURL=https://store.cherryaudio.com/downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : curlOptions=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : appNewVersion=1.4.0
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : appCustomVersion function: Not defined
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : versionKey=CFBundleShortVersionString
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : packageID=com.cherryaudio.pkg.GalacticPackage-StandAlone
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : pkgName=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : choiceChangesXML=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : expectedTeamID=A2XFV22B2X
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : blockingProcesses=Galactic Reverb
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : installerTool=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : CLIInstaller=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : CLIArguments=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : updateTool=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : updateToolArguments=
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : updateToolRunAsCurrentUser=
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : NOTIFY=success
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : LOGGING=DEBUG
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : Label type: pkg
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : archiveName: Galactic Reverb.pkg
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : found packageID com.cherryaudio.pkg.GalacticPackage-StandAlone installed, version 1.4.0
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : appversion: 1.4.0
2024-09-02 15:12:13 : INFO  : cherryaudiogalacticreverb : Latest version of Galactic Reverb is 1.4.0
2024-09-02 15:12:13 : WARN  : cherryaudiogalacticreverb : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:12:13 : REQ   : cherryaudiogalacticreverb : Downloading https://store.cherryaudio.com/downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg to Galactic Reverb.pkg
2024-09-02 15:12:13 : DEBUG : cherryaudiogalacticreverb : No Dialog connection, just download
2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:12 Galactic Reverb.pkg
2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : File type: Galactic Reverb.pkg: xar archive compressed TOC: 6956, SHA-1 checksum
2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/galactic-reverb-macos-installer?file=Galactic-Reverb-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 39120345
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Galactic-Reverb-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:12:13 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6Ik1iSW1CZ0xkY3M3eGI5VnJFaGR4SFE9PSIsInZhbHVlIjoiRk4zVHVKNnVBVGxOeXpQblNpWXlBWXdBZUhUc0VDdlRURGNta0hHcEFhaVVUbFVRZUtrd3llblJlNThpUU9taUgxb28wVmZocm5RZnAxYVRvK2VYRTBhTVlRanpobFRLTjFudG52VzRzdVJVMVR2SmNBa1RrV2FUOUVVZlRkTXMiLCJtYWMiOiJlMjc1MmJmODhlOGIwZGRiYzE5MGU1OGY0NjgyYzE5NDljN2JhMmMzMmQ5MmE3MGM3ZWM0MTliNzM1MDg2YTZmIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:12:13 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Im94SXdXYlJvVExlTmJMakc1UnRWVnc9PSIsInZhbHVlIjoidVF3dUVvZkEwK3lLZkdYUlFLcVJscVpKNHhTU0lvR2Q3Z1NleXdUaXFxbkM2T0hOdmJzUzcvZVFkVW92clZqRkhlVm1JL2ZzOGkvOStNWEExMmFLWDlMcnMzblFJUTdIazFNby9wVmJGNm1lbTNRNVNHWk1wRFRHeDQ5Q0t1UmoiLCJtYWMiOiIzYWZlZjYwNjNlNWJkZTRhMzdkYWFmMTg0ZWVlMWMzYzllYzQwNmNmOWVmYjg5MGNiZGRhYjAxNzVmZTE4ZGMwIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:12:13 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7003 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:12:19 : REQ   : cherryaudiogalacticreverb : Installing Galactic Reverb
2024-09-02 15:12:19 : INFO  : cherryaudiogalacticreverb : Verifying: Galactic Reverb.pkg
2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:12 Galactic Reverb.pkg
2024-09-02 15:12:19 : DEBUG : cherryaudiogalacticreverb : File type: Galactic Reverb.pkg: xar archive compressed TOC: 6956, SHA-1 checksum
2024-09-02 15:12:20 : DEBUG : cherryaudiogalacticreverb : spctlOut is Galactic Reverb.pkg: accepted
2024-09-02 15:12:20 : DEBUG : cherryaudiogalacticreverb : source=Notarized Developer ID
2024-09-02 15:12:20 : DEBUG : cherryaudiogalacticreverb : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:12:20 : INFO  : cherryaudiogalacticreverb : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:12:20 : INFO  : cherryaudiogalacticreverb : Checking package version.
2024-09-02 15:12:20 : INFO  : cherryaudiogalacticreverb : Downloaded package com.cherryaudio.pkg.GalacticPackage-StandAlone version 1.4.0
2024-09-02 15:12:20 : INFO  : cherryaudiogalacticreverb : Downloaded version of Galactic Reverb is the same as installed.
2024-09-02 15:12:20 : DEBUG : cherryaudiogalacticreverb : DEBUG mode 1, not reopening anything
2024-09-02 15:12:20 : REQ   : cherryaudiogalacticreverb : No new version to install
2024-09-02 15:12:20 : REQ   : cherryaudiogalacticreverb : ################## End Installomator, exit code 0 
