### PR TITLE
Create OrbStack label

### DIFF
--- a/fragments/labels/orbstack.sh
+++ b/fragments/labels/orbstack.sh
@@ -1,0 +1,11 @@
+orbstack)
+    name="OrbStack"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://orbstack.dev/download/stable/latest/arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://orbstack.dev/download/stable/latest/amd64"
+    fi
+    appNewVersion="$(curl -fsIL "${downloadURL}" | grep -i ^location | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' | head -1)"
+    expectedTeamID="HUAQ24HBR6"
+    ;;


### PR DESCRIPTION
```
assemble.sh orbstack
2024-09-30 09:42:46 : REQ   : orbstack : ################## Start Installomator v. 10.7beta, date 2024-09-30
2024-09-30 09:42:46 : INFO  : orbstack : ################## Version: 10.7beta
2024-09-30 09:42:46 : INFO  : orbstack : ################## Date: 2024-09-30
2024-09-30 09:42:46 : INFO  : orbstack : ################## orbstack
2024-09-30 09:42:46 : DEBUG : orbstack : DEBUG mode 1 enabled.
2024-09-30 09:42:46 : INFO  : orbstack : SwiftDialog is not installed, clear cmd file var
2024-09-30 09:42:47 : DEBUG : orbstack : name=OrbStack
2024-09-30 09:42:47 : DEBUG : orbstack : appName=
2024-09-30 09:42:47 : DEBUG : orbstack : type=dmg
2024-09-30 09:42:47 : DEBUG : orbstack : archiveName=
2024-09-30 09:42:47 : DEBUG : orbstack : downloadURL=https://orbstack.dev/download/stable/latest/amd64
2024-09-30 09:42:47 : DEBUG : orbstack : curlOptions=
2024-09-30 09:42:47 : DEBUG : orbstack : appNewVersion=1.7.4
2024-09-30 09:42:47 : DEBUG : orbstack : appCustomVersion function: Not defined
2024-09-30 09:42:47 : DEBUG : orbstack : versionKey=CFBundleShortVersionString
2024-09-30 09:42:47 : DEBUG : orbstack : packageID=
2024-09-30 09:42:47 : DEBUG : orbstack : pkgName=
2024-09-30 09:42:47 : DEBUG : orbstack : choiceChangesXML=
2024-09-30 09:42:47 : DEBUG : orbstack : expectedTeamID=HUAQ24HBR6
2024-09-30 09:42:47 : DEBUG : orbstack : blockingProcesses=
2024-09-30 09:42:47 : DEBUG : orbstack : installerTool=
2024-09-30 09:42:47 : DEBUG : orbstack : CLIInstaller=
2024-09-30 09:42:47 : DEBUG : orbstack : CLIArguments=
2024-09-30 09:42:47 : DEBUG : orbstack : updateTool=
2024-09-30 09:42:47 : DEBUG : orbstack : updateToolArguments=
2024-09-30 09:42:47 : DEBUG : orbstack : updateToolRunAsCurrentUser=
2024-09-30 09:42:47 : INFO  : orbstack : BLOCKING_PROCESS_ACTION=tell_user
2024-09-30 09:42:47 : INFO  : orbstack : NOTIFY=success
2024-09-30 09:42:47 : INFO  : orbstack : LOGGING=DEBUG
2024-09-30 09:42:47 : INFO  : orbstack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-09-30 09:42:47 : INFO  : orbstack : Label type: dmg
2024-09-30 09:42:47 : INFO  : orbstack : archiveName: OrbStack.dmg
2024-09-30 09:42:47 : INFO  : orbstack : no blocking processes defined, using OrbStack as default
2024-09-30 09:42:47 : DEBUG : orbstack : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-09-30 09:42:47 : INFO  : orbstack : name: OrbStack, appName: OrbStack.app
2024-09-30 09:42:47.579 mdfind[52171:6768545] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-30 09:42:47.579 mdfind[52171:6768545] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-30 09:42:47.785 mdfind[52171:6768545] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-30 09:42:47 : WARN  : orbstack : No previous app found
2024-09-30 09:42:47 : WARN  : orbstack : could not find OrbStack.app
2024-09-30 09:42:47 : INFO  : orbstack : appversion: 
2024-09-30 09:42:47 : INFO  : orbstack : Latest version of OrbStack is 1.7.4
2024-09-30 09:42:47 : REQ   : orbstack : Downloading https://orbstack.dev/download/stable/latest/amd64 to OrbStack.dmg
2024-09-30 09:42:47 : DEBUG : orbstack : No Dialog connection, just download
2024-09-30 09:44:03 : DEBUG : orbstack : File list: -rw-r--r--  1 gilburns  staff   442M Sep 30 09:44 OrbStack.dmg
2024-09-30 09:44:03 : DEBUG : orbstack : File type: OrbStack.dmg: lzfse encoded, lzvn compressed
2024-09-30 09:44:03 : DEBUG : orbstack : curl output was:
* Host orbstack.dev:443 was resolved.
* IPv6: (none)
* IPv4: 76.76.21.123, 76.76.21.61
*   Trying 76.76.21.123:443...
* Connected to orbstack.dev (76.76.21.123) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [15 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2567 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=orbstack.dev
*  start date: Aug  2 17:42:27 2024 GMT
*  expire date: Oct 31 17:42:26 2024 GMT
*  subjectAltName: host "orbstack.dev" matched cert's "orbstack.dev"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://orbstack.dev/download/stable/latest/amd64
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: orbstack.dev]
* [HTTP/2] [1] [:path: /download/stable/latest/amd64]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /download/stable/latest/amd64 HTTP/2
> Host: orbstack.dev
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 307 
< access-control-allow-origin: https://docs.orbstack.dev
< cache-control: public, max-age=0, must-revalidate
< content-type: text/plain
< date: Mon, 30 Sep 2024 14:42:48 GMT
< location: https://cdn-updates.orbstack.dev/amd64/OrbStack_v1.7.4_17448_amd64.dmg
< permissions-policy: camera=(), microphone=(), geolocation=(), browsing-topics=()
< referrer-policy: same-origin
< server: Vercel
< strict-transport-security: max-age=63072000
< x-content-type-options: nosniff
< x-dns-prefetch-control: on
< x-frame-options: SAMEORIGIN
< x-vercel-id: cle1::9chzq-1727707368005-ade6b445a8f6
< x-xss-protection: 1; mode=block
< 
* Ignoring the response-body
* Connection #0 to host orbstack.dev left intact
* Issue another request to this URL: 'https://cdn-updates.orbstack.dev/amd64/OrbStack_v1.7.4_17448_amd64.dmg'
* Host cdn-updates.orbstack.dev:443 was resolved.
* IPv6: 2606:4700:20::681a:f93, 2606:4700:20::ac43:4588, 2606:4700:20::681a:e93
* IPv4: 172.67.69.136, 104.26.14.147, 104.26.15.147
*   Trying 172.67.69.136:443...
* Connected to cdn-updates.orbstack.dev (172.67.69.136) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2308 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=Cloudflare, Inc.; CN=cdn-updates.orbstack.dev
*  start date: Jan 15 00:00:00 2024 GMT
*  expire date: Dec 31 23:59:59 2024 GMT
*  subjectAltName: host "cdn-updates.orbstack.dev" matched cert's "cdn-updates.orbstack.dev"
*  issuer: C=US; O=Cloudflare, Inc.; CN=Cloudflare Inc ECC CA-3
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /amd64/OrbStack_v1.7.4_17448_amd64.dmg HTTP/1.1
> Host: cdn-updates.orbstack.dev
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Mon, 30 Sep 2024 14:42:48 GMT
< Content-Type: application/x-apple-diskimage
< Content-Length: 463871869
< Connection: keep-alive
< ETag: "3d5267e26c572bd2a027746c68927f71-89"
< Last-Modified: Tue, 24 Sep 2024 23:02:30 GMT
< Vary: Accept-Encoding
< Cache-Control: max-age=14400
< CF-Cache-Status: HIT
< Age: 2017
< Accept-Ranges: bytes
< Report-To: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=qzFsHp0wnq10WtEhXDcFcYzga%2BwFHoYXKvilnHgcHmIAQzNOO%2F1E4vEXmqs4OkVUJyri9MJPq1HbxL4vlrPQZXmqglZxMhIRq1MEKcXxyQkSzm92Op6NQV52AoVwoUkkYB2j4jB3BNlzDA%3D%3D"}],"group":"cf-nel","max_age":604800}
< NEL: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< Server: cloudflare
< CF-RAY: 8cb4fb4aadf6026c-ORD
< 
{ [631 bytes data]
* Connection #1 to host cdn-updates.orbstack.dev left intact

2024-09-30 09:44:03 : DEBUG : orbstack : DEBUG mode 1, not checking for blocking processes
2024-09-30 09:44:03 : REQ   : orbstack : Installing OrbStack
2024-09-30 09:44:03 : INFO  : orbstack : Mounting /Users/gilburns/GitHub/Installomator/build/OrbStack.dmg
2024-09-30 09:44:07 : DEBUG : orbstack : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $65FDD7AC
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $20DA19C4
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $25D6C656
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $CC7624ED
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $25D6C656
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $7C3F2732
verified   CRC32 $6F1C46DF
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Install OrbStack v1.7.4

2024-09-30 09:44:07 : INFO  : orbstack : Mounted: /Volumes/Install OrbStack v1.7.4
2024-09-30 09:44:07 : INFO  : orbstack : Verifying: /Volumes/Install OrbStack v1.7.4/OrbStack.app
2024-09-30 09:44:07 : DEBUG : orbstack : App size: 693M	/Volumes/Install OrbStack v1.7.4/OrbStack.app
2024-09-30 09:44:13 : DEBUG : orbstack : Debugging enabled, App Verification output was:
/Volumes/Install OrbStack v1.7.4/OrbStack.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Orbital Labs, LLC (U.S.) (HUAQ24HBR6)

2024-09-30 09:44:13 : INFO  : orbstack : Team ID matching: HUAQ24HBR6 (expected: HUAQ24HBR6 )
2024-09-30 09:44:13 : INFO  : orbstack : Installing OrbStack version 1.7.4 on versionKey CFBundleShortVersionString.
2024-09-30 09:44:13 : INFO  : orbstack : App has LSMinimumSystemVersion: 12.3
2024-09-30 09:44:13 : DEBUG : orbstack : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-09-30 09:44:13 : INFO  : orbstack : Finishing...
2024-09-30 09:44:16 : INFO  : orbstack : name: OrbStack, appName: OrbStack.app
2024-09-30 09:44:16.554 mdfind[52265:6769881] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-09-30 09:44:16.554 mdfind[52265:6769881] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-09-30 09:44:16.699 mdfind[52265:6769881] Couldn't determine the mapping between prefab keywords and predicates.
2024-09-30 09:44:16 : WARN  : orbstack : No previous app found
2024-09-30 09:44:16 : WARN  : orbstack : could not find OrbStack.app
2024-09-30 09:44:16 : REQ   : orbstack : Installed OrbStack, version 1.7.4
2024-09-30 09:44:16 : INFO  : orbstack : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-09-30 09:44:16 : DEBUG : orbstack : Unmounting /Volumes/Install OrbStack v1.7.4
2024-09-30 09:44:17 : DEBUG : orbstack : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-09-30 09:44:17 : DEBUG : orbstack : DEBUG mode 1, not reopening anything
2024-09-30 09:44:17 : REQ   : orbstack : All done!
2024-09-30 09:44:17 : REQ   : orbstack : ################## End Installomator, exit code 0 

```