### PR TITLE
Create Cherry Audio Mercury-4 label

### DIFF
--- a/fragments/labels/cherryaudiomercury4.sh
+++ b/fragments/labels/cherryaudiomercury4.sh
@@ -2,7 +2,6 @@ cherryaudiomercury4)
     name="Mercury-4"
     type="pkg"
     packageID="com.cherryaudio.pkg.Mercury-4Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/mercury-4/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiomercury4.sh
+++ b/fragments/labels/cherryaudiomercury4.sh
@@ -1,0 +1,9 @@
+cherryaudiomercury4)
+    name="Mercury-4"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Mercury-4Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/mercury-4/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiomercury4  
2024-09-02 15:20:03 : REQ   : cherryaudiomercury4 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : ################## Version: 10.7beta
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : ################## Date: 2024-09-02
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : ################## cherryaudiomercury4
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : DEBUG mode 1 enabled.
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : name=Mercury-4
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : appName=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : type=pkg
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : archiveName=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : downloadURL=https://store.cherryaudio.com/downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : curlOptions=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : appNewVersion=1.6.0
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : appCustomVersion function: Not defined
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : versionKey=CFBundleShortVersionString
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : packageID=com.cherryaudio.pkg.Mercury-4Package-StandAlone
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : pkgName=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : choiceChangesXML=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : expectedTeamID=A2XFV22B2X
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : blockingProcesses=Mercury-4
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : installerTool=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : CLIInstaller=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : CLIArguments=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : updateTool=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : updateToolArguments=
2024-09-02 15:20:03 : DEBUG : cherryaudiomercury4 : updateToolRunAsCurrentUser=
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : NOTIFY=success
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : LOGGING=DEBUG
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:20:03 : INFO  : cherryaudiomercury4 : Label type: pkg
2024-09-02 15:20:04 : INFO  : cherryaudiomercury4 : archiveName: Mercury-4.pkg
2024-09-02 15:20:04 : DEBUG : cherryaudiomercury4 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:20:04 : INFO  : cherryaudiomercury4 : found packageID com.cherryaudio.pkg.Mercury-4Package-StandAlone installed, version 1.6.0
2024-09-02 15:20:04 : INFO  : cherryaudiomercury4 : appversion: 1.6.0
2024-09-02 15:20:04 : INFO  : cherryaudiomercury4 : Latest version of Mercury-4 is 1.6.0
2024-09-02 15:20:04 : WARN  : cherryaudiomercury4 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:20:04 : REQ   : cherryaudiomercury4 : Downloading https://store.cherryaudio.com/downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg to Mercury-4.pkg
2024-09-02 15:20:04 : DEBUG : cherryaudiomercury4 : No Dialog connection, just download
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:20 Mercury-4.pkg
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : File type: Mercury-4.pkg: xar archive compressed TOC: 6906, SHA-1 checksum
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/mercury-4-macos-installer?file=Mercury-4-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38630914
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Mercury-4-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:20:04 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IjB2VlFwNnF3U0xDeVlqUFliQXNoaWc9PSIsInZhbHVlIjoibFNueWx0SkdpbUJPNXNxYzZIU0Nmb2p2bW52WUtjNDM4a1JXdkVhdllPNCtSS2tFZXo2SEtpeGc0cHJNSURId2RpaGgvR0ludjYwcWpTczFmdUYycHFhcVV1ZVdZM1kxNG92UVZ6K0VidXM2WW50OXVORTlXSFNZdzg1QzNKTXgiLCJtYWMiOiJkOGM4MzYyYTFjYTJjMWU3YzcwZmQyYzdjM2Q0OTJkOTViNTRmOWY3NjVlNjA1MzBmOGI5YzNkYjM1MThlYmZlIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:20:04 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IjJFMGZuMlpsM3QzWDJEOVhXY3RFc2c9PSIsInZhbHVlIjoiYWVDaHVUY1Z1WTVxeXRFVURTcHR5dFZ1dkRvZW1LS0tRd3JrTzYwbElXZTlvUWVlM1QvSDRFZ3pFTmpQZUtmWm92UlMrR2VubUhQd1lWKzhZVG0xSEVJUkMweG1SWXBRTitaTGNuSWs3NW5FTzVMY0g5Lzl3aHRaN3JXeE0wVEUiLCJtYWMiOiI3MWU0YTg1NmJkYmE4ZWFmYjE3Njg3NWEzNDFiODljNzg1NzY5ZTdjYzFlOTVlY2E4NWM0ZTJjMTU4ZWUzMDA1IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:20:04 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7009 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:20:09 : REQ   : cherryaudiomercury4 : Installing Mercury-4
2024-09-02 15:20:09 : INFO  : cherryaudiomercury4 : Verifying: Mercury-4.pkg
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:20 Mercury-4.pkg
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : File type: Mercury-4.pkg: xar archive compressed TOC: 6906, SHA-1 checksum
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : spctlOut is Mercury-4.pkg: accepted
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : source=Notarized Developer ID
2024-09-02 15:20:09 : DEBUG : cherryaudiomercury4 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:20:09 : INFO  : cherryaudiomercury4 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:20:09 : INFO  : cherryaudiomercury4 : Checking package version.
2024-09-02 15:20:10 : INFO  : cherryaudiomercury4 : Downloaded package com.cherryaudio.pkg.Mercury-4Package-StandAlone version 1.6.0
2024-09-02 15:20:10 : INFO  : cherryaudiomercury4 : Downloaded version of Mercury-4 is the same as installed.
2024-09-02 15:20:10 : DEBUG : cherryaudiomercury4 : DEBUG mode 1, not reopening anything
2024-09-02 15:20:10 : REQ   : cherryaudiomercury4 : No new version to install
2024-09-02 15:20:10 : REQ   : cherryaudiomercury4 : ################## End Installomator, exit code 0 
