### PR TITLE
Update Telegram label appNewVersion check

### DIFF
--- a/fragments/labels/telegram.sh
+++ b/fragments/labels/telegram.sh
@@ -2,6 +2,6 @@ telegram)
     name="Telegram"
     type="dmg"
     downloadURL="https://telegram.org/dl/macos"
-    appNewVersion="$(curl -s "https://osx.telegram.org/updates/versions.xml" | xpath -e 'string(//rss/channel/item[1]/enclosure/@sparkle:shortVersionString)' 2>/dev/null)"
+    appNewVersion="$(curl -s "https://osx.telegram.org/updates/versions.xml" | xpath 'string(//rss/channel/item[1]/enclosure/@sparkle:shortVersionString)' 2>/dev/null)"
     expectedTeamID="6N38VWS5BX"
     ;;

--- a/fragments/labels/telegram.sh
+++ b/fragments/labels/telegram.sh
@@ -2,6 +2,6 @@ telegram)
     name="Telegram"
     type="dmg"
     downloadURL="https://telegram.org/dl/macos"
-    appNewVersion=$( curl -fs https://macos.telegram.org | grep anchor | head -1 | sed -E 's/.*a>([0-9.]*) .*/\1/g' )
+    appNewVersion="$(curl -s "https://osx.telegram.org/updates/versions.xml" | xpath -e 'string(//rss/channel/item[1]/enclosure/@sparkle:shortVersionString)' 2>/dev/null)"
     expectedTeamID="6N38VWS5BX"
     ;;


### PR DESCRIPTION
assemble.sh telegram
2024-09-22 19:08:55 : REQ   : telegram : ################## Start Installomator v. 10.7beta, date 2024-09-22
2024-09-22 19:08:55 : INFO  : telegram : ################## Version: 10.7beta
2024-09-22 19:08:55 : INFO  : telegram : ################## Date: 2024-09-22
2024-09-22 19:08:55 : INFO  : telegram : ################## telegram
2024-09-22 19:08:55 : DEBUG : telegram : DEBUG mode 1 enabled.
2024-09-22 19:08:55 : INFO  : telegram : SwiftDialog is not installed, clear cmd file var
2024-09-22 19:08:56 : DEBUG : telegram : name=Telegram
2024-09-22 19:08:56 : DEBUG : telegram : appName=
2024-09-22 19:08:56 : DEBUG : telegram : type=dmg
2024-09-22 19:08:56 : DEBUG : telegram : archiveName=
2024-09-22 19:08:56 : DEBUG : telegram : downloadURL=https://telegram.org/dl/macos
2024-09-22 19:08:56 : DEBUG : telegram : curlOptions=
2024-09-22 19:08:56 : DEBUG : telegram : appNewVersion=11.1
2024-09-22 19:08:56 : DEBUG : telegram : appCustomVersion function: Not defined
2024-09-22 19:08:56 : DEBUG : telegram : versionKey=CFBundleShortVersionString
2024-09-22 19:08:56 : DEBUG : telegram : packageID=
2024-09-22 19:08:56 : DEBUG : telegram : pkgName=
2024-09-22 19:08:56 : DEBUG : telegram : choiceChangesXML=
2024-09-22 19:08:56 : DEBUG : telegram : expectedTeamID=6N38VWS5BX
2024-09-22 19:08:56 : DEBUG : telegram : blockingProcesses=
2024-09-22 19:08:56 : DEBUG : telegram : installerTool=
2024-09-22 19:08:56 : DEBUG : telegram : CLIInstaller=
2024-09-22 19:08:56 : DEBUG : telegram : CLIArguments=
2024-09-22 19:08:56 : DEBUG : telegram : updateTool=
2024-09-22 19:08:56 : DEBUG : telegram : updateToolArguments=
2024-09-22 19:08:56 : DEBUG : telegram : updateToolRunAsCurrentUser=
2024-09-22 19:08:56 : INFO  : telegram : BLOCKING_PROCESS_ACTION=tell_user
2024-09-22 19:08:56 : INFO  : telegram : NOTIFY=success
2024-09-22 19:08:56 : INFO  : telegram : LOGGING=DEBUG
2024-09-22 19:08:56 : INFO  : telegram : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-22 19:08:56 : INFO  : telegram : Label type: dmg
2024-09-22 19:08:56 : INFO  : telegram : archiveName: Telegram.dmg
2024-09-22 19:08:56 : INFO  : telegram : no blocking processes defined, using Telegram as default
2024-09-22 19:08:56 : DEBUG : telegram : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-22 19:08:56 : INFO  : telegram : name: Telegram, appName: Telegram.app
2024-09-22 19:08:56.293 mdfind[44377:1944489] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-22 19:08:56.293 mdfind[44377:1944489] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-22 19:08:56.403 mdfind[44377:1944489] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-22 19:08:56 : WARN  : telegram : No previous app found
2024-09-22 19:08:56 : WARN  : telegram : could not find Telegram.app
2024-09-22 19:08:56 : INFO  : telegram : appversion: 
2024-09-22 19:08:56 : INFO  : telegram : Latest version of Telegram is 11.1
2024-09-22 19:08:56 : REQ   : telegram : Downloading https://telegram.org/dl/macos to Telegram.dmg
2024-09-22 19:08:56 : DEBUG : telegram : No Dialog connection, just download
2024-09-22 19:09:17 : DEBUG : telegram : File list: -rw-r--r--  1 gilburns  staff   101M Sep 22 19:09 Telegram.dmg
2024-09-22 19:09:17 : DEBUG : telegram : File type: Telegram.dmg: zlib compressed data
2024-09-22 19:09:17 : DEBUG : telegram : curl output was:
* Host telegram.org:443 was resolved.
* IPv6: 2001:67c:4e8:f004::9
* IPv4: 149.154.167.99
*   Trying 149.154.167.99:443...
* Connected to telegram.org (149.154.167.99) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5131 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.telegram.org
*  start date: Aug 10 13:33:14 2024 GMT
*  expire date: Sep 11 13:33:14 2025 GMT
*  subjectAltName: host "telegram.org" matched cert's "telegram.org"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://telegram.org/dl/macos
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: telegram.org]
* [HTTP/2] [1] [:path: /dl/macos]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /dl/macos HTTP/2
> Host: telegram.org
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: nginx/1.18.0
< date: Mon, 23 Sep 2024 00:08:56 GMT
< content-type: text/html; charset=UTF-8
< content-length: 0
< location: https://osx.telegram.org/updates/Telegram.dmg
< set-cookie: stel_ssid=78a102eb19c3743012_9359820602951182824; expires=Mon, 23 Sep 2024 11:15:36 GMT; path=/; samesite=None; secure; HttpOnly
< pragma: no-cache
< cache-control: no-store
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< 
* Ignoring the response-body
* Connection #0 to host telegram.org left intact
* Issue another request to this URL: 'https://osx.telegram.org/updates/Telegram.dmg'
* Host osx.telegram.org:443 was resolved.
* IPv6: (none)
* IPv4: 149.154.167.99
*   Trying 149.154.167.99:443...
* Connected to osx.telegram.org (149.154.167.99) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5131 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.telegram.org
*  start date: Aug 10 13:33:14 2024 GMT
*  expire date: Sep 11 13:33:14 2025 GMT
*  subjectAltName: host "osx.telegram.org" matched cert's "*.telegram.org"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://osx.telegram.org/updates/Telegram.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: osx.telegram.org]
* [HTTP/2] [1] [:path: /updates/Telegram.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /updates/Telegram.dmg HTTP/2
> Host: osx.telegram.org
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx/1.18.0
< date: Mon, 23 Sep 2024 00:08:57 GMT
< content-type: application/octet-stream
< content-length: 105873844
< last-modified: Fri, 06 Sep 2024 15:04:51 GMT
< etag: "66db1a13-64f81b4"
< strict-transport-security: max-age=35768000
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< accept-ranges: bytes
< 
{ [8192 bytes data]
* Connection #1 to host osx.telegram.org left intact

2024-09-22 19:09:17 : DEBUG : telegram : DEBUG mode 1, not checking for blocking processes
2024-09-22 19:09:17 : REQ   : telegram : Installing Telegram
2024-09-22 19:09:17 : INFO  : telegram : Mounting /Users/gilburns/GitHub/Installomator/build/Telegram.dmg
2024-09-22 19:09:20 : DEBUG : telegram : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $CE5FC7BD
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $48F8D091
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F158A8F6
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $47FEC866
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F158A8F6
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $BB65BD48
verified   CRC32 $51C8BC40
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Telegram

2024-09-22 19:09:20 : INFO  : telegram : Mounted: /Volumes/Telegram
2024-09-22 19:09:20 : INFO  : telegram : Verifying: /Volumes/Telegram/Telegram.app
2024-09-22 19:09:20 : DEBUG : telegram : App size: 248M	/Volumes/Telegram/Telegram.app
2024-09-22 19:09:24 : DEBUG : telegram : Debugging enabled, App Verification output was:
/Volumes/Telegram/Telegram.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TELEGRAM MESSENGER LLP (6N38VWS5BX)

2024-09-22 19:09:24 : INFO  : telegram : Team ID matching: 6N38VWS5BX (expected: 6N38VWS5BX )
2024-09-22 19:09:24 : INFO  : telegram : Installing Telegram version 11.1 on versionKey CFBundleShortVersionString.
2024-09-22 19:09:24 : INFO  : telegram : App has LSMinimumSystemVersion: 10.13
2024-09-22 19:09:24 : DEBUG : telegram : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-22 19:09:24 : INFO  : telegram : Finishing...
2024-09-22 19:09:27 : INFO  : telegram : name: Telegram, appName: Telegram.app
2024-09-22 19:09:27.250 mdfind[44480:1945169] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-22 19:09:27.250 mdfind[44480:1945169] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-22 19:09:27.370 mdfind[44480:1945169] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-22 19:09:27 : WARN  : telegram : No previous app found
2024-09-22 19:09:27 : WARN  : telegram : could not find Telegram.app
2024-09-22 19:09:27 : REQ   : telegram : Installed Telegram, version 11.1
2024-09-22 19:09:27 : INFO  : telegram : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-22 19:09:27 : DEBUG : telegram : Unmounting /Volumes/Telegram
2024-09-22 19:09:27 : DEBUG : telegram : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-22 19:09:27 : DEBUG : telegram : DEBUG mode 1, not reopening anything
2024-09-22 19:09:27 : REQ   : telegram : All done!
2024-09-22 19:09:27 : REQ   : telegram : ################## End Installomator, exit code 0 
