### PR TITLE
amazon corretto jdk 8 

### DIFF
--- a/fragments/labels/amazoncorretto8jdk.sh
+++ b/fragments/labels/amazoncorretto8jdk.sh
@@ -17,4 +17,5 @@ amazoncorretto8jdk)
             | awk '{ print $NF}'
     )"
     expectedTeamID="94KV3E626L"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Info.plist" "CFBundleVersion" ; fi }
     ;;


### PR DESCRIPTION
added installed version check that was missing.
No change to install lines as they work ok.

[amazoncorretto8-update.log](https://github.com/user-attachments/files/17847303/amazoncorretto8-update.log)
