### PR TITLE
Create UVI Portal label

### DIFF
--- a/fragments/labels/uviportal.sh
+++ b/fragments/labels/uviportal.sh
@@ -2,7 +2,6 @@ uviportal)
     name="UVI Portal"
     type="pkgInDmg"
     packageID="net.uvi.pkg.uviportal"
-    blockingProcesses=( "$name" )
     appNewVersion="$(curl -s -i "https://www.uvi.net/dl-portal.php?p=mac" | grep "location" | cut -d\- -f2 | xargs)"
     downloadURL="https://www.uvi.net/dl-portal.php?p=mac"
     expectedTeamID="BB6L4C84AT"

--- a/fragments/labels/uviportal.sh
+++ b/fragments/labels/uviportal.sh
@@ -1,0 +1,9 @@
+uviportal)
+    name="UVI Portal"
+    type="pkgInDmg"
+    packageID="net.uvi.pkg.uviportal"
+    blockingProcesses=( "$name" )
+    appNewVersion="$(curl -s -i "https://www.uvi.net/dl-portal.php?p=mac" | grep "location" | cut -d\- -f2 | xargs)"
+    downloadURL="https://www.uvi.net/dl-portal.php?p=mac"
+    expectedTeamID="BB6L4C84AT"
+    ;;

--- a/fragments/labels/uviportal.sh
+++ b/fragments/labels/uviportal.sh
@@ -2,7 +2,7 @@ uviportal)
     name="UVI Portal"
     type="pkgInDmg"
     packageID="net.uvi.pkg.uviportal"
-    appNewVersion="$(curl -s -i "https://www.uvi.net/dl-portal.php?p=mac" | grep "location" | cut -d\- -f2 | xargs)"
     downloadURL="https://www.uvi.net/dl-portal.php?p=mac"
+    appNewVersion="$(curl -s -i "${downloadURL}" | grep "location" | cut -d\- -f2 | xargs)"
     expectedTeamID="BB6L4C84AT"
     ;;


