### PR TITLE
Update for ARM and INTEL installations

### DIFF
--- a/fragments/labels/mongodbcompass.sh
+++ b/fragments/labels/mongodbcompass.sh
@@ -1,7 +1,11 @@
 mongodbcompass)
     name="MongoDB Compass"
     type="dmg"
-    archiveName="mongodb-compass-[0-9.]*-darwin-x64.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="mongodb-compass-[0-9.]*-darwin-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="mongodb-compass-[0-9.]*-darwin-x64.dmg"
+    fi
     downloadURL="$(downloadURLFromGit mongodb-js compass)"
     appNewVersion="$(versionFromGit mongodb-js compass)"
     expectedTeamID="4XWMY46275"


### PR DESCRIPTION
Current mongodbcompass label is Intel only. Updated to ARM and INTEL versions.

First commit. Please be gentle.


Current mongodbcompass label is Intel only. Updated to ARM and INTEL versions.

First commit. Please be gentle.

2024-10-09 20:39:43 : REQ   : mongodbcompass : ################## Start Installomator v. 10.7beta, date 2024-10-09
2024-10-09 20:39:43 : INFO  : mongodbcompass : ################## Version: 10.7beta
2024-10-09 20:39:43 : INFO  : mongodbcompass : ################## Date: 2024-10-09
2024-10-09 20:39:43 : INFO  : mongodbcompass : ################## mongodbcompass
2024-10-09 20:39:43 : DEBUG : mongodbcompass : DEBUG mode 1 enabled.
2024-10-09 20:39:45 : DEBUG : mongodbcompass : name=MongoDB Compass
2024-10-09 20:39:45 : DEBUG : mongodbcompass : appName=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : type=dmg
2024-10-09 20:39:45 : DEBUG : mongodbcompass : archiveName=mongodb-compass-[0-9.]*-darwin-arm64.dmg
2024-10-09 20:39:45 : DEBUG : mongodbcompass : downloadURL=https://github.com/mongodb-js/compass/releases/download/v1.44.4/mongodb-compass-1.44.4-darwin-arm64.dmg
2024-10-09 20:39:45 : DEBUG : mongodbcompass : curlOptions=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : appNewVersion=1.44.4
2024-10-09 20:39:45 : DEBUG : mongodbcompass : appCustomVersion function: Not defined
2024-10-09 20:39:45 : DEBUG : mongodbcompass : versionKey=CFBundleShortVersionString
2024-10-09 20:39:45 : DEBUG : mongodbcompass : packageID=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : pkgName=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : choiceChangesXML=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : expectedTeamID=4XWMY46275
2024-10-09 20:39:45 : DEBUG : mongodbcompass : blockingProcesses=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : installerTool=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : CLIInstaller=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : CLIArguments=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : updateTool=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : updateToolArguments=
2024-10-09 20:39:45 : DEBUG : mongodbcompass : updateToolRunAsCurrentUser=
2024-10-09 20:39:45 : INFO  : mongodbcompass : BLOCKING_PROCESS_ACTION=tell_user
2024-10-09 20:39:45 : INFO  : mongodbcompass : NOTIFY=success
2024-10-09 20:39:45 : INFO  : mongodbcompass : LOGGING=DEBUG
2024-10-09 20:39:45 : INFO  : mongodbcompass : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-09 20:39:45 : INFO  : mongodbcompass : Label type: dmg
2024-10-09 20:39:45 : INFO  : mongodbcompass : archiveName: mongodb-compass-[0-9.]*-darwin-arm64.dmg
2024-10-09 20:39:45 : INFO  : mongodbcompass : no blocking processes defined, using MongoDB Compass as default
2024-10-09 20:39:45 : DEBUG : mongodbcompass : Changing directory to /Users/mark.kenny/Git/Installomator/build
2024-10-09 20:39:45 : INFO  : mongodbcompass : name: MongoDB Compass, appName: MongoDB Compass.app
2024-10-09 20:39:45.577 mdfind[55350:1028807] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-09 20:39:45.577 mdfind[55350:1028807] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-09 20:39:45.616 mdfind[55350:1028807] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-09 20:39:45 : WARN  : mongodbcompass : No previous app found
2024-10-09 20:39:45 : WARN  : mongodbcompass : could not find MongoDB Compass.app
2024-10-09 20:39:45 : INFO  : mongodbcompass : appversion:
2024-10-09 20:39:45 : INFO  : mongodbcompass : Latest version of MongoDB Compass is 1.44.4
2024-10-09 20:39:45 : REQ   : mongodbcompass : Downloading https://github.com/mongodb-js/compass/releases/download/v1.44.4/mongodb-compass-1.44.4-darwin-arm64.dmg to mongodb-compass-[0-9.]*-darwin-arm64.dmg
2024-10-09 20:39:45 : DEBUG : mongodbcompass : No Dialog connection, just download
2024-10-09 20:39:47 : DEBUG : mongodbcompass : File list: -rw-r--r--  1 mark.kenny  staff   139M Oct  9 20:39 mongodb-compass-[0-9.]*-darwin-arm64.dmg
2024-10-09 20:39:47 : DEBUG : mongodbcompass : File type: mongodb-compass-[0-9.]*-darwin-arm64.dmg: zlib compressed data
2024-10-09 20:39:47 : DEBUG : mongodbcompass : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)




