### PR TITLE
Update LastPass to include appNewVersion variable

### DIFF
--- a/fragments/labels/lastpass.sh
+++ b/fragments/labels/lastpass.sh
@@ -2,6 +2,6 @@ lastpass)
     name="LastPass"
     type="dmg"
     downloadURL="https://download.cloud.lastpass.com/mac/LastPass.dmg"
+    appNewVersion="$(curl -fs "https://download.cloud.lastpass.com/mac/AppCast.xml" | xpath 'string(//rss/channel/item/title)' 2>/dev/null)"
     expectedTeamID="N24REP3BMN"
-    Company="Marvasol, Inc DBA LastPass"
     ;;


### PR DESCRIPTION
```
assemble.sh lastpass
2024-09-26 18:40:34 : REQ   : lastpass : ################## Start Installomator v. 10.7beta, date 2024-09-26
2024-09-26 18:40:34 : INFO  : lastpass : ################## Version: 10.7beta
2024-09-26 18:40:34 : INFO  : lastpass : ################## Date: 2024-09-26
2024-09-26 18:40:34 : INFO  : lastpass : ################## lastpass
2024-09-26 18:40:34 : DEBUG : lastpass : DEBUG mode 1 enabled.
2024-09-26 18:40:34 : INFO  : lastpass : SwiftDialog is not installed, clear cmd file var
2024-09-26 18:40:35 : DEBUG : lastpass : name=LastPass
2024-09-26 18:40:35 : DEBUG : lastpass : appName=
2024-09-26 18:40:35 : DEBUG : lastpass : type=dmg
2024-09-26 18:40:35 : DEBUG : lastpass : archiveName=
2024-09-26 18:40:35 : DEBUG : lastpass : downloadURL=https://download.cloud.lastpass.com/mac/LastPass.dmg
2024-09-26 18:40:35 : DEBUG : lastpass : curlOptions=
2024-09-26 18:40:35 : DEBUG : lastpass : appNewVersion=4.116.0
2024-09-26 18:40:35 : DEBUG : lastpass : appCustomVersion function: Not defined
2024-09-26 18:40:35 : DEBUG : lastpass : versionKey=CFBundleShortVersionString
2024-09-26 18:40:35 : DEBUG : lastpass : packageID=
2024-09-26 18:40:35 : DEBUG : lastpass : pkgName=
2024-09-26 18:40:35 : DEBUG : lastpass : choiceChangesXML=
2024-09-26 18:40:35 : DEBUG : lastpass : expectedTeamID=N24REP3BMN
2024-09-26 18:40:35 : DEBUG : lastpass : blockingProcesses=
2024-09-26 18:40:35 : DEBUG : lastpass : installerTool=
2024-09-26 18:40:35 : DEBUG : lastpass : CLIInstaller=
2024-09-26 18:40:35 : DEBUG : lastpass : CLIArguments=
2024-09-26 18:40:35 : DEBUG : lastpass : updateTool=
2024-09-26 18:40:35 : DEBUG : lastpass : updateToolArguments=
2024-09-26 18:40:35 : DEBUG : lastpass : updateToolRunAsCurrentUser=
2024-09-26 18:40:35 : INFO  : lastpass : BLOCKING_PROCESS_ACTION=tell_user
2024-09-26 18:40:35 : INFO  : lastpass : NOTIFY=success
2024-09-26 18:40:35 : INFO  : lastpass : LOGGING=DEBUG
2024-09-26 18:40:35 : INFO  : lastpass : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-26 18:40:35 : INFO  : lastpass : Label type: dmg
2024-09-26 18:40:35 : INFO  : lastpass : archiveName: LastPass.dmg
2024-09-26 18:40:35 : INFO  : lastpass : no blocking processes defined, using LastPass as default
2024-09-26 18:40:35 : DEBUG : lastpass : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-26 18:40:35 : INFO  : lastpass : name: LastPass, appName: LastPass.app
2024-09-26 18:40:35.620 mdfind[3161:4319708] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-26 18:40:35.621 mdfind[3161:4319708] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-26 18:40:35.830 mdfind[3161:4319708] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-26 18:40:35 : INFO  : lastpass : App(s) found: /Users/gilburns/Applications/LastPass.app
2024-09-26 18:40:35 : WARN  : lastpass : could not determine location of LastPass.app
2024-09-26 18:40:35 : INFO  : lastpass : appversion: 
2024-09-26 18:40:35 : INFO  : lastpass : Latest version of LastPass is 4.116.0
2024-09-26 18:40:35 : REQ   : lastpass : Downloading https://download.cloud.lastpass.com/mac/LastPass.dmg to LastPass.dmg
2024-09-26 18:40:35 : DEBUG : lastpass : No Dialog connection, just download
2024-09-26 18:40:45 : DEBUG : lastpass : File list: -rw-r--r--  1 gilburns  staff    82M Sep 26 18:40 LastPass.dmg
2024-09-26 18:40:45 : DEBUG : lastpass : File type: LastPass.dmg: zlib compressed data
2024-09-26 18:40:45 : DEBUG : lastpass : curl output was:
* Host download.cloud.lastpass.com:443 was resolved.
* IPv6: 2600:9000:2507:8200:b:5f47:9200:93a1, 2600:9000:2507:2e00:b:5f47:9200:93a1, 2600:9000:2507:2a00:b:5f47:9200:93a1, 2600:9000:2507:d000:b:5f47:9200:93a1, 2600:9000:2507:4400:b:5f47:9200:93a1, 2600:9000:2507:7600:b:5f47:9200:93a1, 2600:9000:2507:a00:b:5f47:9200:93a1, 2600:9000:2507:5200:b:5f47:9200:93a1
* IPv4: 18.154.185.27, 18.154.185.92, 18.154.185.105, 18.154.185.67
*   Trying 18.154.185.27:443...
* Connected to download.cloud.lastpass.com (18.154.185.27) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [332 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2831 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=Massachusetts; L=Boston; O=LASTPASS US LP; CN=*.cloud.lastpass.com
*  start date: Dec  4 13:21:03 2023 GMT
*  expire date: Jan  4 13:21:02 2025 GMT
*  subjectAltName: host "download.cloud.lastpass.com" matched cert's "*.cloud.lastpass.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign RSA OV SSL CA 2018
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.cloud.lastpass.com/mac/LastPass.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.cloud.lastpass.com]
* [HTTP/2] [1] [:path: /mac/LastPass.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /mac/LastPass.dmg HTTP/2
> Host: download.cloud.lastpass.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 86044308
< last-modified: Tue, 06 Jun 2023 09:34:20 GMT
< x-amz-server-side-encryption: AES256
< x-amz-version-id: TpaZUlQcdHwJuEh67VfxjIQiKBGWnN.n
< accept-ranges: bytes
< server: AmazonS3
< date: Thu, 26 Sep 2024 23:40:37 GMT
< etag: "78750a4a980d4a6aff04c02a18ff772e"
< x-cache: RefreshHit from cloudfront
< via: 1.1 0bff98411be7553fe46a16d779ea3486.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD58-P7
< x-amz-cf-id: N3y9PwTWyu9MD-T36VnZ2yZ9cu58V9eOW7wKj3l_Da0dkoI2-GmdBw==
< 
{ [8192 bytes data]
* Connection #0 to host download.cloud.lastpass.com left intact

2024-09-26 18:40:45 : DEBUG : lastpass : DEBUG mode 1, not checking for blocking processes
2024-09-26 18:40:45 : REQ   : lastpass : Installing LastPass
2024-09-26 18:40:45 : INFO  : lastpass : Mounting /Users/gilburns/GitHub/Installomator/build/LastPass.dmg
2024-09-26 18:40:48 : DEBUG : lastpass : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DE911CC7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8C74CB1F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $09A117B2
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $664CF8F0
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $09A117B2
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $B0FF6B4F
verified   CRC32 $8FEAEDD9
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/LastPass Installer

2024-09-26 18:40:48 : INFO  : lastpass : Mounted: /Volumes/LastPass Installer
2024-09-26 18:40:48 : INFO  : lastpass : Verifying: /Volumes/LastPass Installer/LastPass.app
2024-09-26 18:40:48 : DEBUG : lastpass : App size: 190M	/Volumes/LastPass Installer/LastPass.app
2024-09-26 18:40:54 : DEBUG : lastpass : Debugging enabled, App Verification output was:
/Volumes/LastPass Installer/LastPass.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Marvasol, Inc DBA LastPass (N24REP3BMN)

2024-09-26 18:40:54 : INFO  : lastpass : Team ID matching: N24REP3BMN (expected: N24REP3BMN )
2024-09-26 18:40:54 : INFO  : lastpass : Installing LastPass version 4.116.0 on versionKey CFBundleShortVersionString.
2024-09-26 18:40:54 : INFO  : lastpass : App has LSMinimumSystemVersion: 10.13
2024-09-26 18:40:54 : DEBUG : lastpass : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-26 18:40:54 : INFO  : lastpass : Finishing...
2024-09-26 18:40:57 : INFO  : lastpass : name: LastPass, appName: LastPass.app
2024-09-26 18:40:57.470 mdfind[3244:4320179] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-26 18:40:57.471 mdfind[3244:4320179] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-26 18:40:57.612 mdfind[3244:4320179] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-26 18:40:57 : INFO  : lastpass : App(s) found: /Users/gilburns/Applications/LastPass.app
2024-09-26 18:40:57 : WARN  : lastpass : could not determine location of LastPass.app
2024-09-26 18:40:57 : REQ   : lastpass : Installed LastPass, version 4.116.0
2024-09-26 18:40:57 : INFO  : lastpass : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-26 18:40:57 : DEBUG : lastpass : Unmounting /Volumes/LastPass Installer
2024-09-26 18:40:58 : DEBUG : lastpass : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-26 18:40:58 : DEBUG : lastpass : DEBUG mode 1, not reopening anything
2024-09-26 18:40:58 : REQ   : lastpass : All done!
2024-09-26 18:40:58 : REQ   : lastpass : ################## End Installomator, exit code 0 

```