### PR TITLE
Create Arturia MIDI Control Center label

### DIFF
--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -1,22 +1,20 @@
 arturiamcc)
     name="MIDI Control Center"
     type="pkg"
-    packageID="com.Arturia.MIDIControlCenter.resources"
     arturiaDetails="$(curl -fsL 'https://www.arturia.com/api/resources?slugs=mccu&types=soft')"
     arturiaCount=0
-    while [[ -z $arturiaMatch ]]
-    do
+    maxEntries=$(getJSONValue "$arturiaDetails" "length" 2>/dev/null) # Get the number of entries
+    downloadURL=""
+    appNewVersion=""
+    while [[ $arturiaCount -lt $maxEntries ]]; do
         arturiaPlatform=$(getJSONValue "$arturiaDetails" "[$arturiaCount].platform_type" 2>/dev/null)
-        if [ $? -eq 1 ]; then
-            downloadURL=""
-            appNewVersion=""
-            break
-        elif [[ $arturiaPlatform == "mac" ]]; then
-            downloadURL="$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")"
-            appNewVersion="$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")"
+        if [[ $arturiaPlatform == "mac" ]]; then
+            # Extract the permalink and version for macOS
+            downloadURL=$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")
+            appNewVersion=$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")
             break
         fi
-        arturiaCount=$(( $arturiaCount + 1 ))
+        arturiaCount=$((arturiaCount + 1))
     done
     expectedTeamID="T53ZHSF36C"
-    ;;
+;;

--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -1,0 +1,23 @@
+arturiamcc)
+	name="MIDI Control Center"
+	type="pkg"
+	packageID="com.Arturia.MIDIControlCenter.resources"
+	arturiaDetails="$(curl -fsL 'https://www.arturia.com/api/resources?slugs=mccu&types=soft')"
+	arturiaCount=0
+	while [[ -z $arturiaMatch ]]
+	do
+		arturiaPlatform=$(getJSONValue "$arturiaDetails" "[$arturiaCount].platform_type" 2>/dev/null)
+		if [ $? -eq 1 ]; then
+			downloadURL=""
+			appNewVersion=""
+			break
+		elif [[ $arturiaPlatform == "mac" ]]; then
+			downloadURL="$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")"
+			appNewVersion="$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")"
+			break
+		fi
+		arturiaCount=$(( $arturiaCount + 1 ))
+	done
+	expectedTeamID="T53ZHSF36C"
+	;;
+

--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -20,4 +20,3 @@ arturiamcc)
     done
     expectedTeamID="T53ZHSF36C"
     ;;
-

--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -3,7 +3,7 @@ arturiamcc)
     type="pkg"
     arturiaDetails="$(curl -fsL 'https://www.arturia.com/api/resources?slugs=mccu&types=soft')"
     arturiaCount=0
-    maxEntries=$(getJSONValue "$arturiaDetails" "length" 2>/dev/null) # Get the number of entries
+    maxEntries=$(getJSONValue "$arturiaDetails" "length" 2>/dev/null)
     downloadURL=""
     appNewVersion=""
     while [[ $arturiaCount -lt $maxEntries ]]; do

--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -1,23 +1,23 @@
 arturiamcc)
-	name="MIDI Control Center"
-	type="pkg"
-	packageID="com.Arturia.MIDIControlCenter.resources"
-	arturiaDetails="$(curl -fsL 'https://www.arturia.com/api/resources?slugs=mccu&types=soft')"
-	arturiaCount=0
-	while [[ -z $arturiaMatch ]]
-	do
-		arturiaPlatform=$(getJSONValue "$arturiaDetails" "[$arturiaCount].platform_type" 2>/dev/null)
-		if [ $? -eq 1 ]; then
-			downloadURL=""
-			appNewVersion=""
-			break
-		elif [[ $arturiaPlatform == "mac" ]]; then
-			downloadURL="$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")"
-			appNewVersion="$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")"
-			break
-		fi
-		arturiaCount=$(( $arturiaCount + 1 ))
-	done
-	expectedTeamID="T53ZHSF36C"
-	;;
+    name="MIDI Control Center"
+    type="pkg"
+    packageID="com.Arturia.MIDIControlCenter.resources"
+    arturiaDetails="$(curl -fsL 'https://www.arturia.com/api/resources?slugs=mccu&types=soft')"
+    arturiaCount=0
+    while [[ -z $arturiaMatch ]]
+    do
+        arturiaPlatform=$(getJSONValue "$arturiaDetails" "[$arturiaCount].platform_type" 2>/dev/null)
+        if [ $? -eq 1 ]; then
+            downloadURL=""
+            appNewVersion=""
+            break
+        elif [[ $arturiaPlatform == "mac" ]]; then
+            downloadURL="$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")"
+            appNewVersion="$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")"
+            break
+        fi
+        arturiaCount=$(( $arturiaCount + 1 ))
+    done
+    expectedTeamID="T53ZHSF36C"
+    ;;
 

