### PR TITLE
Create Cherry Audio Novachord label

### DIFF
--- a/fragments/labels/cherryaudionovachord.sh
+++ b/fragments/labels/cherryaudionovachord.sh
@@ -2,7 +2,6 @@ cherryaudionovachord)
     name="Novachord"
     type="pkg"
     packageID="com.cherryaudio.pkg.NovachordPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/novachord-solovox/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudionovachord.sh
+++ b/fragments/labels/cherryaudionovachord.sh
@@ -1,0 +1,9 @@
+cherryaudionovachord)
+    name="Novachord"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.NovachordPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/novachord-solovox/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudionovachord     
2024-09-02 15:27:08 : REQ   : cherryaudionovachord : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:27:08 : INFO  : cherryaudionovachord : ################## Version: 10.7beta
2024-09-02 15:27:08 : INFO  : cherryaudionovachord : ################## Date: 2024-09-02
2024-09-02 15:27:08 : INFO  : cherryaudionovachord : ################## cherryaudionovachord
2024-09-02 15:27:08 : DEBUG : cherryaudionovachord : DEBUG mode 1 enabled.
2024-09-02 15:27:08 : INFO  : cherryaudionovachord : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : name=Novachord
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : appName=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : type=pkg
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : archiveName=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : downloadURL=https://store.cherryaudio.com/downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : curlOptions=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : appNewVersion=1.0.2
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : appCustomVersion function: Not defined
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : versionKey=CFBundleShortVersionString
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : packageID=com.cherryaudio.pkg.NovachordPackage-StandAlone
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : pkgName=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : choiceChangesXML=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : expectedTeamID=A2XFV22B2X
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : blockingProcesses=Novachord
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : installerTool=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : CLIInstaller=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : CLIArguments=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : updateTool=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : updateToolArguments=
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : updateToolRunAsCurrentUser=
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : NOTIFY=success
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : LOGGING=DEBUG
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : Label type: pkg
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : archiveName: Novachord.pkg
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : found packageID com.cherryaudio.pkg.NovachordPackage-StandAlone installed, version 1.0.2
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : appversion: 1.0.2
2024-09-02 15:27:09 : INFO  : cherryaudionovachord : Latest version of Novachord is 1.0.2
2024-09-02 15:27:09 : WARN  : cherryaudionovachord : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:27:09 : REQ   : cherryaudionovachord : Downloading https://store.cherryaudio.com/downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg to Novachord.pkg
2024-09-02 15:27:09 : DEBUG : cherryaudionovachord : No Dialog connection, just download
2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:27 Novachord.pkg
2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : File type: Novachord.pkg: xar archive compressed TOC: 7031, SHA-1 checksum
2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/novachord-macos-installer?file=Novachord-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38941804
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Novachord-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:27:10 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IlVQaWw4MzdkY1U2M1F1dFRpWTcvcmc9PSIsInZhbHVlIjoiOHV1OXF2NWtQMVNWU254bzZDdWRwTndoMGZrcnhUbzVCZ2VsdmN5eUQrUktaN0c3dHorVlUrcmpaRVhSZ090QldNV1Z5WlZoa1dXV1JwbUdIM1JYL0JsbXNtVjBxWGkvUGVTMEI4V012a3o5TWZyTEo1am9hSVFVNU5XOEhTZXgiLCJtYWMiOiJlYzA4MjE5OTIwYjdiZDRkOTFjZGMwNjI3YTA5OWI0NDUyYjExNWYzMWNmY2ZhYmU2YjY5MTA3NDU4ZjQwMDdlIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:27:10 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InBSdkZYZ0lYUDc4eEVkV0l3OXR2YVE9PSIsInZhbHVlIjoiRnN2Rng3SUQ5ZGRQSzVyRy9TWlY4RWxkTlAwZFN5eTNCQnN4d0pkZCtDNk45VmlZQzRvNndTZ2ZydjV1cm9aYnJjRDBjT0hqQVN5QzQ1ZXd6YWlmSTQ5Z2pPR1RqT1I4aS9GR0kwbHhxQWM1RGNVZ3JJWmRwYzZBWnFQVlNvSVoiLCJtYWMiOiIwMWE5YzZkMzFjNGJkMTE1MDFkMWE0MWMzZDNlNjFhYjBkNWU3NDc0MTBmYmY5ZDU3YmUwNTdmYWM4OWJiNjc1IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:27:10 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7009 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:27:14 : REQ   : cherryaudionovachord : Installing Novachord
2024-09-02 15:27:14 : INFO  : cherryaudionovachord : Verifying: Novachord.pkg
2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:27 Novachord.pkg
2024-09-02 15:27:14 : DEBUG : cherryaudionovachord : File type: Novachord.pkg: xar archive compressed TOC: 7031, SHA-1 checksum
2024-09-02 15:27:15 : DEBUG : cherryaudionovachord : spctlOut is Novachord.pkg: accepted
2024-09-02 15:27:15 : DEBUG : cherryaudionovachord : source=Notarized Developer ID
2024-09-02 15:27:15 : DEBUG : cherryaudionovachord : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:27:15 : INFO  : cherryaudionovachord : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:27:15 : INFO  : cherryaudionovachord : Checking package version.
2024-09-02 15:27:15 : INFO  : cherryaudionovachord : Downloaded package com.cherryaudio.pkg.NovachordPackage-StandAlone version 1.0.2
2024-09-02 15:27:15 : INFO  : cherryaudionovachord : Downloaded version of Novachord is the same as installed.
2024-09-02 15:27:15 : DEBUG : cherryaudionovachord : DEBUG mode 1, not reopening anything
2024-09-02 15:27:15 : REQ   : cherryaudionovachord : No new version to install
2024-09-02 15:27:15 : REQ   : cherryaudionovachord : ################## End Installomator, exit code 0 
