### PR TITLE
Update for Poly Lens to use the atom feed to determine version and download

### DIFF
--- a/fragments/labels/polylens.sh
+++ b/fragments/labels/polylens.sh
@@ -1,7 +1,8 @@
 polylens)
     name="Poly Lens"
     type="dmg"
-    appNewVersion=$(curl -fs "https://info.lens.poly.com/lens-dt-rn/atom.xml" | grep "Version" | head -1 | cut -d "[" -f3 | sed 's/Version //g' | sed 's/]]\>\<\/title\>//g')
-    downloadURL="https://swupdate.lens.poly.com/lens-desktop-mac/$appNewVersion/$appNewVersion/PolyLens-$appNewVersion.dmg"
+    polyDetails="$(curl -fs 'https://api.silica-prod01.io.lens.poly.com/graphql' -X POST -H 'Content-Type: application/json' --data-raw '{"operationName":"LensSoftwareUpdateAvailable","variables":{"productId":"lens-desktop-mac","releaseChannel":null},"query":"query LensSoftwareUpdateAvailable($productId: ID!, $releaseChannel: String) {availableProductSoftwareByPid(pid: $productId, releaseChannel: $releaseChannel) {version productBuild {build archiveUrl __typename} __typename}}"}')"
+    appNewVersion=$(getJSONValue "$polyDetails" "data.availableProductSoftwareByPid.version")
+    downloadURL=$(getJSONValue "$polyDetails" "data.availableProductSoftwareByPid.productBuild.archiveUrl")
     expectedTeamID="SKWK2Q7JJV"
     ;;


### PR DESCRIPTION
This does away with the webpage scraping to find the version and download.


