### PR TITLE
amazoncorretto23jdk - new label

### DIFF
--- a/fragments/labels/amazoncorretto23jdk.sh
+++ b/fragments/labels/amazoncorretto23jdk.sh
@@ -1,0 +1,21 @@
+amazoncorretto23jdk)
+    name="Amazon Corretto 23 JDK"
+    type="pkg"
+    case $(arch) in
+        "arm64")
+            cpu_arch="aarch64"
+        ;;
+        "i386")
+            cpu_arch="x64"
+        ;;
+    esac
+    downloadURL="https://corretto.aws/downloads/latest/amazon-corretto-23-${cpu_arch}-macos-jdk.pkg"
+    appNewVersion="$(
+        curl -Ls https://raw.githubusercontent.com/corretto/corretto-23/develop/CHANGELOG.md \
+            | grep "## Corretto version" \
+            | head -n 1 \
+            | awk '{ print $NF}'
+    )"
+    expectedTeamID="94KV3E626L"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/amazon-corretto-23.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/amazon-corretto-23.jdk/Contents/Info.plist" "CFBundleVersion" ; fi }
+    ;;


### PR DESCRIPTION
label for `amazoncorretto23jdk`.
Clone of `amazoncorretto21jdk` with version numbers changed where required.

[amazoncorretto23jdk-install.log](https://github.com/user-attachments/files/17848349/amazoncorretto23jdk-install.log)
