### PR TITLE
Create Cherry Audio GX-80 label

### DIFF
--- a/fragments/labels/cherryaudiogx80.sh
+++ b/fragments/labels/cherryaudiogx80.sh
@@ -2,7 +2,6 @@ cherryaudiogx80)
     name="GX-80"
     type="pkg"
     packageID="com.cherryaudio.pkg.GX-80Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/gx-80/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiogx80.sh
+++ b/fragments/labels/cherryaudiogx80.sh
@@ -1,0 +1,9 @@
+cherryaudiogx80)
+    name="GX-80"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.GX-80Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/gx-80/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiogx80          
2024-09-02 15:13:29 : REQ   : cherryaudiogx80 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:13:29 : INFO  : cherryaudiogx80 : ################## Version: 10.7beta
2024-09-02 15:13:29 : INFO  : cherryaudiogx80 : ################## Date: 2024-09-02
2024-09-02 15:13:29 : INFO  : cherryaudiogx80 : ################## cherryaudiogx80
2024-09-02 15:13:29 : DEBUG : cherryaudiogx80 : DEBUG mode 1 enabled.
2024-09-02 15:13:29 : INFO  : cherryaudiogx80 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : name=GX-80
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : appName=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : type=pkg
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : archiveName=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : downloadURL=https://store.cherryaudio.com/downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : curlOptions=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : appNewVersion=1.0.13
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : appCustomVersion function: Not defined
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : versionKey=CFBundleShortVersionString
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : packageID=com.cherryaudio.pkg.GX-80Package-StandAlone
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : pkgName=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : choiceChangesXML=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : expectedTeamID=A2XFV22B2X
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : blockingProcesses=GX-80
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : installerTool=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : CLIInstaller=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : CLIArguments=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : updateTool=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : updateToolArguments=
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : updateToolRunAsCurrentUser=
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : NOTIFY=success
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : LOGGING=DEBUG
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : Label type: pkg
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : archiveName: GX-80.pkg
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : found packageID com.cherryaudio.pkg.GX-80Package-StandAlone installed, version 1.0.13
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : appversion: 1.0.13
2024-09-02 15:13:30 : INFO  : cherryaudiogx80 : Latest version of GX-80 is 1.0.13
2024-09-02 15:13:30 : WARN  : cherryaudiogx80 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:13:30 : REQ   : cherryaudiogx80 : Downloading https://store.cherryaudio.com/downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg to GX-80.pkg
2024-09-02 15:13:30 : DEBUG : cherryaudiogx80 : No Dialog connection, just download
2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:13 GX-80.pkg
2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : File type: GX-80.pkg: xar archive compressed TOC: 6950, SHA-1 checksum, contains  DOS executable (COM, 0x8C-variant)
2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/gx-80-macos-installer?file=GX-80-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38673899
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="GX-80-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:13:30 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IlJYNkVIOWhaSDJ0NFZZZTZEZzNvQWc9PSIsInZhbHVlIjoid0xXMmJweXFRWDBYNnU5WWtsS05LaUtGN0I1YWpaWmZBc3RrVjh5QS9uNFlaWVUzZWJmK0Y0OFhldFc2MitFUXgrWWFmTlVhbGZKc0dVMmdTbk9pajdLMFowQnNTNXlzU2pFUnQ2WUI4N1E1dDJ3VlpDc0psNkZ3a2FaeEp6VjkiLCJtYWMiOiIzNTg3YTM3MjI0Mjg4YjQ1MTMxZWM4NGZjY2UxY2Q5ZTI4NGFlNjIxMDg0OTk4MzYwMmM4ZTEzZjVjNzIxYzMyIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:13:30 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InpJQjFVbmlJYnMrMlhXeldGYTdLTnc9PSIsInZhbHVlIjoiU2JQSWFhTkNmS28xK1dCUWJDUTJxbitTS1NRajR4NmNBMXZqdHhLSm1TSSs2aHlIMTlIWkNheGQ1UUFTeHVKdTA2RTVnSkRnM3pFdGt0Sy9uajlOMXI3M0l3dGR5bEF4a0R0SW1vR1pVOVhxNGp1QzVjZkltZks4aFB4ZDdoSWYiLCJtYWMiOiJiOWE1MjIxZWI4ZGQ0OTZhNzE3MmI4MGY1ZjdlYjQ0ZDZkY2Y3NmVlYTllMTJmZmJlZmI3YjYzMzJkYjVkODhiIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:13:30 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7013 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:13:36 : REQ   : cherryaudiogx80 : Installing GX-80
2024-09-02 15:13:36 : INFO  : cherryaudiogx80 : Verifying: GX-80.pkg
2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:13 GX-80.pkg
2024-09-02 15:13:36 : DEBUG : cherryaudiogx80 : File type: GX-80.pkg: xar archive compressed TOC: 6950, SHA-1 checksum, contains  DOS executable (COM, 0x8C-variant)
2024-09-02 15:13:37 : DEBUG : cherryaudiogx80 : spctlOut is GX-80.pkg: accepted
2024-09-02 15:13:37 : DEBUG : cherryaudiogx80 : source=Notarized Developer ID
2024-09-02 15:13:37 : DEBUG : cherryaudiogx80 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:13:37 : INFO  : cherryaudiogx80 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:13:37 : INFO  : cherryaudiogx80 : Checking package version.
2024-09-02 15:13:37 : INFO  : cherryaudiogx80 : Downloaded package com.cherryaudio.pkg.GX-80Package-StandAlone version 1.0.13
2024-09-02 15:13:37 : INFO  : cherryaudiogx80 : Downloaded version of GX-80 is the same as installed.
2024-09-02 15:13:37 : DEBUG : cherryaudiogx80 : DEBUG mode 1, not reopening anything
2024-09-02 15:13:37 : REQ   : cherryaudiogx80 : No new version to install
2024-09-02 15:13:37 : REQ   : cherryaudiogx80 : ################## End Installomator, exit code 0 