--- a/fragments/labels/arturiamcc.sh
+++ b/fragments/labels/arturiamcc.sh
@@ -9,7 +9,6 @@ arturiamcc)
     while [[ $arturiaCount -lt $maxEntries ]]; do
         arturiaPlatform=$(getJSONValue "$arturiaDetails" "[$arturiaCount].platform_type" 2>/dev/null)
         if [[ $arturiaPlatform == "mac" ]]; then
-            # Extract the permalink and version for macOS
             downloadURL=$(getJSONValue "$arturiaDetails" "[$arturiaCount].permalink")
             appNewVersion=$(getJSONValue "$arturiaDetails" "[$arturiaCount].version")
             break


### PR DESCRIPTION
assemble.sh arturiamcc    
2024-09-14 12:56:04 : REQ   : arturiamcc : ################## Start Installomator v. 10.7beta, date 2024-09-14
2024-09-14 12:56:04 : INFO  : arturiamcc : ################## Version: 10.7beta
2024-09-14 12:56:04 : INFO  : arturiamcc : ################## Date: 2024-09-14
2024-09-14 12:56:04 : INFO  : arturiamcc : ################## arturiamcc
2024-09-14 12:56:04 : DEBUG : arturiamcc : DEBUG mode 1 enabled.
2024-09-14 12:56:04 : INFO  : arturiamcc : SwiftDialog is not installed, clear cmd file var
2024-09-14 12:56:05 : DEBUG : arturiamcc : name=MIDI Control Center
2024-09-14 12:56:05 : DEBUG : arturiamcc : appName=
2024-09-14 12:56:05 : DEBUG : arturiamcc : type=pkg
2024-09-14 12:56:05 : DEBUG : arturiamcc : archiveName=
2024-09-14 12:56:05 : DEBUG : arturiamcc : downloadURL=https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_0_247.pkg
2024-09-14 12:56:05 : DEBUG : arturiamcc : curlOptions=
2024-09-14 12:56:05 : DEBUG : arturiamcc : appNewVersion=1.18.0.247
2024-09-14 12:56:06 : DEBUG : arturiamcc : appCustomVersion function: Not defined
2024-09-14 12:56:06 : DEBUG : arturiamcc : versionKey=CFBundleShortVersionString
2024-09-14 12:56:06 : DEBUG : arturiamcc : packageID=com.Arturia.MIDIControlCenter.resources
2024-09-14 12:56:06 : DEBUG : arturiamcc : pkgName=
2024-09-14 12:56:06 : DEBUG : arturiamcc : choiceChangesXML=
2024-09-14 12:56:06 : DEBUG : arturiamcc : expectedTeamID=T53ZHSF36C
2024-09-14 12:56:06 : DEBUG : arturiamcc : blockingProcesses=
2024-09-14 12:56:06 : DEBUG : arturiamcc : installerTool=
2024-09-14 12:56:06 : DEBUG : arturiamcc : CLIInstaller=
2024-09-14 12:56:06 : DEBUG : arturiamcc : CLIArguments=
2024-09-14 12:56:06 : DEBUG : arturiamcc : updateTool=
2024-09-14 12:56:06 : DEBUG : arturiamcc : updateToolArguments=
2024-09-14 12:56:06 : DEBUG : arturiamcc : updateToolRunAsCurrentUser=
2024-09-14 12:56:06 : INFO  : arturiamcc : BLOCKING_PROCESS_ACTION=tell_user
2024-09-14 12:56:06 : INFO  : arturiamcc : NOTIFY=success
2024-09-14 12:56:06 : INFO  : arturiamcc : LOGGING=DEBUG
2024-09-14 12:56:06 : INFO  : arturiamcc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-14 12:56:06 : INFO  : arturiamcc : Label type: pkg
2024-09-14 12:56:06 : INFO  : arturiamcc : archiveName: MIDI Control Center.pkg
2024-09-14 12:56:06 : INFO  : arturiamcc : no blocking processes defined, using MIDI Control Center as default
2024-09-14 12:56:06 : DEBUG : arturiamcc : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-14 12:56:06 : INFO  : arturiamcc : No version found using packageID com.Arturia.MIDIControlCenter.resources
2024-09-14 12:56:06 : INFO  : arturiamcc : name: MIDI Control Center, appName: MIDI Control Center.app
2024-09-14 12:56:06.362 mdfind[6417:8988460] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-14 12:56:06.363 mdfind[6417:8988460] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-14 12:56:06.693 mdfind[6417:8988460] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-14 12:56:06 : WARN  : arturiamcc : No previous app found
2024-09-14 12:56:06 : WARN  : arturiamcc : could not find MIDI Control Center.app
2024-09-14 12:56:06 : INFO  : arturiamcc : appversion: 
2024-09-14 12:56:06 : INFO  : arturiamcc : Latest version of MIDI Control Center is 1.18.0.247
2024-09-14 12:56:06 : REQ   : arturiamcc : Downloading https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_0_247.pkg to MIDI Control Center.pkg
2024-09-14 12:56:06 : DEBUG : arturiamcc : No Dialog connection, just download
2024-09-14 12:56:25 : DEBUG : arturiamcc : File list: -rw-r--r--  1 gilburns  staff    83M Sep 14 12:56 MIDI Control Center.pkg
2024-09-14 12:56:25 : DEBUG : arturiamcc : File type: MIDI Control Center.pkg: xar archive compressed TOC: 5356, SHA-1 checksum
2024-09-14 12:56:25 : DEBUG : arturiamcc : curl output was:
* Host dl.arturia.net:443 was resolved.
* IPv6: 2a02:6ea0:e200::17
* IPv4: 109.61.91.231
*   Trying 109.61.91.231:443...
* Connected to dl.arturia.net (109.61.91.231) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2087 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=1028461442.rsc.cdn77.org
*  start date: Jul 17 02:58:54 2024 GMT
*  expire date: Oct 15 02:58:53 2024 GMT
*  subjectAltName: host "dl.arturia.net" matched cert's "dl.arturia.net"
*  issuer: C=US; O=Let's Encrypt; CN=E6
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.arturia.net/products/mccu/soft/MIDI_Control_Center__1_18_0_247.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.arturia.net]
* [HTTP/2] [1] [:path: /products/mccu/soft/MIDI_Control_Center__1_18_0_247.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /products/mccu/soft/MIDI_Control_Center__1_18_0_247.pkg HTTP/2
> Host: dl.arturia.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Sat, 14 Sep 2024 17:56:07 GMT
< content-type: application/x-xar
< content-length: 86915205
< last-modified: Fri, 23 Aug 2024 12:43:57 GMT
< x-rgw-object-type: Normal
< etag: "a18d4ef062f1691db6ce350b83a0f911-2"
< x-amz-request-id: tx0000085f00c840dcd7f15-0066cddd8b-69a2f55-prg
< x-77-nzt: A209W+U3NzfvztAAAJySO+I3NzffVEsHAFm7vKmLr/0A
< x-77-nzt-ray: 0f63d41978c2f71037cee56678343605
< x-accel-expires: @1726841877
< x-accel-date: 1726283113
< x-accel-date-max: 1724767627
< x-77-cache: HIT
< x-77-age: 53454
< server: CDN77-Turbo
< x-cache: HIT
< x-age: 53454
< x-77-pop: ashburnUSVA
< accept-ranges: bytes
< 
{ [8183 bytes data]
* Connection #0 to host dl.arturia.net left intact

2024-09-14 12:56:25 : DEBUG : arturiamcc : DEBUG mode 1, not checking for blocking processes
2024-09-14 12:56:25 : REQ   : arturiamcc : Installing MIDI Control Center
2024-09-14 12:56:25 : INFO  : arturiamcc : Verifying: MIDI Control Center.pkg
2024-09-14 12:56:25 : DEBUG : arturiamcc : File list: -rw-r--r--  1 gilburns  staff    83M Sep 14 12:56 MIDI Control Center.pkg
2024-09-14 12:56:25 : DEBUG : arturiamcc : File type: MIDI Control Center.pkg: xar archive compressed TOC: 5356, SHA-1 checksum
2024-09-14 12:56:26 : DEBUG : arturiamcc : spctlOut is MIDI Control Center.pkg: accepted
2024-09-14 12:56:26 : DEBUG : arturiamcc : source=Notarized Developer ID
2024-09-14 12:56:26 : DEBUG : arturiamcc : origin=Developer ID Installer: Arturia (T53ZHSF36C)
2024-09-14 12:56:26 : INFO  : arturiamcc : Team ID: T53ZHSF36C (expected: T53ZHSF36C )
2024-09-14 12:56:26 : DEBUG : arturiamcc : DEBUG enabled, skipping installation
2024-09-14 12:56:26 : INFO  : arturiamcc : Finishing...
2024-09-14 12:56:29 : INFO  : arturiamcc : No version found using packageID com.Arturia.MIDIControlCenter.resources
2024-09-14 12:56:29 : INFO  : arturiamcc : name: MIDI Control Center, appName: MIDI Control Center.app
2024-09-14 12:56:29.364 mdfind[6484:8988853] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-14 12:56:29.364 mdfind[6484:8988853] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-14 12:56:29.471 mdfind[6484:8988853] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-14 12:56:29 : WARN  : arturiamcc : No previous app found
2024-09-14 12:56:29 : WARN  : arturiamcc : could not find MIDI Control Center.app
2024-09-14 12:56:29 : REQ   : arturiamcc : Installed MIDI Control Center, version 1.18.0.247
2024-09-14 12:56:29 : INFO  : arturiamcc : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-14 12:56:29 : DEBUG : arturiamcc : DEBUG mode 1, not reopening anything
2024-09-14 12:56:29 : REQ   : arturiamcc : All done!
2024-09-14 12:56:29 : REQ   : arturiamcc : ################## End Installomator, exit code 0 
