### PR TITLE
Create Output Arcade label

### DIFF
--- a/fragments/labels/outputarcade.sh
+++ b/fragments/labels/outputarcade.sh
@@ -1,0 +1,13 @@
+outputarcade)
+	name="Arcade"
+	type="pkg"
+	arcadeVersion="$(curl -fs "https://api.output.com/v1/arcade_version")"
+	if [[ -d "/Applications/Arcade.app" ]]; then
+		downloadURL=$(getJSONValue "$arcadeVersion" packages.mac.url)
+	else
+		downloadUpgrade=$(getJSONValue "$arcadeVersion" packages.mac.url)
+		downloadURL=$(echo "${downloadUpgrade}" | sed "s/Update/Install/")
+	fi
+	appNewVersion=$(getJSONValue "$arcadeVersion" version)
+	expectedTeamID="M4BQRFQ23V"
+	;;


### PR DESCRIPTION
assemble.sh outputarcade
2024-09-09 18:44:53 : REQ   : outputarcade : ################## Start Installomator v. 10.7beta, date 2024-09-09
2024-09-09 18:44:53 : INFO  : outputarcade : ################## Version: 10.7beta
2024-09-09 18:44:53 : INFO  : outputarcade : ################## Date: 2024-09-09
2024-09-09 18:44:53 : INFO  : outputarcade : ################## outputarcade
2024-09-09 18:44:53 : DEBUG : outputarcade : DEBUG mode 1 enabled.
2024-09-09 18:44:53 : INFO  : outputarcade : SwiftDialog is not installed, clear cmd file var
2024-09-09 18:44:54 : DEBUG : outputarcade : name=Arcade
2024-09-09 18:44:54 : DEBUG : outputarcade : appName=
2024-09-09 18:44:54 : DEBUG : outputarcade : type=pkg
2024-09-09 18:44:54 : DEBUG : outputarcade : archiveName=
2024-09-09 18:44:54 : DEBUG : outputarcade : downloadURL=https://dx1vb1559b576.cloudfront.net/Arcade_OSX_Install_2.11.0.R25898.pkg
2024-09-09 18:44:54 : DEBUG : outputarcade : curlOptions=
2024-09-09 18:44:54 : DEBUG : outputarcade : appNewVersion=2.11.0
2024-09-09 18:44:54 : DEBUG : outputarcade : appCustomVersion function: Not defined
2024-09-09 18:44:54 : DEBUG : outputarcade : versionKey=CFBundleShortVersionString
2024-09-09 18:44:54 : DEBUG : outputarcade : packageID=
2024-09-09 18:44:54 : DEBUG : outputarcade : pkgName=
2024-09-09 18:44:54 : DEBUG : outputarcade : choiceChangesXML=
2024-09-09 18:44:54 : DEBUG : outputarcade : expectedTeamID=M4BQRFQ23V
2024-09-09 18:44:54 : DEBUG : outputarcade : blockingProcesses=
2024-09-09 18:44:54 : DEBUG : outputarcade : installerTool=
2024-09-09 18:44:54 : DEBUG : outputarcade : CLIInstaller=
2024-09-09 18:44:54 : DEBUG : outputarcade : CLIArguments=
2024-09-09 18:44:54 : DEBUG : outputarcade : updateTool=
2024-09-09 18:44:54 : DEBUG : outputarcade : updateToolArguments=
2024-09-09 18:44:54 : DEBUG : outputarcade : updateToolRunAsCurrentUser=
2024-09-09 18:44:54 : INFO  : outputarcade : BLOCKING_PROCESS_ACTION=tell_user
2024-09-09 18:44:54 : INFO  : outputarcade : NOTIFY=success
2024-09-09 18:44:54 : INFO  : outputarcade : LOGGING=DEBUG
2024-09-09 18:44:54 : INFO  : outputarcade : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-09 18:44:54 : INFO  : outputarcade : Label type: pkg
2024-09-09 18:44:54 : INFO  : outputarcade : archiveName: Arcade.pkg
2024-09-09 18:44:54 : INFO  : outputarcade : no blocking processes defined, using Arcade as default
2024-09-09 18:44:54 : DEBUG : outputarcade : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-09 18:44:54 : INFO  : outputarcade : name: Arcade, appName: Arcade.app
2024-09-09 18:44:54.937 mdfind[61716:6178092] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 18:44:54.937 mdfind[61716:6178092] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 18:44:55.112 mdfind[61716:6178092] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 18:44:55 : WARN  : outputarcade : No previous app found
2024-09-09 18:44:55 : WARN  : outputarcade : could not find Arcade.app
2024-09-09 18:44:55 : INFO  : outputarcade : appversion: 
2024-09-09 18:44:55 : INFO  : outputarcade : Latest version of Arcade is 2.11.0
2024-09-09 18:44:55 : REQ   : outputarcade : Downloading https://dx1vb1559b576.cloudfront.net/Arcade_OSX_Install_2.11.0.R25898.pkg to Arcade.pkg
2024-09-09 18:44:55 : DEBUG : outputarcade : No Dialog connection, just download
2024-09-09 18:49:51 : DEBUG : outputarcade : File list: -rw-r--r--  1 gilburns  staff   737M Sep  9 18:49 Arcade.pkg
2024-09-09 18:49:51 : DEBUG : outputarcade : File type: Arcade.pkg: xar archive compressed TOC: 6892, SHA-1 checksum
2024-09-09 18:49:51 : DEBUG : outputarcade : curl output was:
* Host dx1vb1559b576.cloudfront.net:443 was resolved.
* IPv6: 2600:9000:24d3:d400:0:4117:480:21, 2600:9000:24d3:c000:0:4117:480:21, 2600:9000:24d3:b000:0:4117:480:21, 2600:9000:24d3:1800:0:4117:480:21, 2600:9000:24d3:2e00:0:4117:480:21, 2600:9000:24d3:7c00:0:4117:480:21, 2600:9000:24d3:c200:0:4117:480:21, 2600:9000:24d3:7000:0:4117:480:21
* IPv4: 18.160.227.142, 18.160.227.58, 18.160.227.80, 18.160.227.197
*   Trying 18.160.227.142:443...
* Connected to dx1vb1559b576.cloudfront.net (18.160.227.142) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4971 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Jul 30 00:00:00 2024 GMT
*  expire date: Jul  3 23:59:59 2025 GMT
*  subjectAltName: host "dx1vb1559b576.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dx1vb1559b576.cloudfront.net/Arcade_OSX_Install_2.11.0.R25898.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dx1vb1559b576.cloudfront.net]
* [HTTP/2] [1] [:path: /Arcade_OSX_Install_2.11.0.R25898.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Arcade_OSX_Install_2.11.0.R25898.pkg HTTP/2
> Host: dx1vb1559b576.cloudfront.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 773151878
< date: Mon, 09 Sep 2024 23:44:56 GMT
< last-modified: Tue, 04 Jun 2024 16:37:43 GMT
< etag: "1cf9c316a81d6bb263904f76e2a6d01f-47"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 066d5eaaff20d6378af3afe6096d7830.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD58-P4
< x-amz-cf-id: JglIWxQNBraoVDcU5kKV1V0OSsh2_JK8vvw0vhxn8XzxKZzgszjZ-w==
< 
{ [8192 bytes data]
* Connection #0 to host dx1vb1559b576.cloudfront.net left intact

2024-09-09 18:49:51 : DEBUG : outputarcade : DEBUG mode 1, not checking for blocking processes
2024-09-09 18:49:51 : REQ   : outputarcade : Installing Arcade
2024-09-09 18:49:51 : INFO  : outputarcade : Verifying: Arcade.pkg
2024-09-09 18:49:51 : DEBUG : outputarcade : File list: -rw-r--r--  1 gilburns  staff   737M Sep  9 18:49 Arcade.pkg
2024-09-09 18:49:51 : DEBUG : outputarcade : File type: Arcade.pkg: xar archive compressed TOC: 6892, SHA-1 checksum
2024-09-09 18:49:52 : DEBUG : outputarcade : spctlOut is Arcade.pkg: accepted
2024-09-09 18:49:52 : DEBUG : outputarcade : source=Notarized Developer ID
2024-09-09 18:49:52 : DEBUG : outputarcade : origin=Developer ID Installer: Output Inc (M4BQRFQ23V)
2024-09-09 18:49:52 : INFO  : outputarcade : Team ID: M4BQRFQ23V (expected: M4BQRFQ23V )
2024-09-09 18:49:52 : DEBUG : outputarcade : DEBUG enabled, skipping installation
2024-09-09 18:49:52 : INFO  : outputarcade : Finishing...
2024-09-09 18:49:55 : INFO  : outputarcade : name: Arcade, appName: Arcade.app
2024-09-09 18:49:55.133 mdfind[61856:6182483] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-09 18:49:55.134 mdfind[61856:6182483] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-09 18:49:55.279 mdfind[61856:6182483] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-09 18:49:55 : WARN  : outputarcade : No previous app found
2024-09-09 18:49:55 : WARN  : outputarcade : could not find Arcade.app
2024-09-09 18:49:55 : REQ   : outputarcade : Installed Arcade, version 2.11.0
2024-09-09 18:49:55 : INFO  : outputarcade : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-09 18:49:55 : DEBUG : outputarcade : DEBUG mode 1, not reopening anything
2024-09-09 18:49:55 : REQ   : outputarcade : All done!
2024-09-09 18:49:55 : REQ   : outputarcade : ################## End Installomator, exit code 0 
