### PR TITLE
Create Cubase LE AI Elements 13 label

### DIFF
--- a/fragments/labels/steinbergcubaseelementsaile13.sh
+++ b/fragments/labels/steinbergcubaseelementsaile13.sh
@@ -1,0 +1,16 @@
+steinbergcubaseelementsaile13)
+    # New installations requires the following labels PRIOR to this label
+    #    steinbergactivationmanager
+    #    steinberglibrarymanager
+    #    steinbergmediabay
+    #
+    #    Your serial number will determine the version Elements/AI/LE
+    name="Cubase LE AI Elements 13"
+    type="pkgInDmg"
+    packageID="com.steinberg.cubasesoft13"
+	cubaseDetails=$(curl -fs "https://o.steinberg.net/en/support/downloads/cubase_13/cubase_elements_13.html")
+	downloadURL=$(echo $cubaseDetails | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | grep -e "Cubase_LE_AI_Elements_[0-9][0-9].[0-9].[0-9][0-9]_Installer_mac.dmg")
+    appNewVersion=$( echo $downloadURL | cut -d_ -f7 )
+    appCustomVersion(){ /usr/bin/defaults read "/Applications/Cubase LE AI Elements 13.app/Contents/Info.plist" CFBundleVersion | cut -d'.' -f1-3 }
+    expectedTeamID="5PMY476BJ6"
+    ;;

--- a/fragments/labels/steinbergcubaseelementsaile13.sh
+++ b/fragments/labels/steinbergcubaseelementsaile13.sh
@@ -8,8 +8,8 @@ steinbergcubaseelementsaile13)
     name="Cubase LE AI Elements 13"
     type="pkgInDmg"
     packageID="com.steinberg.cubasesoft13"
-	cubaseDetails=$(curl -fs "https://o.steinberg.net/en/support/downloads/cubase_13/cubase_elements_13.html")
-	downloadURL=$(echo $cubaseDetails | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | grep -e "Cubase_LE_AI_Elements_[0-9][0-9].[0-9].[0-9][0-9]_Installer_mac.dmg")
+    cubaseDetails=$(curl -fs "https://o.steinberg.net/en/support/downloads/cubase_13/cubase_elements_13.html")
+    downloadURL=$(echo $cubaseDetails | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | grep -e "Cubase_LE_AI_Elements_[0-9][0-9].[0-9].[0-9][0-9]_Installer_mac.dmg")
     appNewVersion=$( echo $downloadURL | cut -d_ -f7 )
     appCustomVersion(){ /usr/bin/defaults read "/Applications/Cubase LE AI Elements 13.app/Contents/Info.plist" CFBundleVersion | cut -d'.' -f1-3 }
     expectedTeamID="5PMY476BJ6"


