### PR TITLE
Update surfdrive.sh

### DIFF
--- a/fragments/labels/surfdrive.sh
+++ b/fragments/labels/surfdrive.sh
@@ -1,9 +1,9 @@
 surfdrive)
     name="SURFdrive"
     type="pkg"
-    downloadURL="https://surfdrive.surf.nl/downloads/surfdrive-latest-x86_64.pkg"
+    downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" |grep $(uname -m)| grep pkg)
     expectedTeamID="4AP2STM4H5"
-    appNewVersion=$(curl -fs https://wiki.surfnet.nl/display/SURFdrive/Downloads+voor+SURFdrive|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg|cut -d- -f2)
+    appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" |grep $(uname -m)| grep pkg|cut -d- -f2)
     appName="surfdrive.app"
     blockingProcesses=( "surfdrive" )
     ;;


### PR DESCRIPTION
updated the surfdrive label to the new url and added arch support
Output:
```
./assemble.sh surfdrive DEBUG=0
2024-09-04 11:21:52 : REQ   : surfdrive : ################## Start Installomator v. 10.7beta, date 2024-09-04
2024-09-04 11:21:52 : INFO  : surfdrive : ################## Version: 10.7beta
2024-09-04 11:21:52 : INFO  : surfdrive : ################## Date: 2024-09-04
2024-09-04 11:21:52 : INFO  : surfdrive : ################## surfdrive
2024-09-04 11:21:52 : DEBUG : surfdrive : DEBUG mode 1 enabled.
2024-09-04 11:21:53 : INFO  : surfdrive : setting variable from argument DEBUG=0
2024-09-04 11:21:53 : DEBUG : surfdrive : name=SURFdrive
2024-09-04 11:21:53 : DEBUG : surfdrive : appName=surfdrive.app
2024-09-04 11:21:53 : DEBUG : surfdrive : type=pkg
2024-09-04 11:21:53 : DEBUG : surfdrive : archiveName=
2024-09-04 11:21:53 : DEBUG : surfdrive : downloadURL=https://surfdrive.surf.nl/downloads/surfdrive-5.3.1.14097-arm64.pkg
2024-09-04 11:21:53 : DEBUG : surfdrive : curlOptions=
2024-09-04 11:21:53 : DEBUG : surfdrive : appNewVersion=5.3.1.14097
2024-09-04 11:21:53 : DEBUG : surfdrive : appCustomVersion function: Not defined
2024-09-04 11:21:53 : DEBUG : surfdrive : versionKey=CFBundleShortVersionString
2024-09-04 11:21:53 : DEBUG : surfdrive : packageID=
2024-09-04 11:21:53 : DEBUG : surfdrive : pkgName=
2024-09-04 11:21:53 : DEBUG : surfdrive : choiceChangesXML=
2024-09-04 11:21:53 : DEBUG : surfdrive : expectedTeamID=4AP2STM4H5
2024-09-04 11:21:53 : DEBUG : surfdrive : blockingProcesses=surfdrive
2024-09-04 11:21:53 : DEBUG : surfdrive : installerTool=
2024-09-04 11:21:53 : DEBUG : surfdrive : CLIInstaller=
2024-09-04 11:21:53 : DEBUG : surfdrive : CLIArguments=
2024-09-04 11:21:53 : DEBUG : surfdrive : updateTool=
2024-09-04 11:21:53 : DEBUG : surfdrive : updateToolArguments=
2024-09-04 11:21:53 : DEBUG : surfdrive : updateToolRunAsCurrentUser=
2024-09-04 11:21:53 : INFO  : surfdrive : BLOCKING_PROCESS_ACTION=tell_user
2024-09-04 11:21:53 : INFO  : surfdrive : NOTIFY=success
2024-09-04 11:21:53 : INFO  : surfdrive : LOGGING=DEBUG
2024-09-04 11:21:53 : INFO  : surfdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-04 11:21:53 : INFO  : surfdrive : Label type: pkg
2024-09-04 11:21:53 : INFO  : surfdrive : archiveName: SURFdrive.pkg
2024-09-04 11:21:53 : DEBUG : surfdrive : Changing directory to /var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.g3Xus2u2Cj
2024-09-04 11:21:53 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2024-09-04 11:21:53 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 5.3.1.14097, on versionKey CFBundleShortVersionString
2024-09-04 11:21:53 : INFO  : surfdrive : appversion: 5.3.1.14097
2024-09-04 11:21:53 : INFO  : surfdrive : Latest version of SURFdrive is 5.3.1.14097
2024-09-04 11:21:53 : INFO  : surfdrive : There is no newer version available.
2024-09-04 11:21:53 : DEBUG : surfdrive : Deleting /var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.g3Xus2u2Cj
2024-09-04 11:21:53 : DEBUG : surfdrive : Debugging enabled, Deleting tmpDir output was:
/var/folders/cr/vk1cprh973723scgxmx20z200000gq/T/tmp.g3Xus2u2Cj
2024-09-04 11:21:53 : INFO  : surfdrive : Installomator did not close any apps, so no need to reopen any apps.
2024-09-04 11:21:53 : REQ   : surfdrive : No newer version.
2024-09-04 11:21:53 : REQ   : surfdrive : ################## End Installomator, exit code 0