### PR TITLE
Create Cherry Audio Pro Soloist label

### DIFF
--- a/fragments/labels/cherryaudioprosoloist.sh
+++ b/fragments/labels/cherryaudioprosoloist.sh
@@ -1,0 +1,9 @@
+cherryaudioprosoloist)
+    name="Pro Soloist"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.ProSoloistPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/pro-soloist/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudioprosoloist.sh
+++ b/fragments/labels/cherryaudioprosoloist.sh
@@ -2,7 +2,6 @@ cherryaudioprosoloist)
     name="Pro Soloist"
     type="pkg"
     packageID="com.cherryaudio.pkg.ProSoloistPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/pro-soloist/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudioprosoloist
2024-09-02 15:31:00 : REQ   : cherryaudioprosoloist : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:31:00 : INFO  : cherryaudioprosoloist : ################## Version: 10.7beta
2024-09-02 15:31:00 : INFO  : cherryaudioprosoloist : ################## Date: 2024-09-02
2024-09-02 15:31:00 : INFO  : cherryaudioprosoloist : ################## cherryaudioprosoloist
2024-09-02 15:31:00 : DEBUG : cherryaudioprosoloist : DEBUG mode 1 enabled.
2024-09-02 15:31:00 : INFO  : cherryaudioprosoloist : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : name=Pro Soloist
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : appName=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : type=pkg
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : archiveName=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : downloadURL=https://store.cherryaudio.com/downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : curlOptions=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : appNewVersion=1.0.4
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : appCustomVersion function: Not defined
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : versionKey=CFBundleShortVersionString
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : packageID=com.cherryaudio.pkg.ProSoloistPackage-StandAlone
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : pkgName=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : choiceChangesXML=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : expectedTeamID=A2XFV22B2X
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : blockingProcesses=Pro Soloist
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : installerTool=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : CLIInstaller=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : CLIArguments=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : updateTool=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : updateToolArguments=
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : updateToolRunAsCurrentUser=
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : NOTIFY=success
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : LOGGING=DEBUG
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : Label type: pkg
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : archiveName: Pro Soloist.pkg
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : found packageID com.cherryaudio.pkg.ProSoloistPackage-StandAlone installed, version 1.0.4
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : appversion: 1.0.4
2024-09-02 15:31:01 : INFO  : cherryaudioprosoloist : Latest version of Pro Soloist is 1.0.4
2024-09-02 15:31:01 : WARN  : cherryaudioprosoloist : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:31:01 : REQ   : cherryaudioprosoloist : Downloading https://store.cherryaudio.com/downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg to Pro Soloist.pkg
2024-09-02 15:31:01 : DEBUG : cherryaudioprosoloist : No Dialog connection, just download
2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:31 Pro Soloist.pkg
2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : File type: Pro Soloist.pkg: xar archive compressed TOC: 7039, SHA-1 checksum
2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/pro-soloist-macos-installer?file=Pro-Soloist-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 39598575
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Pro-Soloist-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:31:01 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IjhYdUhiengveEZvT3hCRzBtNittOXc9PSIsInZhbHVlIjoidithWGdTNk5VSmJnak83eVZxcEFBVFNlVXlJYnY2ZmJHSE5qUGFpZituV0F2ZklOWVFrZy81NUtzSXQ2blJ3S2I2bFdEWmpSbXlCbld3WjVqdUU1UGxhSkkrb09WMXZ4NzQxd0VZR04xM2hlcW9LY1A0OXJQYjUySzh6WUhPbGIiLCJtYWMiOiJkYWQwNmYzNTAwODFmYmFhMDYzNGY2YzU3YzQ4ODc4YjY0MmZmN2NiNGY3MjI4ZjA1Yzc2YjFkOWNhNTVmNGFkIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:31:01 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InNrbzlWNk5KTk9MajRhZEs5R0RjOVE9PSIsInZhbHVlIjoibTJtdWQ4cjJXZEJKWVN6M2dvN1kyaTl0clRyOWxkK25IcmFybmkxT2t2UC8wN0tsTGV3YzM2cjk0OTVHRzZKVWYzV0xTQ1RINjh2QmxTQUs2SVh5MlJjNjFYZkdoWXhPS3VQaGVMd1JqY01SUnhtVWlQLzVxR0U2Tm5PcFRTem8iLCJtYWMiOiJjMjBlYzE4ZDBlZTZiMWZiZDliNjhjN2M5ZTI5MDk1MTY3ZTc5ODA0OWU5ZjkzNDlhYmJlMjQxODIxMzI3NmE4IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:31:01 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7007 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:31:08 : REQ   : cherryaudioprosoloist : Installing Pro Soloist
2024-09-02 15:31:08 : INFO  : cherryaudioprosoloist : Verifying: Pro Soloist.pkg
2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:31 Pro Soloist.pkg
2024-09-02 15:31:08 : DEBUG : cherryaudioprosoloist : File type: Pro Soloist.pkg: xar archive compressed TOC: 7039, SHA-1 checksum
2024-09-02 15:31:09 : DEBUG : cherryaudioprosoloist : spctlOut is Pro Soloist.pkg: accepted
2024-09-02 15:31:09 : DEBUG : cherryaudioprosoloist : source=Notarized Developer ID
2024-09-02 15:31:09 : DEBUG : cherryaudioprosoloist : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:31:09 : INFO  : cherryaudioprosoloist : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:31:09 : INFO  : cherryaudioprosoloist : Checking package version.
2024-09-02 15:31:09 : INFO  : cherryaudioprosoloist : Downloaded package com.cherryaudio.pkg.ProSoloistPackage-StandAlone version 1.0.4
2024-09-02 15:31:09 : INFO  : cherryaudioprosoloist : Downloaded version of Pro Soloist is the same as installed.
2024-09-02 15:31:09 : DEBUG : cherryaudioprosoloist : DEBUG mode 1, not reopening anything
2024-09-02 15:31:09 : REQ   : cherryaudioprosoloist : No new version to install
2024-09-02 15:31:09 : REQ   : cherryaudioprosoloist : ################## End Installomator, exit code 0 
