### PR TITLE
Create Cherry Audio Atomika label

### DIFF
--- a/fragments/labels/cherryaudioatomika.sh
+++ b/fragments/labels/cherryaudioatomika.sh
@@ -1,0 +1,8 @@
+cherryaudioatomika)
+    name="Atomika"
+    type="pkg"
+    packageID="com.cherryaudio.pkg.AtomikaPackage-StandAlone"
+    appNewVersion="$(curl -fs https://cherryaudio.com/products/atomika-synthesizer/version-history | grep -A 6 "info" | grep -Eo "([0-9]+(\.[0-9]+)+)" | head -1 | xargs)"
+    downloadURL="https://store.cherryaudio.com/downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg"
+    expectedTeamID="A2XFV22B2X"
+    ;;


### PR DESCRIPTION
```
assemble.sh cherryaudioatomika
2024-10-12 09:47:06 : REQ   : cherryaudioatomika : ################## Start Installomator v. 10.7beta, date 2024-10-12
2024-10-12 09:47:06 : INFO  : cherryaudioatomika : ################## Version: 10.7beta
2024-10-12 09:47:06 : INFO  : cherryaudioatomika : ################## Date: 2024-10-12
2024-10-12 09:47:06 : INFO  : cherryaudioatomika : ################## cherryaudioatomika
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : DEBUG mode 1 enabled.
2024-10-12 09:47:07 : INFO  : cherryaudioatomika : SwiftDialog is not installed, clear cmd file var
2024-10-12 09:47:07 : INFO  : cherryaudioatomika : setting variable from argument DEBUG=0
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : name=Atomika
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : appName=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : type=pkg
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : archiveName=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : downloadURL=https://store.cherryaudio.com/downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : curlOptions=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : appNewVersion=1.0.3
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : appCustomVersion function: Not defined
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : versionKey=CFBundleShortVersionString
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : packageID=com.cherryaudio.pkg.AtomikaPackage-StandAlone
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : pkgName=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : choiceChangesXML=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : expectedTeamID=A2XFV22B2X
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : blockingProcesses=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : installerTool=
2024-10-12 09:47:07 : DEBUG : cherryaudioatomika : CLIInstaller=
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : CLIArguments=
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : updateTool=
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : updateToolArguments=
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : updateToolRunAsCurrentUser=
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : BLOCKING_PROCESS_ACTION=tell_user
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : NOTIFY=success
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : LOGGING=DEBUG
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : Label type: pkg
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : archiveName: Atomika.pkg
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : no blocking processes defined, using Atomika as default
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : No version found using packageID com.cherryaudio.pkg.AtomikaPackage-StandAlone
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : name: Atomika, appName: Atomika.app
2024-10-12 09:47:08.359 mdfind[26781:13087889] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-12 09:47:08.359 mdfind[26781:13087889] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-12 09:47:08.568 mdfind[26781:13087889] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-12 09:47:08 : WARN  : cherryaudioatomika : No previous app found
2024-10-12 09:47:08 : WARN  : cherryaudioatomika : could not find Atomika.app
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : appversion: 
2024-10-12 09:47:08 : INFO  : cherryaudioatomika : Latest version of Atomika is 1.0.3
2024-10-12 09:47:08 : REQ   : cherryaudioatomika : Downloading https://store.cherryaudio.com/downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg to Atomika.pkg
2024-10-12 09:47:08 : DEBUG : cherryaudioatomika : No Dialog connection, just download
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : File list: -rw-r--r--  1 root  wheel    39M Oct 12 09:47 Atomika.pkg
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : File type: Atomika.pkg: xar archive compressed TOC: 7538, SHA-1 checksum
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : curl output was:
* Host store.cherryaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.90.253.248
*   Trying 164.90.253.248:443...
* Connected to store.cherryaudio.com (164.90.253.248) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4588 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=store.cherryaudio.com
*  start date: Nov 14 00:00:00 2023 GMT
*  expire date: Nov 13 23:59:59 2024 GMT
*  subjectAltName: host "store.cherryaudio.com" matched cert's "store.cherryaudio.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://store.cherryaudio.com/downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: store.cherryaudio.com]
* [HTTP/2] [1] [:path: /downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/atomika-synthesizer-macos-installer?file=Atomika-Installer-macOS.pkg HTTP/2
> Host: store.cherryaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< content-type: application/x-xar
< content-length: 40402401
< cache-control: must-revalidate, post-check=0, pre-check=0, private
< content-disposition: attachment; filename="Atomika-Installer-macOS.pkg"
< pragma: public
< date: Sat, 12 Oct 2024 14:47:09 GMT
< set-cookie: XSRF-TOKEN=eyJpdiI6InU3WlhpcE1TQkZEZFlXRDlMczhNYmc9PSIsInZhbHVlIjoiNDM1a1hHZXpvZjAzWExmVjM4VzFxSWVuclY2WE5kb1pyeUVndHRac2lkeERXSEhCRHZhbjlNVTIzZWdFcDhTYk1HRE5OeTZzRTA3Y0x6L0pNNzIreWFOQ0s3cFJPaVZ2RDBRRFprRE9HWnJsLzdmUU1JN3RmeGlHYituYnFRT1AiLCJtYWMiOiIzNmU3NmQ0ZDA2NzZhNGYzMGNmNWQ5YzEyZjI4ZTVjZmI3OTMyNzAzMmRjZWE0NWUwNmFlNzBhZTU0MzI0ZjdmIiwidGFnIjoiIn0%3D; expires=Sat, 12 Oct 2024 16:47:09 GMT; Max-Age=7200; path=/; secure; samesite=lax
< set-cookie: cherry_audio_store_session=eyJpdiI6Im10Y3k4c3hnMjZDKzF3d0VXQ0hSUEE9PSIsInZhbHVlIjoicVpBN3pSZUVCbEJYRW0wZHpNcFBzc0lvWlNxd1lOZGhqblF6S1lja21sckdpb0IxWXhQYXZNazMwVVVldTIvbFowcGZOeWdtZVZrUmpieVlvYXBTZVh2WWFUT2xFS1hyc2dYWDd6NU1PNEVpN2ZXOFJ1RGhUYUNHeVh3SnJxa0UiLCJtYWMiOiJjNDFmZTY0Njk4MjNiYjU4Y2UyNWQyMWQwMjVjN2MwYTczNDA1YjI4YTk3NDE4NDMzMGQ0YzE0NTg0M2Y2MzEzIiwidGFnIjoiIn0%3D; expires=Sat, 12 Oct 2024 16:47:09 GMT; Max-Age=7200; path=/; httponly; samesite=lax
< x-frame-options: SAMEORIGIN
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< 
{ [7011 bytes data]
* Connection #0 to host store.cherryaudio.com left intact

2024-10-12 09:47:16 : REQ   : cherryaudioatomika : no more blocking processes, continue with update
2024-10-12 09:47:16 : REQ   : cherryaudioatomika : Installing Atomika
2024-10-12 09:47:16 : INFO  : cherryaudioatomika : Verifying: Atomika.pkg
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : File list: -rw-r--r--  1 root  wheel    39M Oct 12 09:47 Atomika.pkg
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : File type: Atomika.pkg: xar archive compressed TOC: 7538, SHA-1 checksum
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : spctlOut is Atomika.pkg: accepted
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : source=Notarized Developer ID
2024-10-12 09:47:16 : DEBUG : cherryaudioatomika : origin=Developer ID Installer: Cherry Audio LLC (A2XFV22B2X)
2024-10-12 09:47:16 : INFO  : cherryaudioatomika : Team ID: A2XFV22B2X (expected: A2XFV22B2X )
2024-10-12 09:47:16 : INFO  : cherryaudioatomika : Installing Atomika.pkg to /
2024-10-12 09:47:23 : DEBUG : cherryaudioatomika : Debugging enabled, installer output was:
Oct 12 09:47:16  installer[26872] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg trustLevel=350
Oct 12 09:47:16  installer[26872] <Debug>: External component packages (5) trustLevel=350
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_Standalone_Application.pkg
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AU_Plug-In.pkg
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST_Plug-In.pkg
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST3_Plug-In.pkg
Oct 12 09:47:16  installer[26872] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AAX_Plug-In.pkg
Oct 12 09:47:16  installer[26872] <Info>: Set authorization level to root for session
Oct 12 09:47:16  installer[26872] <Info>: Authorization is being checked, waiting until authorization arrives.
Oct 12 09:47:16  installer[26872] <Info>: Administrator authorization granted.
Oct 12 09:47:16  installer[26872] <Info>: Packages have been authorized for installation.
Oct 12 09:47:16  installer[26872] <Debug>: Will use PK session
Oct 12 09:47:16  installer[26872] <Debug>: Using authorization level of root for IFPKInstallElement
Oct 12 09:47:16  installer[26872] <Info>: Starting installation:
Oct 12 09:47:16  installer[26872] <Notice>: Configuring volume "Macintosh HD"
Oct 12 09:47:16  installer[26872] <Info>: Preparing disk for local booted install.
Oct 12 09:47:16  installer[26872] <Notice>: Free space on "Macintosh HD": 21.83 GB (21829578752 bytes).
Oct 12 09:47:16  installer[26872] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.26872myaHm2"
Oct 12 09:47:16  installer[26872] <Notice>: IFPKInstallElement (5 packages)
Oct 12 09:47:17  installer[26872] <Info>: Current Path: /usr/sbin/installer
Oct 12 09:47:17  installer[26872] <Info>: Current Path: /bin/zsh
Oct 12 09:47:17  installer[26872] <Info>: Current Path: /usr/bin/sudo
Oct 12 09:47:17  installer[26872] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Atomika 1.0.3
installer: Installing at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Atomika 1.0.3….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Running package scripts….....
#Oct 12 09:47:20  installer[26872] <Info>: PackageKit: Registered bundle file:///Applications/Atomika.app/ for uid 0

installer: Running package scripts….....
installer: Validating packages….....
#Oct 12 09:47:21  installer[26872] <Notice>: Running install actions
Oct 12 09:47:21  installer[26872] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.26872myaHm2"
Oct 12 09:47:21  installer[26872] <Notice>: Finalize disk "Macintosh HD"
Oct 12 09:47:21  installer[26872] <Notice>: Notifying system of updated components
Oct 12 09:47:21  installer[26872] <Notice>:
Oct 12 09:47:21  installer[26872] <Notice>: **** Summary Information ****
Oct 12 09:47:21  installer[26872] <Notice>:   Operation      Elapsed time
Oct 12 09:47:21  installer[26872] <Notice>: -----------------------------
Oct 12 09:47:21  installer[26872] <Notice>:        disk      0.00 seconds
Oct 12 09:47:21  installer[26872] <Notice>:      script      0.00 seconds
Oct 12 09:47:21  installer[26872] <Notice>:        zero      0.00 seconds
Oct 12 09:47:21  installer[26872] <Notice>:     install      4.20 seconds
Oct 12 09:47:21  installer[26872] <Notice>:     -total-      4.21 seconds
Oct 12 09:47:21  installer[26872] <Notice>:

installer: 	Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The install was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg trustLevel=350
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: External component packages (5) trustLevel=350
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_Standalone_Application.pkg
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AU_Plug-In.pkg
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST_Plug-In.pkg
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST3_Plug-In.pkg
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AAX_Plug-In.pkg
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Set authorization level to root for session
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Authorization is being checked, waiting until authorization arrives.
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Administrator authorization granted.
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Packages have been authorized for installation.
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Will use PK session
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Using authorization level of root for IFPKInstallElement
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Starting installation:
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Configuring volume "Macintosh HD"
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Preparing disk for local booted install.
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Free space on "Macintosh HD": 21.83 GB (21829578752 bytes).
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.26872myaHm2"
2024-10-12 09:47:16-05 GB-C02ZL2RALVDL installer[26872]: IFPKInstallElement (5 packages)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installer[26872]: Current Path: /usr/sbin/installer
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installer[26872]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installer[26872]: Current Path: /usr/bin/sudo
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Adding client PKInstallDaemonClient pid=26872, uid=0 (/usr/sbin/installer)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installer[26872]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Set reponsibility for install to 95708
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Hosted team responsibility for install set to team:(A2XFV22B2X)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: ----- Begin install -----
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: request=PKInstallRequest <5 packages, destination=/>
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: packages=(
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_Standalone_Application.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root, uid=0)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AU_Plug-In.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root, uid=0)
2024-10-12 09:47:17-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST_Plug-In.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root, uid=0)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_VST3_Plug-In.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root, uid=0)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg#Atomika_AAX_Plug-In.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root, uid=0)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit: prevent user idle system sleep
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit: suspending backupd
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-StandAlone.BoOJZh
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-StandAlone.BoOJZh
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Set responsibility to pid: 95708, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Hosted team responsibility for script set to team:(A2XFV22B2X)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-StandAlone.BoOJZh
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL install_monitor[26873]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Responsibility set back to self.
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AU.71YTjq
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AU.71YTjq
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Set responsibility to pid: 95708, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Hosted team responsibility for script set to team:(A2XFV22B2X)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AU.71YTjq
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Responsibility set back to self.
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL installd[970]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST.alCkPf
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST.alCkPf
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Set responsibility to pid: 95708, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: Hosted team responsibility for script set to team:(A2XFV22B2X)
2024-10-12 09:47:18-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST.alCkPf
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Responsibility set back to self.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST3.5KLhqH
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST3.5KLhqH
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Set responsibility to pid: 95708, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Hosted team responsibility for script set to team:(A2XFV22B2X)
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-VST3.5KLhqH
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Responsibility set back to self.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AAX.IvKddo
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AAX.IvKddo
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Set responsibility to pid: 95708, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Hosted team responsibility for script set to team:(A2XFV22B2X)
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.mZb5VW/Scripts/com.cherryaudio.pkg.AtomikaPackage-AAX.IvKddo
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: PackageKit: Hosted team responsible for script has been cleared.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL package_script_service[1038]: Responsibility set back to self.
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/2DC0E4DD-6FB5-4204-90DD-B9267DB7A68A.activeSandbox/Root (2 items) to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Writing receipt for com.cherryaudio.pkg.AtomikaPackage-StandAlone to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Writing receipt for com.cherryaudio.pkg.AtomikaPackage-AU to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Writing receipt for com.cherryaudio.pkg.AtomikaPackage-VST to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Writing receipt for com.cherryaudio.pkg.AtomikaPackage-VST3 to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Writing receipt for com.cherryaudio.pkg.AtomikaPackage-AAX to /
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Touched bundle /Applications/Atomika.app
2024-10-12 09:47:19-05 GB-C02ZL2RALVDL installd[970]: Installed "Atomika 1.0.3" ()
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL install_monitor[26873]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: releasing backupd
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: allow user idle system sleep
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: ----- End install -----
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: 3.2s elapsed install time
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Cleared responsibility for install from 26872.
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Hosted team responsible for install has been cleared.
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Running idle tasks
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Done with sandbox removals
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installer[26872]: PackageKit: Registered bundle file:///Applications/Atomika.app/ for uid 0
2024-10-12 09:47:20-05 GB-C02ZL2RALVDL installd[970]: PackageKit: Removing client PKInstallDaemonClient pid=26872, uid=0 (/usr/sbin/installer)
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: Running install actions
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.26872myaHm2"
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: Finalize disk "Macintosh HD"
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: Notifying system of updated components
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: **** Summary Information ****
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:   Operation      Elapsed time
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]: -----------------------------
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:        disk      0.00 seconds
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:      script      0.00 seconds
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:        zero      0.00 seconds
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:     install      4.20 seconds
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:     -total-      4.21 seconds
2024-10-12 09:47:21-05 GB-C02ZL2RALVDL installer[26872]:

2024-10-12 09:47:23 : INFO  : cherryaudioatomika : Finishing...
2024-10-12 09:47:26 : INFO  : cherryaudioatomika : found packageID com.cherryaudio.pkg.AtomikaPackage-StandAlone installed, version 1.0.3
2024-10-12 09:47:26 : REQ   : cherryaudioatomika : Installed Atomika, version 1.0.3
2024-10-12 09:47:26 : INFO  : cherryaudioatomika : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-12 09:47:27 : DEBUG : cherryaudioatomika : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv
2024-10-12 09:47:27 : DEBUG : cherryaudioatomika : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv/Atomika.pkg
2024-10-12 09:47:27 : DEBUG : cherryaudioatomika : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dfrxA0udzv
2024-10-12 09:47:27 : INFO  : cherryaudioatomika : Installomator did not close any apps, so no need to reopen any apps.
2024-10-12 09:47:27 : REQ   : cherryaudioatomika : All done!
2024-10-12 09:47:27 : REQ   : cherryaudioatomika : ################## End Installomator, exit code 0 

```