### PR DESCRIPTION
```
assemble.sh steinbergcubaseelementsaile13
2024-09-18 18:51:43 : REQ   : steinbergcubaseelementsaile13 : ################## Start Installomator v. 10.7beta, date 2024-09-18
2024-09-18 18:51:43 : INFO  : steinbergcubaseelementsaile13 : ################## Version: 10.7beta
2024-09-18 18:51:43 : INFO  : steinbergcubaseelementsaile13 : ################## Date: 2024-09-18
2024-09-18 18:51:43 : INFO  : steinbergcubaseelementsaile13 : ################## steinbergcubaseelementsaile13
2024-09-18 18:51:43 : DEBUG : steinbergcubaseelementsaile13 : DEBUG mode 1 enabled.
2024-09-18 18:51:43 : INFO  : steinbergcubaseelementsaile13 : SwiftDialog is not installed, clear cmd file var
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : name=Cubase LE AI Elements 13
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : appName=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : type=pkgInDmg
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : archiveName=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : downloadURL=https://download.steinberg.net/automated_updates/sda_downloads/91e0b008-8b1e-445a-9393-e7e07437f28a/Cubase_LE_AI_Elements_13.0.41_Installer_mac.dmg
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : curlOptions=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : appNewVersion=13.0.41
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : appCustomVersion function: Defined. 
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : versionKey=CFBundleShortVersionString
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : packageID=com.steinberg.cubasesoft13
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : pkgName=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : choiceChangesXML=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : expectedTeamID=5PMY476BJ6
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : blockingProcesses=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : installerTool=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : CLIInstaller=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : CLIArguments=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : updateTool=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : updateToolArguments=
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : updateToolRunAsCurrentUser=
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : NOTIFY=success
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : LOGGING=DEBUG
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : Label type: pkgInDmg
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : archiveName: Cubase LE AI Elements 13.dmg
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : no blocking processes defined, using Cubase LE AI Elements 13 as default
2024-09-18 18:51:44 : DEBUG : steinbergcubaseelementsaile13 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : Custom App Version detection is used, found 13.0.41
2024-09-18 18:51:44 : INFO  : steinbergcubaseelementsaile13 : appversion: 13.0.41
2024-09-18 18:51:45 : INFO  : steinbergcubaseelementsaile13 : Latest version of Cubase LE AI Elements 13 is 13.0.41
2024-09-18 18:51:45 : WARN  : steinbergcubaseelementsaile13 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-18 18:51:45 : REQ   : steinbergcubaseelementsaile13 : Downloading https://download.steinberg.net/automated_updates/sda_downloads/91e0b008-8b1e-445a-9393-e7e07437f28a/Cubase_LE_AI_Elements_13.0.41_Installer_mac.dmg to Cubase LE AI Elements 13.dmg
2024-09-18 18:51:45 : DEBUG : steinbergcubaseelementsaile13 : No Dialog connection, just download
2024-09-18 18:54:51 : DEBUG : steinbergcubaseelementsaile13 : File list: -rw-r--r--  1 gilburns  staff   532M Sep 18 18:54 Cubase LE AI Elements 13.dmg
2024-09-18 18:54:51 : DEBUG : steinbergcubaseelementsaile13 : File type: Cubase LE AI Elements 13.dmg: zlib compressed data
2024-09-18 18:54:51 : DEBUG : steinbergcubaseelementsaile13 : curl output was:
* Host download.steinberg.net:443 was resolved.
* IPv6: 2600:9000:24d0:9200:6:75be:a080:93a1, 2600:9000:24d0:3400:6:75be:a080:93a1, 2600:9000:24d0:2000:6:75be:a080:93a1, 2600:9000:24d0:8200:6:75be:a080:93a1, 2600:9000:24d0:4400:6:75be:a080:93a1, 2600:9000:24d0:dc00:6:75be:a080:93a1, 2600:9000:24d0:7e00:6:75be:a080:93a1, 2600:9000:24d0:7a00:6:75be:a080:93a1
* IPv4: 13.32.164.28, 13.32.164.75, 13.32.164.106, 13.32.164.70
*   Trying 13.32.164.28:443...
* Connected to download.steinberg.net (13.32.164.28) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5014 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=download.steinberg.net
*  start date: Jun 19 00:00:00 2024 GMT
*  expire date: Jul 19 23:59:59 2025 GMT
*  subjectAltName: host "download.steinberg.net" matched cert's "download.steinberg.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.steinberg.net/automated_updates/sda_downloads/91e0b008-8b1e-445a-9393-e7e07437f28a/Cubase_LE_AI_Elements_13.0.41_Installer_mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.steinberg.net]
* [HTTP/2] [1] [:path: /automated_updates/sda_downloads/91e0b008-8b1e-445a-9393-e7e07437f28a/Cubase_LE_AI_Elements_13.0.41_Installer_mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /automated_updates/sda_downloads/91e0b008-8b1e-445a-9393-e7e07437f28a/Cubase_LE_AI_Elements_13.0.41_Installer_mac.dmg HTTP/2
> Host: download.steinberg.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 557565074
< date: Sat, 06 Jul 2024 13:32:30 GMT
< last-modified: Wed, 12 Jun 2024 11:20:30 GMT
< etag: "70b4dacd55b27cc8d954ebf7ea0bfb60-107"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: SOYQcuk3kGfOOPB2w.EiFxl0kqOvFmSG
< accept-ranges: bytes
< server: AmazonS3
< via: 1.1 f31fa40e0863bae8e02d0ba21cedaeb0.cloudfront.net (CloudFront)
< alt-svc: h3=":443"; ma=86400
< age: 6430756
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-cache: Hit from cloudfront
< x-amz-cf-pop: ORD58-P1
< x-amz-cf-id: hezOpT9WwTY3p3pC_i7gDPrUVAuFLIhtEymQ33ZSZ8yteq6cjBhBhg==
< 
{ [8192 bytes data]
* Connection #0 to host download.steinberg.net left intact

2024-09-18 18:54:51 : DEBUG : steinbergcubaseelementsaile13 : DEBUG mode 1, not checking for blocking processes
2024-09-18 18:54:51 : REQ   : steinbergcubaseelementsaile13 : Installing Cubase LE AI Elements 13
2024-09-18 18:54:51 : INFO  : steinbergcubaseelementsaile13 : Mounting /Users/gilburns/GitHub/Installomator/build/Cubase LE AI Elements 13.dmg
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $208D5FDB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $ABC460F7
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $B249580B
verified   CRC32 $11C99AF1
/dev/disk3          	Apple_partition_scheme
/dev/disk3s1        	Apple_partition_map
/dev/disk3s2        	Apple_HFS                      	/Volumes/Cubase LE AI Elements 13

2024-09-18 18:54:53 : INFO  : steinbergcubaseelementsaile13 : Mounted: /Volumes/Cubase LE AI Elements 13
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : Found pkg(s):
/Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg
2024-09-18 18:54:53 : INFO  : steinbergcubaseelementsaile13 : found pkg: /Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg
2024-09-18 18:54:53 : INFO  : steinbergcubaseelementsaile13 : Verifying: /Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : File list: -rw-r--r--  1 gilburns  staff   398M Jun 10 12:34 /Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : File type: /Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg: xar archive compressed TOC: 7935, SHA-1 checksum
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : spctlOut is /Volumes/Cubase LE AI Elements 13/Cubase LE AI Elements 13.pkg: accepted
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : source=Notarized Developer ID
2024-09-18 18:54:53 : DEBUG : steinbergcubaseelementsaile13 : origin=Developer ID Installer: Steinberg Media Technologies GmbH (5PMY476BJ6)
2024-09-18 18:54:53 : INFO  : steinbergcubaseelementsaile13 : Team ID: 5PMY476BJ6 (expected: 5PMY476BJ6 )
2024-09-18 18:54:53 : INFO  : steinbergcubaseelementsaile13 : Checking package version.
2024-09-18 18:54:55 : INFO  : steinbergcubaseelementsaile13 : Downloaded package com.steinberg.cubasesoft13 version 13.0.41
2024-09-18 18:54:55 : INFO  : steinbergcubaseelementsaile13 : Downloaded version of Cubase LE AI Elements 13 is the same as installed.
2024-09-18 18:54:55 : DEBUG : steinbergcubaseelementsaile13 : Unmounting /Volumes/Cubase LE AI Elements 13
2024-09-18 18:54:56 : DEBUG : steinbergcubaseelementsaile13 : Debugging enabled, Unmounting output was:
"disk3" ejected.
2024-09-18 18:54:56 : DEBUG : steinbergcubaseelementsaile13 : DEBUG mode 1, not reopening anything
2024-09-18 18:54:56 : REQ   : steinbergcubaseelementsaile13 : No new version to install
2024-09-18 18:54:56 : REQ   : steinbergcubaseelementsaile13 : ################## End Installomator, exit code 0 

```