### PR TITLE
new label "chatgpt"

### DIFF
--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -1,0 +1,8 @@
+chatgpt)
+    name="ChatGPT"
+    type="dmg"
+    downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT.dmg"
+    # appNewVersion=""
+    expectedTeamID="2DC432GLL2"
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
2024-09-27 08:18:01 : REQ   : chatgpt : ################## Start Installomator v. 10.7beta, date 2024-09-27
2024-09-27 08:18:01 : INFO  : chatgpt : ################## Version: 10.7beta
2024-09-27 08:18:01 : INFO  : chatgpt : ################## Date: 2024-09-27
2024-09-27 08:18:01 : INFO  : chatgpt : ################## chatgpt
2024-09-27 08:18:01 : DEBUG : chatgpt : DEBUG mode 1 enabled.
2024-09-27 08:18:01 : INFO  : chatgpt : setting variable from argument DEBUG=0
2024-09-27 08:18:01 : DEBUG : chatgpt : name=ChatGPT
2024-09-27 08:18:01 : DEBUG : chatgpt : appName=
2024-09-27 08:18:01 : DEBUG : chatgpt : type=dmg
2024-09-27 08:18:01 : DEBUG : chatgpt : archiveName=
2024-09-27 08:18:01 : DEBUG : chatgpt : downloadURL=https://persistent.oaistatic.com/sidekick/public/ChatGPT.dmg
2024-09-27 08:18:01 : DEBUG : chatgpt : curlOptions=
2024-09-27 08:18:01 : DEBUG : chatgpt : appNewVersion=
2024-09-27 08:18:01 : DEBUG : chatgpt : appCustomVersion function: Not defined
2024-09-27 08:18:01 : DEBUG : chatgpt : versionKey=CFBundleVersion
2024-09-27 08:18:01 : DEBUG : chatgpt : packageID=
2024-09-27 08:18:01 : DEBUG : chatgpt : pkgName=
2024-09-27 08:18:01 : DEBUG : chatgpt : choiceChangesXML=
2024-09-27 08:18:01 : DEBUG : chatgpt : expectedTeamID=2DC432GLL2
2024-09-27 08:18:01 : DEBUG : chatgpt : blockingProcesses=
2024-09-27 08:18:01 : DEBUG : chatgpt : installerTool=
2024-09-27 08:18:01 : DEBUG : chatgpt : CLIInstaller=
2024-09-27 08:18:01 : DEBUG : chatgpt : CLIArguments=
2024-09-27 08:18:01 : DEBUG : chatgpt : updateTool=
2024-09-27 08:18:01 : DEBUG : chatgpt : updateToolArguments=
2024-09-27 08:18:01 : DEBUG : chatgpt : updateToolRunAsCurrentUser=
2024-09-27 08:18:01 : INFO  : chatgpt : BLOCKING_PROCESS_ACTION=tell_user
2024-09-27 08:18:01 : INFO  : chatgpt : NOTIFY=success
2024-09-27 08:18:01 : INFO  : chatgpt : LOGGING=DEBUG
2024-09-27 08:18:01 : INFO  : chatgpt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-27 08:18:01 : INFO  : chatgpt : Label type: dmg
2024-09-27 08:18:01 : INFO  : chatgpt : archiveName: ChatGPT.dmg
2024-09-27 08:18:01 : INFO  : chatgpt : no blocking processes defined, using ChatGPT as default
2024-09-27 08:18:01 : DEBUG : chatgpt : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.89Cteig4NX
2024-09-27 08:18:01 : INFO  : chatgpt : name: ChatGPT, appName: ChatGPT.app
2024-09-27 08:18:01.846 mdfind[17010:304036] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 08:18:01.846 mdfind[17010:304036] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 08:18:01.916 mdfind[17010:304036] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 08:18:02 : INFO  : chatgpt : App(s) found: /Users/robin.johansson/Applications/ChatGPT.app
2024-09-27 08:18:02 : WARN  : chatgpt : could not determine location of ChatGPT.app
2024-09-27 08:18:02 : INFO  : chatgpt : appversion:
2024-09-27 08:18:02 : INFO  : chatgpt : Latest version not specified.
2024-09-27 08:18:02 : REQ   : chatgpt : Downloading https://persistent.oaistatic.com/sidekick/public/ChatGPT.dmg to ChatGPT.dmg
2024-09-27 08:18:02 : DEBUG : chatgpt : No Dialog connection, just download
2024-09-27 08:18:04 : DEBUG : chatgpt : File list: -rw-r--r--  1 root  wheel    61M 27 Sep 08:18 ChatGPT.dmg
2024-09-27 08:18:04 : DEBUG : chatgpt : File type: ChatGPT.dmg: zlib compressed data
2024-09-27 08:18:04 : DEBUG : chatgpt : curl output was:
* Host persistent.oaistatic.com:443 was resolved.
* IPv6: 2606:4700:4400::ac40:9262, 2606:4700:4400::6812:299e
* IPv4: 104.18.41.158, 172.64.146.98
*   Trying 104.18.41.158:443...
* Connected to persistent.oaistatic.com (104.18.41.158) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=persistent.oaistatic.com
*  start date: Aug 23 20:00:58 2024 GMT
*  expire date: Nov 21 20:00:57 2024 GMT
*  subjectAltName: host "persistent.oaistatic.com" matched cert's "persistent.oaistatic.com"
*  issuer: C=US; O=Let's Encrypt; CN=E6
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://persistent.oaistatic.com/sidekick/public/ChatGPT.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: persistent.oaistatic.com]
* [HTTP/2] [1] [:path: /sidekick/public/ChatGPT.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /sidekick/public/ChatGPT.dmg HTTP/2
> Host: persistent.oaistatic.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< date: Fri, 27 Sep 2024 06:18:02 GMT
< content-type: application/x-apple-diskimage
< content-length: 63598779
< cache-control: max-age=300
< content-md5: hgrZD08ldhGLBielgrZEWw==
< last-modified: Tue, 24 Sep 2024 18:00:34 GMT
< etag: 0x8DCDCC2C9F1D5CD
< x-ms-request-id: f684f8a8-201e-0032-78ac-0e567f000000 < x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< access-control-expose-headers: content-length
< access-control-allow-origin: *
< cf-cache-status: HIT
< accept-ranges: bytes
< set-cookie: __cf_bm=o7tjm10w_S8Y74IiVOZ0kagz6B8zg9v_BZLQlo2I7hg-1727417882-1.0.1.1-namWOQB.J1r33xP27fxep2BcLz8hCrc8CzFR_eCer26MYDYqRD9F57geBkw52dY23fCQbN7fUIeSZk2fK2bBgw; path=/; expires=Fri, 27-Sep-24 06:48:02 GMT; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None < strict-transport-security: max-age=31536000; includeSubDomains; preload < x-content-type-options: nosniff
< set-cookie: _cfuvid=XzNUVLWPF1mxIckf94hoC2x4Kjh_kZpxuV1mufjDL4A-1727417882681-0.0.1.1-604800000; path=/; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None < server: cloudflare
< cf-ray: 8c995fc57e2aac1d-GOT
<
{ [1360 bytes data]
* Connection #0 to host persistent.oaistatic.com left intact

2024-09-27 08:18:04 : REQ   : chatgpt : no more blocking processes, continue with update
2024-09-27 08:18:04 : REQ   : chatgpt : Installing ChatGPT
2024-09-27 08:18:04 : INFO  : chatgpt : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.89Cteig4NX/ChatGPT.dmg
2024-09-27 08:18:08 : DEBUG : chatgpt : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $3C32CE83
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $B6532EDD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $BA0E356E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $B4020626
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $BA0E356E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $A82D882B
verified CRC32 $A4ED1E2A
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/ChatGPT Installer

2024-09-27 08:18:08 : INFO  : chatgpt : Mounted: /Volumes/ChatGPT Installer 2024-09-27 08:18:08 : INFO  : chatgpt : Verifying: /Volumes/ChatGPT Installer/ChatGPT.app 2024-09-27 08:18:08 : DEBUG : chatgpt : App size: 142M	/Volumes/ChatGPT Installer/ChatGPT.app 2024-09-27 08:18:09 : DEBUG : chatgpt : Debugging enabled, App Verification output was: /Volumes/ChatGPT Installer/ChatGPT.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: OpenAI, L.L.C. (2DC432GLL2)

2024-09-27 08:18:09 : INFO  : chatgpt : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 ) 2024-09-27 08:18:09 : INFO  : chatgpt : Installing ChatGPT version 1726884870 on versionKey CFBundleVersion. 2024-09-27 08:18:09 : INFO  : chatgpt : App has LSMinimumSystemVersion: 14.0 2024-09-27 08:18:09 : INFO  : chatgpt : Copy /Volumes/ChatGPT Installer/ChatGPT.app to /Applications 2024-09-27 08:18:11 : DEBUG : chatgpt : Debugging enabled, App copy output was: Copying /Volumes/ChatGPT Installer/ChatGPT.app

2024-09-27 08:18:11 : WARN  : chatgpt : Changing owner to robin.johansson 2024-09-27 08:18:11 : INFO  : chatgpt : Finishing... 2024-09-27 08:18:14 : INFO  : chatgpt : App(s) found: /Applications/ChatGPT.app 2024-09-27 08:18:14 : INFO  : chatgpt : found app at /Applications/ChatGPT.app, version 1726884870, on versionKey CFBundleVersion
2024-09-27 08:18:14 : REQ   : chatgpt : Installed ChatGPT, version 1726884870
2024-09-27 08:18:14 : INFO  : chatgpt : notifying
2024-09-27 08:18:14 : DEBUG : chatgpt : Unmounting /Volumes/ChatGPT Installer
2024-09-27 08:18:14 : DEBUG : chatgpt : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-27 08:18:14 : DEBUG : chatgpt : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.89Cteig4NX
2024-09-27 08:18:14 : DEBUG : chatgpt : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.89Cteig4NX/ChatGPT.dmg
2024-09-27 08:18:14 : DEBUG : chatgpt : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.89Cteig4NX
2024-09-27 08:18:14 : INFO  : chatgpt : Installomator did not close any apps, so no need to reopen any apps.
2024-09-27 08:18:14 : REQ   : chatgpt : All done!
2024-09-27 08:18:14 : REQ   : chatgpt : ################## End Installomator, exit code 0