### PR TITLE
Veracrypt label fix

### DIFF
--- a/fragments/labels/veracrypt-fuse-t.sh
+++ b/fragments/labels/veracrypt-fuse-t.sh
@@ -3,6 +3,6 @@ veracrypt-fuse-t)
     type="pkgInDmg"
     archiveName="VeraCrypt_FUSE-T_[0-9.]*.dmg"
     downloadURL=$(curl -sfL "https://api.github.com/repos/veracrypt/VeraCrypt/releases" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_([0-9.]*.*)\.dmg/\1/g')
+    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_FUSE-T_([0-9.]*.*)\.dmg/\1/g')
     expectedTeamID="Z933746L2S"
     ;;

--- a/fragments/labels/veracrypt-fuse-t.sh
+++ b/fragments/labels/veracrypt-fuse-t.sh
@@ -1,8 +1,7 @@
-veracrypt|\
-veracrypt-macfuse)
+veracrypt-fuse-t)
     name="VeraCrypt"
     type="pkgInDmg"
-    archiveName="VeraCrypt_[0-9.]*.dmg"
+    archiveName="VeraCrypt_FUSE-T_[0-9.]*.dmg"
     downloadURL=$(curl -sfL "https://api.github.com/repos/veracrypt/VeraCrypt/releases" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_([0-9.]*.*)\.dmg/\1/g')
     expectedTeamID="Z933746L2S"

--- a/fragments/labels/veracrypt-fuse-t.sh
+++ b/fragments/labels/veracrypt-fuse-t.sh
@@ -1,7 +1,7 @@
 veracrypt-fuse-t)
     name="VeraCrypt"
     type="pkgInDmg"
-    archiveName="VeraCrypt_FUSE-T_[0-9.]*.dmg"
+    archiveName="VeraCrypt_FUSE-T_[0-9.].*\.dmg"
     downloadURL=$(curl -sfL "https://api.github.com/repos/veracrypt/VeraCrypt/releases" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_FUSE-T_([0-9.]*.*)\.dmg/\1/g')
     expectedTeamID="Z933746L2S"

--- a/fragments/labels/veracrypt.sh
+++ b/fragments/labels/veracrypt.sh
@@ -2,7 +2,7 @@ veracrypt|\
 veracrypt-macfuse)
     name="VeraCrypt"
     type="pkgInDmg"
