### PR TITLE
Fix download URL for "microsoftcompanyportal" label

### DIFF
--- a/fragments/labels/microsoftcompanyportal.sh
+++ b/fragments/labels/microsoftcompanyportal.sh
@@ -1,9 +1,7 @@
 microsoftcompanyportal)
     name="Company Portal"
     type="pkg"
-    downloadURL="https://go.microsoft.com/fwlink/?linkid=869655"
-    #appNewVersion=$(curl -fs https://macadmins.software/latest.xml | xpath '//latest/package[id="com.microsoft.intunecompanyportal.standalone"]/cfbundleshortversionstring' 2>/dev/null | sed -E 's/<cfbundleshortversionstring>([0-9.]*)<.*/\1/')
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i location: | grep -o "/CompanyPortal_.*pkg" | cut -d "_" -f 2 | cut -d "-" -f 1)
+    downloadURL="https://go.microsoft.com/fwlink/?linkid=853070"
     expectedTeamID="UBF8T346G9"
     if [[ -x "/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate" && $INSTALL != "force" && $DEBUG -eq 0 ]]; then
         printlog "Running msupdate --list"


### PR DESCRIPTION
Updated downloadURL, removed appNewVersion as the version number is no longer in the filename and a page cannot be found on Microsoft's website that lists the latest version.

