### PR TITLE
Create joplin label

### DIFF
--- a/fragments/labels/joplin.sh
+++ b/fragments/labels/joplin.sh
@@ -1,0 +1,7 @@
+joplin)
+    name="Joplin"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit laurent22 joplin)"
+    appNewVersion="$(versionFromGit laurent22 joplin)"
+    expectedTeamID="A9BXAFS6CT"
+    ;;


### PR DESCRIPTION
sh-3.2# /Users/paul/Documents/GitHub/Installomator/utils/assemble.sh joplin
2024-10-02 13:20:01 : REQ   : joplin : ################## Start Installomator v. 10.7beta, date 2024-10-02
2024-10-02 13:20:01 : INFO  : joplin : ################## Version: 10.7beta
2024-10-02 13:20:01 : INFO  : joplin : ################## Date: 2024-10-02
2024-10-02 13:20:01 : INFO  : joplin : ################## joplin
2024-10-02 13:20:01 : DEBUG : joplin : DEBUG mode 1 enabled.
2024-10-02 13:20:02 : DEBUG : joplin : name=Joplin
2024-10-02 13:20:02 : DEBUG : joplin : appName=
2024-10-02 13:20:02 : DEBUG : joplin : type=dmg
2024-10-02 13:20:02 : DEBUG : joplin : archiveName=
2024-10-02 13:20:02 : DEBUG : joplin : downloadURL=https://github.com/laurent22/joplin/releases/download/v3.0.15/Joplin-3.0.15.dmg
2024-10-02 13:20:02 : DEBUG : joplin : curlOptions=
2024-10-02 13:20:03 : DEBUG : joplin : appNewVersion=3.0.15
2024-10-02 13:20:03 : DEBUG : joplin : appCustomVersion function: Not defined
2024-10-02 13:20:03 : DEBUG : joplin : versionKey=CFBundleShortVersionString
2024-10-02 13:20:03 : DEBUG : joplin : packageID=
2024-10-02 13:20:03 : DEBUG : joplin : pkgName=
2024-10-02 13:20:03 : DEBUG : joplin : choiceChangesXML=
2024-10-02 13:20:03 : DEBUG : joplin : expectedTeamID=A9BXAFS6CT
2024-10-02 13:20:03 : DEBUG : joplin : blockingProcesses=
2024-10-02 13:20:03 : DEBUG : joplin : installerTool=
2024-10-02 13:20:03 : DEBUG : joplin : CLIInstaller=
2024-10-02 13:20:03 : DEBUG : joplin : CLIArguments=
2024-10-02 13:20:03 : DEBUG : joplin : updateTool=
2024-10-02 13:20:03 : DEBUG : joplin : updateToolArguments=
2024-10-02 13:20:03 : DEBUG : joplin : updateToolRunAsCurrentUser=
2024-10-02 13:20:03 : INFO  : joplin : BLOCKING_PROCESS_ACTION=tell_user
2024-10-02 13:20:03 : INFO  : joplin : NOTIFY=success
2024-10-02 13:20:03 : INFO  : joplin : LOGGING=DEBUG
2024-10-02 13:20:03 : INFO  : joplin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-02 13:20:03 : INFO  : joplin : Label type: dmg
2024-10-02 13:20:03 : INFO  : joplin : archiveName: Joplin.dmg
2024-10-02 13:20:03 : INFO  : joplin : no blocking processes defined, using Joplin as default
2024-10-02 13:20:03 : DEBUG : joplin : Changing directory to /Users/paul/Documents/GitHub/Installomator/build
2024-10-02 13:20:03 : INFO  : joplin : name: Joplin, appName: Joplin.app
2024-10-02 13:20:03.536 mdfind[5206:1463684] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-02 13:20:03.536 mdfind[5206:1463684] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-02 13:20:03.590 mdfind[5206:1463684] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-02 13:20:03 : WARN  : joplin : No previous app found
2024-10-02 13:20:03 : WARN  : joplin : could not find Joplin.app
2024-10-02 13:20:03 : INFO  : joplin : appversion:
2024-10-02 13:20:03 : INFO  : joplin : Latest version of Joplin is 3.0.15
2024-10-02 13:20:03 : REQ   : joplin : Downloading https://github.com/laurent22/joplin/releases/download/v3.0.15/Joplin-3.0.15.dmg to Joplin.dmg
2024-10-02 13:20:03 : DEBUG : joplin : No Dialog connection, just download
2024-10-02 13:20:18 : DEBUG : joplin : File list: -rw-r--r--@ 1 root  staff   225M Oct  2 13:20 Joplin.dmg
2024-10-02 13:20:18 : DEBUG : joplin : File type: Joplin.dmg: zlib compressed data
2024-10-02 13:20:18 : DEBUG : joplin : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.121.3
*   Trying 140.82.121.3:443...
* Connected to github.com (140.82.121.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/laurent22/joplin/releases/download/v3.0.15/Joplin-3.0.15.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /laurent22/joplin/releases/download/v3.0.15/Joplin-3.0.15.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /laurent22/joplin/releases/download/v3.0.15/Joplin-3.0.15.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 302
< server: GitHub.com
< date: Wed, 02 Oct 2024 11:20:03 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With < location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/80168ee4-1c25-4f15-b822-8de1cf1c1ad4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241002%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241002T112003Z&X-Amz-Expires=300&X-Amz-Signature=cbe14356093ca4f16f4345904702407440bbbc47c6bc2dd6a2cef1c67a085d23&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DJoplin-3.0.15.dmg&response-content-type=application%2Foctet-stream < cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload < x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/ < content-length: 0
< x-github-request-id: C3DD:358523:8F1FE59:91D7EBF:66FD2C63 <
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/80168ee4-1c25-4f15-b822-8de1cf1c1ad4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241002%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241002T112003Z&X-Amz-Expires=300&X-Amz-Signature=cbe14356093ca4f16f4345904702407440bbbc47c6bc2dd6a2cef1c67a085d23&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DJoplin-3.0.15.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.109.133, 185.199.111.133, 185.199.110.133, 185.199.108.133
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/79162682/80168ee4-1c25-4f15-b822-8de1cf1c1ad4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241002%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241002T112003Z&X-Amz-Expires=300&X-Amz-Signature=cbe14356093ca4f16f4345904702407440bbbc47c6bc2dd6a2cef1c67a085d23&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DJoplin-3.0.15.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/79162682/80168ee4-1c25-4f15-b822-8de1cf1c1ad4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241002%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241002T112003Z&X-Amz-Expires=300&X-Amz-Signature=cbe14356093ca4f16f4345904702407440bbbc47c6bc2dd6a2cef1c67a085d23&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DJoplin-3.0.15.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/79162682/80168ee4-1c25-4f15-b822-8de1cf1c1ad4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241002%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241002T112003Z&X-Amz-Expires=300&X-Amz-Signature=cbe14356093ca4f16f4345904702407440bbbc47c6bc2dd6a2cef1c67a085d23&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DJoplin-3.0.15.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: application/octet-stream
< last-modified: Wed, 21 Aug 2024 08:54:33 GMT
< etag: "0x8DCC1BEE08CBB99"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0 < x-ms-request-id: 68d7b7ef-201e-002d-261e-135226000000 < x-ms-version: 2023-11-03
< x-ms-creation-time: Wed, 21 Aug 2024 08:54:33 GMT < x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Joplin-3.0.15.dmg < x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 340
< date: Wed, 02 Oct 2024 11:20:04 GMT
< x-served-by: cache-iad-kcgs7200124-IAD, cache-fra-etou8220054-FRA < x-cache: HIT, HIT
< x-cache-hits: 9, 0
< x-timer: S1727868004.022921,VS0,VE2
< content-length: 235780290
<
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-10-02 13:20:18 : DEBUG : joplin : DEBUG mode 1, not checking for blocking processes
2024-10-02 13:20:18 : REQ   : joplin : Installing Joplin
2024-10-02 13:20:18 : INFO  : joplin : Mounting /Users/paul/Documents/GitHub/Installomator/build/Joplin.dmg
2024-10-02 13:20:22 : DEBUG : joplin : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0C2FF44C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1BDD5771
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $932F7323
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $0FCC6496
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $932F7323
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $B7B5B0C8
verified   CRC32 $016E7F83
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Joplin 3.0.15

2024-10-02 13:20:22 : INFO  : joplin : Mounted: /Volumes/Joplin 3.0.15 2024-10-02 13:20:22 : INFO  : joplin : Verifying: /Volumes/Joplin 3.0.15/Joplin.app 2024-10-02 13:20:22 : DEBUG : joplin : App size: 684M	/Volumes/Joplin 3.0.15/Joplin.app 2024-10-02 13:20:24 : DEBUG : joplin : Debugging enabled, App Verification output was: /Volumes/Joplin 3.0.15/Joplin.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Laurent Cozic (A9BXAFS6CT)

2024-10-02 13:20:24 : INFO  : joplin : Team ID matching: A9BXAFS6CT (expected: A9BXAFS6CT ) 2024-10-02 13:20:24 : INFO  : joplin : Installing Joplin version 3.0.15 on versionKey CFBundleShortVersionString. 2024-10-02 13:20:24 : INFO  : joplin : App has LSMinimumSystemVersion: 10.15 2024-10-02 13:20:24 : DEBUG : joplin : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-10-02 13:20:24 : INFO  : joplin : Finishing... 2024-10-02 13:20:27 : INFO  : joplin : name: Joplin, appName: Joplin.app 2024-10-02 13:20:27.901 mdfind[5370:1464470] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-10-02 13:20:27.901 mdfind[5370:1464470] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-10-02 13:20:27.972 mdfind[5370:1464470] Couldn't determine the mapping between prefab keywords and predicates. 2024-10-02 13:20:27 : WARN  : joplin : No previous app found 2024-10-02 13:20:28 : WARN  : joplin : could not find Joplin.app
2024-10-02 13:20:28 : REQ   : joplin : Installed Joplin, version 3.0.15
2024-10-02 13:20:28 : INFO  : joplin : notifying
2024-10-02 13:20:28 : DEBUG : joplin : Unmounting /Volumes/Joplin 3.0.15
2024-10-02 13:20:28 : DEBUG : joplin : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-10-02 13:20:28 : DEBUG : joplin : DEBUG mode 1, not reopening anything
2024-10-02 13:20:28 : REQ   : joplin : All done!
2024-10-02 13:20:28 : REQ   : joplin : ################## End Installomator, exit code 0