### PR TITLE
Update expressvpn.sh

### DIFF
--- a/fragments/labels/expressvpn.sh
+++ b/fragments/labels/expressvpn.sh
@@ -4,5 +4,5 @@ expressvpn)
     packageID="com.expressvpn.ExpressVPN"
     downloadURL="https://www.expressvpn.com/clients/latest/mac"
     appNewVersion="$(curl -fsIL https://www.expressvpn.com/clients/latest/mac | grep -i ^location | sed -n -e 's/^\(.*\)\(_release\)\(.*\)$/\3\2\1/p' | sed -n -e 's/^.*mac_//p')"
-    expectedTeamID="VMES9GFUQJ"
+    expectedTeamID="TC292Y5427"
     ;;


### PR DESCRIPTION
ExpressVPN changed team identifier from VMES9GFUQJ to TC292Y5427

Output from new version:
codesign -dv /Applications/ExpressVPN.app
Executable=/Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN
Identifier=com.expressvpn.ExpressVPN
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20500 size=31301 flags=0x10000(runtime) hashes=967+7 location=embedded
Signature size=9086
Timestamp=30 Sep 2024 at 09:55:17
Info.plist entries=39
TeamIdentifier=TC292Y5427
Runtime Version=13.3.0
Sealed Resources version=2 rules=13 files=253
Internal requirements count=1 size=188


Script result: 2024-10-07 09:40:19 : REQ   :  : shifting arguments for Jamf
2024-10-07 09:40:19 : REQ   : expressvpn : ################## Start Installomator v. 10.5, date 2023-10-15
2024-10-07 09:40:19 : INFO  : expressvpn : ################## Version: 10.5
2024-10-07 09:40:19 : INFO  : expressvpn : ################## Date: 2023-10-15
2024-10-07 09:40:19 : INFO  : expressvpn : ################## expressvpn
2024-10-07 09:40:19 : DEBUG : expressvpn : DEBUG mode 1 enabled.
2024-10-07 09:40:20 : INFO  : expressvpn : SwiftDialog is not installed, clear cmd file var
2024-10-07 09:40:20 : INFO  : expressvpn : setting variable from argument DEBUG=0
2024-10-07 09:40:20 : INFO  : expressvpn : setting variable from argument NOTIFY=silent
2024-10-07 09:40:20 : DEBUG : expressvpn : name=ExpressVPN
2024-10-07 09:40:21 : DEBUG : expressvpn : appName=
2024-10-07 09:40:21 : DEBUG : expressvpn : type=pkg
2024-10-07 09:40:21 : DEBUG : expressvpn : archiveName=
2024-10-07 09:40:21 : DEBUG : expressvpn : downloadURL=https://www.expressvpn.com/clients/latest/mac
2024-10-07 09:40:21 : DEBUG : expressvpn : curlOptions=
2024-10-07 09:40:21 : DEBUG : expressvpn : appNewVersion=11.60.0.84830
2024-10-07 09:40:21 : DEBUG : expressvpn : appCustomVersion function: Not defined
2024-10-07 09:40:21 : DEBUG : expressvpn : versionKey=CFBundleShortVersionString
2024-10-07 09:40:21 : DEBUG : expressvpn : packageID=com.expressvpn.ExpressVPN
2024-10-07 09:40:21 : DEBUG : expressvpn : pkgName=
2024-10-07 09:40:21 : DEBUG : expressvpn : choiceChangesXML=
2024-10-07 09:40:21 : DEBUG : expressvpn : expectedTeamID=TC292Y5427
2024-10-07 09:40:21 : DEBUG : expressvpn : blockingProcesses=ExpressVPN
2024-10-07 09:40:21 : DEBUG : expressvpn : installerTool=
2024-10-07 09:40:21 : DEBUG : expressvpn : CLIInstaller=
2024-10-07 09:40:21 : DEBUG : expressvpn : CLIArguments=
2024-10-07 09:40:21 : DEBUG : expressvpn : updateTool=
2024-10-07 09:40:21 : DEBUG : expressvpn : updateToolArguments=
2024-10-07 09:40:21 : DEBUG : expressvpn : updateToolRunAsCurrentUser=
2024-10-07 09:40:21 : INFO  : expressvpn : BLOCKING_PROCESS_ACTION=tell_user
2024-10-07 09:40:21 : INFO  : expressvpn : NOTIFY=silent
2024-10-07 09:40:21 : INFO  : expressvpn : LOGGING=DEBUG
2024-10-07 09:40:21 : INFO  : expressvpn : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-07 09:40:21 : INFO  : expressvpn : Label type: pkg
2024-10-07 09:40:21 : INFO  : expressvpn : archiveName: ExpressVPN.pkg
2024-10-07 09:40:21 : DEBUG : expressvpn : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK
2024-10-07 09:40:22 : INFO  : expressvpn : found packageID com.expressvpn.ExpressVPN installed, version 	<string>11.59.0beta (1234)</string>
2024-10-07 09:40:22 : INFO  : expressvpn : appversion: 	<string>11.59.0beta (1234)</string>
2024-10-07 09:40:22 : INFO  : expressvpn : Latest version of ExpressVPN is 11.60.0.84830
2024-10-07 09:40:22 : REQ   : expressvpn : Downloading https://www.expressvpn.com/clients/latest/mac to ExpressVPN.pkg
2024-10-07 09:40:22 : DEBUG : expressvpn : No Dialog connection, just download
2024-10-07 09:40:26 : DEBUG : expressvpn : File list: -rw-r--r--  1 root  wheel    69M Oct  7 09:40 ExpressVPN.pkg
2024-10-07 09:40:26 : DEBUG : expressvpn : File type: ExpressVPN.pkg: xar archive compressed TOC: 11642, SHA-1 checksum
2024-10-07 09:40:26 : DEBUG : expressvpn : curl output was:
* Host www.expressvpn.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.164.230.58, 3.164.230.95, 3.164.230.16, 3.164.230.83
*   Trying 3.164.230.58:443...
* Connected to www.expressvpn.com (3.164.230.58) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4975 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=expressvpn.com
*  start date: Nov 12 00:00:00 2023 GMT
*  expire date: Dec 11 23:59:59 2024 GMT
*  subjectAltName: host "www.expressvpn.com" matched cert's "www.expressvpn.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.expressvpn.com/clients/latest/mac
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.expressvpn.com]
* [HTTP/2] [1] [:path: /clients/latest/mac]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /clients/latest/mac HTTP/2

