### PR TITLE
Update Tableau labels

### DIFF
--- a/fragments/labels/tableaudesktop.sh
+++ b/fragments/labels/tableaudesktop.sh
@@ -2,7 +2,11 @@ tableaudesktop)
     name="Tableau Desktop"
     type="pkgInDmg"
     packageID="com.tableausoftware.tableaudesktop"
-    downloadURL="https://www.tableau.com/downloads/desktop/mac"
-    appNewVersion=${$(curl -fsIL "$downloadURL" | sed -nE 's/.*Desktop-([0-9-]*).*/\1/p')//-/.}
+    if [[ $(arch) == "arm64" ]]; then
+       downloadURL="https://www.tableau.com/downloads/desktop/mac-arm64"
+    elif [[ $(arch) == "i386" ]]; then
+       downloadURL="https://www.tableau.com/downloads/desktop/mac"
+    fi
+    appNewVersion=${${$(curl -fsIL "$downloadURL" | sed -nE 's/.*Desktop-([0-9-]*).*/\1/p')//-/.}%.}
     expectedTeamID="QJ4XPRK37C"
     ;;

--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -2,7 +2,11 @@ tableaupublic)
     name="Tableau Public"
     type="pkgInDmg"
     packageID="com.tableausoftware.tableaudesktop"
-    downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
-    appNewVersion=$( echo $downloadURL | sed -E 's/.*TableauPublic-([-0-9]*)\.dmg/\1/g' | tr "-" "." )
+    if [[ $(arch) == "arm64" ]]; then
+       downloadURL="https://www.tableau.com/downloads/public/mac-arm64"
+    elif [[ $(arch) == "i386" ]]; then
+       downloadURL="https://www.tableau.com/downloads/public/mac"
+    fi
+    appNewVersion=${${$(curl -fsIL "$downloadURL" | sed -nE 's/.*TableauPublic-([0-9-]*).*/\1/p')//-/.}%.}
     expectedTeamID="QJ4XPRK37C"
     ;;

--- a/fragments/labels/tableaureader.sh
+++ b/fragments/labels/tableaureader.sh
@@ -2,6 +2,12 @@ tableaureader)
     name="Tableau Reader"
     type="pkgInDmg"
     packageID="com.tableausoftware.reader.app"
-    downloadURL="https://www.tableau.com/downloads/reader/mac"
+    downloadURL=""
+    if [[ $(arch) == "arm64" ]]; then
+       downloadURL="https://www.tableau.com/downloads/reader/mac-arm64"
+    elif [[ $(arch) == "i386" ]]; then
+       downloadURL="https://www.tableau.com/downloads/reader/mac"
+    fi
+    appNewVersion=${${$(curl -fsIL "$downloadURL" | sed -nE 's/.*TableauReader-([0-9-]*).*/\1/p')//-/.}%.}
     expectedTeamID="QJ4XPRK37C"
     ;;


### PR DESCRIPTION
Updated Tableau labels to support installing ARM versions.

```
2024-11-13 13:02:08 : REQ   : tableaudesktop : ################## Start Installomator v. 10.7beta, date 2024-11-13
2024-11-13 13:02:08 : INFO  : tableaudesktop : ################## Version: 10.7beta
2024-11-13 13:02:08 : INFO  : tableaudesktop : ################## Date: 2024-11-13
2024-11-13 13:02:08 : INFO  : tableaudesktop : ################## tableaudesktop
2024-11-13 13:02:08 : DEBUG : tableaudesktop : DEBUG mode 1 enabled.
2024-11-13 13:02:08 : INFO  : tableaudesktop : SwiftDialog is not installed, clear cmd file var
2024-11-13 13:02:08 : INFO  : tableaudesktop : setting variable from argument DEBUG=0
2024-11-13 13:02:08 : INFO  : tableaudesktop : setting variable from argument LOGGING=INFO
2024-11-13 13:02:08 : INFO  : tableaudesktop : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2024-11-13 13:02:08 : INFO  : tableaudesktop : BLOCKING_PROCESS_ACTION=kill
2024-11-13 13:02:08 : INFO  : tableaudesktop : NOTIFY=success
2024-11-13 13:02:08 : INFO  : tableaudesktop : LOGGING=INFO
2024-11-13 13:02:09 : INFO  : tableaudesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-13 13:02:09 : INFO  : tableaudesktop : Label type: pkgInDmg
2024-11-13 13:02:09 : INFO  : tableaudesktop : archiveName: Tableau Desktop.dmg
2024-11-13 13:02:09 : INFO  : tableaudesktop : no blocking processes defined, using Tableau Desktop as default
2024-11-13 13:02:09 : INFO  : tableaudesktop : No version found using packageID com.tableausoftware.tableaudesktop
2024-11-13 13:02:09 : INFO  : tableaudesktop : name: Tableau Desktop, appName: Tableau Desktop.app
2024-11-13 13:02:09.191 mdfind[96579:4532230] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-13 13:02:09.192 mdfind[96579:4532230] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-13 13:02:09.260 mdfind[96579:4532230] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-13 13:02:09 : WARN  : tableaudesktop : No previous app found
2024-11-13 13:02:09 : WARN  : tableaudesktop : could not find Tableau Desktop.app
2024-11-13 13:02:09 : INFO  : tableaudesktop : appversion:
2024-11-13 13:02:09 : INFO  : tableaudesktop : Latest version of Tableau Desktop is 2024.3.0
2024-11-13 13:02:09 : REQ   : tableaudesktop : Downloading https://www.tableau.com/downloads/desktop/mac-arm64 to Tableau Desktop.dmg
2024-11-13 13:02:17 : REQ   : tableaudesktop : no more blocking processes, continue with update
2024-11-13 13:02:17 : REQ   : tableaudesktop : Installing Tableau Desktop
2024-11-13 13:02:17 : INFO  : tableaudesktop : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mHpreYjVox/Tableau Desktop.dmg
2024-11-13 13:02:45 : INFO  : tableaudesktop : Mounted: /Volumes/Tableau Desktop
2024-11-13 13:02:45 : INFO  : tableaudesktop : found pkg: /Volumes/Tableau Desktop/Tableau Desktop.pkg
2024-11-13 13:02:45 : INFO  : tableaudesktop : Verifying: /Volumes/Tableau Desktop/Tableau Desktop.pkg
2024-11-13 13:02:46 : INFO  : tableaudesktop : Team ID: QJ4XPRK37C (expected: QJ4XPRK37C )
2024-11-13 13:02:46 : INFO  : tableaudesktop : Installing /Volumes/Tableau Desktop/Tableau Desktop.pkg to /
2024-11-13 13:03:23 : INFO  : tableaudesktop : Finishing...
2024-11-13 13:03:26 : INFO  : tableaudesktop : No version found using packageID com.tableausoftware.tableaudesktop
2024-11-13 13:03:27 : INFO  : tableaudesktop : name: Tableau Desktop, appName: Tableau Desktop.app
2024-11-13 13:03:27.039 mdfind[96748:4556396] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-13 13:03:27.039 mdfind[96748:4556396] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-13 13:03:27.103 mdfind[96748:4556396] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-13 13:03:27 : INFO  : tableaudesktop : App(s) found: /Applications/Tableau Desktop (Apple silicon) 2024.3.app
2024-11-13 13:03:27 : INFO  : tableaudesktop : found app at /Applications/Tableau Desktop (Apple silicon) 2024.3.app, version 2024.3.0, on versionKey CFBundleShortVersionString
2024-11-13 13:03:27 : REQ   : tableaudesktop : Installed Tableau Desktop, version 2024.3.0
2024-11-13 13:03:27 : INFO  : tableaudesktop : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2024-11-13 13:03:27 : INFO  : tableaudesktop : Installomator did not close any apps, so no need to reopen any apps.
2024-11-13 13:03:27 : REQ   : tableaudesktop : All done!
2024-11-13 13:03:27 : REQ   : tableaudesktop : ################## End Installomator, exit code 0
```