### PR TITLE
Update Microsoft Endpoint Manager (Intune) icon

### DIFF
--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -110,7 +110,11 @@ case $LOGO in
         ;;
     microsoft)
         # Microsoft Endpoint Manager (Intune)
-        LOGO="/Library/Intune/Microsoft Intune Agent.app/Contents/Resources/AppIcon.icns"
+        if [[ -d "/Library/Intune/Microsoft Intune Agent.app" ]]; then
+            LOGO="/Library/Intune/Microsoft Intune Agent.app/Contents/Resources/AppIcon.icns"
+        elif [[ -d "/Applications/Company Portal.app" ]]; then
+            LOGO="/Applications/Company Portal.app/Contents/Resources/AppIcon.icns"
+        fi
         if [[ -z $MDMProfileName ]]; then; MDMProfileName="Management Profile"; fi
         ;;
     ws1)


### PR DESCRIPTION
The Intune Agent is only available on devices if there are scripts or pkg installs assigned to run. Likely the agent is there most of the time, but there could be cases where it is not present. Especially if some other process other than the Intune agent is running Installomator and wanting to use the icon.