### PR TITLE
Elevate24 - new product

### DIFF
--- a/fragments/labels/elevate24.sh
+++ b/fragments/labels/elevate24.sh
@@ -1,0 +1,7 @@
+elevate24)
+    name="Elevate24"
+    type="pkg"
+    downloadURL="$(downloadURLFromGit Jigsaw24 Elevate24)"
+    appNewVersion="$(versionFromGit Jigsaw24 Elevate24)"
+    expectedTeamID="BVDW99KYDU"
+    ;;


### PR DESCRIPTION
[Elevate24 ](https://github.com/Jigsaw24/Elevate24/tree/v2.1.2)is an account elevation tool from Jigsaw24.

fragment created using the `buildlabel.sh` script.

logs attached
[elevate24.log](https://github.com/user-attachments/files/17845595/elevate24.log)

