### PR TITLE
Create Steinberg Activation Manager label

### DIFF
--- a/fragments/labels/steinbergactivationmanager.sh
+++ b/fragments/labels/steinbergactivationmanager.sh
@@ -1,0 +1,13 @@
+steinbergactivationmanager)
+    # New installations requires the following labels PRIOR to Cubase
+    #    steinbergactivationmanager
+    #    steinberglibrarymanager
+    #    steinbergmediabay
+    #
+    name="Steinberg Activation Manager"
+    type="pkgInDmg"
+    packageID="com.steinberg.activationmanager"
+	downloadURL="https://www.steinberg.net/sam-mac"
+    appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | cut -d\/ -f7 | cut -d'.' -f1-3 )"
+    expectedTeamID="5PMY476BJ6"
+    ;;

--- a/fragments/labels/steinbergactivationmanager.sh
+++ b/fragments/labels/steinbergactivationmanager.sh
@@ -7,7 +7,7 @@ steinbergactivationmanager)
     name="Steinberg Activation Manager"
     type="pkgInDmg"
     packageID="com.steinberg.activationmanager"
-	downloadURL="https://www.steinberg.net/sam-mac"
+    downloadURL="https://www.steinberg.net/sam-mac"
     appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | cut -d\/ -f7 | cut -d'.' -f1-3 )"
     expectedTeamID="5PMY476BJ6"
     ;;


