### PR TITLE
Update for ChatGPT Label

### DIFF
--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -1,0 +1,8 @@
+chatgpt)
+	 # ChatGPT Mac client developed by OpenAI for general users offers an intuitive platform for accessing AI-powered assistance and support on macOS devices
+    name="ChatGPT"
+    type="dmg"
+    downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
+    appNewVersion="$(curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xmllint --xpath 'string(//rss/channel/item/title[1])' -)"
+    expectedTeamID="2DC432GLL2"
+    ;;


### PR DESCRIPTION
FYI:

The "appNewVersion" isn't working for me referenced in this pull request https://github.com/Installomator/Installomator/pull/1724 which added the appNewVersion variable. But, was pointed out that terminal error because Installomator sets an xpath variable at the beginning of it's run, based on which OS it's running on. https://github.com/Installomator/Installomator/blob/main/Installomator.sh#L550

```bash
curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xpath '(//rss/channel/item/title)[1]/text()'
Usage:
/usr/bin/xpath [options] -e query [-e query...] [filename...]

If no filenames are given, supply XML on STDIN. You must provide at
least one query. Each supplementary query is done in order, the
previous query giving the context of the next one.

Options:

-q quiet, only output the resulting PATH.
-s suffix, use suffix instead of linefeed.
-p postfix, use prefix instead of nothing.
-n Don't use an external DTD.
```