```
assemble.sh polylens     
2024-09-25 20:48:26 : REQ   : polylens : ################## Start Installomator v. 10.7beta, date 2024-09-25
2024-09-25 20:48:26 : INFO  : polylens : ################## Version: 10.7beta
2024-09-25 20:48:26 : INFO  : polylens : ################## Date: 2024-09-25
2024-09-25 20:48:26 : INFO  : polylens : ################## polylens
2024-09-25 20:48:26 : DEBUG : polylens : DEBUG mode 1 enabled.
2024-09-25 20:48:26 : INFO  : polylens : SwiftDialog is not installed, clear cmd file var
2024-09-25 20:48:27 : DEBUG : polylens : name=Poly Lens
2024-09-25 20:48:27 : DEBUG : polylens : appName=
2024-09-25 20:48:27 : DEBUG : polylens : type=dmg
2024-09-25 20:48:27 : DEBUG : polylens : archiveName=
2024-09-25 20:48:27 : DEBUG : polylens : downloadURL=https://swupdate.lens.poly.com/lens-desktop-mac/1.4.0/1.4.0/PolyLens-1.4.0.dmg
2024-09-25 20:48:27 : DEBUG : polylens : curlOptions=
2024-09-25 20:48:27 : DEBUG : polylens : appNewVersion=1.4.0
2024-09-25 20:48:27 : DEBUG : polylens : appCustomVersion function: Not defined
2024-09-25 20:48:27 : DEBUG : polylens : versionKey=CFBundleShortVersionString
2024-09-25 20:48:27 : DEBUG : polylens : packageID=
2024-09-25 20:48:27 : DEBUG : polylens : pkgName=
2024-09-25 20:48:27 : DEBUG : polylens : choiceChangesXML=
2024-09-25 20:48:27 : DEBUG : polylens : expectedTeamID=SKWK2Q7JJV
2024-09-25 20:48:27 : DEBUG : polylens : blockingProcesses=
2024-09-25 20:48:27 : DEBUG : polylens : installerTool=
2024-09-25 20:48:27 : DEBUG : polylens : CLIInstaller=
2024-09-25 20:48:27 : DEBUG : polylens : CLIArguments=
2024-09-25 20:48:27 : DEBUG : polylens : updateTool=
2024-09-25 20:48:27 : DEBUG : polylens : updateToolArguments=
2024-09-25 20:48:27 : DEBUG : polylens : updateToolRunAsCurrentUser=
2024-09-25 20:48:27 : INFO  : polylens : BLOCKING_PROCESS_ACTION=tell_user
2024-09-25 20:48:27 : INFO  : polylens : NOTIFY=success
2024-09-25 20:48:27 : INFO  : polylens : LOGGING=DEBUG
2024-09-25 20:48:27 : INFO  : polylens : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-25 20:48:27 : INFO  : polylens : Label type: dmg
2024-09-25 20:48:27 : INFO  : polylens : archiveName: Poly Lens.dmg
2024-09-25 20:48:27 : INFO  : polylens : no blocking processes defined, using Poly Lens as default
2024-09-25 20:48:27 : DEBUG : polylens : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-25 20:48:27 : INFO  : polylens : name: Poly Lens, appName: Poly Lens.app
2024-09-25 20:48:27.627 mdfind[96678:3999451] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-25 20:48:27.627 mdfind[96678:3999451] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-25 20:48:27.802 mdfind[96678:3999451] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-25 20:48:27 : WARN  : polylens : No previous app found
2024-09-25 20:48:27 : WARN  : polylens : could not find Poly Lens.app
2024-09-25 20:48:27 : INFO  : polylens : appversion: 
2024-09-25 20:48:27 : INFO  : polylens : Latest version of Poly Lens is 1.4.0
2024-09-25 20:48:27 : REQ   : polylens : Downloading https://swupdate.lens.poly.com/lens-desktop-mac/1.4.0/1.4.0/PolyLens-1.4.0.dmg to Poly Lens.dmg
2024-09-25 20:48:27 : DEBUG : polylens : No Dialog connection, just download
2024-09-25 20:49:21 : DEBUG : polylens : File list: -rw-r--r--  1 gilburns  staff   173M Sep 25 20:49 Poly Lens.dmg
2024-09-25 20:49:21 : DEBUG : polylens : File type: Poly Lens.dmg: zlib compressed data
2024-09-25 20:49:21 : DEBUG : polylens : curl output was:
* Host swupdate.lens.poly.com:443 was resolved.
* IPv6: 2620:1ec:bdf::51
* IPv4: 13.107.246.51
*   Trying 13.107.246.51:443...
* Connected to swupdate.lens.poly.com (13.107.246.51) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [88 bytes data]
* (304) (OUT), TLS handshake, Client hello (1):
} [360 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [155 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3929 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Washington; L=Redmond; O=Microsoft Corporation; CN=swupdate.lens.poly.com
*  start date: Jul 31 00:00:00 2024 GMT
*  expire date: Jul 31 23:59:59 2025 GMT
*  subjectAltName: host "swupdate.lens.poly.com" matched cert's "swupdate.lens.poly.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://swupdate.lens.poly.com/lens-desktop-mac/1.4.0/1.4.0/PolyLens-1.4.0.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: swupdate.lens.poly.com]
* [HTTP/2] [1] [:path: /lens-desktop-mac/1.4.0/1.4.0/PolyLens-1.4.0.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /lens-desktop-mac/1.4.0/1.4.0/PolyLens-1.4.0.dmg HTTP/2
> Host: swupdate.lens.poly.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Thu, 26 Sep 2024 01:48:28 GMT
< content-type: application/octet-stream
< content-length: 181042162
< last-modified: Thu, 16 May 2024 17:46:46 GMT
< etag: "0x8DC75D02800E902"
< x-ms-request-id: d2baa8c4-c01e-0014-0cb6-0f8c34000000
< x-ms-version: 2018-03-28
< access-control-allow-origin: *
< x-azure-ref: 20240926T014828Z-1549df5cb8cpzrdsh5dmhp7x2g00000000sg00000000zb0k
< x-fd-int-roxy-purgeid: 0
< x-cache: TCP_MISS
< accept-ranges: bytes
< 
{ [8192 bytes data]
* Connection #0 to host swupdate.lens.poly.com left intact

2024-09-25 20:49:21 : DEBUG : polylens : DEBUG mode 1, not checking for blocking processes
2024-09-25 20:49:21 : REQ   : polylens : Installing Poly Lens
2024-09-25 20:49:21 : INFO  : polylens : Mounting /Users/gilburns/GitHub/Installomator/build/Poly Lens.dmg
2024-09-25 20:49:24 : DEBUG : polylens : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $995A3A79
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $5C3C0E69
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $AB99A171
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $4E8DF8D8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $AB99A171
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $4FE040C9
verified   CRC32 $A06C3EC7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Poly Lens 1.4.0

2024-09-25 20:49:24 : INFO  : polylens : Mounted: /Volumes/Poly Lens 1.4.0
2024-09-25 20:49:24 : INFO  : polylens : Verifying: /Volumes/Poly Lens 1.4.0/Poly Lens.app
2024-09-25 20:49:24 : DEBUG : polylens : App size: 402M	/Volumes/Poly Lens 1.4.0/Poly Lens.app
2024-09-25 20:49:27 : DEBUG : polylens : Debugging enabled, App Verification output was:
/Volumes/Poly Lens 1.4.0/Poly Lens.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Plantronics, Inc. (SKWK2Q7JJV)

2024-09-25 20:49:27 : INFO  : polylens : Team ID matching: SKWK2Q7JJV (expected: SKWK2Q7JJV )
2024-09-25 20:49:27 : INFO  : polylens : Installing Poly Lens version 1.4.0 on versionKey CFBundleShortVersionString.
2024-09-25 20:49:27 : INFO  : polylens : App has LSMinimumSystemVersion: 10.11.0
2024-09-25 20:49:27 : DEBUG : polylens : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-25 20:49:27 : INFO  : polylens : Finishing...
2024-09-25 20:49:30 : INFO  : polylens : name: Poly Lens, appName: Poly Lens.app
2024-09-25 20:49:31.023 mdfind[96767:4000249] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-25 20:49:31.023 mdfind[96767:4000249] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-25 20:49:31.148 mdfind[96767:4000249] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-25 20:49:31 : WARN  : polylens : No previous app found
2024-09-25 20:49:31 : WARN  : polylens : could not find Poly Lens.app
2024-09-25 20:49:31 : REQ   : polylens : Installed Poly Lens, version 1.4.0
2024-09-25 20:49:31 : INFO  : polylens : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-25 20:49:31 : DEBUG : polylens : Unmounting /Volumes/Poly Lens 1.4.0
2024-09-25 20:49:31 : DEBUG : polylens : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-25 20:49:31 : DEBUG : polylens : DEBUG mode 1, not reopening anything
2024-09-25 20:49:31 : REQ   : polylens : All done!
2024-09-25 20:49:31 : REQ   : polylens : ################## End Installomator, exit code 0
```