### PR DESCRIPTION
```
assemble.sh steinbergactivationmanager
2024-09-18 18:44:58 : REQ   : steinbergactivationmanager : ################## Start Installomator v. 10.7beta, date 2024-09-18
2024-09-18 18:44:58 : INFO  : steinbergactivationmanager : ################## Version: 10.7beta
2024-09-18 18:44:58 : INFO  : steinbergactivationmanager : ################## Date: 2024-09-18
2024-09-18 18:44:58 : INFO  : steinbergactivationmanager : ################## steinbergactivationmanager
2024-09-18 18:44:58 : DEBUG : steinbergactivationmanager : DEBUG mode 1 enabled.
2024-09-18 18:44:58 : INFO  : steinbergactivationmanager : SwiftDialog is not installed, clear cmd file var
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : name=Steinberg Activation Manager
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : appName=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : type=pkgInDmg
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : archiveName=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : downloadURL=https://www.steinberg.net/sam-mac
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : curlOptions=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : appNewVersion=1.5.0
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : appCustomVersion function: Not defined
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : versionKey=CFBundleShortVersionString
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : packageID=com.steinberg.activationmanager
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : pkgName=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : choiceChangesXML=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : expectedTeamID=5PMY476BJ6
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : blockingProcesses=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : installerTool=
2024-09-18 18:45:00 : DEBUG : steinbergactivationmanager : CLIInstaller=
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : CLIArguments=
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : updateTool=
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : updateToolArguments=
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : updateToolRunAsCurrentUser=
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : BLOCKING_PROCESS_ACTION=tell_user
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : NOTIFY=success
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : LOGGING=DEBUG
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : Label type: pkgInDmg
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : archiveName: Steinberg Activation Manager.dmg
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : no blocking processes defined, using Steinberg Activation Manager as default
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : found packageID com.steinberg.activationmanager installed, version 1.5.0
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : appversion: 1.5.0
2024-09-18 18:45:01 : INFO  : steinbergactivationmanager : Latest version of Steinberg Activation Manager is 1.5.0
2024-09-18 18:45:01 : WARN  : steinbergactivationmanager : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-18 18:45:01 : REQ   : steinbergactivationmanager : Downloading https://www.steinberg.net/sam-mac to Steinberg Activation Manager.dmg
2024-09-18 18:45:01 : DEBUG : steinbergactivationmanager : No Dialog connection, just download
2024-09-18 18:45:25 : DEBUG : steinbergactivationmanager : File list: -rw-r--r--  1 gilburns  staff    60M Sep 18 18:45 Steinberg Activation Manager.dmg
2024-09-18 18:45:25 : DEBUG : steinbergactivationmanager : File type: Steinberg Activation Manager.dmg: zlib compressed data
2024-09-18 18:45:25 : DEBUG : steinbergactivationmanager : curl output was:
* Host www.steinberg.net:443 was resolved.
* IPv6: 2600:9000:2506:be00:15:db7a:c7c0:93a1, 2600:9000:2506:4800:15:db7a:c7c0:93a1, 2600:9000:2506:e200:15:db7a:c7c0:93a1, 2600:9000:2506:f800:15:db7a:c7c0:93a1, 2600:9000:2506:7400:15:db7a:c7c0:93a1, 2600:9000:2506:8400:15:db7a:c7c0:93a1, 2600:9000:2506:5e00:15:db7a:c7c0:93a1, 2600:9000:2506:d400:15:db7a:c7c0:93a1
* IPv4: 18.154.110.11, 18.154.110.117, 18.154.110.86, 18.154.110.85
*   Trying 18.154.110.11:443...
* Connected to www.steinberg.net (18.154.110.11) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5003 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.steinberg.net
*  start date: Jan 16 00:00:00 2024 GMT
*  expire date: Feb 13 23:59:59 2025 GMT
*  subjectAltName: host "www.steinberg.net" matched cert's "www.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.steinberg.net/sam-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.steinberg.net]
* [HTTP/2] [1] [:path: /sam-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /sam-mac HTTP/2
> Host: www.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-type: text/html
< content-length: 138
< location: https://r.mb.steinberg.net/rc-sam-mac
< date: Wed, 18 Sep 2024 23:45:01 GMT
< referrer-policy: strict-origin-when-cross-origin
< server: nginx
< content-security-policy: default-src https: 'self' 'unsafe-inline' 'unsafe-eval' *.steinberg.net *.usercentrics.eu *.personio.de *.googletagmanager.com fonts.googleapis.com *.soundcloud.com *.youtube-nocookie.com *.optimizely.com *.eu-central-1.compute.amazonaws.com *.onfastspring.com *.impactcdn.com; connect-src https: 'self' wss://ws.hotjar.com; img-src https: 'self' *.steinberg.net *.ytimg.com *.usercentrics.eu data:; font-src https: 'self' fonts.gstatic.com fonts.googleapis.com data:;
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< feature-policy: camera 'none';gamepad 'none';geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';usb 'none'
< permissions-policy: camera=(),gamepad=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),usb=()
< via: 1.1 637c6cc074af01d1a5246ebd8a4d3158.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< cache-control: public, max-age=3600
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Miss from cloudfront
< x-amz-cf-pop: ORD58-P6
< x-amz-cf-id: MndiTEQkbgl-SiRnIbNcXD8UOBL5ynAioO25bJjKvpKgLsmT0eSXLw==
< 
* Ignoring the response-body
* Connection #0 to host www.steinberg.net left intact
* Issue another request to this URL: 'https://r.mb.steinberg.net/rc-sam-mac'
* Host r.mb.steinberg.net:443 was resolved.
* IPv6: (none)
* IPv4: 34.251.132.234, 52.208.213.33
*   Trying 34.251.132.234:443...
* Connected to r.mb.steinberg.net (34.251.132.234) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2814 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.mb.steinberg.net
*  start date: Nov 16 11:10:23 2023 GMT
*  expire date: Dec 17 11:10:22 2024 GMT
*  subjectAltName: host "r.mb.steinberg.net" matched cert's "*.mb.steinberg.net"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=AlphaSSL CA - SHA256 - G4
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://r.mb.steinberg.net/rc-sam-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: r.mb.steinberg.net]
* [HTTP/2] [1] [:path: /rc-sam-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /rc-sam-mac HTTP/2
> Host: r.mb.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Wed, 18 Sep 2024 23:45:02 GMT
< content-length: 0
< location: https://download.steinberg.net/static_content/runtime-components/steinberg-activation-manager/1.5.0.1163-a3380ca2-9856-35bf-8dde-33586c38d820/Steinberg_Activation_Manager_Installer_mac.dmg
< server: nginx/1.22.1
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 0
< cache-control: no-cache, no-store, max-age=0, must-revalidate
< pragma: no-cache
< expires: 0
< strict-transport-security: max-age=31536000 ; includeSubDomains
< x-frame-options: DENY
< 
* Ignoring the response-body
* Connection #1 to host r.mb.steinberg.net left intact
* Issue another request to this URL: 'https://download.steinberg.net/static_content/runtime-components/steinberg-activation-manager/1.5.0.1163-a3380ca2-9856-35bf-8dde-33586c38d820/Steinberg_Activation_Manager_Installer_mac.dmg'
* Host download.steinberg.net:443 was resolved.
* IPv6: 2600:9000:25f4:3800:6:75be:a080:93a1, 2600:9000:25f4:e200:6:75be:a080:93a1, 2600:9000:25f4:7200:6:75be:a080:93a1, 2600:9000:25f4:a600:6:75be:a080:93a1, 2600:9000:25f4:ca00:6:75be:a080:93a1, 2600:9000:25f4:1a00:6:75be:a080:93a1, 2600:9000:25f4:1400:6:75be:a080:93a1, 2600:9000:25f4:7000:6:75be:a080:93a1
* IPv4: 13.32.164.28, 13.32.164.75, 13.32.164.70, 13.32.164.106
*   Trying 13.32.164.28:443...
* Connected to download.steinberg.net (13.32.164.28) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5014 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.steinberg.net
*  start date: Jun 19 00:00:00 2024 GMT
*  expire date: Jul 19 23:59:59 2025 GMT
*  subjectAltName: host "download.steinberg.net" matched cert's "download.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.steinberg.net/static_content/runtime-components/steinberg-activation-manager/1.5.0.1163-a3380ca2-9856-35bf-8dde-33586c38d820/Steinberg_Activation_Manager_Installer_mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.steinberg.net]
* [HTTP/2] [1] [:path: /static_content/runtime-components/steinberg-activation-manager/1.5.0.1163-a3380ca2-9856-35bf-8dde-33586c38d820/Steinberg_Activation_Manager_Installer_mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /static_content/runtime-components/steinberg-activation-manager/1.5.0.1163-a3380ca2-9856-35bf-8dde-33586c38d820/Steinberg_Activation_Manager_Installer_mac.dmg HTTP/2
> Host: download.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 62673494
< date: Tue, 02 Jul 2024 11:47:41 GMT
< last-modified: Tue, 02 Jul 2024 11:37:13 GMT
< etag: "375dc371461518951b7e17ab3ec59ade-12"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: V9J.dYw1R7b0sT_ExNmbq8.1k5qT6n19
< accept-ranges: bytes
< server: AmazonS3
< via: 1.1 f266ac47d4aee3a84c8fc38a6ef92022.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< age: 6782242
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Hit from cloudfront
< x-amz-cf-pop: ORD58-P1
< x-amz-cf-id: 1BzkWWHU0vOpRkbbj1tmhK11_rfW8K3sCoJMyplGAFN8x7-fHip_bw==
< 
{ [8192 bytes data]
* Connection #2 to host download.steinberg.net left intact

2024-09-18 18:45:25 : DEBUG : steinbergactivationmanager : DEBUG mode 1, not checking for blocking processes
2024-09-18 18:45:25 : REQ   : steinbergactivationmanager : Installing Steinberg Activation Manager
2024-09-18 18:45:25 : INFO  : steinbergactivationmanager : Mounting /Users/gilburns/GitHub/Installomator/build/Steinberg Activation Manager.dmg
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $208D5FDB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $ABC460F7
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $EB37F853
verified   CRC32 $3214FAAC
/dev/disk3          	Apple_partition_scheme
/dev/disk3s1        	Apple_partition_map
/dev/disk3s2        	Apple_HFS                      	/Volumes/Steinberg Activation Manager

2024-09-18 18:45:26 : INFO  : steinbergactivationmanager : Mounted: /Volumes/Steinberg Activation Manager
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : Found pkg(s):
/Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg
2024-09-18 18:45:26 : INFO  : steinbergactivationmanager : found pkg: /Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg
2024-09-18 18:45:26 : INFO  : steinbergactivationmanager : Verifying: /Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : File list: -rw-r--r--  1 gilburns  staff    59M Jun 24 09:09 /Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : File type: /Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg: xar archive compressed TOC: 6835, SHA-1 checksum
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : spctlOut is /Volumes/Steinberg Activation Manager/Steinberg Activation Manager.pkg: accepted
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : source=Notarized Developer ID
2024-09-18 18:45:26 : DEBUG : steinbergactivationmanager : origin=Developer ID Installer: Steinberg Media Technologies GmbH (5PMY476BJ6)
2024-09-18 18:45:26 : INFO  : steinbergactivationmanager : Team ID: 5PMY476BJ6 (expected: 5PMY476BJ6 )
2024-09-18 18:45:26 : INFO  : steinbergactivationmanager : Checking package version.
2024-09-18 18:45:27 : INFO  : steinbergactivationmanager : Downloaded package com.steinberg.activationmanager version 1.5.0
2024-09-18 18:45:27 : INFO  : steinbergactivationmanager : Downloaded version of Steinberg Activation Manager is the same as installed.
2024-09-18 18:45:27 : DEBUG : steinbergactivationmanager : Unmounting /Volumes/Steinberg Activation Manager
2024-09-18 18:45:27 : DEBUG : steinbergactivationmanager : Debugging enabled, Unmounting output was:
"disk3" ejected.
2024-09-18 18:45:27 : DEBUG : steinbergactivationmanager : DEBUG mode 1, not reopening anything
2024-09-18 18:45:27 : REQ   : steinbergactivationmanager : No new version to install
2024-09-18 18:45:27 : REQ   : steinbergactivationmanager : ################## End Installomator, exit code 0 
```