### PR TITLE
Create Cherry Audio Quadra label

### DIFF
--- a/fragments/labels/cherryaudioquadra.sh
+++ b/fragments/labels/cherryaudioquadra.sh
@@ -1,0 +1,9 @@
+cherryaudioquadra)
+    name="Quadra"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.QuadraPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/quadra/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudioquadra.sh
+++ b/fragments/labels/cherryaudioquadra.sh
@@ -2,7 +2,6 @@ cherryaudioquadra)
     name="Quadra"
     type="pkg"
     packageID="com.cherryaudio.pkg.QuadraPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/quadra/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudioquadra
2024-09-02 15:34:44 : REQ   : cherryaudioquadra : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:34:44 : INFO  : cherryaudioquadra : ################## Version: 10.7beta
2024-09-02 15:34:44 : INFO  : cherryaudioquadra : ################## Date: 2024-09-02
2024-09-02 15:34:44 : INFO  : cherryaudioquadra : ################## cherryaudioquadra
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : DEBUG mode 1 enabled.
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : name=Quadra
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : appName=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : type=pkg
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : archiveName=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : downloadURL=https://store.cherryaudio.com/downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : curlOptions=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : appNewVersion=1.4.0
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : appCustomVersion function: Not defined
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : versionKey=CFBundleShortVersionString
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : packageID=com.cherryaudio.pkg.QuadraPackage-StandAlone
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : pkgName=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : choiceChangesXML=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : expectedTeamID=A2XFV22B2X
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : blockingProcesses=Quadra
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : installerTool=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : CLIInstaller=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : CLIArguments=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : updateTool=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : updateToolArguments=
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : updateToolRunAsCurrentUser=
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : NOTIFY=success
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : LOGGING=DEBUG
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : Label type: pkg
2024-09-02 15:34:45 : INFO  : cherryaudioquadra : archiveName: Quadra.pkg
2024-09-02 15:34:45 : DEBUG : cherryaudioquadra : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:34:46 : INFO  : cherryaudioquadra : found packageID com.cherryaudio.pkg.QuadraPackage-StandAlone installed, version 1.4.0
2024-09-02 15:34:46 : INFO  : cherryaudioquadra : appversion: 1.4.0
2024-09-02 15:34:46 : INFO  : cherryaudioquadra : Latest version of Quadra is 1.4.0
2024-09-02 15:34:46 : WARN  : cherryaudioquadra : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:34:46 : REQ   : cherryaudioquadra : Downloading https://store.cherryaudio.com/downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg to Quadra.pkg
2024-09-02 15:34:46 : DEBUG : cherryaudioquadra : No Dialog connection, just download
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:34 Quadra.pkg
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : File type: Quadra.pkg: xar archive compressed TOC: 7035, SHA-1 checksum, contains 
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : - OpenPGP Public Key
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/quadra-macos-installer?file=Quadra-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 69097050
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Quadra-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:34:46 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IndNaTlOc3FQMS9zNEM5cU5MZm9NTEE9PSIsInZhbHVlIjoiTzZCcTg3WWF2UVcxemFheUJLWVVLbGZ2bVBUWERTUVJlblV5RVlWYjgycnhGVlVRYmRTazJadXlaVkJoRVhpSFdHOWRoM2RObTVRR3lCYW43dDg5VE9IQ0JLc0lDQUlLcCt2N0lXWnlYNWVYdHNiQ0w3cVlVL3ZndG95dmhnZkkiLCJtYWMiOiJlOTY2NDQwZDBhMGI5MDZmZmNkZDM5ZDQwZGRjZWE2MTY3OWYwNGU0OTk0NDk3MmNmODEwOGZmNzY2ZDcxN2IwIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:34:46 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6ImFzZFVpMnlyTkd5dEZVNXM2L1J1N0E9PSIsInZhbHVlIjoia3BUU0xEQ0gvYmhBWFljbXBDUE1mdGhWRmhVVEtTZG5DTi9rMllialhRSk54VHhUcDZsM2Z5c21rMUJaSy9IaUZUUTZ3YllSVzNXS1VvKzJIL01MbnUvWDlNOGpKQmZOY2dldjFib1ZzSktzTzlWMGFHanNNTHdwdlloTWJNMkQiLCJtYWMiOiJjZmNjNmZkYTZjNjdhZGZjM2NiYzQxZDY3MTZkZDdiOWY0ZmVkZjQ3NmJhMmYxZWJkNmZkYmNjNzk2YTdkYTc0IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:34:46 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7012 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:34:56 : REQ   : cherryaudioquadra : Installing Quadra
2024-09-02 15:34:56 : INFO  : cherryaudioquadra : Verifying: Quadra.pkg
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : File list: -rw-r--r--  1 gilburns  staff    66M Sep  2 15:34 Quadra.pkg
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : File type: Quadra.pkg: xar archive compressed TOC: 7035, SHA-1 checksum, contains 
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : - OpenPGP Public Key
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : spctlOut is Quadra.pkg: accepted
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : source=Notarized Developer ID
2024-09-02 15:34:56 : DEBUG : cherryaudioquadra : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:34:56 : INFO  : cherryaudioquadra : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:34:56 : INFO  : cherryaudioquadra : Checking package version.
2024-09-02 15:34:57 : INFO  : cherryaudioquadra : Downloaded package com.cherryaudio.pkg.QuadraPackage-StandAlone version 1.4.0
2024-09-02 15:34:57 : INFO  : cherryaudioquadra : Downloaded version of Quadra is the same as installed.
2024-09-02 15:34:57 : DEBUG : cherryaudioquadra : DEBUG mode 1, not reopening anything
2024-09-02 15:34:57 : REQ   : cherryaudioquadra : No new version to install
2024-09-02 15:34:57 : REQ   : cherryaudioquadra : ################## End Installomator, exit code 0 
