### PR TITLE
Create Cherry Audio Synthesizer Expander Module label

### DIFF
--- a/fragments/labels/cherryaudiosynthesizerexpander.sh
+++ b/fragments/labels/cherryaudiosynthesizerexpander.sh
@@ -1,0 +1,9 @@
+cherryaudiosynthesizerexpander)
+    name="Synthesizer Expander Module"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.SynthesizerExpanderModulePackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/synthesizer-expander-module/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiosynthesizerexpander.sh
+++ b/fragments/labels/cherryaudiosynthesizerexpander.sh
@@ -2,7 +2,6 @@ cherryaudiosynthesizerexpander)
     name="Synthesizer Expander Module"
     type="pkg"
     packageID="com.cherryaudio.pkg.SynthesizerExpanderModulePackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/synthesizer-expander-module/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiosynthesizerexpander
2024-09-02 15:46:50 : REQ   : cherryaudiosynthesizerexpander : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:46:50 : INFO  : cherryaudiosynthesizerexpander : ################## Version: 10.7beta
2024-09-02 15:46:50 : INFO  : cherryaudiosynthesizerexpander : ################## Date: 2024-09-02
2024-09-02 15:46:50 : INFO  : cherryaudiosynthesizerexpander : ################## cherryaudiosynthesizerexpander
2024-09-02 15:46:50 : DEBUG : cherryaudiosynthesizerexpander : DEBUG mode 1 enabled.
2024-09-02 15:46:50 : INFO  : cherryaudiosynthesizerexpander : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : name=Synthesizer Expander Module
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : appName=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : type=pkg
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : archiveName=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : downloadURL=https://store.cherryaudio.com/downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : curlOptions=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : appNewVersion=1.0.2
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : appCustomVersion function: Not defined
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : versionKey=CFBundleShortVersionString
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : packageID=com.cherryaudio.pkg.SynthesizerExpanderModulePackage-StandAlone
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : pkgName=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : choiceChangesXML=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : expectedTeamID=A2XFV22B2X
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : blockingProcesses=Synthesizer Expander Module
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : installerTool=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : CLIInstaller=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : CLIArguments=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : updateTool=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : updateToolArguments=
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : updateToolRunAsCurrentUser=
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : NOTIFY=success
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : LOGGING=DEBUG
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : Label type: pkg
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : archiveName: Synthesizer Expander Module.pkg
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : found packageID com.cherryaudio.pkg.SynthesizerExpanderModulePackage-StandAlone installed, version 1.0.2
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : appversion: 1.0.2
2024-09-02 15:46:51 : INFO  : cherryaudiosynthesizerexpander : Latest version of Synthesizer Expander Module is 1.0.2
2024-09-02 15:46:51 : WARN  : cherryaudiosynthesizerexpander : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:46:51 : REQ   : cherryaudiosynthesizerexpander : Downloading https://store.cherryaudio.com/downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg to Synthesizer Expander Module.pkg
2024-09-02 15:46:51 : DEBUG : cherryaudiosynthesizerexpander : No Dialog connection, just download
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : File list: -rw-r--r--  1 gilburns  staff    39M Sep  2 15:46 Synthesizer Expander Module.pkg
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : File type: Synthesizer Expander Module.pkg: xar archive compressed TOC: 7062, SHA-1 checksum
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/synthesizer-expander-module-macos-installer?file=Synthesizer-Expander-Module-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 40396056
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Synthesizer-Expander-Module-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:46:51 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6InBMbUlWQkhiYm1kbXBCcEEzMzVoRUE9PSIsInZhbHVlIjoiK0UrWXB3WEVJZ1dJSDZRZU1objFxSVBaUDdsanFTRTJscjFCRnBlanBiRkdld2VFem1DZXcwejUrR1V4WFR3WGdxR3BERWhha3NLQ0NTT0hjN2gwQVVaSGgwSGVtS0NTMEt5WTBZWldTZ1Y1Y1g1Vk9qbXdzTHd5cEQ3WU54ajkiLCJtYWMiOiI5MmFjYmQ2ODBkYTJkMTU3OGQxODA2ZjZlMGY5MWUzMmUxMTA4ODE2MjI3ZWRhMjkxMjJmYjQ5OTY0OWQyNjc5IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:46:51 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6IjlZcGZmdFNhNG5xZnRIeGk3VFkwdFE9PSIsInZhbHVlIjoiUU1ubEhpanZJR3FVMHBPdHJ3MGsxNWkyMm1KcGlGbUdBaWpPdGFFVFRRcENEWk1CUjhYUEtBS0F1ZmhwM3RsbTVBZlk2L254dlkwcVpPNjlFdU9HK1lKSFgwVFhWYi9nOFIwcUorSlh6OVdTamFKY2l1OU4ybXJySWw3WTE3bFIiLCJtYWMiOiJhMGYwOTIxYjM5MDcyYTQyNDAxNThjZDFlNjUzOTYwNGQxY2JlYzQyODA1NTEyMDViNDZjMjFkNDk0Mjg1ZDM0IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:46:51 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [6991 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:46:55 : REQ   : cherryaudiosynthesizerexpander : Installing Synthesizer Expander Module
2024-09-02 15:46:55 : INFO  : cherryaudiosynthesizerexpander : Verifying: Synthesizer Expander Module.pkg
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : File list: -rw-r--r--  1 gilburns  staff    39M Sep  2 15:46 Synthesizer Expander Module.pkg
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : File type: Synthesizer Expander Module.pkg: xar archive compressed TOC: 7062, SHA-1 checksum
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : spctlOut is Synthesizer Expander Module.pkg: accepted
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : source=Notarized Developer ID
2024-09-02 15:46:55 : DEBUG : cherryaudiosynthesizerexpander : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:46:55 : INFO  : cherryaudiosynthesizerexpander : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:46:55 : INFO  : cherryaudiosynthesizerexpander : Checking package version.
2024-09-02 15:46:56 : INFO  : cherryaudiosynthesizerexpander : Downloaded package com.cherryaudio.pkg.SynthesizerExpanderModulePackage-StandAlone version 1.0.2
2024-09-02 15:46:56 : INFO  : cherryaudiosynthesizerexpander : Downloaded version of Synthesizer Expander Module is the same as installed.
2024-09-02 15:46:56 : DEBUG : cherryaudiosynthesizerexpander : DEBUG mode 1, not reopening anything
2024-09-02 15:46:56 : REQ   : cherryaudiosynthesizerexpander : No new version to install
2024-09-02 15:46:56 : REQ   : cherryaudiosynthesizerexpander : ################## End Installomator, exit code 0 
