### PR TITLE
Fix Icons label for type change

### DIFF
--- a/fragments/labels/icons.sh
+++ b/fragments/labels/icons.sh
@@ -1,6 +1,6 @@
 icons)
     name="Icons"
-    type="zip"
+    type="pkg"
     downloadURL=$(downloadURLFromGit SAP macOS-icon-generator )
     appNewVersion=$(versionFromGit SAP macOS-icon-generator )
     expectedTeamID="7R5ZEU67FQ"


### PR DESCRIPTION
```
assemble.sh icons
2024-10-24 19:29:24 : REQ   : icons : ################## Start Installomator v. 10.7beta, date 2024-10-24
2024-10-24 19:29:24 : INFO  : icons : ################## Version: 10.7beta
2024-10-24 19:29:24 : INFO  : icons : ################## Date: 2024-10-24
2024-10-24 19:29:24 : INFO  : icons : ################## icons
2024-10-24 19:29:24 : DEBUG : icons : DEBUG mode 1 enabled.
2024-10-24 19:29:24 : INFO  : icons : SwiftDialog is not installed, clear cmd file var
2024-10-24 19:29:25 : DEBUG : icons : name=Icons
2024-10-24 19:29:25 : DEBUG : icons : appName=
2024-10-24 19:29:25 : DEBUG : icons : type=pkg
2024-10-24 19:29:25 : DEBUG : icons : archiveName=
2024-10-24 19:29:25 : DEBUG : icons : downloadURL=https://github.com/SAP/macOS-icon-generator/releases/download/2.1.0/Icons_2.1.0.pkg
2024-10-24 19:29:25 : DEBUG : icons : curlOptions=
2024-10-24 19:29:25 : DEBUG : icons : appNewVersion=2.1.0
2024-10-24 19:29:25 : DEBUG : icons : appCustomVersion function: Not defined
2024-10-24 19:29:25 : DEBUG : icons : versionKey=CFBundleShortVersionString
2024-10-24 19:29:25 : DEBUG : icons : packageID=
2024-10-24 19:29:25 : DEBUG : icons : pkgName=
2024-10-24 19:29:25 : DEBUG : icons : choiceChangesXML=
2024-10-24 19:29:25 : DEBUG : icons : expectedTeamID=7R5ZEU67FQ
2024-10-24 19:29:25 : DEBUG : icons : blockingProcesses=
2024-10-24 19:29:25 : DEBUG : icons : installerTool=
2024-10-24 19:29:25 : DEBUG : icons : CLIInstaller=
2024-10-24 19:29:25 : DEBUG : icons : CLIArguments=
2024-10-24 19:29:25 : DEBUG : icons : updateTool=
2024-10-24 19:29:25 : DEBUG : icons : updateToolArguments=
2024-10-24 19:29:25 : DEBUG : icons : updateToolRunAsCurrentUser=
2024-10-24 19:29:25 : INFO  : icons : BLOCKING_PROCESS_ACTION=tell_user
2024-10-24 19:29:25 : INFO  : icons : NOTIFY=success
2024-10-24 19:29:25 : INFO  : icons : LOGGING=DEBUG
2024-10-24 19:29:25 : INFO  : icons : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-24 19:29:25 : INFO  : icons : Label type: pkg
2024-10-24 19:29:25 : INFO  : icons : archiveName: Icons.pkg
2024-10-24 19:29:25 : INFO  : icons : no blocking processes defined, using Icons as default
2024-10-24 19:29:26 : DEBUG : icons : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-10-24 19:29:26 : INFO  : icons : App(s) found: /Applications/Icons.app
2024-10-24 19:29:26 : INFO  : icons : found app at /Applications/Icons.app, version 2.1.0, on versionKey CFBundleShortVersionString
2024-10-24 19:29:26 : INFO  : icons : appversion: 2.1.0
2024-10-24 19:29:26 : INFO  : icons : Latest version of Icons is 2.1.0
2024-10-24 19:29:26 : WARN  : icons : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-10-24 19:29:26 : REQ   : icons : Downloading https://github.com/SAP/macOS-icon-generator/releases/download/2.1.0/Icons_2.1.0.pkg to Icons.pkg
2024-10-24 19:29:26 : DEBUG : icons : No Dialog connection, just download
2024-10-24 19:29:27 : DEBUG : icons : File list: -rw-r--r--  1 gilburns  staff   1.2M Oct 24 19:29 Icons.pkg
2024-10-24 19:29:27 : DEBUG : icons : File type: Icons.pkg: xar archive compressed TOC: 5600, SHA-1 checksum
2024-10-24 19:29:27 : DEBUG : icons : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 140.82.113.3
*   Trying 140.82.113.3:443...
* Connected to github.com (140.82.113.3) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [80 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/SAP/macOS-icon-generator/releases/download/2.1.0/Icons_2.1.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /SAP/macOS-icon-generator/releases/download/2.1.0/Icons_2.1.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /SAP/macOS-icon-generator/releases/download/2.1.0/Icons_2.1.0.pkg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< server: GitHub.com
< date: Fri, 25 Oct 2024 00:29:26 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/96461291/1533a4dd-b59b-4f1d-9d57-d908ca0b3af9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241025T002926Z&X-Amz-Expires=300&X-Amz-Signature=061f389852e99b97fbe561c2dcf26edc2be8f70c2f7bba0e4ca8f7d0c80874d2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DIcons_2.1.0.pkg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: F6DF:186300:754F03D:A1A020B:671AE666
< 
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/96461291/1533a4dd-b59b-4f1d-9d57-d908ca0b3af9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241025T002926Z&X-Amz-Expires=300&X-Amz-Signature=061f389852e99b97fbe561c2dcf26edc2be8f70c2f7bba0e4ca8f7d0c80874d2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DIcons_2.1.0.pkg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.110.133, 185.199.111.133, 185.199.109.133, 185.199.108.133
*   Trying 185.199.110.133:443...
* Connected to objects.githubusercontent.com (185.199.110.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/96461291/1533a4dd-b59b-4f1d-9d57-d908ca0b3af9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241025T002926Z&X-Amz-Expires=300&X-Amz-Signature=061f389852e99b97fbe561c2dcf26edc2be8f70c2f7bba0e4ca8f7d0c80874d2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DIcons_2.1.0.pkg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/96461291/1533a4dd-b59b-4f1d-9d57-d908ca0b3af9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241025T002926Z&X-Amz-Expires=300&X-Amz-Signature=061f389852e99b97fbe561c2dcf26edc2be8f70c2f7bba0e4ca8f7d0c80874d2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DIcons_2.1.0.pkg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/96461291/1533a4dd-b59b-4f1d-9d57-d908ca0b3af9?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241025%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241025T002926Z&X-Amz-Expires=300&X-Amz-Signature=061f389852e99b97fbe561c2dcf26edc2be8f70c2f7bba0e4ca8f7d0c80874d2&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DIcons_2.1.0.pkg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< last-modified: Mon, 23 Sep 2024 15:04:17 GMT
< etag: "0x8DCDBE0FEF4AD24"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: a08dd401-101e-0009-061f-13a486000000
< x-ms-version: 2023-11-03
< x-ms-creation-time: Mon, 23 Sep 2024 15:04:17 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=Icons_2.1.0.pkg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 3452
< date: Fri, 25 Oct 2024 00:29:26 GMT
< x-served-by: cache-iad-kiad7000020-IAD, cache-chi-klot8100098-CHI
< x-cache: HIT, HIT
< x-cache-hits: 33, 0
< x-timer: S1729816166.464917,VS0,VE27
< content-length: 1252703
< 
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2024-10-24 19:29:27 : DEBUG : icons : DEBUG mode 1, not checking for blocking processes
2024-10-24 19:29:27 : REQ   : icons : Installing Icons
2024-10-24 19:29:27 : INFO  : icons : Verifying: Icons.pkg
2024-10-24 19:29:27 : DEBUG : icons : File list: -rw-r--r--  1 gilburns  staff   1.2M Oct 24 19:29 Icons.pkg
2024-10-24 19:29:27 : DEBUG : icons : File type: Icons.pkg: xar archive compressed TOC: 5600, SHA-1 checksum
2024-10-24 19:29:28 : DEBUG : icons : spctlOut is Icons.pkg: accepted
2024-10-24 19:29:28 : DEBUG : icons : source=Notarized Developer ID
2024-10-24 19:29:28 : DEBUG : icons : origin=Developer ID Installer: SAP SE (7R5ZEU67FQ)
2024-10-24 19:29:28 : INFO  : icons : Team ID: 7R5ZEU67FQ (expected: 7R5ZEU67FQ )
2024-10-24 19:29:28 : DEBUG : icons : DEBUG enabled, skipping installation
2024-10-24 19:29:28 : INFO  : icons : Finishing...
2024-10-24 19:29:31 : INFO  : icons : App(s) found: /Applications/Icons.app
2024-10-24 19:29:31 : INFO  : icons : found app at /Applications/Icons.app, version 2.1.0, on versionKey CFBundleShortVersionString
2024-10-24 19:29:31 : REQ   : icons : Installed Icons, version 2.1.0
2024-10-24 19:29:31 : INFO  : icons : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:13: no such file or directory: /usr/local/bin/dialog
2024-10-24 19:29:31 : DEBUG : icons : DEBUG mode 1, not reopening anything
2024-10-24 19:29:31 : REQ   : icons : All done!
2024-10-24 19:29:31 : REQ   : icons : ################## End Installomator, exit code 0 

```