### PR TITLE
Create EastWest Play label

### DIFF
--- a/fragments/labels/eastwestplay.sh
+++ b/fragments/labels/eastwestplay.sh
@@ -1,0 +1,10 @@
+eastwestplay)
+	name="Play"
+	type="pkgInZip"
+	downloadXML="$(curl -fs 'http://s3.amazonaws.com/ic-resources/products/PLAY.xml')"
+	downloadURL="$(echo "${downloadXML}" | xpath '(//product/files/file[@platform="mac"]/url/text())' 2>/dev/null)"
+	appNewVersion="$(echo "${downloadXML}" | xpath '(//product/version/text())' 2>/dev/null)"
+	appCustomVersion(){ /usr/bin/defaults read "/Library/Application Support/East West/Play.app/Contents/Info.plist" CFBundleShortVersionString }
+	pkgName="Play Installer ${appNewVersion}.pkg"
+	expectedTeamID="TWK4WE76V9"
+	;;


### PR DESCRIPTION
assemble.sh eastwestplay
2024-09-09 20:49:00 : REQ   : eastwestplay : ################## Start Installomator v. 10.7beta, date 2024-09-09
2024-09-09 20:49:00 : INFO  : eastwestplay : ################## Version: 10.7beta
2024-09-09 20:49:00 : INFO  : eastwestplay : ################## Date: 2024-09-09
2024-09-09 20:49:00 : INFO  : eastwestplay : ################## eastwestplay
2024-09-09 20:49:00 : DEBUG : eastwestplay : DEBUG mode 1 enabled.
2024-09-09 20:49:00 : INFO  : eastwestplay : SwiftDialog is not installed, clear cmd file var
2024-09-09 20:49:01 : DEBUG : eastwestplay : name=Play
2024-09-09 20:49:01 : DEBUG : eastwestplay : appName=
2024-09-09 20:49:01 : DEBUG : eastwestplay : type=pkgInZip
2024-09-09 20:49:01 : DEBUG : eastwestplay : archiveName=
2024-09-09 20:49:01 : DEBUG : eastwestplay : downloadURL=https://software.soundsonline.com/Products/PLAY/Play_6.1.9_Mac.zip
2024-09-09 20:49:01 : DEBUG : eastwestplay : curlOptions=
2024-09-09 20:49:01 : DEBUG : eastwestplay : appNewVersion=6.1.9
2024-09-09 20:49:01 : DEBUG : eastwestplay : appCustomVersion function: Defined. 
2024-09-09 20:49:01 : DEBUG : eastwestplay : versionKey=CFBundleShortVersionString
2024-09-09 20:49:01 : DEBUG : eastwestplay : packageID=
2024-09-09 20:49:01 : DEBUG : eastwestplay : pkgName=Play Installer 6.1.9.pkg
2024-09-09 20:49:01 : DEBUG : eastwestplay : choiceChangesXML=
2024-09-09 20:49:01 : DEBUG : eastwestplay : expectedTeamID=TWK4WE76V9
2024-09-09 20:49:01 : DEBUG : eastwestplay : blockingProcesses=
2024-09-09 20:49:01 : DEBUG : eastwestplay : installerTool=
2024-09-09 20:49:01 : DEBUG : eastwestplay : CLIInstaller=
2024-09-09 20:49:01 : DEBUG : eastwestplay : CLIArguments=
2024-09-09 20:49:01 : DEBUG : eastwestplay : updateTool=
2024-09-09 20:49:01 : DEBUG : eastwestplay : updateToolArguments=
2024-09-09 20:49:01 : DEBUG : eastwestplay : updateToolRunAsCurrentUser=
2024-09-09 20:49:01 : INFO  : eastwestplay : BLOCKING_PROCESS_ACTION=tell_user
2024-09-09 20:49:01 : INFO  : eastwestplay : NOTIFY=success
2024-09-09 20:49:01 : INFO  : eastwestplay : LOGGING=DEBUG
2024-09-09 20:49:01 : INFO  : eastwestplay : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-09 20:49:01 : INFO  : eastwestplay : Label type: pkgInZip
2024-09-09 20:49:01 : INFO  : eastwestplay : archiveName: Play.zip
2024-09-09 20:49:01 : INFO  : eastwestplay : no blocking processes defined, using Play as default
2024-09-09 20:49:01 : DEBUG : eastwestplay : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-09 20:49:01.666 defaults[63744:6255039] 
The domain/default pair of (/Library/Application Support/East West/Play.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2024-09-09 20:49:01 : INFO  : eastwestplay : Custom App Version detection is used, found 
2024-09-09 20:49:01 : INFO  : eastwestplay : appversion: 
2024-09-09 20:49:01 : INFO  : eastwestplay : Latest version of Play is 6.1.9
2024-09-09 20:49:01 : REQ   : eastwestplay : Downloading https://software.soundsonline.com/Products/PLAY/Play_6.1.9_Mac.zip to Play.zip
2024-09-09 20:49:01 : DEBUG : eastwestplay : No Dialog connection, just download
2024-09-09 20:53:03 : DEBUG : eastwestplay : File list: -rw-r--r--  1 gilburns  staff   554M Sep  9 20:53 Play.zip
2024-09-09 20:53:03 : DEBUG : eastwestplay : File type: Play.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2024-09-09 20:53:03 : DEBUG : eastwestplay : curl output was:
* Host software.soundsonline.com:443 was resolved.
* IPv6: 2600:9000:24d0:6000:b:1c41:7480:93a1, 2600:9000:24d0:c800:b:1c41:7480:93a1, 2600:9000:24d0:a600:b:1c41:7480:93a1, 2600:9000:24d0:fe00:b:1c41:7480:93a1, 2600:9000:24d0:de00:b:1c41:7480:93a1, 2600:9000:24d0:0:b:1c41:7480:93a1, 2600:9000:24d0:e200:b:1c41:7480:93a1, 2600:9000:24d0:7a00:b:1c41:7480:93a1
* IPv4: 13.32.164.16, 13.32.164.101, 13.32.164.2, 13.32.164.106
*   Trying 13.32.164.16:443...
* Connected to software.soundsonline.com (13.32.164.16) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [330 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4974 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=software.soundsonline.com
*  start date: Jul 27 00:00:00 2024 GMT
*  expire date: Aug 25 23:59:59 2025 GMT
*  subjectAltName: host "software.soundsonline.com" matched cert's "software.soundsonline.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://software.soundsonline.com/Products/PLAY/Play_6.1.9_Mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: software.soundsonline.com]
* [HTTP/2] [1] [:path: /Products/PLAY/Play_6.1.9_Mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Products/PLAY/Play_6.1.9_Mac.zip HTTP/2
> Host: software.soundsonline.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/zip
< content-length: 580819051
< x-amz-replication-status: COMPLETED
< last-modified: Tue, 07 Jul 2020 16:54:40 GMT
< content-disposition: attachment; filename=Play_6.1.9_Mac.zip
< x-amz-meta-bucketexplorer-filelastmodifieddate: 1594139728000
< x-amz-meta-bucketexplorer-md5: 005ec1532e6f887e5cc23c90e8f7ac71
< x-amz-version-id: k3OmSqIBuWZw5AYwMGh4xgSy37Z6JRqO
< x-amz-meta-md5-hash: 005ec1532e6f887e5cc23c90e8f7ac71
< accept-ranges: bytes
< server: AmazonS3
< date: Tue, 10 Sep 2024 01:49:03 GMT
< etag: "005ec1532e6f887e5cc23c90e8f7ac71"
< vary: Accept-Encoding
< x-cache: RefreshHit from cloudfront
< via: 1.1 87441111f0e4d414e651812e90f76e78.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD58-P1
< x-amz-cf-id: F3F_vYifAPWLTLn-tb9girvZegFr3dnnDdHi6hPQnAyehxW4fIdx4A==
< 
{ [8192 bytes data]
* Connection #0 to host software.soundsonline.com left intact

2024-09-09 20:53:03 : DEBUG : eastwestplay : DEBUG mode 1, not checking for blocking processes
2024-09-09 20:53:03 : REQ   : eastwestplay : Installing Play
2024-09-09 20:53:03 : INFO  : eastwestplay : Unzipping Play.zip
2024-09-09 20:53:04 : INFO  : eastwestplay : Verifying: /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg
2024-09-09 20:53:04 : DEBUG : eastwestplay : File list: -rw-r--r--@ 1 gilburns  staff   555M Jul  7  2020 /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg
2024-09-09 20:53:04 : DEBUG : eastwestplay : File type: /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg: xar archive compressed TOC: 12565, SHA-1 checksum
2024-09-09 20:53:04 : DEBUG : eastwestplay : spctlOut is /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg: accepted
2024-09-09 20:53:04 : DEBUG : eastwestplay : source=Notarized Developer ID
2024-09-09 20:53:04 : DEBUG : eastwestplay : origin=Developer ID Installer: EASTWEST (TWK4WE76V9)
2024-09-09 20:53:04 : INFO  : eastwestplay : Team ID: TWK4WE76V9 (expected: TWK4WE76V9 )
2024-09-09 20:53:04 : DEBUG : eastwestplay : DEBUG enabled, skipping installation
2024-09-09 20:53:04 : INFO  : eastwestplay : Finishing...
2024-09-09 20:53:08.022 defaults[63956:6259099] 
The domain/default pair of (/Library/Application Support/East West/Play.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2024-09-09 20:53:08 : INFO  : eastwestplay : Custom App Version detection is used, found 
2024-09-09 20:53:08 : REQ   : eastwestplay : Installed Play, version 6.1.9
2024-09-09 20:53:08 : INFO  : eastwestplay : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-09 20:53:08 : DEBUG : eastwestplay : DEBUG mode 1, not reopening anything
2024-09-09 20:53:08 : REQ   : eastwestplay : All done!
2024-09-09 20:53:08 : REQ   : eastwestplay : ################## End Installomator, exit code 0 
