### PR TITLE
Create Rogue Amoeba SoundSource 5 label

### DIFF
--- a/fragments/labels/rogueamoebasoundsource.sh
+++ b/fragments/labels/rogueamoebasoundsource.sh
@@ -1,0 +1,7 @@
+rogueamoebasoundsource5)
+    name="SoundSource"
+    type="zip"
+    downloadURL="https://rogueamoeba.com/soundsource/download.php"
+    appNewVersion="$(curl -fs "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.soundsource&platform=osx&version=5000000" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null)"
+    expectedTeamID="7266XEXAPM"
+    ;;


### PR DESCRIPTION
```
assemble.sh rogueamoebasoundsource5                 
2024-09-20 20:40:37 : REQ   : rogueamoebasoundsource5 : ################## Start Installomator v. 10.7beta, date 2024-09-20
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : ################## Version: 10.7beta
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : ################## Date: 2024-09-20
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : ################## rogueamoebasoundsource5
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : DEBUG mode 1 enabled.
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : SwiftDialog is not installed, clear cmd file var
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : name=SoundSource
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : appName=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : type=zip
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : archiveName=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : downloadURL=https://rogueamoeba.com/soundsource/download.php
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : curlOptions=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : appNewVersion=5.3.5
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : appCustomVersion function: Not defined
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : versionKey=CFBundleShortVersionString
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : packageID=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : pkgName=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : choiceChangesXML=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : expectedTeamID=7266XEXAPM
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : blockingProcesses=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : installerTool=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : CLIInstaller=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : CLIArguments=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : updateTool=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : updateToolArguments=
2024-09-20 20:40:37 : DEBUG : rogueamoebasoundsource5 : updateToolRunAsCurrentUser=
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : BLOCKING_PROCESS_ACTION=tell_user
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : NOTIFY=success
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : LOGGING=DEBUG
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-20 20:40:37 : INFO  : rogueamoebasoundsource5 : Label type: zip
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : archiveName: SoundSource.zip
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : no blocking processes defined, using SoundSource as default
2024-09-20 20:40:38 : DEBUG : rogueamoebasoundsource5 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : name: SoundSource, appName: SoundSource.app
2024-09-20 20:40:38.059 mdfind[12230:570009] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-20 20:40:38.060 mdfind[12230:570009] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-20 20:40:38.233 mdfind[12230:570009] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : App(s) found: /Users/gilburns/Applications/SoundSource.app/Users/gilburns/2024-09-20-20-24-21/SoundSource.app/Users/gilburns/Downloads/SoundSource.app
2024-09-20 20:40:38 : WARN  : rogueamoebasoundsource5 : could not determine location of SoundSource.app
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : appversion: 
2024-09-20 20:40:38 : INFO  : rogueamoebasoundsource5 : Latest version of SoundSource is 5.3.5
2024-09-20 20:40:38 : REQ   : rogueamoebasoundsource5 : Downloading https://rogueamoeba.com/soundsource/download.php to SoundSource.zip
2024-09-20 20:40:38 : DEBUG : rogueamoebasoundsource5 : No Dialog connection, just download
2024-09-20 20:40:44 : DEBUG : rogueamoebasoundsource5 : File list: -rw-r--r--  1 gilburns  staff    40M Sep 20 20:40 SoundSource.zip
2024-09-20 20:40:44 : DEBUG : rogueamoebasoundsource5 : File type: SoundSource.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-09-20 20:40:44 : DEBUG : rogueamoebasoundsource5 : curl output was:
* Host rogueamoeba.com:443 was resolved.
* IPv6: (none)
* IPv4: 216.92.184.26
*   Trying 216.92.184.26:443...
* Connected to rogueamoeba.com (216.92.184.26) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2592 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=rogueamoeba.com
*  start date: Aug  9 01:48:04 2024 GMT
*  expire date: Nov  7 01:48:03 2024 GMT
*  subjectAltName: host "rogueamoeba.com" matched cert's "rogueamoeba.com"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /soundsource/download.php HTTP/1.1
> Host: rogueamoeba.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Found
< Date: Sat, 21 Sep 2024 01:40:38 GMT
< Server: Apache
< Location: https://rogueamoeba.com/soundsource/download-ark.php
< Vary: Origin
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
< 
* Ignoring the response-body
* Connection #0 to host rogueamoeba.com left intact
* Issue another request to this URL: 'https://rogueamoeba.com/soundsource/download-ark.php'
* Found bundle for host: 0x60000263c390 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection with host rogueamoeba.com
> GET /soundsource/download-ark.php HTTP/1.1
> Host: rogueamoeba.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Found
< Date: Sat, 21 Sep 2024 01:40:38 GMT
< Server: Apache
< Location: https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip
< Vary: Origin
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
< 
* Ignoring the response-body
* Connection #0 to host rogueamoeba.com left intact
* Issue another request to this URL: 'https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip'
* Host cdn.rogueamoeba.com:443 was resolved.
* IPv6: 2600:9000:25f4:9a00:1a:d7cc:ab00:93a1, 2600:9000:25f4:bc00:1a:d7cc:ab00:93a1, 2600:9000:25f4:2e00:1a:d7cc:ab00:93a1, 2600:9000:25f4:d200:1a:d7cc:ab00:93a1, 2600:9000:25f4:3400:1a:d7cc:ab00:93a1, 2600:9000:25f4:aa00:1a:d7cc:ab00:93a1, 2600:9000:25f4:c800:1a:d7cc:ab00:93a1, 2600:9000:25f4:a200:1a:d7cc:ab00:93a1
* IPv4: 3.160.5.32, 3.160.5.54, 3.160.5.89, 3.160.5.119
*   Trying 3.160.5.32:443...
* Connected to cdn.rogueamoeba.com (3.160.5.32) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4964 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=cdn.rogueamoeba.com
*  start date: Jul  6 00:00:00 2024 GMT
*  expire date: Aug  4 23:59:59 2025 GMT
*  subjectAltName: host "cdn.rogueamoeba.com" matched cert's "cdn.rogueamoeba.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cdn.rogueamoeba.com]
* [HTTP/2] [1] [:path: /soundsource/download/SoundSource.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /soundsource/download/SoundSource.zip HTTP/2
> Host: cdn.rogueamoeba.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/zip
< content-length: 41847709
< date: Fri, 20 Sep 2024 21:16:20 GMT
< server: Apache
< last-modified: Fri, 20 Sep 2024 20:00:57 GMT
< etag: "27e8b9d-622927f624af4"
< accept-ranges: bytes
< cache-control: must-revalidate, max-age=43200
< x-cache: Hit from cloudfront
< via: 1.1 4cdcf8406ed0f002560c00fdc60b6ee0.cloudfront.net (CloudFront)
< x-amz-cf-pop: CMH68-P4
< alt-svc: h3=":443"; ma=86400
< x-amz-cf-id: lDl7CTcNE0_6Hsf01fkT3_hfeaNjPdoAMcvXbHwHrYDJ4LUv24PnDw==
< age: 15858
< 
{ [8192 bytes data]
* Connection #1 to host cdn.rogueamoeba.com left intact

2024-09-20 20:40:44 : DEBUG : rogueamoebasoundsource5 : DEBUG mode 1, not checking for blocking processes
2024-09-20 20:40:44 : REQ   : rogueamoebasoundsource5 : Installing SoundSource
2024-09-20 20:40:44 : INFO  : rogueamoebasoundsource5 : Unzipping SoundSource.zip
2024-09-20 20:40:45 : INFO  : rogueamoebasoundsource5 : Verifying: /Users/gilburns/GitHub/Installomator/build/SoundSource.app
2024-09-20 20:40:45 : DEBUG : rogueamoebasoundsource5 : App size:  62M	/Users/gilburns/GitHub/Installomator/build/SoundSource.app
2024-09-20 20:40:45 : DEBUG : rogueamoebasoundsource5 : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/SoundSource.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Rogue Amoeba Software, Inc. (7266XEXAPM)

2024-09-20 20:40:45 : INFO  : rogueamoebasoundsource5 : Team ID matching: 7266XEXAPM (expected: 7266XEXAPM )
2024-09-20 20:40:45 : INFO  : rogueamoebasoundsource5 : Installing SoundSource version 5.7.1 on versionKey CFBundleShortVersionString.
2024-09-20 20:40:45 : INFO  : rogueamoebasoundsource5 : App has LSMinimumSystemVersion: 11.0.0
2024-09-20 20:40:45 : DEBUG : rogueamoebasoundsource5 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-20 20:40:45 : INFO  : rogueamoebasoundsource5 : Finishing...
2024-09-20 20:40:48 : INFO  : rogueamoebasoundsource5 : name: SoundSource, appName: SoundSource.app
2024-09-20 20:40:48.792 mdfind[12296:570346] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-20 20:40:48.792 mdfind[12296:570346] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-20 20:40:48.924 mdfind[12296:570346] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-20 20:40:48 : INFO  : rogueamoebasoundsource5 : App(s) found: /Users/gilburns/GitHub/Installomator/build/SoundSource.app/Users/gilburns/Applications/SoundSource.app/Users/gilburns/2024-09-20-20-24-21/SoundSource.app/Users/gilburns/Downloads/SoundSource.app
2024-09-20 20:40:48 : WARN  : rogueamoebasoundsource5 : could not determine location of SoundSource.app
2024-09-20 20:40:48 : REQ   : rogueamoebasoundsource5 : Installed SoundSource, version 5.7.1
2024-09-20 20:40:48 : INFO  : rogueamoebasoundsource5 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-20 20:40:49 : DEBUG : rogueamoebasoundsource5 : DEBUG mode 1, not reopening anything
2024-09-20 20:40:49 : REQ   : rogueamoebasoundsource5 : All done!
2024-09-20 20:40:49 : REQ   : rogueamoebasoundsource5 : ################## End Installomator, exit code 0 

```