### PR TITLE
New Label: Papers

### DIFF
--- a/fragments/labels/papers.sh
+++ b/fragments/labels/papers.sh
@@ -1,0 +1,11 @@
+papers)
+    name="Papers"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.readcube.com/app/Papers_Setup-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.readcube.com/app/Papers_Setup-x64.dmg"
+    fi
+    appNewVersion="$(curl -fs "https://update.readcube.com/desktop/updates/latest-mac.yml" | grep "version:" | awk '{ print $2 }')"
+    expectedTeamID="FY6R4ETYH7"
+    ;;


### PR DESCRIPTION
A fixed and modified version of #1528.

-----

2024-09-20 15:14:07 : REQ   : papers : ################## Start Installomator v. 10.7beta, date 2024-09-20
2024-09-20 15:14:07 : INFO  : papers : ################## Version: 10.7beta
2024-09-20 15:14:07 : INFO  : papers : ################## Date: 2024-09-20
2024-09-20 15:14:07 : INFO  : papers : ################## papers
2024-09-20 15:14:07 : DEBUG : papers : DEBUG mode 1 enabled.
2024-09-20 15:14:07 : INFO  : papers : SwiftDialog is not installed, clear cmd file var
2024-09-20 15:14:08 : INFO  : papers : setting variable from argument DEBUG=0
2024-09-20 15:14:08 : DEBUG : papers : name=Papers
2024-09-20 15:14:08 : DEBUG : papers : appName=
2024-09-20 15:14:08 : DEBUG : papers : type=dmg
2024-09-20 15:14:08 : DEBUG : papers : archiveName=
2024-09-20 15:14:08 : DEBUG : papers : downloadURL=https://download.readcube.com/app/Papers_Setup-arm64.dmg
2024-09-20 15:14:08 : DEBUG : papers : curlOptions=
2024-09-20 15:14:08 : DEBUG : papers : appNewVersion=4.37.2394
2024-09-20 15:14:08 : DEBUG : papers : appCustomVersion function: Not defined
2024-09-20 15:14:08 : DEBUG : papers : versionKey=CFBundleShortVersionString
2024-09-20 15:14:08 : DEBUG : papers : packageID=
2024-09-20 15:14:08 : DEBUG : papers : pkgName=
2024-09-20 15:14:08 : DEBUG : papers : choiceChangesXML=
2024-09-20 15:14:08 : DEBUG : papers : expectedTeamID=FY6R4ETYH7
2024-09-20 15:14:08 : DEBUG : papers : blockingProcesses=
2024-09-20 15:14:08 : DEBUG : papers : installerTool=
2024-09-20 15:14:08 : DEBUG : papers : CLIInstaller=
2024-09-20 15:14:08 : DEBUG : papers : CLIArguments=
2024-09-20 15:14:08 : DEBUG : papers : updateTool=
2024-09-20 15:14:08 : DEBUG : papers : updateToolArguments=
2024-09-20 15:14:08 : DEBUG : papers : updateToolRunAsCurrentUser=
2024-09-20 15:14:08 : INFO  : papers : BLOCKING_PROCESS_ACTION=tell_user
2024-09-20 15:14:08 : INFO  : papers : NOTIFY=success
2024-09-20 15:14:08 : INFO  : papers : LOGGING=DEBUG
2024-09-20 15:14:08 : INFO  : papers : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-20 15:14:08 : INFO  : papers : Label type: dmg
2024-09-20 15:14:08 : INFO  : papers : archiveName: Papers.dmg
2024-09-20 15:14:08 : INFO  : papers : no blocking processes defined, using Papers as default
2024-09-20 15:14:08 : DEBUG : papers : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t835UOTWSt
2024-09-20 15:14:08 : INFO  : papers : name: Papers, appName: Papers.app
2024-09-20 15:14:08.493 mdfind[15751:406181] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-20 15:14:08.493 mdfind[15751:406181] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-20 15:14:08.550 mdfind[15751:406181] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-20 15:14:08 : WARN  : papers : No previous app found
2024-09-20 15:14:08 : WARN  : papers : could not find Papers.app
2024-09-20 15:14:08 : INFO  : papers : appversion:
2024-09-20 15:14:08 : INFO  : papers : Latest version of Papers is 4.37.2394
2024-09-20 15:14:08 : REQ   : papers : Downloading https://download.readcube.com/app/Papers_Setup-arm64.dmg to Papers.dmg
2024-09-20 15:14:08 : DEBUG : papers : No Dialog connection, just download
2024-09-20 15:14:23 : DEBUG : papers : File list: -rw-r--r--  1 root  wheel   186M Sep 20 15:14 Papers.dmg
2024-09-20 15:14:23 : DEBUG : papers : File type: Papers.dmg: zlib compressed data
2024-09-20 15:14:23 : DEBUG : papers : curl output was:
* Host download.readcube.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.164.230.73, 3.164.230.3, 3.164.230.89, 3.164.230.109
*   Trying 3.164.230.73:443...
* Connected to download.readcube.com (3.164.230.73) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4973 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.readcube.com
*  start date: Apr 26 00:00:00 2024 GMT
*  expire date: May 25 23:59:59 2025 GMT
*  subjectAltName: host "download.readcube.com" matched cert's "*.readcube.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.readcube.com/app/Papers_Setup-arm64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.readcube.com]
* [HTTP/2] [1] [:path: /app/Papers_Setup-arm64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /app/Papers_Setup-arm64.dmg HTTP/2
> Host: download.readcube.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: binary/octet-stream
< content-length: 195358227
< date: Fri, 20 Sep 2024 13:10:24 GMT
< last-modified: Tue, 25 Jun 2024 13:30:42 GMT
< etag: "45adde2edc0cf929c4a843f5dd35bb4d"
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 aee4cdab0c79f3c4e94a27882c60be92.cloudfront.net (CloudFront) < x-amz-cf-pop: ARN53-P1
< alt-svc: h3=":443"; ma=86400
< x-amz-cf-id: a9cIUrUlRXafF30ZCh8LdVHZqeBWVqzfUhSW2GUo95TTSb3LdsowwQ== < age: 225
<
{ [8192 bytes data]
* Connection #0 to host download.readcube.com left intact

2024-09-20 15:14:24 : REQ   : papers : no more blocking processes, continue with update
2024-09-20 15:14:24 : REQ   : papers : Installing Papers
2024-09-20 15:14:24 : INFO  : papers : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t835UOTWSt/Papers.dmg
2024-09-20 15:14:27 : DEBUG : papers : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $EC8C673A
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $D7072F75
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $F70D4030
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $8116B7CA
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified CRC32 $F70D4030
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified CRC32 $0A7E57E2
verified CRC32 $EFF2D54B
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_HFS                      	/Volumes/Papers

2024-09-20 15:14:27 : INFO  : papers : Mounted: /Volumes/Papers 2024-09-20 15:14:27 : INFO  : papers : Verifying: /Volumes/Papers/Papers.app 2024-09-20 15:14:28 : DEBUG : papers : App size: 522M	/Volumes/Papers/Papers.app 2024-09-20 15:14:29 : DEBUG : papers : Debugging enabled, App Verification output was: /Volumes/Papers/Papers.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Labtiva Inc (FY6R4ETYH7)

2024-09-20 15:14:29 : INFO  : papers : Team ID matching: FY6R4ETYH7 (expected: FY6R4ETYH7 ) 2024-09-20 15:14:29 : INFO  : papers : Installing Papers version 4.37.2394 on versionKey CFBundleShortVersionString. 2024-09-20 15:14:29 : INFO  : papers : App has LSMinimumSystemVersion: 10.13 2024-09-20 15:14:29 : INFO  : papers : Copy /Volumes/Papers/Papers.app to /Applications 2024-09-20 15:14:30 : DEBUG : papers : Debugging enabled, App copy output was: Copying /Volumes/Papers/Papers.app

2024-09-20 15:14:30 : WARN  : papers : Changing owner to kryptonit 2024-09-20 15:14:30 : INFO  : papers : Finishing... 2024-09-20 15:14:33 : INFO  : papers : App(s) found: /Applications/Papers.app 2024-09-20 15:14:33 : INFO  : papers : found app at /Applications/Papers.app, version 4.37.2394, on versionKey CFBundleShortVersionString
2024-09-20 15:14:33 : REQ   : papers : Installed Papers, version 4.37.2394
2024-09-20 15:14:33 : INFO  : papers : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-09-20 15:14:33 : DEBUG : papers : Unmounting /Volumes/Papers
2024-09-20 15:14:34 : DEBUG : papers : Debugging enabled, Unmounting output was:
"disk13" ejected.
2024-09-20 15:14:34 : DEBUG : papers : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t835UOTWSt
2024-09-20 15:14:34 : DEBUG : papers : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t835UOTWSt/Papers.dmg
2024-09-20 15:14:34 : DEBUG : papers : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.t835UOTWSt
2024-09-20 15:14:34 : INFO  : papers : Installomator did not close any apps, so no need to reopen any apps.
2024-09-20 15:14:34 : REQ   : papers : All done!
2024-09-20 15:14:34 : REQ   : papers : ################## End Installomator, exit code 0