### PR TITLE
Update crashplansmb.sh

### DIFF
--- a/fragments/labels/crashplansmb.sh
+++ b/fragments/labels/crashplansmb.sh
@@ -2,8 +2,8 @@ crashplansmb)
     name="CrashPlan"
     type="pkgInDmg"
     pkgName="Install Crashplan.pkg"
-    downloadURL="https://download.crashplan.com/installs/agent/latest-smb-mac.dmg"
-    appNewVersion=$( curl https://download.crashplan.com/installs/agent/latest-smb-mac.dmg  -s -L -I -o /dev/null -w '%{url_effective}' | cut -d "/" -f7 )
+    downloadURL="https://download.crashplan.com/installs/agent/latest-mac.dmg"
+    appNewVersion=$( curl https://download.crashplan.com/installs/agent/latest-mac.dmg  -s -L -I -o /dev/null -w '%{url_effective}' | cut -d "/" -f7 )
     expectedTeamID="UGHXR79U6M"
     blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
CrashPlan SMB specific download URLs were removed. Updating to point to the default latest application link.