### PR TITLE
Create Steinberg Library Manager label

### DIFF
--- a/fragments/labels/steinberglibrarymanager.sh
+++ b/fragments/labels/steinberglibrarymanager.sh
@@ -7,7 +7,7 @@ steinberglibrarymanager)
     name="Steinberg Library Manager"
     type="pkgInDmg"
     packageID="com.steinberg.SteinbergLibraryManager"
-	downloadURL="https://www.steinberg.net/slm-mac"
+    downloadURL="https://www.steinberg.net/slm-mac"
     appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | cut -d\/ -f7 | cut -d'.' -f1-3 )"
     expectedTeamID="5PMY476BJ6"
     ;;

--- a/fragments/labels/steinberglibrarymanager.sh
+++ b/fragments/labels/steinberglibrarymanager.sh
@@ -1,0 +1,13 @@
+steinberglibrarymanager)
+    # New installations requires the following labels PRIOR to Cubase
+    #    steinbergactivationmanager
+    #    steinberglibrarymanager
+    #    steinbergmediabay
+    #
+    name="Steinberg Library Manager"
+    type="pkgInDmg"
+    packageID="com.steinberg.SteinbergLibraryManager"
+	downloadURL="https://www.steinberg.net/slm-mac"
+    appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | cut -d\/ -f7 | cut -d'.' -f1-3 )"
+    expectedTeamID="5PMY476BJ6"
+    ;;


