### PR TITLE
Create SC Menu label

### DIFF
--- a/fragments/labels/scmenu.sh
+++ b/fragments/labels/scmenu.sh
@@ -1,0 +1,7 @@
+scmenu)
+    name="SC Menu"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit boberito sc_menu)"
+    appNewVersion="$(versionFromGit boberito sc_menu)"
+    expectedTeamID="2WUMX954UB"
+    ;;


### PR DESCRIPTION
```
assemble.sh scmenu  
2024-10-21 06:52:36 : REQ   : scmenu : ################## Start Installomator v. 10.7beta, date 2024-10-21
2024-10-21 06:52:36 : INFO  : scmenu : ################## Version: 10.7beta
2024-10-21 06:52:36 : INFO  : scmenu : ################## Date: 2024-10-21
2024-10-21 06:52:36 : INFO  : scmenu : ################## scmenu
2024-10-21 06:52:36 : DEBUG : scmenu : DEBUG mode 1 enabled.
2024-10-21 06:52:36 : INFO  : scmenu : SwiftDialog is not installed, clear cmd file var
2024-10-21 06:52:37 : DEBUG : scmenu : name=SC Menu
2024-10-21 06:52:37 : DEBUG : scmenu : appName=
2024-10-21 06:52:37 : DEBUG : scmenu : type=dmg
2024-10-21 06:52:37 : DEBUG : scmenu : archiveName=
2024-10-21 06:52:37 : DEBUG : scmenu : downloadURL=https://github.com/boberito/sc_menu/releases/download/1.5/SC_Menu.dmg
2024-10-21 06:52:37 : DEBUG : scmenu : curlOptions=
2024-10-21 06:52:37 : DEBUG : scmenu : appNewVersion=1.5
2024-10-21 06:52:37 : DEBUG : scmenu : appCustomVersion function: Not defined
2024-10-21 06:52:37 : DEBUG : scmenu : versionKey=CFBundleShortVersionString
2024-10-21 06:52:37 : DEBUG : scmenu : packageID=
2024-10-21 06:52:37 : DEBUG : scmenu : pkgName=
2024-10-21 06:52:37 : DEBUG : scmenu : choiceChangesXML=
2024-10-21 06:52:37 : DEBUG : scmenu : expectedTeamID=2WUMX954UB
2024-10-21 06:52:37 : DEBUG : scmenu : blockingProcesses=
2024-10-21 06:52:37 : DEBUG : scmenu : installerTool=
2024-10-21 06:52:37 : DEBUG : scmenu : CLIInstaller=
2024-10-21 06:52:37 : DEBUG : scmenu : CLIArguments=
2024-10-21 06:52:37 : DEBUG : scmenu : updateTool=
2024-10-21 06:52:37 : DEBUG : scmenu : updateToolArguments=
2024-10-21 06:52:37 : DEBUG : scmenu : updateToolRunAsCurrentUser=
2024-10-21 06:52:37 : INFO  : scmenu : BLOCKING_PROCESS_ACTION=tell_user
2024-10-21 06:52:37 : INFO  : scmenu : NOTIFY=success
2024-10-21 06:52:37 : INFO  : scmenu : LOGGING=DEBUG
2024-10-21 06:52:37 : INFO  : scmenu : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-21 06:52:37 : INFO  : scmenu : Label type: dmg
2024-10-21 06:52:37 : INFO  : scmenu : archiveName: SC Menu.dmg
2024-10-21 06:52:37 : INFO  : scmenu : no blocking processes defined, using SC Menu as default
2024-10-21 06:52:37 : DEBUG : scmenu : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-10-21 06:52:37 : INFO  : scmenu : name: SC Menu, appName: SC Menu.app
2024-10-21 06:52:37.459 mdfind[13680:18423862] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-21 06:52:37.460 mdfind[13680:18423862] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-21 06:52:37.596 mdfind[13680:18423862] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-21 06:52:37 : INFO  : scmenu : App(s) found: /System/Library/CoreServices/Script Menu.app
2024-10-21 06:52:37 : WARN  : scmenu : could not determine location of SC Menu.app
2024-10-21 06:52:37 : INFO  : scmenu : appversion: 
2024-10-21 06:52:37 : INFO  : scmenu : Latest version of SC Menu is 1.5
2024-10-21 06:52:37 : REQ   : scmenu : Downloading https://github.com/boberito/sc_menu/releases/download/1.5/SC_Menu.dmg to SC Menu.dmg
2024-10-21 06:52:37 : DEBUG : scmenu : No Dialog connection, just download
2024-10-21 06:52:38 : DEBUG : scmenu : File list: -rw-r--r--  1 gilburns  staff   658K Oct 21 06:52 SC Menu.dmg
2024-10-21 06:52:38 : DEBUG : scmenu : File type: SC Menu.dmg: zlib compressed data
2024-10-21 06:52:38 : DEBUG : scmenu : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.113.4
*   Trying 140.82.113.4:443...
* Connected to github.com (140.82.113.4) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/boberito/sc_menu/releases/download/1.5/SC_Menu.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /boberito/sc_menu/releases/download/1.5/SC_Menu.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /boberito/sc_menu/releases/download/1.5/SC_Menu.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: GitHub.com
< date: Mon, 21 Oct 2024 11:52:38 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/758606893/b8e28049-0c7c-4f38-8a5e-4a11f1304a27?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241021T115237Z&X-Amz-Expires=300&X-Amz-Signature=99502a8a185c60ef142316b7886774ef0ea948aff19faea8278ae1091513d84c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DSC_Menu.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: F430:3A904F:5A9141:7FC567:67164085
< 
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/758606893/b8e28049-0c7c-4f38-8a5e-4a11f1304a27?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241021T115237Z&X-Amz-Expires=300&X-Amz-Signature=99502a8a185c60ef142316b7886774ef0ea948aff19faea8278ae1091513d84c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DSC_Menu.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.109.133, 185.199.111.133, 185.199.108.133, 185.199.110.133
*   Trying 185.199.109.133:443...
* Connected to objects.githubusercontent.com (185.199.109.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/758606893/b8e28049-0c7c-4f38-8a5e-4a11f1304a27?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241021T115237Z&X-Amz-Expires=300&X-Amz-Signature=99502a8a185c60ef142316b7886774ef0ea948aff19faea8278ae1091513d84c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DSC_Menu.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/758606893/b8e28049-0c7c-4f38-8a5e-4a11f1304a27?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241021T115237Z&X-Amz-Expires=300&X-Amz-Signature=99502a8a185c60ef142316b7886774ef0ea948aff19faea8278ae1091513d84c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DSC_Menu.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/758606893/b8e28049-0c7c-4f38-8a5e-4a11f1304a27?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241021%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241021T115237Z&X-Amz-Expires=300&X-Amz-Signature=99502a8a185c60ef142316b7886774ef0ea948aff19faea8278ae1091513d84c&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DSC_Menu.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Tue, 15 Oct 2024 14:41:44 GMT
< etag: "0x8DCED277D45A379"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 61afaf09-601e-003c-4a10-1fc892000000
< x-ms-version: 2024-08-04
< x-ms-creation-time: Tue, 15 Oct 2024 14:41:44 GMT
< x-ms-blob-content-md5: UWUnCQMiArURssvWe5mY4A==
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=SC_Menu.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 115
< date: Mon, 21 Oct 2024 11:52:38 GMT
< x-served-by: cache-iad-kcgs7200132-IAD, cache-chi-kigq8000024-CHI
< x-cache: HIT, HIT
< x-cache-hits: 3, 0
< x-timer: S1729511558.096469,VS0,VE1
< content-length: 673994
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-10-21 06:52:38 : DEBUG : scmenu : DEBUG mode 1, not checking for blocking processes
2024-10-21 06:52:38 : REQ   : scmenu : Installing SC Menu
2024-10-21 06:52:38 : INFO  : scmenu : Mounting /Users/gilburns/GitHub/Installomator/build/SC Menu.dmg
2024-10-21 06:52:39 : DEBUG : scmenu : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DF54A609
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $80BD2EE5
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $4553194C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $09555131
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $4553194C
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $3AE9F239
verified   CRC32 $1E945B0D
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_APFS
/dev/disk3          	EF57347C-0000-11AA-AA11-0030654
/dev/disk3s1        	41504653-0000-11AA-AA11-0030654	/Volumes/SC Menu

2024-10-21 06:52:39 : INFO  : scmenu : Mounted: /Volumes/SC Menu
2024-10-21 06:52:39 : INFO  : scmenu : Verifying: /Volumes/SC Menu/SC Menu.app
2024-10-21 06:52:39 : DEBUG : scmenu : App size: 648K	/Volumes/SC Menu/SC Menu.app
2024-10-21 06:52:39 : DEBUG : scmenu : Debugging enabled, App Verification output was:
/Volumes/SC Menu/SC Menu.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bob Gendler (2WUMX954UB)

2024-10-21 06:52:39 : INFO  : scmenu : Team ID matching: 2WUMX954UB (expected: 2WUMX954UB )
2024-10-21 06:52:39 : INFO  : scmenu : Installing SC Menu version 1.5 on versionKey CFBundleShortVersionString.
2024-10-21 06:52:39 : INFO  : scmenu : App has LSMinimumSystemVersion: 13.0
2024-10-21 06:52:39 : DEBUG : scmenu : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-10-21 06:52:39 : INFO  : scmenu : Finishing...
2024-10-21 06:52:42 : INFO  : scmenu : name: SC Menu, appName: SC Menu.app
2024-10-21 06:52:42.532 mdfind[13763:18424186] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-21 06:52:42.532 mdfind[13763:18424186] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-21 06:52:42.619 mdfind[13763:18424186] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-21 06:52:42 : INFO  : scmenu : App(s) found: /System/Library/CoreServices/Script Menu.app
2024-10-21 06:52:42 : WARN  : scmenu : could not determine location of SC Menu.app
2024-10-21 06:52:42 : REQ   : scmenu : Installed SC Menu, version 1.5
2024-10-21 06:52:42 : INFO  : scmenu : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-21 06:52:42 : DEBUG : scmenu : Unmounting /Volumes/SC Menu
2024-10-21 06:52:43 : DEBUG : scmenu : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-10-21 06:52:43 : DEBUG : scmenu : DEBUG mode 1, not reopening anything
2024-10-21 06:52:43 : REQ   : scmenu : All done!
2024-10-21 06:52:43 : REQ   : scmenu : ################## End Installomator, exit code 0 

```