### PR TITLE
Create Cherry Audio Voltage Modular label

### DIFF
--- a/fragments/labels/cherryaudiovoltagemodular.sh
+++ b/fragments/labels/cherryaudiovoltagemodular.sh
@@ -1,0 +1,9 @@
+cherryaudiovoltagemodular)
+    name="Voltage Modular"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.VoltageModularPackageUniversal-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/voltage-modular/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/voltage-mac/download?file=Voltage-Modular-Installer-macOS-Universal.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;

--- a/fragments/labels/cherryaudiovoltagemodular.sh
+++ b/fragments/labels/cherryaudiovoltagemodular.sh
@@ -2,7 +2,6 @@ cherryaudiovoltagemodular)
     name="Voltage Modular"
     type="pkg"
     packageID="com.cherryaudio.pkg.VoltageModularPackageUniversal-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/voltage-modular/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/voltage-mac/download?file=Voltage-Modular-Installer-macOS-Universal.pkg"
     expectedTeamID="A2XFV22B2X"


### PR DESCRIPTION
assemble.sh cherryaudiovoltagemodular
2024-09-02 15:51:04 : REQ   : cherryaudiovoltagemodular : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : ################## Version: 10.7beta
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : ################## Date: 2024-09-02
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : ################## cherryaudiovoltagemodular
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : DEBUG mode 1 enabled.
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : name=Voltage Modular
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : appName=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : type=pkg
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : archiveName=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : downloadURL=https://store.cherryaudio.com/voltage-mac/download?file=Voltage-Modular-Installer-macOS-Universal.pkg
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : curlOptions=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : appNewVersion=2.9.2
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : appCustomVersion function: Not defined
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : versionKey=CFBundleShortVersionString
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : packageID=com.cherryaudio.pkg.VoltageModularPackageUniversal-StandAlone
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : pkgName=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : choiceChangesXML=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : expectedTeamID=A2XFV22B2X
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : blockingProcesses=Voltage Modular
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : installerTool=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : CLIInstaller=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : CLIArguments=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : updateTool=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : updateToolArguments=
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : updateToolRunAsCurrentUser=
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : NOTIFY=success
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : LOGGING=DEBUG
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : Label type: pkg
2024-09-02 15:51:04 : INFO  : cherryaudiovoltagemodular : archiveName: Voltage Modular.pkg
2024-09-02 15:51:04 : DEBUG : cherryaudiovoltagemodular : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : found packageID com.cherryaudio.pkg.VoltageModularPackageUniversal-StandAlone installed, version 2.9.2
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : appversion: 2.9.2
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : Latest version of Voltage Modular is 2.9.2
2024-09-02 15:51:05 : WARN  : cherryaudiovoltagemodular : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : Voltage Modular.pkg exists and DEBUG mode 1 enabled, skipping download
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:51:05 : REQ   : cherryaudiovoltagemodular : Installing Voltage Modular
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : Verifying: Voltage Modular.pkg
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : File list: -rw-r--r--  1 gilburns  staff   342M Sep  2 15:48 Voltage Modular.pkg
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : File type: Voltage Modular.pkg: xar archive compressed TOC: 7932, SHA-1 checksum
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : spctlOut is Voltage Modular.pkg: accepted
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : source=Notarized Developer ID
2024-09-02 15:51:05 : DEBUG : cherryaudiovoltagemodular : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:51:05 : INFO  : cherryaudiovoltagemodular : Checking package version.
2024-09-02 15:51:07 : INFO  : cherryaudiovoltagemodular : Downloaded package com.cherryaudio.pkg.VoltageModularPackageUniversal-StandAlone version 2.9.2
2024-09-02 15:51:07 : INFO  : cherryaudiovoltagemodular : Downloaded version of Voltage Modular is the same as installed.
2024-09-02 15:51:07 : DEBUG : cherryaudiovoltagemodular : DEBUG mode 1, not reopening anything
2024-09-02 15:51:07 : REQ   : cherryaudiovoltagemodular : No new version to install
2024-09-02 15:51:07 : REQ   : cherryaudiovoltagemodular : ################## End Installomator, exit code 0 
