### PR TITLE
Create Steinberg Media Bay label

### DIFF
--- a/fragments/labels/steinbergmediabay.sh
+++ b/fragments/labels/steinbergmediabay.sh
@@ -1,0 +1,13 @@
+steinbergmediabay)
+    # New installations requires the following labels PRIOR to Cubase
+    #    steinbergactivationmanager
+    #    steinberglibrarymanager
+    #    steinbergmediabay
+    #
+    name="Steinberg Media Bay"
+    type="pkgInDmg"
+    packageID="com.steinberg.MediaClient"
+	downloadURL="https://www.steinberg.net/smb-mac"
+    appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | grep -o '[0-9]\.[0-9]\.[0-9][0-9]')"
+    expectedTeamID="5PMY476BJ6"
+    ;;

--- a/fragments/labels/steinbergmediabay.sh
+++ b/fragments/labels/steinbergmediabay.sh
@@ -7,7 +7,7 @@ steinbergmediabay)
     name="Steinberg Media Bay"
     type="pkgInDmg"
     packageID="com.steinberg.MediaClient"
-	downloadURL="https://www.steinberg.net/smb-mac"
+    downloadURL="https://www.steinberg.net/smb-mac"
     appNewVersion="$( curl -LIs "${downloadURL}" | grep -i "location:" | grep "dmg" | grep -o '[0-9]\.[0-9]\.[0-9][0-9]')"
     expectedTeamID="5PMY476BJ6"
     ;;


