### PR TITLE
Create Cherry Audio PS-20 label

### DIFF
--- a/fragments/labels/cherryaudiops20.sh
+++ b/fragments/labels/cherryaudiops20.sh
@@ -1,0 +1,9 @@
+cherryaudiops20)
+    name="PS-20"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.PS-20Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/ps-20/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiops20      
2024-09-02 15:32:14 : REQ   : cherryaudiops20 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:32:14 : INFO  : cherryaudiops20 : ################## Version: 10.7beta
2024-09-02 15:32:14 : INFO  : cherryaudiops20 : ################## Date: 2024-09-02
2024-09-02 15:32:14 : INFO  : cherryaudiops20 : ################## cherryaudiops20
2024-09-02 15:32:14 : DEBUG : cherryaudiops20 : DEBUG mode 1 enabled.
2024-09-02 15:32:14 : INFO  : cherryaudiops20 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : name=PS-20
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : appName=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : type=pkg
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : archiveName=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : downloadURL=https://store.cherryaudio.com/downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : curlOptions=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : appNewVersion=1.4.0
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : appCustomVersion function: Not defined
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : versionKey=CFBundleShortVersionString
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : packageID=com.cherryaudio.pkg.PS-20Package-StandAlone
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : pkgName=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : choiceChangesXML=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : expectedTeamID=A2XFV22B2X
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : blockingProcesses=PS-20
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : installerTool=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : CLIInstaller=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : CLIArguments=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : updateTool=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : updateToolArguments=
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : updateToolRunAsCurrentUser=
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : NOTIFY=success
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : LOGGING=DEBUG
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : Label type: pkg
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : archiveName: PS-20.pkg
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : found packageID com.cherryaudio.pkg.PS-20Package-StandAlone installed, version 1.4.0
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : appversion: 1.4.0
2024-09-02 15:32:15 : INFO  : cherryaudiops20 : Latest version of PS-20 is 1.4.0
2024-09-02 15:32:15 : WARN  : cherryaudiops20 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:32:15 : REQ   : cherryaudiops20 : Downloading https://store.cherryaudio.com/downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg to PS-20.pkg
2024-09-02 15:32:15 : DEBUG : cherryaudiops20 : No Dialog connection, just download
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:32 PS-20.pkg
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : File type: PS-20.pkg: xar archive compressed TOC: 7005, SHA-1 checksum
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/ps-20-macos-installer?file=PS-20-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 69167322
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="PS-20-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:32:15 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6InBwS2dNQzB5M3VLa0lCTlhoZzhtZHc9PSIsInZhbHVlIjoiL2VUSDN6QmlCRHBpWHA0US9ZbExsMWY4TVB4Q0h0dUt6NTduQlErRUk4TlpycVFoUHIvZHlMcVFCT0xobzJsYlZYQ0ZBT0xqNGJFb0lMZzdHOUdYMnBvVVZaRXh6RGY4bUpKOTIvTXJ3MThjV09ReWFFOTFyQ1JyRlE3MXdOOUoiLCJtYWMiOiI0ZGExNDc1ZmI2YWZlNTQ0OWQ5MjlhNzM5YmVhYWZlZmFiZjk5ZGE5OTY0MjAwNmM4M2Q4NzcwMDkzMjg4OWQ0IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:32:15 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Ii8yeVBoNzlXWTQ4T2dSSzJKdFUwd0E9PSIsInZhbHVlIjoiTVozbkFQQllmcG54Q2o5NVNsdWNPV1RhOS9Gdmw5cExwRVQwbFZFOWtTS2RGc1k4N21JaDJ5TXBpb0lwYWs2TlVtRmhYRkhqZm00a3JGQ3JjNlZlMlVjUG96cFl6RzlOWkRNNmFMSU44dm83UG5UakRxRVNxeHlyUGRGUnVGYVIiLCJtYWMiOiJkNDU4ZjA4YThiMGQyYTVjNTQ4NjE4NmU1YzliZjIwMjVmZjU4MTYyN2Q5ZjAxMWE0YzAzMTZiYzYyODY4N2MzIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:32:15 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7013 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:32:24 : REQ   : cherryaudiops20 : Installing PS-20
2024-09-02 15:32:24 : INFO  : cherryaudiops20 : Verifying: PS-20.pkg
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:32 PS-20.pkg
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : File type: PS-20.pkg: xar archive compressed TOC: 7005, SHA-1 checksum
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : spctlOut is PS-20.pkg: accepted
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : source=Notarized Developer ID
2024-09-02 15:32:24 : DEBUG : cherryaudiops20 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:32:24 : INFO  : cherryaudiops20 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:32:24 : INFO  : cherryaudiops20 : Checking package version.
2024-09-02 15:32:25 : INFO  : cherryaudiops20 : Downloaded package com.cherryaudio.pkg.PS-20Package-StandAlone version 1.4.0
2024-09-02 15:32:25 : INFO  : cherryaudiops20 : Downloaded version of PS-20 is the same as installed.
2024-09-02 15:32:25 : DEBUG : cherryaudiops20 : DEBUG mode 1, not reopening anything
2024-09-02 15:32:25 : REQ   : cherryaudiops20 : No new version to install
2024-09-02 15:32:25 : REQ   : cherryaudiops20 : ################## End Installomator, exit code 0 
