### PR TITLE
Update functions.sh to fix swiftDialog bug

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -72,8 +72,6 @@ displaynotification() { # $1: message $2: title
          "$manageaction" -message "$message" -title "$title" &
     elif [[ -x "$hubcli" ]]; then
          "$hubcli" notify -t "$title" -i "$message" -c "Dismiss"
-    elif [[ "$($swiftdialog --version | cut -d "." -f1)" -ge 2 ]]; then
-         "$swiftdialog" --notification --title "$title" --message "$message"
     else
         runAsUser osascript -e "display notification \"$message\" with title \"$title\""
     fi


### PR DESCRIPTION
Removing second swiftDialog check which is not needed. The second time we were checking it, we were then not checking NOTIFY_DIALOG so swiftDialog would be used even if NOTIFY_DIALOG was set to false.