### PR DESCRIPTION
```
assemble.sh steinbergmediabay
2024-09-18 18:45:57 : REQ   : steinbergmediabay : ################## Start Installomator v. 10.7beta, date 2024-09-18
2024-09-18 18:45:57 : INFO  : steinbergmediabay : ################## Version: 10.7beta
2024-09-18 18:45:57 : INFO  : steinbergmediabay : ################## Date: 2024-09-18
2024-09-18 18:45:57 : INFO  : steinbergmediabay : ################## steinbergmediabay
2024-09-18 18:45:57 : DEBUG : steinbergmediabay : DEBUG mode 1 enabled.
2024-09-18 18:45:57 : INFO  : steinbergmediabay : SwiftDialog is not installed, clear cmd file var
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : name=Steinberg Media Bay
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : appName=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : type=pkgInDmg
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : archiveName=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : downloadURL=https://www.steinberg.net/smb-mac
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : curlOptions=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : appNewVersion=1.1.90
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : appCustomVersion function: Not defined
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : versionKey=CFBundleShortVersionString
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : packageID=com.steinberg.MediaClient
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : pkgName=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : choiceChangesXML=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : expectedTeamID=5PMY476BJ6
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : blockingProcesses=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : installerTool=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : CLIInstaller=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : CLIArguments=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : updateTool=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : updateToolArguments=
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : updateToolRunAsCurrentUser=
2024-09-18 18:45:59 : INFO  : steinbergmediabay : BLOCKING_PROCESS_ACTION=tell_user
2024-09-18 18:45:59 : INFO  : steinbergmediabay : NOTIFY=success
2024-09-18 18:45:59 : INFO  : steinbergmediabay : LOGGING=DEBUG
2024-09-18 18:45:59 : INFO  : steinbergmediabay : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-18 18:45:59 : INFO  : steinbergmediabay : Label type: pkgInDmg
2024-09-18 18:45:59 : INFO  : steinbergmediabay : archiveName: Steinberg Media Bay.dmg
2024-09-18 18:45:59 : INFO  : steinbergmediabay : no blocking processes defined, using Steinberg Media Bay as default
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-18 18:45:59 : INFO  : steinbergmediabay : found packageID com.steinberg.MediaClient installed, version 1.1.90
2024-09-18 18:45:59 : INFO  : steinbergmediabay : appversion: 1.1.90
2024-09-18 18:45:59 : INFO  : steinbergmediabay : Latest version of Steinberg Media Bay is 1.1.90
2024-09-18 18:45:59 : WARN  : steinbergmediabay : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-18 18:45:59 : REQ   : steinbergmediabay : Downloading https://www.steinberg.net/smb-mac to Steinberg Media Bay.dmg
2024-09-18 18:45:59 : DEBUG : steinbergmediabay : No Dialog connection, just download
2024-09-18 18:46:23 : DEBUG : steinbergmediabay : File list: -rw-r--r--  1 gilburns  staff    72M Sep 18 18:46 Steinberg Media Bay.dmg
2024-09-18 18:46:23 : DEBUG : steinbergmediabay : File type: Steinberg Media Bay.dmg: zlib compressed data
2024-09-18 18:46:23 : DEBUG : steinbergmediabay : curl output was:
* Host www.steinberg.net:443 was resolved.
* IPv6: 2600:9000:2506:be00:15:db7a:c7c0:93a1, 2600:9000:2506:4800:15:db7a:c7c0:93a1, 2600:9000:2506:e200:15:db7a:c7c0:93a1, 2600:9000:2506:f800:15:db7a:c7c0:93a1, 2600:9000:2506:7400:15:db7a:c7c0:93a1, 2600:9000:2506:8400:15:db7a:c7c0:93a1, 2600:9000:2506:5e00:15:db7a:c7c0:93a1, 2600:9000:2506:d400:15:db7a:c7c0:93a1
* IPv4: 18.154.110.85, 18.154.110.117, 18.154.110.86, 18.154.110.11
*   Trying 18.154.110.85:443...
* Connected to www.steinberg.net (18.154.110.85) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5003 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.steinberg.net
*  start date: Jan 16 00:00:00 2024 GMT
*  expire date: Feb 13 23:59:59 2025 GMT
*  subjectAltName: host "www.steinberg.net" matched cert's "www.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.steinberg.net/smb-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.steinberg.net]
* [HTTP/2] [1] [:path: /smb-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /smb-mac HTTP/2
> Host: www.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-type: text/html
< content-length: 138
< location: https://r.mb.steinberg.net/rc-mediabay-mac
< date: Wed, 18 Sep 2024 23:45:59 GMT
< referrer-policy: strict-origin-when-cross-origin
< server: nginx
< content-security-policy: default-src https: 'self' 'unsafe-inline' 'unsafe-eval' *.steinberg.net *.usercentrics.eu *.personio.de *.googletagmanager.com fonts.googleapis.com *.soundcloud.com *.youtube-nocookie.com *.optimizely.com *.eu-central-1.compute.amazonaws.com *.onfastspring.com *.impactcdn.com; connect-src https: 'self' wss://ws.hotjar.com; img-src https: 'self' *.steinberg.net *.ytimg.com *.usercentrics.eu data:; font-src https: 'self' fonts.gstatic.com fonts.googleapis.com data:;
< x-frame-options: SAMEORIGIN
< x-content-type-options: nosniff
< feature-policy: camera 'none';gamepad 'none';geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';usb 'none'
< permissions-policy: camera=(),gamepad=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),usb=()
< via: 1.1 2341d404f0654d8c9202a57e4ff35570.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< cache-control: public, max-age=3600
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Miss from cloudfront
< x-amz-cf-pop: ORD58-P6
< x-amz-cf-id: VkcjdpJVn67Vgwr2T230KDjzQnOdT5qiIj5hPU08WNVL7fip_DlgxA==
< 
* Ignoring the response-body
* Connection #0 to host www.steinberg.net left intact
* Issue another request to this URL: 'https://r.mb.steinberg.net/rc-mediabay-mac'
* Host r.mb.steinberg.net:443 was resolved.
* IPv6: (none)
* IPv4: 52.208.213.33, 34.251.132.234
*   Trying 52.208.213.33:443...
* Connected to r.mb.steinberg.net (52.208.213.33) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2814 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.mb.steinberg.net
*  start date: Nov 16 11:10:23 2023 GMT
*  expire date: Dec 17 11:10:22 2024 GMT
*  subjectAltName: host "r.mb.steinberg.net" matched cert's "*.mb.steinberg.net"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=AlphaSSL CA - SHA256 - G4
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://r.mb.steinberg.net/rc-mediabay-mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: r.mb.steinberg.net]
* [HTTP/2] [1] [:path: /rc-mediabay-mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /rc-mediabay-mac HTTP/2
> Host: r.mb.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Wed, 18 Sep 2024 23:46:00 GMT
< content-length: 0
< location: https://download.steinberg.net/static_content/runtime-components/steinberg-media-bay/1.1.90.84-b863c2e0-3c91-3c77-bd28-980e7111de68/MediaBay_Installer_mac.dmg
< server: nginx/1.22.1
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 0
< cache-control: no-cache, no-store, max-age=0, must-revalidate
< pragma: no-cache
< expires: 0
< strict-transport-security: max-age=31536000 ; includeSubDomains
< x-frame-options: DENY
< 
* Ignoring the response-body
* Connection #1 to host r.mb.steinberg.net left intact
* Issue another request to this URL: 'https://download.steinberg.net/static_content/runtime-components/steinberg-media-bay/1.1.90.84-b863c2e0-3c91-3c77-bd28-980e7111de68/MediaBay_Installer_mac.dmg'
* Host download.steinberg.net:443 was resolved.
* IPv6: 2600:9000:25f4:3800:6:75be:a080:93a1, 2600:9000:25f4:e200:6:75be:a080:93a1, 2600:9000:25f4:7200:6:75be:a080:93a1, 2600:9000:25f4:a600:6:75be:a080:93a1, 2600:9000:25f4:ca00:6:75be:a080:93a1, 2600:9000:25f4:1a00:6:75be:a080:93a1, 2600:9000:25f4:1400:6:75be:a080:93a1, 2600:9000:25f4:7000:6:75be:a080:93a1
* IPv4: 13.32.164.106, 13.32.164.28, 13.32.164.75, 13.32.164.70
*   Trying 13.32.164.106:443...
* Connected to download.steinberg.net (13.32.164.106) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5014 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.steinberg.net
*  start date: Jun 19 00:00:00 2024 GMT
*  expire date: Jul 19 23:59:59 2025 GMT
*  subjectAltName: host "download.steinberg.net" matched cert's "download.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.steinberg.net/static_content/runtime-components/steinberg-media-bay/1.1.90.84-b863c2e0-3c91-3c77-bd28-980e7111de68/MediaBay_Installer_mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.steinberg.net]
* [HTTP/2] [1] [:path: /static_content/runtime-components/steinberg-media-bay/1.1.90.84-b863c2e0-3c91-3c77-bd28-980e7111de68/MediaBay_Installer_mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /static_content/runtime-components/steinberg-media-bay/1.1.90.84-b863c2e0-3c91-3c77-bd28-980e7111de68/MediaBay_Installer_mac.dmg HTTP/2
> Host: download.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 75925830
< date: Tue, 10 Sep 2024 11:01:07 GMT
< last-modified: Tue, 10 Sep 2024 09:27:37 GMT
< etag: "4b1f2aef44a1c7963eb8900bbf9b6b6c-15"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: Mx._vOQSKHn1mD73eCxO4TKsmYOkRJa2
< accept-ranges: bytes
< server: AmazonS3
< via: 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< age: 737094
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Hit from cloudfront
< x-amz-cf-pop: ORD58-P1
< x-amz-cf-id: B-_cdY5w2gU5_z_QuHm-UsHvhEZGR8fMjFIrhBux0V20lEKGjRPFLQ==
< 
{ [8192 bytes data]
* Connection #2 to host download.steinberg.net left intact

2024-09-18 18:46:23 : DEBUG : steinbergmediabay : DEBUG mode 1, not checking for blocking processes
2024-09-18 18:46:23 : REQ   : steinbergmediabay : Installing Steinberg Media Bay
2024-09-18 18:46:23 : INFO  : steinbergmediabay : Mounting /Users/gilburns/GitHub/Installomator/build/Steinberg Media Bay.dmg
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $208D5FDB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $ABC460F7
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $E8476AB3
verified   CRC32 $972D37F2
/dev/disk3          	Apple_partition_scheme
/dev/disk3s1        	Apple_partition_map
/dev/disk3s2        	Apple_HFS                      	/Volumes/MediaBay 1.1.90

2024-09-18 18:46:24 : INFO  : steinbergmediabay : Mounted: /Volumes/MediaBay 1.1.90
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : Found pkg(s):
/Volumes/MediaBay 1.1.90/MediaBay.pkg
2024-09-18 18:46:24 : INFO  : steinbergmediabay : found pkg: /Volumes/MediaBay 1.1.90/MediaBay.pkg
2024-09-18 18:46:24 : INFO  : steinbergmediabay : Verifying: /Volumes/MediaBay 1.1.90/MediaBay.pkg
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : File list: -rwxr-xr-x  1 gilburns  staff    68M Sep  3 04:56 /Volumes/MediaBay 1.1.90/MediaBay.pkg
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : File type: /Volumes/MediaBay 1.1.90/MediaBay.pkg: xar archive compressed TOC: 6616, SHA-1 checksum
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : spctlOut is /Volumes/MediaBay 1.1.90/MediaBay.pkg: accepted
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : source=Notarized Developer ID
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : origin=Developer ID Installer: Steinberg Media Technologies GmbH (5PMY476BJ6)
2024-09-18 18:46:24 : INFO  : steinbergmediabay : Team ID: 5PMY476BJ6 (expected: 5PMY476BJ6 )
2024-09-18 18:46:24 : INFO  : steinbergmediabay : Checking package version.
2024-09-18 18:46:24 : INFO  : steinbergmediabay : Downloaded package com.steinberg.MediaClient version 1.1.90
2024-09-18 18:46:24 : INFO  : steinbergmediabay : Downloaded version of Steinberg Media Bay is the same as installed.
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : Unmounting /Volumes/MediaBay 1.1.90
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : Debugging enabled, Unmounting output was:
"disk3" ejected.
2024-09-18 18:46:24 : DEBUG : steinbergmediabay : DEBUG mode 1, not reopening anything
2024-09-18 18:46:24 : REQ   : steinbergmediabay : No new version to install
2024-09-18 18:46:24 : REQ   : steinbergmediabay : ################## End Installomator, exit code 0 

```