### PR TITLE
microsoftcompanyportal update downloadURL

### DIFF
--- a/fragments/labels/microsoftcompanyportal.sh
+++ b/fragments/labels/microsoftcompanyportal.sh
@@ -1,7 +1,7 @@
 microsoftcompanyportal)
     name="Company Portal"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869655"
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=853070"
     #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.intunecompanyportal.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/CompanyPortal_.*pkg" | cut -d "_" -f 2 | cut -d "-" -f 1)
     expectedTeamID="UBF8T346G9"


### PR DESCRIPTION
The current downloadURL downloads CompanyPortal_5.2310.5-Installer.pkg however v5.2409.1 has now been released that resolves numerous issues associated with macOS 15 Sequoia testing.