I believe this error is occurring because macOS uses an older version of xpath that does not support XPath 1.0 syntax with expressions in parentheses (such as (//rss/channel/item/title)[1]). You can resolve this by using an alternative method like xmllint, which is commonly available by default on macOS.

```bash
curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xmllint --xpath 'string(//rss/channel/item/title[1])' -
1.2024.261
```
Here is the output for the updated label with the fix for the "appNewVersion" code...

```bash
sudo Installomator/utils/assemble.sh chatgpt DEBUG=0
2024-09-27 09:37:18 : REQ   : chatgpt : ################## Start Installomator v. 10.7beta, date 2024-09-27
2024-09-27 09:37:18 : INFO  : chatgpt : ################## Version: 10.7beta
2024-09-27 09:37:18 : INFO  : chatgpt : ################## Date: 2024-09-27
2024-09-27 09:37:18 : INFO  : chatgpt : ################## chatgpt
2024-09-27 09:37:18 : DEBUG : chatgpt : DEBUG mode 1 enabled.
2024-09-27 09:37:19 : INFO  : chatgpt : setting variable from argument DEBUG=0
2024-09-27 09:37:19 : DEBUG : chatgpt : name=ChatGPT
2024-09-27 09:37:19 : DEBUG : chatgpt : appName=
2024-09-27 09:37:19 : DEBUG : chatgpt : type=dmg
2024-09-27 09:37:19 : DEBUG : chatgpt : archiveName=
2024-09-27 09:37:19 : DEBUG : chatgpt : downloadURL=https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg
2024-09-27 09:37:19 : DEBUG : chatgpt : curlOptions=
2024-09-27 09:37:19 : DEBUG : chatgpt : appNewVersion=1.2024.261
2024-09-27 09:37:19 : DEBUG : chatgpt : appCustomVersion function: Not defined
2024-09-27 09:37:19 : DEBUG : chatgpt : versionKey=CFBundleShortVersionString
2024-09-27 09:37:19 : DEBUG : chatgpt : packageID=
2024-09-27 09:37:19 : DEBUG : chatgpt : pkgName=
2024-09-27 09:37:19 : DEBUG : chatgpt : choiceChangesXML=
2024-09-27 09:37:19 : DEBUG : chatgpt : expectedTeamID=2DC432GLL2
2024-09-27 09:37:19 : DEBUG : chatgpt : blockingProcesses=
2024-09-27 09:37:19 : DEBUG : chatgpt : installerTool=
2024-09-27 09:37:19 : DEBUG : chatgpt : CLIInstaller=
2024-09-27 09:37:19 : DEBUG : chatgpt : CLIArguments=
2024-09-27 09:37:19 : DEBUG : chatgpt : updateTool=
2024-09-27 09:37:19 : DEBUG : chatgpt : updateToolArguments=
2024-09-27 09:37:19 : DEBUG : chatgpt : updateToolRunAsCurrentUser=
2024-09-27 09:37:19 : INFO  : chatgpt : BLOCKING_PROCESS_ACTION=tell_user
2024-09-27 09:37:19 : INFO  : chatgpt : NOTIFY=success
2024-09-27 09:37:19 : INFO  : chatgpt : LOGGING=DEBUG
2024-09-27 09:37:19 : INFO  : chatgpt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-27 09:37:19 : INFO  : chatgpt : Label type: dmg
2024-09-27 09:37:19 : INFO  : chatgpt : archiveName: ChatGPT.dmg
2024-09-27 09:37:19 : INFO  : chatgpt : no blocking processes defined, using ChatGPT as default
2024-09-27 09:37:19 : DEBUG : chatgpt : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZtgxrIOcT0
2024-09-27 09:37:19 : INFO  : chatgpt : name: ChatGPT, appName: ChatGPT.app
2024-09-27 09:37:19.529 mdfind[64881:9667980] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 09:37:19.529 mdfind[64881:9667980] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 09:37:19.567 mdfind[64881:9667980] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 09:37:19 : WARN  : chatgpt : No previous app found
2024-09-27 09:37:19 : WARN  : chatgpt : could not find ChatGPT.app
2024-09-27 09:37:19 : INFO  : chatgpt : appversion:
2024-09-27 09:37:19 : INFO  : chatgpt : Latest version of ChatGPT is 1.2024.261
2024-09-27 09:37:19 : REQ   : chatgpt : Downloading https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg to ChatGPT.dmg
2024-09-27 09:37:19 : DEBUG : chatgpt : No Dialog connection, just download
2024-09-27 09:37:21 : DEBUG : chatgpt : File list: -rw-r--r--  1 root  wheel    61M Sep 27 09:37 ChatGPT.dmg
2024-09-27 09:37:21 : DEBUG : chatgpt : File type: ChatGPT.dmg: zlib compressed data
2024-09-27 09:37:21 : DEBUG : chatgpt : curl output was:
* Host persistent.oaistatic.com:443 was resolved.
* IPv6: (none)
* IPv4: 172.64.146.98, 104.18.41.158
*   Trying 172.64.146.98:443...
* Connected to persistent.oaistatic.com (172.64.146.98) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2050 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=persistent.oaistatic.com
*  start date: Aug 23 20:00:58 2024 GMT
*  expire date: Nov 21 20:00:57 2024 GMT
*  subjectAltName: host "persistent.oaistatic.com" matched cert's "persistent.oaistatic.com"
*  issuer: C=US; O=Let's Encrypt; CN=E6
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: persistent.oaistatic.com]
* [HTTP/2] [1] [:path: /sidekick/public/ChatGPT_Desktop_public_latest.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /sidekick/public/ChatGPT_Desktop_public_latest.dmg HTTP/2
> Host: persistent.oaistatic.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< date: Fri, 27 Sep 2024 15:37:19 GMT
< content-type: application/x-apple-diskimage
< content-length: 63598779
< cache-control: max-age=300
< content-md5: hgrZD08ldhGLBielgrZEWw==
< last-modified: Tue, 24 Sep 2024 18:00:27 GMT
< etag: 0x8DCDCC2C5BD9C6F
< x-ms-request-id: 947616a8-301e-0005-2dac-0e7cdd000000
< x-ms-version: 2009-09-19
< x-ms-lease-status: unlocked
< x-ms-blob-type: BlockBlob
< access-control-expose-headers: content-length
< access-control-allow-origin: *
< cf-cache-status: REVALIDATED
< accept-ranges: bytes
< set-cookie: __cf_bm=Cn6oxAGqv4VpuUcBa9GXHMAs3LnG8wKzJBNJ4y2sELw-1727451439-1.0.1.1-BVmj2Y83rGWulsXqrgflJvENsUmmCL1QYXNslSRgp7ccZ0FJZybz94nfZ2I9sjhJC6Gyjg8WE1EG.8vJJu6DAQ; path=/; expires=Fri, 27-Sep-24 16:07:19 GMT; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< set-cookie: _cfuvid=EcTvLnn5Ng3pOL0Nc9Id5hzORwrfPBUlHlUz96Rh9n4-1727451439860-0.0.1.1-604800000; path=/; domain=.oaistatic.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8c9c930a2f0d530c-SLC
< alt-svc: h3=":443"; ma=86400
<
{ [1360 bytes data]
* Connection #0 to host persistent.oaistatic.com left intact

2024-09-27 09:37:21 : REQ   : chatgpt : no more blocking processes, continue with update
2024-09-27 09:37:21 : REQ   : chatgpt : Installing ChatGPT
2024-09-27 09:37:21 : INFO  : chatgpt : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZtgxrIOcT0/ChatGPT.dmg
2024-09-27 09:37:23 : DEBUG : chatgpt : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3C32CE83
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B6532EDD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $BA0E356E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $B4020626
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $BA0E356E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $A82D882B
verified   CRC32 $A4ED1E2A
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/ChatGPT Installer

2024-09-27 09:37:23 : INFO  : chatgpt : Mounted: /Volumes/ChatGPT Installer
2024-09-27 09:37:23 : INFO  : chatgpt : Verifying: /Volumes/ChatGPT Installer/ChatGPT.app
2024-09-27 09:37:23 : DEBUG : chatgpt : App size: 142M	/Volumes/ChatGPT Installer/ChatGPT.app
2024-09-27 09:37:24 : DEBUG : chatgpt : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Installer/ChatGPT.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI, L.L.C. (2DC432GLL2)

2024-09-27 09:37:24 : INFO  : chatgpt : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2024-09-27 09:37:24 : INFO  : chatgpt : Installing ChatGPT version 1.2024.261 on versionKey CFBundleShortVersionString.
2024-09-27 09:37:24 : INFO  : chatgpt : App has LSMinimumSystemVersion: 14.0
2024-09-27 09:37:24 : INFO  : chatgpt : Copy /Volumes/ChatGPT Installer/ChatGPT.app to /Applications
2024-09-27 09:37:25 : DEBUG : chatgpt : Debugging enabled, App copy output was:
Copying /Volumes/ChatGPT Installer/ChatGPT.app

2024-09-27 09:37:25 : WARN  : chatgpt : Changing owner to u0105821
2024-09-27 09:37:25 : INFO  : chatgpt : Finishing...
2024-09-27 09:37:28 : INFO  : chatgpt : App(s) found: /Applications/ChatGPT.app
2024-09-27 09:37:29 : INFO  : chatgpt : found app at /Applications/ChatGPT.app, version 1.2024.261, on versionKey CFBundleShortVersionString
2024-09-27 09:37:29 : REQ   : chatgpt : Installed ChatGPT, version 1.2024.261
2024-09-27 09:37:29 : INFO  : chatgpt : notifying
2024-09-27 09:37:29 : DEBUG : chatgpt : Unmounting /Volumes/ChatGPT Installer
2024-09-27 09:37:29 : DEBUG : chatgpt : Debugging enabled, Unmounting output was:
"disk8" ejected.
2024-09-27 09:37:29 : DEBUG : chatgpt : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZtgxrIOcT0
2024-09-27 09:37:30 : DEBUG : chatgpt : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZtgxrIOcT0/ChatGPT.dmg
2024-09-27 09:37:30 : DEBUG : chatgpt : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.ZtgxrIOcT0
2024-09-27 09:37:30 : INFO  : chatgpt : Installomator did not close any apps, so no need to reopen any apps.
2024-09-27 09:37:30 : REQ   : chatgpt : All done!
2024-09-27 09:37:30 : REQ   : chatgpt : ################## End Installomator, exit code 0
```