### PR TITLE
Working appNewVersion for spotify

### DIFF
--- a/fragments/labels/spotify.sh
+++ b/fragments/labels/spotify.sh
@@ -6,6 +6,6 @@ spotify)
     elif [[ $(arch) == i386 ]]; then
         downloadURL="https://download.scdn.co/Spotify.dmg"
     fi
-    # appNewVersion=$(curl -fs https://www.spotify.com/us/opensource/ | cat | grep -o "<td>.*.</td>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1) # does not result in the same version as downloaded
+    appNewVersion=$(curl -fs https://www.spotify.com/us/opensource/ | sed 's/","/\n/g' | grep "clientVersion" | sed -e 's/clientVersion":"\(.*\)"}.*bz2/\1/' | head -1 | awk -F "." '{print$1"."$2"."$3"."$4}')
     expectedTeamID="2FNC3A47ZF"
     ;;


### PR DESCRIPTION
Yes, the oneliner could be a bit nicer but that's beyond my knowledge.

```2024-11-27 13:50:13 : REQ   : spotify : ################## Start Installomator v. 10.7beta, date 2024-11-27
2024-11-27 13:50:13 : INFO  : spotify : ################## Version: 10.7beta
2024-11-27 13:50:13 : INFO  : spotify : ################## Date: 2024-11-27
2024-11-27 13:50:13 : INFO  : spotify : ################## spotify
2024-11-27 13:50:13 : DEBUG : spotify : DEBUG mode 1 enabled.
2024-11-27 13:50:13 : DEBUG : spotify : name=Spotify
2024-11-27 13:50:13 : DEBUG : spotify : appName=
2024-11-27 13:50:13 : DEBUG : spotify : type=dmg
2024-11-27 13:50:13 : DEBUG : spotify : archiveName=
2024-11-27 13:50:13 : DEBUG : spotify : downloadURL=https://download.scdn.co/SpotifyARM64.dmg
2024-11-27 13:50:13 : DEBUG : spotify : curlOptions=
2024-11-27 13:50:13 : DEBUG : spotify : appNewVersion=1.2.51.345
2024-11-27 13:50:13 : DEBUG : spotify : appCustomVersion function: Not defined
2024-11-27 13:50:13 : DEBUG : spotify : versionKey=CFBundleShortVersionString
2024-11-27 13:50:13 : DEBUG : spotify : packageID=
2024-11-27 13:50:13 : DEBUG : spotify : pkgName=
2024-11-27 13:50:13 : DEBUG : spotify : choiceChangesXML=
2024-11-27 13:50:13 : DEBUG : spotify : expectedTeamID=2FNC3A47ZF
2024-11-27 13:50:13 : DEBUG : spotify : blockingProcesses=
2024-11-27 13:50:13 : DEBUG : spotify : installerTool=
2024-11-27 13:50:13 : DEBUG : spotify : CLIInstaller=
2024-11-27 13:50:13 : DEBUG : spotify : CLIArguments=
2024-11-27 13:50:13 : DEBUG : spotify : updateTool=
2024-11-27 13:50:13 : DEBUG : spotify : updateToolArguments=
2024-11-27 13:50:13 : DEBUG : spotify : updateToolRunAsCurrentUser=
2024-11-27 13:50:14 : INFO  : spotify : BLOCKING_PROCESS_ACTION=tell_user
2024-11-27 13:50:14 : INFO  : spotify : NOTIFY=success
2024-11-27 13:50:14 : INFO  : spotify : LOGGING=DEBUG
2024-11-27 13:50:14 : INFO  : spotify : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-27 13:50:14 : INFO  : spotify : Label type: dmg
2024-11-27 13:50:14 : INFO  : spotify : archiveName: Spotify.dmg
2024-11-27 13:50:14 : INFO  : spotify : no blocking processes defined, using Spotify as default
2024-11-27 13:50:14 : DEBUG : spotify : Changing directory to /PathToGitDirectory/Installomator/build
2024-11-27 13:50:14 : INFO  : spotify : name: Spotify, appName: Spotify.app
2024-11-27 13:50:14.192 mdfind[37693:22094193] [UserQueryParser] Loading keywords and predicates for locale "sv_SE"
2024-11-27 13:50:14.193 mdfind[37693:22094193] [UserQueryParser] Loading keywords and predicates for locale "sv"
2024-11-27 13:50:14.234 mdfind[37693:22094193] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 13:50:14.234 mdfind[37693:22094193] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 13:50:14 : WARN  : spotify : No previous app found
2024-11-27 13:50:14 : WARN  : spotify : could not find Spotify.app
2024-11-27 13:50:14 : INFO  : spotify : appversion: 
2024-11-27 13:50:14 : INFO  : spotify : Latest version of Spotify is 1.2.51.345
2024-11-27 13:50:14 : INFO  : spotify : Spotify.dmg exists and DEBUG mode 1 enabled, skipping download
2024-11-27 13:50:14 : DEBUG : spotify : DEBUG mode 1, not checking for blocking processes
2024-11-27 13:50:14 : REQ   : spotify : Installing Spotify
2024-11-27 13:50:14 : INFO  : spotify : Mounting /Volumes/Data/Power/Programmerat/Installomator/build/Spotify.dmg
2024-11-27 13:50:15 : DEBUG : spotify : Debugging enabled, dmgmount output was:
förväntade   CRC32 $ABFDDD5D
/dev/disk6              GUID_partition_scheme
/dev/disk6s1            Apple_HFS                       /Volumes/Spotify

2024-11-27 13:50:15 : INFO  : spotify : Mounted: /Volumes/Spotify
2024-11-27 13:50:15 : INFO  : spotify : Verifying: /Volumes/Spotify/Spotify.app
2024-11-27 13:50:15 : DEBUG : spotify : App size: 315M  /Volumes/Spotify/Spotify.app
2024-11-27 13:50:26 : DEBUG : spotify : Debugging enabled, App Verification output was:
/Volumes/Spotify 2/Spotify.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Spotify (2FNC3A47ZF)

2024-11-27 13:50:26 : INFO  : spotify : Team ID matching: 2FNC3A47ZF (expected: 2FNC3A47ZF )
2024-11-27 13:50:26 : INFO  : spotify : Installing Spotify version 1.2.51.345 on versionKey CFBundleShortVersionString.
2024-11-27 13:50:26 : INFO  : spotify : App has LSMinimumSystemVersion: 11.0
2024-11-27 13:50:26 : DEBUG : spotify : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-11-27 13:50:26 : INFO  : spotify : Finishing...
2024-11-27 13:50:29 : INFO  : spotify : name: Spotify, appName: Spotify.app
2024-11-27 13:50:29.235 mdfind[37834:22095817] [UserQueryParser] Loading keywords and predicates for locale "sv_SE"
2024-11-27 13:50:29.236 mdfind[37834:22095817] [UserQueryParser] Loading keywords and predicates for locale "sv"
2024-11-27 13:50:29.285 mdfind[37834:22095817] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 13:50:29.285 mdfind[37834:22095817] Couldn't determine the mapping between prefab keywords and predicates.
2024-11-27 13:50:29 : WARN  : spotify : No previous app found
2024-11-27 13:50:29 : WARN  : spotify : could not find Spotify.app
2024-11-27 13:50:29 : REQ   : spotify : Installed Spotify, version 1.2.51.345
2024-11-27 13:50:29 : INFO  : spotify : notifying
2024-11-27 13:50:30 : DEBUG : spotify : Unmounting /Volumes/Spotify
2024-11-27 13:50:30 : DEBUG : spotify : Debugging enabled, Unmounting output was:
"disk6" ejected.
2024-11-27 13:50:30 : DEBUG : spotify : DEBUG mode 1, not reopening anything
2024-11-27 13:50:30 : REQ   : spotify : All done!
2024-11-27 13:50:30 : REQ   : spotify : ################## End Installomator, exit code 0 
```