### PR TITLE
amazoncorretto22jdk - new label

### DIFF
--- a/fragments/labels/amazoncorretto22jdk.sh
+++ b/fragments/labels/amazoncorretto22jdk.sh
@@ -1,0 +1,21 @@
+amazoncorretto22jdk)
+    name="Amazon Corretto 22 JDK"
+    type="pkg"
+    case $(arch) in
+        "arm64")
+            cpu_arch="aarch64"
+        ;;
+        "i386")
+            cpu_arch="x64"
+        ;;
+    esac
+    downloadURL="https://corretto.aws/downloads/latest/amazon-corretto-22-${cpu_arch}-macos-jdk.pkg"
+    appNewVersion="$(
+        curl -Ls https://raw.githubusercontent.com/corretto/corretto-22/develop/CHANGELOG.md \
+            | grep "## Corretto version" \
+            | head -n 1 \
+            | awk '{ print $NF}'
+    )"
+    expectedTeamID="94KV3E626L"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/amazon-corretto-22.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/amazon-corretto-22.jdk/Contents/Info.plist" "CFBundleVersion" ; fi }
+    ;;


### PR DESCRIPTION
label for `amazoncorretto22jdk`.
Clone of `amazoncorretto21jdk` with version numbers changed where required.

[amazoncorretto22jdk-install.log](https://github.com/user-attachments/files/17848269/amazoncorretto22jdk-install.log)
