### PR TITLE
Fix for broken app label displaylinkmanagergraphicsconnectivity

### DIFF
--- a/fragments/labels/displaylinkmanagergraphicsconnectivity.sh
+++ b/fragments/labels/displaylinkmanagergraphicsconnectivity.sh
@@ -2,7 +2,7 @@ displaylinkmanagergraphicsconnectivity)
     name="DisplayLink Manager Graphics Connectivity"
     type="pkg"
     packageID="com.displaylink.displaylinkmanagerapp"
-    downloadURL=https://www.synaptics.com$(curl -fLs "https://www.synaptics.com$(curl -fLs https://www.synaptics.com/products/displaylink-graphics/downloads/macos | xmllint --html --format - 2>/dev/null | grep -oE '"/node/.+?"' | head -n1 | tr -d '"')" | xmllint --html --format - 2>/dev/null | grep -oE "/.+\.pkg")
+    downloadURL=https://www.synaptics.com$(curl -fLs "https://www.synaptics.com$(curl -fLs https://www.synaptics.com/products/displaylink-graphics/downloads/macos | xmllint --html --format - 2>/dev/null | grep "download-link" | head -n1 | cut -d'"' -f2)" | xmllint --html --format - 2>/dev/null | grep -oE "/.+\.pkg")
     appNewVersion=$(echo "${downloadURL}" | grep -Eo '[0-9]\.[0-9]+(\.[0-9])?')
     expectedTeamID="73YQY62QM3"
     ;;


