### PR TITLE
Create Splice label

### DIFF
--- a/fragments/labels/splice.sh
+++ b/fragments/labels/splice.sh
@@ -1,0 +1,12 @@
+splice)
+    name="Splice"
+    type="zip"
+    if [[ "$(arch)" == "arm64" ]]; then
+        appNewVersion=$(getJSONValue "$(curl -fs 'https://api.splice.com/v2/desktop/darwin/stable/latest?v=1.0.0&architecture=arm64')" "name")
+        downloadURL="https://desktop.splice.com/darwin/stable/arm64/Splice.app.zip"
+    else
+        appNewVersion=$(getJSONValue "$(curl -fs 'https://api.splice.com/v2/desktop/darwin/stable/latest?v=1.0.0&architecture=x64')" "name")
+        downloadURL="https://desktop.splice.com/darwin/stable/x64/Splice.app.zip"
+    fi
+    expectedTeamID="9962T6AKMH"
+    ;;


### PR DESCRIPTION
```
assemble.sh splice         
2024-09-29 11:03:03 : REQ   : splice : ################## Start Installomator v. 10.7beta, date 2024-09-29
2024-09-29 11:03:03 : INFO  : splice : ################## Version: 10.7beta
2024-09-29 11:03:03 : INFO  : splice : ################## Date: 2024-09-29
2024-09-29 11:03:03 : INFO  : splice : ################## splice
2024-09-29 11:03:03 : DEBUG : splice : DEBUG mode 1 enabled.
2024-09-29 11:03:04 : INFO  : splice : SwiftDialog is not installed, clear cmd file var
2024-09-29 11:03:04 : DEBUG : splice : name=Splice
2024-09-29 11:03:04 : DEBUG : splice : appName=
2024-09-29 11:03:04 : DEBUG : splice : type=zip
2024-09-29 11:03:04 : DEBUG : splice : archiveName=
2024-09-29 11:03:04 : DEBUG : splice : downloadURL=https://desktop.splice.com/darwin/stable/x64/Splice.app.zip
2024-09-29 11:03:04 : DEBUG : splice : curlOptions=
2024-09-29 11:03:04 : DEBUG : splice : appNewVersion=5.1.5
2024-09-29 11:03:04 : DEBUG : splice : appCustomVersion function: Not defined
2024-09-29 11:03:04 : DEBUG : splice : versionKey=CFBundleShortVersionString
2024-09-29 11:03:04 : DEBUG : splice : packageID=
2024-09-29 11:03:04 : DEBUG : splice : pkgName=
2024-09-29 11:03:04 : DEBUG : splice : choiceChangesXML=
2024-09-29 11:03:04 : DEBUG : splice : expectedTeamID=9962T6AKMH
2024-09-29 11:03:04 : DEBUG : splice : blockingProcesses=
2024-09-29 11:03:04 : DEBUG : splice : installerTool=
2024-09-29 11:03:04 : DEBUG : splice : CLIInstaller=
2024-09-29 11:03:04 : DEBUG : splice : CLIArguments=
2024-09-29 11:03:04 : DEBUG : splice : updateTool=
2024-09-29 11:03:04 : DEBUG : splice : updateToolArguments=
2024-09-29 11:03:04 : DEBUG : splice : updateToolRunAsCurrentUser=
2024-09-29 11:03:04 : INFO  : splice : BLOCKING_PROCESS_ACTION=tell_user
2024-09-29 11:03:04 : INFO  : splice : NOTIFY=success
2024-09-29 11:03:04 : INFO  : splice : LOGGING=DEBUG
2024-09-29 11:03:04 : INFO  : splice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-29 11:03:04 : INFO  : splice : Label type: zip
2024-09-29 11:03:04 : INFO  : splice : archiveName: Splice.zip
2024-09-29 11:03:04 : INFO  : splice : no blocking processes defined, using Splice as default
2024-09-29 11:03:04 : DEBUG : splice : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-29 11:03:04 : INFO  : splice : App(s) found: /Applications/Splice.app
2024-09-29 11:03:04 : INFO  : splice : found app at /Applications/Splice.app, version 5.1.5, on versionKey CFBundleShortVersionString
2024-09-29 11:03:04 : INFO  : splice : appversion: 5.1.5
2024-09-29 11:03:04 : INFO  : splice : Latest version of Splice is 5.1.5
2024-09-29 11:03:04 : WARN  : splice : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-09-29 11:03:04 : REQ   : splice : Downloading https://desktop.splice.com/darwin/stable/x64/Splice.app.zip to Splice.zip
2024-09-29 11:03:04 : DEBUG : splice : No Dialog connection, just download
2024-09-29 11:03:18 : DEBUG : splice : File list: -rw-r--r--  1 gilburns  staff   102M Sep 29 11:03 Splice.zip
2024-09-29 11:03:18 : DEBUG : splice : File type: Splice.zip: Zip archive data, at least v1.0 to extract, compression method=store
2024-09-29 11:03:18 : DEBUG : splice : curl output was:
* Host desktop.splice.com:443 was resolved.
* IPv6: 2606:4700::6810:416, 2606:4700::6810:516
* IPv4: 104.16.5.22, 104.16.4.22
*   Trying 104.16.5.22:443...
* Connected to desktop.splice.com (104.16.5.22) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2543 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=splice.com
*  start date: Sep  6 18:55:40 2024 GMT
*  expire date: Dec  5 19:55:38 2024 GMT
*  subjectAltName: host "desktop.splice.com" matched cert's "*.splice.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://desktop.splice.com/darwin/stable/x64/Splice.app.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: desktop.splice.com]
* [HTTP/2] [1] [:path: /darwin/stable/x64/Splice.app.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /darwin/stable/x64/Splice.app.zip HTTP/2
> Host: desktop.splice.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Sun, 29 Sep 2024 16:03:05 GMT
< content-type: binary/octet-stream
< content-length: 106978408
< x-amz-id-2: 3miDGiGEDQuCqHTXNrlf7uS5JeOIH0gCa+85GYqGD3rG2Bum+FhLxDHpzXIFd7f2PL7jKY1tKPVUvVqLuFFpCw==
< x-amz-request-id: 1YYH0EAAA5SAM31B
< last-modified: Thu, 26 Sep 2024 15:56:47 GMT
< etag: "9a88cdae9a9ac494d52e40b210c683c3-21"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: MTSo9j8FGymm7wIjE1s6E192_MQeP1FC
< cf-cache-status: HIT
< age: 1494
< expires: Mon, 07 Oct 2024 16:03:05 GMT
< cache-control: public, max-age=691200
< accept-ranges: bytes
< set-cookie: __cf_bm=m0IB1ItMg99leBxBayFXJ7_luXBGUNJ53uRRk_twgjA-1727625785-1.0.1.1-t75lDgIRI56FkXk779XdRGLWa9TAYobaSAG5OsOSdz9wpJk67IxezURC3g8_f0aSRVGFrmIIJn_B7m4M4nRmgKbr5oMnfWWPRbYvxhfocjU; path=/; expires=Sun, 29-Sep-24 16:33:05 GMT; domain=.splice.com; HttpOnly; Secure; SameSite=None
< set-cookie: _cfuvid=B0xyIFpr3ZysaVrdYSCGHOmDSfA7ZRLJi4M3x8VpvN0-1727625785217-0.0.1.1-604800000; path=/; domain=.splice.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8cad33857c591121-ORD
< 
{ [1360 bytes data]
* Connection #0 to host desktop.splice.com left intact

2024-09-29 11:03:18 : DEBUG : splice : DEBUG mode 1, not checking for blocking processes
2024-09-29 11:03:18 : REQ   : splice : Installing Splice
2024-09-29 11:03:18 : INFO  : splice : Unzipping Splice.zip
2024-09-29 11:03:20 : INFO  : splice : Verifying: /Users/gilburns/GitHub/Installomator/build/Splice.app
2024-09-29 11:03:20 : DEBUG : splice : App size: 248M	/Users/gilburns/GitHub/Installomator/build/Splice.app
2024-09-29 11:03:21 : DEBUG : splice : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/Splice.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Distributed Creation Inc (9962T6AKMH)

2024-09-29 11:03:21 : INFO  : splice : Team ID matching: 9962T6AKMH (expected: 9962T6AKMH )
2024-09-29 11:03:21 : INFO  : splice : Downloaded version of Splice is 5.1.5 on versionKey CFBundleShortVersionString, same as installed.
2024-09-29 11:03:21 : DEBUG : splice : DEBUG mode 1, not reopening anything
2024-09-29 11:03:21 : REG   : splice : No new version to install
2024-09-29 11:03:21 : REQ   : splice : ################## End Installomator, exit code 0 

```