### PR TITLE
Create new install type pkgInDmgInZip

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -859,6 +859,31 @@ installAppInDmgInZip() {
     installFromDMG
 }
 
+installPkgInDmgInZip() {
+    # unzip the archive
+    printlog "Unzipping $archiveName"
+    tar -xf "$archiveName"
+
+    # locate dmg in zip
+    if [[ -z $pkgName ]]; then
+        # find first file ending with 'dmg'
+        findfiles=$(find "$tmpDir" -iname "*.dmg" -maxdepth 2  )
+        filearray=( ${(f)findfiles} )
+        if [[ ${#filearray} -eq 0 ]]; then
+            cleanupAndExit 22 "couldn't find dmg in zip $archiveName" ERROR
+        fi
+        archiveName="$(basename ${filearray[1]})"
+        # it is now safe to overwrite archiveName for installFromDMG
+        printlog "found dmg: $tmpDir/$archiveName"
+    else
+        # it is now safe to overwrite archiveName for installFromDMG
+        archiveName="$pkgName"
+    fi
+
+    # installPkgInDmg, DMG expected to include an pkg (will not work with app)
+    installPkgInDmg
+}
+
 runUpdateTool() {
     printlog "Function called: runUpdateTool"
     if [[ -x $updateTool ]]; then

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -834,7 +834,7 @@ installPkgInZip() {
     installFromPKG
 }
 
-installAppInDmgInZip() {
+installItemInDmgInZip() {
     # unzip the archive
     printlog "Unzipping $archiveName"
     tar -xf "$archiveName"
@@ -855,34 +855,21 @@ installAppInDmgInZip() {
         archiveName="$pkgName"
     fi
 
-    # installFromDMG, DMG expected to include an app (will not work with pkg)
-    installFromDMG
+    case $type in
+        appInDmgInZip)
+            # installFromDMG, DMG expected to include an app (will not work with pkg)
+            installFromDMG
+            ;;
+        pkgInDmgInZip)
+            # installPkgInDmg, DMG expected to include an pkg (will not work with app)
+            installPkgInDmg
+            ;;
+        *)
+            cleanupAndExit 99 "Cannot handle type $type" ERROR
+            ;;
+    esac
 }
 
-installPkgInDmgInZip() {
-    # unzip the archive
-    printlog "Unzipping $archiveName"
-    tar -xf "$archiveName"
-
-    # locate dmg in zip
-    if [[ -z $pkgName ]]; then
-        # find first file ending with 'dmg'
-        findfiles=$(find "$tmpDir" -iname "*.dmg" -maxdepth 2  )
-        filearray=( ${(f)findfiles} )
-        if [[ ${#filearray} -eq 0 ]]; then
-            cleanupAndExit 22 "couldn't find dmg in zip $archiveName" ERROR
-        fi
-        archiveName="$(basename ${filearray[1]})"
-        # it is now safe to overwrite archiveName for installFromDMG
-        printlog "found dmg: $tmpDir/$archiveName"
-    else
-        # it is now safe to overwrite archiveName for installFromDMG
-        archiveName="$pkgName"
-    fi
-
-    # installPkgInDmg, DMG expected to include an pkg (will not work with app)
-    installPkgInDmg
-}
 
 runUpdateTool() {
     printlog "Function called: runUpdateTool"

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -192,6 +192,7 @@ NOTIFY_DIALOG=0
 #     - pkgInDmg
 #     - pkgInZip
 #     - appInDmgInZip
+#     - pkgInDmgInZip
 #     - updateronly     This last one is for labels that should only run an updateTool (see below)
 #
 # - packageID: (optional)

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -363,11 +363,8 @@ case $type in
     pkgInZip)
         installPkgInZip
         ;;
-    appInDmgInZip)
-        installAppInDmgInZip
-        ;;
-    pkgInDmgInZip)
-        installPkgInDmgInZip
+    *InDmgInZip)
+        installItemInDmgInZip
         ;;
     *)
         cleanupAndExit 99 "Cannot handle type $type" ERROR

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -366,6 +366,9 @@ case $type in
     appInDmgInZip)
         installAppInDmgInZip
         ;;
+    pkgInDmgInZip)
+        installPkgInDmgInZip
+        ;;
     *)
         cleanupAndExit 99 "Cannot handle type $type" ERROR
         ;;


### PR DESCRIPTION
Added additional code to support type "pkgInDmgInZip". Mostly the code needed was already present. All that was needed was to add an additional case to the type check and branch appropriately to the new function. The new function "installPkgInDmgInZip" was more or less a copy of "installAppInDmgInZip" just calling a different function call at the end.

Yes, I understand that putting a pkg in a dmg and then in a zip is totally redundant and terrible. Unfortunately, some vendors do it. Trying to get them to change, is probably not always possible. IT needs to support with they provide, not what we wished they would provide. 😁