### PR TITLE
Create Output Hub label

### DIFF
--- a/fragments/labels/outputhub.sh
+++ b/fragments/labels/outputhub.sh
@@ -1,7 +1,7 @@
 outputhub)
     name="Output Hub"
     type="dmg"
-	downloadURL="$(curl -fs "https://output.com/hub"| grep "Mac Download" | cut -d\" -f4)"
+    downloadURL="$(curl -fs "https://output.com/hub"| grep "Mac Download" | cut -d\" -f4)"
     appNewVersion=$( curl -fs "https://output-hub-builds.s3.amazonaws.com/latest-mac.yml" | grep "^version:" | cut -d" " -f2 )
     expectedTeamID="M4BQRFQ23V"
     ;;

--- a/fragments/labels/outputhub.sh
+++ b/fragments/labels/outputhub.sh
@@ -1,0 +1,7 @@
+outputhub)
+    name="Output Hub"
+    type="dmg"
+	downloadURL="$(curl -fs "https://output.com/hub"| grep "Mac Download" | cut -d\" -f4)"
+    appNewVersion=$( curl -fs "https://output-hub-builds.s3.amazonaws.com/latest-mac.yml" | grep "^version:" | cut -d" " -f2 )
+    expectedTeamID="M4BQRFQ23V"
+    ;;

--- a/fragments/labels/outputhub.sh
+++ b/fragments/labels/outputhub.sh
@@ -1,7 +1,7 @@
 outputhub)
     name="Output Hub"
     type="dmg"
-    downloadURL="$(curl -fs "https://output.com/hub"| grep "Mac Download" | cut -d\" -f4)"
-    appNewVersion=$( curl -fs "https://output-hub-builds.s3.amazonaws.com/latest-mac.yml" | grep "^version:" | cut -d" " -f2 )
+    downloadURL="$(curl -fsL "https://output.com/hub"| grep "Mac Download" | cut -d\" -f4)"
+    appNewVersion=$( curl -fsL "https://output-hub-builds.s3.amazonaws.com/latest-mac.yml" | grep "^version:" | cut -d" " -f2 )
     expectedTeamID="M4BQRFQ23V"
     ;;


