### PR TITLE
Create Cherry Audio Octave Cat label

### DIFF
--- a/fragments/labels/cherryaudiooctavecat.sh
+++ b/fragments/labels/cherryaudiooctavecat.sh
@@ -1,0 +1,9 @@
+cherryaudiooctavecat)
+    name="Octave Cat"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.OctaveCatPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/octave-cat/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiooctavecat.sh
+++ b/fragments/labels/cherryaudiooctavecat.sh
@@ -2,7 +2,6 @@ cherryaudiooctavecat)
     name="Octave Cat"
     type="pkg"
     packageID="com.cherryaudio.pkg.OctaveCatPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/octave-cat/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiooctavecat
2024-09-02 15:28:09 : REQ   : cherryaudiooctavecat : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:28:09 : INFO  : cherryaudiooctavecat : ################## Version: 10.7beta
2024-09-02 15:28:09 : INFO  : cherryaudiooctavecat : ################## Date: 2024-09-02
2024-09-02 15:28:09 : INFO  : cherryaudiooctavecat : ################## cherryaudiooctavecat
2024-09-02 15:28:09 : DEBUG : cherryaudiooctavecat : DEBUG mode 1 enabled.
2024-09-02 15:28:09 : INFO  : cherryaudiooctavecat : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : name=Octave Cat
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : appName=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : type=pkg
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : archiveName=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : downloadURL=https://store.cherryaudio.com/downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : curlOptions=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : appNewVersion=1.0.2
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : appCustomVersion function: Not defined
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : versionKey=CFBundleShortVersionString
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : packageID=com.cherryaudio.pkg.OctaveCatPackage-StandAlone
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : pkgName=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : choiceChangesXML=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : expectedTeamID=A2XFV22B2X
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : blockingProcesses=Octave Cat
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : installerTool=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : CLIInstaller=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : CLIArguments=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : updateTool=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : updateToolArguments=
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : updateToolRunAsCurrentUser=
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : NOTIFY=success
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : LOGGING=DEBUG
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : Label type: pkg
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : archiveName: Octave Cat.pkg
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : found packageID com.cherryaudio.pkg.OctaveCatPackage-StandAlone installed, version 1.0.2
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : appversion: 1.0.2
2024-09-02 15:28:10 : INFO  : cherryaudiooctavecat : Latest version of Octave Cat is 1.0.2
2024-09-02 15:28:10 : WARN  : cherryaudiooctavecat : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:28:10 : REQ   : cherryaudiooctavecat : Downloading https://store.cherryaudio.com/downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg to Octave Cat.pkg
2024-09-02 15:28:10 : DEBUG : cherryaudiooctavecat : No Dialog connection, just download
2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:28 Octave Cat.pkg
2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : File type: Octave Cat.pkg: xar archive compressed TOC: 7054, SHA-1 checksum
2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/octave-cat-macos-installer?file=Octave-Cat-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38850407
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Octave-Cat-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:28:10 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IjlMTElpSmsxR3VpZWZ4Q0EwOTdpZEE9PSIsInZhbHVlIjoiSUkxYzF5dFBwWUczaGhldkRhMjg5eDBBY2IrMzcySkhSZ1A4V1ZaTEJiQzhpR29xT2N2OHYvYU9uNVJOMXZ4RmpzQ3hjSDN5bE5hdEptMHROS3Y0aVJGTVprcVBvYXpmTFNUZGI3d2FqMHphbVVoOTRKVkVIeW44aHNJeCtjcGciLCJtYWMiOiJlZDVhNTY5MDc3YWQyZDg4ZjY0MGJkYjkzZjUyNzJjNDQ0YjYzMmYzN2RhZDEwMzU2MmU5ZTJhNGRlN2IzYWNiIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:28:10 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6ImJFY21jSDFRTGUrNFpTeTZrSGlxWlE9PSIsInZhbHVlIjoiK1FLR096T2RhRGJzeklBWDZGT25sWDlLQ2FlV0xNVU1kbHBFbmZRdUl5dVZZdzNDdlRCZ3l6aDFRY1hGRExBRWJjRThxekVjdGhDUFl6NkYybk5KbTdvaGk1ZTZEa0VZT2NESU1vRVpabkhqRk0wUHg2N05RdVhvZndjNThNbjIiLCJtYWMiOiI1YjMwOTRhOTQ2YjY3OTU1OWJlZTQ5OTM3ZGQ4Y2I0YTg4YTcwOTk3OTY5MDNhZmFiMjE0MmZkODdhYWZmZDZhIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:28:10 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7008 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:28:23 : REQ   : cherryaudiooctavecat : Installing Octave Cat
2024-09-02 15:28:23 : INFO  : cherryaudiooctavecat : Verifying: Octave Cat.pkg
2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:28 Octave Cat.pkg
2024-09-02 15:28:23 : DEBUG : cherryaudiooctavecat : File type: Octave Cat.pkg: xar archive compressed TOC: 7054, SHA-1 checksum
2024-09-02 15:28:24 : DEBUG : cherryaudiooctavecat : spctlOut is Octave Cat.pkg: accepted
2024-09-02 15:28:24 : DEBUG : cherryaudiooctavecat : source=Notarized Developer ID
2024-09-02 15:28:24 : DEBUG : cherryaudiooctavecat : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:28:24 : INFO  : cherryaudiooctavecat : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:28:24 : INFO  : cherryaudiooctavecat : Checking package version.
2024-09-02 15:28:24 : INFO  : cherryaudiooctavecat : Downloaded package com.cherryaudio.pkg.OctaveCatPackage-StandAlone version 1.0.2
2024-09-02 15:28:24 : INFO  : cherryaudiooctavecat : Downloaded version of Octave Cat is the same as installed.
2024-09-02 15:28:24 : DEBUG : cherryaudiooctavecat : DEBUG mode 1, not reopening anything
2024-09-02 15:28:24 : REQ   : cherryaudiooctavecat : No new version to install
2024-09-02 15:28:24 : REQ   : cherryaudiooctavecat : ################## End Installomator, exit code 0 
