### PR TITLE
Fix downloadURL empty for sketchupviewer.sh #1779

### DIFF
--- a/fragments/labels/sketchupviewer.sh
+++ b/fragments/labels/sketchupviewer.sh
@@ -1,6 +1,6 @@
 sketchupviewer)
     name="SketchUpViewer"
     type="dmg"
-    downloadURL="$(curl -fs https://www.sketchup.com/sketchup/SketchUpViewer-en-dmg | grep "<a href=" | sed 's/.*href="//' | sed 's/".*//')"
+    downloadURL="$(curl -fs https://www.sketchup.com/sketchup/SketchUpViewer-en-dmg | awk -F' ' '{ print $3 }')"
     expectedTeamID="J8PVMCY7KL"
     ;;


### PR DESCRIPTION
Closes: #1779 