### PR TITLE
Updated fragments for Google Drive and Microsoft Teams 2

### DIFF
--- a/fragments/labels/googledrive.sh
+++ b/fragments/labels/googledrive.sh
@@ -1,7 +1,7 @@
 googledrive|\
 googledrivefilestream)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
-    name="Google Drive File Stream"
+    name="Google Drive"
     type="pkgInDmg"
     if [[ $(arch) == "arm64" ]]; then
        packageID="com.google.drivefs.arm64"

--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -1,5 +1,5 @@
 microsoftteamsnew)
-    name="Microsoft Teams (work or school)"
+    name="Microsoft Teams"
     type="pkg"
     #packageID="com.microsoft.teams2"
     downloadURL="https://go.microsoft.com/fwlink/?linkid=2249065"

--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -9,6 +9,10 @@ microsoftteamsnew)
     #versionKey="CFBundleGetInfoString"
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher" "Microsoft Teams (work preview)")
+    updateToolPlist="/Library/LaunchAgents/com.microsoft.update.agent.plist"
+    # Reload the msupdate launchAgent
+    sudo launchctl bootout system "${msupdatePlist}" 2>/dev/null
+    sudo launchctl bootstrap system "${msupdatePlist}" 2>/dev/null
     # msupdate requires a PPPC profile pushed out from Jamf to work, https://github.com/pbowden-msft/MobileConfigs/tree/master/Jamf-MSUpdate
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"

--- a/fragments/labels/topazgigapixel.sh
+++ b/fragments/labels/topazgigapixel.sh
@@ -1,0 +1,10 @@
+topazgigapixel|\
+topazgigapixelai)
+    # credit: @tully_jagoe
+    name="Topaz Gigapixel AI"
+    type="pkg"
+    appNewVersion=$(curl -sSL "https://formulae.brew.sh/api/cask/topaz-gigapixel-ai.json" | awk -F'"version":' '{split($2, a, "\""); print a[2]}' | grep -oE '[0-9.]+')
+    versionKey="CFBundleShortVersionString"
+    downloadURL="https://downloads.topazlabs.com/deploy/TopazGigapixelAI/${appNewVersion}/TopazGigapixelAI-${appNewVersion}.pkg"
+    expectedTeamID="3G3JE37ZHF"
+    ;;


### PR DESCRIPTION
Google Drive app name that is pulled from existing fragment downloadURL is now named "Google Drive",  no longer "Google Drive File Stream", updated name variable to match 

Microsoft Teams app name that is pulled from existing fragment downloadURL is now named "Microsoft Teams", no longer "Microsoft Teams (work or school)", updated name variable to match 
Also added function to reload the Launch Agent for msupdate tool which helps with reliability and prevents some errors