### PR TITLE
Create VirtualBox label set

### DIFF
--- a/fragments/labels/virtualboxbeta.sh
+++ b/fragments/labels/virtualboxbeta.sh
@@ -1,0 +1,13 @@
+virtualboxbeta)
+    name="VirtualBox"
+    type="pkgInDmg"
+    pkgName="VirtualBox.pkg"
+    betaVersion="$(curl -fs "https://download.virtualbox.org/virtualbox/LATEST-BETA.TXT")"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.virtualbox.org/virtualbox/${betaVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${betaVersion}/" | grep "macOSArm64" | cut -d\" -f2)"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.virtualbox.org/virtualbox/${betaVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${betaVersion}/" | grep "OSX.dmg" | cut -d\" -f2)"
+    fi
+    appNewVersion="$(echo $betaVersion | cut -d_ -f1)"
+    expectedTeamID="VB5E2TV963"
+    ;;

--- a/fragments/labels/virtualboxlatest.sh
+++ b/fragments/labels/virtualboxlatest.sh
@@ -4,7 +4,7 @@ virtualboxlatest)
     pkgName="VirtualBox.pkg"
     appNewVersion=$(curl -fs "https://download.virtualbox.org/virtualbox/LATEST.TXT")
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/7.1.0/" | grep "macOSArm64" | cut -d\" -f2)"
+        downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "macOSArm64" | cut -d\" -f2)"
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "OSX.dmg" | cut -d\" -f2)"
     fi

--- a/fragments/labels/virtualboxlatest.sh
+++ b/fragments/labels/virtualboxlatest.sh
@@ -1,0 +1,12 @@
+virtualboxlatest)
+    name="VirtualBox"
+    type="pkgInDmg"
+    pkgName="VirtualBox.pkg"
+    appNewVersion=$(curl -fs "https://download.virtualbox.org/virtualbox/LATEST.TXT")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/7.1.0/" | grep "macOSArm64" | cut -d\" -f2)"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "OSX.dmg" | cut -d\" -f2)"
+    fi
+    expectedTeamID="VB5E2TV963"
+    ;;

--- a/fragments/labels/virtualboxstable.sh
+++ b/fragments/labels/virtualboxstable.sh
@@ -1,0 +1,16 @@
+virtualboxstable)
+    name="VirtualBox"
+    type="pkgInDmg"
+    pkgName="VirtualBox.pkg"
+    appNewVersion=$(curl -fs "https://download.virtualbox.org/virtualbox/LATEST-STABLE.TXT")
+    if [[ $(arch) == "arm64" ]]; then
+        if [[ ! -z "$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "macOSArm64")" ]]; then
+            downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "macOSArm64" | cut -d\" -f2)"
+        else 
+            downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "OSX.dmg" | cut -d\" -f2)"
+        fi
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.virtualbox.org/virtualbox/${appNewVersion}/$(curl -fs "https://download.virtualbox.org/virtualbox/${appNewVersion}/" | grep "OSX.dmg" | cut -d\" -f2)"
+    fi
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
Adds three new options for installing VirtualBox build types

Beta - virtualboxbeta
Latest - virtualboxlatest
Stable - virtualboxstable

Additionally adds support for installing the arm64 version when the build type supports it. (Stable build is currently only available as Intel.)