### PR TITLE
Fix appNewVersion in "grandperspective" label

### DIFF
--- a/fragments/labels/grandperspective.sh
+++ b/fragments/labels/grandperspective.sh
@@ -2,6 +2,6 @@ grandperspective)
     name="GrandPerspective"
     type="dmg"
     downloadURL="https://sourceforge.net/projects/grandperspectiv/files/latest/download"
-    appNewVersion=$(curl -s https://sourceforge.net/projects/grandperspectiv/files/grandperspective/ | grep -A1 'Click to enter' | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+    appNewVersion=$(curl -fs https://sourceforge.net/projects/grandperspectiv/files/grandperspective/ | grep -B 2 'Download Latest Version' | grep -oE '\/(\d|\.)+\/' | sed 's/\///g')
     expectedTeamID="3Z75QZGN66"
     ;;


### PR DESCRIPTION
Fixed appNewVersion variable, improved how this is scraped from SourceForge, added -f to curl command to fail silently

Output:
```
./assemble.sh grandperspective
2024-11-21 09:18:27 : REQ   : grandperspective : ################## Start Installomator v. 10.7beta, date 2024-11-21
2024-11-21 09:18:27 : INFO  : grandperspective : ################## Version: 10.7beta
2024-11-21 09:18:27 : INFO  : grandperspective : ################## Date: 2024-11-21
2024-11-21 09:18:27 : INFO  : grandperspective : ################## grandperspective
2024-11-21 09:18:27 : DEBUG : grandperspective : DEBUG mode 1 enabled.
2024-11-21 09:18:28 : DEBUG : grandperspective : name=GrandPerspective
2024-11-21 09:18:28 : DEBUG : grandperspective : appName=
2024-11-21 09:18:28 : DEBUG : grandperspective : type=dmg
2024-11-21 09:18:28 : DEBUG : grandperspective : archiveName=
2024-11-21 09:18:28 : DEBUG : grandperspective : downloadURL=https://sourceforge.net/projects/grandperspectiv/files/latest/download
2024-11-21 09:18:28 : DEBUG : grandperspective : curlOptions=
2024-11-21 09:18:28 : DEBUG : grandperspective : appNewVersion=3.4.2
2024-11-21 09:18:28 : DEBUG : grandperspective : appCustomVersion function: Not defined
2024-11-21 09:18:28 : DEBUG : grandperspective : versionKey=CFBundleShortVersionString
2024-11-21 09:18:28 : DEBUG : grandperspective : packageID=
2024-11-21 09:18:28 : DEBUG : grandperspective : pkgName=
2024-11-21 09:18:28 : DEBUG : grandperspective : choiceChangesXML=
2024-11-21 09:18:28 : DEBUG : grandperspective : expectedTeamID=3Z75QZGN66
2024-11-21 09:18:28 : DEBUG : grandperspective : blockingProcesses=
2024-11-21 09:18:28 : DEBUG : grandperspective : installerTool=
2024-11-21 09:18:28 : DEBUG : grandperspective : CLIInstaller=
2024-11-21 09:18:28 : DEBUG : grandperspective : CLIArguments=
2024-11-21 09:18:28 : DEBUG : grandperspective : updateTool=
2024-11-21 09:18:28 : DEBUG : grandperspective : updateToolArguments=
2024-11-21 09:18:28 : DEBUG : grandperspective : updateToolRunAsCurrentUser=
2024-11-21 09:18:28 : INFO  : grandperspective : BLOCKING_PROCESS_ACTION=tell_user
2024-11-21 09:18:28 : INFO  : grandperspective : NOTIFY=success
2024-11-21 09:18:28 : INFO  : grandperspective : LOGGING=DEBUG
2024-11-21 09:18:28 : INFO  : grandperspective : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-21 09:18:28 : INFO  : grandperspective : Label type: dmg
2024-11-21 09:18:28 : INFO  : grandperspective : archiveName: GrandPerspective.dmg
2024-11-21 09:18:28 : INFO  : grandperspective : no blocking processes defined, using GrandPerspective as default
2024-11-21 09:18:28 : DEBUG : grandperspective : Changing directory to /Users/jaredschwager/Documents/Repositories/Installomator/build
2024-11-21 09:18:29 : INFO  : grandperspective : name: GrandPerspective, appName: GrandPerspective.app
2024-11-21 09:18:29.072 mdfind[66500:1608756] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-21 09:18:29.073 mdfind[66500:1608756] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-21 09:18:29.271 mdfind[66500:1608756] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-21 09:18:29 : WARN  : grandperspective : No previous app found
2024-11-21 09:18:29 : WARN  : grandperspective : could not find GrandPerspective.app
2024-11-21 09:18:29 : INFO  : grandperspective : appversion: 
2024-11-21 09:18:29 : INFO  : grandperspective : Latest version of GrandPerspective is 3.4.2
2024-11-21 09:18:29 : INFO  : grandperspective : GrandPerspective.dmg exists and DEBUG mode 1 enabled, skipping download
2024-11-21 09:18:29 : DEBUG : grandperspective : DEBUG mode 1, not checking for blocking processes
2024-11-21 09:18:29 : REQ   : grandperspective : Installing GrandPerspective
2024-11-21 09:18:29 : INFO  : grandperspective : Mounting /Users/jaredschwager/Documents/Repositories/Installomator/build/GrandPerspective.dmg
2024-11-21 09:18:30 : DEBUG : grandperspective : Debugging enabled, dmgmount output was:
expected   CRC32 $0D25096F
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/GrandPerspective 3.4.2

2024-11-21 09:18:30 : INFO  : grandperspective : Mounted: /Volumes/GrandPerspective 3.4.2
2024-11-21 09:18:30 : INFO  : grandperspective : Verifying: /Volumes/GrandPerspective 3.4.2/GrandPerspective.app
2024-11-21 09:18:30 : DEBUG : grandperspective : App size: 5.0M	/Volumes/GrandPerspective 3.4.2/GrandPerspective.app
2024-11-21 09:18:32 : DEBUG : grandperspective : Debugging enabled, App Verification output was:
/Volumes/GrandPerspective 3.4.2/GrandPerspective.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Erwin Bonsma (3Z75QZGN66)

2024-11-21 09:18:32 : INFO  : grandperspective : Team ID matching: 3Z75QZGN66 (expected: 3Z75QZGN66 )
2024-11-21 09:18:32 : INFO  : grandperspective : Installing GrandPerspective version 3.4.2 on versionKey CFBundleShortVersionString.
2024-11-21 09:18:32 : INFO  : grandperspective : App has LSMinimumSystemVersion: 11.0
2024-11-21 09:18:32 : DEBUG : grandperspective : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-11-21 09:18:32 : INFO  : grandperspective : Finishing...
2024-11-21 09:18:35 : INFO  : grandperspective : name: GrandPerspective, appName: GrandPerspective.app
2024-11-21 09:18:35.947 mdfind[66649:1609467] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-11-21 09:18:35.948 mdfind[66649:1609467] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-11-21 09:18:35.990 mdfind[66649:1609467] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-21 09:18:36 : WARN  : grandperspective : No previous app found
2024-11-21 09:18:36 : WARN  : grandperspective : could not find GrandPerspective.app
2024-11-21 09:18:36 : REQ   : grandperspective : Installed GrandPerspective, version 3.4.2
2024-11-21 09:18:36 : INFO  : grandperspective : notifying
2024-11-21 09:18:36 : DEBUG : grandperspective : Unmounting /Volumes/GrandPerspective 3.4.2
2024-11-21 09:18:36 : DEBUG : grandperspective : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-11-21 09:18:36 : DEBUG : grandperspective : DEBUG mode 1, not reopening anything
2024-11-21 09:18:36 : REQ   : grandperspective : All done!
2024-11-21 09:18:36 : REQ   : grandperspective : ################## End Installomator, exit code 0
```