### PR TITLE
Create Waves Central label

### DIFF
--- a/fragments/labels/wavescentral.sh
+++ b/fragments/labels/wavescentral.sh
@@ -1,0 +1,8 @@
+wavescentral)
+    name="Waves Central"
+    type="dmg"
+    downloadURL="https://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg"
+    appNewVersion=$( curl -sf "https://register.waves.com/Autoupdate/Updates/ByProductId/1/central-mac" | grep version | cut -d" " -f2 | xargs )
+    expectedTeamID="GT6E3XD798"
+    ;;
+    


### PR DESCRIPTION
assemble.sh wavescentral
2024-09-09 17:58:53 : REQ   : wavescentral : ################## Start Installomator v. 10.7beta, date 2024-09-09
2024-09-09 17:58:53 : INFO  : wavescentral : ################## Version: 10.7beta
2024-09-09 17:58:53 : INFO  : wavescentral : ################## Date: 2024-09-09
2024-09-09 17:58:53 : INFO  : wavescentral : ################## wavescentral
2024-09-09 17:58:53 : DEBUG : wavescentral : DEBUG mode 1 enabled.
2024-09-09 17:58:53 : INFO  : wavescentral : SwiftDialog is not installed, clear cmd file var
2024-09-09 17:58:54 : DEBUG : wavescentral : name=Waves Central
2024-09-09 17:58:54 : DEBUG : wavescentral : appName=
2024-09-09 17:58:54 : DEBUG : wavescentral : type=dmg
2024-09-09 17:58:54 : DEBUG : wavescentral : archiveName=
2024-09-09 17:58:54 : DEBUG : wavescentral : downloadURL=https://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg
2024-09-09 17:58:54 : DEBUG : wavescentral : curlOptions=
2024-09-09 17:58:54 : DEBUG : wavescentral : appNewVersion=15.1.3
2024-09-09 17:58:54 : DEBUG : wavescentral : appCustomVersion function: Not defined
2024-09-09 17:58:54 : DEBUG : wavescentral : versionKey=CFBundleShortVersionString
2024-09-09 17:58:54 : DEBUG : wavescentral : packageID=
2024-09-09 17:58:54 : DEBUG : wavescentral : pkgName=
2024-09-09 17:58:54 : DEBUG : wavescentral : choiceChangesXML=
2024-09-09 17:58:54 : DEBUG : wavescentral : expectedTeamID=GT6E3XD798
2024-09-09 17:58:54 : DEBUG : wavescentral : blockingProcesses=
2024-09-09 17:58:54 : DEBUG : wavescentral : installerTool=
2024-09-09 17:58:54 : DEBUG : wavescentral : CLIInstaller=
2024-09-09 17:58:54 : DEBUG : wavescentral : CLIArguments=
2024-09-09 17:58:54 : DEBUG : wavescentral : updateTool=
2024-09-09 17:58:54 : DEBUG : wavescentral : updateToolArguments=
2024-09-09 17:58:54 : DEBUG : wavescentral : updateToolRunAsCurrentUser=
2024-09-09 17:58:54 : INFO  : wavescentral : BLOCKING_PROCESS_ACTION=tell_user
2024-09-09 17:58:54 : INFO  : wavescentral : NOTIFY=success
2024-09-09 17:58:54 : INFO  : wavescentral : LOGGING=DEBUG
2024-09-09 17:58:54 : INFO  : wavescentral : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-09 17:58:54 : INFO  : wavescentral : Label type: dmg
2024-09-09 17:58:54 : INFO  : wavescentral : archiveName: Waves Central.dmg
2024-09-09 17:58:54 : INFO  : wavescentral : no blocking processes defined, using Waves Central as default
2024-09-09 17:58:54 : DEBUG : wavescentral : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-09 17:58:54 : INFO  : wavescentral : name: Waves Central, appName: Waves Central.app
2024-09-09 17:58:54.710 mdfind[59206:6128994] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 17:58:54.711 mdfind[59206:6128994] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 17:58:54.890 mdfind[59206:6128994] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 17:58:54 : WARN  : wavescentral : No previous app found
2024-09-09 17:58:54 : WARN  : wavescentral : could not find Waves Central.app
2024-09-09 17:58:54 : INFO  : wavescentral : appversion: 
2024-09-09 17:58:54 : INFO  : wavescentral : Latest version of Waves Central is 15.1.3
2024-09-09 17:58:54 : REQ   : wavescentral : Downloading https://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg to Waves Central.dmg
2024-09-09 17:58:54 : DEBUG : wavescentral : No Dialog connection, just download
2024-09-09 18:00:16 : DEBUG : wavescentral : File list: -rw-r--r--  1 gilburns  staff   230M Sep  9 18:00 Waves Central.dmg
2024-09-09 18:00:16 : DEBUG : wavescentral : File type: Waves Central.dmg: zlib compressed data
2024-09-09 18:00:16 : DEBUG : wavescentral : curl output was:
* Host cf-installers.waves.com:443 was resolved.
* IPv6: 2600:9000:27fb:b200:e:9d63:3380:93a1, 2600:9000:27fb:cc00:e:9d63:3380:93a1, 2600:9000:27fb:a800:e:9d63:3380:93a1, 2600:9000:27fb:3600:e:9d63:3380:93a1, 2600:9000:27fb:2a00:e:9d63:3380:93a1, 2600:9000:27fb:9c00:e:9d63:3380:93a1, 2600:9000:27fb:9600:e:9d63:3380:93a1, 2600:9000:27fb:d200:e:9d63:3380:93a1
* IPv4: 3.168.40.39, 3.168.40.126, 3.168.40.47, 3.168.40.41
*   Trying 3.168.40.39:443...
* Connected to cf-installers.waves.com (3.168.40.39) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4972 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cf-installers.waves.com
*  start date: Sep 18 00:00:00 2023 GMT
*  expire date: Oct 17 23:59:59 2024 GMT
*  subjectAltName: host "cf-installers.waves.com" matched cert's "cf-installers.waves.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cf-installers.waves.com/WavesCentral/Install_Waves_Central.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cf-installers.waves.com]
* [HTTP/2] [1] [:path: /WavesCentral/Install_Waves_Central.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /WavesCentral/Install_Waves_Central.dmg HTTP/2
> Host: cf-installers.waves.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 241432448
< last-modified: Sun, 08 Sep 2024 10:15:56 GMT
< x-amz-server-side-encryption: AES256
< x-amz-meta-cb-modifiedtime: Wed, 28 Aug 2024 11:22:43 GMT
< accept-ranges: bytes
< server: AmazonS3
< date: Mon, 09 Sep 2024 16:42:27 GMT
< etag: "2e0d93907c78d1583ad6b18df34225ba"
< x-cache: Hit from cloudfront
< via: 1.1 0e484100c0132fa0149795dba26d1b12.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD58-P8
< x-amz-cf-id: h2YVpei-jpHJr5MTixDc7xBtyjSw20bfQW7W0zAl3wJCYQhw-ItM7A==
< age: 22589
< 
{ [8192 bytes data]
* Connection #0 to host cf-installers.waves.com left intact

2024-09-09 18:00:16 : DEBUG : wavescentral : DEBUG mode 1, not checking for blocking processes
2024-09-09 18:00:16 : REQ   : wavescentral : Installing Waves Central
2024-09-09 18:00:16 : INFO  : wavescentral : Mounting /Users/gilburns/GitHub/Installomator/build/Waves Central.dmg
2024-09-09 18:00:21 : DEBUG : wavescentral : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3B0CEEED
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $793C313E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CC9F7AD7
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $4F1454B5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CC9F7AD7
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $DE3FE5A3
verified   CRC32 $68B81575
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Waves Central 15.1.3

2024-09-09 18:00:21 : INFO  : wavescentral : Mounted: /Volumes/Waves Central 15.1.3
2024-09-09 18:00:21 : INFO  : wavescentral : Verifying: /Volumes/Waves Central 15.1.3/Waves Central.app
2024-09-09 18:00:21 : DEBUG : wavescentral : App size: 506M	/Volumes/Waves Central 15.1.3/Waves Central.app
2024-09-09 18:00:27 : DEBUG : wavescentral : Debugging enabled, App Verification output was:
/Volumes/Waves Central 15.1.3/Waves Central.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Waves Inc (GT6E3XD798)

2024-09-09 18:00:27 : INFO  : wavescentral : Team ID matching: GT6E3XD798 (expected: GT6E3XD798 )
2024-09-09 18:00:27 : INFO  : wavescentral : Installing Waves Central version 15.1.3 on versionKey CFBundleShortVersionString.
2024-09-09 18:00:27 : INFO  : wavescentral : App has LSMinimumSystemVersion: 10.15
2024-09-09 18:00:27 : DEBUG : wavescentral : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-09 18:00:27 : INFO  : wavescentral : Finishing...
2024-09-09 18:00:30 : INFO  : wavescentral : name: Waves Central, appName: Waves Central.app
2024-09-09 18:00:30.859 mdfind[59307:6130645] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 18:00:30.860 mdfind[59307:6130645] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 18:00:31.011 mdfind[59307:6130645] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 18:00:31 : WARN  : wavescentral : No previous app found
2024-09-09 18:00:31 : WARN  : wavescentral : could not find Waves Central.app
2024-09-09 18:00:31 : REQ   : wavescentral : Installed Waves Central, version 15.1.3
2024-09-09 18:00:31 : INFO  : wavescentral : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-09 18:00:31 : DEBUG : wavescentral : Unmounting /Volumes/Waves Central 15.1.3
2024-09-09 18:00:31 : DEBUG : wavescentral : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-09 18:00:31 : DEBUG : wavescentral : DEBUG mode 1, not reopening anything
2024-09-09 18:00:31 : REQ   : wavescentral : All done!
2024-09-09 18:00:31 : REQ   : wavescentral : ################## End Installomator, exit code 0 
