### PR TITLE
Create Reaper label

### DIFF
--- a/fragments/labels/reaper.sh
+++ b/fragments/labels/reaper.sh
@@ -1,0 +1,8 @@
+reaper)
+    name="REAPER"
+    type="dmg"
+    appNewVersion="$(curl "https://www.reaper.fm/download.php" | grep -a1 "DOWNLOAD REAPER" | sed -ne 's/[^0-9]*\(\([0-9]\.\)\{0,4\}[0-9][^.]\).*/\1/p')"
+    downloadURL="https://www.reaper.fm/files/7.x/reaper$(echo $appNewVersion | tr -d '.')_universal.dmg"
+    appCustomVersion(){ /usr/bin/defaults read "/Applications/REAPER.app/Contents/Info.plist" CFBundleShortVersionString | cut -d'.' -f1-2 }
+    expectedTeamID="Y3T58622SG"
+    ;;


### PR DESCRIPTION
```
sudo ./assemble.sh reaper DEBUG=0
Password:
2024-10-19 17:05:01 : REQ   : reaper : ################## Start Installomator v. 10.7beta, date 2024-10-19
2024-10-19 17:05:01 : INFO  : reaper : ################## Version: 10.7beta
2024-10-19 17:05:01 : INFO  : reaper : ################## Date: 2024-10-19
2024-10-19 17:05:01 : INFO  : reaper : ################## reaper
2024-10-19 17:05:01 : DEBUG : reaper : DEBUG mode 1 enabled.
2024-10-19 17:05:01 : INFO  : reaper : SwiftDialog is not installed, clear cmd file var
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 18062    0 18062    0     0  28577      0 --:--:-- --:--:-- --:--:-- 28579
2024-10-19 17:05:01 : INFO  : reaper : setting variable from argument DEBUG=0
2024-10-19 17:05:01 : DEBUG : reaper : name=REAPER
2024-10-19 17:05:01 : DEBUG : reaper : appName=
2024-10-19 17:05:01 : DEBUG : reaper : type=dmg
2024-10-19 17:05:02 : DEBUG : reaper : archiveName=
2024-10-19 17:05:02 : DEBUG : reaper : downloadURL=https://www.reaper.fm/files/7.x/reaper725_universal.dmg
2024-10-19 17:05:02 : DEBUG : reaper : curlOptions=
2024-10-19 17:05:02 : DEBUG : reaper : appNewVersion=7.25
2024-10-19 17:05:02 : DEBUG : reaper : appCustomVersion function: Defined. 
2024-10-19 17:05:02 : DEBUG : reaper : versionKey=CFBundleShortVersionString
2024-10-19 17:05:02 : DEBUG : reaper : packageID=
2024-10-19 17:05:02 : DEBUG : reaper : pkgName=
2024-10-19 17:05:02 : DEBUG : reaper : choiceChangesXML=
2024-10-19 17:05:02 : DEBUG : reaper : expectedTeamID=Y3T58622SG
2024-10-19 17:05:02 : DEBUG : reaper : blockingProcesses=
2024-10-19 17:05:02 : DEBUG : reaper : installerTool=
2024-10-19 17:05:02 : DEBUG : reaper : CLIInstaller=
2024-10-19 17:05:02 : DEBUG : reaper : CLIArguments=
2024-10-19 17:05:02 : DEBUG : reaper : updateTool=
2024-10-19 17:05:02 : DEBUG : reaper : updateToolArguments=
2024-10-19 17:05:02 : DEBUG : reaper : updateToolRunAsCurrentUser=
2024-10-19 17:05:02 : INFO  : reaper : BLOCKING_PROCESS_ACTION=tell_user
2024-10-19 17:05:02 : INFO  : reaper : NOTIFY=success
2024-10-19 17:05:02 : INFO  : reaper : LOGGING=DEBUG
2024-10-19 17:05:02 : INFO  : reaper : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-19 17:05:02 : INFO  : reaper : Label type: dmg
2024-10-19 17:05:02 : INFO  : reaper : archiveName: REAPER.dmg
2024-10-19 17:05:02 : INFO  : reaper : no blocking processes defined, using REAPER as default
2024-10-19 17:05:02 : DEBUG : reaper : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rjaa8N7DYD
2024-10-19 17:05:02 : INFO  : reaper : Custom App Version detection is used, found 7.22
2024-10-19 17:05:02 : INFO  : reaper : appversion: 7.22
2024-10-19 17:05:02 : INFO  : reaper : Latest version of REAPER is 7.25
2024-10-19 17:05:02 : REQ   : reaper : Downloading https://www.reaper.fm/files/7.x/reaper725_universal.dmg to REAPER.dmg
2024-10-19 17:05:02 : DEBUG : reaper : No Dialog connection, just download
2024-10-19 17:05:06 : DEBUG : reaper : File list: -rw-r--r--  1 root  wheel    27M Oct 19 17:05 REAPER.dmg
2024-10-19 17:05:06 : DEBUG : reaper : File type: REAPER.dmg: bzip2 compressed data, block size = 900k
2024-10-19 17:05:06 : DEBUG : reaper : curl output was:
* Host www.reaper.fm:443 was resolved.
* IPv6: (none)
* IPv4: 174.129.249.41
*   Trying 174.129.249.41:443...
* Connected to www.reaper.fm (174.129.249.41) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [93 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2700 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=reaper.fm
*  start date: Sep 26 17:13:52 2024 GMT
*  expire date: Dec 25 17:13:51 2024 GMT
*  subjectAltName: host "www.reaper.fm" matched cert's "www.reaper.fm"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /files/7.x/reaper725_universal.dmg HTTP/1.1
> Host: www.reaper.fm
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Found
< Date: Sat, 19 Oct 2024 22:05:02 GMT
< Server: Apache/2.4.7 (Ubuntu)
< Location: https://dlcf.reaper.fm/7.x/reaper725_universal.dmg
< Content-Length: 313
< Content-Type: text/html; charset=iso-8859-1
< 
* Ignoring the response-body
* Connection #0 to host www.reaper.fm left intact
* Issue another request to this URL: 'https://dlcf.reaper.fm/7.x/reaper725_universal.dmg'
* Host dlcf.reaper.fm:443 was resolved.
* IPv6: (none)
* IPv4: 18.172.134.96, 18.172.134.129, 18.172.134.39, 18.172.134.56
*   Trying 18.172.134.96:443...
* Connected to dlcf.reaper.fm (18.172.134.96) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4952 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=dlcf.reaper.fm
*  start date: Dec 21 00:00:00 2023 GMT
*  expire date: Jan 18 23:59:59 2025 GMT
*  subjectAltName: host "dlcf.reaper.fm" matched cert's "dlcf.reaper.fm"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dlcf.reaper.fm/7.x/reaper725_universal.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dlcf.reaper.fm]
* [HTTP/2] [1] [:path: /7.x/reaper725_universal.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /7.x/reaper725_universal.dmg HTTP/2
> Host: dlcf.reaper.fm
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/x-apple-diskimage
< content-length: 27994819
< date: Sat, 19 Oct 2024 13:11:29 GMT
< last-modified: Mon, 14 Oct 2024 13:10:35 GMT
< etag: "fb59eaa2cffdb8a85fda14d016a8578c-2"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 9e7854575c9c6d7acca8b6996ff7f2ee.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD56-P7
< x-amz-cf-id: gWU30J12dg7sLHSe1ZmA9lkmVWOpnlMQziS4Hr4B_QRzlNUfYsuqPQ==
< age: 32015
< 
{ [8192 bytes data]
* Connection #1 to host dlcf.reaper.fm left intact

2024-10-19 17:05:07 : REQ   : reaper : no more blocking processes, continue with update
2024-10-19 17:05:07 : REQ   : reaper : Installing REAPER
2024-10-19 17:05:07 : INFO  : reaper : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rjaa8N7DYD/REAPER.dmg
2024-10-19 17:05:11 : DEBUG : reaper : Debugging enabled, dmgmount output was:
END USER LICENSE AGREEMENT For REAPER

IMPORTANT:  This REAPER ("Software") End User License Agreement
("EULA") is a legal agreement between you (either an individual or,
if purchased for an entity, an entity) and Cockos Incorporated
("Cockos").  READ IT CAREFULLY BEFORE COMPLETING THE INSTALLATION
PROCESS AND USING THIS SOFTWARE.  It provides a license to use this
software and contains warranty and liability disclaimers.  BY
DOWNLOADING OR INSTALLING THE SOFTWARE YOU ARE INDICATING YOUR FULL
AND VOLUNTARY ASSENT TO THE TERMS OF THIS LICENSE.  If you do not
agree to all of the following terms, do not download or install the
software or discontinue use immediately and destroy all copies on
your computer.

1. License Grants and Purchase:

1.1  Trial Period License.  You may download and use the Software
for free for sixty (60) days after installation ("Trial Period").
During the Trial Period, Cockos grants you a limited, non-exclusive
and non-transferable license to copy and use the Software for
evaluation purposes only. The evaluation copy of the Software is
fully functional.

1.2  License After Trial Period. If you continue to use this Software
after the Trial Period, you are required to purchase a license.
The license fee varies according to your use, as follows:
a)  A commercial license currently is $225.00 USD.  b)  The
following users are granted permission to purchase a discounted
license for $60 USD:
i) You are an individual, using REAPER only for personal and
non-commercial uses.  ii) You are either an individual or
business, using REAPER for a commercial purpose, and your annual
gross revenue derived from commercial activity does not exceed
$20,000 USD.  iii) You are an educational or other non-profit
organization.

1.3  To Purchase License.  To purchase one of the licenses specified
above, visit our web site at http://www.reaper.fm and follow the
links.

1.4  Those interested in licensing REAPER for any other purpose
should contact Cockos Incorporated at licensing@cockos.com.

1.5  Subject to the terms and conditions of this Agreement, you are
granted a limited non-exclusive license to use the Software on one
(1) computer any given time.  This License is not a sale of the
Software or any other copy.  Cockos retains title and ownership of
the Software and documentation, including all intellectual property
rights.  No title to the intellectual property in the Software is
transferred to you.  You will not acquire any rights to the Software
except as expressly set forth herein.

1.6  Said purchased license shall apply to the current version of
REAPER and any future versions of REAPER up through and including
version 8.99.

1.7  Cockos reserves the right within its sole discretion to modify
the terms of its license for all future versions of REAPER.

2.  End User Support:  At Cockos discretion, Cockos may provide
limited support through email or discussion forums at http://www.reaper.fm.

3.  License Restrictions:

3.1  You may not alter, merge, modify, adapt or translate the
Software, or decompile, reverse engineer, disassemble, or otherwise
reduce the Software to a human-perceivable form.

3.2  You may not sell, rent, lease, sublicense, transfer, resell
for profit or otherwise distribute the Software, its documentation,
or any part thereof.

3.3  You may not modify the Software or create derivative works
based upon the Software.  However, you may develop, distribute, and
sell plug-ins and extension software that interacts with REAPER
using the VST, Audio Units, or REAPER Extensions APIs, provided
that such activity does not conflict with any other provision of
this Agreement.  (Use of third party APIs may require you to enter
into additional legal agreements with the third party. Use of the
REAPER Extensions API does not require any additional legal agreement.)

3.4  You may not remove or obscure any copyright and trademark
notices relating to the Software.

3.5  Note that specific included libraries/executables, including
SoundTouch, MP3DEC, cdrecord.exe, and FFmpeg, are licensed under
the GNU GPL and/or LGPL; these libraries/executables do not have
the above restrictions, and we make their source code for these
libraries available at http://www.reaper.fm/lgpl

4.  Ownership and Intellectual Property Rights:   This Agreement
gives you limited rights to use the Software.  Cockos retains any
and all rights, title and interest in and to the Software and all
copies thereof, including copyrights, patents, trade secret rights,
trademarks and other intellectual property rights.  All rights not
specifically granted in this Agreement, including International
Copyrights, are reserved by Cockos.  The structure, organization
and code of the Software are valuable trade secrets and confidential
information of Cockos.

5.  Disclaimer of Warranties: Cockos does not warrant that the
Software is error free.  Cockos offers the Software as is and with
all faults and by using the Software, you accept it as is and with
all faults.  Cockos disclaims all other warranties, either express
or implied, including but not limited to implied warranties of
merchantability and fitness for a particular purpose.  Should the
Software prove defective, you assume the entire cost of all necessary
servicing, repair or correction.  Some jurisdictions may not allow
the exclusion of implied warranties, so the above disclaimers may
not apply to you.

6.  No Refund:  Because the Software is provided free of charge
during the Trial Period to allow potential customers to evaluate
and test it before paying the license fee, Cockos enforces a strict
no-refund policy.  Please evaluate and test the Software carefully
during the Trial Period.  Once you pay the license fee, your payment
is final and may not be reimbursed.

7.  Limitations on Liability:  To the maximum extent permitted by
applicable law, Cockos shall not be liable for any special, incidental,
indirect, or consequential damages whatsoever, (including, but not
limited to, damages for loss of profits or loss of confidential or
other information, for business interruption, for personal injury,
for loss of privacy, for failure to meet any duty including of good
faith or of reasonable care, for negligence, and for any other
pecuniary or other loss whatsoever), arising out of or in any way
related to the use or inability to use the Software, the provision
of or failure to provide support services, or otherwise under or
in connection with any provision of this EULA, even in event of
fault, tort (including negligence), strict liability, breach of
contract or breach of warranty of Cockos, and even if Cockos has
been advised of the possibility of such damages.  In any case,
Cockos entire liability under the provisions of this EULA or the
applicable law shall be limited to the amount paid by you for the
Software.  Some jurisdictions may not allow the exclusion of
consequential damages, so the above limitations and exclusions may
not apply to you.  This Agreement sets forth Cockos entire liability
and your exclusive remedy with respect to the Software.

8.  Termination of EULA:  This Agreement is effective until terminated.
This Agreement, including the license to use the Software, will
terminate automatically if you fail to comply with any term or
condition.

9.  General:

9.1  Cockos reserves the right at any time to cease the support of
the Software and to alter prices, features, specifications,
capabilities, functions, licensing terms, release dates, general
availability or other characteristics of the Software.

9.2  If any provision hereof shall be held illegal, invalid or
unenforceable, in whole or in part, such provision shall be modified
to the minimum extent necessary to make it legal, valid and
enforceable, and the legality, validity and enforceability of all
other provisions of this Agreement shall not be affected.

9.3  This Agreement is to be governed by and construed in accordance
with the laws of California.  Each party for itself and its property,
hereby submits to the jurisdiction and venue of San Francisco,
California in relation to any claim or dispute that may arise with
respect to this Agreement and any judgment that may be rendered in
connection with any such claim or dispute.  This Agreement will be
will be interpreted as if the agreement were made between California
residents and performed entirely within California.

9.4 You may not assign this Agreement. Any attempt by You to assign
this Agreement will be null and void.

9.5  This Agreement contains the entire agreement between Cockos
and You related to the software and supersedes all prior agreements
and understandings, whether oral or written. All questions concerning
this Agreement shall be directed to licensing@cockos.com.

10. Software license agreements of third parties:

10.1 Xiph.org's BSD license - libflac:     Copyright (c) 2000-2007
Josh Coalson - libogg:      Copyright (c) 2002, Xiph.org Foundation
- libvorbis:   Copyright (c) 2002-2008 Xiph.org Foundation -
libopusfile: Copyright (c) 1994-2013 Xiph.Org Foundation - libopus:
Copyright (c) 2001-2011 Xiph.Org, Skype Limited,
Octasic, Jean-Marc Valin, Timothy B. Terriberry,
CSIRO, Gregory Maxwell, Mark Borgerding, Erik de
Castro Lopo
Redistribution and use in source and binary forms, with or without
modification, are permitted provided that the following conditions
are met: - Redistributions of source code must retain the above
copyright notice, this list of conditions and the following disclaimer.
- Redistributions in binary form must reproduce the above copyright
notice, this list of conditions and the following disclaimer in the
documentation and/or other materials provided with the distribution.
- Neither the name of the Xiph.Org Foundation nor the names of its
contributors may be used to endorse or promote products derived
from this software without specific prior written permission.  THIS
SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
FOUNDATION OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
POSSIBILITY OF SUCH DAMAGE.

10.2 r8brain free MIT license - r8brain free: Copyright (c) 2013-2021
Aleksey Vaneev Permission is hereby granted, free of charge, to any
person obtaining a copy of this software and associated documentation
files (the "Software"), to deal in the Software without restriction,
including without limitation the rights to use, copy, modify, merge,
publish, distribute, sublicense, and/or sell copies of the Software,
and to permit persons to whom the Software is furnished to do so,
subject to the following conditions:

The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

Last Log repeated 2 times
Cockos Incorporated
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1CACC936
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $681702F1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $6D7F9C7C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $00857F54
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $6D7F9C7C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $05F69C78
verified   CRC32 $3F8799C5
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/REAPER_INSTALL_UNIVERSAL

2024-10-19 17:05:11 : INFO  : reaper : Mounted: /Volumes/REAPER_INSTALL_UNIVERSAL
2024-10-19 17:05:11 : INFO  : reaper : Verifying: /Volumes/REAPER_INSTALL_UNIVERSAL/REAPER.app
2024-10-19 17:05:11 : DEBUG : reaper : App size: 158M	/Volumes/REAPER_INSTALL_UNIVERSAL/REAPER.app
2024-10-19 17:05:26 : DEBUG : reaper : Debugging enabled, App Verification output was:
/Volumes/REAPER_INSTALL_UNIVERSAL/REAPER.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Cockos Incorporated (Y3T58622SG)

2024-10-19 17:05:26 : INFO  : reaper : Team ID matching: Y3T58622SG (expected: Y3T58622SG )
2024-10-19 17:05:26 : INFO  : reaper : Downloaded version of REAPER is 7.25.0_f6d64bau on versionKey CFBundleShortVersionString (replacing version 7.22).
2024-10-19 17:05:26 : INFO  : reaper : App has LSMinimumSystemVersion: 10.9
2024-10-19 17:05:26 : WARN  : reaper : Removing existing /Applications/REAPER.app
2024-10-19 17:05:27 : DEBUG : reaper : Debugging enabled, App removing output was:
/Applications/REAPER.app/Contents/
Last Log repeated 2725 times
/Applications/REAPER.app/Contents
/Applications/REAPER.app

2024-10-19 17:05:27 : INFO  : reaper : Copy /Volumes/REAPER_INSTALL_UNIVERSAL/REAPER.app to /Applications
2024-10-19 17:05:29 : DEBUG : reaper : Debugging enabled, App copy output was:
Copying /Volumes/REAPER_INSTALL_UNIVERSAL/REAPER.app

2024-10-19 17:05:29 : WARN  : reaper : Changing owner to gilburns
2024-10-19 17:05:29 : INFO  : reaper : Finishing...
2024-10-19 17:05:32 : INFO  : reaper : Custom App Version detection is used, found 7.25
2024-10-19 17:05:32 : REQ   : reaper : Installed REAPER, version 7.25.0_f6d64bau
2024-10-19 17:05:32 : INFO  : reaper : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-19 17:05:32 : DEBUG : reaper : Unmounting /Volumes/REAPER_INSTALL_UNIVERSAL
2024-10-19 17:05:32 : DEBUG : reaper : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-10-19 17:05:32 : DEBUG : reaper : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rjaa8N7DYD
2024-10-19 17:05:32 : DEBUG : reaper : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rjaa8N7DYD/REAPER.dmg
2024-10-19 17:05:32 : DEBUG : reaper : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rjaa8N7DYD
2024-10-19 17:05:32 : INFO  : reaper : Installomator did not close any apps, so no need to reopen any apps.
2024-10-19 17:05:32 : REQ   : reaper : All done!
2024-10-19 17:05:32 : REQ   : reaper : ################## End Installomator, exit code 0 

```