### PR TITLE
New Label: NVivo 15

### DIFF
--- a/fragments/labels/nvivo15.sh
+++ b/fragments/labels/nvivo15.sh
@@ -1,8 +1,9 @@
-nvivo14)
-    name="NVivo 14"
+nvivo|\
+nvivo15)
+    name="NVivo 15"
     type="dmg"
-    downloadURL="https://download.qsrinternational.com/Software/NVivo14forMac/NVivo.dmg"
+    downloadURL="https://download.qsrinternational.com/Software/NVivo15forMac/NVivo.dmg"
     appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | awk -F'/' '{ print $6 }' | cut -d "." -f1-3)
     expectedTeamID="8F4S7H8S59"
-    blockingProcesses=( NVivo NVivoHelper "Nvivo 14" )
+    blockingProcesses=( NVivo NVivoHelper "Nvivo 15" )
     ;;

--- a/fragments/labels/nvivo15.sh
+++ b/fragments/labels/nvivo15.sh
@@ -2,7 +2,7 @@ nvivo|\
 nvivo15)
     name="NVivo 15"
     type="dmg"
-    downloadURL="https://download.qsrinternational.com/Software/NVivo15forMac/NVivo.dmg"
+    downloadURL="https://download.qsrinternational.com/Software/NVivo15forMac/NVivo15.dmg"
     appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | awk -F'/' '{ print $6 }' | cut -d "." -f1-3)
     expectedTeamID="8F4S7H8S59"
     blockingProcesses=( NVivo NVivoHelper "Nvivo 15" )


### PR DESCRIPTION
NVivo 15 has been released, so version 15 is now the latest major version of NVivo. I've therefore created a nvivo15 label and moved "nvivo" from the nvivo14 label name to the nvivo15 label name and just kept "nvivo14" for the nvivo14 label.

---

