### PR TITLE
Update catoclient.sh

### DIFF
--- a/fragments/labels/catoclient.sh
+++ b/fragments/labels/catoclient.sh
@@ -1,8 +1,7 @@
 catoclient)
     name="CatoClient"
     type="pkg"
-    packageID="com.catonetworks.pkg.CatoClient"
-    downloadURL="https://myvpn.catonetworks.com/public/clients/CatoClient.pkg"
+    downloadURL="https://clientdownload.catonetworks.com/public/clients/CatoClient.pkg"
     appNewVersion=$(curl -Ls -o /dev/null -w %{url_effective} "${downloadURL}" | sed -E 's/.*\/([0-9.]*)\/.*/\1/g' | awk -F '.' '{print $1 "." $2 "." $3}')
     expectedTeamID="CKGSB8CH43"
     blockingProcesses=( "CatoClient" "CatoClientExtension" )


### PR DESCRIPTION

```sh
$ ./assemble.sh catoclient                                                 
2024-10-28 14:36:36 : REQ   : catoclient : ################## Start Installomator v. 10.7beta, date 2024-10-28
2024-10-28 14:36:36 : INFO  : catoclient : ################## Version: 10.7beta
2024-10-28 14:36:36 : INFO  : catoclient : ################## Date: 2024-10-28
2024-10-28 14:36:36 : INFO  : catoclient : ################## catoclient
2024-10-28 14:36:36 : DEBUG : catoclient : DEBUG mode 1 enabled.
2024-10-28 14:36:43 : DEBUG : catoclient : name=CatoClient
2024-10-28 14:36:43 : DEBUG : catoclient : appName=
2024-10-28 14:36:43 : DEBUG : catoclient : type=pkg
2024-10-28 14:36:43 : DEBUG : catoclient : archiveName=
2024-10-28 14:36:43 : DEBUG : catoclient : downloadURL=https://clientdownload.catonetworks.com/public/clients/CatoClient.pkg
2024-10-28 14:36:43 : DEBUG : catoclient : curlOptions=
2024-10-28 14:36:43 : DEBUG : catoclient : appNewVersion=5.7.0
2024-10-28 14:36:43 : DEBUG : catoclient : appCustomVersion function: Not defined
2024-10-28 14:36:43 : DEBUG : catoclient : versionKey=CFBundleShortVersionString
2024-10-28 14:36:43 : DEBUG : catoclient : packageID=
2024-10-28 14:36:43 : DEBUG : catoclient : pkgName=
2024-10-28 14:36:43 : DEBUG : catoclient : choiceChangesXML=
2024-10-28 14:36:43 : DEBUG : catoclient : expectedTeamID=CKGSB8CH43
2024-10-28 14:36:43 : DEBUG : catoclient : blockingProcesses=CatoClient CatoClientExtension
2024-10-28 14:36:43 : DEBUG : catoclient : installerTool=
2024-10-28 14:36:43 : DEBUG : catoclient : CLIInstaller=
2024-10-28 14:36:43 : DEBUG : catoclient : CLIArguments=
2024-10-28 14:36:43 : DEBUG : catoclient : updateTool=
2024-10-28 14:36:43 : DEBUG : catoclient : updateToolArguments=
2024-10-28 14:36:43 : DEBUG : catoclient : updateToolRunAsCurrentUser=
2024-10-28 14:36:43 : INFO  : catoclient : BLOCKING_PROCESS_ACTION=tell_user
2024-10-28 14:36:43 : INFO  : catoclient : NOTIFY=success
2024-10-28 14:36:43 : INFO  : catoclient : LOGGING=DEBUG
2024-10-28 14:36:43 : INFO  : catoclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-28 14:36:43 : INFO  : catoclient : Label type: pkg
2024-10-28 14:36:43 : INFO  : catoclient : archiveName: CatoClient.pkg
2024-10-28 14:36:43 : DEBUG : catoclient : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2024-10-28 14:36:43 : INFO  : catoclient : App(s) found: /Applications/CatoClient.app
2024-10-28 14:36:43 : INFO  : catoclient : found app at /Applications/CatoClient.app, version 5.7.0, on versionKey CFBundleShortVersionString
2024-10-28 14:36:43 : INFO  : catoclient : appversion: 5.7.0
2024-10-28 14:36:43 : INFO  : catoclient : Latest version of CatoClient is 5.7.0
2024-10-28 14:36:43 : WARN  : catoclient : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-10-28 14:36:43 : REQ   : catoclient : Downloading https://clientdownload.catonetworks.com/public/clients/CatoClient.pkg to CatoClient.pkg
2024-10-28 14:36:43 : DEBUG : catoclient : No Dialog connection, just download
2024-10-28 14:36:49 : DEBUG : catoclient : File list: -rw-r--r--  1 kenchan0130  staff   118M 10 28 14:36 CatoClient.pkg
2024-10-28 14:36:49 : DEBUG : catoclient : File type: CatoClient.pkg: xar archive compressed TOC: 4903, SHA-1 checksum
2024-10-28 14:36:49 : DEBUG : catoclient : curl output was:
* Host clientdownload.catonetworks.com:443 was resolved.
* IPv6: (none)
* IPv4: 107.154.247.90
*   Trying 107.154.247.90:443...
* Connected to clientdownload.catonetworks.com (107.154.247.90) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [336 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3431 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=imperva.com
*  start date: Sep  4 13:23:02 2024 GMT
*  expire date: Mar  3 13:23:02 2025 GMT
*  subjectAltName: host "clientdownload.catonetworks.com" matched cert's "clientdownload.catonetworks.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Atlas R3 DV TLS CA 2024 Q3
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://clientdownload.catonetworks.com/public/clients/CatoClient.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: clientdownload.catonetworks.com]
* [HTTP/2] [1] [:path: /public/clients/CatoClient.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /public/clients/CatoClient.pkg HTTP/2
> Host: clientdownload.catonetworks.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 301
< date: Mon, 28 Oct 2024 05:36:44 GMT
< content-type: text/html
< content-length: 162
< location: https://clients.catonetworks.com/macos/5.7.0.518/CatoClient.pkg
< content-type: application/octet-stream
< content-disposition: attachment; filename="CatoClient.pkg"
< set-cookie: visid_incap_2864567=OivNzMqbRbyedKuHh9knN+siH2cAAAAAQUIPAAAAAACpN+H6JVOuEP6hXW30un/0; expires=Mon, 27 Oct 2025 16:14:09 GMT; HttpOnly; path=/; Domain=.catonetworks.com; Secure; SameSite=None
< set-cookie: nlbi_2864567=iHEzVDOnm1RYuTPTYDx8VgAAAACOeI3CHqrURQKgV9r9s5e0; HttpOnly; path=/; Domain=.catonetworks.com; Secure; SameSite=None
< set-cookie: incap_ses_135_2864567=gLXhanLoQ2C8ANkU3J3fAesiH2cAAAAAsRpLanh7gfnW7ij0i66IHw==; path=/; Domain=.catonetworks.com; Secure; SameSite=None
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-cdn: Imperva
< x-iinfo: 58-714697289-714697295 NNNN CT(272 276 0) RT(1730093803042 13) q(0 0 6 -1) r(8 8) U11
<
* Ignoring the response-body
* Connection #0 to host clientdownload.catonetworks.com left intact
* Issue another request to this URL: 'https://clients.catonetworks.com/macos/5.7.0.518/CatoClient.pkg'
* Host clients.catonetworks.com:443 was resolved.
* IPv6: 2600:9000:27af:b200:0:bb98:5e80:93a1, 2600:9000:27af:ac00:0:bb98:5e80:93a1, 2600:9000:27af:400:0:bb98:5e80:93a1, 2600:9000:27af:c800:0:bb98:5e80:93a1, 2600:9000:27af:aa00:0:bb98:5e80:93a1, 2600:9000:27af:9200:0:bb98:5e80:93a1, 2600:9000:27af:8800:0:bb98:5e80:93a1, 2600:9000:27af:7200:0:bb98:5e80:93a1
* IPv4: 3.164.143.84, 3.164.143.56, 3.164.143.12, 3.164.143.4
*   Trying 3.164.143.84:443...
* Connected to clients.catonetworks.com (3.164.143.84) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [329 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4972 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=clients.catonetworks.com
*  start date: Jun  8 00:00:00 2024 GMT
*  expire date: Jul  6 23:59:59 2025 GMT
*  subjectAltName: host "clients.catonetworks.com" matched cert's "clients.catonetworks.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://clients.catonetworks.com/macos/5.7.0.518/CatoClient.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: clients.catonetworks.com]
* [HTTP/2] [1] [:path: /macos/5.7.0.518/CatoClient.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /macos/5.7.0.518/CatoClient.pkg HTTP/2
> Host: clients.catonetworks.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 123478281
< date: Mon, 28 Oct 2024 05:16:37 GMT
< last-modified: Mon, 12 Aug 2024 13:50:26 GMT
< etag: "0a71997f3d8c36c52b22541bf19f9b6c-15"
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 2cad7b83f1a1ab449fa1f920dcdd250e.cloudfront.net (CloudFront)
< x-amz-cf-pop: NRT20-P3
< x-amz-cf-id: Ft-t72IwjYeJrTakyEz3YGh9lwJ7szKCG4X7uxEZJkIYhvXWdiSb2A==
< age: 1208
<
{ [8192 bytes data]
* Connection #1 to host clients.catonetworks.com left intact

2024-10-28 14:36:49 : DEBUG : catoclient : DEBUG mode 1, not checking for blocking processes
2024-10-28 14:36:49 : REQ   : catoclient : Installing CatoClient
2024-10-28 14:36:49 : INFO  : catoclient : Verifying: CatoClient.pkg
2024-10-28 14:36:49 : DEBUG : catoclient : File list: -rw-r--r--  1 kenchan0130  staff   118M 10 28 14:36 CatoClient.pkg
2024-10-28 14:36:49 : DEBUG : catoclient : File type: CatoClient.pkg: xar archive compressed TOC: 4903, SHA-1 checksum
2024-10-28 14:36:49 : DEBUG : catoclient : spctlOut is CatoClient.pkg: accepted
2024-10-28 14:36:49 : DEBUG : catoclient : source=Notarized Developer ID
2024-10-28 14:36:49 : DEBUG : catoclient : origin=Developer ID Installer: Cato Networks Ltd (CKGSB8CH43)
2024-10-28 14:36:49 : INFO  : catoclient : Team ID: CKGSB8CH43 (expected: CKGSB8CH43 )
2024-10-28 14:36:49 : DEBUG : catoclient : DEBUG enabled, skipping installation
2024-10-28 14:36:49 : INFO  : catoclient : Finishing...
2024-10-28 14:36:52 : INFO  : catoclient : App(s) found: /Applications/CatoClient.app
2024-10-28 14:36:52 : INFO  : catoclient : found app at /Applications/CatoClient.app, version 5.7.0, on versionKey CFBundleShortVersionString
2024-10-28 14:36:53 : REQ   : catoclient : Installed CatoClient, version 5.7.0
2024-10-28 14:36:53 : INFO  : catoclient : notifying
2024-10-28 14:36:53 : DEBUG : catoclient : DEBUG mode 1, not reopening anything
2024-10-28 14:36:53 : REQ   : catoclient : All done!
2024-10-28 14:36:53 : REQ   : catoclient : ################## End Installomator, exit code 0
```

And because the pkg recipe does not have valid version, I remove the `packageID` variable.

```sh
$ pkgutil --pkg-info-plist "com.catonetworks.pkg.CatoClient" 2>/dev/null
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>install-location</key>
	<string>Applications</string>
	<key>install-time</key>
	<integer>1728552004</integer>
	<key>pkg-version</key>
	<string>0</string>
	<key>pkgid</key>
	<string>com.catonetworks.pkg.CatoClient</string>
	<key>receipt-plist-version</key>
	<real>1</real>
	<key>volume</key>
	<string>/</string>
</dict>
</plist>
```