### PR TITLE
Mise à jour du script pour Screaming Frog SEO avec screaming-frog-seo…

### DIFF
--- a/fragments/labels/screamingfrogseospider.sh
+++ b/fragments/labels/screamingfrogseospider.sh
@@ -1,12 +1,33 @@
 screamingfrogseospider)
     name="Screaming Frog SEO Spider"
     type="dmg"
-    if [[ $(arch) == i386 ]]; then
-        platform="Mac - (intel)"
-    elif [[ $(arch) == arm64 ]]; then
-        platform="Mac - (apple silicon)"
+    json_url="https://formulae.brew.sh/api/cask/screaming-frog-seo-spider.json"
+
+    # Télécharger les données JSON
+    json_data=$(curl -s "$json_url")
+
+    # Extraire la version
+    version=$(echo "$json_data" | awk -F '"' '/"version":/ {print $4}')
+
+    # Déterminer l'architecture et sélectionner le bon URL de téléchargement
+    if [[ $(arch) == i386 || $(arch) == "x86_64" ]]; then
+        platform="x86_64"
+    elif [[ $(arch) == "arm64" ]]; then
+        platform="aarch64"
     fi
-    downloadURL=$(curl -fs "https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php" | grep "${platform}" | grep -i -o "https.*\.dmg" | head -1)
-    appNewVersion=$(print "$downloadURL" | sed -E 's/https.*\/[a-zA-Z]*-([0-9.]*)\.dmg/\1/g')".0"
+
+    # Construire l'URL de téléchargement
+    downloadURL="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-${version}-${platform}.dmg"
+
+    # Vérifier la version récupérée
+    appNewVersion=${version}
+
+    # Team ID attendu pour l'authentification
     expectedTeamID="CAHEVC3HZC"
+
+    # Affichage des informations pour vérification
+    echo "Name: $name"
+    echo "Version: $appNewVersion"
+    echo "Download URL: $downloadURL"
+    echo "Expected Team ID: $expectedTeamID"
     ;;

--- a/fragments/labels/screamingfrogseospider.sh
+++ b/fragments/labels/screamingfrogseospider.sh
@@ -1,30 +1,12 @@
 screamingfrogseospider)
     name="Screaming Frog SEO Spider"
     type="dmg"
-    
-    # Extraire la version de la page d'historique des versions
-    version=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o '<td style="border: 1px solid; padding: 10px;"><a href="/seo-spider-[0-9]*/#[0-9.]*">[0-9.]*</a></td>' | head -1 | grep -o '[0-9.]*</a>' | cut -d'<' -f1)
-    
-    # Construire les URLs de téléchargement
-    baseURL="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-${version}"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="${baseURL}-aarch64.dmg"
+        downloadURL="$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-aarch64.dmg"' | cut -d'"' -f2)"
+        appNewVersion="$(echo "$downloadURL" | grep -o '[0-9.]*-aarch64' | cut -d'-' -f1)"
     else
-        downloadURL="${baseURL}-x86_64.dmg"
+        downloadURL="$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-x86_64.dmg"' | cut -d'"' -f2)"
+        appNewVersion="$(echo "$downloadURL" | grep -o '[0-9.]*-x86_64' | cut -d'-' -f1)"
     fi
-    
-    appNewVersion="${version}"
     expectedTeamID="CAHEVC3HZC"
-    
-    # Vérification
-    if [ -z "$version" ] || [ -z "$downloadURL" ]; then
-        echo "Erreur: Impossible de déterminer la version ou l'URL de téléchargement pour Screaming Frog SEO Spider"
-        exit 1
-    fi
-    
-    # Affichage des informations pour vérification
-    echo "Name: $name"
-    echo "Version: $appNewVersion"
-    echo "Download URL: $downloadURL"
-    echo "Expected Team ID: $expectedTeamID"
 ;;

--- a/fragments/labels/screamingfrogseospider.sh
+++ b/fragments/labels/screamingfrogseospider.sh
@@ -1,33 +1,33 @@
 screamingfrogseospider)
     name="Screaming Frog SEO Spider"
     type="dmg"
-    json_url="https://formulae.brew.sh/api/cask/screaming-frog-seo-spider.json"
-
-    # Télécharger les données JSON
-    json_data=$(curl -s "$json_url")
-
-    # Extraire la version
-    version=$(echo "$json_data" | awk -F '"' '/"version":/ {print $4}')
-
-    # Déterminer l'architecture et sélectionner le bon URL de téléchargement
-    if [[ $(arch) == i386 || $(arch) == "x86_64" ]]; then
-        platform="x86_64"
-    elif [[ $(arch) == "arm64" ]]; then
-        platform="aarch64"
+    
+    # Extraire les URLs de téléchargement
+    apple_silicon_url=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-aarch64.dmg"' | cut -d'"' -f2)
+    intel_url=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-x86_64.dmg"' | cut -d'"' -f2)
+    
+    # Extraire la version du nom de fichier
+    version=$(echo "$apple_silicon_url" | grep -o '[0-9.]*-aarch64' | cut -d'-' -f1)
+    
+    # Déterminer l'architecture et sélectionner l'URL appropriée
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="$apple_silicon_url"
+    else
+        downloadURL="$intel_url"
     fi
