### PR TITLE
Create Cherry Audio PS-3300 label

### DIFF
--- a/fragments/labels/cherryaudiops3300.sh
+++ b/fragments/labels/cherryaudiops3300.sh
@@ -2,7 +2,6 @@ cherryaudiops3300)
     name="PS-3300"
     type="pkg"
     packageID="com.cherryaudio.pkg.PS-3300Package-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/ps-3300/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiops3300.sh
+++ b/fragments/labels/cherryaudiops3300.sh
@@ -1,0 +1,9 @@
+cherryaudiops3300)
+    name="PS-3300"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.PS-3300Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/ps-3300/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiops3300    
2024-09-02 15:33:40 : REQ   : cherryaudiops3300 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:33:40 : INFO  : cherryaudiops3300 : ################## Version: 10.7beta
2024-09-02 15:33:40 : INFO  : cherryaudiops3300 : ################## Date: 2024-09-02
2024-09-02 15:33:40 : INFO  : cherryaudiops3300 : ################## cherryaudiops3300
2024-09-02 15:33:40 : DEBUG : cherryaudiops3300 : DEBUG mode 1 enabled.
2024-09-02 15:33:40 : INFO  : cherryaudiops3300 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : name=PS-3300
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : appName=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : type=pkg
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : archiveName=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : downloadURL=https://store.cherryaudio.com/downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : curlOptions=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : appNewVersion=1.0.4
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : appCustomVersion function: Not defined
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : versionKey=CFBundleShortVersionString
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : packageID=com.cherryaudio.pkg.PS-3300Package-StandAlone
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : pkgName=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : choiceChangesXML=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : expectedTeamID=A2XFV22B2X
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : blockingProcesses=PS-3300
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : installerTool=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : CLIInstaller=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : CLIArguments=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : updateTool=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : updateToolArguments=
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : updateToolRunAsCurrentUser=
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : NOTIFY=success
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : LOGGING=DEBUG
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : Label type: pkg
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : archiveName: PS-3300.pkg
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : found packageID com.cherryaudio.pkg.PS-3300Package-StandAlone installed, version 1.0.4
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : appversion: 1.0.4
2024-09-02 15:33:41 : INFO  : cherryaudiops3300 : Latest version of PS-3300 is 1.0.4
2024-09-02 15:33:41 : WARN  : cherryaudiops3300 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:33:41 : REQ   : cherryaudiops3300 : Downloading https://store.cherryaudio.com/downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg to PS-3300.pkg
2024-09-02 15:33:41 : DEBUG : cherryaudiops3300 : No Dialog connection, just download
2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:33 PS-3300.pkg
2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : File type: PS-3300.pkg: xar archive compressed TOC: 7031, SHA-1 checksum
2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/ps-3300-macos-installer?file=PS-3300-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 39809842
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="PS-3300-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:33:42 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6Im9mekhMZGdGNGxMSWZvMTdEWCtxUUE9PSIsInZhbHVlIjoidHFNRWF6QkE2QVJnUTIvdFFoNGhJMUFGN01SSU82cHB0TVV2SG5TY1dXelgvaXFON0hUTkI3TEsvTGxhM3h0V3pqc2gyajhlNXZIMVZ1NkduNWpJRjRtL203eGxLZTZJL08wYmVxOCt6UkFHR2FBM0pYZUFqbFhzUk1pV1ZTeFYiLCJtYWMiOiI5MDFjYjNkOTc1MjhhYTFlOTM2MTlmOWZhMDk3ODgzNmJhOWI4ZmIxMmQzYmUzNTcxOTk2MmNmNjQzMmRiZjQ2IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:33:42 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InBNZTZ2V1ZpQTJSaS94bXo4aGlBNkE9PSIsInZhbHVlIjoiRWxwUlNmQkJ4Z3VBQnU4RjliY0w4VGQ2QkRaQU1GRmZjOExHT0NuWUtYUzJLdlUvRkpjM296T1dPaGxMN1MwZEZBcmZFVGpEb2FsS05PSnRYc3phdVFZK3RvMzVPdXUyU2NrZ2tBOWM5OHBmMFI5VUtUSVNNV2RBVkErTWx6clAiLCJtYWMiOiJmMDZiYTMyMWY2NDczN2VjOWUyNmFlY2EwMTRkNGI4NjQ3ZGMyZmZlZjcxODA1NDMyMDkxNTUxN2RkNGU2OTFmIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:33:42 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7011 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:33:53 : REQ   : cherryaudiops3300 : Installing PS-3300
2024-09-02 15:33:53 : INFO  : cherryaudiops3300 : Verifying: PS-3300.pkg
2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : File list: -rw-r--r--  1 gilburns  staff    38M Sep  2 15:33 PS-3300.pkg
2024-09-02 15:33:53 : DEBUG : cherryaudiops3300 : File type: PS-3300.pkg: xar archive compressed TOC: 7031, SHA-1 checksum
2024-09-02 15:33:54 : DEBUG : cherryaudiops3300 : spctlOut is PS-3300.pkg: accepted
2024-09-02 15:33:54 : DEBUG : cherryaudiops3300 : source=Notarized Developer ID
2024-09-02 15:33:54 : DEBUG : cherryaudiops3300 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:33:54 : INFO  : cherryaudiops3300 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:33:54 : INFO  : cherryaudiops3300 : Checking package version.
2024-09-02 15:33:54 : INFO  : cherryaudiops3300 : Downloaded package com.cherryaudio.pkg.PS-3300Package-StandAlone version 1.0.4
2024-09-02 15:33:54 : INFO  : cherryaudiops3300 : Downloaded version of PS-3300 is the same as installed.
2024-09-02 15:33:54 : DEBUG : cherryaudiops3300 : DEBUG mode 1, not reopening anything
2024-09-02 15:33:54 : REQ   : cherryaudiops3300 : No new version to install
2024-09-02 15:33:54 : REQ   : cherryaudiops3300 : ################## End Installomator, exit code 0 
