### PR TITLE
Create Midi Monitor label

### DIFF
--- a/fragments/labels/midimonitor.sh
+++ b/fragments/labels/midimonitor.sh
@@ -1,0 +1,7 @@
+midimonitor)
+    name="MIDI Monitor"
+    type="dmg"
+    downloadURL="https://www.snoize.com/MIDIMonitor/MIDIMonitor.dmg"
+    appNewVersion=$(curl -fs "https://www.snoize.com/MIDIMonitor/MIDIMonitor.xml" | xpath 'string(//rss/channel/item[1]/sparkle:version)' 2>/dev/null)
+    expectedTeamID="YDJAW5GX9U"
+    ;;


### PR DESCRIPTION
```
assemble.sh midimonitor
2024-09-15 08:10:31 : REQ   : midimonitor : ################## Start Installomator v. 10.7beta, date 2024-09-15
2024-09-15 08:10:31 : INFO  : midimonitor : ################## Version: 10.7beta
2024-09-15 08:10:31 : INFO  : midimonitor : ################## Date: 2024-09-15
2024-09-15 08:10:31 : INFO  : midimonitor : ################## midimonitor
2024-09-15 08:10:31 : DEBUG : midimonitor : DEBUG mode 1 enabled.
2024-09-15 08:10:31 : INFO  : midimonitor : SwiftDialog is not installed, clear cmd file var
2024-09-15 08:10:31 : DEBUG : midimonitor : name=MIDI Monitor
2024-09-15 08:10:31 : DEBUG : midimonitor : appName=
2024-09-15 08:10:31 : DEBUG : midimonitor : type=dmg
2024-09-15 08:10:31 : DEBUG : midimonitor : archiveName=
2024-09-15 08:10:31 : DEBUG : midimonitor : downloadURL=https://www.snoize.com/MIDIMonitor/MIDIMonitor.dmg
2024-09-15 08:10:31 : DEBUG : midimonitor : curlOptions=
2024-09-15 08:10:31 : DEBUG : midimonitor : appNewVersion=1.5.4
2024-09-15 08:10:31 : DEBUG : midimonitor : appCustomVersion function: Not defined
2024-09-15 08:10:31 : DEBUG : midimonitor : versionKey=CFBundleShortVersionString
2024-09-15 08:10:31 : DEBUG : midimonitor : packageID=
2024-09-15 08:10:31 : DEBUG : midimonitor : pkgName=
2024-09-15 08:10:31 : DEBUG : midimonitor : choiceChangesXML=
2024-09-15 08:10:31 : DEBUG : midimonitor : expectedTeamID=YDJAW5GX9U
2024-09-15 08:10:31 : DEBUG : midimonitor : blockingProcesses=
2024-09-15 08:10:31 : DEBUG : midimonitor : installerTool=
2024-09-15 08:10:31 : DEBUG : midimonitor : CLIInstaller=
2024-09-15 08:10:31 : DEBUG : midimonitor : CLIArguments=
2024-09-15 08:10:31 : DEBUG : midimonitor : updateTool=
2024-09-15 08:10:31 : DEBUG : midimonitor : updateToolArguments=
2024-09-15 08:10:31 : DEBUG : midimonitor : updateToolRunAsCurrentUser=
2024-09-15 08:10:31 : INFO  : midimonitor : BLOCKING_PROCESS_ACTION=tell_user
2024-09-15 08:10:31 : INFO  : midimonitor : NOTIFY=success
2024-09-15 08:10:31 : INFO  : midimonitor : LOGGING=DEBUG
2024-09-15 08:10:31 : INFO  : midimonitor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-15 08:10:31 : INFO  : midimonitor : Label type: dmg
2024-09-15 08:10:31 : INFO  : midimonitor : archiveName: MIDI Monitor.dmg
2024-09-15 08:10:31 : INFO  : midimonitor : no blocking processes defined, using MIDI Monitor as default
2024-09-15 08:10:31 : DEBUG : midimonitor : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-15 08:10:31 : INFO  : midimonitor : name: MIDI Monitor, appName: MIDI Monitor.app
2024-09-15 08:10:31.820 mdfind[14450:9425269] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-15 08:10:31.820 mdfind[14450:9425269] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-15 08:10:31.904 mdfind[14450:9425269] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-15 08:10:31 : WARN  : midimonitor : No previous app found
2024-09-15 08:10:31 : WARN  : midimonitor : could not find MIDI Monitor.app
2024-09-15 08:10:31 : INFO  : midimonitor : appversion: 
2024-09-15 08:10:31 : INFO  : midimonitor : Latest version of MIDI Monitor is 1.5.4
2024-09-15 08:10:31 : REQ   : midimonitor : Downloading https://www.snoize.com/MIDIMonitor/MIDIMonitor.dmg to MIDI Monitor.dmg
2024-09-15 08:10:31 : DEBUG : midimonitor : No Dialog connection, just download
2024-09-15 08:10:34 : DEBUG : midimonitor : File list: -rw-r--r--  1 gilburns  staff   9.7M Sep 15 08:10 MIDI Monitor.dmg
2024-09-15 08:10:34 : DEBUG : midimonitor : File type: MIDI Monitor.dmg: lzfse encoded, lzvn compressed
2024-09-15 08:10:34 : DEBUG : midimonitor : curl output was:
* Host www.snoize.com:443 was resolved.
* IPv6: 2606:4700:3032::6815:4806, 2606:4700:3035::ac43:ad64
* IPv4: 172.67.173.100, 104.21.72.6
*   Trying 172.67.173.100:443...
* Connected to www.snoize.com (172.67.173.100) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2518 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.snoize.com
*  start date: Aug 24 13:51:31 2024 GMT
*  expire date: Nov 22 13:51:30 2024 GMT
*  subjectAltName: host "www.snoize.com" matched cert's "www.snoize.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.snoize.com/MIDIMonitor/MIDIMonitor.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.snoize.com]
* [HTTP/2] [1] [:path: /MIDIMonitor/MIDIMonitor.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /MIDIMonitor/MIDIMonitor.dmg HTTP/2
> Host: www.snoize.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Sun, 15 Sep 2024 13:10:32 GMT
< content-type: application/octet-stream
< content-length: 10157376
< access-control-allow-origin: *
< cache-control: public, max-age=14400, must-revalidate
< etag: "0835f441fe0eb1f9ccd554652a7355d3"
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=6Mf4gs97hPJiqB0nP0WxWwKoAJNrurLirbE4Vk58gwHBw0vTM4rvlaE%2Fo9EKXUlYg1QOET0Y%2FD8P%2F2tTvYJKw4%2FGzyq9%2FixnYCbISWPYKU%2B6uWSMWJTP51eYaYws9Dy%2BDw%3D%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< vary: Accept-Encoding
< cf-cache-status: REVALIDATED
< accept-ranges: bytes
< server: cloudflare
< cf-ray: 8c38db835d8210cc-ORD
< alt-svc: h3=":443"; ma=86400
< 
{ [1360 bytes data]
* Connection #0 to host www.snoize.com left intact

2024-09-15 08:10:34 : DEBUG : midimonitor : DEBUG mode 1, not checking for blocking processes
2024-09-15 08:10:34 : REQ   : midimonitor : Installing MIDI Monitor
2024-09-15 08:10:34 : INFO  : midimonitor : Mounting /Users/gilburns/GitHub/Installomator/build/MIDI Monitor.dmg
2024-09-15 08:10:37 : DEBUG : midimonitor : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $520391B7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1E00AE31
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $073C8E56
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $30CB565C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $073C8E56
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $4DEBC2E3
verified   CRC32 $636C4A99
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_APFS
/dev/disk3          	EF57347C-0000-11AA-AA11-0030654
/dev/disk3s1        	41504653-0000-11AA-AA11-0030654	/Volumes/MIDI Monitor

2024-09-15 08:10:37 : INFO  : midimonitor : Mounted: /Volumes/MIDI Monitor
2024-09-15 08:10:37 : INFO  : midimonitor : Verifying: /Volumes/MIDI Monitor/MIDI Monitor.app
2024-09-15 08:10:37 : DEBUG : midimonitor : App size:  21M	/Volumes/MIDI Monitor/MIDI Monitor.app
2024-09-15 08:10:37 : DEBUG : midimonitor : Debugging enabled, App Verification output was:
/Volumes/MIDI Monitor/MIDI Monitor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Kurt Revis (YDJAW5GX9U)

2024-09-15 08:10:37 : INFO  : midimonitor : Team ID matching: YDJAW5GX9U (expected: YDJAW5GX9U )
2024-09-15 08:10:37 : INFO  : midimonitor : Installing MIDI Monitor version 1.5.4 on versionKey CFBundleShortVersionString.
2024-09-15 08:10:37 : INFO  : midimonitor : App has LSMinimumSystemVersion: 10.13
2024-09-15 08:10:37 : DEBUG : midimonitor : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-15 08:10:37 : INFO  : midimonitor : Finishing...
2024-09-15 08:10:40 : INFO  : midimonitor : name: MIDI Monitor, appName: MIDI Monitor.app
2024-09-15 08:10:40.996 mdfind[14533:9425615] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-15 08:10:40.997 mdfind[14533:9425615] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-15 08:10:41.098 mdfind[14533:9425615] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-15 08:10:41 : WARN  : midimonitor : No previous app found
2024-09-15 08:10:41 : WARN  : midimonitor : could not find MIDI Monitor.app
2024-09-15 08:10:41 : REQ   : midimonitor : Installed MIDI Monitor, version 1.5.4
2024-09-15 08:10:41 : INFO  : midimonitor : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-15 08:10:41 : DEBUG : midimonitor : Unmounting /Volumes/MIDI Monitor
2024-09-15 08:10:41 : DEBUG : midimonitor : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-15 08:10:41 : DEBUG : midimonitor : DEBUG mode 1, not reopening anything
2024-09-15 08:10:41 : REQ   : midimonitor : All done!
2024-09-15 08:10:41 : REQ   : midimonitor : ################## End Installomator, exit code 0 

```