### PR TITLE
Create foxitpdfreader.sh Label

### DIFF
--- a/fragments/labels/foxitpdfreader.sh
+++ b/fragments/labels/foxitpdfreader.sh
@@ -3,7 +3,8 @@ foxitpdfreader)
     type="pkg"
     #the packageID versioning seems to be in line with Foxit PDF Editor and does not reflect the installed versionNumber
     #packageID="com.foxit.pkg.pdfreader"
-    downloadURL="https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Mac-OS-X&version=&package_type=&distID="
-    appNewVersion="$(curl -fsL "https://www.foxit.com/pdf-reader/version-history.html" | grep -m 1 "name=\"Version" | awk -F "Version_" '{ print $2 }' | awk -F "\"" '{ print $1 }')"
+    downloadURL=$(curl -fsIL "https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Mac-OS-X&version=&package_type=&language=English&distID=" | grep location | cut -d \  -f 2)
+    appNewVersion=$(curl -fsSL "https://www.foxit.com/pdf-editor/version-history.html" | awk '/<div class="tab-product hide" id="tab-editor-suite-mac">/,/<\/div>/' | sed -n 's/.*<h3>Version \([0-9.]*\)<\/h3>.*/\1/p' | head -n 1) 
     expectedTeamID="8GN47HTP75"
+    blockingProcesses=( "Foxit PDF Reader" "FoxitPDFReaderUpdateService" )
     ;;

--- a/fragments/labels/foxitpdfreader.sh
+++ b/fragments/labels/foxitpdfreader.sh
@@ -1,0 +1,9 @@
+foxitpdfreader)
+    name="Foxit PDF Reader"
+    type="pkg"
+    #the packageID versioning seems to be in line with Foxit PDF Editor and does not reflect the installed versionNumber
+    #packageID="com.foxit.pkg.pdfreader"
+    downloadURL="https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Mac-OS-X&version=&package_type=&distID="
+    appNewVersion="$(curl -fsL "https://www.foxit.com/pdf-reader/version-history.html" | grep -m 1 "name=\"Version" | awk -F "Version_" '{ print $2 }' | awk -F "\"" '{ print $1 }')"
+    expectedTeamID="8GN47HTP75"
+    ;;


### PR DESCRIPTION
Log from installation

Script result: 2024-10-04 13:40:40 : REQ   :  : shifting arguments for Jamf
2024-10-04 13:40:40 : REQ   : foxitpdfreader : ################## Start Installomator v. 10.6, date 2024-08-30
2024-10-04 13:40:40 : INFO  : foxitpdfreader : ################## Version: 10.6
2024-10-04 13:40:40 : INFO  : foxitpdfreader : ################## Date: 2024-08-30
2024-10-04 13:40:40 : INFO  : foxitpdfreader : ################## foxitpdfreader
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument NOTIFY=silent
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument BLOCKING_PROCESS_ACTION=silent_fail
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument LOGO=appstore
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument IGNORE_APP_STORE_APPS=yes
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument REOPEN=yes
2024-10-04 13:40:41 : INFO  : foxitpdfreader : setting variable from argument TRACKINGSTAT=silent
2024-10-04 13:40:41 : INFO  : foxitpdfreader : BLOCKING_PROCESS_ACTION=silent_fail
2024-10-04 13:40:41 : INFO  : foxitpdfreader : NOTIFY=silent
2024-10-04 13:40:41 : INFO  : foxitpdfreader : LOGGING=INFO
2024-10-04 13:40:41 : INFO  : foxitpdfreader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-04 13:40:41 : INFO  : foxitpdfreader : Label type: pkg
2024-10-04 13:40:41 : INFO  : foxitpdfreader : archiveName: Foxit PDF Reader.pkg
2024-10-04 13:40:41 : INFO  : foxitpdfreader : no blocking processes defined, using Foxit PDF Reader as default
2024-10-04 13:40:41 : INFO  : foxitpdfreader : App(s) found: /Applications/Foxit PDF Reader.app
2024-10-04 13:40:41 : INFO  : foxitpdfreader : found app at /Applications/Foxit PDF Reader.app, version 2024.3.0.65538, on versionKey CFBundleShortVersionString
2024-10-04 13:40:41 : INFO  : foxitpdfreader : appversion: 2024.3.0.65538
2024-10-04 13:40:41 : INFO  : foxitpdfreader : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2024-10-04 13:40:41 : INFO  : foxitpdfreader : Latest version of Foxit PDF Reader is 2024.3.0.26795
2024-10-04 13:40:41 : REQ   : foxitpdfreader : Downloading https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Mac-OS-X&version=&package_type=&distID= to Foxit PDF Reader.pkg
2024-10-04 13:41:08 : INFO  : foxitpdfreader : No blockingProcesses found
2024-10-04 13:41:08 : REQ   : foxitpdfreader : no more blocking processes, continue with update
2024-10-04 13:41:08 : REQ   : foxitpdfreader : Installing Foxit PDF Reader
2024-10-04 13:41:08 : INFO  : foxitpdfreader : Verifying: Foxit PDF Reader.pkg
2024-10-04 13:41:09 : INFO  : foxitpdfreader : Team ID: 8GN47HTP75 (expected: 8GN47HTP75 )
2024-10-04 13:41:09 : INFO  : foxitpdfreader : Installing Foxit PDF Reader.pkg to /
2024-10-04 13:41:28 : INFO  : foxitpdfreader : Finishing...
2024-10-04 13:41:31 : INFO  : foxitpdfreader : App(s) found: /Applications/Foxit PDF Reader.app
2024-10-04 13:41:31 : INFO  : foxitpdfreader : found app at /Applications/Foxit PDF Reader.app, version 2024.3.0.65538, on versionKey CFBundleShortVersionString
2024-10-04 13:41:31 : REQ   : foxitpdfreader : Installed Foxit PDF Reader, version 2024.3.0.26795
2024-10-04 13:41:31 : INFO  : foxitpdfreader : Installomator did not close any apps, so no need to reopen any apps.
2024-10-04 13:41:31 : REQ   : foxitpdfreader : All done!
2024-10-04 13:41:32 : REQ   : foxitpdfreader : ################## End Installomator, exit code 0