### PR TITLE
Create Cherry Audio Surrealistic MG-1 Plus label

### DIFF
--- a/fragments/labels/cherryaudiosurrealisticmg1plus.sh
+++ b/fragments/labels/cherryaudiosurrealisticmg1plus.sh
@@ -2,7 +2,6 @@ cherryaudiosurrealisticmg1plus)
     name="Surrealistic MG-1 Plus"
     type="pkg"
     packageID="com.cherryaudio.pkg.MG-1PlusPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/surrealistic-mg-1-plus/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiosurrealisticmg1plus.sh
+++ b/fragments/labels/cherryaudiosurrealisticmg1plus.sh
@@ -1,0 +1,9 @@
+cherryaudiosurrealisticmg1plus)
+    name="Surrealistic MG-1 Plus"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.MG-1PlusPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/surrealistic-mg-1-plus/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiosurrealisticmg1plus
2024-09-02 15:45:25 : REQ   : cherryaudiosurrealisticmg1plus : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:45:25 : INFO  : cherryaudiosurrealisticmg1plus : ################## Version: 10.7beta
2024-09-02 15:45:25 : INFO  : cherryaudiosurrealisticmg1plus : ################## Date: 2024-09-02
2024-09-02 15:45:25 : INFO  : cherryaudiosurrealisticmg1plus : ################## cherryaudiosurrealisticmg1plus
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : DEBUG mode 1 enabled.
2024-09-02 15:45:25 : INFO  : cherryaudiosurrealisticmg1plus : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : name=Surrealistic MG-1 Plus
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : appName=
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : type=pkg
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : archiveName=
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : downloadURL=https://store.cherryaudio.com/downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : curlOptions=
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : appNewVersion=1.4.0
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : appCustomVersion function: Not defined
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : versionKey=CFBundleShortVersionString
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : packageID=com.cherryaudio.pkg.MG-1PlusPackage-StandAlone
2024-09-02 15:45:25 : DEBUG : cherryaudiosurrealisticmg1plus : pkgName=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : choiceChangesXML=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : expectedTeamID=A2XFV22B2X
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : blockingProcesses=Surrealistic MG-1 Plus
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : installerTool=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : CLIInstaller=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : CLIArguments=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : updateTool=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : updateToolArguments=
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : updateToolRunAsCurrentUser=
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : NOTIFY=success
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : LOGGING=DEBUG
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : Label type: pkg
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : archiveName: Surrealistic MG-1 Plus.pkg
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : found packageID com.cherryaudio.pkg.MG-1PlusPackage-StandAlone installed, version 1.4.0
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : appversion: 1.4.0
2024-09-02 15:45:26 : INFO  : cherryaudiosurrealisticmg1plus : Latest version of Surrealistic MG-1 Plus is 1.4.0
2024-09-02 15:45:26 : WARN  : cherryaudiosurrealisticmg1plus : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:45:26 : REQ   : cherryaudiosurrealisticmg1plus : Downloading https://store.cherryaudio.com/downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg to Surrealistic MG-1 Plus.pkg
2024-09-02 15:45:26 : DEBUG : cherryaudiosurrealisticmg1plus : No Dialog connection, just download
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:45 Surrealistic MG-1 Plus.pkg
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : File type: Surrealistic MG-1 Plus.pkg: xar archive compressed TOC: 6969, SHA-1 checksum
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/surrealistic-mg-1-plus-macos-installer?file=Surrealistic-MG-1-Plus-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 38411378
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Surrealistic-MG-1-Plus-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:45:26 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6Ind6UXFFTTJ5WVN6QzVPSFAwTVgzQVE9PSIsInZhbHVlIjoidmdoWFZBUTczdDhPOUNJOHd4N1lLTVltN3hqYWcvN0doZVV0U1ZuUCtRTWh3MUNObmxTWXNCU1MvdHA3eUd5dHgwUHJJdFdROEEvVVdVVUw2SHg2aTMxbndadGcrbU04SDN1VC9vcFhkSGdEdGxld25qR2pwVlRBeUY4Y0laT1UiLCJtYWMiOiI5MTBlNTEzZWQ3MTUyNTVjZTlhZDNmYmE5ODdjZTA3NDgyZTdmNzc5NzE0MWI3ZjUyMzQ1YjQ4NzlhODNhNjk1IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:45:26 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Ik1Pd0htZXRncFFxRzhpQzRZbFVFNnc9PSIsInZhbHVlIjoiZ00xeUFmWWdhMld6aURjTFdxdzkvcUFSeFRucUpkYUdsWXdnMlgydHZMSy9OcW5pTUd4U0txcGw2S3h2M3ZqeUd0L0I1dmE3K1lOS04xcFZ3Q3JMWGp1Q1p6UklUdjZENVlwSjhXS2duRnVwK3FPbzAvRWlUbllLV1BneGJkVEoiLCJtYWMiOiJlMWY1OTZlNTY4YWFhNzM0MmJiZGY4ZTgyYzdlMzlhNjdmMDZlNDhlNzA4MDU3ZWVhYmE4ZWRkODdjM2FkNDMxIiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:45:26 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [6996 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:45:29 : REQ   : cherryaudiosurrealisticmg1plus : Installing Surrealistic MG-1 Plus
2024-09-02 15:45:29 : INFO  : cherryaudiosurrealisticmg1plus : Verifying: Surrealistic MG-1 Plus.pkg
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : File list: -rw-r--r--  1 gilburns  staff    37M Sep  2 15:45 Surrealistic MG-1 Plus.pkg
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : File type: Surrealistic MG-1 Plus.pkg: xar archive compressed TOC: 6969, SHA-1 checksum
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : spctlOut is Surrealistic MG-1 Plus.pkg: accepted
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : source=Notarized Developer ID
2024-09-02 15:45:29 : DEBUG : cherryaudiosurrealisticmg1plus : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:45:29 : INFO  : cherryaudiosurrealisticmg1plus : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:45:29 : INFO  : cherryaudiosurrealisticmg1plus : Checking package version.
2024-09-02 15:45:30 : INFO  : cherryaudiosurrealisticmg1plus : Downloaded package com.cherryaudio.pkg.MG-1PlusPackage-StandAlone version 1.4.0
2024-09-02 15:45:30 : INFO  : cherryaudiosurrealisticmg1plus : Downloaded version of Surrealistic MG-1 Plus is the same as installed.
2024-09-02 15:45:30 : DEBUG : cherryaudiosurrealisticmg1plus : DEBUG mode 1, not reopening anything
2024-09-02 15:45:30 : REQ   : cherryaudiosurrealisticmg1plus : No new version to install
2024-09-02 15:45:30 : REQ   : cherryaudiosurrealisticmg1plus : ################## End Installomator, exit code 0 
