### PR TITLE
Update googlechrome.sh

### DIFF
--- a/fragments/labels/googlechrome.sh
+++ b/fragments/labels/googlechrome.sh
@@ -2,7 +2,7 @@ googlechrome)
     name="Google Chrome"
     type="dmg"
     downloadURL="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
-    appNewVersion=$(curl -s https://omahaproxy.appspot.com/history | awk -F',' '/mac_arm64,stable/{print $3; exit}')
+    appNewVersion=$(getJSONValue "$(curl -s "https://chromiumdash.appspot.com/fetch_releases?platform=Mac&channel=Stable&num=1")" "[0].version")
     expectedTeamID="EQHXZ8M8AV"
     printlog "WARNING for ERROR: Label googlechrome should not be used. Instead use googlechromepkg as per recommendations from Google. It's not fully certain that the app actually gets updated here. googlechromepkg will have built in updates and make sure the client is updated in the future." REQ
     ;;


### PR DESCRIPTION
The googlechrome) recipe is still set to use omahaproxy.appspot.com (including the current latest, v 10.6) - but that site has been shut down, and refers us to https://chromiumdash.appspot.com

This updated recipe uses getJSONValue to parse the value of https://chromiumdash.appspot.com/fetch_releases?platform=Mac&channel=Stable&num=1 for the version number.