### PR TITLE
Create UA Connect label

### DIFF
--- a/fragments/labels/uaconnect.sh
+++ b/fragments/labels/uaconnect.sh
@@ -1,0 +1,7 @@
+uaconnect)
+    name="UA Connect"
+    type="dmg"
+    downloadURL="https://www.uaudio.com/apps/uaconnect/mac/installer"
+    appNewVersion="$(curl -Ifs "$downloadURL" | grep 'location:' | cut -d'_' -f4-6 | tr '_' '.')"
+    expectedTeamID="4KAC9AX6CG"
+    ;;


### PR DESCRIPTION
assemble.sh uaconnect                                                 
2024-11-02 11:57:56 : REQ   : uaconnect : ################## Start Installomator v. 10.7beta, date 2024-11-02
2024-11-02 11:57:56 : INFO  : uaconnect : ################## Version: 10.7beta
2024-11-02 11:57:56 : INFO  : uaconnect : ################## Date: 2024-11-02
2024-11-02 11:57:56 : INFO  : uaconnect : ################## uaconnect
2024-11-02 11:57:56 : DEBUG : uaconnect : DEBUG mode 1 enabled.
2024-11-02 11:57:58 : DEBUG : uaconnect : name=UA Connect
2024-11-02 11:57:58 : DEBUG : uaconnect : appName=
2024-11-02 11:57:58 : DEBUG : uaconnect : type=dmg
2024-11-02 11:57:58 : DEBUG : uaconnect : archiveName=
2024-11-02 11:57:58 : DEBUG : uaconnect : downloadURL=https://www.uaudio.com/apps/uaconnect/mac/installer
2024-11-02 11:57:58 : DEBUG : uaconnect : curlOptions=
2024-11-02 11:57:58 : DEBUG : uaconnect : appNewVersion=1.4.19
2024-11-02 11:57:58 : DEBUG : uaconnect : appCustomVersion function: Not defined
2024-11-02 11:57:58 : DEBUG : uaconnect : versionKey=CFBundleShortVersionString
2024-11-02 11:57:58 : DEBUG : uaconnect : packageID=
2024-11-02 11:57:58 : DEBUG : uaconnect : pkgName=
2024-11-02 11:57:58 : DEBUG : uaconnect : choiceChangesXML=
2024-11-02 11:57:58 : DEBUG : uaconnect : expectedTeamID=4KAC9AX6CG
2024-11-02 11:57:58 : DEBUG : uaconnect : blockingProcesses=
2024-11-02 11:57:58 : DEBUG : uaconnect : installerTool=
2024-11-02 11:57:58 : DEBUG : uaconnect : CLIInstaller=
2024-11-02 11:57:58 : DEBUG : uaconnect : CLIArguments=
2024-11-02 11:57:58 : DEBUG : uaconnect : updateTool=
2024-11-02 11:57:58 : DEBUG : uaconnect : updateToolArguments=
2024-11-02 11:57:58 : DEBUG : uaconnect : updateToolRunAsCurrentUser=
2024-11-02 11:57:58 : INFO  : uaconnect : BLOCKING_PROCESS_ACTION=tell_user
2024-11-02 11:57:58 : INFO  : uaconnect : NOTIFY=success
2024-11-02 11:57:58 : INFO  : uaconnect : LOGGING=DEBUG
2024-11-02 11:57:58 : INFO  : uaconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-02 11:57:58 : INFO  : uaconnect : Label type: dmg
2024-11-02 11:57:58 : INFO  : uaconnect : archiveName: UA Connect.dmg
2024-11-02 11:57:58 : INFO  : uaconnect : no blocking processes defined, using UA Connect as default
2024-11-02 11:57:58 : DEBUG : uaconnect : Changing directory to /Users/gilburns/GitHub/Installomator/build
2024-11-02 11:57:58 : INFO  : uaconnect : name: UA Connect, appName: UA Connect.app
2024-11-02 11:57:58.707 mdfind[57047:5626740] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-02 11:57:58.708 mdfind[57047:5626740] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-02 11:57:59.011 mdfind[57047:5626740] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-02 11:57:59 : WARN  : uaconnect : No previous app found
2024-11-02 11:57:59 : WARN  : uaconnect : could not find UA Connect.app
2024-11-02 11:57:59 : INFO  : uaconnect : appversion: 
2024-11-02 11:57:59 : INFO  : uaconnect : Latest version of UA Connect is 1.4.19
2024-11-02 11:57:59 : REQ   : uaconnect : Downloading https://www.uaudio.com/apps/uaconnect/mac/installer to UA Connect.dmg
2024-11-02 11:57:59 : DEBUG : uaconnect : No Dialog connection, just download
2024-11-02 11:58:41 : DEBUG : uaconnect : File list: -rw-r--r--  1 root  staff   295M Nov  2 11:58 UA Connect.dmg
2024-11-02 11:58:41 : DEBUG : uaconnect : File type: UA Connect.dmg: zlib compressed data
2024-11-02 11:58:41 : DEBUG : uaconnect : curl output was:
* Host www.uaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 13.57.99.150, 54.215.6.114
*   Trying 13.57.99.150:443...
* Connected to www.uaudio.com (13.57.99.150) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [319 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [100 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5336 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=inet1.uaudio.com
*  start date: Jan 31 22:42:31 2024 GMT
*  expire date: Mar  3 22:42:31 2025 GMT
*  subjectAltName: host "www.uaudio.com" matched cert's "www.uaudio.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.uaudio.com/apps/uaconnect/mac/installer
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.uaudio.com]
* [HTTP/2] [1] [:path: /apps/uaconnect/mac/installer]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /apps/uaconnect/mac/installer HTTP/2
> Host: www.uaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Sat, 02 Nov 2024 16:57:59 GMT
< content-type: text/html; charset=UTF-8
< location: https://builds.uaudio.com/apps/UA_Connect/UA_Connect_1_4_19_2936_Mac.dmg
< set-cookie: store=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; domain=.uaudio.com; secure; HttpOnly
< cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
< pragma: no-cache
< 
* Ignoring the response-body
* Connection #0 to host www.uaudio.com left intact
* Issue another request to this URL: 'https://builds.uaudio.com/apps/UA_Connect/UA_Connect_1_4_19_2936_Mac.dmg'
* Host builds.uaudio.com:443 was resolved.
* IPv6: (none)
* IPv4: 52.84.18.55, 52.84.18.83, 52.84.18.119, 52.84.18.65
*   Trying 52.84.18.55:443...
* Connected to builds.uaudio.com (52.84.18.55) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5123 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.uaudio.com
*  start date: Nov 30 11:39:15 2023 GMT
*  expire date: Dec 31 11:39:15 2024 GMT
*  subjectAltName: host "builds.uaudio.com" matched cert's "*.uaudio.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /apps/UA_Connect/UA_Connect_1_4_19_2936_Mac.dmg HTTP/1.1
> Host: builds.uaudio.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: binary/octet-stream
< Content-Length: 309732171
< Connection: keep-alive
< Date: Sat, 02 Nov 2024 16:50:26 GMT
< Last-Modified: Mon, 28 Oct 2024 19:23:22 GMT
< ETag: "a87593b2655f5e49b6989a3d9e623e71"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: YUlCbkBMqlR3QTV96XQ1JSmGgG4XO1ao
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 571f78e931e0effaaaf554b69f260bf0.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD53-C2
< X-Amz-Cf-Id: S93YgId0EkVkXvb8psL6nFC9C8cqJgMOlSPZKr49wPynlLBdSCPzVg==
< Age: 455
< 
{ [16384 bytes data]
* Connection #1 to host builds.uaudio.com left intact

2024-11-02 11:58:41 : DEBUG : uaconnect : DEBUG mode 1, not checking for blocking processes
2024-11-02 11:58:41 : REQ   : uaconnect : Installing UA Connect
2024-11-02 11:58:41 : INFO  : uaconnect : Mounting /Users/gilburns/GitHub/Installomator/build/UA Connect.dmg
2024-11-02 11:58:44 : DEBUG : uaconnect : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $FFF14C01
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $5FDB009B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CD225C34
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $0A0DAF04
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CD225C34
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $359AE014
verified   CRC32 $FDE253C7
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/UA Connect

2024-11-02 11:58:44 : INFO  : uaconnect : Mounted: /Volumes/UA Connect
2024-11-02 11:58:44 : INFO  : uaconnect : Verifying: /Volumes/UA Connect/UA Connect.app
2024-11-02 11:58:44 : DEBUG : uaconnect : App size: 583M	/Volumes/UA Connect/UA Connect.app
2024-11-02 11:58:49 : DEBUG : uaconnect : Debugging enabled, App Verification output was:
/Volumes/UA Connect/UA Connect.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Universal Audio (4KAC9AX6CG)

2024-11-02 11:58:49 : INFO  : uaconnect : Team ID matching: 4KAC9AX6CG (expected: 4KAC9AX6CG )
2024-11-02 11:58:49 : INFO  : uaconnect : Installing UA Connect version 1.4.19 on versionKey CFBundleShortVersionString.
2024-11-02 11:58:50 : INFO  : uaconnect : App has LSMinimumSystemVersion: 10.14
2024-11-02 11:58:50 : DEBUG : uaconnect : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-11-02 11:58:50 : INFO  : uaconnect : Finishing...
2024-11-02 11:58:53 : INFO  : uaconnect : name: UA Connect, appName: UA Connect.app
2024-11-02 11:58:53.113 mdfind[57190:5627726] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-02 11:58:53.114 mdfind[57190:5627726] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-02 11:58:53.241 mdfind[57190:5627726] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-02 11:58:53 : WARN  : uaconnect : No previous app found
2024-11-02 11:58:53 : WARN  : uaconnect : could not find UA Connect.app
2024-11-02 11:58:53 : REQ   : uaconnect : Installed UA Connect, version 1.4.19
2024-11-02 11:58:53 : INFO  : uaconnect : notifying
2024-11-02 11:58:54 : DEBUG : uaconnect : Unmounting /Volumes/UA Connect
2024-11-02 11:58:54 : DEBUG : uaconnect : Debugging enabled, Unmounting output was:
"disk2" ejected.
2024-11-02 11:58:54 : DEBUG : uaconnect : DEBUG mode 1, not reopening anything
2024-11-02 11:58:54 : REQ   : uaconnect : All done!
2024-11-02 11:58:54 : REQ   : uaconnect : ################## End Installomator, exit code 0 