> Host: www.expressvpn.com

> User-Agent: curl/8.7.1

> Accept: */*

> 

* Request completely sent off
< HTTP/2 302 

< content-type: text/html; charset=utf-8

< location: https://www.expressvpn.works/clients/mac/expressvpn_mac_11.60.0.84830_release.pkg

< date: Mon, 07 Oct 2024 07:40:22 GMT

< referrer-policy: no-referrer-when-downgrade

< x-frame-options: SAMEORIGIN

< server: nginx

< cache-control: no-cache

< set-cookie: landing_page=https%3A%2F%2Fwww.expressvpn.com%2Fclients%2Flatest%2Fmac; path=/; expires=Tue, 07 Oct 2025 07:40:22 -0000; secure; HttpOnly; SameSite=Lax

< set-cookie: page_type=Legacy; path=/; secure; SameSite=Lax

< set-cookie: xvid=2tlf7826gzc28UU6xvMU64rJI6EiAuenptZe9jzPyYM%3D; path=/; expires=Tue, 07 Oct 2025 07:40:22 -0000; secure; SameSite=Lax

< set-cookie: xvgtm=%7B%22location%22%3A%22SE%22%2C%22logged_in%22%3Afalse%2C%22report_aid_to_ga%22%3Afalse%7D; path=/; secure; SameSite=Lax

< x-request-id: d80b4470-c715-4730-9ec6-8a2a0d758039

< x-runtime: 0.022751

< strict-transport-security: max-age=31536000; includeSubDomains; preload

< x-content-type-options: nosniff

< x-xss-protection: 1; mode=block

< x-cache: Miss from cloudfront

< via: 1.1 1db03b964c596a103fbc1af4b6ebb7c4.cloudfront.net (CloudFront)

< x-amz-cf-pop: ARN53-P1

< x-amz-cf-id: FDgk8m2mr_bsnajS7AGBKUuPBX2anOo9UFKaBf8JIPDXBGjyFI_SFA==

< 

* Ignoring the response-body
* Connection #0 to host www.expressvpn.com left intact
* Issue another request to this URL: 'https://www.expressvpn.works/clients/mac/expressvpn_mac_11.60.0.84830_release.pkg'
* Host www.expressvpn.works:443 was resolved.
* IPv6: (none)
* IPv4: 108.157.229.117, 108.157.229.103, 108.157.229.40, 108.157.229.4
*   Trying 108.157.229.117:443...
* Connected to www.expressvpn.works (108.157.229.117) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4978 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=expressvpn.works
*  start date: Nov 12 00:00:00 2023 GMT
*  expire date: Dec 11 23:59:59 2024 GMT
*  subjectAltName: host "www.expressvpn.works" matched cert's "www.expressvpn.works"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.expressvpn.works/clients/mac/expressvpn_mac_11.60.0.84830_release.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.expressvpn.works]
* [HTTP/2] [1] [:path: /clients/mac/expressvpn_mac_11.60.0.84830_release.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /clients/mac/expressvpn_mac_11.60.0.84830_release.pkg HTTP/2

> Host: www.expressvpn.works

> User-Agent: curl/8.7.1

> Accept: */*

