### PR TITLE
correct Garmin Express (garminexpress) appNewVersion

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -4,7 +4,7 @@ garminexpress)
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
     garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')
-    appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print$2}').0"
+    appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print}').0"
     expectedTeamID="72ES32VZUA"
     appName="Garmin Express.app"
     ;;


### PR DESCRIPTION
Can't understand how the original PR could work. Garmin web seems to look the same, but now it gives a bad version number:
```➜  Installomator git:(correct_garminexpress_appNewVersion) ./utils/assemble.sh garminexpress
2024-11-18 11:14:35 : REQ   : garminexpress : ################## Start Installomator v. 10.7beta, date 2024-11-18
2024-11-18 11:14:35 : INFO  : garminexpress : ################## Version: 10.7beta
2024-11-18 11:14:35 : INFO  : garminexpress : ################## Date: 2024-11-18
2024-11-18 11:14:35 : INFO  : garminexpress : ################## garminexpress
2024-11-18 11:14:35 : DEBUG : garminexpress : DEBUG mode 1 enabled.
2024-11-18 11:14:39 : DEBUG : garminexpress : name=Garmin Express
2024-11-18 11:14:39 : DEBUG : garminexpress : appName=Garmin Express.app
2024-11-18 11:14:39 : DEBUG : garminexpress : type=pkgInDmg
2024-11-18 11:14:39 : DEBUG : garminexpress : archiveName=
2024-11-18 11:14:39 : DEBUG : garminexpress : downloadURL=https://download.garmin.com/omt/express/GarminExpress.dmg
2024-11-18 11:14:39 : DEBUG : garminexpress : curlOptions=
2024-11-18 11:14:39 : DEBUG : garminexpress : appNewVersion=.0
```

After fix in PR is applied:
```➜  Installomator git:(correct_garminexpress_appNewVersion) ./utils/assemble.sh garminexpress
2024-11-18 11:15:13 : REQ   : garminexpress : ################## Start Installomator v. 10.7beta, date 2024-11-18
2024-11-18 11:15:13 : INFO  : garminexpress : ################## Version: 10.7beta
2024-11-18 11:15:13 : INFO  : garminexpress : ################## Date: 2024-11-18
2024-11-18 11:15:13 : INFO  : garminexpress : ################## garminexpress
2024-11-18 11:15:13 : DEBUG : garminexpress : DEBUG mode 1 enabled.
2024-11-18 11:15:17 : DEBUG : garminexpress : name=Garmin Express
2024-11-18 11:15:17 : DEBUG : garminexpress : appName=Garmin Express.app
2024-11-18 11:15:17 : DEBUG : garminexpress : type=pkgInDmg
2024-11-18 11:15:17 : DEBUG : garminexpress : archiveName=
2024-11-18 11:15:17 : DEBUG : garminexpress : downloadURL=https://download.garmin.com/omt/express/GarminExpress.dmg
2024-11-18 11:15:17 : DEBUG : garminexpress : curlOptions=
2024-11-18 11:15:17 : DEBUG : garminexpress : appNewVersion=7.24.0.0
```