### PR DESCRIPTION
assemble.sh uviportal                 
2024-09-03 21:57:41 : REQ   : uviportal : ################## Start Installomator v. 10.7beta, date 2024-09-03
2024-09-03 21:57:41 : INFO  : uviportal : ################## Version: 10.7beta
2024-09-03 21:57:41 : INFO  : uviportal : ################## Date: 2024-09-03
2024-09-03 21:57:41 : INFO  : uviportal : ################## uviportal
2024-09-03 21:57:41 : DEBUG : uviportal : DEBUG mode 1 enabled.
2024-09-03 21:57:41 : INFO  : uviportal : SwiftDialog is not installed, clear cmd file var
2024-09-03 21:57:43 : DEBUG : uviportal : name=UVI Portal
2024-09-03 21:57:43 : DEBUG : uviportal : appName=
2024-09-03 21:57:43 : DEBUG : uviportal : type=pkgInDmg
2024-09-03 21:57:43 : DEBUG : uviportal : archiveName=
2024-09-03 21:57:43 : DEBUG : uviportal : downloadURL=https://www.uvi.net/dl-portal.php?p=mac
2024-09-03 21:57:43 : DEBUG : uviportal : curlOptions=
2024-09-03 21:57:43 : DEBUG : uviportal : appNewVersion=3.0.4
2024-09-03 21:57:43 : DEBUG : uviportal : appCustomVersion function: Not defined
2024-09-03 21:57:43 : DEBUG : uviportal : versionKey=CFBundleShortVersionString
2024-09-03 21:57:43 : DEBUG : uviportal : packageID=net.uvi.pkg.uviportal
2024-09-03 21:57:43 : DEBUG : uviportal : pkgName=
2024-09-03 21:57:43 : DEBUG : uviportal : choiceChangesXML=
2024-09-03 21:57:43 : DEBUG : uviportal : expectedTeamID=BB6L4C84AT
2024-09-03 21:57:43 : DEBUG : uviportal : blockingProcesses=UVI Portal
2024-09-03 21:57:43 : DEBUG : uviportal : installerTool=
2024-09-03 21:57:43 : DEBUG : uviportal : CLIInstaller=
2024-09-03 21:57:43 : DEBUG : uviportal : CLIArguments=
2024-09-03 21:57:43 : DEBUG : uviportal : updateTool=
2024-09-03 21:57:43 : DEBUG : uviportal : updateToolArguments=
2024-09-03 21:57:43 : DEBUG : uviportal : updateToolRunAsCurrentUser=
2024-09-03 21:57:43 : INFO  : uviportal : BLOCKING_PROCESS_ACTION=tell_user
2024-09-03 21:57:43 : INFO  : uviportal : NOTIFY=success
2024-09-03 21:57:43 : INFO  : uviportal : LOGGING=DEBUG
2024-09-03 21:57:43 : INFO  : uviportal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-03 21:57:43 : INFO  : uviportal : Label type: pkgInDmg
2024-09-03 21:57:43 : INFO  : uviportal : archiveName: UVI Portal.dmg
2024-09-03 21:57:43 : DEBUG : uviportal : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-03 21:57:43 : INFO  : uviportal : found packageID net.uvi.pkg.uviportal installed, version 3.0.4
2024-09-03 21:57:43 : INFO  : uviportal : appversion: 3.0.4
2024-09-03 21:57:43 : INFO  : uviportal : Latest version of UVI Portal is 3.0.4
2024-09-03 21:57:43 : WARN  : uviportal : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-03 21:57:43 : REQ   : uviportal : Downloading https://www.uvi.net/dl-portal.php?p=mac to UVI Portal.dmg
2024-09-03 21:57:43 : DEBUG : uviportal : No Dialog connection, just download
2024-09-03 21:58:28 : DEBUG : uviportal : File list: -rw-r--r--  1 gilburns  staff   130M Sep  3 21:58 UVI Portal.dmg
2024-09-03 21:58:28 : DEBUG : uviportal : File type: UVI Portal.dmg: zlib compressed data
2024-09-03 21:58:28 : DEBUG : uviportal : curl output was:
* Host www.uvi.net:443 was resolved.
* IPv6: (none)
* IPv4: 193.33.169.129
*   Trying 193.33.169.129:443...
* Connected to www.uvi.net (193.33.169.129) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3295 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.uvi.net
*  start date: Apr 24 00:00:00 2024 GMT
*  expire date: Apr 28 23:59:59 2025 GMT
*  subjectAltName: host "www.uvi.net" matched cert's "*.uvi.net"
*  issuer: C=FR; O=Gandi; CN=Gandi RSA Domain Validation Secure Server CA 3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.uvi.net/dl-portal.php?p=mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.uvi.net]
* [HTTP/2] [1] [:path: /dl-portal.php?p=mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /dl-portal.php?p=mac HTTP/2
> Host: www.uvi.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: nginx
< date: Wed, 04 Sep 2024 02:57:44 GMT
< content-type: text/html; charset=UTF-8
< content-length: 0
< location: https://cdn.uvi.net/PORTAL/4-3.0.4-0_UVIPortal-3.0.4.dmg
< x-powered-by: PleskLin
< 
* Ignoring the response-body
* Connection #0 to host www.uvi.net left intact
* Issue another request to this URL: 'https://cdn.uvi.net/PORTAL/4-3.0.4-0_UVIPortal-3.0.4.dmg'
* Host cdn.uvi.net:443 was resolved.
* IPv6: 2400:52e0:1a00::894:1
* IPv4: 185.93.1.243
*   Trying 185.93.1.243:443...
* Connected to cdn.uvi.net (185.93.1.243) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [1658 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.uvi.net
*  start date: Apr 24 00:00:00 2024 GMT
*  expire date: Apr 28 23:59:59 2025 GMT
*  subjectAltName: host "cdn.uvi.net" matched cert's "*.uvi.net"
*  issuer: C=FR; O=Gandi; CN=Gandi RSA Domain Validation Secure Server CA 3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cdn.uvi.net/PORTAL/4-3.0.4-0_UVIPortal-3.0.4.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cdn.uvi.net]
* [HTTP/2] [1] [:path: /PORTAL/4-3.0.4-0_UVIPortal-3.0.4.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /PORTAL/4-3.0.4-0_UVIPortal-3.0.4.dmg HTTP/2
> Host: cdn.uvi.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Wed, 04 Sep 2024 02:57:44 GMT
< content-type: application/x-apple-diskimage
< content-length: 135834120
< server: BunnyCDN-IL1-718
< cdn-pullzone: 1258587
< cdn-uid: 246ea544-8613-4d13-bf35-965a35beeed7
< cdn-requestcountrycode: US
< cache-control: public, max-age=31919000
< etag: "6659c01c-818aa08"
< last-modified: Fri, 31 May 2024 12:18:36 GMT
< cdn-storageserver: NY-427
< cdn-requestpullsuccess: True
< cdn-fileserver: 622
< perma-cache: HIT
< cdn-proxyver: 1.04
< cdn-requestpullcode: 200
< cdn-cachedat: 05/31/2024 13:31:52
< cdn-edgestorageid: 1068
< cdn-status: 200
< cdn-requestid: 6de6039df7960fa57856036d7998d1e8
< cdn-cache: HIT
< accept-ranges: bytes
< 
{ [5792 bytes data]
* Connection #1 to host cdn.uvi.net left intact

2024-09-03 21:58:28 : DEBUG : uviportal : DEBUG mode 1, not checking for blocking processes
2024-09-03 21:58:28 : REQ   : uviportal : Installing UVI Portal
2024-09-03 21:58:28 : INFO  : uviportal : Mounting /Users/gilburns/GitHub/Installomator/build/UVI Portal.dmg
2024-09-03 21:58:31 : DEBUG : uviportal : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $CDC3A42B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ECA3C64C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $4E1C4F39
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A007BC2B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $4E1C4F39
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FD3BBB19
verified   CRC32 $87EA7B99
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/UVIPortal-3.0.4

2024-09-03 21:58:31 : INFO  : uviportal : Mounted: /Volumes/UVIPortal-3.0.4
2024-09-03 21:58:31 : DEBUG : uviportal : Found pkg(s):
/Volumes/UVIPortal-3.0.4/UVI Portal.pkg
2024-09-03 21:58:31 : INFO  : uviportal : found pkg: /Volumes/UVIPortal-3.0.4/UVI Portal.pkg
2024-09-03 21:58:31 : INFO  : uviportal : Verifying: /Volumes/UVIPortal-3.0.4/UVI Portal.pkg
2024-09-03 21:58:31 : DEBUG : uviportal : File list: -rw-r--r--  1 gilburns  staff   129M May 31 03:53 /Volumes/UVIPortal-3.0.4/UVI Portal.pkg
2024-09-03 21:58:31 : DEBUG : uviportal : File type: /Volumes/UVIPortal-3.0.4/UVI Portal.pkg: xar archive compressed TOC: 6465, SHA-1 checksum
2024-09-03 21:58:31 : DEBUG : uviportal : spctlOut is /Volumes/UVIPortal-3.0.4/UVI Portal.pkg: accepted
2024-09-03 21:58:31 : DEBUG : uviportal : source=Notarized Developer ID
2024-09-03 21:58:31 : DEBUG : uviportal : origin=Developer ID Installer: UVI (BB6L4C84AT)
2024-09-03 21:58:31 : INFO  : uviportal : Team ID: BB6L4C84AT (expected: BB6L4C84AT )
2024-09-03 21:58:31 : INFO  : uviportal : Checking package version.
2024-09-03 21:58:32 : INFO  : uviportal : Downloaded package net.uvi.pkg.uviportal version 3.0.4
2024-09-03 21:58:32 : INFO  : uviportal : Downloaded version of UVI Portal is the same as installed.
2024-09-03 21:58:32 : DEBUG : uviportal : Unmounting /Volumes/UVIPortal-3.0.4
2024-09-03 21:58:33 : DEBUG : uviportal : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-03 21:58:33 : DEBUG : uviportal : DEBUG mode 1, not reopening anything
2024-09-03 21:58:33 : REQ   : uviportal : No new version to install
2024-09-03 21:58:33 : REQ   : uviportal : ################## End Installomator, exit code 0 
