### PR TITLE
Create UVI Workstation label

### DIFF
--- a/fragments/labels/uviworkstation.sh
+++ b/fragments/labels/uviworkstation.sh
@@ -1,0 +1,8 @@
+uviworkstation)
+    name="UVIWorksation"
+    type="pkgInDmg"
+    packageID="net.uvi.pkg.UVIWorkstation.SA"
+    downloadURL="https://www.uvi.net/dwl.php?p=mac"
+    appNewVersion="$(curl -s -i "${downloadURL}" | grep "location" | cut -d\- -f2 | xargs)"
+    expectedTeamID="BB6L4C84AT"
+    ;;


### PR DESCRIPTION
assemble.sh uviworkstation
2024-09-09 18:02:08 : REQ   : uviworkstation : ################## Start Installomator v. 10.7beta, date 2024-09-09
2024-09-09 18:02:08 : INFO  : uviworkstation : ################## Version: 10.7beta
2024-09-09 18:02:08 : INFO  : uviworkstation : ################## Date: 2024-09-09
2024-09-09 18:02:08 : INFO  : uviworkstation : ################## uviworkstation
2024-09-09 18:02:08 : DEBUG : uviworkstation : DEBUG mode 1 enabled.
2024-09-09 18:02:08 : INFO  : uviworkstation : SwiftDialog is not installed, clear cmd file var
2024-09-09 18:02:10 : DEBUG : uviworkstation : name=UVIWorksation
2024-09-09 18:02:10 : DEBUG : uviworkstation : appName=
2024-09-09 18:02:10 : DEBUG : uviworkstation : type=pkgInDmg
2024-09-09 18:02:10 : DEBUG : uviworkstation : archiveName=
2024-09-09 18:02:10 : DEBUG : uviworkstation : downloadURL=https://www.uvi.net/dwl.php?p=mac
2024-09-09 18:02:10 : DEBUG : uviworkstation : curlOptions=
2024-09-09 18:02:10 : DEBUG : uviworkstation : appNewVersion=3.1.15
2024-09-09 18:02:10 : DEBUG : uviworkstation : appCustomVersion function: Not defined
2024-09-09 18:02:10 : DEBUG : uviworkstation : versionKey=CFBundleShortVersionString
2024-09-09 18:02:10 : DEBUG : uviworkstation : packageID=net.uvi.pkg.UVIWorkstation.SA
2024-09-09 18:02:10 : DEBUG : uviworkstation : pkgName=
2024-09-09 18:02:10 : DEBUG : uviworkstation : choiceChangesXML=
2024-09-09 18:02:10 : DEBUG : uviworkstation : expectedTeamID=BB6L4C84AT
2024-09-09 18:02:10 : DEBUG : uviworkstation : blockingProcesses=
2024-09-09 18:02:10 : DEBUG : uviworkstation : installerTool=
2024-09-09 18:02:10 : DEBUG : uviworkstation : CLIInstaller=
2024-09-09 18:02:10 : DEBUG : uviworkstation : CLIArguments=
2024-09-09 18:02:10 : DEBUG : uviworkstation : updateTool=
2024-09-09 18:02:10 : DEBUG : uviworkstation : updateToolArguments=
2024-09-09 18:02:10 : DEBUG : uviworkstation : updateToolRunAsCurrentUser=
2024-09-09 18:02:10 : INFO  : uviworkstation : BLOCKING_PROCESS_ACTION=tell_user
2024-09-09 18:02:10 : INFO  : uviworkstation : NOTIFY=success
2024-09-09 18:02:10 : INFO  : uviworkstation : LOGGING=DEBUG
2024-09-09 18:02:10 : INFO  : uviworkstation : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-09 18:02:10 : INFO  : uviworkstation : Label type: pkgInDmg
2024-09-09 18:02:10 : INFO  : uviworkstation : archiveName: UVIWorksation.dmg
2024-09-09 18:02:10 : INFO  : uviworkstation : no blocking processes defined, using UVIWorksation as default
2024-09-09 18:02:10 : DEBUG : uviworkstation : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-09 18:02:10 : INFO  : uviworkstation : No version found using packageID net.uvi.pkg.UVIWorkstation.SA
2024-09-09 18:02:10 : INFO  : uviworkstation : name: UVIWorksation, appName: UVIWorksation.app
2024-09-09 18:02:10.779 mdfind[59535:6133218] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 18:02:10.779 mdfind[59535:6133218] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 18:02:10.929 mdfind[59535:6133218] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 18:02:10 : WARN  : uviworkstation : No previous app found
2024-09-09 18:02:10 : WARN  : uviworkstation : could not find UVIWorksation.app
2024-09-09 18:02:10 : INFO  : uviworkstation : appversion: 
2024-09-09 18:02:10 : INFO  : uviworkstation : Latest version of UVIWorksation is 3.1.15
2024-09-09 18:02:10 : REQ   : uviworkstation : Downloading https://www.uvi.net/dwl.php?p=mac to UVIWorksation.dmg
2024-09-09 18:02:11 : DEBUG : uviworkstation : No Dialog connection, just download
2024-09-09 18:09:53 : DEBUG : uviworkstation : File list: -rw-r--r--  1 gilburns  staff   368M Sep  9 18:09 UVIWorksation.dmg
2024-09-09 18:09:53 : DEBUG : uviworkstation : File type: UVIWorksation.dmg: zlib compressed data
2024-09-09 18:09:53 : DEBUG : uviworkstation : curl output was:
* Host www.uvi.net:443 was resolved.
* IPv6: (none)
* IPv4: 193.33.169.129
*   Trying 193.33.169.129:443...
* Connected to www.uvi.net (193.33.169.129) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3295 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.uvi.net
*  start date: Apr 24 00:00:00 2024 GMT
*  expire date: Apr 28 23:59:59 2025 GMT
*  subjectAltName: host "www.uvi.net" matched cert's "*.uvi.net"
*  issuer: C=FR; O=Gandi; CN=Gandi RSA Domain Validation Secure Server CA 3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.uvi.net/dwl.php?p=mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.uvi.net]
* [HTTP/2] [1] [:path: /dwl.php?p=mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /dwl.php?p=mac HTTP/2
> Host: www.uvi.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: nginx
< date: Mon, 09 Sep 2024 23:02:11 GMT
< content-type: text/html; charset=UTF-8
< content-length: 0
< location: https://contentmanager.uvi.net/UVIWS/4-3.1.15-0_uviworkstation-3.1.15.dmg
< x-powered-by: PleskLin
< 
* Ignoring the response-body
* Connection #0 to host www.uvi.net left intact
* Issue another request to this URL: 'https://contentmanager.uvi.net/UVIWS/4-3.1.15-0_uviworkstation-3.1.15.dmg'
* Host contentmanager.uvi.net:443 was resolved.
* IPv6: (none)
* IPv4: 193.33.169.127
*   Trying 193.33.169.127:443...
* Connected to contentmanager.uvi.net (193.33.169.127) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3295 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.uvi.net
*  start date: Apr 24 00:00:00 2024 GMT
*  expire date: Apr 28 23:59:59 2025 GMT
*  subjectAltName: host "contentmanager.uvi.net" matched cert's "*.uvi.net"
*  issuer: C=FR; O=Gandi; CN=Gandi RSA Domain Validation Secure Server CA 3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /UVIWS/4-3.1.15-0_uviworkstation-3.1.15.dmg HTTP/1.1
> Host: contentmanager.uvi.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Mon, 09 Sep 2024 23:02:12 GMT
< Server: Apache/2.4.52 (Ubuntu)
< Strict-Transport-Security: max-age=15552000; includeSubDomains; preload
< Upgrade: h2,h2c
< Connection: Upgrade
< Last-Modified: Wed, 03 Jul 2024 17:48:44 GMT
< ETag: "170541bf-61c5b711390db"
< Accept-Ranges: bytes
< Content-Length: 386220479
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Referrer-Policy: no-referrer
< Permissions-Policy: accelerometer=(), camera=(), geolocation=(), camera=(), display-capture=(), encrypted-media=(*)
< Content-Type: application/x-apple-diskimage
< 
{ [7608 bytes data]
* Connection #1 to host contentmanager.uvi.net left intact

2024-09-09 18:09:53 : DEBUG : uviworkstation : DEBUG mode 1, not checking for blocking processes
2024-09-09 18:09:53 : REQ   : uviworkstation : Installing UVIWorksation
2024-09-09 18:09:53 : INFO  : uviworkstation : Mounting /Users/gilburns/GitHub/Installomator/build/UVIWorksation.dmg
2024-09-09 18:09:54 : DEBUG : uviworkstation : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $35A7047E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9299CD9A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $77F8DDE4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $6AD08D08
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $77F8DDE4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $64140328
verified   CRC32 $D8E5614E
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/UVIWorkstation-3.1.15

2024-09-09 18:09:54 : INFO  : uviworkstation : Mounted: /Volumes/UVIWorkstation-3.1.15
2024-09-09 18:09:54 : DEBUG : uviworkstation : Found pkg(s):
/Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg
2024-09-09 18:09:54 : INFO  : uviworkstation : found pkg: /Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg
2024-09-09 18:09:54 : INFO  : uviworkstation : Verifying: /Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg
2024-09-09 18:09:54 : DEBUG : uviworkstation : File list: -rw-r--r--  1 gilburns  staff   365M Jul  3 12:35 /Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg
2024-09-09 18:09:54 : DEBUG : uviworkstation : File type: /Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg: xar archive compressed TOC: 7455, SHA-1 checksum
2024-09-09 18:09:55 : DEBUG : uviworkstation : spctlOut is /Volumes/UVIWorkstation-3.1.15/UVI Workstation.pkg: accepted
2024-09-09 18:09:55 : DEBUG : uviworkstation : source=Notarized Developer ID
2024-09-09 18:09:55 : DEBUG : uviworkstation : origin=Developer ID Installer: UVI (BB6L4C84AT)
2024-09-09 18:09:55 : INFO  : uviworkstation : Team ID: BB6L4C84AT (expected: BB6L4C84AT )
2024-09-09 18:09:55 : DEBUG : uviworkstation : DEBUG enabled, skipping installation
2024-09-09 18:09:55 : INFO  : uviworkstation : Finishing...
2024-09-09 18:09:58 : INFO  : uviworkstation : No version found using packageID net.uvi.pkg.UVIWorkstation.SA
2024-09-09 18:09:58 : INFO  : uviworkstation : name: UVIWorksation, appName: UVIWorksation.app
2024-09-09 18:09:58.837 mdfind[59721:6141186] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 18:09:58.837 mdfind[59721:6141186] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 18:09:59.013 mdfind[59721:6141186] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 18:09:59 : WARN  : uviworkstation : No previous app found
2024-09-09 18:09:59 : WARN  : uviworkstation : could not find UVIWorksation.app
2024-09-09 18:09:59 : REQ   : uviworkstation : Installed UVIWorksation, version 3.1.15
2024-09-09 18:09:59 : INFO  : uviworkstation : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-09 18:09:59 : DEBUG : uviworkstation : Unmounting /Volumes/UVIWorkstation-3.1.15
2024-09-09 18:09:59 : DEBUG : uviworkstation : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-09 18:09:59 : DEBUG : uviworkstation : DEBUG mode 1, not reopening anything
2024-09-09 18:09:59 : REQ   : uviworkstation : All done!
2024-09-09 18:09:59 : REQ   : uviworkstation : ################## End Installomator, exit code 0 