### PR DESCRIPTION
```
assemble.sh steinberglibrarymanager
2024-09-18 18:45:43 : REQ   : steinberglibrarymanager : ################## Start Installomator v. 10.7beta, date 2024-09-18
2024-09-18 18:45:43 : INFO  : steinberglibrarymanager : ################## Version: 10.7beta
2024-09-18 18:45:43 : INFO  : steinberglibrarymanager : ################## Date: 2024-09-18
2024-09-18 18:45:43 : INFO  : steinberglibrarymanager : ################## steinberglibrarymanager
2024-09-18 18:45:43 : DEBUG : steinberglibrarymanager : DEBUG mode 1 enabled.
2024-09-18 18:45:43 : INFO  : steinberglibrarymanager : SwiftDialog is not installed, clear cmd file var
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : name=Steinberg Library Manager
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : appName=
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : type=pkgInDmg
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : archiveName=
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : downloadURL=https://www.steinberg.net/slm-mac
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : curlOptions=
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : appNewVersion=3.2.50
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : appCustomVersion function: Not defined
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : versionKey=CFBundleShortVersionString
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : packageID=com.steinberg.SteinbergLibraryManager
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : pkgName=
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : choiceChangesXML=
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : expectedTeamID=5PMY476BJ6
2024-09-18 18:45:44 : DEBUG : steinberglibrarymanager : blockingProcesses=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : installerTool=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : CLIInstaller=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : CLIArguments=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : updateTool=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : updateToolArguments=
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : updateToolRunAsCurrentUser=
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : BLOCKING_PROCESS_ACTION=tell_user
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : NOTIFY=success
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : LOGGING=DEBUG
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : Label type: pkgInDmg
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : archiveName: Steinberg Library Manager.dmg
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : no blocking processes defined, using Steinberg Library Manager as default
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : found packageID com.steinberg.SteinbergLibraryManager installed, version 3.2.50
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : appversion: 3.2.50
2024-09-18 18:45:45 : INFO  : steinberglibrarymanager : Latest version of Steinberg Library Manager is 3.2.50
2024-09-18 18:45:45 : WARN  : steinberglibrarymanager : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-18 18:45:45 : REQ   : steinberglibrarymanager : Downloading https://www.steinberg.net/slm-mac to Steinberg Library Manager.dmg
2024-09-18 18:45:45 : DEBUG : steinberglibrarymanager : No Dialog connection, just download
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : File list: -rw-r--r--  1 gilburns  staff   9.4M Sep 18 18:45 Steinberg Library Manager.dmg
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : File type: Steinberg Library Manager.dmg: zlib compressed data
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : curl output was:
* Host www.steinberg.net:443 was resolved.
* IPv6: 2600:9000:2506:be00:15:db7a:c7c0:93a1, 2600:9000:2506:4800:15:db7a:c7c0:93a1, 2600:9000:2506:e200:15:db7a:c7c0:93a1, 2600:9000:2506:f800:15:db7a:c7c0:93a1, 2600:9000:2506:7400:15:db7a:c7c0:93a1, 2600:9000:2506:8400:15:db7a:c7c0:93a1, 2600:9000:2506:5e00:15:db7a:c7c0:93a1, 2600:9000:2506:d400:15:db7a:c7c0:93a1
* IPv4: 18.154.110.117, 18.154.110.86, 18.154.110.85, 18.154.110.11
*   Trying 18.154.110.117:443...
* Connected to www.steinberg.net (18.154.110.117) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5003 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.steinberg.net
*  start date: Jan 16 00:00:00 2024 GMT
*  expire date: Feb 13 23:59:59 2025 GMT
*  subjectAltName: host "www.steinberg.net" matched cert's "www.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.steinberg.net/slm-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.steinberg.net]
* [HTTP/2] [1] [:path: /slm-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /slm-mac HTTP/2
> Host: www.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-type: text/html
< content-length: 138
< location: https://r.mb.steinberg.net/rc-slm-mac
< date: Wed, 18 Sep 2024 23:45:45 GMT
< referrer-policy: strict-origin-when-cross-origin
< server: nginx
< content-security-policy: default-src https: 'self' 'unsafe-inline' 'unsafe-eval' *.steinberg.net *.usercentrics.eu *.personio.de *.googletagmanager.com fonts.googleapis.com *.soundcloud.com *.youtube-nocookie.com *.optimizely.com *.eu-central-1.compute.amazonaws.com *.onfastspring.com *.impactcdn.com; connect-src https: 'self' wss://ws.hotjar.com; img-src https: 'self' *.steinberg.net *.ytimg.com *.usercentrics.eu data:; font-src https: 'self' fonts.gstatic.com fonts.googleapis.com data:;
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< feature-policy: camera 'none';gamepad 'none';geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';usb 'none'
< permissions-policy: camera=(),gamepad=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),usb=()
< via: 1.1 0b5cc5a573e4c995578b77dbd389ca2c.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< cache-control: public, max-age=3600
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Miss from cloudfront
< x-amz-cf-pop: ORD58-P6
< x-amz-cf-id: crRnGoHZplhf-GXVvvXZeiMmjuG11B5ecPHnRe9wX8zfw-WytuaQEQ==
< 
* Ignoring the response-body
* Connection #0 to host www.steinberg.net left intact
* Issue another request to this URL: 'https://r.mb.steinberg.net/rc-slm-mac'
* Host r.mb.steinberg.net:443 was resolved.
* IPv6: (none)
* IPv4: 52.208.213.33, 34.251.132.234
*   Trying 52.208.213.33:443...
* Connected to r.mb.steinberg.net (52.208.213.33) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2814 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.mb.steinberg.net
*  start date: Nov 16 11:10:23 2023 GMT
*  expire date: Dec 17 11:10:22 2024 GMT
*  subjectAltName: host "r.mb.steinberg.net" matched cert's "*.mb.steinberg.net"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=AlphaSSL CA - SHA256 - G4
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://r.mb.steinberg.net/rc-slm-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: r.mb.steinberg.net]
* [HTTP/2] [1] [:path: /rc-slm-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /rc-slm-mac HTTP/2
> Host: r.mb.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Wed, 18 Sep 2024 23:45:46 GMT
< content-length: 0
< location: https://download.steinberg.net/static_content/runtime-components/steinberg-library-manager/3.2.50.300-99604c6c-120b-397a-822a-80ea66cfb62c/Steinberg_Library_Manager_mac.dmg
< server: nginx/1.22.1
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 0
< cache-control: no-cache, no-store, max-age=0, must-revalidate
< pragma: no-cache
< expires: 0
< strict-transport-security: max-age=31536000 ; includeSubDomains
< x-frame-options: DENY
< 
* Ignoring the response-body
* Connection #1 to host r.mb.steinberg.net left intact
* Issue another request to this URL: 'https://download.steinberg.net/static_content/runtime-components/steinberg-library-manager/3.2.50.300-99604c6c-120b-397a-822a-80ea66cfb62c/Steinberg_Library_Manager_mac.dmg'
* Host download.steinberg.net:443 was resolved.
* IPv6: 2600:9000:25f4:3800:6:75be:a080:93a1, 2600:9000:25f4:e200:6:75be:a080:93a1, 2600:9000:25f4:7200:6:75be:a080:93a1, 2600:9000:25f4:a600:6:75be:a080:93a1, 2600:9000:25f4:ca00:6:75be:a080:93a1, 2600:9000:25f4:1a00:6:75be:a080:93a1, 2600:9000:25f4:1400:6:75be:a080:93a1, 2600:9000:25f4:7000:6:75be:a080:93a1
* IPv4: 13.32.164.75, 13.32.164.70, 13.32.164.106, 13.32.164.28
*   Trying 13.32.164.75:443...
* Connected to download.steinberg.net (13.32.164.75) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5014 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.steinberg.net
*  start date: Jun 19 00:00:00 2024 GMT
*  expire date: Jul 19 23:59:59 2025 GMT
*  subjectAltName: host "download.steinberg.net" matched cert's "download.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.steinberg.net/static_content/runtime-components/steinberg-library-manager/3.2.50.300-99604c6c-120b-397a-822a-80ea66cfb62c/Steinberg_Library_Manager_mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.steinberg.net]
* [HTTP/2] [1] [:path: /static_content/runtime-components/steinberg-library-manager/3.2.50.300-99604c6c-120b-397a-822a-80ea66cfb62c/Steinberg_Library_Manager_mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /static_content/runtime-components/steinberg-library-manager/3.2.50.300-99604c6c-120b-397a-822a-80ea66cfb62c/Steinberg_Library_Manager_mac.dmg HTTP/2
> Host: download.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 9851034
< date: Wed, 07 Aug 2024 12:49:41 GMT
< last-modified: Wed, 07 Aug 2024 12:40:20 GMT
< etag: "d5a23431d069543222509e5a5f46a168"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: F9i0FOc.V3SJgRD8b22OlZh58cNJkpX.
< accept-ranges: bytes
< server: AmazonS3
< via: 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< age: 3668166
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Hit from cloudfront
< x-amz-cf-pop: ORD58-P1
< x-amz-cf-id: 9wurFogPtIvy5HZZZouCIb1EBuLUSlm8mqDdCyC2Vfgw7yMUMlqttw==
< 
{ [8192 bytes data]
* Connection #2 to host download.steinberg.net left intact

2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : DEBUG mode 1, not checking for blocking processes
2024-09-18 18:45:48 : REQ   : steinberglibrarymanager : Installing Steinberg Library Manager
2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : Mounting /Users/gilburns/GitHub/Installomator/build/Steinberg Library Manager.dmg
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $208D5FDB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $ABC460F7
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $12FE0D9F
verified   CRC32 $AC1D952D
/dev/disk3          	Apple_partition_scheme
/dev/disk3s1        	Apple_partition_map
/dev/disk3s2        	Apple_HFS                      	/Volumes/Steinberg Library Manager

2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : Mounted: /Volumes/Steinberg Library Manager
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : Found pkg(s):
/Volumes/Steinberg Library Manager/Library Manager.pkg
2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : found pkg: /Volumes/Steinberg Library Manager/Library Manager.pkg
2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : Verifying: /Volumes/Steinberg Library Manager/Library Manager.pkg
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : File list: -rw-r--r--  1 gilburns  staff   8.6M Jul 31 07:40 /Volumes/Steinberg Library Manager/Library Manager.pkg
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : File type: /Volumes/Steinberg Library Manager/Library Manager.pkg: xar archive compressed TOC: 5962, SHA-1 checksum
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : spctlOut is /Volumes/Steinberg Library Manager/Library Manager.pkg: accepted
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : source=Notarized Developer ID
2024-09-18 18:45:48 : DEBUG : steinberglibrarymanager : origin=Developer ID Installer: Steinberg Media Technologies GmbH (5PMY476BJ6)
2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : Team ID: 5PMY476BJ6 (expected: 5PMY476BJ6 )
2024-09-18 18:45:48 : INFO  : steinberglibrarymanager : Checking package version.
2024-09-18 18:45:49 : INFO  : steinberglibrarymanager : Downloaded package com.steinberg.SteinbergLibraryManager version 3.2.50
2024-09-18 18:45:49 : INFO  : steinberglibrarymanager : Downloaded version of Steinberg Library Manager is the same as installed.
2024-09-18 18:45:49 : DEBUG : steinberglibrarymanager : Unmounting /Volumes/Steinberg Library Manager
2024-09-18 18:45:49 : DEBUG : steinberglibrarymanager : Debugging enabled, Unmounting output was:
"disk3" ejected.
2024-09-18 18:45:49 : DEBUG : steinberglibrarymanager : DEBUG mode 1, not reopening anything
2024-09-18 18:45:49 : REQ   : steinberglibrarymanager : No new version to install
2024-09-18 18:45:49 : REQ   : steinberglibrarymanager : ################## End Installomator, exit code 0 

```