### PR TITLE
Add Shutter Encoder

### DIFF
--- a/fragments/labels/shutterencoder.sh
+++ b/fragments/labels/shutterencoder.sh
@@ -1,0 +1,14 @@
+shutterencoder)
+    name="Shutter Encoder"
+    type="pkg"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
+    webSource=$(curl -L $curlOptions --request GET --url "https://www.shutterencoder.com/changelog.html&render_js=1")
+    if [[ $(arch) == "arm64" ]]; then
+        appNewVersion=$(grep "href=\"Shutter Encoder .* Apple Silicon" <<< $webSource | awk '{print$4}')
+        downloadURL=$(grep "APPLE SILICON VERSION" <<< $webSource | grep -oe "https://.*\" class" | sed -e 's/" class//')
+    elif [[ $(arch) == "i386" ]]; then
+        appNewVersion=$(grep "href=\"Shutter Encoder .* Mac 64bits" <<< $webSource | awk '{print$4}')
+        downloadURL=$(grep ">INTEL 64-BITS VERSION" <<< $webSource | grep -oe "https://.*\" class" | sed -e 's/" class//')
+    fi
+    expectedTeamID="LZ28YRG3Q4"
+    ;;


### PR DESCRIPTION
This PR rely on #1982
If installFromPKG doesn't handle multiple parenthesis in TeamID, this label will fail.

With the other PR in place, this one installs ok:
```➜  Installomator git:(main) ✗ ./assemble.sh shutterencoder
2024-10-25 15:20:51 : REQ   : shutterencoder : ################## Start Installomator v. 10.7beta, date 2024-10-25
2024-10-25 15:20:51 : INFO  : shutterencoder : ################## Version: 10.7beta
2024-10-25 15:20:51 : INFO  : shutterencoder : ################## Date: 2024-10-25
2024-10-25 15:20:51 : INFO  : shutterencoder : ################## shutterencoder
2024-10-25 15:20:51 : DEBUG : shutterencoder : DEBUG mode 1 enabled.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 99410    0 99410    0     0  57530      0 --:--:--  0:00:01 --:--:--  451k
2024-10-25 15:20:54 : DEBUG : shutterencoder : name=Shutter Encoder
2024-10-25 15:20:54 : DEBUG : shutterencoder : appName=
2024-10-25 15:20:54 : DEBUG : shutterencoder : type=pkg
2024-10-25 15:20:54 : DEBUG : shutterencoder : archiveName=
2024-10-25 15:20:54 : DEBUG : shutterencoder : downloadURL=https://www.shutterencoder.com/sdc_download/495/?key=zl9l0n42vg88r4bjm1dwm0plwq35u9
2024-10-25 15:20:54 : DEBUG : shutterencoder : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
2024-10-25 15:20:54 : DEBUG : shutterencoder : appNewVersion=18.5
2024-10-25 15:20:54 : DEBUG : shutterencoder : appCustomVersion function: Not defined
2024-10-25 15:20:54 : DEBUG : shutterencoder : versionKey=CFBundleShortVersionString
2024-10-25 15:20:54 : DEBUG : shutterencoder : packageID=
2024-10-25 15:20:54 : DEBUG : shutterencoder : pkgName=
2024-10-25 15:20:54 : DEBUG : shutterencoder : choiceChangesXML=
2024-10-25 15:20:54 : DEBUG : shutterencoder : expectedTeamID=LZ28YRG3Q4
2024-10-25 15:20:54 : DEBUG : shutterencoder : blockingProcesses=
2024-10-25 15:20:54 : DEBUG : shutterencoder : installerTool=
2024-10-25 15:20:54 : DEBUG : shutterencoder : CLIInstaller=
2024-10-25 15:20:54 : DEBUG : shutterencoder : CLIArguments=
2024-10-25 15:20:54 : DEBUG : shutterencoder : updateTool=
2024-10-25 15:20:54 : DEBUG : shutterencoder : updateToolArguments=
2024-10-25 15:20:54 : DEBUG : shutterencoder : updateToolRunAsCurrentUser=
2024-10-25 15:20:54 : INFO  : shutterencoder : BLOCKING_PROCESS_ACTION=tell_user
2024-10-25 15:20:54 : INFO  : shutterencoder : NOTIFY=success
2024-10-25 15:20:54 : INFO  : shutterencoder : LOGGING=DEBUG
2024-10-25 15:20:54 : INFO  : shutterencoder : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-25 15:20:54 : INFO  : shutterencoder : Label type: pkg
2024-10-25 15:20:54 : INFO  : shutterencoder : archiveName: Shutter Encoder.pkg
2024-10-25 15:20:54 : INFO  : shutterencoder : no blocking processes defined, using Shutter Encoder as default
2024-10-25 15:20:54 : DEBUG : shutterencoder : Changing directory to /local_path/Installomator/build
2024-10-25 15:20:54 : INFO  : shutterencoder : App(s) found: /Applications/Shutter Encoder.app
2024-10-25 15:20:54 : INFO  : shutterencoder : found app at /Applications/Shutter Encoder.app, version 16.9, on versionKey CFBundleShortVersionString
2024-10-25 15:20:54 : INFO  : shutterencoder : appversion: 16.9
2024-10-25 15:20:54 : INFO  : shutterencoder : Latest version of Shutter Encoder is 18.5
2024-10-25 15:20:54 : INFO  : shutterencoder : Shutter Encoder.pkg exists and DEBUG mode 1 enabled, skipping download
2024-10-25 15:20:54 : DEBUG : shutterencoder : DEBUG mode 1, not checking for blocking processes
2024-10-25 15:20:54 : REQ   : shutterencoder : Installing Shutter Encoder
2024-10-25 15:20:54 : INFO  : shutterencoder : Verifying: Shutter Encoder.pkg
2024-10-25 15:20:54 : DEBUG : shutterencoder : File list: -rw-r--r--@ 1 user  staff   100M Oct 25 13:28 Shutter Encoder.pkg
2024-10-25 15:20:54 : DEBUG : shutterencoder : File type: Shutter Encoder.pkg: xar archive compressed TOC: 4607, SHA-1 checksum
2024-10-25 15:20:57 : DEBUG : shutterencoder : spctlOut is Shutter Encoder.pkg: accepted
2024-10-25 15:20:57 : DEBUG : shutterencoder : source=Notarized Developer ID
2024-10-25 15:20:57 : DEBUG : shutterencoder : origin=Developer ID Installer: Codebase Media UG (haftungsbeschrankt) (LZ28YRG3Q4)
2024-10-25 15:20:57 : INFO  : shutterencoder : Team ID: LZ28YRG3Q4 (expected: LZ28YRG3Q4 )
2024-10-25 15:20:57 : DEBUG : shutterencoder : DEBUG enabled, skipping installation
2024-10-25 15:20:57 : INFO  : shutterencoder : Finishing...
2024-10-25 15:21:00 : INFO  : shutterencoder : App(s) found: /Applications/Shutter Encoder.app
2024-10-25 15:21:00 : INFO  : shutterencoder : found app at /Applications/Shutter Encoder.app, version 16.9, on versionKey CFBundleShortVersionString
2024-10-25 15:21:00 : REQ   : shutterencoder : Installed Shutter Encoder, version 18.5
2024-10-25 15:21:00 : INFO  : shutterencoder : notifying
2024-10-25 15:21:01 : DEBUG : shutterencoder : DEBUG mode 1, not reopening anything
2024-10-25 15:21:01 : REQ   : shutterencoder : All done!
2024-10-25 15:21:01 : REQ   : shutterencoder : ################## End Installomator, exit code 0 
```