### PR DESCRIPTION
```
assemble.sh displaylinkmanagergraphicsconnectivity
2024-09-24 17:54:44 : REQ   : displaylinkmanagergraphicsconnectivity : ################## Start Installomator v. 10.7beta, date 2024-09-24
2024-09-24 17:54:44 : INFO  : displaylinkmanagergraphicsconnectivity : ################## Version: 10.7beta
2024-09-24 17:54:44 : INFO  : displaylinkmanagergraphicsconnectivity : ################## Date: 2024-09-24
2024-09-24 17:54:44 : INFO  : displaylinkmanagergraphicsconnectivity : ################## displaylinkmanagergraphicsconnectivity
2024-09-24 17:54:44 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1 enabled.
2024-09-24 17:54:44 : INFO  : displaylinkmanagergraphicsconnectivity : SwiftDialog is not installed, clear cmd file var
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : name=DisplayLink Manager Graphics Connectivity
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : appName=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : type=pkg
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : archiveName=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : downloadURL=https://www.synaptics.com/sites/default/files/exe_files/2024-08/DisplayLink%20Manager%20Graphics%20Connectivity1.10.3-EXE.pkg
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : curlOptions=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : appNewVersion=1.10.3
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : appCustomVersion function: Not defined
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : versionKey=CFBundleShortVersionString
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : packageID=com.displaylink.displaylinkmanagerapp
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : pkgName=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : choiceChangesXML=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : expectedTeamID=73YQY62QM3
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : blockingProcesses=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : installerTool=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : CLIInstaller=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : CLIArguments=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : updateTool=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : updateToolArguments=
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : updateToolRunAsCurrentUser=
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : BLOCKING_PROCESS_ACTION=tell_user
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : NOTIFY=success
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : LOGGING=DEBUG
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : Label type: pkg
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : archiveName: DisplayLink Manager Graphics Connectivity.pkg
2024-09-24 17:54:46 : INFO  : displaylinkmanagergraphicsconnectivity : no blocking processes defined, using DisplayLink Manager Graphics Connectivity as default
2024-09-24 17:54:46 : DEBUG : displaylinkmanagergraphicsconnectivity : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-24 17:54:47 : INFO  : displaylinkmanagergraphicsconnectivity : No version found using packageID com.displaylink.displaylinkmanagerapp
2024-09-24 17:54:47 : INFO  : displaylinkmanagergraphicsconnectivity : name: DisplayLink Manager Graphics Connectivity, appName: DisplayLink Manager Graphics Connectivity.app
2024-09-24 17:54:47.051 mdfind[65785:3147088] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-24 17:54:47.052 mdfind[65785:3147088] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-24 17:54:47.292 mdfind[65785:3147088] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-24 17:54:47 : WARN  : displaylinkmanagergraphicsconnectivity : No previous app found
2024-09-24 17:54:47 : WARN  : displaylinkmanagergraphicsconnectivity : could not find DisplayLink Manager Graphics Connectivity.app
2024-09-24 17:54:47 : INFO  : displaylinkmanagergraphicsconnectivity : appversion: 
2024-09-24 17:54:47 : INFO  : displaylinkmanagergraphicsconnectivity : Latest version of DisplayLink Manager Graphics Connectivity is 1.10.3
2024-09-24 17:54:47 : REQ   : displaylinkmanagergraphicsconnectivity : Downloading https://www.synaptics.com/sites/default/files/exe_files/2024-08/DisplayLink%20Manager%20Graphics%20Connectivity1.10.3-EXE.pkg to DisplayLink Manager Graphics Connectivity.pkg
2024-09-24 17:54:47 : DEBUG : displaylinkmanagergraphicsconnectivity : No Dialog connection, just download
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : File list: -rw-r--r--  1 gilburns  staff   7.0M Sep 24 17:54 DisplayLink Manager Graphics Connectivity.pkg
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : File type: DisplayLink Manager Graphics Connectivity.pkg: xar archive compressed TOC: 5002, SHA-1 checksum
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : curl output was:
* Host www.synaptics.com:443 was resolved.
* IPv6: (none)
* IPv4: 54.245.106.105
*   Trying 54.245.106.105:443...
* Connected to www.synaptics.com (54.245.106.105) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3171 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Synaptics Inc.; CN=www.synaptics.com
*  start date: Jul 31 00:00:00 2024 GMT
*  expire date: Aug 31 23:59:59 2025 GMT
*  subjectAltName: host "www.synaptics.com" matched cert's "www.synaptics.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.synaptics.com/sites/default/files/exe_files/2024-08/DisplayLink%20Manager%20Graphics%20Connectivity1.10.3-EXE.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.synaptics.com]
* [HTTP/2] [1] [:path: /sites/default/files/exe_files/2024-08/DisplayLink%20Manager%20Graphics%20Connectivity1.10.3-EXE.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /sites/default/files/exe_files/2024-08/DisplayLink%20Manager%20Graphics%20Connectivity1.10.3-EXE.pkg HTTP/2
> Host: www.synaptics.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< date: Tue, 24 Sep 2024 22:54:47 GMT
< content-length: 7324819
< x-content-type-options: nosniff
< last-modified: Tue, 27 Aug 2024 09:37:55 GMT
< accept-ranges: bytes
< cache-control: max-age=1209600
< expires: Tue, 08 Oct 2024 22:54:47 GMT
< x-request-id: v-ffc0df4a-7ac7-11ef-89c6-37b1a253ed24
< x-ah-environment: prod
< age: 0
< via: varnish
< x-cache: MISS
< 
{ [8192 bytes data]
* Connection #0 to host www.synaptics.com left intact

2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1, not checking for blocking processes
2024-09-24 17:54:49 : REQ   : displaylinkmanagergraphicsconnectivity : Installing DisplayLink Manager Graphics Connectivity
2024-09-24 17:54:49 : INFO  : displaylinkmanagergraphicsconnectivity : Verifying: DisplayLink Manager Graphics Connectivity.pkg
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : File list: -rw-r--r--  1 gilburns  staff   7.0M Sep 24 17:54 DisplayLink Manager Graphics Connectivity.pkg
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : File type: DisplayLink Manager Graphics Connectivity.pkg: xar archive compressed TOC: 5002, SHA-1 checksum
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : spctlOut is DisplayLink Manager Graphics Connectivity.pkg: accepted
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : source=Notarized Developer ID
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : origin=Developer ID Installer: DisplayLink Corp (73YQY62QM3)
2024-09-24 17:54:49 : INFO  : displaylinkmanagergraphicsconnectivity : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2024-09-24 17:54:49 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG enabled, skipping installation
2024-09-24 17:54:49 : INFO  : displaylinkmanagergraphicsconnectivity : Finishing...
2024-09-24 17:54:52 : INFO  : displaylinkmanagergraphicsconnectivity : No version found using packageID com.displaylink.displaylinkmanagerapp
2024-09-24 17:54:52 : INFO  : displaylinkmanagergraphicsconnectivity : name: DisplayLink Manager Graphics Connectivity, appName: DisplayLink Manager Graphics Connectivity.app
2024-09-24 17:54:52.946 mdfind[65849:3147411] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-24 17:54:52.947 mdfind[65849:3147411] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-24 17:54:53.029 mdfind[65849:3147411] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-24 17:54:53 : WARN  : displaylinkmanagergraphicsconnectivity : No previous app found
2024-09-24 17:54:53 : WARN  : displaylinkmanagergraphicsconnectivity : could not find DisplayLink Manager Graphics Connectivity.app
2024-09-24 17:54:53 : REQ   : displaylinkmanagergraphicsconnectivity : Installed DisplayLink Manager Graphics Connectivity, version 1.10.3
2024-09-24 17:54:53 : INFO  : displaylinkmanagergraphicsconnectivity : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-24 17:54:53 : DEBUG : displaylinkmanagergraphicsconnectivity : DEBUG mode 1, not reopening anything
2024-09-24 17:54:53 : REQ   : displaylinkmanagergraphicsconnectivity : All done!
2024-09-24 17:54:53 : REQ   : displaylinkmanagergraphicsconnectivity : ################## End Installomator, exit code 0 

```