### PR TITLE
Create Cherry Audio Mercury-6 label

### DIFF
--- a/fragments/labels/cherryaudiomercury6.sh
+++ b/fragments/labels/cherryaudiomercury6.sh
@@ -2,7 +2,6 @@ cherryaudiomercury6)
     name="Mercury-6"
     type="pkg"
     packageID="com.cherryaudio.pkg.Mercury-6Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/mercury-6/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiomercury6.sh
+++ b/fragments/labels/cherryaudiomercury6.sh
@@ -1,0 +1,9 @@
+cherryaudiomercury6)
+    name="Mercury-6"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Mercury-6Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/mercury-6/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiomercury6
2024-09-02 15:22:45 : REQ   : cherryaudiomercury6 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : ################## Version: 10.7beta
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : ################## Date: 2024-09-02
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : ################## cherryaudiomercury6
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : DEBUG mode 1 enabled.
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : name=Mercury-6
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : appName=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : type=pkg
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : archiveName=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : downloadURL=https://store.cherryaudio.com/downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : curlOptions=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : appNewVersion=1.0.5
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : appCustomVersion function: Not defined
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : versionKey=CFBundleShortVersionString
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : packageID=com.cherryaudio.pkg.Mercury-6Package-StandAlone
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : pkgName=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : choiceChangesXML=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : expectedTeamID=A2XFV22B2X
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : blockingProcesses=Mercury-6
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : installerTool=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : CLIInstaller=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : CLIArguments=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : updateTool=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : updateToolArguments=
2024-09-02 15:22:45 : DEBUG : cherryaudiomercury6 : updateToolRunAsCurrentUser=
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : NOTIFY=success
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : LOGGING=DEBUG
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:22:45 : INFO  : cherryaudiomercury6 : Label type: pkg
2024-09-02 15:22:46 : INFO  : cherryaudiomercury6 : archiveName: Mercury-6.pkg
2024-09-02 15:22:46 : DEBUG : cherryaudiomercury6 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:22:46 : INFO  : cherryaudiomercury6 : found packageID com.cherryaudio.pkg.Mercury-6Package-StandAlone installed, version 1.0.5
2024-09-02 15:22:46 : INFO  : cherryaudiomercury6 : appversion: 1.0.5
2024-09-02 15:22:46 : INFO  : cherryaudiomercury6 : Latest version of Mercury-6 is 1.0.5
2024-09-02 15:22:46 : WARN  : cherryaudiomercury6 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:22:46 : REQ   : cherryaudiomercury6 : Downloading https://store.cherryaudio.com/downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg to Mercury-6.pkg
2024-09-02 15:22:46 : DEBUG : cherryaudiomercury6 : No Dialog connection, just download
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:22 Mercury-6.pkg
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : File type: Mercury-6.pkg: xar archive compressed TOC: 7020, SHA-1 checksum
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/mercury-6-macos-installer?file=Mercury-6-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38761297
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Mercury-6-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:22:46 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IitDVnNndVpDVGtVMnF0eHdDWHpSMnc9PSIsInZhbHVlIjoiRjlQZGd1Y0JZTVZFYXBZR1ZnbmZvU3ltbUhQY3BjNFEyMS9GQkphQk01Y1dWdlViT1JWRklZaHl2YjZPSnptVGcrM0k1RzZ1eGxWZy9pamdoVGk0Wm9lR3BkaHJHTDhsMEhMdUE2VU02Z3hYM1FmYm5POE9kS0JSTnFoeEZIUGEiLCJtYWMiOiIzZDhjOWFjMTQ3ZmExZjc2ZDJmMjZmOTlkZjBiOTU5YzVmYjg1NzMyZGQ3ZWYzOGRjMjBiMjg1NDdjNjMwYzBjIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:22:46 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IlAxU2ptNVAxejdick04bVpScFlrUFE9PSIsInZhbHVlIjoiSDJzWnJMekpMTEdmZEFlNUQ3bElhT28wOEdESmpROWd2NzVndE9qaHo2WUFURUpmSFlRSm1KQW1qZ2FJRTJWTVk0VHZGbDVHRUk0c0YzRUlSUkUwWUhhS0J0dkxkTWZlY1dsYUZINEM4VWZrYnlRTHYxMHY5SXlQRUprTHBiRnMiLCJtYWMiOiIwN2YzMTg1NjQxZDhlYmMzYTA0NzAwNDM3Y2FiYjNhMTlhNTc0ODg4YmJhMGIzMWJhMzQyNDM0MjliNjQ1ZDA1IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:22:46 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7009 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:22:51 : REQ   : cherryaudiomercury6 : Installing Mercury-6
2024-09-02 15:22:51 : INFO  : cherryaudiomercury6 : Verifying: Mercury-6.pkg
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:22 Mercury-6.pkg
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : File type: Mercury-6.pkg: xar archive compressed TOC: 7020, SHA-1 checksum
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : spctlOut is Mercury-6.pkg: accepted
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : source=Notarized Developer ID
2024-09-02 15:22:51 : DEBUG : cherryaudiomercury6 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:22:51 : INFO  : cherryaudiomercury6 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:22:51 : INFO  : cherryaudiomercury6 : Checking package version.
2024-09-02 15:22:52 : INFO  : cherryaudiomercury6 : Downloaded package com.cherryaudio.pkg.Mercury-6Package-StandAlone version 1.0.5
2024-09-02 15:22:52 : INFO  : cherryaudiomercury6 : Downloaded version of Mercury-6 is the same as installed.
2024-09-02 15:22:52 : DEBUG : cherryaudiomercury6 : DEBUG mode 1, not reopening anything
2024-09-02 15:22:52 : REQ   : cherryaudiomercury6 : No new version to install
2024-09-02 15:22:52 : REQ   : cherryaudiomercury6 : ################## End Installomator, exit code 0 