2024-10-09 20:39:47 : DEBUG : mongodbcompass : DEBUG mode 1, not checking for blocking processes
2024-10-09 20:39:47 : REQ   : mongodbcompass : Installing MongoDB Compass
2024-10-09 20:39:47 : INFO  : mongodbcompass : Mounting /Users/mark.kenny/Git/Installomator/build/mongodb-compass-[0-9.]*-darwin-arm64.dmg
2024-10-09 20:40:01 : DEBUG : mongodbcompass : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3F8C8379
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7E9D8CC8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $C9023727
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $EB68593D
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $C9023727
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $1BA4B098
verified   CRC32 $34684827
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_HFS                       /Volumes/MongoDB Compass

2024-10-09 20:40:01 : INFO  : mongodbcompass : Mounted: /Volumes/MongoDB Compass 2024-10-09 20:40:01 : INFO  : mongodbcompass : Verifying: /Volumes/MongoDB Compass/MongoDB Compass.app
2024-10-09 20:40:01 : DEBUG : mongodbcompass : App size: 387M   /Volumes/MongoDB Compass/MongoDB Compass.app
2024-10-09 20:40:03 : DEBUG : mongodbcompass : Debugging enabled, App Verification output was:
/Volumes/MongoDB Compass/MongoDB Compass.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: MongoDB, Inc. (4XWMY46275)

2024-10-09 20:40:03 : INFO  : mongodbcompass : Team ID matching: 4XWMY46275 (expected: 4XWMY46275 ) 2024-10-09 20:40:03 : INFO  : mongodbcompass : Installing MongoDB Compass version 1.44.4 on versionKey CFBundleShortVersionString. 2024-10-09 20:40:03 : INFO  : mongodbcompass : App has LSMinimumSystemVersion: 10.15 2024-10-09 20:40:03 : DEBUG : mongodbcompass : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2024-10-09 20:40:03 : INFO  : mongodbcompass : Finishing... 2024-10-09 20:40:06 : INFO  : mongodbcompass : name: MongoDB Compass, appName: MongoDB Compass.app 2024-10-09 20:40:06.399 mdfind[55455:1029838] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2024-10-09 20:40:06.400 mdfind[55455:1029838] [UserQueryParser] Loading keywords and predicates for locale "en" 2024-10-09 20:40:06.450 mdfind[55455:1029838] Couldn't determine the mapping between prefab keywords and predicates. 2024-10-09 20:40:06 : WARN  : mongodbcompass : No previous app found 2024-10-09 20:40:06 : WARN  : mongodbcompass : could not find MongoDB Compass.app
2024-10-09 20:40:06 : REQ   : mongodbcompass : Installed MongoDB Compass, version 1.44.4
2024-10-09 20:40:06 : INFO  : mongodbcompass : notifying
2024-10-09 20:40:06 : DEBUG : mongodbcompass : Unmounting /Volumes/MongoDB Compass
2024-10-09 20:40:07 : DEBUG : mongodbcompass : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-10-09 20:40:07 : DEBUG : mongodbcompass : DEBUG mode 1, not reopening anything
2024-10-09 20:40:07 : REQ   : mongodbcompass : All done!
2024-10-09 20:40:07 : REQ   : mongodbcompass : ################## End Installomator, exit code 0