### PR TITLE
Create Cherry Audio Voltage Module Designer label

### DIFF
--- a/fragments/labels/cherryaudiomoduledesigner.sh
+++ b/fragments/labels/cherryaudiomoduledesigner.sh
@@ -2,7 +2,6 @@ cherryaudiomoduledesigner)
     name="Voltage Module Designer"
     type="pkg"
     packageID="com.cherryaudio.pkg.VoltageModuleDesigner"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/voltage-module-designer/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiomoduledesigner.sh
+++ b/fragments/labels/cherryaudiomoduledesigner.sh
@@ -1,0 +1,9 @@
+cherryaudiomoduledesigner)
+    name="Voltage Module Designer"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.VoltageModuleDesigner"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/voltage-module-designer/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiomoduledesigner
2024-09-02 15:25:30 : REQ   : cherryaudiomoduledesigner : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:25:30 : INFO  : cherryaudiomoduledesigner : ################## Version: 10.7beta
2024-09-02 15:25:30 : INFO  : cherryaudiomoduledesigner : ################## Date: 2024-09-02
2024-09-02 15:25:30 : INFO  : cherryaudiomoduledesigner : ################## cherryaudiomoduledesigner
2024-09-02 15:25:30 : DEBUG : cherryaudiomoduledesigner : DEBUG mode 1 enabled.
2024-09-02 15:25:30 : INFO  : cherryaudiomoduledesigner : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : name=Voltage Module Designer
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : appName=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : type=pkg
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : archiveName=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : downloadURL=https://store.cherryaudio.com/module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : curlOptions=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : appNewVersion=2.9.2
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : appCustomVersion function: Not defined
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : versionKey=CFBundleShortVersionString
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : packageID=com.cherryaudio.pkg.VoltageModuleDesigner
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : pkgName=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : choiceChangesXML=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : expectedTeamID=A2XFV22B2X
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : blockingProcesses=Voltage Module Designer
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : installerTool=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : CLIInstaller=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : CLIArguments=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : updateTool=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : updateToolArguments=
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : updateToolRunAsCurrentUser=
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : NOTIFY=success
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : LOGGING=DEBUG
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : Label type: pkg
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : archiveName: Voltage Module Designer.pkg
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : found packageID com.cherryaudio.pkg.VoltageModuleDesigner installed, version 2.9.2
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : appversion: 2.9.2
2024-09-02 15:25:31 : INFO  : cherryaudiomoduledesigner : Latest version of Voltage Module Designer is 2.9.2
2024-09-02 15:25:31 : WARN  : cherryaudiomoduledesigner : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:25:31 : REQ   : cherryaudiomoduledesigner : Downloading https://store.cherryaudio.com/module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg to Voltage Module Designer.pkg
2024-09-02 15:25:31 : DEBUG : cherryaudiomoduledesigner : No Dialog connection, just download
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : File list: -rw-r--r--  1 gilburns  staff    17M Sep  2 15:25 Voltage Module Designer.pkg
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : File type: Voltage Module Designer.pkg: xar archive compressed TOC: 5864, SHA-1 checksum
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /module-designer-mac/download?file=Voltage-Module-Designer-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 17744515
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Voltage-Module-Designer-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:25:32 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IlNUZDYzY1BOMUN4MFVTb3gweUFBWlE9PSIsInZhbHVlIjoiM0NnWnVlLytLMCtEb1hjMVdKSVAyT3NYanRLRDA0OVV0RnE0N1FRMzZ4SUMwWENQb3ZKTnBranpEc3FsQlY3aGtFT3YvSVdwRzdKaWxnUFMvZlpycHdpRUVIWGkvamJ5R2Z5UHYrY1JzNG54VDhESWhwVjhUNHZTWjNDWUNlaE8iLCJtYWMiOiJlOGRkNmM5MTllM2VkN2Q1MDRjZDg5ZDY5NWY4MmE1YTU0Y2Q2YTg3ZjBiY2I3ZGM1ODA1OTVkNjYyZjMxOGUwIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:25:32 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InR6Q3h4VytMODRnd2MyTGg0VWFJMkE9PSIsInZhbHVlIjoicGNsMEFKZ25FRkhhc2ZWWWhEUlBBTlNVZGg0MGFKeE0xVkRyZ2F6eVIvUkk0cms1cTRmMElZM0FYRVU1V2dNbEkwWm5aVE9rck9PRHBKN2xDenpZdkJSa1IxRFBqVW5VN1grRXlJOHZRRlp0Z0FsKzVpNEg4cFFDZDRBRVdCMFkiLCJtYWMiOiI0NzJjMTFiN2I0YTYzYmY3ODg3NTRkNjM1ODViZTM5NjMxMjc3NWJmZTVhMzBlMjVjMTllNDdiNTk0M2UxM2FhIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:25:32 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [6995 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:25:34 : REQ   : cherryaudiomoduledesigner : Installing Voltage Module Designer
2024-09-02 15:25:34 : INFO  : cherryaudiomoduledesigner : Verifying: Voltage Module Designer.pkg
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : File list: -rw-r--r--  1 gilburns  staff    17M Sep  2 15:25 Voltage Module Designer.pkg
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : File type: Voltage Module Designer.pkg: xar archive compressed TOC: 5864, SHA-1 checksum
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : spctlOut is Voltage Module Designer.pkg: accepted
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : source=Notarized Developer ID
2024-09-02 15:25:34 : DEBUG : cherryaudiomoduledesigner : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:25:34 : INFO  : cherryaudiomoduledesigner : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:25:34 : INFO  : cherryaudiomoduledesigner : Checking package version.
2024-09-02 15:25:35 : INFO  : cherryaudiomoduledesigner : Downloaded package com.cherryaudio.pkg.VoltageModuleDesigner version 2.9.2
2024-09-02 15:25:35 : INFO  : cherryaudiomoduledesigner : Downloaded version of Voltage Module Designer is the same as installed.
2024-09-02 15:25:35 : DEBUG : cherryaudiomoduledesigner : DEBUG mode 1, not reopening anything
2024-09-02 15:25:35 : REQ   : cherryaudiomoduledesigner : No new version to install
2024-09-02 15:25:35 : REQ   : cherryaudiomoduledesigner : ################## End Installomator, exit code 0 
