### PR TITLE
Update nodejs: added `-L` to curl to follow redirects after website changes

### DIFF
--- a/fragments/labels/nodejs.sh
+++ b/fragments/labels/nodejs.sh
@@ -1,8 +1,8 @@
 nodejs)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(curl -s https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')
+    appNewVersion=$(curl -s -L https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')
     appCustomVersion(){/usr/local/bin/node -v}
-    downloadURL="https://nodejs.org/dist/latest/node-$(curl -s https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p').pkg"
+    downloadURL="https://nodejs.org/dist/latest/node-$(curl -s -L https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p').pkg"
     expectedTeamID="HX7739G8FX"
     ;;


### PR DESCRIPTION
Output:

```
sudo utils/assemble.sh nodejs DEBUG=0
Password:
2024-11-27 14:22:52 : REQ   : nodejs : ################## Start Installomator v. 10.7beta, date 2024-11-27
2024-11-27 14:22:52 : INFO  : nodejs : ################## Version: 10.7beta
2024-11-27 14:22:52 : INFO  : nodejs : ################## Date: 2024-11-27
2024-11-27 14:22:52 : INFO  : nodejs : ################## nodejs
2024-11-27 14:22:52 : DEBUG : nodejs : DEBUG mode 1 enabled.
2024-11-27 14:22:53 : INFO  : nodejs : setting variable from argument DEBUG=0
2024-11-27 14:22:53 : DEBUG : nodejs : name=nodejs
2024-11-27 14:22:53 : DEBUG : nodejs : appName=
2024-11-27 14:22:53 : DEBUG : nodejs : type=pkg
2024-11-27 14:22:53 : DEBUG : nodejs : archiveName=
2024-11-27 14:22:53 : DEBUG : nodejs : downloadURL=https://nodejs.org/dist/latest/node-v23.3.0.pkg
2024-11-27 14:22:53 : DEBUG : nodejs : curlOptions=
2024-11-27 14:22:53 : DEBUG : nodejs : appNewVersion=v23.3.0
2024-11-27 14:22:53 : DEBUG : nodejs : appCustomVersion function: Defined.
2024-11-27 14:22:53 : DEBUG : nodejs : versionKey=CFBundleShortVersionString
2024-11-27 14:22:53 : DEBUG : nodejs : packageID=
2024-11-27 14:22:53 : DEBUG : nodejs : pkgName=
2024-11-27 14:22:53 : DEBUG : nodejs : choiceChangesXML=
2024-11-27 14:22:53 : DEBUG : nodejs : expectedTeamID=HX7739G8FX
2024-11-27 14:22:53 : DEBUG : nodejs : blockingProcesses=
2024-11-27 14:22:53 : DEBUG : nodejs : installerTool=
2024-11-27 14:22:53 : DEBUG : nodejs : CLIInstaller=
2024-11-27 14:22:53 : DEBUG : nodejs : CLIArguments=
2024-11-27 14:22:54 : DEBUG : nodejs : updateTool=
2024-11-27 14:22:54 : DEBUG : nodejs : updateToolArguments=
2024-11-27 14:22:54 : DEBUG : nodejs : updateToolRunAsCurrentUser=
2024-11-27 14:22:54 : INFO  : nodejs : BLOCKING_PROCESS_ACTION=tell_user
2024-11-27 14:22:54 : INFO  : nodejs : NOTIFY=success
2024-11-27 14:22:54 : INFO  : nodejs : LOGGING=DEBUG
2024-11-27 14:22:54 : INFO  : nodejs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-11-27 14:22:54 : INFO  : nodejs : Label type: pkg
2024-11-27 14:22:54 : INFO  : nodejs : archiveName: nodejs.pkg
2024-11-27 14:22:54 : INFO  : nodejs : no blocking processes defined, using nodejs as default
2024-11-27 14:22:54 : DEBUG : nodejs : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc
2024-11-27 14:22:55 : INFO  : nodejs : Custom App Version detection is used, found v22.6.0
2024-11-27 14:22:55 : INFO  : nodejs : appversion: v22.6.0
2024-11-27 14:22:55 : INFO  : nodejs : Latest version of nodejs is v23.3.0
2024-11-27 14:22:55 : REQ   : nodejs : Downloading https://nodejs.org/dist/latest/node-v23.3.0.pkg to nodejs.pkg
2024-11-27 14:22:55 : DEBUG : nodejs : No Dialog connection, just download
2024-11-27 14:22:58 : DEBUG : nodejs : File list: -rw-r--r--  1 root  wheel    85M Nov 27 14:22 nodejs.pkg
2024-11-27 14:22:58 : DEBUG : nodejs : File type: nodejs.pkg: xar archive compressed TOC: 5339, SHA-1 checksum
2024-11-27 14:22:58 : DEBUG : nodejs : curl output was:
* Host nodejs.org:443 was resolved.
* IPv6: 2606:4700:10::6814:162e, 2606:4700:10::6814:172e
* IPv4: 104.20.23.46, 104.20.22.46
*   Trying 104.20.23.46:443...
* Connected to nodejs.org (104.20.23.46) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4835 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.nodejs.org
*  start date: Feb 28 00:00:00 2024 GMT
*  expire date: Mar 30 23:59:59 2025 GMT
*  subjectAltName: host "nodejs.org" matched cert's "nodejs.org"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://nodejs.org/dist/latest/node-v23.3.0.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: nodejs.org]
* [HTTP/2] [1] [:path: /dist/latest/node-v23.3.0.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /dist/latest/node-v23.3.0.pkg HTTP/2
> Host: nodejs.org
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 302
< date: Wed, 27 Nov 2024 14:22:55 GMT
< content-length: 0
< location: https://nodejs.org/dist/v23.3.0/node-v23.3.0.pkg
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8e92c5efaae0ef41-LHR
<
* Ignoring the response-body
* Connection #0 to host nodejs.org left intact
* Issue another request to this URL: 'https://nodejs.org/dist/v23.3.0/node-v23.3.0.pkg'
* Found bundle for host: 0x600002edc060 [can multiplex]
* Re-using existing connection with host nodejs.org
* [HTTP/2] [3] OPENED stream for https://nodejs.org/dist/v23.3.0/node-v23.3.0.pkg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: nodejs.org]
* [HTTP/2] [3] [:path: /dist/v23.3.0/node-v23.3.0.pkg]
* [HTTP/2] [3] [user-agent: curl/8.7.1]
* [HTTP/2] [3] [accept: */*]
> GET /dist/v23.3.0/node-v23.3.0.pkg HTTP/2
> Host: nodejs.org
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< date: Wed, 27 Nov 2024 14:22:55 GMT
< content-type: application/x-xar
< content-length: 89259918
< cf-ray: 8e92c5efcb3eef41-LHR
< cf-cache-status: HIT
< accept-ranges: bytes
< age: 2591
< cache-control: public, max-age=3600, s-maxage=14400
< etag: "4ecd60bbc89f1e9d6efd96c5363fdef4"
< last-modified: Wed, 20 Nov 2024 18:06:12 GMT
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< vary: Accept-Encoding
< accept-range: bytes
< x-content-type-options: nosniff
< server: cloudflare
<
{ [1360 bytes data]
* Connection #0 to host nodejs.org left intact

2024-11-27 14:22:58 : REQ   : nodejs : no more blocking processes, continue with update
2024-11-27 14:22:58 : REQ   : nodejs : Installing nodejs
2024-11-27 14:22:58 : INFO  : nodejs : Verifying: nodejs.pkg
2024-11-27 14:22:58 : DEBUG : nodejs : File list: -rw-r--r--  1 root  wheel    85M Nov 27 14:22 nodejs.pkg
2024-11-27 14:22:58 : DEBUG : nodejs : File type: nodejs.pkg: xar archive compressed TOC: 5339, SHA-1 checksum
2024-11-27 14:22:59 : DEBUG : nodejs : spctlOut is nodejs.pkg: accepted
2024-11-27 14:22:59 : DEBUG : nodejs : source=Notarized Developer ID
2024-11-27 14:22:59 : DEBUG : nodejs : origin=Developer ID Installer: Node.js Foundation (HX7739G8FX)
2024-11-27 14:22:59 : INFO  : nodejs : Team ID: HX7739G8FX (expected: HX7739G8FX )
2024-11-27 14:22:59 : INFO  : nodejs : Installing nodejs.pkg to /
2024-11-27 14:23:09 : DEBUG : nodejs : Debugging enabled, installer output was:
Nov 27 14:22:59  installer[12587] <Debug>: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg trustLevel=350
Nov 27 14:22:59  installer[12587] <Debug>: External component packages (2) trustLevel=350
Nov 27 14:22:59  installer[12587] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Nov 27 14:22:59  installer[12587] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#node-v23.3.0.pkg
Nov 27 14:22:59  installer[12587] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#npm-v10.9.0.pkg
Nov 27 14:22:59  installer[12587] <Info>: Set authorization level to root for session
Nov 27 14:22:59  installer[12587] <Info>: Authorization is being checked, waiting until authorization arrives.
Nov 27 14:22:59  installer[12587] <Info>: Administrator authorization granted.
Nov 27 14:22:59  installer[12587] <Info>: Packages have been authorized for installation.
Nov 27 14:22:59  installer[12587] <Debug>: Will use PK session
Nov 27 14:22:59  installer[12587] <Debug>: Using authorization level of root for IFPKInstallElement
Nov 27 14:22:59  installer[12587] <Info>: Starting installation:
Nov 27 14:22:59  installer[12587] <Notice>: Configuring volume "Macintosh HD"
Nov 27 14:22:59  installer[12587] <Info>: Preparing disk for local booted install.
Nov 27 14:22:59  installer[12587] <Notice>: Free space on "Macintosh HD": 875.71 GB (875705020416 bytes).
Nov 27 14:22:59  installer[12587] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12587OxCLHl"
Nov 27 14:22:59  installer[12587] <Notice>: IFPKInstallElement (2 packages)
Nov 27 14:22:59  installer[12587] <Info>: Current Path: /usr/sbin/installer
Nov 27 14:22:59  installer[12587] <Info>: Current Path: /bin/zsh
Nov 27 14:22:59  installer[12587] <Info>: Current Path: /usr/bin/sudo
Nov 27 14:22:59  installer[12587] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is Node.js
installer: Upgrading at base path /
installer: Preparing for installation….....
installer: Preparing the disk….....
installer: Preparing Node.js….....
installer: Waiting for other installations to complete….....
installer: Configuring the installation….....
installer:
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Writing files….....
#
installer: Running package scripts….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Moving items into place….....
#
installer: Running package scripts….....
installer: Validating packages….....
#Nov 27 14:23:07  installer[12587] <Notice>: Running install actions
Nov 27 14:23:07  installer[12587] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12587OxCLHl"
Nov 27 14:23:07  installer[12587] <Notice>: Finalize disk "Macintosh HD"
Nov 27 14:23:07  installer[12587] <Notice>: Notifying system of updated components
Nov 27 14:23:07  installer[12587] <Notice>:
Nov 27 14:23:07  installer[12587] <Notice>: **** Summary Information ****
Nov 27 14:23:07  installer[12587] <Notice>:   Operation      Elapsed time
Nov 27 14:23:07  installer[12587] <Notice>: -----------------------------
Nov 27 14:23:07  installer[12587] <Notice>:        disk      0.00 seconds
Nov 27 14:23:07  installer[12587] <Notice>:      script      0.00 seconds
Nov 27 14:23:07  installer[12587] <Notice>:        zero      0.00 seconds
Nov 27 14:23:07  installer[12587] <Notice>:     install      8.13 seconds
Nov 27 14:23:07  installer[12587] <Notice>:     -total-      8.14 seconds
Nov 27 14:23:07  installer[12587] <Notice>:

installer:      Running installer actions…
installer:
installer: Finishing the Installation….....
installer:
#
installer: The software was successfully installed......
installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Product archive /private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg trustLevel=350
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: External component packages (2) trustLevel=350
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#node-v23.3.0.pkg
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#npm-v10.9.0.pkg
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Set authorization level to root for session
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Authorization is being checked, waiting until authorization arrives.
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Administrator authorization granted.
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Packages have been authorized for installation.
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Will use PK session
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Using authorization level of root for IFPKInstallElement
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Starting installation:
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Configuring volume "Macintosh HD"
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Preparing disk for local booted install.
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Free space on "Macintosh HD": 875.71 GB (875705020416 bytes).
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12587OxCLHl"
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: IFPKInstallElement (2 packages)
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Current Path: /usr/sbin/installer
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Current Path: /bin/zsh
Last Log repeated 2 times
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: Current Path: /usr/bin/sudo
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Adding client PKInstallDaemonClient pid=12587, uid=0 (/usr/sbin/installer)
2024-11-27 14:22:59+00 UKLDNPC0198 installer[12587]: PackageKit: Enqueuing install with framework-specified quality of service (utility)
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Set reponsibility for install to 82937
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Hosted team responsibility for install set to team:(HX7739G8FX)
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: ----- Begin install -----
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: packages=(
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Will do receipt-based obsoleting for package identifier org.nodejs.node.pkg (prefix path=/)
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Will do receipt-based obsoleting for package identifier org.nodejs.npm.pkg (prefix path=/)
2024-11-27 14:22:59+00 UKLDNPC0198 installd[1165]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#node-v23.3.0.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/514ADC49-08FA-4D1C-A592-3DC4F4F195EC.activeSandbox/Root, uid=0)
2024-11-27 14:23:00+00 UKLDNPC0198 installd[1165]: PackageKit: Extracting file:///var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg#npm-v10.9.0.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/514ADC49-08FA-4D1C-A592-3DC4F4F195EC.activeSandbox/Root, uid=0)
2024-11-27 14:23:01+00 UKLDNPC0198 installd[1165]: PackageKit: prevent user idle system sleep
2024-11-27 14:23:01+00 UKLDNPC0198 installd[1165]: PackageKit: suspending backupd
2024-11-27 14:23:01+00 UKLDNPC0198 installd[1165]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: Set responsibility to pid: 82937, responsible_path: /Applications/Visual Studio Code.app/Contents/MacOS/Electron
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: Hosted team responsibility for script set to team:(HX7739G8FX)
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:01+00 UKLDNPC0198 install_monitor[12588]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Hosted team responsible for script has been cleared.
2024-11-27 14:23:01+00 UKLDNPC0198 package_script_service[6352]: Responsibility set back to self.
2024-11-27 14:23:01+00 UKLDNPC0198 installd[1165]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/514ADC49-08FA-4D1C-A592-3DC4F4F195EC.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/514ADC49-08FA-4D1C-A592-3DC4F4F195EC.activeSandbox
2024-11-27 14:23:02+00 UKLDNPC0198 installd[1165]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/514ADC49-08FA-4D1C-A592-3DC4F4F195EC.activeSandbox/Root (1 items) to /
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: Set responsibility to pid: 82937, responsible_path: /Applications/Visual Studio Code.app/Contents/MacOS/Electron
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: Hosted team responsibility for script set to team:(HX7739G8FX)
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.f6WrZQ/Scripts/org.nodejs.npm.pkg.DPjesA
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: PackageKit: Hosted team responsible for script has been cleared.
2024-11-27 14:23:06+00 UKLDNPC0198 package_script_service[6352]: Responsibility set back to self.
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: PackageKit: Writing receipt for org.nodejs.node.pkg to /
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: PackageKit: Writing receipt for org.nodejs.npm.pkg to /
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: PackageKit: No Intel binaries to translate.
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: Installed "Node.js" ()
2024-11-27 14:23:06+00 UKLDNPC0198 installd[1165]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
2024-11-27 14:23:06+00 UKLDNPC0198 install_monitor[12588]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: releasing backupd
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: allow user idle system sleep
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: ----- End install -----
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: 7.7s elapsed install time
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: Cleared responsibility for install from 12587.
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: Hosted team responsible for install has been cleared.
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: Running idle tasks
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: Removing client PKInstallDaemonClient pid=12587, uid=0 (/usr/sbin/installer)
2024-11-27 14:23:07+00 UKLDNPC0198 installd[1165]: PackageKit: Done with sandbox removals
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: Running install actions
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.12587OxCLHl"
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: Finalize disk "Macintosh HD"
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: Notifying system of updated components
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: **** Summary Information ****
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:   Operation      Elapsed time
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]: -----------------------------
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:        disk      0.00 seconds
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:      script      0.00 seconds
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:        zero      0.00 seconds
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:     install      8.13 seconds
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:     -total-      8.14 seconds
2024-11-27 14:23:07+00 UKLDNPC0198 installer[12587]:

2024-11-27 14:23:09 : INFO  : nodejs : Finishing...
2024-11-27 14:23:16 : INFO  : nodejs : Custom App Version detection is used, found v23.3.0
2024-11-27 14:23:16 : REQ   : nodejs : Installed nodejs, version v23.3.0
2024-11-27 14:23:16 : INFO  : nodejs : notifying
2024-11-27 14:23:16 : DEBUG : nodejs : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc
2024-11-27 14:23:16 : DEBUG : nodejs : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc/nodejs.pkg
2024-11-27 14:23:16 : DEBUG : nodejs : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rYSY47HZGc
2024-11-27 14:23:16 : INFO  : nodejs : Installomator did not close any apps, so no need to reopen any apps.
2024-11-27 14:23:16 : REQ   : nodejs : All done!
2024-11-27 14:23:16 : REQ   : nodejs : ################## End Installomator, exit code 0
```