### PR TITLE
amazoncorretto21jdk - new label

### DIFF
--- a/fragments/labels/amazoncorretto21jdk.sh
+++ b/fragments/labels/amazoncorretto21jdk.sh
@@ -1,0 +1,21 @@
+amazoncorretto21jdk)
+    name="Amazon Corretto 21 JDK"
+    type="pkg"
+    case $(arch) in
+        "arm64")
+            cpu_arch="aarch64"
+        ;;
+        "i386")
+            cpu_arch="x64"
+        ;;
+    esac
+    downloadURL="https://corretto.aws/downloads/latest/amazon-corretto-21-${cpu_arch}-macos-jdk.pkg"
+    appNewVersion="$(
+        curl -Ls https://raw.githubusercontent.com/corretto/corretto-21/develop/CHANGELOG.md \
+            | grep "## Corretto version" \
+            | head -n 1 \
+            | awk '{ print $NF}'
+    )"
+    expectedTeamID="94KV3E626L"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Info.plist" "CFBundleVersion" ; fi }
+    ;;


### PR DESCRIPTION
label for `amazoncorretto21jdk`. 
Clone of `amazoncorretto11jdk` with version numbers changed where required.

[amazoncorretto21jdk-installs.log](https://github.com/user-attachments/files/17848165/amazoncorretto21jdk-installs.log)