-    archiveName="VeraCrypt_[0-9.]*.dmg"
+    archiveName="VeraCrypt_[0-9.].*\.dmg"
     downloadURL=$(curl -sfL "https://api.github.com/repos/veracrypt/VeraCrypt/releases" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_([0-9.]*.*)\.dmg/\1/g')
     expectedTeamID="Z933746L2S"


### PR DESCRIPTION
The current VeraCrypt label is broken due to the release of another variant of VeraCrypt which supports [FUSE-T](https://www.fuse-t.org/), so I've fixed the label and created an additional one which downloads the new variant of VeraCrypt.

**veracrypt**
```
2024-09-27 13:36:47 : REQ   : veracrypt : ################## Start Installomator v. 10.7beta, date 2024-09-27
2024-09-27 13:36:47 : INFO  : veracrypt : ################## Version: 10.7beta
2024-09-27 13:36:47 : INFO  : veracrypt : ################## Date: 2024-09-27
2024-09-27 13:36:47 : INFO  : veracrypt : ################## veracrypt
2024-09-27 13:36:47 : DEBUG : veracrypt : DEBUG mode 1 enabled.
2024-09-27 13:36:47 : INFO  : veracrypt : SwiftDialog is not installed, clear cmd file var
2024-09-27 13:36:48 : INFO  : veracrypt : setting variable from argument DEBUG=0
2024-09-27 13:36:48 : DEBUG : veracrypt : name=VeraCrypt
2024-09-27 13:36:48 : DEBUG : veracrypt : appName=
2024-09-27 13:36:48 : DEBUG : veracrypt : type=pkgInDmg
2024-09-27 13:36:48 : DEBUG : veracrypt : archiveName=VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:36:48 : DEBUG : veracrypt : downloadURL=https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_1.26.14.dmg
2024-09-27 13:36:48 : DEBUG : veracrypt : curlOptions=
2024-09-27 13:36:48 : DEBUG : veracrypt : appNewVersion=1.26.14
2024-09-27 13:36:48 : DEBUG : veracrypt : appCustomVersion function: Not defined
2024-09-27 13:36:49 : DEBUG : veracrypt : versionKey=CFBundleShortVersionString
2024-09-27 13:36:49 : DEBUG : veracrypt : packageID=
2024-09-27 13:36:49 : DEBUG : veracrypt : pkgName=
2024-09-27 13:36:49 : DEBUG : veracrypt : choiceChangesXML=
2024-09-27 13:36:49 : DEBUG : veracrypt : expectedTeamID=Z933746L2S
2024-09-27 13:36:49 : DEBUG : veracrypt : blockingProcesses=
2024-09-27 13:36:49 : DEBUG : veracrypt : installerTool=
2024-09-27 13:36:49 : DEBUG : veracrypt : CLIInstaller=
2024-09-27 13:36:49 : DEBUG : veracrypt : CLIArguments=
2024-09-27 13:36:49 : DEBUG : veracrypt : updateTool=
2024-09-27 13:36:49 : DEBUG : veracrypt : updateToolArguments=
2024-09-27 13:36:49 : DEBUG : veracrypt : updateToolRunAsCurrentUser=
2024-09-27 13:36:49 : INFO  : veracrypt : BLOCKING_PROCESS_ACTION=tell_user
2024-09-27 13:36:49 : INFO  : veracrypt : NOTIFY=success
2024-09-27 13:36:49 : INFO  : veracrypt : LOGGING=DEBUG
2024-09-27 13:36:49 : INFO  : veracrypt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-27 13:36:49 : INFO  : veracrypt : Label type: pkgInDmg
2024-09-27 13:36:49 : INFO  : veracrypt : archiveName: VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:36:49 : INFO  : veracrypt : no blocking processes defined, using VeraCrypt as default
2024-09-27 13:36:49 : DEBUG : veracrypt : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7eUFue3R0z
2024-09-27 13:36:49 : INFO  : veracrypt : name: VeraCrypt, appName: VeraCrypt.app
2024-09-27 13:36:49.438 mdfind[10778:2589294] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 13:36:49.439 mdfind[10778:2589294] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 13:36:49.685 mdfind[10778:2589294] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 13:36:49 : WARN  : veracrypt : No previous app found
2024-09-27 13:36:49 : WARN  : veracrypt : could not find VeraCrypt.app
2024-09-27 13:36:49 : INFO  : veracrypt : appversion: 
2024-09-27 13:36:49 : INFO  : veracrypt : Latest version of VeraCrypt is 1.26.14
2024-09-27 13:36:49 : REQ   : veracrypt : Downloading https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_1.26.14.dmg to VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:36:49 : DEBUG : veracrypt : No Dialog connection, just download
2024-09-27 13:36:52 : DEBUG : veracrypt : File list: -rw-r--r--  1 root  wheel    13M Sep 27 13:36 VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:36:52 : DEBUG : veracrypt : File type: VeraCrypt_[0-9.].*\.dmg: zlib compressed data
2024-09-27 13:36:53 : DEBUG : veracrypt : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.121.3
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_1.26.14.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_1.26.14.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_1.26.14.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: GitHub.com
< date: Fri, 27 Sep 2024 11:36:50 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/4ff5d049-6a22-4463-9f87-45ec351d1897?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T113650Z&X-Amz-Expires=300&X-Amz-Signature=448a2fd320474f71accc96cb151ad684955a756cc99753d3d467ce5eda5321dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_1.26.14.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: CDDE:3C7C55:24BC1DF:257E5E5:66F698D1
< 
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/4ff5d049-6a22-4463-9f87-45ec351d1897?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T113650Z&X-Amz-Expires=300&X-Amz-Signature=448a2fd320474f71accc96cb151ad684955a756cc99753d3d467ce5eda5321dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_1.26.14.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.109.133, 185.199.108.133, 185.199.110.133, 185.199.111.133
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/4ff5d049-6a22-4463-9f87-45ec351d1897?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T113650Z&X-Amz-Expires=300&X-Amz-Signature=448a2fd320474f71accc96cb151ad684955a756cc99753d3d467ce5eda5321dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_1.26.14.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/26376490/4ff5d049-6a22-4463-9f87-45ec351d1897?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T113650Z&X-Amz-Expires=300&X-Amz-Signature=448a2fd320474f71accc96cb151ad684955a756cc99753d3d467ce5eda5321dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_1.26.14.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/26376490/4ff5d049-6a22-4463-9f87-45ec351d1897?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T113650Z&X-Amz-Expires=300&X-Amz-Signature=448a2fd320474f71accc96cb151ad684955a756cc99753d3d467ce5eda5321dd&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_1.26.14.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Tue, 27 Aug 2024 20:35:27 GMT
< etag: "0x8DCC6D7C8E5AE3C"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 589cb494-001e-0058-56c3-10390a000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Tue, 27 Aug 2024 20:35:27 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=VeraCrypt_1.26.14.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 1005
< date: Fri, 27 Sep 2024 11:36:50 GMT
< x-served-by: cache-iad-kiad7000133-IAD, cache-bma1624-BMA
< x-cache: HIT, HIT
< x-cache-hits: 1, 0
< x-timer: S1727437010.216882,VS0,VE1
< content-length: 14151870
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-09-27 13:36:53 : REQ   : veracrypt : no more blocking processes, continue with update
2024-09-27 13:36:53 : REQ   : veracrypt : Installing VeraCrypt
2024-09-27 13:36:53 : INFO  : veracrypt : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7eUFue3R0z/VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:36:54 : DEBUG : veracrypt : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $8DDD83CB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $A46BB3AE
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified CRC32 $48B2A6FD
verified CRC32 $21025C6D
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_HFS                      	/Volumes/VeraCrypt for OSX

2024-09-27 13:36:54 : INFO  : veracrypt : Mounted: /Volumes/VeraCrypt for OSX
2024-09-27 13:36:54 : DEBUG : veracrypt : Found pkg(s):
/Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:36:54 : INFO  : veracrypt : found pkg: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:36:54 : INFO  : veracrypt : Verifying: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:36:54 : DEBUG : veracrypt : File list: -rw-r--r--@ 1 kryptonit  staff    13M Aug 26 05:22 /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:36:54 : DEBUG : veracrypt : File type: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg: xar archive compressed TOC: 5326, SHA-1 checksum
2024-09-27 13:36:54 : DEBUG : veracrypt : spctlOut is /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg: accepted
2024-09-27 13:36:54 : DEBUG : veracrypt : source=Notarized Developer ID
2024-09-27 13:36:54 : DEBUG : veracrypt : origin=Developer ID Installer: IDRIX (Z933746L2S)
2024-09-27 13:36:54 : INFO  : veracrypt : Team ID: Z933746L2S (expected: Z933746L2S )
2024-09-27 13:36:54 : INFO  : veracrypt : Installing /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg to /
2024-09-27 13:36:59 : DEBUG : veracrypt : Debugging enabled, installer output was:
Sep 27 13:36:55  installer[10917] <Debug>: Product archive /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg trustLevel=350
Sep 27 13:36:55  installer[10917] <Debug>: External component packages (1) trustLevel=350
Sep 27 13:36:55  installer[10917] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Sep 27 13:36:55  installer[10917] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg
Sep 27 13:36:55  installer[10917] <Info>: Set authorization level to root for session
Sep 27 13:36:55  installer[10917] <Info>: Authorization is being checked, waiting until authorization arrives.
Sep 27 13:36:55  installer[10917] <Info>: Administrator authorization granted.
Sep 27 13:36:55  installer[10917] <Info>: Packages have been authorized for installation.
Sep 27 13:36:55  installer[10917] <Debug>: Will use PK session
Sep 27 13:36:55  installer[10917] <Debug>: Using authorization level of root for IFPKInstallElement
Sep 27 13:36:55  installer[10917] <Info>: Starting installation:
Sep 27 13:36:55  installer[10917] <Notice>: Configuring volume "Macintosh HD"
Sep 27 13:36:55  installer[10917] <Info>: Preparing disk for local booted install.
Sep 27 13:36:55  installer[10917] <Notice>: Free space on "Macintosh HD": 41.94 GB (41941327872 bytes).
Sep 27 13:36:55  installer[10917] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.109179gGPUE"
Sep 27 13:36:55  installer[10917] <Notice>: IFPKInstallElement (1 packages)
Sep 27 13:36:55  installer[10917] <Info>: Current Path: /usr/sbin/installer
Sep 27 13:36:55  installer[10917] <Info>: Current Path: /bin/zsh
Sep 27 13:36:55  installer[10917] <Info>: Current Path: /usr/bin/sudo
Sep 27 13:36:55  installer[10917] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is VeraCrypt 1.26.14
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing VeraCrypt 1.26.14….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
installer: Validating packages….....
#Sep 27 13:36:57  installer[10917] <Info>: PackageKit: Registered bundle file:///Applications/VeraCrypt.app/ for uid 0

installer: Registering updated applications….....
#Sep 27 13:36:57  installer[10917] <Notice>: Running install actions
Sep 27 13:36:57  installer[10917] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.109179gGPUE"
Sep 27 13:36:57  installer[10917] <Notice>: Finalize disk "Macintosh HD"
Sep 27 13:36:57  installer[10917] <Notice>: Notifying system of updated components
Sep 27 13:36:57  installer[10917] <Notice>:
Sep 27 13:36:57  installer[10917] <Notice>: **** Summary Information ****
Sep 27 13:36:57  installer[10917] <Notice>:   Operation      Elapsed time
Sep 27 13:36:57  installer[10917] <Notice>: -----------------------------
Sep 27 13:36:57  installer[10917] <Notice>:        disk      0.01 seconds
Sep 27 13:36:57  installer[10917] <Notice>:      script      0.00 seconds
Sep 27 13:36:57  installer[10917] <Notice>:        zero      0.00 seconds
Sep 27 13:36:57  installer[10917] <Notice>:     install      2.03 seconds
Sep 27 13:36:57  installer[10917] <Notice>:     -total-      2.04 seconds
Sep 27 13:36:57  installer[10917] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/01743281-2B3A-4895-9FCE-1E431C6D65A6.activeSandbox
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Product archive /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg trustLevel=350
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: External component packages (1) trustLevel=350
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Set authorization level to root for session
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Authorization is being checked, waiting until authorization arrives.
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Administrator authorization granted.
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Packages have been authorized for installation.
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Will use PK session
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Using authorization level of root for IFPKInstallElement
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Starting installation:
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Configuring volume "Macintosh HD"
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Preparing disk for local booted install.
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Free space on "Macintosh HD": 41.94 GB (41941327872 bytes).
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.109179gGPUE"
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: IFPKInstallElement (1 packages)
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Current Path: /usr/sbin/installer
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: Current Path: /usr/bin/sudo
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Adding client PKInstallDaemonClient pid=10917, uid=0 (/usr/sbin/installer)
2024-09-27 13:36:55+02 kryptonit-mac installer[10917]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Set reponsibility for install to 1039
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Hosted team responsibility for install set to team:(Z933746L2S)
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: ----- Begin install -----
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: packages=(
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/01743281-2B3A-4895-9FCE-1E431C6D65A6.activeSandbox
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/1E5D914C-B5CD-428B-976B-E608ACE7970A.activeSandbox
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/922D2D04-6EEB-4C58-AED5-6FD8E68180B1.activeSandbox
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Will do receipt-based obsoleting for package identifier com.idrix.pkg.veracrypt (prefix path=)
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/1E5D914C-B5CD-428B-976B-E608ACE7970A.activeSandbox
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Extracting file:///Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/508CD0CE-5CCD-46F7-8939-6B51B1457261.activeSandbox/Root, uid=0)
2024-09-27 13:36:55+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/922D2D04-6EEB-4C58-AED5-6FD8E68180B1.activeSandbox
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: prevent user idle system sleep
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: suspending backupd
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/508CD0CE-5CCD-46F7-8939-6B51B1457261.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/508CD0CE-5CCD-46F7-8939-6B51B1457261.activeSandbox
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/508CD0CE-5CCD-46F7-8939-6B51B1457261.activeSandbox/Root (1 items) to /
2024-09-27 13:36:56+02 kryptonit-mac install_monitor[10918]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.FKfbeb/Scripts/com.idrix.pkg.veracrypt.6j4m8e
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.FKfbeb/Scripts/com.idrix.pkg.veracrypt.6j4m8e
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: Set responsibility to pid: 1039, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: Hosted team responsibility for script set to team:(Z933746L2S)
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.FKfbeb/Scripts/com.idrix.pkg.veracrypt.6j4m8e
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: PackageKit: Hosted team responsible for script has been cleared.
2024-09-27 13:36:56+02 kryptonit-mac package_script_service[7616]: Responsibility set back to self.
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: Writing receipt for com.idrix.pkg.veracrypt to /
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: No Intel binaries to translate.
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: PackageKit: Touched bundle /Applications/VeraCrypt.app
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: Installed "VeraCrypt 1.26.14" ()
2024-09-27 13:36:56+02 kryptonit-mac installd[1106]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-09-27 13:36:56+02 kryptonit-mac install_monitor[10918]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: releasing backupd
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: allow user idle system sleep
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: ----- End install -----
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: 1.5s elapsed install time
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: Cleared responsibility for install from 10917.
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: Hosted team responsible for install has been cleared.
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: Running idle tasks
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: Done with sandbox removals
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: PackageKit: Registered bundle file:///Applications/VeraCrypt.app/ for uid 0
2024-09-27 13:36:57+02 kryptonit-mac installd[1106]: PackageKit: Removing client PKInstallDaemonClient pid=10917, uid=0 (/usr/sbin/installer)
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: Running install actions
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.109179gGPUE"
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: Finalize disk "Macintosh HD"
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: Notifying system of updated components
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: **** Summary Information ****
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:   Operation      Elapsed time
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]: -----------------------------
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:        disk      0.01 seconds
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:      script      0.00 seconds
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:        zero      0.00 seconds
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:     install      2.03 seconds
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:     -total-      2.04 seconds
2024-09-27 13:36:57+02 kryptonit-mac installer[10917]:

2024-09-27 13:36:59 : INFO  : veracrypt : Finishing...
2024-09-27 13:37:02 : INFO  : veracrypt : App(s) found: /Applications/VeraCrypt.app
2024-09-27 13:37:02 : INFO  : veracrypt : found app at /Applications/VeraCrypt.app, version 1.26.14, on versionKey CFBundleShortVersionString
2024-09-27 13:37:02 : REQ   : veracrypt : Installed VeraCrypt, version 1.26.14
2024-09-27 13:37:02 : INFO  : veracrypt : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-09-27 13:37:02 : DEBUG : veracrypt : Unmounting /Volumes/VeraCrypt for OSX
2024-09-27 13:37:02 : DEBUG : veracrypt : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-09-27 13:37:02 : DEBUG : veracrypt : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7eUFue3R0z
2024-09-27 13:37:02 : DEBUG : veracrypt : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7eUFue3R0z/VeraCrypt_[0-9.].*\.dmg
2024-09-27 13:37:02 : DEBUG : veracrypt : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7eUFue3R0z
2024-09-27 13:37:02 : INFO  : veracrypt : Installomator did not close any apps, so no need to reopen any apps.
2024-09-27 13:37:02 : REQ   : veracrypt : All done!
2024-09-27 13:37:02 : REQ   : veracrypt : ################## End Installomator, exit code 0 
```

**veracrypt-fuse-t**
```
2024-09-27 13:25:34 : REQ   : veracrypt-fuse-t : ################## Start Installomator v. 10.7beta, date 2024-09-27
2024-09-27 13:25:34 : INFO  : veracrypt-fuse-t : ################## Version: 10.7beta
2024-09-27 13:25:34 : INFO  : veracrypt-fuse-t : ################## Date: 2024-09-27
2024-09-27 13:25:34 : INFO  : veracrypt-fuse-t : ################## veracrypt-fuse-t
2024-09-27 13:25:34 : DEBUG : veracrypt-fuse-t : DEBUG mode 1 enabled.
2024-09-27 13:25:35 : INFO  : veracrypt-fuse-t : SwiftDialog is not installed, clear cmd file var
2024-09-27 13:25:35 : INFO  : veracrypt-fuse-t : setting variable from argument DEBUG=0
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : name=VeraCrypt
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : appName=
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : type=pkgInDmg
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : archiveName=VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : downloadURL=https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_FUSE-T_1.26.14.dmg
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : curlOptions=
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : appNewVersion=1.26.14
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : appCustomVersion function: Not defined
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : versionKey=CFBundleShortVersionString
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : packageID=
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : pkgName=
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : choiceChangesXML=
2024-09-27 13:25:35 : DEBUG : veracrypt-fuse-t : expectedTeamID=Z933746L2S
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : blockingProcesses=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : installerTool=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : CLIInstaller=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : CLIArguments=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : updateTool=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : updateToolArguments=
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : updateToolRunAsCurrentUser=
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : BLOCKING_PROCESS_ACTION=tell_user
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : NOTIFY=success
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : LOGGING=DEBUG
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : Label type: pkgInDmg
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : archiveName: VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : no blocking processes defined, using VeraCrypt as default
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PmqnVI4zHY
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : name: VeraCrypt, appName: VeraCrypt.app
2024-09-27 13:25:36.147 mdfind[10021:2578698] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 13:25:36.147 mdfind[10021:2578698] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 13:25:36.244 mdfind[10021:2578698] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 13:25:36 : WARN  : veracrypt-fuse-t : No previous app found
2024-09-27 13:25:36 : WARN  : veracrypt-fuse-t : could not find VeraCrypt.app
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : appversion: 
2024-09-27 13:25:36 : INFO  : veracrypt-fuse-t : Latest version of VeraCrypt is 1.26.14
2024-09-27 13:25:36 : REQ   : veracrypt-fuse-t : Downloading https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_FUSE-T_1.26.14.dmg to VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:36 : DEBUG : veracrypt-fuse-t : No Dialog connection, just download
2024-09-27 13:25:39 : DEBUG : veracrypt-fuse-t : File list: -rw-r--r--  1 root  wheel    14M Sep 27 13:25 VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:39 : DEBUG : veracrypt-fuse-t : File type: VeraCrypt_FUSE-T_[0-9.].*\.dmg: zlib compressed data
2024-09-27 13:25:39 : DEBUG : veracrypt-fuse-t : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.121.3
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_FUSE-T_1.26.14.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_FUSE-T_1.26.14.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.14/VeraCrypt_FUSE-T_1.26.14.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: GitHub.com
< date: Fri, 27 Sep 2024 11:25:36 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/91e8dbf4-f01a-45b1-aa27-a5b33ff00df2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T112536Z&X-Amz-Expires=300&X-Amz-Signature=d0edfb736ec46bc1d3f8eeaa6978e41a098b192df36dd76a78ff2e41936eac9c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_FUSE-T_1.26.14.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: CD58:1F091D:239DC57:245C6D5:66F69630
< 
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/91e8dbf4-f01a-45b1-aa27-a5b33ff00df2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T112536Z&X-Amz-Expires=300&X-Amz-Signature=d0edfb736ec46bc1d3f8eeaa6978e41a098b192df36dd76a78ff2e41936eac9c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_FUSE-T_1.26.14.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.111.133, 185.199.109.133, 185.199.110.133, 185.199.108.133
*   Trying 185.199.111.133:443...
* Connected to objects.githubusercontent.com (185.199.111.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/26376490/91e8dbf4-f01a-45b1-aa27-a5b33ff00df2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T112536Z&X-Amz-Expires=300&X-Amz-Signature=d0edfb736ec46bc1d3f8eeaa6978e41a098b192df36dd76a78ff2e41936eac9c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_FUSE-T_1.26.14.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/26376490/91e8dbf4-f01a-45b1-aa27-a5b33ff00df2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T112536Z&X-Amz-Expires=300&X-Amz-Signature=d0edfb736ec46bc1d3f8eeaa6978e41a098b192df36dd76a78ff2e41936eac9c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_FUSE-T_1.26.14.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/26376490/91e8dbf4-f01a-45b1-aa27-a5b33ff00df2?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240927%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240927T112536Z&X-Amz-Expires=300&X-Amz-Signature=d0edfb736ec46bc1d3f8eeaa6978e41a098b192df36dd76a78ff2e41936eac9c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DVeraCrypt_FUSE-T_1.26.14.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Tue, 27 Aug 2024 20:32:57 GMT
< etag: "0x8DCC6D76FA87DA0"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: d99e3416-601e-004e-3737-10cfdd000000
< x-ms-version: 2020-10-02
< x-ms-creation-time: Tue, 27 Aug 2024 20:32:57 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=VeraCrypt_FUSE-T_1.26.14.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 1937
< date: Fri, 27 Sep 2024 11:25:37 GMT
< x-served-by: cache-iad-kjyo7100105-IAD, cache-bma1658-BMA
< x-cache: HIT, HIT
< x-cache-hits: 0, 0
< x-timer: S1727436337.719359,VS0,VE1
< content-length: 14158776
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-09-27 13:25:39 : REQ   : veracrypt-fuse-t : no more blocking processes, continue with update
2024-09-27 13:25:39 : REQ   : veracrypt-fuse-t : Installing VeraCrypt
2024-09-27 13:25:39 : INFO  : veracrypt-fuse-t : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PmqnVI4zHY/VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $8DDD83CB
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $A46BB3AE
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified CRC32 $D5D73A98
verified CRC32 $C0183C1E
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_HFS                      	/Volumes/VeraCrypt for OSX

2024-09-27 13:25:40 : INFO  : veracrypt-fuse-t : Mounted: /Volumes/VeraCrypt for OSX
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : Found pkg(s):
/Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:25:40 : INFO  : veracrypt-fuse-t : found pkg: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:25:40 : INFO  : veracrypt-fuse-t : Verifying: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : File list: -rw-r--r--@ 1 kryptonit  staff    13M Aug 26 05:28 /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : File type: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg: xar archive compressed TOC: 5305, SHA-1 checksum
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : spctlOut is /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg: accepted
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : source=Notarized Developer ID
2024-09-27 13:25:40 : DEBUG : veracrypt-fuse-t : origin=Developer ID Installer: IDRIX (Z933746L2S)
2024-09-27 13:25:40 : INFO  : veracrypt-fuse-t : Team ID: Z933746L2S (expected: Z933746L2S )
2024-09-27 13:25:40 : INFO  : veracrypt-fuse-t : Installing /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg to /
2024-09-27 13:25:44 : DEBUG : veracrypt-fuse-t : Debugging enabled, installer output was:
Sep 27 13:25:41  installer[10157] <Debug>: Product archive /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg trustLevel=350
Sep 27 13:25:41  installer[10157] <Debug>: External component packages (1) trustLevel=350
Sep 27 13:25:41  installer[10157] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Sep 27 13:25:41  installer[10157] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg
Sep 27 13:25:41  installer[10157] <Info>: Set authorization level to root for session
Sep 27 13:25:41  installer[10157] <Info>: Authorization is being checked, waiting until authorization arrives.
Sep 27 13:25:41  installer[10157] <Info>: Administrator authorization granted.
Sep 27 13:25:41  installer[10157] <Info>: Packages have been authorized for installation.
Sep 27 13:25:41  installer[10157] <Debug>: Will use PK session
Sep 27 13:25:41  installer[10157] <Debug>: Using authorization level of root for IFPKInstallElement
Sep 27 13:25:41  installer[10157] <Info>: Starting installation:
Sep 27 13:25:41  installer[10157] <Notice>: Configuring volume "Macintosh HD"
Sep 27 13:25:41  installer[10157] <Info>: Preparing disk for local booted install.
Sep 27 13:25:41  installer[10157] <Notice>: Free space on "Macintosh HD": 41.12 GB (41115987968 bytes).
Sep 27 13:25:41  installer[10157] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10157ME0hsT"
Sep 27 13:25:41  installer[10157] <Notice>: IFPKInstallElement (1 packages)
Sep 27 13:25:41  installer[10157] <Info>: Current Path: /usr/sbin/installer
Sep 27 13:25:41  installer[10157] <Info>: Current Path: /bin/zsh
Sep 27 13:25:41  installer[10157] <Info>: Current Path: /usr/bin/sudo
Sep 27 13:25:41  installer[10157] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is VeraCrypt 1.26.14
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing VeraCrypt 1.26.14….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#Sep 27 13:25:43  installer[10157] <Info>: PackageKit: Registered bundle file:///Applications/VeraCrypt.app/ for uid 0

installer: Running package scripts….....
installer: Validating packages….....
#Sep 27 13:25:43  installer[10157] <Notice>: Running install actions
Sep 27 13:25:43  installer[10157] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10157ME0hsT"
Sep 27 13:25:43  installer[10157] <Notice>: Finalize disk "Macintosh HD"
Sep 27 13:25:43  installer[10157] <Notice>: Notifying system of updated components
Sep 27 13:25:43  installer[10157] <Notice>:
Sep 27 13:25:43  installer[10157] <Notice>: **** Summary Information ****
Sep 27 13:25:43  installer[10157] <Notice>:   Operation      Elapsed time
Sep 27 13:25:43  installer[10157] <Notice>: -----------------------------
Sep 27 13:25:43  installer[10157] <Notice>:        disk      0.01 seconds
Sep 27 13:25:43  installer[10157] <Notice>:      script      0.00 seconds
Sep 27 13:25:43  installer[10157] <Notice>:        zero      0.01 seconds
Sep 27 13:25:43  installer[10157] <Notice>:     install      2.02 seconds
Sep 27 13:25:43  installer[10157] <Notice>:     -total-      2.04 seconds
Sep 27 13:25:43  installer[10157] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Product archive /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg trustLevel=350
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: External component packages (1) trustLevel=350
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Set authorization level to root for session
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Authorization is being checked, waiting until authorization arrives.
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Administrator authorization granted.
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Packages have been authorized for installation.
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Will use PK session
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Using authorization level of root for IFPKInstallElement
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Starting installation:
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Configuring volume "Macintosh HD"
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Preparing disk for local booted install.
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Free space on "Macintosh HD": 41.12 GB (41115987968 bytes).
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10157ME0hsT"
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: IFPKInstallElement (1 packages)
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Current Path: /usr/sbin/installer
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: Current Path: /usr/bin/sudo
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Adding client PKInstallDaemonClient pid=10157, uid=0 (/usr/sbin/installer)
2024-09-27 13:25:41+02 kryptonit-mac installer[10157]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Set reponsibility for install to 1039
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Hosted team responsibility for install set to team:(Z933746L2S)
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: ----- Begin install -----
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: packages=(
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/01743281-2B3A-4895-9FCE-1E431C6D65A6.activeSandbox
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/1E5D914C-B5CD-428B-976B-E608ACE7970A.activeSandbox
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/922D2D04-6EEB-4C58-AED5-6FD8E68180B1.activeSandbox
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Will do receipt-based obsoleting for package identifier com.idrix.pkg.veracrypt (prefix path=)
2024-09-27 13:25:41+02 kryptonit-mac installd[1106]: PackageKit: Extracting file:///Volumes/VeraCrypt%20for%20OSX/VeraCrypt_Installer.pkg#veracrypt.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/E1C3C0A5-0FBD-47F2-933B-C04E72789452.activeSandbox/Root, uid=0)
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: prevent user idle system sleep
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: suspending backupd
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/E1C3C0A5-0FBD-47F2-933B-C04E72789452.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/E1C3C0A5-0FBD-47F2-933B-C04E72789452.activeSandbox
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/E1C3C0A5-0FBD-47F2-933B-C04E72789452.activeSandbox/Root (1 items) to /
2024-09-27 13:25:42+02 kryptonit-mac install_monitor[10164]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.MzrhUP/Scripts/com.idrix.pkg.veracrypt.QGWyrk
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.MzrhUP/Scripts/com.idrix.pkg.veracrypt.QGWyrk
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: Set responsibility to pid: 1039, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: Hosted team responsibility for script set to team:(Z933746L2S)
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.MzrhUP/Scripts/com.idrix.pkg.veracrypt.QGWyrk
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: PackageKit: Hosted team responsible for script has been cleared.
2024-09-27 13:25:42+02 kryptonit-mac package_script_service[7616]: Responsibility set back to self.
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: Writing receipt for com.idrix.pkg.veracrypt to /
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: No Intel binaries to translate.
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: PackageKit: Touched bundle /Applications/VeraCrypt.app
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: Installed "VeraCrypt 1.26.14" ()
2024-09-27 13:25:42+02 kryptonit-mac installd[1106]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-09-27 13:25:42+02 kryptonit-mac install_monitor[10164]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: releasing backupd
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: allow user idle system sleep
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: ----- End install -----
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: 1.7s elapsed install time
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: Cleared responsibility for install from 10157.
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: Hosted team responsible for install has been cleared.
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: Running idle tasks
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: Done with sandbox removals
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: PackageKit: Registered bundle file:///Applications/VeraCrypt.app/ for uid 0
2024-09-27 13:25:43+02 kryptonit-mac installd[1106]: PackageKit: Removing client PKInstallDaemonClient pid=10157, uid=0 (/usr/sbin/installer)
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: Running install actions
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.10157ME0hsT"
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: Finalize disk "Macintosh HD"
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: Notifying system of updated components
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: **** Summary Information ****
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:   Operation      Elapsed time
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]: -----------------------------
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:        disk      0.01 seconds
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:      script      0.00 seconds
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:        zero      0.01 seconds
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:     install      2.02 seconds
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:     -total-      2.04 seconds
2024-09-27 13:25:43+02 kryptonit-mac installer[10157]:

2024-09-27 13:25:44 : INFO  : veracrypt-fuse-t : Finishing...
2024-09-27 13:25:47 : INFO  : veracrypt-fuse-t : App(s) found: /Applications/VeraCrypt.app
2024-09-27 13:25:47 : INFO  : veracrypt-fuse-t : found app at /Applications/VeraCrypt.app, version 1.26.14, on versionKey CFBundleShortVersionString
2024-09-27 13:25:47 : REQ   : veracrypt-fuse-t : Installed VeraCrypt, version 1.26.14
2024-09-27 13:25:47 : INFO  : veracrypt-fuse-t : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-09-27 13:25:47 : DEBUG : veracrypt-fuse-t : Unmounting /Volumes/VeraCrypt for OSX
2024-09-27 13:25:48 : DEBUG : veracrypt-fuse-t : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-09-27 13:25:48 : DEBUG : veracrypt-fuse-t : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PmqnVI4zHY
2024-09-27 13:25:48 : DEBUG : veracrypt-fuse-t : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PmqnVI4zHY/VeraCrypt_FUSE-T_[0-9.].*\.dmg
2024-09-27 13:25:48 : DEBUG : veracrypt-fuse-t : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PmqnVI4zHY
2024-09-27 13:25:48 : INFO  : veracrypt-fuse-t : Installomator did not close any apps, so no need to reopen any apps.
2024-09-27 13:25:48 : REQ   : veracrypt-fuse-t : All done!
2024-09-27 13:25:48 : REQ   : veracrypt-fuse-t : ################## End Installomator, exit code 0
```