### PR TITLE
Create Microsoft Windows App label

### DIFF
--- a/fragments/labels/microsoftwindowsapp.sh
+++ b/fragments/labels/microsoftwindowsapp.sh
@@ -1,0 +1,9 @@
+microsoftwindowsapp)
+    name="Windows App"
+    type="pkg"
+    packageID="com.microsoft.rdc.macos"
+    blockingProcesses=( "Windows App" "Microsoft Remote Desktop" )
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=868963"
+    appNewVersion="$(curl -is "${downloadURL}" | grep "Location" | grep -o '[0-9][0-9]\.[0-9]*\.[0-9]*')"
+    expectedTeamID="UBF8T346G9"
+    ;;


### PR DESCRIPTION
```
assemble.sh microsoftwindowsapp    
2024-09-21 10:23:08 : REQ   : microsoftwindowsapp : ################## Start Installomator v. 10.7beta, date 2024-09-21
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : ################## Version: 10.7beta
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : ################## Date: 2024-09-21
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : ################## microsoftwindowsapp
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : DEBUG mode 1 enabled.
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : SwiftDialog is not installed, clear cmd file var
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : name=Windows App
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : appName=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : type=pkg
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : archiveName=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : downloadURL=https://go.microsoft.com/fwlink/?linkid=868963
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : curlOptions=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : appNewVersion=11.0.0
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : appCustomVersion function: Not defined
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : versionKey=CFBundleShortVersionString
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : packageID=com.microsoft.rdc.macos
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : pkgName=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : choiceChangesXML=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : expectedTeamID=UBF8T346G9
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : blockingProcesses=Windows App Microsoft Remote Desktop
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : installerTool=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : CLIInstaller=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : CLIArguments=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : updateTool=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : updateToolArguments=
2024-09-21 10:23:08 : DEBUG : microsoftwindowsapp : updateToolRunAsCurrentUser=
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : BLOCKING_PROCESS_ACTION=tell_user
2024-09-21 10:23:08 : INFO  : microsoftwindowsapp : NOTIFY=success
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : LOGGING=DEBUG
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : Label type: pkg
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : archiveName: Windows App.pkg
2024-09-21 10:23:09 : DEBUG : microsoftwindowsapp : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : found packageID com.microsoft.rdc.macos installed, version 10.9.10
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : appversion: 10.9.10
2024-09-21 10:23:09 : INFO  : microsoftwindowsapp : Latest version of Windows App is 11.0.0
2024-09-21 10:23:09 : REQ   : microsoftwindowsapp : Downloading https://go.microsoft.com/fwlink/?linkid=868963 to Windows App.pkg
2024-09-21 10:23:09 : DEBUG : microsoftwindowsapp : No Dialog connection, just download
2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : File list: -rw-r--r--  1 gilburns  staff   154M Sep 21 10:23 Windows App.pkg
2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : File type: Windows App.pkg: xar archive compressed TOC: 7940, SHA-1 checksum
2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : curl output was:
* Host go.microsoft.com:443 was resolved.
* IPv6: 2600:1407:3c00:1681::2c1a, 2600:1407:3c00:168f::2c1a, 2600:1407:3c00:168d::2c1a, 2600:1407:3c00:1684::2c1a, 2600:1407:3c00:1687::2c1a
* IPv4: 23.44.17.219
*   Trying 23.44.17.219:443...
* Connected to go.microsoft.com (23.44.17.219) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3686 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=go.microsoft.com
*  start date: Aug 29 20:17:58 2024 GMT
*  expire date: Aug 24 20:17:58 2025 GMT
*  subjectAltName: host "go.microsoft.com" matched cert's "go.microsoft.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure RSA TLS Issuing CA 07
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /fwlink/?linkid=868963 HTTP/1.1
> Host: go.microsoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Moved Temporarily
< Content-Length: 0
< Server: Kestrel
< Location: https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.0.0_installer.pkg
< Request-Context: appId=cid-v1:26ef1154-5995-4d24-ad78-ef0b04f11587
< X-Response-Cache-Status: True
< Expires: Sat, 21 Sep 2024 15:23:09 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Sat, 21 Sep 2024 15:23:09 GMT
< Connection: keep-alive
< Strict-Transport-Security: max-age=31536000 ; includeSubDomains
< 
* Ignoring the response-body
* Connection #0 to host go.microsoft.com left intact
* Issue another request to this URL: 'https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.0.0_installer.pkg'
* Host officecdnmac.microsoft.com:443 was resolved.
* IPv6: 2600:1407:3c00:12::b819:71aa, 2600:1407:3c00:12::b819:71b3
* IPv4: 23.220.246.61, 23.220.246.48, 23.220.246.43
*   Trying 23.220.246.61:443...
* Connected to officecdnmac.microsoft.com (23.220.246.61) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [331 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2434 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=officecdnmac.microsoft.com
*  start date: Apr 25 21:44:04 2024 GMT
*  expire date: Oct 22 21:44:04 2024 GMT
*  subjectAltName: host "officecdnmac.microsoft.com" matched cert's "officecdnmac.microsoft.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure ECC TLS Issuing CA 08
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.0.0_installer.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: officecdnmac.microsoft.com]
* [HTTP/2] [1] [:path: /pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.0.0_installer.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Windows_App_11.0.0_installer.pkg HTTP/2
> Host: officecdnmac.microsoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< accept-ranges: bytes
< content-disposition: attachment; filename=Windows_App_11.0.0_installer.pkg; filename*=UTF-8''Windows_App_11.0.0_installer.pkg
< content-type: application/octet-stream
< server: ECAcc (chd/075A)
< x-cid: 11
< x-ms-apiversion: Distribute 1.2
< x-ms-region: prod-eus2-z1
< last-modified: Thu, 19 Sep 2024 22:52:41 GMT
< etag: "0x56CB4882C8C2B188CEDF1027E55ED213F4FD80547E17703FD2EFA5654FEC9831"
< content-length: 161275054
< cache-control: public, max-age=259200
< date: Sat, 21 Sep 2024 15:23:09 GMT
< x-cache: TCP_HIT from a23-66-232-61.deploy.akamaitechnologies.com (AkamaiGHost/11.6.3-f27d542afa37241d2fddd9371d528b09) (-)
< akamai-grn: 0.3de84217.1726932189.168165a5
< akamai-cache-status: Hit from child
< strict-transport-security: max-age=15768000 ; includeSubDomains
< 
{ [16375 bytes data]
* Connection #1 to host officecdnmac.microsoft.com left intact

2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : DEBUG mode 1, not checking for blocking processes
2024-09-21 10:23:28 : REQ   : microsoftwindowsapp : Installing Windows App
2024-09-21 10:23:28 : INFO  : microsoftwindowsapp : Verifying: Windows App.pkg
2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : File list: -rw-r--r--  1 gilburns  staff   154M Sep 21 10:23 Windows App.pkg
2024-09-21 10:23:28 : DEBUG : microsoftwindowsapp : File type: Windows App.pkg: xar archive compressed TOC: 7940, SHA-1 checksum
2024-09-21 10:23:29 : DEBUG : microsoftwindowsapp : spctlOut is Windows App.pkg: accepted
2024-09-21 10:23:29 : DEBUG : microsoftwindowsapp : source=Notarized Developer ID
2024-09-21 10:23:29 : DEBUG : microsoftwindowsapp : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2024-09-21 10:23:29 : INFO  : microsoftwindowsapp : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2024-09-21 10:23:29 : INFO  : microsoftwindowsapp : Checking package version.
2024-09-21 10:23:30 : INFO  : microsoftwindowsapp : Downloaded package com.microsoft.rdc.macos version 11.0.0
2024-09-21 10:23:30 : DEBUG : microsoftwindowsapp : DEBUG enabled, skipping installation
2024-09-21 10:23:30 : INFO  : microsoftwindowsapp : Finishing...
2024-09-21 10:23:33 : INFO  : microsoftwindowsapp : found packageID com.microsoft.rdc.macos installed, version 10.9.10
2024-09-21 10:23:33 : REQ   : microsoftwindowsapp : Installed Windows App, version 11.0.0
2024-09-21 10:23:33 : INFO  : microsoftwindowsapp : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-21 10:23:33 : DEBUG : microsoftwindowsapp : DEBUG mode 1, not reopening anything
2024-09-21 10:23:33 : REQ   : microsoftwindowsapp : All done!
2024-09-21 10:23:33 : REQ   : microsoftwindowsapp : ################## End Installomator, exit code 0 

```