### PR TITLE
amazoncorretto11jdk - installed version check

### DIFF
--- a/fragments/labels/amazoncorretto11jdk.sh
+++ b/fragments/labels/amazoncorretto11jdk.sh
@@ -17,4 +17,5 @@ amazoncorretto11jdk)
             | awk '{ print $NF}'
     )"
     expectedTeamID="94KV3E626L"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Info.plist" "CFBundleVersion" ; fi }
     ;;


### PR DESCRIPTION
added installed version check. nothing else changed.

[amazoncorretto11jdk.log](https://github.com/user-attachments/files/17847996/amazoncorretto11jdk.log)
