### PR TITLE
Created Cherry Audio Blue3 Tonewheel Organ label

### DIFF
--- a/fragments/labels/cherryaudioblue3.sh
+++ b/fragments/labels/cherryaudioblue3.sh
@@ -1,0 +1,8 @@
+cherryaudioblue3)
+    name="Blue3 Organ"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.Blue3Package-StandAlone"
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/blue3-tonewheel-organ/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
assemble.sh cherryaudioblue3     
2024-09-04 20:01:08 : REQ   : cherryaudioblue3 : ################## Start Installomator v. 10.7beta, date 2024-09-04
2024-09-04 20:01:08 : INFO  : cherryaudioblue3 : ################## Version: 10.7beta
2024-09-04 20:01:08 : INFO  : cherryaudioblue3 : ################## Date: 2024-09-04
2024-09-04 20:01:08 : INFO  : cherryaudioblue3 : ################## cherryaudioblue3
2024-09-04 20:01:08 : DEBUG : cherryaudioblue3 : DEBUG mode 1 enabled.
2024-09-04 20:01:08 : INFO  : cherryaudioblue3 : SwiftDialog is not installed, clear cmd file var
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : name=Blue3 Organ
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : appName=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : type=pkg
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : archiveName=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : downloadURL=https://store.cherryaudio.com/downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : curlOptions=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : appNewVersion=1.0.9
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : appCustomVersion function: Not defined
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : versionKey=CFBundleShortVersionString
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : packageID=com.cherryaudio.pkg.Blue3Package-StandAlone
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : pkgName=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : choiceChangesXML=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : expectedTeamID=A2XFV22B2X
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : blockingProcesses=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : installerTool=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : CLIInstaller=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : CLIArguments=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : updateTool=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : updateToolArguments=
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : updateToolRunAsCurrentUser=
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : NOTIFY=success
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : LOGGING=DEBUG
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : Label type: pkg
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : archiveName: Blue3 Organ.pkg
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : no blocking processes defined, using Blue3 Organ as default
2024-09-04 20:01:09 : DEBUG : cherryaudioblue3 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : No version found using packageID com.cherryaudio.pkg.Blue3Package-StandAlone
2024-09-04 20:01:09 : INFO  : cherryaudioblue3 : name: Blue3 Organ, appName: Blue3 Organ.app
2024-09-04 20:01:09.899 mdfind[71009:2353371] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-04 20:01:09.899 mdfind[71009:2353371] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-04 20:01:10.028 mdfind[71009:2353371] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-04 20:01:10 : WARN  : cherryaudioblue3 : No previous app found
2024-09-04 20:01:10 : WARN  : cherryaudioblue3 : could not find Blue3 Organ.app
2024-09-04 20:01:10 : INFO  : cherryaudioblue3 : appversion: 
2024-09-04 20:01:10 : INFO  : cherryaudioblue3 : Latest version of Blue3 Organ is 1.0.9
2024-09-04 20:01:10 : REQ   : cherryaudioblue3 : Downloading https://store.cherryaudio.com/downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg to Blue3 Organ.pkg
2024-09-04 20:01:10 : DEBUG : cherryaudioblue3 : No Dialog connection, just download
2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : File list: -rw-r--r--  1 gilburns  staff    38M Sep  4 20:01 Blue3 Organ.pkg
2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : File type: Blue3 Organ.pkg: xar archive compressed TOC: 7183, SHA-1 checksum
2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/blue3-tonewheel-organ-macos-installer?file=Blue3-Organ-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 40230815
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Blue3-Organ-Installer-macOS.pkg"
< pragma: public
< date: Thu, 05 Sep 2024 01:01:10 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6ImR4aWVFeGJwRzFGOFcyaDIxR1pGSmc9PSIsInZhbHVlIjoiU3ZqaTF6QktpT1pLTVloM2M2WGNPUDFYUC9jTDdDK2VReVpkYy9nZXduVFN5ejdyTGEzN1dTcm5HT0F0TjZpZ1RsbSsxUmRibEZoMGRqOXFZRzhXQkJRZ0dkZ0RRZ3h2am4zQlVNeVRISis4QndEWnNmSmhVeW45bzE3R2lONFgiLCJtYWMiOiIyNDMwZDhlYjVkZWZhMzRkOTVjZjFiN2Q4MTM2NTg3ZDNkNjY1YTcyMjYzNGRlMmEzZjZjMjdkOWVlMzVlMzRmIiwidGFnIjoiIn0%3D; expires=Thu, 05 Sep 2024 03:01:10 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Inc2R2RxNnlJb0tZZTN2dkhCdHBzdEE9PSIsInZhbHVlIjoiU3ZvUXZrSzlQanhyMlUyRmR6czF3K3Y5RDRlOG1nNEQvOXlreHB0dnJPOXBWQzl2UHhldkVscnZOZUVHQmlFYWVpQ2JFZk5ZYkJiZkVoRWR5ZnZVM1Q1OXMzTWhVRWViZmVyTU1tOHZDNk9YUzE0SWRQV0NXUFNSelp5N1h2blQiLCJtYWMiOiIyNzJmMjViOWNmOGI3YzI2NmM3MDQ5MTBkZDUwMmVkM2Y2NzI1NGU2NjRiNmJhNjkzMGIxNDVkMDNlNmNlNzEwIiwidGFnIjoiIn0%3D; expires=Thu, 05 Sep 2024 03:01:10 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7007 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : DEBUG mode 1, not checking for blocking processes
2024-09-04 20:01:39 : REQ   : cherryaudioblue3 : Installing Blue3 Organ
2024-09-04 20:01:39 : INFO  : cherryaudioblue3 : Verifying: Blue3 Organ.pkg
2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : File list: -rw-r--r--  1 gilburns  staff    38M Sep  4 20:01 Blue3 Organ.pkg
2024-09-04 20:01:39 : DEBUG : cherryaudioblue3 : File type: Blue3 Organ.pkg: xar archive compressed TOC: 7183, SHA-1 checksum
2024-09-04 20:01:40 : DEBUG : cherryaudioblue3 : spctlOut is Blue3 Organ.pkg: accepted
2024-09-04 20:01:40 : DEBUG : cherryaudioblue3 : source=Notarized Developer ID
2024-09-04 20:01:40 : DEBUG : cherryaudioblue3 : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-09-04 20:01:40 : INFO  : cherryaudioblue3 : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-09-04 20:01:40 : DEBUG : cherryaudioblue3 : DEBUG enabled, skipping installation
2024-09-04 20:01:40 : INFO  : cherryaudioblue3 : Finishing...
2024-09-04 20:01:43 : INFO  : cherryaudioblue3 : No version found using packageID com.cherryaudio.pkg.Blue3Package-StandAlone
2024-09-04 20:01:43 : INFO  : cherryaudioblue3 : name: Blue3 Organ, appName: Blue3 Organ.app
2024-09-04 20:01:43.391 mdfind[71072:2354035] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-04 20:01:43.392 mdfind[71072:2354035] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-04 20:01:43.493 mdfind[71072:2354035] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-04 20:01:43 : WARN  : cherryaudioblue3 : No previous app found
2024-09-04 20:01:43 : WARN  : cherryaudioblue3 : could not find Blue3 Organ.app
2024-09-04 20:01:43 : REQ   : cherryaudioblue3 : Installed Blue3 Organ, version 1.0.9
2024-09-04 20:01:43 : INFO  : cherryaudioblue3 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-04 20:01:43 : DEBUG : cherryaudioblue3 : DEBUG mode 1, not reopening anything
2024-09-04 20:01:43 : REQ   : cherryaudioblue3 : All done!
2024-09-04 20:01:43 : REQ   : cherryaudioblue3 : ################## End Installomator, exit code 0 
