### PR TITLE
Create-Notioncalender

### DIFF
--- a/fragments/labels/notioncalendar.sh
+++ b/fragments/labels/notioncalendar.sh
@@ -1,0 +1,7 @@
+notioncalendar)
+    name="Notion Calendar"
+    type="dmg"
+    downloadURL=$(curl -fsIL "https://www.notion.so/calendar/desktop/mac-apple-silicon/download" | grep -i "^location" | awk '{print $2}' | tr -d '\r\n')
+    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^etag" | awk '{print $2}' | tr -d '"')
+    expectedTeamID="R8DNJ3GNHX"
+    ;;


### PR DESCRIPTION
Output
```
sudo Installomator/utils/assemble.sh notioncalendar DEBUG=0
2024-09-19 09:59:46 : REQ   : notioncalendar : ################## Start Installomator v. 10.7beta, date 2024-09-19
2024-09-19 09:59:46 : INFO  : notioncalendar : ################## Version: 10.7beta
2024-09-19 09:59:46 : INFO  : notioncalendar : ################## Date: 2024-09-19
2024-09-19 09:59:46 : INFO  : notioncalendar : ################## notioncalendar
2024-09-19 09:59:46 : DEBUG : notioncalendar : DEBUG mode 1 enabled.
2024-09-19 09:59:47 : INFO  : notioncalendar : setting variable from argument DEBUG=0
2024-09-19 09:59:47 : DEBUG : notioncalendar : name=Notion Calendar
2024-09-19 09:59:47 : DEBUG : notioncalendar : appName=
2024-09-19 09:59:47 : DEBUG : notioncalendar : type=dmg
2024-09-19 09:59:47 : DEBUG : notioncalendar : archiveName=
2024-09-19 09:59:47 : DEBUG : notioncalendar : downloadURL=https://dl.todesktop.com/210303leazlircz/mac/universal
2024-09-19 09:59:47 : DEBUG : notioncalendar : curlOptions=
2024-09-19 09:59:47 : DEBUG : notioncalendar : appNewVersion=
2024-09-19 09:59:47 : DEBUG : notioncalendar : appCustomVersion function: Not defined
2024-09-19 09:59:47 : DEBUG : notioncalendar : versionKey=CFBundleShortVersionString
2024-09-19 09:59:47 : DEBUG : notioncalendar : packageID=
2024-09-19 09:59:47 : DEBUG : notioncalendar : pkgName=
2024-09-19 09:59:47 : DEBUG : notioncalendar : choiceChangesXML=
2024-09-19 09:59:47 : DEBUG : notioncalendar : expectedTeamID=R8DNJ3GNHX
2024-09-19 09:59:47 : DEBUG : notioncalendar : blockingProcesses=
2024-09-19 09:59:47 : DEBUG : notioncalendar : installerTool=
2024-09-19 09:59:47 : DEBUG : notioncalendar : CLIInstaller=
2024-09-19 09:59:47 : DEBUG : notioncalendar : CLIArguments=
2024-09-19 09:59:47 : DEBUG : notioncalendar : updateTool=
2024-09-19 09:59:47 : DEBUG : notioncalendar : updateToolArguments=
2024-09-19 09:59:47 : DEBUG : notioncalendar : updateToolRunAsCurrentUser=
2024-09-19 09:59:47 : INFO  : notioncalendar : BLOCKING_PROCESS_ACTION=tell_user
2024-09-19 09:59:47 : INFO  : notioncalendar : NOTIFY=success
2024-09-19 09:59:47 : INFO  : notioncalendar : LOGGING=DEBUG
2024-09-19 09:59:47 : INFO  : notioncalendar : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-19 09:59:47 : INFO  : notioncalendar : Label type: dmg
2024-09-19 09:59:47 : INFO  : notioncalendar : archiveName: Notion Calendar.dmg
2024-09-19 09:59:47 : INFO  : notioncalendar : no blocking processes defined, using Notion Calendar as default
2024-09-19 09:59:47 : DEBUG : notioncalendar : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Z7uNsbmwCX
2024-09-19 09:59:47 : INFO  : notioncalendar : name: Notion Calendar, appName: Notion Calendar.app
2024-09-19 09:59:47.891 mdfind[95785:819853] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-19 09:59:47.892 mdfind[95785:819853] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-19 09:59:48.153 mdfind[95785:819853] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-19 09:59:48 : WARN  : notioncalendar : No previous app found
2024-09-19 09:59:48 : WARN  : notioncalendar : could not find Notion Calendar.app
2024-09-19 09:59:48 : INFO  : notioncalendar : appversion:
2024-09-19 09:59:48 : INFO  : notioncalendar : Latest version not specified.
2024-09-19 09:59:48 : REQ   : notioncalendar : Downloading https://dl.todesktop.com/210303leazlircz/mac/universal to Notion Calendar.dmg
2024-09-19 09:59:48 : DEBUG : notioncalendar : No Dialog connection, just download
2024-09-19 10:00:00 : DEBUG : notioncalendar : File list: -rw-r--r--@ 1 root  wheel   127M Sep 19 10:00 Notion Calendar.dmg
2024-09-19 10:00:00 : DEBUG : notioncalendar : File type: Notion Calendar.dmg: zlib compressed data
2024-09-19 10:00:00 : DEBUG : notioncalendar : curl output was:
* Host dl.todesktop.com:443 was resolved.
* IPv6: 2606:4700::6812:cf3, 2606:4700::6812:df3
* IPv4: 104.18.13.243, 104.18.12.243
*   Trying 104.18.13.243:443...
* Connected to dl.todesktop.com (104.18.13.243) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2523 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=dl.todesktop.com
*  start date: Aug 16 03:20:49 2024 GMT
*  expire date: Nov 14 03:20:48 2024 GMT
*  subjectAltName: host "dl.todesktop.com" matched cert's "dl.todesktop.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.todesktop.com/210303leazlircz/mac/universal
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.todesktop.com]
* [HTTP/2] [1] [:path: /210303leazlircz/mac/universal]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /210303leazlircz/mac/universal HTTP/2
> Host: dl.todesktop.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< date: Thu, 19 Sep 2024 07:59:50 GMT
< content-type: application/octet-stream
< content-length: 132998631
< accept-ranges: bytes
< cache-control: no-store
< content-disposition: attachment; filename="Notion Calendar 1.122.0 - x64.dmg"
< etag: "254a0321804567a24bef51b265683d74"
< expires: Fri, 26 Apr 2024 03:04:05 GMT
< last-modified: Thu, 25 Apr 2024 23:04:15 GMT
< server: cloudflare
< cf-ray: 8c5809d72bff977d-CPT
<
{ [1360 bytes data]
* Connection #0 to host dl.todesktop.com left intact

2024-09-19 10:00:00 : REQ   : notioncalendar : no more blocking processes, continue with update
2024-09-19 10:00:00 : REQ   : notioncalendar : Installing Notion Calendar
2024-09-19 10:00:00 : INFO  : notioncalendar : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Z7uNsbmwCX/Notion Calendar.dmg
2024-09-19 10:00:04 : DEBUG : notioncalendar : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $E80E5B83
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $BCDA9580
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $27A61D2B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $8F2C68EA
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $27A61D2B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E681FC1A
verified   CRC32 $4EC47EA7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Notion Calendar 1.122.0

2024-09-19 10:00:04 : INFO  : notioncalendar : Mounted: /Volumes/Notion Calendar 1.122.0
2024-09-19 10:00:04 : INFO  : notioncalendar : Verifying: /Volumes/Notion Calendar 1.122.0/Notion Calendar.app
2024-09-19 10:00:04 : DEBUG : notioncalendar : App size: 374M	/Volumes/Notion Calendar 1.122.0/Notion Calendar.app
2024-09-19 10:00:09 : DEBUG : notioncalendar : Debugging enabled, App Verification output was:
/Volumes/Notion Calendar 1.122.0/Notion Calendar.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Cron Inc. (R8DNJ3GNHX)

2024-09-19 10:00:09 : INFO  : notioncalendar : Team ID matching: R8DNJ3GNHX (expected: R8DNJ3GNHX )
2024-09-19 10:00:09 : INFO  : notioncalendar : Installing Notion Calendar version 1.122.0 on versionKey CFBundleShortVersionString.
2024-09-19 10:00:09 : INFO  : notioncalendar : App has LSMinimumSystemVersion: 10.15
2024-09-19 10:00:09 : INFO  : notioncalendar : Copy /Volumes/Notion Calendar 1.122.0/Notion Calendar.app to /Applications
2024-09-19 10:00:10 : DEBUG : notioncalendar : Debugging enabled, App copy output was:
Copying /Volumes/Notion Calendar 1.122.0/Notion Calendar.app

2024-09-19 10:00:10 : WARN  : notioncalendar : Changing owner to justinvanderross
2024-09-19 10:00:10 : INFO  : notioncalendar : Finishing...
2024-09-19 10:00:13 : INFO  : notioncalendar : App(s) found: /Applications/Notion Calendar.app
2024-09-19 10:00:13 : INFO  : notioncalendar : found app at /Applications/Notion Calendar.app, version 1.122.0, on versionKey CFBundleShortVersionString
2024-09-19 10:00:13 : REQ   : notioncalendar : Installed Notion Calendar, version 1.122.0
2024-09-19 10:00:14 : INFO  : notioncalendar : notifying
2024-09-19 10:00:14 : DEBUG : notioncalendar : Unmounting /Volumes/Notion Calendar 1.122.0
2024-09-19 10:00:15 : DEBUG : notioncalendar : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-19 10:00:15 : DEBUG : notioncalendar : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Z7uNsbmwCX
2024-09-19 10:00:15 : DEBUG : notioncalendar : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Z7uNsbmwCX/Notion Calendar.dmg
2024-09-19 10:00:15 : DEBUG : notioncalendar : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Z7uNsbmwCX
2024-09-19 10:00:15 : INFO  : notioncalendar : Installomator did not close any apps, so no need to reopen any apps.
2024-09-19 10:00:15 : REQ   : notioncalendar : All done!
2024-09-19 10:00:15 : REQ   : notioncalendar : ################## End Installomator, exit code 0

```