### PR TITLE
Create UJAM Portal label

### DIFF
--- a/fragments/labels/ujamportal.sh
+++ b/fragments/labels/ujamportal.sh
@@ -2,10 +2,10 @@ ujamportal)
     name="UJAM"
     type="dmg"
     appNewVersion="$(curl -s -i "https://software.ujam.com/ujamapp/latest-mac.yml" | grep "version" | cut -d" " -f2 | xargs)"
-	if [[ $(arch) == "arm64" ]]; then
-    	downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}-arm64.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}-arm64.dmg"
     elif [[ $(arch) == "i386" ]]; then
-    	downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}.dmg"
+        downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}.dmg"
     fi
     expectedTeamID="9PRN6T272N"
     ;;

--- a/fragments/labels/ujamportal.sh
+++ b/fragments/labels/ujamportal.sh
@@ -1,0 +1,11 @@
+ujamportal)
+    name="UJAM"
+    type="dmg"
+    appNewVersion="$(curl -s -i "https://software.ujam.com/ujamapp/latest-mac.yml" | grep "version" | cut -d" " -f2 | xargs)"
+	if [[ $(arch) == "arm64" ]]; then
+    	downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+    	downloadURL="https://software.ujam.com/ujamapp/UJAM-${appNewVersion}.dmg"
+    fi
+    expectedTeamID="9PRN6T272N"
+    ;;