> 

* Request completely sent off
< HTTP/2 200 

< content-type: application/x-newton-compatible-pkg

< content-length: 71900063

< date: Mon, 07 Oct 2024 07:40:23 GMT

< last-modified: Mon, 30 Sep 2024 10:07:15 GMT

< etag: "add14728c536ad0c35ca5d9d285bede5"

< x-amz-server-side-encryption: AES256

< x-amz-meta-md5: add14728c536ad0c35ca5d9d285bede5

< x-amz-meta-sha256: d332e457b1c2e2f190fad75dbc9c3dce54967d611cc5869e8d89134ea6319f1c

< content-disposition: attachment

< x-amz-version-id: 1Ak0XvctNfKDJFb_0vHS4CmVWIFntSle

< accept-ranges: bytes

< server: AmazonS3

< x-cache: Miss from cloudfront

< via: 1.1 d5d7b369f72f565a0dffcd2db50ec516.cloudfront.net (CloudFront)

< x-amz-cf-pop: ARN56-P2

< x-amz-cf-id: -MuGE78DrLwIBfqc93i8rCtFm1OoatcAybxYuZoDJCorisFqbjxEnQ==

< 

{ [8192 bytes data]
* Connection #1 to host www.expressvpn.works left intact

2024-10-07 09:40:26 : INFO  : expressvpn : found blocking process ExpressVPN
2024-10-07 09:40:26.735 osascript[13627:484366] +[IMKClient subclass]: chose IMKClient_Legacy
2024-10-07 09:40:26.736 osascript[13627:484366] +[IMKInputSession subclass]: chose IMKInputSession_Legacy
2024-10-07 09:42:11 : INFO  : expressvpn : telling app ExpressVPN to quit
2024-10-07 09:42:11 : INFO  : expressvpn : waiting 30 seconds for processes to quit
2024-10-07 09:42:41 : REQ   : expressvpn : no more blocking processes, continue with update
2024-10-07 09:42:41 : REQ   : expressvpn : Installing ExpressVPN
2024-10-07 09:42:41 : INFO  : expressvpn : Verifying: ExpressVPN.pkg
2024-10-07 09:42:41 : DEBUG : expressvpn : File list: -rw-r--r--  1 root  wheel    69M Oct  7 09:40 ExpressVPN.pkg
2024-10-07 09:42:41 : DEBUG : expressvpn : File type: ExpressVPN.pkg: xar archive compressed TOC: 11642, SHA-1 checksum
2024-10-07 09:42:44 : DEBUG : expressvpn : spctlOut is ExpressVPN.pkg: accepted
2024-10-07 09:42:44 : DEBUG : expressvpn : source=Notarized Developer ID
2024-10-07 09:42:44 : DEBUG : expressvpn : origin=Developer ID Installer: Expressco Services, LLC (TC292Y5427)
2024-10-07 09:42:46 : INFO  : expressvpn : Team ID: TC292Y5427 (expected: TC292Y5427 )
2024-10-07 09:42:46 : INFO  : expressvpn : Checking package version.
2024-10-07 09:42:46 : INFO  : expressvpn : Downloaded package com.expressvpn.ExpressVPN version 11.59.0beta (1234)
2024-10-07 09:42:46 : INFO  : expressvpn : Installing ExpressVPN.pkg to /
2024-10-07 09:43:01 : DEBUG : expressvpn : Debugging enabled, installer output was:
Oct  7 09:42:46  installer[13715] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg trustLevel=350
Oct  7 09:42:46  installer[13715] <Debug>: External component packages (1) trustLevel=350
Oct  7 09:42:46  installer[13715] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Oct  7 09:42:46  installer[13715] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg#ExpressVPN.pkg
Oct  7 09:42:46  installer[13715] <Info>: Set authorization level to root for session
Oct  7 09:42:46  installer[13715] <Info>: Authorization is being checked, waiting until authorization arrives.
Oct  7 09:42:46  installer[13715] <Info>: Administrator authorization granted.
Oct  7 09:42:46  installer[13715] <Info>: Packages have been authorized for installation.
Oct  7 09:42:46  installer[13715] <Debug>: Will use PK session
Oct  7 09:42:46  installer[13715] <Debug>: Using authorization level of root for IFPKInstallElement
Oct  7 09:42:46  installer[13715] <Info>: Starting installation:
Oct  7 09:42:46  installer[13715] <Notice>: Configuring volume "Macintosh HD"
Oct  7 09:42:46  installer[13715] <Info>: Preparing disk for local booted install.
Oct  7 09:42:46  installer[13715] <Notice>: Free space on "Macintosh HD": 849.34 GB (849343946752 bytes).
Oct  7 09:42:46  installer[13715] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13715IS6RRu"
Oct  7 09:42:46  installer[13715] <Notice>: IFPKInstallElement (1 packages)
Oct  7 09:42:46  installer[13715] <Info>: Current Path: /usr/sbin/installer
Oct  7 09:42:46  installer[13715] <Info>: Current Path: /bin/zsh
Oct  7 09:42:46  installer[13715] <Info>: Current Path: /bin/bash
Oct  7 09:42:46  installer[13715] <Info>: Current Path: /usr/local/jamf/bin/jamf
Oct  7 09:42:46  installer[13715] <Info>: Current Path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon
Oct  7 09:42:46  installer[13715] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is ExpressVPN
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing ExpressVPN….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
Last Log repeated 6 times
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#
installer: Registering updated components….....
#Oct  7 09:42:58  installer[13715] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN%20Launcher.app/ for uid 0
Oct  7 09:42:58  installer[13715] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN%20IKEv2.app/ for uid 0
Oct  7 09:42:58  installer[13715] <Info>: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/ for uid 0

installer: Registering updated components….....
installer: Validating packages….....
#Oct  7 09:42:59  installer[13715] <Notice>: Running install actions
Oct  7 09:42:59  installer[13715] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13715IS6RRu"
Oct  7 09:42:59  installer[13715] <Notice>: Finalize disk "Macintosh HD"
Oct  7 09:42:59  installer[13715] <Notice>: Notifying system of updated components
Oct  7 09:42:59  installer[13715] <Notice>:
Oct  7 09:42:59  installer[13715] <Notice>: **** Summary Information ****
Oct  7 09:42:59  installer[13715] <Notice>:   Operation      Elapsed time
Oct  7 09:42:59  installer[13715] <Notice>: -----------------------------
Oct  7 09:42:59  installer[13715] <Notice>:        disk      0.00 seconds
Oct  7 09:42:59  installer[13715] <Notice>:      script      0.00 seconds
Oct  7 09:42:59  installer[13715] <Notice>:        zero      0.00 seconds
Oct  7 09:42:59  installer[13715] <Notice>:     install      12.78 seconds
Oct  7 09:42:59  installer[13715] <Notice>:     -total-      12.79 seconds
Oct  7 09:42:59  installer[13715] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg trustLevel=350
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: External component packages (1) trustLevel=350
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg#ExpressVPN.pkg
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Set authorization level to root for session
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Authorization is being checked, waiting until authorization arrives.
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Administrator authorization granted.
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Packages have been authorized for installation.
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Will use PK session
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Using authorization level of root for IFPKInstallElement
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Starting installation:
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Configuring volume "Macintosh HD"
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Preparing disk for local booted install.
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Free space on "Macintosh HD": 849.34 GB (849343946752 bytes).
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13715IS6RRu"
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: IFPKInstallElement (1 packages)
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Current Path: /usr/sbin/installer
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Current Path: /bin/zsh
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Current Path: /bin/bash
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Current Path: /usr/local/jamf/bin/jamf
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: Current Path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon
2024-10-07 09:42:46+02 LTF3G9NQK1 installd[1425]: PackageKit: Adding client PKInstallDaemonClient pid=13715, uid=0 (/usr/sbin/installer)
2024-10-07 09:42:46+02 LTF3G9NQK1 installer[13715]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-10-07 09:42:46+02 LTF3G9NQK1 installd[1425]: PackageKit: Set reponsibility for install to 837
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: Hosted team responsibility for install set to team:(TC292Y5427)
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: ----- Begin install -----
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: packages=(
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: Will do receipt-based obsoleting for package identifier com.expressvpn.ExpressVPN (prefix path=Applications)
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg#ExpressVPN.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/7EDB7952-29A7-4EFB-B3ED-9C07E7102F8D.activeSandbox/Root/Applications, uid=0)
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: prevent user idle system sleep
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit: suspending backupd
2024-10-07 09:42:47+02 LTF3G9NQK1 installd[1425]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:47+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:47+02 LTF3G9NQK1 package_script_service[12764]: Set responsibility to pid: 837, responsible_path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon
2024-10-07 09:42:47+02 LTF3G9NQK1 package_script_service[12764]: Hosted team responsibility for script set to team:(TC292Y5427)
2024-10-07 09:42:47+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:47+02 LTF3G9NQK1 install_monitor[13716]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: Responsibility set back to self.
2024-10-07 09:42:48+02 LTF3G9NQK1 installd[1425]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/7EDB7952-29A7-4EFB-B3ED-9C07E7102F8D.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/7EDB7952-29A7-4EFB-B3ED-9C07E7102F8D.activeSandbox
2024-10-07 09:42:48+02 LTF3G9NQK1 installd[1425]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/7EDB7952-29A7-4EFB-B3ED-9C07E7102F8D.activeSandbox/Root (1 items) to /
2024-10-07 09:42:48+02 LTF3G9NQK1 installd[1425]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: Set responsibility to pid: 837, responsible_path: /Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: Hosted team responsibility for script set to team:(TC292Y5427)
2024-10-07 09:42:48+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.xA8yxX/Scripts/com.expressvpn.ExpressVPN.rML8KE
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: Lightway: 1.47.1
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: library versions:
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall:   Lightway Core: 1.16.7
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall:   WolfSSL: 5.6.6
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall:   Balloon: 1.26.3
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: Copyright (C) 2009-2024 ExpressVPN. All rights reserved.
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: OpenVPN 2.4.7 [git:production/72431482784367ad] aarch64-apple-darwin [SSL (OpenSSL)] [MH/RECVDA] [AEAD] built on Feb  8 2023
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: library versions: OpenSSL 1.1.1t  7 Feb 2023
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: Originally developed by James Yonan
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: Copyright (C) 2002-2018 OpenVPN Inc <sales@openvpn.net>
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: Compile time defines: enable_async_push=no enable_comp_stub=no enable_crypto=yes enable_crypto_ofb_cfb=yes enable_debug=no enable_def_auth=yes enable_dependency_tracking=no enable_dlopen=unknown enable_dlopen_self=unknown enable_dlopen_self_static=unknown enable_fast_install=needless enable_fragment=yes enable_iproute2=no enable_libtool_lock=yes enable_lz4=no enable_lzo=no enable_management=yes enable_multihome=yes enable_pam_dlopen=no enable_pedantic=no enable_pf=no enable_pkcs11=no enable_plugin_auth_pam=no enable_plugin_down_root=no enable_plugins=no enable_port_share=yes enable_selinux=no enable_server=no enable_shared=no enable_shared_with_static_runtimes=no enable_small=no enable_static=yes enable_strict=no enable_strict_options=no enable_systemd=no enable_werror=no enable_win32_dll=yes enable_x509_alt_username=no with_aix_soname=aix with_crypto_library=openssl with_gnu_ld=no with_mem_check=no with_sysroot=no
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: 2024-10-07 09:42:52.659 defaults[13842:486530]
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: The domain/default pair of (com.expressvpn.ExpressVPN, enableXVCA) does not exist
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: 2024-10-07 09:42:52.684 defaults[13844:486536]
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: ./postinstall: The domain/default pair of (com.expressvpn.ExpressVPN, launchOnStartup) does not exist
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-07 09:42:52+02 LTF3G9NQK1 package_script_service[12764]: Responsibility set back to self.
2024-10-07 09:42:52+02 LTF3G9NQK1 installd[1425]: PackageKit: Writing receipt for com.expressvpn.ExpressVPN to /
2024-10-07 09:42:52+02 LTF3G9NQK1 installd[1425]: AOT translation failed for /Applications/ExpressVPN.app/Contents/Resources/ExpressVPNSplitTunnel.kext/Contents/MacOS/ExpressVPNSplitTunnel
2024-10-07 09:42:53+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftAppKit.dylib
2024-10-07 09:42:54+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftCore.dylib
2024-10-07 09:42:54+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftCoreData.dylib
2024-10-07 09:42:54+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftCoreFoundation.dylib
2024-10-07 09:42:54+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftCoreGraphics.dylib
2024-10-07 09:42:55+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftCoreImage.dylib
2024-10-07 09:42:55+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftDarwin.dylib
2024-10-07 09:42:55+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftDispatch.dylib
2024-10-07 09:42:56+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftFoundation.dylib
2024-10-07 09:42:56+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftIOKit.dylib
2024-10-07 09:42:56+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftMetal.dylib
2024-10-07 09:42:57+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftObjectiveC.dylib
2024-10-07 09:42:57+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftQuartzCore.dylib
2024-10-07 09:42:57+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftXPC.dylib
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: oahd translated /Applications/ExpressVPN.app/Contents/Frameworks/libswiftos.dylib
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Translated 16 binaries.
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Touched bundle /Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN Launcher.app
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Touched bundle /Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN IKEv2.app
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Touched bundle /Applications/ExpressVPN.app
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: Installed "ExpressVPN" ()
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-10-07 09:42:58+02 LTF3G9NQK1 install_monitor[13716]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: releasing backupd
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: allow user idle system sleep
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: ----- End install -----
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: 11.6s elapsed install time
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Cleared responsibility for install from 13715.
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Hosted team responsible for install has been cleared.
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Running idle tasks
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Done with sandbox removals
2024-10-07 09:42:58+02 LTF3G9NQK1 installer[13715]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/Library/LoginItems/ExpressVPN%20Launcher.app/ for uid 0
2024-10-07 09:42:58+02 LTF3G9NQK1 installer[13715]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/Contents/MacOS/ExpressVPN%20IKEv2.app/ for uid 0
2024-10-07 09:42:58+02 LTF3G9NQK1 installer[13715]: PackageKit: Registered bundle file:///Applications/ExpressVPN.app/ for uid 0
2024-10-07 09:42:58+02 LTF3G9NQK1 installd[1425]: PackageKit: Removing client PKInstallDaemonClient pid=13715, uid=0 (/usr/sbin/installer)
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: Running install actions
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.13715IS6RRu"
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: Finalize disk "Macintosh HD"
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: Notifying system of updated components
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: **** Summary Information ****
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:   Operation      Elapsed time
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]: -----------------------------
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:        disk      0.00 seconds
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:      script      0.00 seconds
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:        zero      0.00 seconds
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:     install      12.78 seconds
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:     -total-      12.79 seconds
2024-10-07 09:42:59+02 LTF3G9NQK1 installer[13715]:

2024-10-07 09:43:01 : INFO  : expressvpn : Finishing...
2024-10-07 09:43:04 : INFO  : expressvpn : found packageID com.expressvpn.ExpressVPN installed, version 	<string>11.59.0beta (1234)</string>
2024-10-07 09:43:04 : REQ   : expressvpn : Installed ExpressVPN, version 11.59.0beta (1234)
2024-10-07 09:43:04 : DEBUG : expressvpn : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK
2024-10-07 09:43:04 : DEBUG : expressvpn : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK/ExpressVPN.pkg
2024-10-07 09:43:04 : DEBUG : expressvpn : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AS4C02o4cK
2024-10-07 09:43:04 : INFO  : expressvpn : Telling app ExpressVPN.app to open
2024-10-07 09:43:04 : INFO  : expressvpn : Reopened ExpressVPN.app as user
2024-10-07 09:43:04 : INFO  : expressvpn : root
2024-10-07 09:43:04 : REQ   : expressvpn : All done!
2024-10-07 09:43:04 : REQ   : expressvpn : ################## End Installomator, exit code 0 