### PR TITLE
Create webexvdiplugin.sh

### DIFF
--- a/fragments/labels/webexvdiplugin.sh
+++ b/fragments/labels/webexvdiplugin.sh
@@ -1,0 +1,11 @@
+webexvdiplugin)
+    name="Cisco Webex VDI Plugin"
+    type="pkg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(curl -fsSL https://help.webex.com/en-us/article/ntp1us7/Webex-App-%7C-VDI-release-notes#reference-template_e92f9ad6-4f8c-4f69-b967-8615da1788ad 2>/dev/null | awk -F 'href="' '/<td align="" headers="">MacOS \(Apple Silicon\)/ {split($2, a, "\""); print a[1]; exit}')
+    else
+        downloadURL=$(curl -fsSl https://help.webex.com/en-us/article/ntp1us7/Webex-App-%7C-VDI-release-notes#reference-template_e92f9ad6-4f8c-4f69-b967-8615da1788ad 2>/dev/null | awk -F 'href="' '/<td align="" headers="">MacOS \(Intel base\)/ {split($2, a, "\""); print a[1]; exit}')
+    fi
+    expectedTeamID="DE8Y96K9QP"
+    appNewVersion=$(curl -fsSL https://help.webex.com/en-us/article/ntp1us7/Webex-App-%7C-VDI-release-notes#reference-template_e92f9ad6-4f8c-4f69-b967-8615da1788ad 2>/dev/null | awk '/<th align="" font-weight="bold" id="">Webex App VDI Plugin/ {gsub(/.*\(/, "", $0); gsub(/\).*/, "", $0); print; exit}')
+    ;;


### PR DESCRIPTION
2024-11-27 09:43:59 : REQ   : webexvdiplugin : ################## Start Installomator v. 10.7beta, date 2024-11-27
2024-11-27 09:43:59 : INFO  : webexvdiplugin : ################## Version: 10.7beta
2024-11-27 09:43:59 : INFO  : webexvdiplugin : ################## Date: 2024-11-27
2024-11-27 09:43:59 : INFO  : webexvdiplugin : ################## webexvdiplugin
2024-11-27 09:43:59 : DEBUG : webexvdiplugin : DEBUG mode 1 enabled.
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : name=Cisco Webex VDI Plugin
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : appName=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : type=pkg
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : archiveName=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : downloadURL=https://binaries.webex.com/vdi-mac-aws-gold/20241121035310/WebexVDIPlugin_arm64.pkg
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : curlOptions=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : appNewVersion=44.10.2.31237
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : appCustomVersion function: Not defined
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : versionKey=CFBundleShortVersionString
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : packageID=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : pkgName=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : choiceChangesXML=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : expectedTeamID=DE8Y96K9QP
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : blockingProcesses=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : installerTool=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : CLIInstaller=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : CLIArguments=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : updateTool=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : updateToolArguments=
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : updateToolRunAsCurrentUser=
2024-11-27 09:44:03 : INFO  : webexvdiplugin : BLOCKING_PROCESS_ACTION=tell_user
2024-11-27 09:44:03 : INFO  : webexvdiplugin : NOTIFY=success
2024-11-27 09:44:03 : INFO  : webexvdiplugin : LOGGING=DEBUG
2024-11-27 09:44:03 : INFO  : webexvdiplugin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-27 09:44:03 : INFO  : webexvdiplugin : Label type: pkg
2024-11-27 09:44:03 : INFO  : webexvdiplugin : archiveName: Cisco Webex VDI Plugin.pkg
2024-11-27 09:44:03 : INFO  : webexvdiplugin : no blocking processes defined, using Cisco Webex VDI Plugin as default
2024-11-27 09:44:03 : DEBUG : webexvdiplugin : Changing directory to .
2024-11-27 09:44:03 : INFO  : webexvdiplugin : name: Cisco Webex VDI Plugin, appName: Cisco Webex VDI Plugin.app
2024-11-27 09:44:03.626 mdfind[53273:4330878] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-11-27 09:44:03.626 mdfind[53273:4330878] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-11-27 09:44:03.768 mdfind[53273:4330878] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 09:44:04 : WARN  : webexvdiplugin : No previous app found
2024-11-27 09:44:04 : WARN  : webexvdiplugin : could not find Cisco Webex VDI Plugin.app
2024-11-27 09:44:04 : INFO  : webexvdiplugin : appversion:
2024-11-27 09:44:04 : INFO  : webexvdiplugin : Latest version of Cisco Webex VDI Plugin is 44.10.2.31237
2024-11-27 09:44:04 : REQ   : webexvdiplugin : Downloading https://binaries.webex.com/vdi-mac-aws-gold/20241121035310/WebexVDIPlugin_arm64.pkg to Cisco Webex VDI Plugin.pkg
2024-11-27 09:44:04 : DEBUG : webexvdiplugin : No Dialog connection, just download
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : File list: -rw-r--r--@ 1 root  staff   160M 27 Nov 09:44 Cisco Webex VDI Plugin.pkg
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : File type: Cisco Webex VDI Plugin.pkg: xar archive compressed TOC: 12462, SHA-1 checksum
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : curl output was:
* Host binaries.webex.com:443 was resolved.
* IPv6: 2600:9000:20eb:7a00:1d:4485:9bc0:93a1, 2600:9000:20eb:5600:1d:4485:9bc0:93a1, 2600:9000:20eb:9400:1d:4485:9bc0:93a1, 2600:9000:20eb:9200:1d:4485:9bc0:93a1, 2600:9000:20eb:1000:1d:4485:9bc0:93a1, 2600:9000:20eb:de00:1d:4485:9bc0:93a1, 2600:9000:20eb:cc00:1d:4485:9bc0:93a1, 2600:9000:20eb:9a00:1d:4485:9bc0:93a1
* IPv4: 18.66.112.32, 18.66.112.21, 18.66.112.129, 18.66.112.85
*   Trying 18.66.112.32:443...
* Connected to binaries.webex.com (18.66.112.32) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4814 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Cisco Systems Inc.; CN=binaries.webex.com
*  start date: Jul 23 14:47:03 2024 GMT
*  expire date: Jul 23 14:46:03 2025 GMT
*  subjectAltName: host "binaries.webex.com" matched cert's "binaries.webex.com"
*  issuer: C=US; O=IdenTrust; OU=HydrantID Trusted Certificate Service; CN=HydrantID Server CA O1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://binaries.webex.com/vdi-mac-aws-gold/20241121035310/WebexVDIPlugin_arm64.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: binaries.webex.com]
* [HTTP/2] [1] [:path: /vdi-mac-aws-gold/20241121035310/WebexVDIPlugin_arm64.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /vdi-mac-aws-gold/20241121035310/WebexVDIPlugin_arm64.pkg HTTP/2
> Host: binaries.webex.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: binary/octet-stream
< content-length: 167658471
< date: Wed, 27 Nov 2024 08:44:05 GMT
< last-modified: Thu, 21 Nov 2024 03:53:13 GMT
< etag: "d9b07f3ed9c4edc6e8c2839065589c6b-20"
< x-amz-storage-class: REDUCED_REDUNDANCY
< x-amz-server-side-encryption: AES256
< x-amz-version-id: null
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 98652de9f742fc1df9de714d921e14c2.cloudfront.net (CloudFront) < x-amz-cf-pop: FRA56-P5
< x-amz-cf-id: nKIjcZb9hAiBHO_J_W4Lqn2Xhv5oohZ5rXCjSoSdKjjyC8_-8WiiQg== <
{ [8192 bytes data]
* Connection #0 to host binaries.webex.com left intact

2024-11-27 09:44:12 : DEBUG : webexvdiplugin : DEBUG mode 1, not checking for blocking processes
2024-11-27 09:44:12 : REQ   : webexvdiplugin : Installing Cisco Webex VDI Plugin
2024-11-27 09:44:12 : INFO  : webexvdiplugin : Verifying: Cisco Webex VDI Plugin.pkg
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : File list: -rw-r--r--@ 1 root  staff   160M 27 Nov 09:44 Cisco Webex VDI Plugin.pkg
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : File type: Cisco Webex VDI Plugin.pkg: xar archive compressed TOC: 12462, SHA-1 checksum
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : spctlOut is Cisco Webex VDI Plugin.pkg: accepted
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : source=Notarized Developer ID
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : origin=Developer ID Installer: Cisco (DE8Y96K9QP)
2024-11-27 09:44:12 : INFO  : webexvdiplugin : Team ID: DE8Y96K9QP (expected: DE8Y96K9QP )
2024-11-27 09:44:12 : DEBUG : webexvdiplugin : DEBUG enabled, skipping installation
2024-11-27 09:44:12 : INFO  : webexvdiplugin : Finishing...
2024-11-27 09:44:15 : INFO  : webexvdiplugin : name: Cisco Webex VDI Plugin, appName: Cisco Webex VDI Plugin.app
2024-11-27 09:44:15.628 mdfind[53383:4331296] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-11-27 09:44:15.629 mdfind[53383:4331296] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-11-27 09:44:15.669 mdfind[53383:4331296] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 09:44:15 : WARN  : webexvdiplugin : No previous app found
2024-11-27 09:44:15 : WARN  : webexvdiplugin : could not find Cisco Webex VDI Plugin.app
2024-11-27 09:44:15 : REQ   : webexvdiplugin : Installed Cisco Webex VDI Plugin, version 44.10.2.31237
2024-11-27 09:44:15 : INFO  : webexvdiplugin : notifying
2024-11-27 09:44:16 : DEBUG : webexvdiplugin : DEBUG mode 1, not reopening anything
2024-11-27 09:44:16 : REQ   : webexvdiplugin : All done!
2024-11-27 09:44:16 : REQ   : webexvdiplugin : ################## End Installomator, exit code 0