### PR TITLE
Update zulujdk17

### DIFF
--- a/fragments/labels/zulujdk17.sh
+++ b/fragments/labels/zulujdk17.sh
@@ -10,4 +10,4 @@ zulujdk17)
     expectedTeamID="TDTHCUPYFR" 
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; fi }
     appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//" | sed 's/jdk//') 
-;;
+    ;;  


### PR DESCRIPTION
Cane to light during an audit the Azul jdk isn't being updated by installomater. This is an updated fragment that fixes that issue. 

### download URL was pulling incorrect info and trunkating the path:
#### original downloadURL line:
`downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)`

#### replacement line:
`downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | cut -d "<" -f 1 | tail -1)`

**removes**` cut c11-` and adds `cut -d "<" -f 1`

### installed version check simplified
 modified to use contents of info.plist:
`appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; fi }`

logs from a clean install and an update check:

[zulujdk17-clean install.log](https://github.com/user-attachments/files/17832361/zulujdk17-clean.install.log)
[zulujdk17-update-same-version.log](https://github.com/user-attachments/files/17832364/zulujdk17-update-same-version.log)
