### PR TITLE
Create Cherry Audio Sines label

### DIFF
--- a/fragments/labels/cherryaudiosines.sh
+++ b/fragments/labels/cherryaudiosines.sh
@@ -2,7 +2,6 @@ cherryaudiosines)
     name="Sines"
     type="pkg"
     packageID="com.cherryaudio.pkg.SinesPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/sines/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiosines.sh
+++ b/fragments/labels/cherryaudiosines.sh
@@ -1,0 +1,9 @@
+cherryaudiosines)
+    name="Sines"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.SinesPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/sines/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiosines   
2024-09-02 15:39:36 : REQ   : cherryaudiosines : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:39:36 : INFO  : cherryaudiosines : ################## Version: 10.7beta
2024-09-02 15:39:36 : INFO  : cherryaudiosines : ################## Date: 2024-09-02
2024-09-02 15:39:36 : INFO  : cherryaudiosines : ################## cherryaudiosines
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : DEBUG mode 1 enabled.
2024-09-02 15:39:36 : INFO  : cherryaudiosines : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : name=Sines
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : appName=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : type=pkg
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : archiveName=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : downloadURL=https://store.cherryaudio.com/downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : curlOptions=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : appNewVersion=1.4.0
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : appCustomVersion function: Not defined
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : versionKey=CFBundleShortVersionString
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : packageID=com.cherryaudio.pkg.SinesPackage-StandAlone
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : pkgName=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : choiceChangesXML=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : expectedTeamID=A2XFV22B2X
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : blockingProcesses=Sines
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : installerTool=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : CLIInstaller=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : CLIArguments=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : updateTool=
2024-09-02 15:39:36 : DEBUG : cherryaudiosines : updateToolArguments=
2024-09-02 15:39:37 : DEBUG : cherryaudiosines : updateToolRunAsCurrentUser=
2024-09-02 15:39:37 : INFO  : cherryaudiosines : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:39:37 : INFO  : cherryaudiosines : NOTIFY=success
2024-09-02 15:39:37 : INFO  : cherryaudiosines : LOGGING=DEBUG
2024-09-02 15:39:37 : INFO  : cherryaudiosines : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:39:37 : INFO  : cherryaudiosines : Label type: pkg
2024-09-02 15:39:37 : INFO  : cherryaudiosines : archiveName: Sines.pkg
2024-09-02 15:39:37 : DEBUG : cherryaudiosines : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:39:37 : INFO  : cherryaudiosines : found packageID com.cherryaudio.pkg.SinesPackage-StandAlone installed, version 1.4.0
2024-09-02 15:39:37 : INFO  : cherryaudiosines : appversion: 1.4.0
2024-09-02 15:39:37 : INFO  : cherryaudiosines : Latest version of Sines is 1.4.0
2024-09-02 15:39:37 : WARN  : cherryaudiosines : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:39:37 : REQ   : cherryaudiosines : Downloading https://store.cherryaudio.com/downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg to Sines.pkg
2024-09-02 15:39:37 : DEBUG : cherryaudiosines : No Dialog connection, just download
2024-09-02 15:39:40 : DEBUG : cherryaudiosines : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:39 Sines.pkg
2024-09-02 15:39:40 : DEBUG : cherryaudiosines : File type: Sines.pkg: xar archive compressed TOC: 6989, SHA-1 checksum
2024-09-02 15:39:40 : DEBUG : cherryaudiosines : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/sines-macos-installer?file=Sines-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38933964
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Sines-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:39:37 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6ImxXRmhTQm85ZWZUZU5UWExJbTZqWUE9PSIsInZhbHVlIjoiZUhKdDI4Zml4TysvVVJtWFlVcnlWWVFKbW5jQ2JteFBKdk52T0REbzZ2Ly9wZFcxaHUzWkR3MmlUS3lDaWdxQi9BaDUvQkZGKy9ybjdOQlJpWC9qUzJaRXZwUVhrMTRvWW8rKzhldVgrUEVva3NuRVJCdExtUmlFbVB3SHRiU3giLCJtYWMiOiJiYWFkMWZiYjViNWRlYmY5MDI4Y2M2NmU4ZDE1YmIzOGY2YWUyOGQ2NzY0YmQ1YzdlNTA1ZjJmMGY1NWRlZmU3IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:39:37 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6ImVONExIL1FmVmQyOU1wQThrSzZHWWc9PSIsInZhbHVlIjoiQ0pCOVU5Vk9PR3pNY3lNY3JsZjJGRFRNSGI1R1J3eTUvMkVJb0pFZlBHYlZSL0dkL0xpaWRGZ2NiNWV4ZE40OHpoSm95MS81S0MyRVgzTXVpd1loTDZkYUJsZDhjcCtTUDRjOEFmQnQ5eXpxdzF3SnNtV2E2RXRheGFuV081R2siLCJtYWMiOiJmN2NlZTU5ZjMzZDcyM2FmN2U0YTFjZjAzZTk0NWJhMzZlNzhkOWY0MTdkNmVjMmE5ZGU2ZGM2ZTM1MWFmYWYzIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:39:37 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7013 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:39:40 : DEBUG : cherryaudiosines : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:39:40 : REQ   : cherryaudiosines : Installing Sines
2024-09-02 15:39:40 : INFO  : cherryaudiosines : Verifying: Sines.pkg
2024-09-02 15:39:40 : DEBUG : cherryaudiosines : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:39 Sines.pkg
2024-09-02 15:39:40 : DEBUG : cherryaudiosines : File type: Sines.pkg: xar archive compressed TOC: 6989, SHA-1 checksum
2024-09-02 15:39:41 : DEBUG : cherryaudiosines : spctlOut is Sines.pkg: accepted
2024-09-02 15:39:41 : DEBUG : cherryaudiosines : source=Notarized Developer ID
2024-09-02 15:39:41 : DEBUG : cherryaudiosines : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:39:41 : INFO  : cherryaudiosines : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:39:41 : INFO  : cherryaudiosines : Checking package version.
2024-09-02 15:39:41 : INFO  : cherryaudiosines : Downloaded package com.cherryaudio.pkg.SinesPackage-StandAlone version 1.4.0
2024-09-02 15:39:41 : INFO  : cherryaudiosines : Downloaded version of Sines is the same as installed.
2024-09-02 15:39:41 : DEBUG : cherryaudiosines : DEBUG mode 1, not reopening anything
2024-09-02 15:39:41 : REQ   : cherryaudiosines : No new version to install
2024-09-02 15:39:41 : REQ   : cherryaudiosines : ################## End Installomator, exit code 0 
