### PR TITLE
Create Cherry Audio Wurlybird 140B label

### DIFF
--- a/fragments/labels/cherryaudiowurlybird140b.sh
+++ b/fragments/labels/cherryaudiowurlybird140b.sh
@@ -2,7 +2,6 @@ cherryaudiowurlybird140b)
     name="Wurlybird 140B"
     type="pkg"
     packageID="com.cherryaudio.pkg.Wurlybird140bPackage-StandAlone"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -fs https://cherryaudio.com/products/wurlybird140b/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
     downloadURL="https://store.cherryaudio.com/downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg"
     expectedTeamID="A2XFV22B2X"

--- a/fragments/labels/cherryaudiowurlybird140b.sh
+++ b/fragments/labels/cherryaudiowurlybird140b.sh
@@ -1,0 +1,9 @@
+cherryaudiowurlybird140b)
+    name="Wurlybird 140B"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Wurlybird140bPackage-StandAlone"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/wurlybird140b/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudiowurlybird140b 
2024-09-02 15:54:49 : REQ   : cherryaudiowurlybird140b : ################## Start Installomator v. 10.7beta, date 2024-09-02
2024-09-02 15:54:49 : INFO  : cherryaudiowurlybird140b : ################## Version: 10.7beta
2024-09-02 15:54:49 : INFO  : cherryaudiowurlybird140b : ################## Date: 2024-09-02
2024-09-02 15:54:49 : INFO  : cherryaudiowurlybird140b : ################## cherryaudiowurlybird140b
2024-09-02 15:54:49 : DEBUG : cherryaudiowurlybird140b : DEBUG mode 1 enabled.
2024-09-02 15:54:49 : INFO  : cherryaudiowurlybird140b : SwiftDialog is not installed, clear cmd file var
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : name=Wurlybird 140B
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : appName=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : type=pkg
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : archiveName=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : downloadURL=https://store.cherryaudio.com/downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : curlOptions=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : appNewVersion=1.0.12
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : appCustomVersion function: Not defined
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : versionKey=CFBundleShortVersionString
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : packageID=com.cherryaudio.pkg.Wurlybird140bPackage-StandAlone
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : pkgName=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : choiceChangesXML=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : expectedTeamID=A2XFV22B2X
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : blockingProcesses=Wurlybird 140B
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : installerTool=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : CLIInstaller=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : CLIArguments=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : updateTool=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : updateToolArguments=
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : updateToolRunAsCurrentUser=
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : BLOCKING_PROCESS_ACTION=tell_user
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : NOTIFY=success
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : LOGGING=DEBUG
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : Label type: pkg
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : archiveName: Wurlybird 140B.pkg
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : found packageID com.cherryaudio.pkg.Wurlybird140bPackage-StandAlone installed, version 1.0.12
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : appversion: 1.0.12
2024-09-02 15:54:50 : INFO  : cherryaudiowurlybird140b : Latest version of Wurlybird 140B is 1.0.12
2024-09-02 15:54:50 : WARN  : cherryaudiowurlybird140b : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-02 15:54:50 : REQ   : cherryaudiowurlybird140b : Downloading https://store.cherryaudio.com/downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg to Wurlybird 140B.pkg
2024-09-02 15:54:50 : DEBUG : cherryaudiowurlybird140b : No Dialog connection, just download
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : File list: -rw-r--r--  1 gilburns  staff   287M Sep  2 15:55 Wurlybird 140B.pkg
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : File type: Wurlybird 140B.pkg: xar archive compressed TOC: 7976, SHA-1 checksum
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/wurlybird140b-macos-installer?file=Wurlybird140B.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: nginx
< date: Mon, 02 Sep 2024 20:54:50 GMT
< content-type: text/html
< content-length: 138
< location: https://store.cherryaudio.com/downloads/wurlybird-140b-macos-installer?file=Wurlybird140B.pkg
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
* Ignoring the response-body
* Connection #0 to host store.cherryaudio.com left intact
* Issue another request to this URL: 'https://store.cherryaudio.com/downloads/wurlybird-140b-macos-installer?file=Wurlybird140B.pkg'
* Found bundle for host: 0x600003d0c510 [can multiplex]
* Re-using existing connection with host store.cherryaudio.com
* [HTTP/2] [3] OPENED stream for https://store.cherryaudio.com/downloads/wurlybird-140b-macos-installer?file=Wurlybird140B.pkg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: store.cherryaudio.com]
* [HTTP/2] [3] [:path: /downloads/wurlybird-140b-macos-installer?file=Wurlybird140B.pkg]
* [HTTP/2] [3] [user-agent: curl/8.7.1]
* [HTTP/2] [3] [accept: */*]
> GET /downloads/wurlybird-140b-macos-installer?file=Wurlybird140B.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 300670142
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Wurlybird-140B-Installer-macOS.pkg"
< pragma: public
< date: Mon, 02 Sep 2024 20:54:51 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6Im1UckwxaHRBWEliVFlWTE9rNFZlUGc9PSIsInZhbHVlIjoiWTdYZyt2a1REeXFFVGM2WGk2UXZQRGFKdTBVWDl4Q0w3c0pkV1orN0xUaGZhQ2NCcWY3NStLZzJQS3VvdTRMbzBpWkpPWXNzZVRaQlNwYW5FVkMrdDV5VldlRDN1NGhveFFzb3ZkVlljWGpkQjZCLzFKOG1ad3plWEtyWXB3dloiLCJtYWMiOiI2OTdiZjVlYjJiZTZlYmI4YTZmOGUyODUzYzZkMDI3MzkxODRlZTg1Yjc1M2M1NzEwNTA2YjY1MjRkMzczOTU4IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:54:51 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6InJXZGFFY3FrWnkzUnJGYXdQemxBeXc9PSIsInZhbHVlIjoiWktHVlRFQjdEbDd3ZG9ZRGUxMXZKaXRhNDdoMHFNcHRxVDJQQWJmZTRIQmZHd1AyZU5iampraUMwVlVJQ3RlUXV2TDZML1lMSFRyb2ZuMGlnOTRYNGdJNGJJUzYvTUtDSlJYU0Q3SCtFWjZoL2dGUVd5Qi9zNEUzRXp2MTlZVmsiLCJtYWMiOiJiZjliZjJhMTc5NzQ5MWNjYmI0ZDUwMWMzMDA1YTdkZTBmODY4ZTdiZjRjNjc3OWVkOTcxZjk5N2E2NzEyMzM4IiwidGFnIjoiIn0%3D; expires=Mon, 02 Sep 2024 22:54:51 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7003 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : DEBUG mode 1, not checking for blocking processes
2024-09-02 15:55:17 : REQ   : cherryaudiowurlybird140b : Installing Wurlybird 140B
2024-09-02 15:55:17 : INFO  : cherryaudiowurlybird140b : Verifying: Wurlybird 140B.pkg
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : File list: -rw-r--r--  1 gilburns  staff   287M Sep  2 15:55 Wurlybird 140B.pkg
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : File type: Wurlybird 140B.pkg: xar archive compressed TOC: 7976, SHA-1 checksum
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : spctlOut is Wurlybird 140B.pkg: accepted
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : source=Notarized Developer ID
2024-09-02 15:55:17 : DEBUG : cherryaudiowurlybird140b : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-02 15:55:17 : INFO  : cherryaudiowurlybird140b : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-02 15:55:17 : INFO  : cherryaudiowurlybird140b : Checking package version.
2024-09-02 15:55:19 : INFO  : cherryaudiowurlybird140b : Downloaded package com.cherryaudio.pkg.Wurlybird140bPackage-StandAlone version 1.0.12
2024-09-02 15:55:19 : INFO  : cherryaudiowurlybird140b : Downloaded version of Wurlybird 140B is the same as installed.
2024-09-02 15:55:19 : DEBUG : cherryaudiowurlybird140b : DEBUG mode 1, not reopening anything
2024-09-02 15:55:19 : REQ   : cherryaudiowurlybird140b : No new version to install
2024-09-02 15:55:19 : REQ   : cherryaudiowurlybird140b : ################## End Installomator, exit code 0 