-
-    # Construire l'URL de téléchargement
-    downloadURL="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-${version}-${platform}.dmg"
-
-    # Vérifier la version récupérée
-    appNewVersion=${version}
-
-    # Team ID attendu pour l'authentification
+    
+    appNewVersion="$version"
     expectedTeamID="CAHEVC3HZC"
-
+    
+    # Vérification du téléchargement
+    if [ -z "$downloadURL" ]; then
+        echo "Erreur: Impossible de trouver l'URL de téléchargement pour Screaming Frog SEO Spider"
+        exit 1
+    fi
+    
     # Affichage des informations pour vérification
     echo "Name: $name"
     echo "Version: $appNewVersion"
     echo "Download URL: $downloadURL"
     echo "Expected Team ID: $expectedTeamID"
-    ;;
+;;

--- a/fragments/labels/screamingfrogseospider.sh
+++ b/fragments/labels/screamingfrogseospider.sh
@@ -2,26 +2,23 @@ screamingfrogseospider)
     name="Screaming Frog SEO Spider"
     type="dmg"
     
-    # Extraire les URLs de téléchargement
-    apple_silicon_url=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-aarch64.dmg"' | cut -d'"' -f2)
-    intel_url=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o 'href="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-[0-9.]*-x86_64.dmg"' | cut -d'"' -f2)
+    # Extraire la version de la page d'historique des versions
+    version=$(curl -s https://www.screamingfrog.co.uk/seo-spider/release-history/ | grep -o '<td style="border: 1px solid; padding: 10px;"><a href="/seo-spider-[0-9]*/#[0-9.]*">[0-9.]*</a></td>' | head -1 | grep -o '[0-9.]*</a>' | cut -d'<' -f1)
     
-    # Extraire la version du nom de fichier
-    version=$(echo "$apple_silicon_url" | grep -o '[0-9.]*-aarch64' | cut -d'-' -f1)
-    
-    # Déterminer l'architecture et sélectionner l'URL appropriée
+    # Construire les URLs de téléchargement
+    baseURL="https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-${version}"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="$apple_silicon_url"
+        downloadURL="${baseURL}-aarch64.dmg"
     else
-        downloadURL="$intel_url"
+        downloadURL="${baseURL}-x86_64.dmg"
     fi
     
-    appNewVersion="$version"
+    appNewVersion="${version}"
     expectedTeamID="CAHEVC3HZC"
     
-    # Vérification du téléchargement
-    if [ -z "$downloadURL" ]; then
-        echo "Erreur: Impossible de trouver l'URL de téléchargement pour Screaming Frog SEO Spider"
+    # Vérification
+    if [ -z "$version" ] || [ -z "$downloadURL" ]; then
+        echo "Erreur: Impossible de déterminer la version ou l'URL de téléchargement pour Screaming Frog SEO Spider"
         exit 1
     fi
     


### PR DESCRIPTION
…-spider.json
Mise à jour du script pour Screaming Frog SEO Spider

Cette modification améliore la gestion de Screaming Frog SEO Spider dans Installomator en utilisant l'API Homebrew pour obtenir dynamiquement la dernière version disponible. Les principaux changements sont :

1. Utilisation de l'API Homebrew pour récupérer les informations de la dernière version.
2. Détermination dynamique de l'architecture (x86_64 ou aarch64) pour télécharger la version appropriée.
3. Construction dynamique de l'URL de téléchargement basée sur la version et l'architecture.

Ces modifications permettent :
- Une mise à jour automatique de la version sans modification manuelle du script.
- Une meilleure compatibilité avec différentes architectures de Mac.
- Une réduction des risques d'erreurs liées à des versions obsolètes.

Le script a été testé sur macOS Ventura (x86_64 et Apple Silicon).

Update script for Screaming Frog SEO Spider

This modification enhances the handling of Screaming Frog SEO Spider in Installomator by using the Homebrew API to dynamically fetch the latest available version. The main changes are:

1. Use of the Homebrew API to retrieve the latest version information.
2. Dynamic determination of architecture (x86_64 or aarch64) to download the appropriate version.
3. Dynamic construction of the download URL based on version and architecture.

These changes allow for:
- Automatic version updates without manual script modification.
- Better compatibility with different Mac architectures.
- Reduced risk of errors related to outdated versions.

The script has been tested on macOS Ventura (x86_64 and Apple Silicon).