### PR DESCRIPTION
assemble.sh outputhub
2024-09-09 18:42:39 : REQ   : outputhub : ################## Start Installomator v. 10.7beta, date 2024-09-09
2024-09-09 18:42:39 : INFO  : outputhub : ################## Version: 10.7beta
2024-09-09 18:42:39 : INFO  : outputhub : ################## Date: 2024-09-09
2024-09-09 18:42:39 : INFO  : outputhub : ################## outputhub
2024-09-09 18:42:39 : DEBUG : outputhub : DEBUG mode 1 enabled.
2024-09-09 18:42:39 : INFO  : outputhub : SwiftDialog is not installed, clear cmd file var
2024-09-09 18:42:41 : DEBUG : outputhub : name=Output Hub
2024-09-09 18:42:41 : DEBUG : outputhub : appName=
2024-09-09 18:42:41 : DEBUG : outputhub : type=dmg
2024-09-09 18:42:41 : DEBUG : outputhub : archiveName=
2024-09-09 18:42:41 : DEBUG : outputhub : downloadURL=https://d3tas2olp7glw9.cloudfront.net/Hub2/Output+Hub-2.0.21.308-mac-x64.dmg
2024-09-09 18:42:41 : DEBUG : outputhub : curlOptions=
2024-09-09 18:42:41 : DEBUG : outputhub : appNewVersion=2.0.21
2024-09-09 18:42:41 : DEBUG : outputhub : appCustomVersion function: Not defined
2024-09-09 18:42:41 : DEBUG : outputhub : versionKey=CFBundleShortVersionString
2024-09-09 18:42:41 : DEBUG : outputhub : packageID=
2024-09-09 18:42:41 : DEBUG : outputhub : pkgName=
2024-09-09 18:42:41 : DEBUG : outputhub : choiceChangesXML=
2024-09-09 18:42:41 : DEBUG : outputhub : expectedTeamID=M4BQRFQ23V
2024-09-09 18:42:41 : DEBUG : outputhub : blockingProcesses=
2024-09-09 18:42:41 : DEBUG : outputhub : installerTool=
2024-09-09 18:42:41 : DEBUG : outputhub : CLIInstaller=
2024-09-09 18:42:41 : DEBUG : outputhub : CLIArguments=
2024-09-09 18:42:41 : DEBUG : outputhub : updateTool=
2024-09-09 18:42:41 : DEBUG : outputhub : updateToolArguments=
2024-09-09 18:42:41 : DEBUG : outputhub : updateToolRunAsCurrentUser=
2024-09-09 18:42:41 : INFO  : outputhub : BLOCKING_PROCESS_ACTION=tell_user
2024-09-09 18:42:41 : INFO  : outputhub : NOTIFY=success
2024-09-09 18:42:41 : INFO  : outputhub : LOGGING=DEBUG
2024-09-09 18:42:41 : INFO  : outputhub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-09 18:42:41 : INFO  : outputhub : Label type: dmg
2024-09-09 18:42:41 : INFO  : outputhub : archiveName: Output Hub.dmg
2024-09-09 18:42:41 : INFO  : outputhub : no blocking processes defined, using Output Hub as default
2024-09-09 18:42:41 : DEBUG : outputhub : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-09 18:42:41 : INFO  : outputhub : App(s) found: /Applications/Output Hub.app
2024-09-09 18:42:41 : INFO  : outputhub : found app at /Applications/Output Hub.app, version 2.0.21, on versionKey CFBundleShortVersionString
2024-09-09 18:42:41 : INFO  : outputhub : appversion: 2.0.21
2024-09-09 18:42:41 : INFO  : outputhub : Latest version of Output Hub is 2.0.21
2024-09-09 18:42:41 : WARN  : outputhub : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-09 18:42:41 : REQ   : outputhub : Downloading https://d3tas2olp7glw9.cloudfront.net/Hub2/Output+Hub-2.0.21.308-mac-x64.dmg to Output Hub.dmg
2024-09-09 18:42:41 : DEBUG : outputhub : No Dialog connection, just download
2024-09-09 18:43:12 : DEBUG : outputhub : File list: -rw-r--r--  1 gilburns  staff    82M Sep  9 18:43 Output Hub.dmg
2024-09-09 18:43:12 : DEBUG : outputhub : File type: Output Hub.dmg: zlib compressed data
2024-09-09 18:43:12 : DEBUG : outputhub : curl output was:
* Host d3tas2olp7glw9.cloudfront.net:443 was resolved.
* IPv6: (none)
* IPv4: 18.172.139.213, 18.172.139.107, 18.172.139.180, 18.172.139.230
*   Trying 18.172.139.213:443...
* Connected to d3tas2olp7glw9.cloudfront.net (18.172.139.213) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4971 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Jul 30 00:00:00 2024 GMT
*  expire date: Jul  3 23:59:59 2025 GMT
*  subjectAltName: host "d3tas2olp7glw9.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /Hub2/Output+Hub-2.0.21.308-mac-x64.dmg HTTP/1.1
> Host: d3tas2olp7glw9.cloudfront.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/x-apple-diskimage
< Content-Length: 86371528
< Connection: keep-alive
< Last-Modified: Tue, 26 Oct 2021 16:37:59 GMT
< Accept-Ranges: bytes
< Server: AmazonS3
< Date: Mon, 09 Sep 2024 23:42:43 GMT
< ETag: "e9a86b6f2d4de15330fbc7863633ced9-6"
< X-Cache: RefreshHit from cloudfront
< Via: 1.1 e97a1ac424196b355214d47c2768b37c.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD56-P7
< X-Amz-Cf-Id: MlatoKRlqlgNu6ErM2wjPYemlBfKU5ZDh5zmotmL1dkIi4533sB7yA==
< 
{ [16384 bytes data]
* Connection #0 to host d3tas2olp7glw9.cloudfront.net left intact

2024-09-09 18:43:12 : DEBUG : outputhub : DEBUG mode 1, not checking for blocking processes
2024-09-09 18:43:12 : REQ   : outputhub : Installing Output Hub
2024-09-09 18:43:12 : INFO  : outputhub : Mounting /Users/gilburns/GitHub/Installomator/build/Output Hub.dmg
2024-09-09 18:43:15 : DEBUG : outputhub : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $AF949373
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3E42CCCF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $1488B6C4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $63CCBBB7
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $1488B6C4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $A7B4295D
verified   CRC32 $F1D14D60
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Output Hub 2.0.21

2024-09-09 18:43:15 : INFO  : outputhub : Mounted: /Volumes/Output Hub 2.0.21
2024-09-09 18:43:15 : INFO  : outputhub : Verifying: /Volumes/Output Hub 2.0.21/Output Hub.app
2024-09-09 18:43:15 : DEBUG : outputhub : App size: 194M	/Volumes/Output Hub 2.0.21/Output Hub.app
2024-09-09 18:43:18 : DEBUG : outputhub : Debugging enabled, App Verification output was:
/Volumes/Output Hub 2.0.21/Output Hub.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Output Inc (M4BQRFQ23V)

2024-09-09 18:43:18 : INFO  : outputhub : Team ID matching: M4BQRFQ23V (expected: M4BQRFQ23V )
2024-09-09 18:43:18 : INFO  : outputhub : Downloaded version of Output Hub is 2.0.21 on versionKey CFBundleShortVersionString, same as installed.
2024-09-09 18:43:18 : DEBUG : outputhub : Unmounting /Volumes/Output Hub 2.0.21
2024-09-09 18:43:18 : DEBUG : outputhub : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-09 18:43:18 : DEBUG : outputhub : DEBUG mode 1, not reopening anything
2024-09-09 18:43:18 : REG   : outputhub : No new version to install
2024-09-09 18:43:18 : REQ   : outputhub : ################## End Installomator, exit code 0 
