### PR TITLE
Create Descript label

### DIFF
--- a/fragments/labels/descript.sh
+++ b/fragments/labels/descript.sh
@@ -1,0 +1,7 @@
+descript)
+    name="Descript"
+    type="dmg"
+    downloadURL=$(curl -fsL "https://web.descript.com/download?platform=mac" -w "%{url_effective}" -o /dev/null)
+    appNewVersion=$(echo "$downloadURL" | sed -nE 's/.*Descript-([0-9.]+-release\.[0-9.]+)\.dmg/\1/p')
+    expectedTeamID="D4CJQGP2T7"
+    ;;


### PR DESCRIPTION
New label for Descript.
https://www.descript.com

Output:

./assemble.sh descript
2024-11-19 12:28:56 : REQ   : descript : ################## Start Installomator v. 10.7beta, date 2024-11-19
2024-11-19 12:28:56 : INFO  : descript : ################## Version: 10.7beta
2024-11-19 12:28:56 : INFO  : descript : ################## Date: 2024-11-19
2024-11-19 12:28:56 : INFO  : descript : ################## descript
2024-11-19 12:28:56 : DEBUG : descript : DEBUG mode 1 enabled.
2024-11-19 12:29:09 : DEBUG : descript : name=Descript
2024-11-19 12:29:09 : DEBUG : descript : appName=
2024-11-19 12:29:09 : DEBUG : descript : type=dmg
2024-11-19 12:29:09 : DEBUG : descript : archiveName=
2024-11-19 12:29:09 : DEBUG : descript : downloadURL=https://electron.descript.com/Descript-102.0.2-release.20241113.3535.dmg
2024-11-19 12:29:09 : DEBUG : descript : curlOptions=
2024-11-19 12:29:09 : DEBUG : descript : appNewVersion=102.0.2-release.20241113.3535
2024-11-19 12:29:09 : DEBUG : descript : appCustomVersion function: Not defined
2024-11-19 12:29:09 : DEBUG : descript : versionKey=CFBundleShortVersionString
2024-11-19 12:29:09 : DEBUG : descript : packageID=
2024-11-19 12:29:10 : DEBUG : descript : pkgName=
2024-11-19 12:29:10 : DEBUG : descript : choiceChangesXML=
2024-11-19 12:29:10 : DEBUG : descript : expectedTeamID=D4CJQGP2T7
2024-11-19 12:29:10 : DEBUG : descript : blockingProcesses=
2024-11-19 12:29:10 : DEBUG : descript : installerTool=
2024-11-19 12:29:10 : DEBUG : descript : CLIInstaller=
2024-11-19 12:29:10 : DEBUG : descript : CLIArguments=
2024-11-19 12:29:10 : DEBUG : descript : updateTool=
2024-11-19 12:29:10 : DEBUG : descript : updateToolArguments=
2024-11-19 12:29:10 : DEBUG : descript : updateToolRunAsCurrentUser=
2024-11-19 12:29:10 : INFO  : descript : BLOCKING_PROCESS_ACTION=tell_user
2024-11-19 12:29:10 : INFO  : descript : NOTIFY=success
2024-11-19 12:29:10 : INFO  : descript : LOGGING=DEBUG
2024-11-19 12:29:10 : INFO  : descript : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-19 12:29:10 : INFO  : descript : Label type: dmg
2024-11-19 12:29:10 : INFO  : descript : archiveName: Descript.dmg
2024-11-19 12:29:10 : INFO  : descript : no blocking processes defined, using Descript as default
2024-11-19 12:29:10 : DEBUG : descript : Changing directory to /Users/REDACTED/Documents/GitHub/Installomator/build
2024-11-19 12:29:10 : INFO  : descript : App(s) found: /Applications/Descript.app
2024-11-19 12:29:10 : INFO  : descript : found app at /Applications/Descript.app, version 102.0.2-release.20241113.3535, on versionKey CFBundleShortVersionString
2024-11-19 12:29:10 : INFO  : descript : appversion: 102.0.2-release.20241113.3535
2024-11-19 12:29:10 : INFO  : descript : Latest version of Descript is 102.0.2-release.20241113.3535
2024-11-19 12:29:10 : WARN  : descript : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-11-19 12:29:10 : REQ   : descript : Downloading https://electron.descript.com/Descript-102.0.2-release.20241113.3535.dmg to Descript.dmg
2024-11-19 12:29:10 : DEBUG : descript : No Dialog connection, just download
2024-11-19 12:29:22 : DEBUG : descript : File list: -rw-r--r--  1 REDACTED  staff   190M Nov 19 12:29 Descript.dmg
2024-11-19 12:29:22 : DEBUG : descript : File type: Descript.dmg: zlib compressed data
2024-11-19 12:29:22 : DEBUG : descript : curl output was:
* Host electron.descript.com:443 was resolved.
* IPv6: 2600:9000:24f9:400:18:91a4:d880:93a1, 2600:9000:24f9:e400:18:91a4:d880:93a1, 2600:9000:24f9:1200:18:91a4:d880:93a1, 2600:9000:24f9:2600:18:91a4:d880:93a1, 2600:9000:24f9:7a00:18:91a4:d880:93a1, 2600:9000:24f9:be00:18:91a4:d880:93a1, 2600:9000:24f9:d400:18:91a4:d880:93a1, 2600:9000:24f9:200:18:91a4:d880:93a1
* IPv4: 65.9.42.87, 65.9.42.10, 65.9.42.21, 65.9.42.88
*   Trying [2600:9000:24f9:400:18:91a4:d880:93a1]:443...
* Connected to electron.descript.com (2600:9000:24f9:400:18:91a4:d880:93a1) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4968 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=electron.descript.com
*  start date: Jun 27 00:00:00 2024 GMT
*  expire date: Jul 26 23:59:59 2025 GMT
*  subjectAltName: host "electron.descript.com" matched cert's "electron.descript.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M03
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://electron.descript.com/Descript-102.0.2-release.20241113.3535.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: electron.descript.com]
* [HTTP/2] [1] [:path: /Descript-102.0.2-release.20241113.3535.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Descript-102.0.2-release.20241113.3535.dmg HTTP/2
> Host: electron.descript.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: application/x-apple-diskimage
< content-length: 199731484
< date: Wed, 13 Nov 2024 22:00:42 GMT
< last-modified: Wed, 13 Nov 2024 18:20:43 GMT
< etag: "625e2abc849b9700015df1cccdf8e00d-24"
< x-amz-server-side-encryption: AES256
< cache-control: public,max-age=31536000
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 d42baf2176175bbe44a0ffaa3781bc56.cloudfront.net (CloudFront) < x-amz-cf-pop: MCI50-P2
< x-amz-cf-id: Er20TVcawiQf_nnnPUjinGf2JHYwd8elwA8tIJax68bf9o7s42YVBA== < age: 480508
<
{ [8192 bytes data]
* Connection #0 to host electron.descript.com left intact

2024-11-19 12:29:22 : DEBUG : descript : DEBUG mode 1, not checking for blocking processes
2024-11-19 12:29:22 : REQ   : descript : Installing Descript
2024-11-19 12:29:22 : INFO  : descript : Mounting /Users/REDACTED/Documents/GitHub/Installomator/build/Descript.dmg
2024-11-19 12:29:25 : DEBUG : descript : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $25D94A77
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $34DFA144
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D24D075C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $846970C7
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D24D075C
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $FA130338
verified   CRC32 $E64867C7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Descript 102.0.2-release.20241113.3535

2024-11-19 12:29:25 : INFO  : descript : Mounted: /Volumes/Descript 102.0.2-release.20241113.3535 2024-11-19 12:29:25 : INFO  : descript : Verifying: /Volumes/Descript 102.0.2-release.20241113.3535/Descript.app 2024-11-19 12:29:25 : DEBUG : descript : App size: 483M	/Volumes/Descript 102.0.2-release.20241113.3535/Descript.app 2024-11-19 12:29:27 : DEBUG : descript : Debugging enabled, App Verification output was: /Volumes/Descript 102.0.2-release.20241113.3535/Descript.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Descript, Inc. (D4CJQGP2T7)

2024-11-19 12:29:27 : INFO  : descript : Team ID matching: D4CJQGP2T7 (expected: D4CJQGP2T7 ) 2024-11-19 12:29:27 : INFO  : descript : Downloaded version of Descript is 102.0.2-release.20241113.3535 on versionKey CFBundleShortVersionString, same as installed. 2024-11-19 12:29:27 : DEBUG : descript : Unmounting /Volumes/Descript 102.0.2-release.20241113.3535 2024-11-19 12:29:28 : DEBUG : descript : Debugging enabled, Unmounting output was: "disk4" ejected.
2024-11-19 12:29:28 : DEBUG : descript : DEBUG mode 1, not reopening anything
2024-11-19 12:29:28 : REG   : descript : No new version to install
2024-11-19 12:29:28 : REQ   : descript : ################## End Installomator, exit code 0