### PR TITLE
Update broken download for OnScreen Control (onscreencontrol) label

### DIFF
--- a/fragments/labels/onscreencontrol.sh
+++ b/fragments/labels/onscreencontrol.sh
@@ -2,8 +2,8 @@ onscreencontrol)
     name="OnScreen Control"
     type="pkgInZip"
     packageID="com.LGSI.OnScreen-Control"
-    releaseURL="https://www.lg.com/de/support/software-select-category-result?csSalesCode=34WK95U-W.AEU"
-    appNewVersion=$(curl -sf $releaseURL | grep -m 1 "Mac_OSC_" | sed -E 's/.*OSC_([0-9.]*).zip.*/\1/g')
-    downloadURL=$(curl -sf $releaseURL | grep -m 1 "Mac_OSC_" | sed "s|.*href=\"\(.*\)\" title.*|\\1|")
+    downloadFile=$(curl -sf https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControlLatestVersion.txt)
+    appNewVersion=$(echo $downloadFile | grep -o '[0-9].[0-9][0-9]')
+    downloadURL="https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/${downloadFile}"
     expectedTeamID="5SKT5H4CPQ"
     ;;


### PR DESCRIPTION
```
assemble.sh onscreencontrol
2024-10-23 19:31:01 : REQ   : onscreencontrol : ################## Start Installomator v. 10.7beta, date 2024-10-23
2024-10-23 19:31:01 : INFO  : onscreencontrol : ################## Version: 10.7beta
2024-10-23 19:31:01 : INFO  : onscreencontrol : ################## Date: 2024-10-23
2024-10-23 19:31:01 : INFO  : onscreencontrol : ################## onscreencontrol
2024-10-23 19:31:01 : DEBUG : onscreencontrol : DEBUG mode 1 enabled.
2024-10-23 19:31:01 : INFO  : onscreencontrol : SwiftDialog is not installed, clear cmd file var
2024-10-23 19:31:01 : DEBUG : onscreencontrol : name=OnScreen Control
2024-10-23 19:31:02 : DEBUG : onscreencontrol : appName=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : type=pkgInZip
2024-10-23 19:31:02 : DEBUG : onscreencontrol : archiveName=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : downloadURL=https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControl_6.34.zip
2024-10-23 19:31:02 : DEBUG : onscreencontrol : curlOptions=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : appNewVersion=6.34
2024-10-23 19:31:02 : DEBUG : onscreencontrol : appCustomVersion function: Not defined
2024-10-23 19:31:02 : DEBUG : onscreencontrol : versionKey=CFBundleShortVersionString
2024-10-23 19:31:02 : DEBUG : onscreencontrol : packageID=com.LGSI.OnScreen-Control
2024-10-23 19:31:02 : DEBUG : onscreencontrol : pkgName=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : choiceChangesXML=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : expectedTeamID=5SKT5H4CPQ
2024-10-23 19:31:02 : DEBUG : onscreencontrol : blockingProcesses=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : installerTool=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : CLIInstaller=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : CLIArguments=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : updateTool=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : updateToolArguments=
2024-10-23 19:31:02 : DEBUG : onscreencontrol : updateToolRunAsCurrentUser=
2024-10-23 19:31:02 : INFO  : onscreencontrol : BLOCKING_PROCESS_ACTION=tell_user
2024-10-23 19:31:02 : INFO  : onscreencontrol : NOTIFY=success
2024-10-23 19:31:02 : INFO  : onscreencontrol : LOGGING=DEBUG
2024-10-23 19:31:02 : INFO  : onscreencontrol : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-23 19:31:02 : INFO  : onscreencontrol : Label type: pkgInZip
2024-10-23 19:31:02 : INFO  : onscreencontrol : archiveName: OnScreen Control.zip
2024-10-23 19:31:02 : INFO  : onscreencontrol : no blocking processes defined, using OnScreen Control as default
2024-10-23 19:31:02 : DEBUG : onscreencontrol : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-10-23 19:31:02 : INFO  : onscreencontrol : No version found using packageID com.LGSI.OnScreen-Control
2024-10-23 19:31:02 : INFO  : onscreencontrol : App(s) found: /Applications/OnScreen Control.app
2024-10-23 19:31:02 : INFO  : onscreencontrol : found app at /Applications/OnScreen Control.app, version 6.34, on versionKey CFBundleShortVersionString
2024-10-23 19:31:02 : INFO  : onscreencontrol : appversion: 6.34
2024-10-23 19:31:02 : INFO  : onscreencontrol : Latest version of OnScreen Control is 6.34
2024-10-23 19:31:02 : WARN  : onscreencontrol : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-10-23 19:31:02 : REQ   : onscreencontrol : Downloading https://lmu.lge.com/ExternalService/onscreencontrol/mac/2.0/OnScreenControl_6.34.zip to OnScreen Control.zip
2024-10-23 19:31:02 : DEBUG : onscreencontrol : No Dialog connection, just download
2024-10-23 19:31:10 : DEBUG : onscreencontrol : File list: -rw-r--r--  1 gilburns  staff    71M Oct 23 19:31 OnScreen Control.zip
2024-10-23 19:31:10 : DEBUG : onscreencontrol : File type: OnScreen Control.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2024-10-23 19:31:10 : DEBUG : onscreencontrol : curl output was:
* Host lmu.lge.com:443 was resolved.
* IPv6: (none)
* IPv4: 184.25.119.45, 184.25.119.41
*   Trying 184.25.119.45:443...
* Connected to lmu.lge.com (184.25.119.45) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2563 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=lmu.lge.com
*  start date: Sep 15 11:54:46 2024 GMT
*  expire date: Dec 14 11:54:45 2024 GMT
*  subjectAltName: host "lmu.lge.com" matched cert's "lmu.lge.com"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /ExternalService/onscreencontrol/mac/2.0/OnScreenControl_6.34.zip HTTP/1.1
> Host: lmu.lge.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Type: application/zip
< ETag: "b2e73129d4fe3fa76b17e7be4083693b:1723078677.459949"
< Last-Modified: Thu, 08 Aug 2024 00:57:57 GMT
< Server: AkamaiNetStorage
< Content-Length: 74799267
< Expires: Thu, 24 Oct 2024 00:31:02 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Thu, 24 Oct 2024 00:31:02 GMT
< Connection: keep-alive
< 
{ [15989 bytes data]
* Connection #0 to host lmu.lge.com left intact

2024-10-23 19:31:10 : DEBUG : onscreencontrol : DEBUG mode 1, not checking for blocking processes
2024-10-23 19:31:10 : REQ   : onscreencontrol : Installing OnScreen Control
2024-10-23 19:31:10 : INFO  : onscreencontrol : Unzipping OnScreen Control.zip
2024-10-23 19:31:11 : DEBUG : onscreencontrol : Found pkg(s):
/Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg
2024-10-23 19:31:11 : INFO  : onscreencontrol : found pkg: /Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg
2024-10-23 19:31:11 : INFO  : onscreencontrol : Verifying: /Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg
2024-10-23 19:31:11 : DEBUG : onscreencontrol : File list: -rw-r--r--  1 gilburns  staff    71M Jul 31 00:12 /Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg
2024-10-23 19:31:11 : DEBUG : onscreencontrol : File type: /Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg: xar archive compressed TOC: 8480, SHA-1 checksum
2024-10-23 19:31:11 : DEBUG : onscreencontrol : spctlOut is /Users/gilburns/GitHub/Installomator/build/OSC_V6.34_signed.pkg: accepted
2024-10-23 19:31:11 : DEBUG : onscreencontrol : source=Notarized Developer ID
2024-10-23 19:31:11 : DEBUG : onscreencontrol : origin=Developer ID Installer: LG Electronics (5SKT5H4CPQ)
2024-10-23 19:31:11 : INFO  : onscreencontrol : Team ID: 5SKT5H4CPQ (expected: 5SKT5H4CPQ )
2024-10-23 19:31:11 : INFO  : onscreencontrol : Checking package version.
2024-10-23 19:31:11 : INFO  : onscreencontrol : Downloaded package com.LGSI.OnScreen-Control version 
2024-10-23 19:31:11 : DEBUG : onscreencontrol : DEBUG enabled, skipping installation
2024-10-23 19:31:11 : INFO  : onscreencontrol : Finishing...
2024-10-23 19:31:14 : INFO  : onscreencontrol : No version found using packageID com.LGSI.OnScreen-Control
2024-10-23 19:31:14 : INFO  : onscreencontrol : App(s) found: /Applications/OnScreen Control.app
2024-10-23 19:31:14 : INFO  : onscreencontrol : found app at /Applications/OnScreen Control.app, version 6.34, on versionKey CFBundleShortVersionString
2024-10-23 19:31:14 : REQ   : onscreencontrol : Installed OnScreen Control
2024-10-23 19:31:14 : INFO  : onscreencontrol : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-23 19:31:15 : DEBUG : onscreencontrol : DEBUG mode 1, not reopening anything
2024-10-23 19:31:15 : REQ   : onscreencontrol : All done!
2024-10-23 19:31:15 : REQ   : onscreencontrol : ################## End Installomator, exit code 0 

```