### PR TITLE
Create Cherry Audio Stardust 201 Tape Echo label

### DIFF
--- a/fragments/labels/cherryaudiostardust201.sh
+++ b/fragments/labels/cherryaudiostardust201.sh
@@ -1,0 +1,9 @@
+cherryaudiostardust201)
+    name="Stardust 201 Tape Echo"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Stardust201Package-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/stardust-201/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiostardust201
2024-09-02 15:43:51 : REQ   : cherryaudiostardust201 : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:43:51 : INFO  : cherryaudiostardust201 : ################## Version: 10.7beta
2024-09-02 15:43:51 : INFO  : cherryaudiostardust201 : ################## Date: 2024-09-02
2024-09-02 15:43:51 : INFO  : cherryaudiostardust201 : ################## cherryaudiostardust201
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : DEBUG mode 1 enabled.
2024-09-02 15:43:51 : INFO  : cherryaudiostardust201 : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : name=Stardust 201 Tape Echo
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : appName=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : type=pkg
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : archiveName=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : downloadURL=https://store.cherryaudio.com/downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : curlOptions=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : appNewVersion=1.4.0
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : appCustomVersion function: Not defined
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : versionKey=CFBundleShortVersionString
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : packageID=com.cherryaudio.pkg.Stardust201Package-StandAlone
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : pkgName=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : choiceChangesXML=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : expectedTeamID=A2XFV22B2X
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : blockingProcesses=Stardust 201 Tape Echo
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : installerTool=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : CLIInstaller=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : CLIArguments=
2024-09-02 15:43:51 : DEBUG : cherryaudiostardust201 : updateTool=
2024-09-02 15:43:52 : DEBUG : cherryaudiostardust201 : updateToolArguments=
2024-09-02 15:43:52 : DEBUG : cherryaudiostardust201 : updateToolRunAsCurrentUser=
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : NOTIFY=success
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : LOGGING=DEBUG
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : Label type: pkg
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : archiveName: Stardust 201 Tape Echo.pkg
2024-09-02 15:43:52 : DEBUG : cherryaudiostardust201 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : found packageID com.cherryaudio.pkg.Stardust201Package-StandAlone installed, version 1.4.0
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : appversion: 1.4.0
2024-09-02 15:43:52 : INFO  : cherryaudiostardust201 : Latest version of Stardust 201 Tape Echo is 1.4.0
2024-09-02 15:43:52 : WARN  : cherryaudiostardust201 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:43:52 : REQ   : cherryaudiostardust201 : Downloading https://store.cherryaudio.com/downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg to Stardust 201 Tape Echo.pkg
2024-09-02 15:43:52 : DEBUG : cherryaudiostardust201 : No Dialog connection, just download
2024-09-02 15:43:55 : DEBUG : cherryaudiostardust201 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:43 Stardust 201 Tape Echo.pkg
2024-09-02 15:43:55 : DEBUG : cherryaudiostardust201 : File type: Stardust 201 Tape Echo.pkg: xar archive compressed TOC: 6907, SHA-1 checksum
2024-09-02 15:43:55 : DEBUG : cherryaudiostardust201 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/stardust-201-macos-installer?file=Stardust-201-Tape-Echo-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38676116
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Stardust-201-Tape-Echo-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:43:52 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6IlNWalhxRUo3ZFJuY2JYS3g4Rkd5cnc9PSIsInZhbHVlIjoiZnJqT3BKaks2eGxhcDlka1kxY2VWNmx1ZEdJbU0zYWtxZUVwM1A4RHo2UXZFYm5Yd1JNc1hCQlo4SmYwVnRDSU5FZ3YzUUpOUlB2cmFpbVVFMzZkRnoyOHo3aFhlN2lCbzcvWkpUQXpuNkkvWDAySktCcXE5T1lmMHBMSEZQNUwiLCJtYWMiOiI3ZjdjMWYyZTk3MjBiMGU5ZWVlNDIwZGRhZGU2YTAwY2M1ZjA2ZjViY2RkNDM1NjFjOWRiZDlmMjVlZGFiYmQ4IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:43:52 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IktYNkpoa0FtTmtLMi9sRU55bWFqU2c9PSIsInZhbHVlIjoib1dLYktMNVFwaUQ2RW0ydUlDUFJwZHQ5VGsvYm53TXNDRlZJQVdRd0h2L1dBTmlQMnBLaldIejlqajdlRzJpL2tPU1EwcmZKamJ3VmhrZVJwakNxQzdCakIzc1ozS3BPMFNHY2VHMzVQZ2lYQkhTTFdES0dtVTYvekh2eDkwOUUiLCJtYWMiOiJjNmY1MjhkZDgxNWZhZjU0ZjFjZjE3ZGEwNTU2MjEwYzAxMmM0M2NjZmYxMzIzYjI3MzNhYWM4NTQxNTM2NjM5IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:43:52 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [6996 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:43:55 : DEBUG : cherryaudiostardust201 : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:43:56 : REQ   : cherryaudiostardust201 : Installing Stardust 201 Tape Echo
2024-09-02 15:43:56 : INFO  : cherryaudiostardust201 : Verifying: Stardust 201 Tape Echo.pkg
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:43 Stardust 201 Tape Echo.pkg
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : File type: Stardust 201 Tape Echo.pkg: xar archive compressed TOC: 6907, SHA-1 checksum
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : spctlOut is Stardust 201 Tape Echo.pkg: accepted
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : source=Notarized Developer ID
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:43:56 : INFO  : cherryaudiostardust201 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:43:56 : INFO  : cherryaudiostardust201 : Checking package version.
2024-09-02 15:43:56 : INFO  : cherryaudiostardust201 : Downloaded package com.cherryaudio.pkg.Stardust201Package-StandAlone version 1.4.0
2024-09-02 15:43:56 : INFO  : cherryaudiostardust201 : Downloaded version of Stardust 201 Tape Echo is the same as installed.
2024-09-02 15:43:56 : DEBUG : cherryaudiostardust201 : DEBUG mode 1, not reopening anything
2024-09-02 15:43:56 : REQ   : cherryaudiostardust201 : No new version to install
2024-09-02 15:43:56 : REQ   : cherryaudiostardust201 : ################## End Installomator, exit code 0 
