### PR TITLE
Update Packages label to include appNewVersion variable

### DIFF
--- a/fragments/labels/packages.sh
+++ b/fragments/labels/packages.sh
@@ -1,9 +1,9 @@
-
 packages)
-   #NOTE: Packages is signed but _not_ notarized, so spctl will reject it
-   name="Packages"
-   type="pkgInDmg"
-   pkgName="Install Packages.pkg"
-   downloadURL="http://s.sudre.free.fr/Software/files/Packages.dmg"
-   expectedTeamID="NL5M9E394P"
+    name="Packages"
+    type="pkgInDmg"
+    pkgName="Install Packages.pkg"
+    pkgsDetails="$(curl -fs "http://s.sudre.free.fr/Software/documentation/RemoteVersion.plist")"
+    appNewVersion=$(echo "${pkgsDetails}"| xpath 'string(//dict/string[1])' 2>/dev/null)
+    downloadURL=$(echo "${pkgsDetails}"| xpath 'string(//dict/string[2])' 2>/dev/null)
+    expectedTeamID="NL5M9E394P"
    ;;


### PR DESCRIPTION
```
assemble.sh packages
2024-09-27 17:54:55 : REQ   : packages : ################## Start Installomator v. 10.7beta, date 2024-09-27
2024-09-27 17:54:55 : INFO  : packages : ################## Version: 10.7beta
2024-09-27 17:54:55 : INFO  : packages : ################## Date: 2024-09-27
2024-09-27 17:54:55 : INFO  : packages : ################## packages
2024-09-27 17:54:55 : DEBUG : packages : DEBUG mode 1 enabled.
2024-09-27 17:54:55 : INFO  : packages : SwiftDialog is not installed, clear cmd file var
2024-09-27 17:54:56 : DEBUG : packages : name=Packages
2024-09-27 17:54:56 : DEBUG : packages : appName=
2024-09-27 17:54:56 : DEBUG : packages : type=pkgInDmg
2024-09-27 17:54:56 : DEBUG : packages : archiveName=
2024-09-27 17:54:56 : DEBUG : packages : downloadURL=http://s.sudre.free.fr/Software/files/Packages.dmg
2024-09-27 17:54:56 : DEBUG : packages : curlOptions=
2024-09-27 17:54:56 : DEBUG : packages : appNewVersion=1.2.10
2024-09-27 17:54:56 : DEBUG : packages : appCustomVersion function: Not defined
2024-09-27 17:54:56 : DEBUG : packages : versionKey=CFBundleShortVersionString
2024-09-27 17:54:56 : DEBUG : packages : packageID=
2024-09-27 17:54:56 : DEBUG : packages : pkgName=Install Packages.pkg
2024-09-27 17:54:56 : DEBUG : packages : choiceChangesXML=
2024-09-27 17:54:56 : DEBUG : packages : expectedTeamID=NL5M9E394P
2024-09-27 17:54:56 : DEBUG : packages : blockingProcesses=
2024-09-27 17:54:56 : DEBUG : packages : installerTool=
2024-09-27 17:54:56 : DEBUG : packages : CLIInstaller=
2024-09-27 17:54:56 : DEBUG : packages : CLIArguments=
2024-09-27 17:54:56 : DEBUG : packages : updateTool=
2024-09-27 17:54:56 : DEBUG : packages : updateToolArguments=
2024-09-27 17:54:56 : DEBUG : packages : updateToolRunAsCurrentUser=
2024-09-27 17:54:56 : INFO  : packages : BLOCKING_PROCESS_ACTION=tell_user
2024-09-27 17:54:56 : INFO  : packages : NOTIFY=success
2024-09-27 17:54:56 : INFO  : packages : LOGGING=DEBUG
2024-09-27 17:54:56 : INFO  : packages : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-27 17:54:56 : INFO  : packages : Label type: pkgInDmg
2024-09-27 17:54:56 : INFO  : packages : archiveName: Packages.dmg
2024-09-27 17:54:56 : INFO  : packages : no blocking processes defined, using Packages as default
2024-09-27 17:54:56 : DEBUG : packages : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-27 17:54:56 : INFO  : packages : name: Packages, appName: Packages.app
2024-09-27 17:54:56.658 mdfind[9165:4592473] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 17:54:56.659 mdfind[9165:4592473] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 17:54:56.934 mdfind[9165:4592473] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 17:54:56 : WARN  : packages : No previous app found
2024-09-27 17:54:56 : WARN  : packages : could not find Packages.app
2024-09-27 17:54:56 : INFO  : packages : appversion: 
2024-09-27 17:54:56 : INFO  : packages : Latest version of Packages is 1.2.10
2024-09-27 17:54:57 : REQ   : packages : Downloading http://s.sudre.free.fr/Software/files/Packages.dmg to Packages.dmg
2024-09-27 17:54:57 : DEBUG : packages : No Dialog connection, just download
2024-09-27 17:54:59 : DEBUG : packages : File list: -rw-r--r--  1 gilburns  staff   8.0M Sep 27 17:54 Packages.dmg
2024-09-27 17:54:59 : DEBUG : packages : File type: Packages.dmg: zlib compressed data
2024-09-27 17:54:59 : DEBUG : packages : curl output was:
* Host s.sudre.free.fr:80 was resolved.
* IPv6: (none)
* IPv4: 212.27.63.116
*   Trying 212.27.63.116:80...
* Connected to s.sudre.free.fr (212.27.63.116) port 80
> GET /Software/files/Packages.dmg HTTP/1.1
> Host: s.sudre.free.fr
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Fri, 27 Sep 2024 22:54:55 GMT
< Server: Apache/ProXad [Jan 23 2019 20:05:46]
< Last-Modified: Sat, 23 Sep 2023 20:43:31 GMT
< ETag: "2d84996d8-802681-650f4df3"
< Connection: close
< Accept-Ranges: bytes
< Content-Length: 8398465
< Content-Type: application/x-apple-diskimage
< 
{ [2626 bytes data]
* Closing connection

2024-09-27 17:54:59 : DEBUG : packages : DEBUG mode 1, not checking for blocking processes
2024-09-27 17:54:59 : REQ   : packages : Installing Packages
2024-09-27 17:54:59 : INFO  : packages : Mounting /Users/gilburns/GitHub/Installomator/build/Packages.dmg
2024-09-27 17:55:00 : DEBUG : packages : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $767AD93D
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $DD66DE0F
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $6F4A58A3
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $919D8FD2
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/Packages 1.2.10

2024-09-27 17:55:00 : INFO  : packages : Mounted: /Volumes/Packages 1.2.10
2024-09-27 17:55:00 : INFO  : packages : found pkg: /Volumes/Packages 1.2.10/Install Packages.pkg
2024-09-27 17:55:00 : INFO  : packages : Verifying: /Volumes/Packages 1.2.10/Install Packages.pkg
2024-09-27 17:55:00 : DEBUG : packages : File list: -rw-r--r--  1 gilburns  staff   7.7M Feb  7  2022 /Volumes/Packages 1.2.10/Install Packages.pkg
2024-09-27 17:55:00 : DEBUG : packages : File type: /Volumes/Packages 1.2.10/Install Packages.pkg: xar archive compressed TOC: 6728, SHA-1 checksum
2024-09-27 17:55:00 : DEBUG : packages : spctlOut is /Volumes/Packages 1.2.10/Install Packages.pkg: accepted
2024-09-27 17:55:00 : DEBUG : packages : source=Notarized Developer ID
2024-09-27 17:55:00 : DEBUG : packages : origin=Developer ID Installer: Stephane Sudre (NL5M9E394P)
2024-09-27 17:55:00 : INFO  : packages : Team ID: NL5M9E394P (expected: NL5M9E394P )
2024-09-27 17:55:00 : DEBUG : packages : DEBUG enabled, skipping installation
2024-09-27 17:55:00 : INFO  : packages : Finishing...
2024-09-27 17:55:03 : INFO  : packages : name: Packages, appName: Packages.app
2024-09-27 17:55:03.917 mdfind[9254:4592883] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-27 17:55:03.917 mdfind[9254:4592883] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-27 17:55:04.040 mdfind[9254:4592883] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-27 17:55:04 : WARN  : packages : No previous app found
2024-09-27 17:55:04 : WARN  : packages : could not find Packages.app
2024-09-27 17:55:04 : REQ   : packages : Installed Packages, version 1.2.10
2024-09-27 17:55:04 : INFO  : packages : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-27 17:55:04 : DEBUG : packages : Unmounting /Volumes/Packages 1.2.10
2024-09-27 17:55:04 : DEBUG : packages : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-27 17:55:04 : DEBUG : packages : DEBUG mode 1, not reopening anything
2024-09-27 17:55:04 : REQ   : packages : All done!
2024-09-27 17:55:04 : REQ   : packages : ################## End Installomator, exit code 0 

```