### PR TITLE
Create Workbrew label

### DIFF
--- a/fragments/labels/workbrew.sh
+++ b/fragments/labels/workbrew.sh
@@ -1,0 +1,9 @@
+workbrew)
+    name="Workbrew"
+    type="pkg"
+    packageID="com.workbrew.Workbrew"
+    downloadURL="https://console.workbrew.com/downloads/macos"
+    appNewVersion="$(curl -ifs "https://console.workbrew.com/downloads/macos" | grep -o "Workbrew-[0-9].[0.9].[0-9][0-9].pkg" | grep -o "[0-9].[0.9].[0-9][0-9]")"
+    appCustomVersion(){ /opt/workbrew/bin/brew --version | grep "Workbrew " | awk '{ print $2 }' | cut -d'-' -f1 }
+    expectedTeamID="676JW3JDLF"
+    ;;


### PR DESCRIPTION
assemble.sh workbrew 
2024-10-23 20:01:29 : REQ   : workbrew : ################## Start Installomator v. 10.7beta, date 2024-10-23
2024-10-23 20:01:29 : INFO  : workbrew : ################## Version: 10.7beta
2024-10-23 20:01:29 : INFO  : workbrew : ################## Date: 2024-10-23
2024-10-23 20:01:29 : INFO  : workbrew : ################## workbrew
2024-10-23 20:01:29 : DEBUG : workbrew : DEBUG mode 1 enabled.
2024-10-23 20:01:29 : INFO  : workbrew : SwiftDialog is not installed, clear cmd file var
2024-10-23 20:01:30 : DEBUG : workbrew : name=Workbrew
2024-10-23 20:01:30 : DEBUG : workbrew : appName=
2024-10-23 20:01:30 : DEBUG : workbrew : type=pkg
2024-10-23 20:01:30 : DEBUG : workbrew : archiveName=
2024-10-23 20:01:30 : DEBUG : workbrew : downloadURL=https://console.workbrew.com/downloads/macos
2024-10-23 20:01:30 : DEBUG : workbrew : curlOptions=
2024-10-23 20:01:30 : DEBUG : workbrew : appNewVersion=0.9.10
2024-10-23 20:01:30 : DEBUG : workbrew : appCustomVersion function: Defined. 
2024-10-23 20:01:30 : DEBUG : workbrew : versionKey=CFBundleShortVersionString
2024-10-23 20:01:30 : DEBUG : workbrew : packageID=com.workbrew.Workbrew
2024-10-23 20:01:30 : DEBUG : workbrew : pkgName=
2024-10-23 20:01:30 : DEBUG : workbrew : choiceChangesXML=
2024-10-23 20:01:30 : DEBUG : workbrew : expectedTeamID=676JW3JDLF
2024-10-23 20:01:30 : DEBUG : workbrew : blockingProcesses=
2024-10-23 20:01:30 : DEBUG : workbrew : installerTool=
2024-10-23 20:01:30 : DEBUG : workbrew : CLIInstaller=
2024-10-23 20:01:30 : DEBUG : workbrew : CLIArguments=
2024-10-23 20:01:30 : DEBUG : workbrew : updateTool=
2024-10-23 20:01:30 : DEBUG : workbrew : updateToolArguments=
2024-10-23 20:01:30 : DEBUG : workbrew : updateToolRunAsCurrentUser=
2024-10-23 20:01:30 : INFO  : workbrew : BLOCKING_PROCESS_ACTION=tell_user
2024-10-23 20:01:30 : INFO  : workbrew : NOTIFY=success
2024-10-23 20:01:30 : INFO  : workbrew : LOGGING=DEBUG
2024-10-23 20:01:30 : INFO  : workbrew : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-23 20:01:30 : INFO  : workbrew : Label type: pkg
2024-10-23 20:01:30 : INFO  : workbrew : archiveName: Workbrew.pkg
2024-10-23 20:01:30 : INFO  : workbrew : no blocking processes defined, using Workbrew as default
2024-10-23 20:01:30 : DEBUG : workbrew : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-10-23 20:01:31 : INFO  : workbrew : Custom App Version detection is used, found 0.9.10
2024-10-23 20:01:31 : INFO  : workbrew : appversion: 0.9.10
2024-10-23 20:01:31 : INFO  : workbrew : Latest version of Workbrew is 0.9.10
2024-10-23 20:01:31 : WARN  : workbrew : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-10-23 20:01:31 : REQ   : workbrew : Downloading https://console.workbrew.com/downloads/macos to Workbrew.pkg
2024-10-23 20:01:31 : DEBUG : workbrew : No Dialog connection, just download
2024-10-23 20:02:03 : DEBUG : workbrew : File list: -rw-r--r--  1 gilburns  staff   137M Oct 23 20:02 Workbrew.pkg
2024-10-23 20:02:03 : DEBUG : workbrew : File type: Workbrew.pkg: xar archive compressed TOC: 4907, SHA-1 checksum
2024-10-23 20:02:03 : DEBUG : workbrew : curl output was:
* Host console.workbrew.com:443 was resolved.
* IPv6: 2606:4700:7::60, 2a06:98c1:58::60
* IPv4: 162.159.140.98, 172.66.0.96
*   Trying 162.159.140.98:443...
* Connected to console.workbrew.com (162.159.140.98) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [325 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2531 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=console.workbrew.com
*  start date: Sep  9 16:59:32 2024 GMT
*  expire date: Dec  8 16:59:31 2024 GMT
*  subjectAltName: host "console.workbrew.com" matched cert's "console.workbrew.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://console.workbrew.com/downloads/macos
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: console.workbrew.com]
* [HTTP/2] [1] [:path: /downloads/macos]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/macos HTTP/2
> Host: console.workbrew.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 303 
< date: Thu, 24 Oct 2024 01:01:31 GMT
< content-type: text/html; charset=utf-8
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/706576996/e8f90e86-95b2-4471-8036-dce4aa08abc8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241024T010130Z&X-Amz-Expires=300&X-Amz-Signature=aa4a837748939b59d5aea6805696be0ba64c16bcae47bf76d1e7168e5e3a3be4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DWorkbrew-0.9.10.pkg&response-content-type=application%2Foctet-stream
< x-frame-options: SAMEORIGIN
< x-xss-protection: 0
< x-content-type-options: nosniff
< x-download-options: noopen
< x-permitted-cross-domain-policies: none
< referrer-policy: strict-origin-when-cross-origin
< cache-control: no-cache
< content-security-policy: object-src 'none'; default-src 'self'; font-src 'self'; worker-src 'self' blob:; child-src 'self' blob:; connect-src 'self' https://workbrew.unthread.io https://*.sentry.io; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https://assets.unthread.io https://avatars.githubusercontent.com https://www.gravatar.com; frame-src 'self' https://workbrew.unthread.io; script-src 'self' https://workbrew.unthread.io 'nonce-'; report-uri https://o4505029715558400.ingest.us.sentry.io/api/4506399518097408/security/?sentry_key=c0a7f02155fbe4f88026aece6b6ab8cb;
< x-request-id: cd62d96a-69eb-4f03-bbb1-79872fc2f3ef
< x-runtime: 0.007178
< x-do-app-origin: b1368c45-3612-4ca8-a5cc-176de0b1b99a
< x-do-orig-status: 303
< cf-cache-status: MISS
< set-cookie: __cf_bm=3H7RPKCXmIdX_r181HwCuvKO8_7_ICMClL98Ac9O99I-1729731691-1.0.1.1-9RPF_aNUXfqKJ8rbUe3LFQCxwyE7FsrISYzWupk6T.O2j6y2.bNPeCfLiM5OJ0GmmEkXGodpW3_6tDHc2Bd5PA; path=/; expires=Thu, 24-Oct-24 01:31:31 GMT; domain=.console.workbrew.com; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 8d76093f488902b4-ORD
< alt-svc: h3=":443"; ma=86400
< 
* Ignoring the response-body
* Connection #0 to host console.workbrew.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/706576996/e8f90e86-95b2-4471-8036-dce4aa08abc8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241024T010130Z&X-Amz-Expires=300&X-Amz-Signature=aa4a837748939b59d5aea6805696be0ba64c16bcae47bf76d1e7168e5e3a3be4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DWorkbrew-0.9.10.pkg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.108.133, 185.199.109.133, 185.199.110.133, 185.199.111.133
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/706576996/e8f90e86-95b2-4471-8036-dce4aa08abc8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241024T010130Z&X-Amz-Expires=300&X-Amz-Signature=aa4a837748939b59d5aea6805696be0ba64c16bcae47bf76d1e7168e5e3a3be4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DWorkbrew-0.9.10.pkg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/706576996/e8f90e86-95b2-4471-8036-dce4aa08abc8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241024T010130Z&X-Amz-Expires=300&X-Amz-Signature=aa4a837748939b59d5aea6805696be0ba64c16bcae47bf76d1e7168e5e3a3be4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DWorkbrew-0.9.10.pkg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/706576996/e8f90e86-95b2-4471-8036-dce4aa08abc8?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241024%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241024T010130Z&X-Amz-Expires=300&X-Amz-Signature=aa4a837748939b59d5aea6805696be0ba64c16bcae47bf76d1e7168e5e3a3be4&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DWorkbrew-0.9.10.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Mon, 21 Oct 2024 15:04:06 GMT
< etag: "0x8DCF1E19C1DD6AA"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: 6e6e0639-101e-006b-3fcf-2366a1000000
< x-ms-version: 2024-08-04
< x-ms-creation-time: Mon, 21 Oct 2024 15:04:06 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Workbrew-0.9.10.pkg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 3106
< date: Thu, 24 Oct 2024 01:01:31 GMT
< x-served-by: cache-iad-kiad7000042-IAD, cache-chi-klot8100085-CHI
< x-cache: HIT, HIT
< x-cache-hits: 179, 0
< x-timer: S1729731692.607584,VS0,VE3
< content-length: 143906185
< 
{ [16375 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-10-23 20:02:03 : DEBUG : workbrew : DEBUG mode 1, not checking for blocking processes
2024-10-23 20:02:03 : REQ   : workbrew : Installing Workbrew
2024-10-23 20:02:03 : INFO  : workbrew : Verifying: Workbrew.pkg
2024-10-23 20:02:03 : DEBUG : workbrew : File list: -rw-r--r--  1 gilburns  staff   137M Oct 23 20:02 Workbrew.pkg
2024-10-23 20:02:03 : DEBUG : workbrew : File type: Workbrew.pkg: xar archive compressed TOC: 4907, SHA-1 checksum
2024-10-23 20:02:04 : DEBUG : workbrew : spctlOut is Workbrew.pkg: accepted
2024-10-23 20:02:04 : DEBUG : workbrew : source=Notarized Developer ID
2024-10-23 20:02:04 : DEBUG : workbrew : origin=Developer ID Installer: Workbrew Inc. (676JW3JDLF)
2024-10-23 20:02:04 : INFO  : workbrew : Team ID: 676JW3JDLF (expected: 676JW3JDLF )
2024-10-23 20:02:04 : INFO  : workbrew : Checking package version.
2024-10-23 20:02:04 : INFO  : workbrew : Downloaded package com.workbrew.Workbrew version 0.9.10
2024-10-23 20:02:04 : INFO  : workbrew : Downloaded version of Workbrew is the same as installed.
2024-10-23 20:02:04 : DEBUG : workbrew : DEBUG mode 1, not reopening anything
2024-10-23 20:02:04 : REQ   : workbrew : No new version to install
2024-10-23 20:02:04 : REQ   : workbrew : ################## End Installomator, exit code 0 