```
2024-10-28 11:23:00 : REQ   : nvivo15 : ################## Start Installomator v. 10.7beta, date 2024-10-28
2024-10-28 11:23:00 : INFO  : nvivo15 : ################## Version: 10.7beta
2024-10-28 11:23:00 : INFO  : nvivo15 : ################## Date: 2024-10-28
2024-10-28 11:23:00 : INFO  : nvivo15 : ################## nvivo15
2024-10-28 11:23:00 : DEBUG : nvivo15 : DEBUG mode 1 enabled.
2024-10-28 11:23:00 : INFO  : nvivo15 : SwiftDialog is not installed, clear cmd file var
2024-10-28 11:23:00 : DEBUG : nvivo15 : name=NVivo 15
2024-10-28 11:23:01 : DEBUG : nvivo15 : appName=
2024-10-28 11:23:01 : DEBUG : nvivo15 : type=dmg
2024-10-28 11:23:01 : DEBUG : nvivo15 : archiveName=
2024-10-28 11:23:01 : DEBUG : nvivo15 : downloadURL=https://download.qsrinternational.com/Software/NVivo15forMac/NVivo.dmg
2024-10-28 11:23:01 : DEBUG : nvivo15 : curlOptions=
2024-10-28 11:23:01 : DEBUG : nvivo15 : appNewVersion=15.0.0
2024-10-28 11:23:01 : DEBUG : nvivo15 : appCustomVersion function: Not defined
2024-10-28 11:23:01 : DEBUG : nvivo15 : versionKey=CFBundleShortVersionString
2024-10-28 11:23:01 : DEBUG : nvivo15 : packageID=
2024-10-28 11:23:01 : DEBUG : nvivo15 : pkgName=
2024-10-28 11:23:01 : DEBUG : nvivo15 : choiceChangesXML=
2024-10-28 11:23:01 : DEBUG : nvivo15 : expectedTeamID=8F4S7H8S59
2024-10-28 11:23:01 : DEBUG : nvivo15 : blockingProcesses=NVivo NVivoHelper Nvivo 15
2024-10-28 11:23:01 : DEBUG : nvivo15 : installerTool=
2024-10-28 11:23:01 : DEBUG : nvivo15 : CLIInstaller=
2024-10-28 11:23:01 : DEBUG : nvivo15 : CLIArguments=
2024-10-28 11:23:01 : DEBUG : nvivo15 : updateTool=
2024-10-28 11:23:01 : DEBUG : nvivo15 : updateToolArguments=
2024-10-28 11:23:01 : DEBUG : nvivo15 : updateToolRunAsCurrentUser=
2024-10-28 11:23:01 : INFO  : nvivo15 : BLOCKING_PROCESS_ACTION=tell_user
2024-10-28 11:23:01 : INFO  : nvivo15 : NOTIFY=success
2024-10-28 11:23:01 : INFO  : nvivo15 : LOGGING=DEBUG
2024-10-28 11:23:01 : INFO  : nvivo15 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-10-28 11:23:01 : INFO  : nvivo15 : Label type: dmg
2024-10-28 11:23:01 : INFO  : nvivo15 : archiveName: NVivo 15.dmg
2024-10-28 11:23:01 : DEBUG : nvivo15 : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2024-10-28 11:23:01 : INFO  : nvivo15 : name: NVivo 15, appName: NVivo 15.app
2024-10-28 11:23:01.515 mdfind[66181:1746230] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-28 11:23:01.516 mdfind[66181:1746230] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-28 11:23:01.850 mdfind[66181:1746230] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-28 11:23:01 : WARN  : nvivo15 : No previous app found
2024-10-28 11:23:01 : WARN  : nvivo15 : could not find NVivo 15.app
2024-10-28 11:23:01 : INFO  : nvivo15 : appversion: 
2024-10-28 11:23:01 : INFO  : nvivo15 : Latest version of NVivo 15 is 15.0.0
2024-10-28 11:23:01 : REQ   : nvivo15 : Downloading https://download.qsrinternational.com/Software/NVivo15forMac/NVivo.dmg to NVivo 15.dmg
2024-10-28 11:23:01 : DEBUG : nvivo15 : No Dialog connection, just download
2024-10-28 11:23:56 : DEBUG : nvivo15 : File list: -rw-r--r--  1 root  staff   703M Oct 28 11:23 NVivo 15.dmg
2024-10-28 11:23:56 : DEBUG : nvivo15 : File type: NVivo 15.dmg: zlib compressed data
2024-10-28 11:23:56 : DEBUG : nvivo15 : curl output was:
* Host download.qsrinternational.com:443 was resolved.
* IPv6: (none)
* IPv4: 108.157.214.31, 108.157.214.29, 108.157.214.42, 108.157.214.104
*   Trying 108.157.214.31:443...
* Connected to download.qsrinternational.com (108.157.214.31) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [6004 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=AU; ST=Victoria; O=Lumivero PTY LTD; CN=*.qsrinternational.com
*  start date: Jul  4 00:00:00 2024 GMT
*  expire date: Aug  4 23:59:59 2025 GMT
*  subjectAltName: host "download.qsrinternational.com" matched cert's "*.qsrinternational.com"
*  issuer: C=US; O=Corporation Service Company; CN=Corporation Service Company RSA OV SSL CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.qsrinternational.com/Software/NVivo15forMac/NVivo.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.qsrinternational.com]
* [HTTP/2] [1] [:path: /Software/NVivo15forMac/NVivo.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Software/NVivo15forMac/NVivo.dmg HTTP/2
> Host: download.qsrinternational.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-length: 0
< location: https://download.qsrinternational.com/Software/NVivo15forMac/15.0.0.42/NVivo15.dmg
< date: Mon, 28 Oct 2024 10:23:03 GMT
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 94251f2595ef5679fba3c952e8743886.cloudfront.net (CloudFront)
< x-amz-cf-pop: ARN56-P1
< x-amz-cf-id: 80RAXcFF8UfVQSLGLnTcIJMxc2FmBe1YhX58HwIbyiTLHcrkp8G2eA==
< 
* Ignoring the response-body
* Connection #0 to host download.qsrinternational.com left intact
* Issue another request to this URL: 'https://download.qsrinternational.com/Software/NVivo15forMac/15.0.0.42/NVivo15.dmg'
* Found bundle for host: 0x6000037b02d0 [can multiplex]
* Re-using existing connection with host download.qsrinternational.com
* [HTTP/2] [3] OPENED stream for https://download.qsrinternational.com/Software/NVivo15forMac/15.0.0.42/NVivo15.dmg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: download.qsrinternational.com]
* [HTTP/2] [3] [:path: /Software/NVivo15forMac/15.0.0.42/NVivo15.dmg]
* [HTTP/2] [3] [user-agent: curl/8.7.1]
* [HTTP/2] [3] [accept: */*]
> GET /Software/NVivo15forMac/15.0.0.42/NVivo15.dmg HTTP/2
> Host: download.qsrinternational.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 737357450
< date: Mon, 28 Oct 2024 10:23:03 GMT
< last-modified: Wed, 28 Aug 2024 01:40:49 GMT
< etag: "32fe53b1c5831a855dbd150f2c2d2b1e-141"
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 94251f2595ef5679fba3c952e8743886.cloudfront.net (CloudFront)
< x-amz-cf-pop: ARN56-P1
< x-amz-cf-id: zY-p7mgm9HT4U_lfRkTxilyVHE8_4g0zFBO6DneXK74NvJiYxJiqrQ==
< 
{ [8192 bytes data]
* Connection #0 to host download.qsrinternational.com left intact

2024-10-28 11:23:56 : DEBUG : nvivo15 : DEBUG mode 1, not checking for blocking processes
2024-10-28 11:23:56 : REQ   : nvivo15 : Installing NVivo 15
2024-10-28 11:23:56 : INFO  : nvivo15 : Mounting /Users/kryptonit/Documents/github/Installomator/build/NVivo 15.dmg
2024-10-28 11:24:02 : DEBUG : nvivo15 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $605B3127
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $C1A75CFE
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $D0A71666
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified CRC32 $B6D2B54C
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified CRC32 $D0A71666
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified CRC32 $12564D67
verified CRC32 $930E81FC
/dev/disk17         	GUID_partition_scheme
/dev/disk17s1       	EFI
/dev/disk17s2       	Apple_HFS                      	/Volumes/NVivo 15

2024-10-28 11:24:02 : INFO  : nvivo15 : Mounted: /Volumes/NVivo 15
2024-10-28 11:24:02 : INFO  : nvivo15 : Verifying: /Volumes/NVivo 15/NVivo 15.app
2024-10-28 11:24:02 : DEBUG : nvivo15 : App size: 1.6G	/Volumes/NVivo 15/NVivo 15.app
2024-10-28 11:24:17 : DEBUG : nvivo15 : Debugging enabled, App Verification output was:
/Volumes/NVivo 15/NVivo 15.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Lumivero, LLC (8F4S7H8S59)

2024-10-28 11:24:17 : INFO  : nvivo15 : Team ID matching: 8F4S7H8S59 (expected: 8F4S7H8S59 )
2024-10-28 11:24:17 : INFO  : nvivo15 : Installing NVivo 15 version 15.0.0 on versionKey CFBundleShortVersionString.
2024-10-28 11:24:17 : INFO  : nvivo15 : App has LSMinimumSystemVersion: 10.15
2024-10-28 11:24:17 : DEBUG : nvivo15 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-10-28 11:24:17 : INFO  : nvivo15 : Finishing...
2024-10-28 11:24:20 : INFO  : nvivo15 : name: NVivo 15, appName: NVivo 15.app
2024-10-28 11:24:20.208 mdfind[66328:1747467] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-10-28 11:24:20.208 mdfind[66328:1747467] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-10-28 11:24:20.324 mdfind[66328:1747467] Couldn't determine the mapping between prefab keywords and predicates.
2024-10-28 11:24:20 : WARN  : nvivo15 : No previous app found
2024-10-28 11:24:20 : WARN  : nvivo15 : could not find NVivo 15.app
2024-10-28 11:24:20 : REQ   : nvivo15 : Installed NVivo 15, version 15.0.0
2024-10-28 11:24:20 : INFO  : nvivo15 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-10-28 11:24:20 : DEBUG : nvivo15 : Unmounting /Volumes/NVivo 15
2024-10-28 11:24:20 : DEBUG : nvivo15 : Debugging enabled, Unmounting output was:
"disk17" ejected.
2024-10-28 11:24:20 : DEBUG : nvivo15 : DEBUG mode 1, not reopening anything
2024-10-28 11:24:20 : REQ   : nvivo15 : All done!
2024-10-28 11:24:20 : REQ   : nvivo15 : ################## End Installomator, exit code 0 
```