### PR TITLE
Create Cherry Audio Rackmode label

### DIFF
--- a/fragments/labels/cherryaudiorackmode.sh
+++ b/fragments/labels/cherryaudiorackmode.sh
@@ -1,0 +1,9 @@
+cherryaudiorackmode)
+    name="Rackmode"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.RackmodePackage-StandAlone"
+    blockingProcesses=( "Rackmode Frequency Shifter" "Rackmode Graphic EQ" "Rackmode Parametric EQ" "Rackmode Phaser" "Rackmode Ring Modulator" "Rackmode String Filter" "Rackmode Vocoder" "Rackmode Vocoder FX" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/rackmode/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiorackmode
2024-09-02 15:36:21 : REQ   : cherryaudiorackmode : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : ################## Version: 10.7beta
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : ################## Date: 2024-09-02
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : ################## cherryaudiorackmode
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : DEBUG mode 1 enabled.
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : name=Rackmode
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : appName=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : type=pkg
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : archiveName=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : downloadURL=https://store.cherryaudio.com/downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : curlOptions=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : appNewVersion=1.4.0
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : appCustomVersion function: Not defined
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : versionKey=CFBundleShortVersionString
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : packageID=com.cherryaudio.pkg.RackmodePackage-StandAlone
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : pkgName=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : choiceChangesXML=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : expectedTeamID=A2XFV22B2X
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : blockingProcesses=Rackmode Frequency Shifter Rackmode Graphic EQ Rackmode Parametric EQ Rackmode Phaser Rackmode Ring Modulator Rackmode String Filter Rackmode Vocoder Rackmode Vocoder FX
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : installerTool=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : CLIInstaller=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : CLIArguments=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : updateTool=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : updateToolArguments=
2024-09-02 15:36:21 : DEBUG : cherryaudiorackmode : updateToolRunAsCurrentUser=
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : NOTIFY=success
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : LOGGING=DEBUG
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : Label type: pkg
2024-09-02 15:36:21 : INFO  : cherryaudiorackmode : archiveName: Rackmode.pkg
2024-09-02 15:36:22 : DEBUG : cherryaudiorackmode : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:36:22 : INFO  : cherryaudiorackmode : found packageID com.cherryaudio.pkg.RackmodePackage-StandAlone installed, version 1.4.0
2024-09-02 15:36:22 : INFO  : cherryaudiorackmode : appversion: 1.4.0
2024-09-02 15:36:22 : INFO  : cherryaudiorackmode : Latest version of Rackmode is 1.4.0
2024-09-02 15:36:22 : WARN  : cherryaudiorackmode : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:36:22 : REQ   : cherryaudiorackmode : Downloading https://store.cherryaudio.com/downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg to Rackmode.pkg
2024-09-02 15:36:22 : DEBUG : cherryaudiorackmode : No Dialog connection, just download
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : File list: -rw-r--r--  1 gilburns  staff   293M Sep  2 15:36 Rackmode.pkg
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : File type: Rackmode.pkg: xar archive compressed TOC: 7124, SHA-1 checksum
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/rackmode-macos-installer?file=Rackmode-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 306775836
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Rackmode-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:36:22 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6Ik1GekNERWM1V1g4RE5jM1ArQ2gxSGc9PSIsInZhbHVlIjoiaFlGeEFld0F4VStTc2lPTm8vRXM4ellSQm9FZFlsKysrQUhRU1NTemF6YTR0ZzF3eUx6b2dBbG5tVXpReElpVEFLenBuM1ZoWVE2emRCaU5pMUd4cG5rUCs5R3ZYZ1k3M0NkU1J4TXV3MmJsanp6dEVNYTRjNTNkNWFpLzRCUW4iLCJtYWMiOiJlMjI0YjRlOTE0MzhjNmI5OTQxNjQ3OTFlNzhjZmU0ZmFiNjg4NTViMjQ3N2U4YmI1NzBkODA2MjRkMjRiZWE2IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:36:22 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Ik9vZlhSd3FaS0tBc1hEdlk4b2Q3U3c9PSIsInZhbHVlIjoiMERmYWp0anFaUjMxNE5oc2s5a0M0S0Z3MFJtWitVdWJoeFBQbm90MGlVSVg3bGhhamI4L0lncmxTSVRlcjF1emhUZUovZUQxekxPSzN5SEVDT1piYjF2T0hLSm1SaXIyS1Niem8vR3dVWFVDd0FaZkx5S0pJM2VsNXowRUhZWHEiLCJtYWMiOiIzYTVjNGU3ZmRhNTVkNDZhMDJjODE5ZTRlZjk1ZWVlYWE5ZDdiOTUzMDNmMjkyOWIwZjE4ZmJjNDg2YjlhNzc3IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:36:22 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7009 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:36:59 : REQ   : cherryaudiorackmode : Installing Rackmode
2024-09-02 15:36:59 : INFO  : cherryaudiorackmode : Verifying: Rackmode.pkg
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : File list: -rw-r--r--  1 gilburns  staff   293M Sep  2 15:36 Rackmode.pkg
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : File type: Rackmode.pkg: xar archive compressed TOC: 7124, SHA-1 checksum
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : spctlOut is Rackmode.pkg: accepted
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : source=Notarized Developer ID
2024-09-02 15:36:59 : DEBUG : cherryaudiorackmode : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:36:59 : INFO  : cherryaudiorackmode : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:36:59 : INFO  : cherryaudiorackmode : Checking package version.
2024-09-02 15:37:01 : INFO  : cherryaudiorackmode : Downloaded package com.cherryaudio.pkg.RackmodePackage-StandAlone version 1.4.0
2024-09-02 15:37:01 : INFO  : cherryaudiorackmode : Downloaded version of Rackmode is the same as installed.
2024-09-02 15:37:01 : DEBUG : cherryaudiorackmode : DEBUG mode 1, not reopening anything
2024-09-02 15:37:01 : REQ   : cherryaudiorackmode : No new version to install
2024-09-02 15:37:01 : REQ   : cherryaudiorackmode : ################## End Installomator, exit code 0 