### PR DESCRIPTION
assemble.sh ujamportal                                     
2024-09-03 22:04:09 : REQ   : ujamportal : ################## Start Installomator v. 10.7beta, date 2024-09-03
2024-09-03 22:04:09 : INFO  : ujamportal : ################## Version: 10.7beta
2024-09-03 22:04:09 : INFO  : ujamportal : ################## Date: 2024-09-03
2024-09-03 22:04:09 : INFO  : ujamportal : ################## ujamportal
2024-09-03 22:04:09 : DEBUG : ujamportal : DEBUG mode 1 enabled.
2024-09-03 22:04:09 : INFO  : ujamportal : SwiftDialog is not installed, clear cmd file var
2024-09-03 22:04:09 : DEBUG : ujamportal : name=UJAM
2024-09-03 22:04:09 : DEBUG : ujamportal : appName=
2024-09-03 22:04:09 : DEBUG : ujamportal : type=dmg
2024-09-03 22:04:09 : DEBUG : ujamportal : archiveName=
2024-09-03 22:04:09 : DEBUG : ujamportal : downloadURL=https://software.ujam.com/ujamapp/UJAM-1.0.6.dmg
2024-09-03 22:04:09 : DEBUG : ujamportal : curlOptions=
2024-09-03 22:04:10 : DEBUG : ujamportal : appNewVersion=1.0.6
2024-09-03 22:04:10 : DEBUG : ujamportal : appCustomVersion function: Not defined
2024-09-03 22:04:10 : DEBUG : ujamportal : versionKey=CFBundleShortVersionString
2024-09-03 22:04:10 : DEBUG : ujamportal : packageID=
2024-09-03 22:04:10 : DEBUG : ujamportal : pkgName=
2024-09-03 22:04:10 : DEBUG : ujamportal : choiceChangesXML=
2024-09-03 22:04:10 : DEBUG : ujamportal : expectedTeamID=9PRN6T272N
2024-09-03 22:04:10 : DEBUG : ujamportal : blockingProcesses=
2024-09-03 22:04:10 : DEBUG : ujamportal : installerTool=
2024-09-03 22:04:10 : DEBUG : ujamportal : CLIInstaller=
2024-09-03 22:04:10 : DEBUG : ujamportal : CLIArguments=
2024-09-03 22:04:10 : DEBUG : ujamportal : updateTool=
2024-09-03 22:04:10 : DEBUG : ujamportal : updateToolArguments=
2024-09-03 22:04:10 : DEBUG : ujamportal : updateToolRunAsCurrentUser=
2024-09-03 22:04:10 : INFO  : ujamportal : BLOCKING_PROCESS_ACTION=tell_user
2024-09-03 22:04:10 : INFO  : ujamportal : NOTIFY=success
2024-09-03 22:04:10 : INFO  : ujamportal : LOGGING=DEBUG
2024-09-03 22:04:10 : INFO  : ujamportal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-03 22:04:10 : INFO  : ujamportal : Label type: dmg
2024-09-03 22:04:10 : INFO  : ujamportal : archiveName: UJAM.dmg
2024-09-03 22:04:10 : INFO  : ujamportal : no blocking processes defined, using UJAM as default
2024-09-03 22:04:10 : DEBUG : ujamportal : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-03 22:04:10 : INFO  : ujamportal : App(s) found: /Applications/UJAM.app
2024-09-03 22:04:10 : INFO  : ujamportal : found app at /Applications/UJAM.app, version 1.0.6, on versionKey CFBundleShortVersionString
2024-09-03 22:04:10 : INFO  : ujamportal : appversion: 1.0.6
2024-09-03 22:04:10 : INFO  : ujamportal : Latest version of UJAM is 1.0.6
2024-09-03 22:04:10 : WARN  : ujamportal : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-03 22:04:10 : REQ   : ujamportal : Downloading https://software.ujam.com/ujamapp/UJAM-1.0.6.dmg to UJAM.dmg
2024-09-03 22:04:10 : DEBUG : ujamportal : No Dialog connection, just download
2024-09-03 22:05:10 : DEBUG : ujamportal : File list: -rw-r--r--  1 gilburns  staff   166M Sep  3 22:05 UJAM.dmg
2024-09-03 22:05:10 : DEBUG : ujamportal : File type: UJAM.dmg: zlib compressed data
2024-09-03 22:05:10 : DEBUG : ujamportal : curl output was:
* Host software.ujam.com:443 was resolved.
* IPv6: (none)
* IPv4: 13.32.164.46, 13.32.164.14, 13.32.164.69, 13.32.164.76
*   Trying 13.32.164.46:443...
* Connected to software.ujam.com (13.32.164.46) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4958 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=software.ujam.com
*  start date: May 10 00:00:00 2024 GMT
*  expire date: Jun  7 23:59:59 2025 GMT
*  subjectAltName: host "software.ujam.com" matched cert's "software.ujam.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /ujamapp/UJAM-1.0.6.dmg HTTP/1.1
> Host: software.ujam.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 173682855
< Connection: keep-alive
< Date: Wed, 04 Sep 2024 03:04:11 GMT
< Last-Modified: Wed, 08 May 2024 14:58:33 GMT
< ETag: "e4026cae142648993ee9e3486d932353-34"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Miss from cloudfront
< Via: 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD58-P1
< X-Amz-Cf-Id: 6-hr2rMBHExGnKqoV-lkXNwnCdhiKTUuHHW9dadlR4VrafV4MlJ_Lg==
< 
{ [1515 bytes data]
* Connection #0 to host software.ujam.com left intact

2024-09-03 22:05:10 : DEBUG : ujamportal : DEBUG mode 1, not checking for blocking processes
2024-09-03 22:05:10 : REQ   : ujamportal : Installing UJAM
2024-09-03 22:05:10 : INFO  : ujamportal : Mounting /Users/gilburns/GitHub/Installomator/build/UJAM.dmg
2024-09-03 22:05:13 : DEBUG : ujamportal : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $B153F1BD
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D7A4767A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F8772CD8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $38622988
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F8772CD8
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FE998758
verified   CRC32 $9BA788FF
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/UJAM 1.0.6

2024-09-03 22:05:13 : INFO  : ujamportal : Mounted: /Volumes/UJAM 1.0.6
2024-09-03 22:05:13 : INFO  : ujamportal : Verifying: /Volumes/UJAM 1.0.6/UJAM.app
2024-09-03 22:05:13 : DEBUG : ujamportal : App size: 467M	/Volumes/UJAM 1.0.6/UJAM.app
2024-09-03 22:05:16 : DEBUG : ujamportal : Debugging enabled, App Verification output was:
/Volumes/UJAM 1.0.6/UJAM.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: UJAM Music Technology GmbH (9PRN6T272N)

2024-09-03 22:05:16 : INFO  : ujamportal : Team ID matching: 9PRN6T272N (expected: 9PRN6T272N )
2024-09-03 22:05:16 : INFO  : ujamportal : Downloaded version of UJAM is 1.0.6 on versionKey CFBundleShortVersionString, same as installed.
2024-09-03 22:05:16 : DEBUG : ujamportal : Unmounting /Volumes/UJAM 1.0.6
2024-09-03 22:05:17 : DEBUG : ujamportal : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-03 22:05:17 : DEBUG : ujamportal : DEBUG mode 1, not reopening anything
2024-09-03 22:05:17 : REG   : ujamportal : No new version to install
2024-09-03 22:05:17 : REQ   : ujamportal : ################## End Installomator, exit code 0 
