### PR TITLE
Create SysEx Librarian label

### DIFF
--- a/fragments/labels/sysexlibrarian.sh
+++ b/fragments/labels/sysexlibrarian.sh
@@ -1,0 +1,7 @@
+sysexlibrarian)
+    name="SysEx Librarian"
+    type="dmg"
+    downloadURL="https://www.snoize.com/SysExLibrarian/SysExLibrarian.dmg"
+    appNewVersion=$(curl -fs "https://www.snoize.com/SysExLibrarian/SysExLibrarian.xml" | xpath 'string(//rss/channel/item[1]/sparkle:version)' 2>/dev/null)
+    expectedTeamID="YDJAW5GX9U"
+    ;;


### PR DESCRIPTION
```
assemble.sh sysexlibrarian
2024-09-15 08:17:53 : REQ   : sysexlibrarian : ################## Start Installomator v. 10.7beta, date 2024-09-15
2024-09-15 08:17:53 : INFO  : sysexlibrarian : ################## Version: 10.7beta
2024-09-15 08:17:53 : INFO  : sysexlibrarian : ################## Date: 2024-09-15
2024-09-15 08:17:53 : INFO  : sysexlibrarian : ################## sysexlibrarian
2024-09-15 08:17:53 : DEBUG : sysexlibrarian : DEBUG mode 1 enabled.
2024-09-15 08:17:53 : INFO  : sysexlibrarian : SwiftDialog is not installed, clear cmd file var
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : name=SysEx Librarian
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : appName=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : type=dmg
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : archiveName=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : downloadURL=https://www.snoize.com/SysExLibrarian/SysExLibrarian.dmg
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : curlOptions=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : appNewVersion=1.5.2
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : appCustomVersion function: Not defined
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : versionKey=CFBundleShortVersionString
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : packageID=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : pkgName=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : choiceChangesXML=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : expectedTeamID=YDJAW5GX9U
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : blockingProcesses=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : installerTool=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : CLIInstaller=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : CLIArguments=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : updateTool=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : updateToolArguments=
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : updateToolRunAsCurrentUser=
2024-09-15 08:17:55 : INFO  : sysexlibrarian : BLOCKING_PROCESS_ACTION=tell_user
2024-09-15 08:17:55 : INFO  : sysexlibrarian : NOTIFY=success
2024-09-15 08:17:55 : INFO  : sysexlibrarian : LOGGING=DEBUG
2024-09-15 08:17:55 : INFO  : sysexlibrarian : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-15 08:17:55 : INFO  : sysexlibrarian : Label type: dmg
2024-09-15 08:17:55 : INFO  : sysexlibrarian : archiveName: SysEx Librarian.dmg
2024-09-15 08:17:55 : INFO  : sysexlibrarian : no blocking processes defined, using SysEx Librarian as default
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-15 08:17:55 : INFO  : sysexlibrarian : name: SysEx Librarian, appName: SysEx Librarian.app
2024-09-15 08:17:55.397 mdfind[15466:9433967] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-15 08:17:55.397 mdfind[15466:9433967] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-15 08:17:55.478 mdfind[15466:9433967] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-15 08:17:55 : WARN  : sysexlibrarian : No previous app found
2024-09-15 08:17:55 : WARN  : sysexlibrarian : could not find SysEx Librarian.app
2024-09-15 08:17:55 : INFO  : sysexlibrarian : appversion: 
2024-09-15 08:17:55 : INFO  : sysexlibrarian : Latest version of SysEx Librarian is 1.5.2
2024-09-15 08:17:55 : REQ   : sysexlibrarian : Downloading https://www.snoize.com/SysExLibrarian/SysExLibrarian.dmg to SysEx Librarian.dmg
2024-09-15 08:17:55 : DEBUG : sysexlibrarian : No Dialog connection, just download
2024-09-15 08:17:57 : DEBUG : sysexlibrarian : File list: -rw-r--r--  1 gilburns  staff   6.5M Sep 15 08:17 SysEx Librarian.dmg
2024-09-15 08:17:57 : DEBUG : sysexlibrarian : File type: SysEx Librarian.dmg: lzfse encoded, lzvn compressed
2024-09-15 08:17:57 : DEBUG : sysexlibrarian : curl output was:
* Host www.snoize.com:443 was resolved.
* IPv6: 2606:4700:3035::ac43:ad64, 2606:4700:3032::6815:4806
* IPv4: 104.21.72.6, 172.67.173.100
*   Trying 104.21.72.6:443...
* Connected to www.snoize.com (104.21.72.6) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2518 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.snoize.com
*  start date: Aug 24 13:51:31 2024 GMT
*  expire date: Nov 22 13:51:30 2024 GMT
*  subjectAltName: host "www.snoize.com" matched cert's "www.snoize.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.snoize.com/SysExLibrarian/SysExLibrarian.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.snoize.com]
* [HTTP/2] [1] [:path: /SysExLibrarian/SysExLibrarian.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /SysExLibrarian/SysExLibrarian.dmg HTTP/2
> Host: www.snoize.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Sun, 15 Sep 2024 13:17:56 GMT
< content-type: application/octet-stream
< content-length: 6834617
< access-control-allow-origin: *
< cache-control: public, max-age=14400, must-revalidate
< etag: "4f5f67f3f6e61b5f2b88b980d8e2d2f5"
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=7JIr56eZas%2FONkw3n8gcyWze1Iekzxzln6%2BC3QQvV5dEjjrKM3gc%2BLKe5Mmxhopk%2FVHESJifp4ELrVlAy9Ovwpmp9K2oC4Wm4Fp6JNCxqG6yDWF%2FTx7hhrt2rmipa1MUGQ%3D%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< vary: Accept-Encoding
< cf-cache-status: MISS
< accept-ranges: bytes
< server: cloudflare
< cf-ray: 8c38e657ad166160-ORD
< alt-svc: h3=":443"; ma=86400
< 
{ [1360 bytes data]
* Connection #0 to host www.snoize.com left intact

2024-09-15 08:17:57 : DEBUG : sysexlibrarian : DEBUG mode 1, not checking for blocking processes
2024-09-15 08:17:57 : REQ   : sysexlibrarian : Installing SysEx Librarian
2024-09-15 08:17:57 : INFO  : sysexlibrarian : Mounting /Users/gilburns/GitHub/Installomator/build/SysEx Librarian.dmg
2024-09-15 08:17:59 : DEBUG : sysexlibrarian : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $111BAFC3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8276A4A6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $4CB8A20C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $A147EF82
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $4CB8A20C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $59F2D8DF
verified   CRC32 $7DC12A55
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_APFS
/dev/disk3          	EF57347C-0000-11AA-AA11-0030654
/dev/disk3s1        	41504653-0000-11AA-AA11-0030654	/Volumes/SysEx Librarian

2024-09-15 08:17:59 : INFO  : sysexlibrarian : Mounted: /Volumes/SysEx Librarian
2024-09-15 08:17:59 : INFO  : sysexlibrarian : Verifying: /Volumes/SysEx Librarian/SysEx Librarian.app
2024-09-15 08:17:59 : DEBUG : sysexlibrarian : App size:  10M	/Volumes/SysEx Librarian/SysEx Librarian.app
2024-09-15 08:17:59 : DEBUG : sysexlibrarian : Debugging enabled, App Verification output was:
/Volumes/SysEx Librarian/SysEx Librarian.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Kurt Revis (YDJAW5GX9U)

2024-09-15 08:17:59 : INFO  : sysexlibrarian : Team ID matching: YDJAW5GX9U (expected: YDJAW5GX9U )
2024-09-15 08:17:59 : INFO  : sysexlibrarian : Installing SysEx Librarian version 1.5.2 on versionKey CFBundleShortVersionString.
2024-09-15 08:17:59 : INFO  : sysexlibrarian : App has LSMinimumSystemVersion: 10.14.6
2024-09-15 08:17:59 : DEBUG : sysexlibrarian : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-15 08:17:59 : INFO  : sysexlibrarian : Finishing...
2024-09-15 08:18:02 : INFO  : sysexlibrarian : name: SysEx Librarian, appName: SysEx Librarian.app
2024-09-15 08:18:02.911 mdfind[15549:9434318] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-15 08:18:02.912 mdfind[15549:9434318] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-15 08:18:03.025 mdfind[15549:9434318] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-15 08:18:03 : WARN  : sysexlibrarian : No previous app found
2024-09-15 08:18:03 : WARN  : sysexlibrarian : could not find SysEx Librarian.app
2024-09-15 08:18:03 : REQ   : sysexlibrarian : Installed SysEx Librarian, version 1.5.2
2024-09-15 08:18:03 : INFO  : sysexlibrarian : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-15 08:18:03 : DEBUG : sysexlibrarian : Unmounting /Volumes/SysEx Librarian
2024-09-15 08:18:03 : DEBUG : sysexlibrarian : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-15 08:18:03 : DEBUG : sysexlibrarian : DEBUG mode 1, not reopening anything
2024-09-15 08:18:03 : REQ   : sysexlibrarian : All done!
2024-09-15 08:18:03 : REQ   : sysexlibrarian : ################## End Installomator, exit code 0 

```