### PR TITLE
Create Bitwig Studio label

### DIFF
--- a/fragments/labels/bitwigstudio.sh
+++ b/fragments/labels/bitwigstudio.sh
@@ -1,0 +1,7 @@
+bitwigstudio)
+    name="Bitwig Studio"
+    type="dmg"
+    appNewVersion="$(curl -fs "https://www.bitwig.com/download/" | grep 'changelog' | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')"
+    downloadURL="https://www.bitwig.com/dl/Bitwig%20Studio/${appNewVersion}/installer_mac/"
+    expectedTeamID="2B6K987585"
+    ;;


### PR DESCRIPTION
```
sudo ./assemble.sh bitwigstudio DEBUG=0
Password:
2024-10-19 13:49:30 : REQ   : bitwigstudio : ################## Start Installomator v. 10.7beta, date 2024-10-19
2024-10-19 13:49:30 : INFO  : bitwigstudio : ################## Version: 10.7beta
2024-10-19 13:49:30 : INFO  : bitwigstudio : ################## Date: 2024-10-19
2024-10-19 13:49:30 : INFO  : bitwigstudio : ################## bitwigstudio
2024-10-19 13:49:30 : DEBUG : bitwigstudio : DEBUG mode 1 enabled.
2024-10-19 13:49:30 : INFO  : bitwigstudio : SwiftDialog is not installed, clear cmd file var
2024-10-19 13:49:31 : INFO  : bitwigstudio : setting variable from argument DEBUG=0
2024-10-19 13:49:31 : DEBUG : bitwigstudio : name=Bitwig Studio
2024-10-19 13:49:31 : DEBUG : bitwigstudio : appName=
2024-10-19 13:49:31 : DEBUG : bitwigstudio : type=dmg
2024-10-19 13:49:31 : DEBUG : bitwigstudio : archiveName=
2024-10-19 13:49:31 : DEBUG : bitwigstudio : downloadURL=https://www.bitwig.com/dl/Bitwig%20Studio/5.2.5/installer_mac/
2024-10-19 13:49:31 : DEBUG : bitwigstudio : curlOptions=
2024-10-19 13:49:31 : DEBUG : bitwigstudio : appNewVersion=5.2.5
2024-10-19 13:49:32 : DEBUG : bitwigstudio : appCustomVersion function: Not defined
2024-10-19 13:49:32 : DEBUG : bitwigstudio : versionKey=CFBundleShortVersionString
2024-10-19 13:49:32 : DEBUG : bitwigstudio : packageID=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : pkgName=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : choiceChangesXML=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : expectedTeamID=2B6K987585
2024-10-19 13:49:32 : DEBUG : bitwigstudio : blockingProcesses=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : installerTool=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : CLIInstaller=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : CLIArguments=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : updateTool=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : updateToolArguments=
2024-10-19 13:49:32 : DEBUG : bitwigstudio : updateToolRunAsCurrentUser=
2024-10-19 13:49:32 : INFO  : bitwigstudio : BLOCKING_PROCESS_ACTION=tell_user
2024-10-19 13:49:32 : INFO  : bitwigstudio : NOTIFY=success
2024-10-19 13:49:32 : INFO  : bitwigstudio : LOGGING=DEBUG
2024-10-19 13:49:32 : INFO  : bitwigstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-19 13:49:32 : INFO  : bitwigstudio : Label type: dmg
2024-10-19 13:49:32 : INFO  : bitwigstudio : archiveName: Bitwig Studio.dmg
2024-10-19 13:49:32 : INFO  : bitwigstudio : no blocking processes defined, using Bitwig Studio as default
2024-10-19 13:49:32 : DEBUG : bitwigstudio : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OwdKyo0h9k
2024-10-19 13:49:32 : INFO  : bitwigstudio : App(s) found: /Applications/Bitwig Studio.app
2024-10-19 13:49:32 : INFO  : bitwigstudio : found app at /Applications/Bitwig Studio.app, version 5.2.3, on versionKey CFBundleShortVersionString
2024-10-19 13:49:32 : INFO  : bitwigstudio : appversion: 5.2.3
2024-10-19 13:49:32 : INFO  : bitwigstudio : Latest version of Bitwig Studio is 5.2.5
2024-10-19 13:49:32 : REQ   : bitwigstudio : Downloading https://www.bitwig.com/dl/Bitwig%20Studio/5.2.5/installer_mac/ to Bitwig Studio.dmg
2024-10-19 13:49:32 : DEBUG : bitwigstudio : No Dialog connection, just download
2024-10-19 13:50:24 : DEBUG : bitwigstudio : File list: -rw-r--r--  1 root  wheel   441M Oct 19 13:50 Bitwig Studio.dmg
2024-10-19 13:50:25 : DEBUG : bitwigstudio : File type: Bitwig Studio.dmg: zlib compressed data
2024-10-19 13:50:25 : DEBUG : bitwigstudio : curl output was:
* Host www.bitwig.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.31.213.113
*   Trying 185.31.213.113:443...
* Connected to www.bitwig.com (185.31.213.113) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2069 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [112 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.bitwig.com
*  start date: Oct 18 01:19:36 2024 GMT
*  expire date: Jan 16 01:19:35 2025 GMT
*  subjectAltName: host "www.bitwig.com" matched cert's "www.bitwig.com"
*  issuer: C=US; O=Let's Encrypt; CN=E5
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.bitwig.com/dl/Bitwig%20Studio/5.2.5/installer_mac/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.bitwig.com]
* [HTTP/2] [1] [:path: /dl/Bitwig%20Studio/5.2.5/installer_mac/]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /dl/Bitwig%20Studio/5.2.5/installer_mac/ HTTP/2
> Host: www.bitwig.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: nginx
< date: Sat, 19 Oct 2024 18:49:32 GMT
< content-type: text/html; charset=utf-8
< location: https://downloads-secure.bitwig.com/5.2.5/Bitwig%20Studio%205.2.5.dmg?__token__=st=1729363772.0~exp=1729364372.0~hmac=6c54d1cefb6e8b939d56ff7620fb2ab86cd9ddc0d58f5698f98691729f9bcc8a&source_url=/dl/Bitwig%20Studio/5.2.5/installer_mac/
< content-language: en
< expires: Sat, 19 Oct 2024 18:49:32 GMT
< vary: Accept-Language, Cookie
< last-modified: Sat, 19 Oct 2024 18:49:32 GMT
< cache-control: no-cache, no-store, must-revalidate, max-age=0
< set-cookie: sessionid=iesbi4dsq90nfn68jla724wnidbqzi3o; expires=Mon, 18-Nov-2024 18:49:32 GMT; httponly; Max-Age=2592000; Path=/; secure
< set-cookie: pery-deviceid=".eJyrVkouUrJSUDIsMXINN1HSUVDKTAHxDVJTLEwsE1N1jQyNzHRNUgwMdROTDU10DcxSk5ITTQ3MTI3AqkuLgaqjY0GsAiRzagHGYBXC:1t2EW4:_2Ig66lQXxkUU6MRkH-WEGETvFo"; expires=Thu, 18-Oct-2029 18:49:32 GMT; httponly; Max-Age=157680000; Path=/; secure
< set-cookie: pery-id=104afbad-c4ac-4e6b-89d1-ca4ff2463a8b; expires=Wed, 18-Dec-2024 20:49:32 GMT; httponly; Max-Age=5191200; Path=/; secure
< strict-transport-security: max-age=63072000
< x-content-type-options: nosniff
< 
* Ignoring the response-body
* Connection #0 to host www.bitwig.com left intact
* Issue another request to this URL: 'https://downloads-secure.bitwig.com/5.2.5/Bitwig%20Studio%205.2.5.dmg?__token__=st=1729363772.0~exp=1729364372.0~hmac=6c54d1cefb6e8b939d56ff7620fb2ab86cd9ddc0d58f5698f98691729f9bcc8a&source_url=/dl/Bitwig%20Studio/5.2.5/installer_mac/'
* Host downloads-secure.bitwig.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.220.246.29, 23.220.246.14
*   Trying 23.220.246.29:443...
* Connected to downloads-secure.bitwig.com (23.220.246.29) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [332 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2817 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=bitwig.net
*  start date: Oct  8 09:47:40 2024 GMT
*  expire date: Jan  6 09:47:39 2025 GMT
*  subjectAltName: host "downloads-secure.bitwig.com" matched cert's "downloads-secure.bitwig.com"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads-secure.bitwig.com/5.2.5/Bitwig%20Studio%205.2.5.dmg?__token__=st=1729363772.0~exp=1729364372.0~hmac=6c54d1cefb6e8b939d56ff7620fb2ab86cd9ddc0d58f5698f98691729f9bcc8a&source_url=/dl/Bitwig%20Studio/5.2.5/installer_mac/
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads-secure.bitwig.com]
* [HTTP/2] [1] [:path: /5.2.5/Bitwig%20Studio%205.2.5.dmg?__token__=st=1729363772.0~exp=1729364372.0~hmac=6c54d1cefb6e8b939d56ff7620fb2ab86cd9ddc0d58f5698f98691729f9bcc8a&source_url=/dl/Bitwig%20Studio/5.2.5/installer_mac/]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /5.2.5/Bitwig%20Studio%205.2.5.dmg?__token__=st=1729363772.0~exp=1729364372.0~hmac=6c54d1cefb6e8b939d56ff7620fb2ab86cd9ddc0d58f5698f98691729f9bcc8a&source_url=/dl/Bitwig%20Studio/5.2.5/installer_mac/ HTTP/2
> Host: downloads-secure.bitwig.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< accept-ranges: bytes
< server: AkamaiNetStorage
< last-modified: Fri, 11 Oct 2024 12:25:30 GMT
< etag: "dc6ed5a1829c323881214889899f9f64:1728649487.30122"
< content-length: 461914182
< date: Sat, 19 Oct 2024 18:49:33 GMT
< content-type: application/octet-stream
< 
{ [16375 bytes data]
* Connection #1 to host downloads-secure.bitwig.com left intact

2024-10-19 13:50:25 : REQ   : bitwigstudio : no more blocking processes, continue with update
2024-10-19 13:50:25 : REQ   : bitwigstudio : Installing Bitwig Studio
2024-10-19 13:50:25 : INFO  : bitwigstudio : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OwdKyo0h9k/Bitwig Studio.dmg
2024-10-19 13:50:27 : DEBUG : bitwigstudio : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $9D82A96A
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $993E0BBD
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $024B830A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $71DB13CD
/dev/disk2          	Apple_partition_scheme
/dev/disk2s1        	Apple_partition_map
/dev/disk2s2        	Apple_HFS                      	/Volumes/Bitwig Studio 5.2.5

2024-10-19 13:50:27 : INFO  : bitwigstudio : Mounted: /Volumes/Bitwig Studio 5.2.5
2024-10-19 13:50:27 : INFO  : bitwigstudio : Verifying: /Volumes/Bitwig Studio 5.2.5/Bitwig Studio.app
2024-10-19 13:50:27 : DEBUG : bitwigstudio : App size: 777M	/Volumes/Bitwig Studio 5.2.5/Bitwig Studio.app
2024-10-19 13:50:35 : DEBUG : bitwigstudio : Debugging enabled, App Verification output was:
/Volumes/Bitwig Studio 5.2.5/Bitwig Studio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bitwig GmbH (2B6K987585)

2024-10-19 13:50:35 : INFO  : bitwigstudio : Team ID matching: 2B6K987585 (expected: 2B6K987585 )
2024-10-19 13:50:35 : INFO  : bitwigstudio : Downloaded version of Bitwig Studio is 5.2.5 on versionKey CFBundleShortVersionString (replacing version 5.2.3).
2024-10-19 13:50:35 : INFO  : bitwigstudio : App has LSMinimumSystemVersion: 10.7
2024-10-19 13:50:35 : WARN  : bitwigstudio : Removing existing /Applications/Bitwig Studio.app
2024-10-19 13:50:36 : DEBUG : bitwigstudio : Debugging enabled, App removing output was:
/Applications/Bitwig Studio.app/Contents/
Last Log repeated 4892 times
/Applications/Bitwig Studio.app/Contents
/Applications/Bitwig Studio.app

2024-10-19 13:50:36 : INFO  : bitwigstudio : Copy /Volumes/Bitwig Studio 5.2.5/Bitwig Studio.app to /Applications
2024-10-19 13:50:41 : DEBUG : bitwigstudio : Debugging enabled, App copy output was:
Copying /Volumes/Bitwig Studio 5.2.5/Bitwig Studio.app

2024-10-19 13:50:41 : WARN  : bitwigstudio : Changing owner to gilburns
2024-10-19 13:50:42 : INFO  : bitwigstudio : Finishing...
2024-10-19 13:50:45 : INFO  : bitwigstudio : App(s) found: /Applications/Bitwig Studio.app
2024-10-19 13:50:45 : INFO  : bitwigstudio : found app at /Applications/Bitwig Studio.app, version 5.2.5, on versionKey CFBundleShortVersionString
2024-10-19 13:50:45 : REQ   : bitwigstudio : Installed Bitwig Studio, version 5.2.5
2024-10-19 13:50:45 : INFO  : bitwigstudio : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-19 13:50:45 : DEBUG : bitwigstudio : Unmounting /Volumes/Bitwig Studio 5.2.5
2024-10-19 13:50:45 : DEBUG : bitwigstudio : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-10-19 13:50:45 : DEBUG : bitwigstudio : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OwdKyo0h9k
2024-10-19 13:50:45 : DEBUG : bitwigstudio : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OwdKyo0h9k/Bitwig Studio.dmg
2024-10-19 13:50:45 : DEBUG : bitwigstudio : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OwdKyo0h9k
2024-10-19 13:50:45 : INFO  : bitwigstudio : Installomator did not close any apps, so no need to reopen any apps.
2024-10-19 13:50:45 : REQ   : bitwigstudio : All done!
2024-10-19 13:50:45 : REQ   : bitwigstudio : ################## End Installomator, exit code 0 

```