### PR TITLE
Update codemeter.sh

### DIFF
--- a/fragments/labels/codemeter.sh
+++ b/fragments/labels/codemeter.sh
@@ -2,8 +2,9 @@ codemeter)
     name="CodeMeter"
     type="pkgInDmg"
     archiveName="CmInstall.pkg"
+    appCustomVersion(){ defaults read "/Applications/Codemeter.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-2 }
     html_page_source="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware.html"
-    macos_value=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo '10.15"> <option value=".*?"' | cut -d '"' -f3)
+    macos_value=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo -m1 ' 12"> <option value=".*?"' | cut -d '"' -f3)
     downloadHTML="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/$macos_value.html"
     downloadURL="https://www.wibu.com"$(curl -fs $downloadHTML | xmllint --html --format - 2>/dev/null | grep -Eo 'rel="nofollow" href=".*?"' | cut -d '"' -f4)
     appNewVersion=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo "option value=\"$macos_value\" style=\"\">Version .*?\"" | sed -E 's/.*Version (.*) \| 2.*/\1/g')


### PR DESCRIPTION
1. The text of the page has changed and the label has not detected the latest version
2. Added appCustomVersion so that the installed and new versions match and no reinstallation takes place

2024-12-01 12:00:56 : REQ   : codemeter : ################## Start Installomator v. 10.6, date 2024-12-01
2024-12-01 12:00:56 : INFO  : codemeter : ################## Version: 10.6
2024-12-01 12:00:56 : INFO  : codemeter : ################## Date: 2024-12-01
2024-12-01 12:00:56 : INFO  : codemeter : ################## codemeter
2024-12-01 12:00:56 : DEBUG : codemeter : DEBUG mode 1 enabled.
2024-12-01 12:01:00 : INFO  : codemeter : setting variable from argument DEBUG=0
2024-12-01 12:01:00 : DEBUG : codemeter : name=CodeMeter
2024-12-01 12:01:00 : DEBUG : codemeter : appName=
2024-12-01 12:01:00 : DEBUG : codemeter : type=pkgInDmg
2024-12-01 12:01:00 : DEBUG : codemeter : archiveName=CmInstall.pkg
2024-12-01 12:01:00 : DEBUG : codemeter : downloadURL=https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/14402.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd
2024-12-01 12:01:00 : DEBUG : codemeter : curlOptions=
2024-12-01 12:01:00 : DEBUG : codemeter : appNewVersion=8.20
2024-12-01 12:01:00 : DEBUG : codemeter : appCustomVersion function: Defined.
2024-12-01 12:01:00 : DEBUG : codemeter : versionKey=CFBundleShortVersionString
2024-12-01 12:01:00 : DEBUG : codemeter : packageID=
2024-12-01 12:01:00 : DEBUG : codemeter : pkgName=
2024-12-01 12:01:00 : DEBUG : codemeter : choiceChangesXML=
2024-12-01 12:01:00 : DEBUG : codemeter : expectedTeamID=2SE7W37452
2024-12-01 12:01:00 : DEBUG : codemeter : blockingProcesses=
2024-12-01 12:01:00 : DEBUG : codemeter : installerTool=
2024-12-01 12:01:00 : DEBUG : codemeter : CLIInstaller=
2024-12-01 12:01:00 : DEBUG : codemeter : CLIArguments=
2024-12-01 12:01:00 : DEBUG : codemeter : updateTool=
2024-12-01 12:01:00 : DEBUG : codemeter : updateToolArguments=
2024-12-01 12:01:00 : DEBUG : codemeter : updateToolRunAsCurrentUser=
2024-12-01 12:01:00 : INFO  : codemeter : BLOCKING_PROCESS_ACTION=tell_user
2024-12-01 12:01:00 : INFO  : codemeter : NOTIFY=success
2024-12-01 12:01:01 : INFO  : codemeter : LOGGING=DEBUG
2024-12-01 12:01:01 : INFO  : codemeter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-01 12:01:01 : INFO  : codemeter : Label type: pkgInDmg
2024-12-01 12:01:01 : INFO  : codemeter : archiveName: CmInstall.pkg
2024-12-01 12:01:01 : INFO  : codemeter : no blocking processes defined, using CodeMeter as default
2024-12-01 12:01:01 : DEBUG : codemeter : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PL26qCzetR
2024-12-01 12:01:01.119 defaults[25697:601432]
The domain/default pair of (/Applications/Codemeter.app/Contents/Info.plist, CFBundleVersion) does not exist
2024-12-01 12:01:01 : INFO  : codemeter : Custom App Version detection is used, found
2024-12-01 12:01:01 : INFO  : codemeter : appversion:
2024-12-01 12:01:01 : INFO  : codemeter : Latest version of CodeMeter is 8.20
2024-12-01 12:01:01 : REQ   : codemeter : Downloading https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/14402.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd to CmInstall.pkg
2024-12-01 12:01:01 : DEBUG : codemeter : No Dialog connection, just download
2024-12-01 12:01:05 : DEBUG : codemeter : File list: -rw-r--r--  1 root  wheel    91M  1 Dez 12:01 CmInstall.pkg
2024-12-01 12:01:05 : DEBUG : codemeter : File type: CmInstall.pkg: zlib compressed data
2024-12-01 12:01:05 : DEBUG : codemeter : curl output was:
* Host www.wibu.com:443 was resolved.
* IPv6: (none)
* IPv4: 91.184.33.136
*   Trying 91.184.33.136:443...
* Connected to www.wibu.com (91.184.33.136) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [317 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2848 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=DE; ST=Baden-Wuerttemberg; L=Karlsruhe; O=WIBU-SYSTEMS AG; CN=wibu.com
*  start date: Oct 22 13:11:05 2024 GMT
*  expire date: Nov 23 13:11:04 2025 GMT
*  subjectAltName: host "www.wibu.com" matched cert's "www.wibu.com"
*  issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign RSA OV SSL CA 2018
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/14402.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.wibu.com]
* [HTTP/2] [1] [:path: /de/support/anwendersoftware/anwendersoftware/file/download/14402.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /de/support/anwendersoftware/anwendersoftware/file/download/14402.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd HTTP/2
> Host: www.wibu.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 302
< location: https://d1fa9c7844vy1r.cloudfront.net//wibu_downloads/codemeter/user/8.20/mac/CmRuntimeUser_8.20.6539.500.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_8.20.6539.500.dmg&response-content-type=application%2Fforce-download&Expires=1733051161&Signature=kbcFlNJUd2-YsKW43G8aW5H1pHmcgXspgiA2zMNlhcsQvhzTPrAg8AcbLdePPoZpEaMMwXctBJ9o6-BORyFfT5n4Pw-IFxdiZ6gpDPV~60ZHmoeDwIs0xY4oPEmiU65q7o0xOJygZWH9Mdr3KzW3155csoMA0~iuYssYsUbpZwH3ZvbGGu3HoLt02GHM5dHYKlWhfmnErLuA7mIg6tIGZFMJie4r0pryuHcpJcrm35ATHB0fysxZr2hYj~w3~tJ-MMs~wZgMasUy0uv9VvkvqBdCiJU-S1FjE6C9zMDeCUim5oKOSO-u5NxY4pN8DUj7z8kqXF54DUD0OLyV6jxWpg__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ < cache-control: max-age=0
< expires: Sun, 01 Dec 2024 11:01:01 GMT
< x-ua-compatible: IE=edge
< x-content-type-options: nosniff
< content-length: 0
< content-type: text/html; charset=UTF-8
< date: Sun, 01 Dec 2024 11:01:01 GMT
< server: Apache
<
* Ignoring the response-body
* Connection #0 to host www.wibu.com left intact
* Issue another request to this URL: 'https://d1fa9c7844vy1r.cloudfront.net//wibu_downloads/codemeter/user/8.20/mac/CmRuntimeUser_8.20.6539.500.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_8.20.6539.500.dmg&response-content-type=application%2Fforce-download&Expires=1733051161&Signature=kbcFlNJUd2-YsKW43G8aW5H1pHmcgXspgiA2zMNlhcsQvhzTPrAg8AcbLdePPoZpEaMMwXctBJ9o6-BORyFfT5n4Pw-IFxdiZ6gpDPV~60ZHmoeDwIs0xY4oPEmiU65q7o0xOJygZWH9Mdr3KzW3155csoMA0~iuYssYsUbpZwH3ZvbGGu3HoLt02GHM5dHYKlWhfmnErLuA7mIg6tIGZFMJie4r0pryuHcpJcrm35ATHB0fysxZr2hYj~w3~tJ-MMs~wZgMasUy0uv9VvkvqBdCiJU-S1FjE6C9zMDeCUim5oKOSO-u5NxY4pN8DUj7z8kqXF54DUD0OLyV6jxWpg__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ'
* Host d1fa9c7844vy1r.cloudfront.net:443 was resolved.
* IPv6: (none)
* IPv4: 18.154.71.46, 18.154.71.154, 18.154.71.217, 18.154.71.225
*   Trying 18.154.71.46:443...
* Connected to d1fa9c7844vy1r.cloudfront.net (18.154.71.46) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4971 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.cloudfront.net
*  start date: Jul 30 00:00:00 2024 GMT
*  expire date: Jul  3 23:59:59 2025 GMT
*  subjectAltName: host "d1fa9c7844vy1r.cloudfront.net" matched cert's "*.cloudfront.net"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://d1fa9c7844vy1r.cloudfront.net//wibu_downloads/codemeter/user/8.20/mac/CmRuntimeUser_8.20.6539.500.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_8.20.6539.500.dmg&response-content-type=application%2Fforce-download&Expires=1733051161&Signature=kbcFlNJUd2-YsKW43G8aW5H1pHmcgXspgiA2zMNlhcsQvhzTPrAg8AcbLdePPoZpEaMMwXctBJ9o6-BORyFfT5n4Pw-IFxdiZ6gpDPV~60ZHmoeDwIs0xY4oPEmiU65q7o0xOJygZWH9Mdr3KzW3155csoMA0~iuYssYsUbpZwH3ZvbGGu3HoLt02GHM5dHYKlWhfmnErLuA7mIg6tIGZFMJie4r0pryuHcpJcrm35ATHB0fysxZr2hYj~w3~tJ-MMs~wZgMasUy0uv9VvkvqBdCiJU-S1FjE6C9zMDeCUim5oKOSO-u5NxY4pN8DUj7z8kqXF54DUD0OLyV6jxWpg__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: d1fa9c7844vy1r.cloudfront.net]
* [HTTP/2] [1] [:path: //wibu_downloads/codemeter/user/8.20/mac/CmRuntimeUser_8.20.6539.500.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_8.20.6539.500.dmg&response-content-type=application%2Fforce-download&Expires=1733051161&Signature=kbcFlNJUd2-YsKW43G8aW5H1pHmcgXspgiA2zMNlhcsQvhzTPrAg8AcbLdePPoZpEaMMwXctBJ9o6-BORyFfT5n4Pw-IFxdiZ6gpDPV~60ZHmoeDwIs0xY4oPEmiU65q7o0xOJygZWH9Mdr3KzW3155csoMA0~iuYssYsUbpZwH3ZvbGGu3HoLt02GHM5dHYKlWhfmnErLuA7mIg6tIGZFMJie4r0pryuHcpJcrm35ATHB0fysxZr2hYj~w3~tJ-MMs~wZgMasUy0uv9VvkvqBdCiJU-S1FjE6C9zMDeCUim5oKOSO-u5NxY4pN8DUj7z8kqXF54DUD0OLyV6jxWpg__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET //wibu_downloads/codemeter/user/8.20/mac/CmRuntimeUser_8.20.6539.500.dmg?response-content-disposition=attachment%3B%20filename%3DCmRuntimeUser_8.20.6539.500.dmg&response-content-type=application%2Fforce-download&Expires=1733051161&Signature=kbcFlNJUd2-YsKW43G8aW5H1pHmcgXspgiA2zMNlhcsQvhzTPrAg8AcbLdePPoZpEaMMwXctBJ9o6-BORyFfT5n4Pw-IFxdiZ6gpDPV~60ZHmoeDwIs0xY4oPEmiU65q7o0xOJygZWH9Mdr3KzW3155csoMA0~iuYssYsUbpZwH3ZvbGGu3HoLt02GHM5dHYKlWhfmnErLuA7mIg6tIGZFMJie4r0pryuHcpJcrm35ATHB0fysxZr2hYj~w3~tJ-MMs~wZgMasUy0uv9VvkvqBdCiJU-S1FjE6C9zMDeCUim5oKOSO-u5NxY4pN8DUj7z8kqXF54DUD0OLyV6jxWpg__&Key-Pair-Id=APKAI544HQODB4S5Z6KQ HTTP/2
> Host: d1fa9c7844vy1r.cloudfront.net
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< content-type: application/force-download
< content-length: 95338133
< date: Sat, 30 Nov 2024 22:08:37 GMT
< last-modified: Wed, 18 Sep 2024 10:01:05 GMT
< etag: "65f0cb922686569b2a3077140c364f71"
< x-amz-storage-class: REDUCED_REDUNDANCY
< x-amz-server-side-encryption: AES256
< content-disposition: attachment; filename=CmRuntimeUser_8.20.6539.500.dmg < accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 0f614fbd956590bdb4b3def9e1395ca6.cloudfront.net (CloudFront) < x-amz-cf-pop: DUS51-P4
< x-amz-cf-id: 4C_3lrbEZvyYc1ZxWhoqLkPuyhccqM4AfshwqcFq6zJ5LtBalhkicA== < age: 46346
<
{ [8192 bytes data]
* Connection #1 to host d1fa9c7844vy1r.cloudfront.net left intact

2024-12-01 12:01:05 : REQ   : codemeter : no more blocking processes, continue with update
2024-12-01 12:01:05 : REQ   : codemeter : Installing CodeMeter
2024-12-01 12:01:05 : INFO  : codemeter : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PL26qCzetR/CmInstall.pkg
2024-12-01 12:01:06 : DEBUG : codemeter : Debugging enabled, dmgmount output was:
Prüfsumme für whole disk (Apple_HFS : 0) berechnen …
whole disk (Apple_HFS : 0): Die überprüfte CRC32-Prüfsumme ist $45EE676F
Die überprüfte CRC32-Prüfsumme ist $D9430B10
/dev/disk12         	                               	/Volumes/CM-Install

2024-12-01 12:01:06 : INFO  : codemeter : Mounted: /Volumes/CM-Install 2024-12-01 12:01:06 : DEBUG : codemeter : Found pkg(s): /Volumes/CM-Install/CmInstall.pkg
2024-12-01 12:01:06 : INFO  : codemeter : found pkg: /Volumes/CM-Install/CmInstall.pkg 2024-12-01 12:01:06 : INFO  : codemeter : Verifying: /Volumes/CM-Install/CmInstall.pkg
2024-12-01 12:01:06 : DEBUG : codemeter : File list: -rw-r--r--  1 cadmin  staff    91M 10 Sep 19:38 /Volumes/CM-Install/CmInstall.pkg
2024-12-01 12:01:06 : DEBUG : codemeter : File type: /Volumes/CM-Install/CmInstall.pkg: xar archive compressed TOC: 5279, SHA-1 checksum
2024-12-01 12:01:06 : DEBUG : codemeter : spctlOut is /Volumes/CM-Install/CmInstall.pkg: accepted
2024-12-01 12:01:06 : DEBUG : codemeter : source=Notarized Developer ID
2024-12-01 12:01:06 : DEBUG : codemeter : override=security disabled
2024-12-01 12:01:06 : DEBUG : codemeter : origin=Developer ID Installer: WIBU-SYSTEMS AG (2SE7W37452)
2024-12-01 12:01:06 : INFO  : codemeter : Team ID: 2SE7W37452 (expected: 2SE7W37452 )
2024-12-01 12:01:06 : INFO  : codemeter : Installing /Volumes/CM-Install/CmInstall.pkg to /
2024-12-01 12:01:20 : DEBUG : codemeter : Debugging enabled, installer output was:
Dec  1 12:01:07  installer[25834] <Debug>: Product archive /Volumes/CM-Install/CmInstall.pkg trustLevel=350
Dec  1 12:01:07  installer[25834] <Debug>: External component packages (2) trustLevel=350
Dec  1 12:01:07  installer[25834] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Dec  1 12:01:07  installer[25834] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg
Dec  1 12:01:07  installer[25834] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg
Dec  1 12:01:07  installer[25834] <Info>: Set authorization level to root for session
Dec  1 12:01:07  installer[25834] <Info>: Authorization is being checked, waiting until authorization arrives.
Dec  1 12:01:07  installer[25834] <Info>: Administrator authorization granted.
Dec  1 12:01:07  installer[25834] <Info>: Packages have been authorized for installation.
Dec  1 12:01:07  installer[25834] <Debug>: Will use PK session
Dec  1 12:01:07  installer[25834] <Debug>: Using authorization level of root for IFPKInstallElement
Dec  1 12:01:07  installer[25834] <Info>: Starting installation:
Dec  1 12:01:07  installer[25834] <Notice>: Configuring volume "Macintosh HD"
Dec  1 12:01:07  installer[25834] <Info>: Preparing disk for local booted install.
Dec  1 12:01:07  installer[25834] <Notice>: Free space on "Macintosh HD": 311,39 GB (311391338496 bytes).
Dec  1 12:01:07  installer[25834] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.25834sluo4M"
Dec  1 12:01:07  installer[25834] <Notice>: IFPKInstallElement (2 packages)
Dec  1 12:01:07  installer[25834] <Info>: Current Path: /usr/sbin/installer
Dec  1 12:01:07  installer[25834] <Info>: Current Path: /bin/zsh
Dec  1 12:01:07  installer[25834] <Info>: Current Path: /usr/bin/sudo
Dec  1 12:01:07  installer[25834] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is CodeMeter Runtime Kit
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „CodeMeter Runtime Kit“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Dateien schreiben ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
Last Log repeated 2 times
#
installer: Objekte an Zielort bewegen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#Dec  1 12:01:18  installer[25834] <Info>: PackageKit: Registered bundle file:///Applications/CodeMeter.app/ for uid 0

installer: Paketskripte ausführen ….....
Last Log repeated 7 times
installer: Pakete überprüfen ….....
#Dec  1 12:01:18  installer[25834] <Notice>: Running install actions Dec  1 12:01:18  installer[25834] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.25834sluo4M" Dec  1 12:01:18  installer[25834] <Notice>: Finalize disk "Macintosh HD" Dec  1 12:01:18  installer[25834] <Notice>: Notifying system of updated components Dec  1 12:01:18  installer[25834] <Notice>:
Dec  1 12:01:18  installer[25834] <Notice>: **** Summary Information ****
Dec  1 12:01:18  installer[25834] <Notice>:   Operation      Elapsed time
Dec  1 12:01:18  installer[25834] <Notice>: -----------------------------
Dec  1 12:01:18  installer[25834] <Notice>:        disk      0.00 seconds
Dec  1 12:01:18  installer[25834] <Notice>:      script      0.00 seconds
Dec  1 12:01:18  installer[25834] <Notice>:        zero      0.00 seconds
Dec  1 12:01:18  installer[25834] <Notice>:     install      11.07 seconds
Dec  1 12:01:18  installer[25834] <Notice>:     -total-      11.07 seconds
Dec  1 12:01:18  installer[25834] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert...... installer: The upgrade was successful.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Product archive /Volumes/CM-Install/CmInstall.pkg trustLevel=350 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Product archive /Volumes/CM-Install/CmInstall.pkg trustLevel=350 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: External component packages (2) trustLevel=350 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Set authorization level to root for session 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Authorization is being checked, waiting until authorization arrives. Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Administrator authorization granted. 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Packages have been authorized for installation. Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Will use PK session 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Using authorization level of root for IFPKInstallElement Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Starting installation: 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Configuring volume "Macintosh HD" Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Preparing disk for local booted install. 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Free space on "Macintosh HD": 311,39 GB (311391338496 bytes). Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.25834sluo4M" 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: IFPKInstallElement (2 packages) Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Current Path: /usr/sbin/installer 2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Current Path: /bin/zsh Last Log repeated 4 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: Current Path: /usr/bin/sudo 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Adding client PKInstallDaemonClient pid=25834, uid=0 (/usr/sbin/installer) Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installer[25834]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Set reponsibility for install to 20609 Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Hosted team responsibility for install set to team:(2SE7W37452) 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: ----- Begin install ----- Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: request=PKInstallRequest <2 packages, destination=/>
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: packages=( Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/156F18CF-27DF-44AE-B9E6-B44CDA41D20F.activeSandbox 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/B74B1466-ADF9-494E-8D4A-9D61E4731092.activeSandbox Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/32AA90C2-8717-4CE4-A0D6-A1313380B657.activeSandbox 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/AE2B4A2B-BAC9-4708-966B-B94DC18E2781.activeSandbox Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/968A49C8-FA71-4E0C-928B-21F55730403F.activeSandbox 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/A8E99944-B605-4006-AC35-DC74132FF9D7.activeSandbox Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/0BD34AEF-D776-4E4A-9B3C-52CA7C5F5977.activeSandbox 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/45C2D2B7-FFF5-45A6-82F3-AC326DD0CA1F.activeSandbox Last Log repeated 2 times
2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Will do receipt-based obsoleting for package identifier com.wibu.axprotector (prefix path=/) 2024-12-01 12:01:07+01 savvasly25wvcx3 installd[965]: PackageKit: Extracting file:///Volumes/CM-Install/CmInstall.pkg#CmDriver.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/C3EDD2D3-7065-47B0-9DD0-4318C65D03D7.activeSandbox/Root, uid=0) Last Log repeated 2 times
2024-12-01 12:01:08+01 savvasly25wvcx3 installd[965]: PackageKit: Extracting file:///Volumes/CM-Install/CmInstall.pkg#AxProtector.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/C3EDD2D3-7065-47B0-9DD0-4318C65D03D7.activeSandbox/Root, uid=0) 2024-12-01 12:01:09+01 savvasly25wvcx3 installd[965]: PackageKit: prevent user idle system sleep Last Log repeated 2 times
2024-12-01 12:01:09+01 savvasly25wvcx3 installd[965]: PackageKit: suspending backupd 2024-12-01 12:01:09+01 savvasly25wvcx3 installd[965]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 Last Log repeated 2 times
2024-12-01 12:01:09+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 2024-12-01 12:01:09+01 savvasly25wvcx3 package_script_service[22054]: Set responsibility to pid: 20609, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal Last Log repeated 2 times
2024-12-01 12:01:09+01 savvasly25wvcx3 package_script_service[22054]: Hosted team responsibility for script set to team:(2SE7W37452) 2024-12-01 12:01:09+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 Last Log repeated 2 times
2024-12-01 12:01:09+01 savvasly25wvcx3 install_monitor[25836]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2024-12-01 12:01:09+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Starting preinstall Last Log repeated 2 times
2024-12-01 12:01:11+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: No matching processes were found Last Log repeated 3 times
2024-12-01 12:01:11+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Finished preinstall 2024-12-01 12:01:11+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Hosted team responsible for script has been cleared. Last Log repeated 2 times
2024-12-01 12:01:11+01 savvasly25wvcx3 package_script_service[22054]: Responsibility set back to self. 2024-12-01 12:01:11+01 savvasly25wvcx3 installd[965]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/C3EDD2D3-7065-47B0-9DD0-4318C65D03D7.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/C3EDD2D3-7065-47B0-9DD0-4318C65D03D7.activeSandbox Last Log repeated 2 times
2024-12-01 12:01:11+01 savvasly25wvcx3 installd[965]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/C3EDD2D3-7065-47B0-9DD0-4318C65D03D7.activeSandbox/Root (3 items) to / 2024-12-01 12:01:12+01 savvasly25wvcx3 installd[965]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: Set responsibility to pid: 20609, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: Hosted team responsibility for script set to team:(2SE7W37452) 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6 Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:3> echo Starting postinstall 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Starting postinstall Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:6> /bin/mkdir -p /Library/Logs/CodeMeter/ 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:7> /bin/chmod a+rwx /Library/Logs/CodeMeter Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:10> [ -L '/Library/Application Support/CodeMeter' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:13> /bin/mkdir -p '/Library/Application Support/CodeMeter' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:14> [ -d /Applications/CodeMeter.app/Backup ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:17> [ -d /Users/savvas/CmRemover/Backup ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:21> [ -d /Applications/CodeMeter.app/CmAct ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:28> /bin/mkdir -p '/Library/Application Support/CodeMeter/CmAct' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:29> /bin/mkdir -p '/Library/Application Support/CodeMeter/CmCloud' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:30> /bin/mkdir -p '/Library/Application Support/CodeMeter/Backup' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:31> /bin/mkdir -p '/Library/Application Support/CodeMeter/WebAdmin' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:32> /bin/mkdir -p '/Library/Application Support/CodeMeter/NamedUser' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:35> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/Backup' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:36> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/CmAct' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:37> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/CmCloud' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:38> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/WebAdmin' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:39> /bin/chmod a+rwx '/Library/Application Support/CodeMeter/NamedUser' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:42> [ -f /Library/Preferences/com.wibu.CodeMeter.Server.ini_save ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:43> /bin/mv /Library/Preferences/com.wibu.CodeMeter.Server.ini_save /Library/Preferences/com.wibu.CodeMeter.Server.ini 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:45> cat /Library/Preferences/com.wibu.CodeMeter.Server.ini Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:45> sed 's//Applications/CodeMeter.app/Backup//Library/Application Support/CodeMeter/Backup//' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:46> mv /tmp/cminstaller /Library/Preferences/com.wibu.CodeMeter.Server.ini Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:47> /bin/chmod a+rw /Library/Preferences/com.wibu.CodeMeter.Server.ini 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:50> [ -f /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:51> /usr/bin/chgrp wheel /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:52> /usr/sbin/chown root /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:53> /bin/chmod 0644 /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:55> [ -f /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:56> /usr/bin/chgrp wheel /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:57> /usr/sbin/chown root /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:58> /bin/chmod 0644 /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:61> echo 'setup CmAct permissions' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: setup CmAct permissions 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:62> [ -d '/Library/Application Support/CodeMeter/CmAct' ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:63> echo 'setup CmAct permissions - 42' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: setup CmAct permissions - 42 Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:64: no matches found: /Library/Application Support/CodeMeter/CmAct/*.wbb 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:65: no matches found: /Library/Application Support/CodeMeter/CmAct/*.wbb Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:68> echo 'setup CmCloud permissions' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: setup CmCloud permissions Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:69> [ -d '/Library/Application Support/CodeMeter/CmCloud' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:70> echo 'setup CmCloud permissions - 42' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: setup CmCloud permissions - 42 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:71: no matches found: /Library/Application Support/CodeMeter/CmCloud/*.wbc Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: /tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:72: no matches found: /Library/Application Support/CodeMeter/CmCloud/*.wbc 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:76> [ -f /usr/bin/ranlib ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:77> [ -f '/Applications/WIBU-SYSTEMS Devkit/CodeMeter/lib/libwibucmmac.a' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:82> [ -f '/Library/Application Support/CodeMeter/CmFirm.wbc_save' ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:86> [ -f '/Library/Application Support/CodeMeter/CmFirm.wbc' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:91> [ -d /Library/Extensions/CmUSBMassStorage.kext ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:101> [ -f '/Applications/WIBU-SYSTEMS Devkit/CodeMeter/Java/WibuCmTrigger.jar' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:106> [ -d '/Applications/WIBU-SYSTEMS Devkit/AxProtector/axprotector-nc.app' ']' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:109> [ -d '/Applications/WIBU-SYSTEMS Devkit/AxProtector/AxProtectorNCGui.app' ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:113> MAJOR_VERSION=+/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:113> sw_vers -productVersion Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:113> MAJOR_VERSION=+/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:113> cut -f 1 -d . 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:113> MAJOR_VERSION=14 Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:114> [ 14 -gt 12 ']' 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:116> echo 'start CodeMeterCC' Last Log repeated 2 times
2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: start CodeMeterCC 2024-12-01 12:01:12+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:117> su root -c '/Applications/CodeMeter.app/Contents/MacOS/CodeMeterCC -f163' Last Log repeated 2 times
2024-12-01 12:01:13+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: 2024-12-01 12:01:13.408 CodeMeterCC[25891:602313] WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES. 2024-12-01 12:01:15+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:121> sleep 1 Last Log repeated 2 times
2024-12-01 12:01:16+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:122> /Applications/CodeMeter.app/Contents/MacOS/CodeMeterMacX -x 2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:125> /bin/launchctl load /Library/LaunchDaemons/com.wibu.CodeMeter.Server.plist Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:126> /bin/launchctl start com.wibu.CodeMeter.Server 2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:128> /bin/launchctl load /Library/LaunchDaemons/com.wibu.CodeMeter.WebAdmin.plist Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:129> /bin/launchctl start com.wibu.CodeMeter.WebAdmin 2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:131> echo Finished postinstall Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Finished postinstall 2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: +/tmp/PKInstallSandbox.QArz8j/Scripts/com.wibu.cmdriver.ohDiG6/postinstall:132> exit 0 Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Hosted team responsible for script has been cleared. 2024-12-01 12:01:17+01 savvasly25wvcx3 package_script_service[22054]: Responsibility set back to self. Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: PackageKit: Writing receipt for com.wibu.cmdriver to / 2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: PackageKit: Writing receipt for com.wibu.axprotector to / Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: PackageKit: No Intel binaries to translate. 2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: PackageKit: Touched bundle /Applications/CodeMeter.app Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: Installed "CodeMeter Runtime Kit" (8.20.6539.500) 2024-12-01 12:01:17+01 savvasly25wvcx3 installd[965]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist Last Log repeated 2 times
2024-12-01 12:01:17+01 savvasly25wvcx3 install_monitor[25836]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr 2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: releasing backupd Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: allow user idle system sleep 2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: ----- End install ----- Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: 10.8s elapsed install time 2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: Cleared responsibility for install from 25834. Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: Hosted team responsible for install has been cleared. 2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: Running idle tasks Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: Done with sandbox removals 2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: PackageKit: Registered bundle file:///Applications/CodeMeter.app/ for uid 0 Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installd[965]: PackageKit: Removing client PKInstallDaemonClient pid=25834, uid=0 (/usr/sbin/installer) 2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: Running install actions Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.25834sluo4M" 2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: Finalize disk "Macintosh HD" Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: Notifying system of updated components 2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: **** Summary Information ****
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:   Operation      Elapsed time
Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]: -----------------------------
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:        disk      0.00 seconds
Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:      script      0.00 seconds
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:        zero      0.00 seconds
Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:     install      11.07 seconds
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:     -total-      11.07 seconds
Last Log repeated 2 times
2024-12-01 12:01:18+01 savvasly25wvcx3 installer[25834]:

2024-12-01 12:01:20 : INFO  : codemeter : Finishing... 2024-12-01 12:01:23 : INFO  : codemeter : Custom App Version detection is used, found 8.20
2024-12-01 12:01:23 : REQ   : codemeter : Installed CodeMeter, version 8.20
2024-12-01 12:01:23 : INFO  : codemeter : notifying
ERROR: Notifications are not allowed for this application
2024-12-01 12:01:24 : DEBUG : codemeter : Unmounting /Volumes/CM-Install
2024-12-01 12:01:24 : DEBUG : codemeter : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-12-01 12:01:24 : DEBUG : codemeter : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PL26qCzetR
2024-12-01 12:01:24 : DEBUG : codemeter : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PL26qCzetR/CmInstall.pkg
2024-12-01 12:01:24 : DEBUG : codemeter : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PL26qCzetR
2024-12-01 12:01:24 : INFO  : codemeter : Installomator did not close any apps, so no need to reopen any apps.
2024-12-01 12:01:24 : REQ   : codemeter : All done!
2024-12-01 12:01:24 : REQ   : codemeter : ################## End Installomator, exit code 0