### PR TITLE
Create Native-Instruments Native Access label

### DIFF
--- a/fragments/labels/nativeaccess.sh
+++ b/fragments/labels/nativeaccess.sh
@@ -1,0 +1,14 @@
+nativeaccess)
+    name="Native Access"
+    type="zip"
+    if [[ $(arch) == "arm64" ]]; then
+        naDetails="$(curl -fs "https://na-update.native-instruments.com/arm64/latest-mac.yml")"
+        naItem="arm64/$(echo "$naDetails" | grep "path" | awk '{print $2}' | xargs)"
+    elif [[ $(arch) == "i386" ]]; then
+        naDetails="$(curl -fs "https://na-update.native-instruments.com/latest-mac.yml")"
+        naItem="$(echo "$naDetails" | grep "path" | awk '{print $2}' | xargs)"
+    fi
+    downloadURL="https://na-update.native-instruments.com/${naItem}"
+    appNewVersion="$(echo "$naDetails" | grep "version" | awk '{print $2}' | xargs)"
+    expectedTeamID="83K5EG6Z9V"
+    ;;


### PR DESCRIPTION
```
assemble.sh nativeaccess
2024-09-22 18:11:05 : REQ   : nativeaccess : ################## Start Installomator v. 10.7beta, date 2024-09-22
2024-09-22 18:11:05 : INFO  : nativeaccess : ################## Version: 10.7beta
2024-09-22 18:11:05 : INFO  : nativeaccess : ################## Date: 2024-09-22
2024-09-22 18:11:05 : INFO  : nativeaccess : ################## nativeaccess
2024-09-22 18:11:05 : DEBUG : nativeaccess : DEBUG mode 1 enabled.
2024-09-22 18:11:05 : INFO  : nativeaccess : SwiftDialog is not installed, clear cmd file var
2024-09-22 18:11:08 : DEBUG : nativeaccess : name=Native Access
2024-09-22 18:11:08 : DEBUG : nativeaccess : appName=
2024-09-22 18:11:08 : DEBUG : nativeaccess : type=zip
2024-09-22 18:11:08 : DEBUG : nativeaccess : archiveName=
2024-09-22 18:11:08 : DEBUG : nativeaccess : downloadURL=https://na-update.native-instruments.com/Native-Access-x64-mac.zip
2024-09-22 18:11:08 : DEBUG : nativeaccess : curlOptions=
2024-09-22 18:11:08 : DEBUG : nativeaccess : appNewVersion=3.14.0
2024-09-22 18:11:08 : DEBUG : nativeaccess : appCustomVersion function: Not defined
2024-09-22 18:11:08 : DEBUG : nativeaccess : versionKey=CFBundleShortVersionString
2024-09-22 18:11:08 : DEBUG : nativeaccess : packageID=
2024-09-22 18:11:08 : DEBUG : nativeaccess : pkgName=
2024-09-22 18:11:08 : DEBUG : nativeaccess : choiceChangesXML=
2024-09-22 18:11:08 : DEBUG : nativeaccess : expectedTeamID=83K5EG6Z9V
2024-09-22 18:11:08 : DEBUG : nativeaccess : blockingProcesses=
2024-09-22 18:11:08 : DEBUG : nativeaccess : installerTool=
2024-09-22 18:11:08 : DEBUG : nativeaccess : CLIInstaller=
2024-09-22 18:11:08 : DEBUG : nativeaccess : CLIArguments=
2024-09-22 18:11:08 : DEBUG : nativeaccess : updateTool=
2024-09-22 18:11:08 : DEBUG : nativeaccess : updateToolArguments=
2024-09-22 18:11:08 : DEBUG : nativeaccess : updateToolRunAsCurrentUser=
2024-09-22 18:11:08 : INFO  : nativeaccess : BLOCKING_PROCESS_ACTION=tell_user
2024-09-22 18:11:08 : INFO  : nativeaccess : NOTIFY=success
2024-09-22 18:11:08 : INFO  : nativeaccess : LOGGING=DEBUG
2024-09-22 18:11:08 : INFO  : nativeaccess : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-22 18:11:08 : INFO  : nativeaccess : Label type: zip
2024-09-22 18:11:08 : INFO  : nativeaccess : archiveName: Native Access.zip
2024-09-22 18:11:08 : INFO  : nativeaccess : no blocking processes defined, using Native Access as default
2024-09-22 18:11:08 : DEBUG : nativeaccess : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-22 18:11:08 : INFO  : nativeaccess : App(s) found: /Applications/Native Access.app
2024-09-22 18:11:08 : INFO  : nativeaccess : found app at /Applications/Native Access.app, version 3.14.0, on versionKey CFBundleShortVersionString
2024-09-22 18:11:08 : INFO  : nativeaccess : appversion: 3.14.0
2024-09-22 18:11:08 : INFO  : nativeaccess : Latest version of Native Access is 3.14.0
2024-09-22 18:11:08 : WARN  : nativeaccess : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-22 18:11:08 : REQ   : nativeaccess : Downloading https://na-update.native-instruments.com/Native-Access-x64-mac.zip to Native Access.zip
2024-09-22 18:11:08 : DEBUG : nativeaccess : No Dialog connection, just download
2024-09-22 18:11:25 : DEBUG : nativeaccess : File list: -rw-r--r--  1 gilburns  staff   125M Sep 22 18:11 Native Access.zip
2024-09-22 18:11:25 : DEBUG : nativeaccess : File type: Native Access.zip: Zip archive data, at least v2.0 to extract, compression method=store
2024-09-22 18:11:25 : DEBUG : nativeaccess : curl output was:
* Host na-update.native-instruments.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.48.99.18, 23.48.99.25
*   Trying 23.48.99.18:443...
* Connected to na-update.native-instruments.com (23.48.99.18) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [337 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2642 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=na-update.native-instruments.com
*  start date: Jul 19 04:49:26 2024 GMT
*  expire date: Oct 17 04:49:25 2024 GMT
*  subjectAltName: host "na-update.native-instruments.com" matched cert's "na-update.native-instruments.com"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://na-update.native-instruments.com/Native-Access-x64-mac.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: na-update.native-instruments.com]
* [HTTP/2] [1] [:path: /Native-Access-x64-mac.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Native-Access-x64-mac.zip HTTP/2
> Host: na-update.native-instruments.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< accept-ranges: bytes
< content-type: application/zip
< server: WasabiS3/7.20.2957-2024-08-05-c5ee44c55d (head06)
< x-amz-id-2: vemXDXlzZ1ZkvWVja+TFOkwF6qfQSfnlBfITG+v0zPehuwrafxRQRakBEkcsVdN2HcCHFmCETelr
< x-amz-request-id: A34E13516C8A31DA:A
< last-modified: Mon, 16 Sep 2024 10:47:48 GMT
< etag: "7e70683501dd5b1de6d35dfa9ca1b84d-16"
< content-length: 131324918
< date: Sun, 22 Sep 2024 23:11:09 GMT
< alt-svc: h3=":443"; ma=93600,h3-29=":443"; ma=93600,h3-Q050=":443"; ma=93600,quic=":443"; ma=93600; v="46,43"
< 
{ [16375 bytes data]
* Connection #0 to host na-update.native-instruments.com left intact

2024-09-22 18:11:25 : DEBUG : nativeaccess : DEBUG mode 1, not checking for blocking processes
2024-09-22 18:11:25 : REQ   : nativeaccess : Installing Native Access
2024-09-22 18:11:25 : INFO  : nativeaccess : Unzipping Native Access.zip
2024-09-22 18:11:27 : INFO  : nativeaccess : Verifying: /Users/gilburns/GitHub/Installomator/build/Native Access.app
2024-09-22 18:11:27 : DEBUG : nativeaccess : App size: 306M	/Users/gilburns/GitHub/Installomator/build/Native Access.app
2024-09-22 18:11:28 : DEBUG : nativeaccess : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/Native Access.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Native Instruments GmbH (83K5EG6Z9V)

2024-09-22 18:11:28 : INFO  : nativeaccess : Team ID matching: 83K5EG6Z9V (expected: 83K5EG6Z9V )
2024-09-22 18:11:29 : INFO  : nativeaccess : Downloaded version of Native Access is 3.14.0 on versionKey CFBundleShortVersionString, same as installed.
2024-09-22 18:11:29 : DEBUG : nativeaccess : DEBUG mode 1, not reopening anything
2024-09-22 18:11:29 : REG   : nativeaccess : No new version to install
2024-09-22 18:11:29 : REQ   : nativeaccess : ################## End Installomator, exit code 0 

```