### PR TITLE
Create particulars label

### DIFF
--- a/fragments/labels/particulars.sh
+++ b/fragments/labels/particulars.sh
@@ -1,0 +1,9 @@
+particulars)
+    name="Particulars"
+    type="pkg"
+    packageID="net.glencode.Particulars"
+    downloadURL="https://particulars.app/_downloads/Particulars-latest.pkg"
+    appNewVersion=$(curl -fsI "${downloadURL}" | grep -i location | grep -oE "[0-9]+\.[0-9]+")
+    expectedTeamID="2Z25XDNP2X"
+    blockingProcesses=( NONE )
+    ;;


### PR DESCRIPTION
Output:
```
% utils/assemble.sh particulars
2024-10-23 21:16:15 : REQ   : particulars : ################## Start Installomator v. 10.6beta, date 2024-10-23
2024-10-23 21:16:15 : INFO  : particulars : ################## Version: 10.6beta
2024-10-23 21:16:15 : INFO  : particulars : ################## Date: 2024-10-23
2024-10-23 21:16:15 : INFO  : particulars : ################## particulars
2024-10-23 21:16:15 : DEBUG : particulars : DEBUG mode 1 enabled.
2024-10-23 21:16:16 : DEBUG : particulars : name=Particulars
2024-10-23 21:16:16 : DEBUG : particulars : appName=
2024-10-23 21:16:16 : DEBUG : particulars : type=pkg
2024-10-23 21:16:16 : DEBUG : particulars : archiveName=
2024-10-23 21:16:16 : DEBUG : particulars : downloadURL=https://particulars.app/_downloads/Particulars-latest.pkg
2024-10-23 21:16:16 : DEBUG : particulars : curlOptions=
2024-10-23 21:16:16 : DEBUG : particulars : appNewVersion=62.423
2024-10-23 21:16:16 : DEBUG : particulars : appCustomVersion function: Not defined
2024-10-23 21:16:16 : DEBUG : particulars : versionKey=CFBundleShortVersionString
2024-10-23 21:16:16 : DEBUG : particulars : packageID=net.glencode.Particulars
2024-10-23 21:16:16 : DEBUG : particulars : pkgName=
2024-10-23 21:16:16 : DEBUG : particulars : choiceChangesXML=
2024-10-23 21:16:16 : DEBUG : particulars : expectedTeamID=2Z25XDNP2X
2024-10-23 21:16:16 : DEBUG : particulars : blockingProcesses=NONE
2024-10-23 21:16:16 : DEBUG : particulars : installerTool=
2024-10-23 21:16:16 : DEBUG : particulars : CLIInstaller=
2024-10-23 21:16:16 : DEBUG : particulars : CLIArguments=
2024-10-23 21:16:16 : DEBUG : particulars : updateTool=
2024-10-23 21:16:16 : DEBUG : particulars : updateToolArguments=
2024-10-23 21:16:16 : DEBUG : particulars : updateToolRunAsCurrentUser=
2024-10-23 21:16:16 : INFO  : particulars : BLOCKING_PROCESS_ACTION=tell_user
2024-10-23 21:16:16 : INFO  : particulars : NOTIFY=success
2024-10-23 21:16:16 : INFO  : particulars : LOGGING=DEBUG
2024-10-23 21:16:16 : INFO  : particulars : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-23 21:16:16 : INFO  : particulars : Label type: pkg
2024-10-23 21:16:16 : INFO  : particulars : archiveName: Particulars.pkg
2024-10-23 21:16:16 : DEBUG : particulars : Changing directory to /Users/hessf/Git/Installomator/build
2024-10-23 21:16:16 : INFO  : particulars : found packageID net.glencode.Particulars installed, version 62.0.0
2024-10-23 21:16:16 : INFO  : particulars : appversion: 62.0.0
2024-10-23 21:16:16 : INFO  : particulars : Latest version of Particulars is 62.423
2024-10-23 21:16:16 : REQ   : particulars : Downloading https://particulars.app/_downloads/Particulars-latest.pkg to Particulars.pkg
2024-10-23 21:16:16 : DEBUG : particulars : No Dialog connection, just download
2024-10-23 21:16:18 : DEBUG : particulars : File list: -rw-r--r--@ 1 hessf  staff   2.4M Oct 23 21:16 Particulars.pkg
2024-10-23 21:16:19 : DEBUG : particulars : File type: Particulars.pkg: xar archive compressed TOC: 5264, SHA-1 checksum
2024-10-23 21:16:19 : DEBUG : particulars : curl output was:
* Host particulars.app:443 was resolved.
* IPv6: (none)
* IPv4: 35.185.44.232
*   Trying 35.185.44.232:443...
* Connected to particulars.app (35.185.44.232) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [6 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3266 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=particulars.app
*  start date: Sep 24 03:16:15 2024 GMT
*  expire date: Oct 24 03:16:15 2025 GMT
*  subjectAltName: host "particulars.app" matched cert's "particulars.app"
*  issuer: C=US; ST=CO; L=Denver; O=Pinnacol Assurance; OU=deff624896835b1e68d49e88950204c0; CN=ca.pinnacol.goskope.com; emailAddress=certadmin@netskope.com
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /_downloads/Particulars-latest.pkg HTTP/1.1
> Host: particulars.app
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 302 Found
< Content-Type: text/html; charset=utf-8
< Location: https://particulars.app/_downloads/Particulars-62.423.pkg
< Permissions-Policy: interest-cohort=()
< Vary: Origin
< Date: Thu, 24 Oct 2024 03:16:17 GMT
< Content-Length: 80
<
* Ignoring the response-body
* Connection #0 to host particulars.app left intact
* Issue another request to this URL: 'https://particulars.app/_downloads/Particulars-62.423.pkg'
* Found bundle for host: 0x600000764690 [serially]
* Can not multiplex, even if we wanted to
* Re-using existing connection with host particulars.app
> GET /_downloads/Particulars-62.423.pkg HTTP/1.1
> Host: particulars.app
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 302 Found
< Content-Type: text/html; charset=utf-8
< Location: https://gitlab.com/fraserhess/particulars/-/package_files/154423041/download
< Permissions-Policy: interest-cohort=()
< Vary: Origin
< Date: Thu, 24 Oct 2024 03:16:17 GMT
< Content-Length: 99
<
* Ignoring the response-body
* Connection #0 to host particulars.app left intact
* Issue another request to this URL: 'https://gitlab.com/fraserhess/particulars/-/package_files/154423041/download'
* Host gitlab.com:443 was resolved.
* IPv6: (none)
* IPv4: 172.65.251.78
*   Trying 172.65.251.78:443...
* Connected to gitlab.com (172.65.251.78) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [6 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3256 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=gitlab.com
*  start date: Sep 22 19:13:43 2024 GMT
*  expire date: Oct 22 19:13:43 2025 GMT
*  subjectAltName: host "gitlab.com" matched cert's "gitlab.com"
*  issuer: C=US; ST=CO; L=Denver; O=Pinnacol Assurance; OU=deff624896835b1e68d49e88950204c0; CN=ca.pinnacol.goskope.com; emailAddress=certadmin@netskope.com
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /fraserhess/particulars/-/package_files/154423041/download HTTP/1.1
> Host: gitlab.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Thu, 24 Oct 2024 03:16:18 GMT
< Content-Type: application/octet-stream
< Connection: keep-alive
< cache-control: no-cache
< content-disposition: attachment; filename="Particulars-62.423.pkg"; filename*=UTF-8''Particulars-62.423.pkg
< content-security-policy: base-uri 'self'; child-src https://www.google.com/recaptcha/ https://www.recaptcha.net/ https://www.googletagmanager.com/ns.html https://*.zuora.com/apps/PublicHostedPageLite.do https://gitlab.com/admin/ https://gitlab.com/assets/ https://gitlab.com/-/speedscope/index.html https://gitlab.com/-/sandbox/ 'self' https://gitlab.com/assets/ blob: data:; connect-src 'self' https://gitlab.com wss://gitlab.com https://sentry.gitlab.net https://new-sentry.gitlab.net https://customers.gitlab.com https://snowplow.trx.gitlab.net https://sourcegraph.com https://collector.prd-278964.gl-product-analytics.com snowplow.trx.gitlab.net; default-src 'self'; font-src 'self'; form-action 'self' https: http:; frame-ancestors 'self'; frame-src https://www.google.com/recaptcha/ https://www.recaptcha.net/ https://www.googletagmanager.com/ns.html https://*.zuora.com/apps/PublicHostedPageLite.do https://gitlab.com/admin/ https://gitlab.com/assets/ https://gitlab.com/-/speedscope/index.html https://gitlab.com/-/sandbox/; img-src 'self' data: blob: http: https:; manifest-src 'self'; media-src 'self' data: blob: http: https:; object-src 'none'; report-uri https://new-sentry.gitlab.net/api/4/security/?sentry_key=f5573e26de8f4293b285e556c35dfd6e&sentry_environment=gprd; script-src 'strict-dynamic' 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.recaptcha.net/ https://apis.google.com https://*.zuora.com/apps/PublicHostedPageLite.do 'nonce-AeV2NYiJXTHK/HXopRnqVQ=='; style-src 'self' 'unsafe-inline'; worker-src 'self' https://gitlab.com/assets/ blob: data:
< etag: "e0196e74366118c1aa5b78e6963db741"
< last-modified: Thu, 24 Oct 2024 01:10:52 GMT
< permissions-policy: interest-cohort=()
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< x-download-options: noopen
< x-frame-options: SAMEORIGIN
< x-gitlab-meta: {"correlation_id":"01JAY8CSTFY9B4P89CXX0VZP04","version":"1"}
< x-goog-generation: 1729732252771763
< x-goog-hash: crc32c=EEKKZA==
< x-goog-hash: md5=4BludDZhGMGqW3jmlj23QQ==
< x-goog-metageneration: 1
< x-goog-storage-class: STANDARD
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 2485839
< x-guploader-uploadid: AHmUCY3oEGXfUxB7bjNHO1V0KGTvdritPOelcqK8g8tBEXENoCt2wVQRxCgJeFX2SUPtUoFF5zY
< x-permitted-cross-domain-policies: none
< x-request-id: 01JAY8CSTFY9B4P89CXX0VZP04
< x-runtime: 0.077721
< x-ua-compatible: IE=edge
< x-xss-protection: 1; mode=block
< gitlab-lb: haproxy-main-01-lb-gprd
< gitlab-sv: web-gke-us-east1-c
< CF-Cache-Status: MISS
< Accept-Ranges: bytes
< Report-To: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=FDGCoVnbxiM4RwQsJTBywJqDYRjutgMobHF3ObB9YYmNuD3hWDhdR8sjHJcP%2FTmJf2kmMs3qFcuPv4eJ21XEERIaExrNuuS8oKZXRrxukSB0lfdMuT7bceBUj3A%3D"}],"group":"cf-nel","max_age":604800}
< NEL: {"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}
< Strict-Transport-Security: max-age=31536000
< Set-Cookie: _cfuvid=viCZbh0MFDXLNbP2hGaS7kLjBWKhDxRHdjQ34cicQ9U-1729739778120-0.0.1.1-604800000; path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
< Server: cloudflare
< CF-RAY: 8d76ceab6e675211-DEN
< Content-Length: 2485839
<
{ [10220 bytes data]
* Connection #1 to host gitlab.com left intact

2024-10-23 21:16:19 : REQ   : particulars : Installing Particulars
2024-10-23 21:16:19 : INFO  : particulars : Verifying: Particulars.pkg
2024-10-23 21:16:19 : DEBUG : particulars : File list: -rw-r--r--@ 1 hessf  staff   2.4M Oct 23 21:16 Particulars.pkg
2024-10-23 21:16:19 : DEBUG : particulars : File type: Particulars.pkg: xar archive compressed TOC: 5264, SHA-1 checksum
2024-10-23 21:16:19 : DEBUG : particulars : spctlOut is Particulars.pkg: accepted
2024-10-23 21:16:19 : DEBUG : particulars : source=Notarized Developer ID
2024-10-23 21:16:19 : DEBUG : particulars : origin=Developer ID Installer: Fraser Hess (2Z25XDNP2X)
2024-10-23 21:16:19 : INFO  : particulars : Team ID: 2Z25XDNP2X (expected: 2Z25XDNP2X )
2024-10-23 21:16:19 : INFO  : particulars : Checking package version.
2024-10-23 21:16:20 : INFO  : particulars : Downloaded package net.glencode.Particulars version 62.423
2024-10-23 21:16:20 : DEBUG : particulars : DEBUG enabled, skipping installation
2024-10-23 21:16:20 : INFO  : particulars : Finishing...
2024-10-23 21:16:23 : INFO  : particulars : found packageID net.glencode.Particulars installed, version 62.0.0
2024-10-23 21:16:23 : REQ   : particulars : Installed Particulars, version 62.423
2024-10-23 21:16:23 : INFO  : particulars : notifying
2024-10-23 21:16:23 : DEBUG : particulars : DEBUG mode 1, not reopening anything
2024-10-23 21:16:23 : REQ   : particulars : All done!
2024-10-23 21:16:23 : REQ   : particulars : ################## End Installomator, exit code 0```