### PR TITLE
Create iZotope Product Portal label

### DIFF
--- a/fragments/labels/izotopeproductportal.sh
+++ b/fragments/labels/izotopeproductportal.sh
@@ -1,0 +1,11 @@
+izotopeproductportal)
+    name="iZotope Product Portal"
+    type="dmg"
+    izotopeDetails="$(curl -fs 'https://productportal.izotope.com/api/productupdate' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 ProductPortal/1.4.8/b28/macOS-x86_64 Safari/537.36')"
+    appNewVersion=$(getJSONValue "${izotopeDetails}" "[0].Version")
+    downloadURL=$(getJSONValue "${izotopeDetails}" "[0].OSXDownloadURL")
+    installerTool="Install Product Portal.app"
+    CLIInstaller="Install Product Portal.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=( --mode unattended --disable-components launch_after_install )
+    expectedTeamID="QGULMAPEB2"
+    ;;


### PR DESCRIPTION
```
sudo ./build/Installomator.sh izotopeproductportal DEBUG=0
Password:
2024-09-29 10:51:59 : REQ   : izotopeproductportal : ################## Start Installomator v. 10.7beta, date 2024-09-29
2024-09-29 10:51:59 : INFO  : izotopeproductportal : ################## Version: 10.7beta
2024-09-29 10:51:59 : INFO  : izotopeproductportal : ################## Date: 2024-09-29
2024-09-29 10:51:59 : INFO  : izotopeproductportal : ################## izotopeproductportal
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : DEBUG mode 1 enabled.
2024-09-29 10:51:59 : INFO  : izotopeproductportal : SwiftDialog is not installed, clear cmd file var
2024-09-29 10:51:59 : INFO  : izotopeproductportal : setting variable from argument DEBUG=0
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : name=iZotope Product Portal
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : appName=
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : type=dmg
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : archiveName=
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : downloadURL=https://downloads.izotope.com/product_download/iZotope_Product_Portal_v1_4_8.dmg
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : curlOptions=
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : appNewVersion=1.4.8
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : appCustomVersion function: Not defined
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : versionKey=CFBundleShortVersionString
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : packageID=
2024-09-29 10:51:59 : DEBUG : izotopeproductportal : pkgName=
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : choiceChangesXML=
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : expectedTeamID=QGULMAPEB2
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : blockingProcesses=
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : installerTool=Install Product Portal.app
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : CLIInstaller=Install Product Portal.app/Contents/MacOS/installbuilder.sh
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : CLIArguments=--mode unattended --disable-components launch_after_install
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : updateTool=
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : updateToolArguments=
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : updateToolRunAsCurrentUser=
2024-09-29 10:52:00 : INFO  : izotopeproductportal : BLOCKING_PROCESS_ACTION=tell_user
2024-09-29 10:52:00 : INFO  : izotopeproductportal : NOTIFY=success
2024-09-29 10:52:00 : INFO  : izotopeproductportal : LOGGING=DEBUG
2024-09-29 10:52:00 : INFO  : izotopeproductportal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-29 10:52:00 : INFO  : izotopeproductportal : Label type: dmg
2024-09-29 10:52:00 : INFO  : izotopeproductportal : archiveName: iZotope Product Portal.dmg
2024-09-29 10:52:00 : INFO  : izotopeproductportal : no blocking processes defined, using iZotope Product Portal as default
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8N12nAXpQw
2024-09-29 10:52:00 : INFO  : izotopeproductportal : name: iZotope Product Portal, appName: iZotope Product Portal.app
2024-09-29 10:52:00.268 mdfind[37351:5719224] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-29 10:52:00.269 mdfind[37351:5719224] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-29 10:52:00.373 mdfind[37351:5719224] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-29 10:52:00 : WARN  : izotopeproductportal : No previous app found
2024-09-29 10:52:00 : WARN  : izotopeproductportal : could not find iZotope Product Portal.app
2024-09-29 10:52:00 : INFO  : izotopeproductportal : appversion: 
2024-09-29 10:52:00 : INFO  : izotopeproductportal : Latest version of iZotope Product Portal is 1.4.8
2024-09-29 10:52:00 : REQ   : izotopeproductportal : Downloading https://downloads.izotope.com/product_download/iZotope_Product_Portal_v1_4_8.dmg to iZotope Product Portal.dmg
2024-09-29 10:52:00 : DEBUG : izotopeproductportal : No Dialog connection, just download
2024-09-29 10:52:18 : DEBUG : izotopeproductportal : File list: -rw-r--r--  1 root  wheel   147M Sep 29 10:52 iZotope Product Portal.dmg
2024-09-29 10:52:19 : DEBUG : izotopeproductportal : File type: iZotope Product Portal.dmg: zlib compressed data
2024-09-29 10:52:19 : DEBUG : izotopeproductportal : curl output was:
* Host downloads.izotope.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.220.246.55, 23.220.246.29
*   Trying 23.220.246.55:443...
* Connected to downloads.izotope.com (23.220.246.55) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [29 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2629 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=downloads.izotope.com
*  start date: Sep  4 03:59:41 2024 GMT
*  expire date: Dec  3 03:59:40 2024 GMT
*  subjectAltName: host "downloads.izotope.com" matched cert's "downloads.izotope.com"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.izotope.com/product_download/iZotope_Product_Portal_v1_4_8.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.izotope.com]
* [HTTP/2] [1] [:path: /product_download/iZotope_Product_Portal_v1_4_8.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /product_download/iZotope_Product_Portal_v1_4_8.dmg HTTP/2
> Host: downloads.izotope.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: binary/octet-stream
< x-amz-server-side-encryption: AES256
< x-amz-version-id: xaRrNAH4zTh63HL3ObH442PI_WsEHL.g
< accept-ranges: bytes
< server: AmazonS3
< x-amz-cf-pop: ORD56-P2
< x-amz-cf-id: UfspZ1OxycaKn0BxX_Y-jAI6nWXaeSE-Pccbk91acqcdqTRnhupMVw==
< last-modified: Thu, 20 Jul 2023 19:17:51 GMT
< etag: "dced75e42a7c291fe6a22926f37632f5-19"
< content-length: 153645346
< date: Sun, 29 Sep 2024 15:52:00 GMT
< alt-svc: h3=":443"; ma=93600,h3-29=":443"; ma=93600,h3-Q050=":443"; ma=93600,quic=":443"; ma=93600; v="46,43"
< 
{ [1047 bytes data]
* Connection #0 to host downloads.izotope.com left intact

2024-09-29 10:52:19 : REQ   : izotopeproductportal : no more blocking processes, continue with update
2024-09-29 10:52:19 : REQ   : izotopeproductportal : Installing iZotope Product Portal
2024-09-29 10:52:19 : REQ   : izotopeproductportal : installerTool used: Install Product Portal.app
2024-09-29 10:52:19 : INFO  : izotopeproductportal : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8N12nAXpQw/iZotope Product Portal.dmg
2024-09-29 10:52:22 : DEBUG : izotopeproductportal : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $9F6FF6CB
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D467B302
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9B0E123A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $CE0D0B6A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9B0E123A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $82E86EAD
verified   CRC32 $1EA5E87B
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Product Portal

2024-09-29 10:52:22 : INFO  : izotopeproductportal : Mounted: /Volumes/Product Portal
2024-09-29 10:52:22 : INFO  : izotopeproductportal : Verifying: /Volumes/Product Portal/Install Product Portal.app
2024-09-29 10:52:22 : DEBUG : izotopeproductportal : App size: 148M	/Volumes/Product Portal/Install Product Portal.app
2024-09-29 10:52:22 : DEBUG : izotopeproductportal : Debugging enabled, App Verification output was:
/Volumes/Product Portal/Install Product Portal.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: iZotope, Inc. (QGULMAPEB2)

2024-09-29 10:52:22 : INFO  : izotopeproductportal : Team ID matching: QGULMAPEB2 (expected: QGULMAPEB2 )
2024-09-29 10:52:22 : INFO  : izotopeproductportal : Installing iZotope Product Portal version 1.4.8 on versionKey CFBundleShortVersionString.
2024-09-29 10:52:22 : INFO  : izotopeproductportal : CLIInstaller exists, running installer command /Volumes/Product Portal/Install Product Portal.app/Contents/MacOS/installbuilder.sh --mode unattended --disable-components launch_after_install
2024-09-29 10:52:42 : INFO  : izotopeproductportal : Succesfully ran /Volumes/Product Portal/Install Product Portal.app/Contents/MacOS/installbuilder.sh --mode unattended --disable-components launch_after_install
2024-09-29 10:52:42 : DEBUG : izotopeproductportal : Debugging enabled, update tool output was:
Log

2024-09-29 10:52:42 : INFO  : izotopeproductportal : Finishing...
2024-09-29 10:52:45 : INFO  : izotopeproductportal : name: iZotope Product Portal, appName: Install Product Portal.app
2024-09-29 10:52:45.854 mdfind[37576:5720512] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-29 10:52:45.854 mdfind[37576:5720512] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-29 10:52:45.953 mdfind[37576:5720512] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-29 10:52:45 : INFO  : izotopeproductportal : App(s) found: /Applications/iZotope Product Portal.app
2024-09-29 10:52:46 : INFO  : izotopeproductportal : found app at /Applications/iZotope Product Portal.app, version 1.4.8, on versionKey CFBundleShortVersionString
2024-09-29 10:52:46 : REQ   : izotopeproductportal : Installed iZotope Product Portal, version 1.4.8
2024-09-29 10:52:46 : INFO  : izotopeproductportal : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-29 10:52:46 : DEBUG : izotopeproductportal : Unmounting /Volumes/Product Portal
2024-09-29 10:52:46 : DEBUG : izotopeproductportal : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-09-29 10:52:46 : DEBUG : izotopeproductportal : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8N12nAXpQw
2024-09-29 10:52:46 : DEBUG : izotopeproductportal : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8N12nAXpQw/iZotope Product Portal.dmg
2024-09-29 10:52:46 : DEBUG : izotopeproductportal : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8N12nAXpQw
2024-09-29 10:52:46 : INFO  : izotopeproductportal : Installomator did not close any apps, so no need to reopen any apps.
2024-09-29 10:52:46 : REQ   : izotopeproductportal : All done!
2024-09-29 10:52:46 : REQ   : izotopeproductportal : ################## End Installomator, exit code 0 

```