Output:
```
jaredschwager@Jareds-MacBook-Air-M3 Installomator % ./assemble.sh microsoftcompanyportal
2024-11-12 11:00:57 : REQ   : microsoftcompanyportal : ################## Start Installomator v. 10.7beta, date 2024-11-12
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : ################## Version: 10.7beta
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : ################## Date: 2024-11-12
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : ################## microsoftcompanyportal
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : DEBUG mode 1 enabled.
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : name=Company Portal
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : appName=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : type=pkg
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : archiveName=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : downloadURL=https://go.microsoft.com/fwlink/?linkid=853070
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : curlOptions=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : appNewVersion=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : appCustomVersion function: Not defined
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : versionKey=CFBundleShortVersionString
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : packageID=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : pkgName=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : choiceChangesXML=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : expectedTeamID=UBF8T346G9
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : blockingProcesses=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : installerTool=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : CLIInstaller=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : CLIArguments=
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : updateToolArguments=--install --apps IMCP01
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : updateToolRunAsCurrentUser=
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : BLOCKING_PROCESS_ACTION=tell_user
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : NOTIFY=success
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : LOGGING=DEBUG
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : Label type: pkg
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : archiveName: Company Portal.pkg
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : no blocking processes defined, using Company Portal as default
2024-11-12 11:00:57 : DEBUG : microsoftcompanyportal : Changing directory to /Users/jaredschwager/Documents/Repositories/Installomator/build
2024-11-12 11:00:57 : INFO  : microsoftcompanyportal : name: Company Portal, appName: Company Portal.app
2024-11-12 11:00:57.879 mdfind[20638:347267] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-12 11:00:57.879 mdfind[20638:347267] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-12 11:00:58.100 mdfind[20638:347267] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-12 11:00:58 : WARN  : microsoftcompanyportal : No previous app found
2024-11-12 11:00:58 : WARN  : microsoftcompanyportal : could not find Company Portal.app
2024-11-12 11:00:58 : INFO  : microsoftcompanyportal : appversion: 
2024-11-12 11:00:58 : INFO  : microsoftcompanyportal : Latest version not specified.
2024-11-12 11:00:58 : REQ   : microsoftcompanyportal : Downloading https://go.microsoft.com/fwlink/?linkid=853070 to Company Portal.pkg
2024-11-12 11:00:58 : DEBUG : microsoftcompanyportal : No Dialog connection, just download
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : File list: -rw-r--r--@ 1 jaredschwager  staff    60M Nov 12 11:01 Company Portal.pkg
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : File type: Company Portal.pkg: xar archive compressed TOC: 7273, SHA-1 checksum
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : curl output was:
* Host go.microsoft.com:443 was resolved.
* IPv6: (none)
* IPv4: 23.62.166.208
*   Trying 23.62.166.208:443...
* Connected to go.microsoft.com (23.62.166.208) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3686 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=go.microsoft.com
*  start date: Aug 29 20:17:58 2024 GMT
*  expire date: Aug 24 20:17:58 2025 GMT
*  subjectAltName: host "go.microsoft.com" matched cert's "go.microsoft.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure RSA TLS Issuing CA 07
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /fwlink/?linkid=853070 HTTP/1.1
> Host: go.microsoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Moved Temporarily
< Content-Length: 0
< Server: Kestrel
< Location: https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg
< Request-Context: appId=cid-v1:d94c0f68-64bf-4036-8409-a0e761bb7ee1
< X-Response-Cache-Status: True
< Expires: Tue, 12 Nov 2024 16:00:58 GMT
< Cache-Control: max-age=0, no-cache, no-store
< Pragma: no-cache
< Date: Tue, 12 Nov 2024 16:00:58 GMT
< Connection: keep-alive
< Strict-Transport-Security: max-age=31536000 ; includeSubDomains
< 
* Ignoring the response-body
* Connection #0 to host go.microsoft.com left intact
* Issue another request to this URL: 'https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg'
* Host officecdn.microsoft.com:443 was resolved.
* IPv6: (none)
* IPv4: 69.164.46.136
*   Trying 69.164.46.136:443...
* Connected to officecdn.microsoft.com (69.164.46.136) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3771 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=WA; L=Redmond; O=Microsoft Corporation; CN=ll.c2r.ts.cdn.office.net
*  start date: Sep 26 06:22:37 2024 GMT
*  expire date: Mar 25 06:22:37 2025 GMT
*  subjectAltName: host "officecdn.microsoft.com" matched cert's "officecdn.microsoft.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft Azure RSA TLS Issuing CA 04
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: officecdn.microsoft.com]
* [HTTP/2] [1] [:path: /pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg HTTP/2
> Host: officecdn.microsoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< accept-ranges: bytes
< cache-control: public, max-age=259200
< content-disposition: attachment; filename=CompanyPortal-Installer.pkg; filename*=UTF-8''CompanyPortal-Installer.pkg
< content-type: application/octet-stream
< server: ECAcc (dce/26C2)
< x-ms-apiversion: Distribute 1.2
< x-ms-region: prod-eus-z1
< x-llid: 63e74e70da2017a8e94b4f273a652385
< age: 211101
< date: Tue, 12 Nov 2024 16:00:59 GMT
< last-modified: Fri, 06 Sep 2024 19:46:30 GMT
< expires: Wed, 13 Nov 2024 05:22:38 GMT
< content-length: 62637574
< x-cid: 4
< uuid: 4e7376b4-c516-42ae-b925-9fcc0b88747e
< x-ccc: us
< 
{ [9495 bytes data]
* Connection #1 to host officecdn.microsoft.com left intact

2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : DEBUG mode 1, not checking for blocking processes
2024-11-12 11:01:00 : REQ   : microsoftcompanyportal : Installing Company Portal
2024-11-12 11:01:00 : INFO  : microsoftcompanyportal : Verifying: Company Portal.pkg
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : File list: -rw-r--r--@ 1 jaredschwager  staff    60M Nov 12 11:01 Company Portal.pkg
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : File type: Company Portal.pkg: xar archive compressed TOC: 7273, SHA-1 checksum
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : spctlOut is Company Portal.pkg: accepted
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : source=Notarized Developer ID
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2024-11-12 11:01:00 : INFO  : microsoftcompanyportal : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2024-11-12 11:01:00 : DEBUG : microsoftcompanyportal : DEBUG enabled, skipping installation
2024-11-12 11:01:00 : INFO  : microsoftcompanyportal : Finishing...
2024-11-12 11:01:03 : INFO  : microsoftcompanyportal : name: Company Portal, appName: Company Portal.app
2024-11-12 11:01:03.887 mdfind[20705:347540] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-12 11:01:03.887 mdfind[20705:347540] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-12 11:01:03.931 mdfind[20705:347540] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-12 11:01:03 : WARN  : microsoftcompanyportal : No previous app found
2024-11-12 11:01:03 : WARN  : microsoftcompanyportal : could not find Company Portal.app
2024-11-12 11:01:03 : REQ   : microsoftcompanyportal : Installed Company Portal
2024-11-12 11:01:03 : INFO  : microsoftcompanyportal : notifying
2024-11-12 11:01:04 : DEBUG : microsoftcompanyportal : DEBUG mode 1, not reopening anything
2024-11-12 11:01:04 : REQ   : microsoftcompanyportal : All done!
2024-11-12 11:01:04 : REQ   : microsoftcompanyportal : ################## End Installomator, exit code 0
```