### PR TITLE
Update lcadvancedvpnclient.sh

### DIFF
--- a/fragments/labels/lcadvancedvpnclient.sh
+++ b/fragments/labels/lcadvancedvpnclient.sh
@@ -1,7 +1,10 @@
 lcadvancedvpnclient)
     name="LANCOM Advanced VPN Client"
     type="pkgInDmg"
-    appNewVersion=$(curl -fs https://www.ncp-e.com/de/service/download-vpn-client | grep -m 1 "NCP Secure Entry macOS Client" -A 6 | grep -i Version | sed  "s|.*Version \(.*\) Rev.*|\\1|")
-    downloadURL=$(appShortVersion=`sed 's/[^0-9]//g' <<< $appNewVersion` && echo https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-"${appShortVersion}"-Rel-x86-64.dmg)
+    archiveName="LANCOM Advanced VPN Client.pkg"
+    appShortVersion=$(curl -fs https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/ | grep "macOS"| tail -1 | sed  "s|.*macOS-\(.*\)-Rel.*|\\1|")
+    appNewVersion=(`sed 's/./&./1' <<< $appShortVersion`)
+    downloadURL=(https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-"${appShortVersion}"-Rel-x86-64.dmg)
+    blockingProcesses=( "LANCOM Advanced VPN Client" "ncprwsmac" )
     expectedTeamID="LL3KBL2M3A"
     ;;


### PR DESCRIPTION
Changed appNewVersion to  get the right latest version information

2024-12-01 12:55:51 : REQ   : lcadvancedvpnclient : ################## Start Installomator v. 10.6, date 2024-12-01
2024-12-01 12:55:51 : INFO  : lcadvancedvpnclient : ################## Version: 10.6
2024-12-01 12:55:51 : INFO  : lcadvancedvpnclient : ################## Date: 2024-12-01
2024-12-01 12:55:51 : INFO  : lcadvancedvpnclient : ################## lcadvancedvpnclient
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : DEBUG mode 1 enabled.
2024-12-01 12:55:51 : INFO  : lcadvancedvpnclient : setting variable from argument BLOCKING_PROCESS_ACTION=kill
2024-12-01 12:55:51 : INFO  : lcadvancedvpnclient : setting variable from argument DEBUG=0
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : name=LANCOM Advanced VPN Client
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : appName=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : type=pkgInDmg
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : archiveName=LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : downloadURL=https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-470-Rel-x86-64.dmg
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : curlOptions=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : appNewVersion=4.70
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : appCustomVersion function: Not defined
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : versionKey=CFBundleShortVersionString
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : packageID=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : pkgName=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : choiceChangesXML=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : expectedTeamID=LL3KBL2M3A
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : blockingProcesses=LANCOM Advanced VPN Client ncprwsmac
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : installerTool=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : CLIInstaller=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : CLIArguments=
2024-12-01 12:55:51 : DEBUG : lcadvancedvpnclient : updateTool=
2024-12-01 12:55:52 : DEBUG : lcadvancedvpnclient : updateToolArguments=
2024-12-01 12:55:52 : DEBUG : lcadvancedvpnclient : updateToolRunAsCurrentUser=
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : BLOCKING_PROCESS_ACTION=kill
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : NOTIFY=success
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : LOGGING=DEBUG
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : Label type: pkgInDmg
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : archiveName: LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:52 : DEBUG : lcadvancedvpnclient : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.RzCYQEvn6q
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : name: LANCOM Advanced VPN Client, appName: LANCOM Advanced VPN Client.app
2024-12-01 12:55:52.170 mdfind[30577:721664] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-12-01 12:55:52.170 mdfind[30577:721664] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-12-01 12:55:52.242 mdfind[30577:721664] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-01 12:55:52 : WARN  : lcadvancedvpnclient : No previous app found
2024-12-01 12:55:52 : WARN  : lcadvancedvpnclient : could not find LANCOM Advanced VPN Client.app
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : appversion:
2024-12-01 12:55:52 : INFO  : lcadvancedvpnclient : Latest version of LANCOM Advanced VPN Client is 4.70
2024-12-01 12:55:52 : REQ   : lcadvancedvpnclient : Downloading https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-470-Rel-x86-64.dmg to LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:52 : DEBUG : lcadvancedvpnclient : No Dialog connection, just download
2024-12-01 12:55:54 : DEBUG : lcadvancedvpnclient : File list: -rw-r--r--  1 root  wheel    12M  1 Dez 12:55 LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:54 : DEBUG : lcadvancedvpnclient : File type: LANCOM Advanced VPN Client.pkg: zlib compressed data
2024-12-01 12:55:54 : DEBUG : lcadvancedvpnclient : curl output was:
* Host ftp.lancom.de:443 was resolved.
* IPv6: (none)
* IPv4: 62.153.130.142
*   Trying 62.153.130.142:443...
* Connected to ftp.lancom.de (62.153.130.142) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2568 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=ftp.lancom.de
*  start date: Nov  8 01:10:35 2024 GMT
*  expire date: Feb  6 01:10:34 2025 GMT
*  subjectAltName: host "ftp.lancom.de" matched cert's "ftp.lancom.de"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://ftp.lancom.de/LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-470-Rel-x86-64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: ftp.lancom.de]
* [HTTP/2] [1] [:path: /LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-470-Rel-x86-64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /LANCOM-Releases/LC-VPN-Client/LC-Advanced-VPN-Client-macOS-470-Rel-x86-64.dmg HTTP/2
> Host: ftp.lancom.de
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< server: nginx
< date: Sun, 01 Dec 2024 11:55:37 GMT
< content-type: application/octet-stream
< content-length: 12459370
< last-modified: Mon, 24 Apr 2023 12:26:24 GMT
< etag: "64467570-be1d6a"
< strict-transport-security: max-age=63072000
< accept-ranges: bytes
<
{ [8192 bytes data]
* Connection #0 to host ftp.lancom.de left intact

2024-12-01 12:55:54 : REQ   : lcadvancedvpnclient : no more blocking processes, continue with update
2024-12-01 12:55:54 : REQ   : lcadvancedvpnclient : Installing LANCOM Advanced VPN Client
2024-12-01 12:55:54 : INFO  : lcadvancedvpnclient : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.RzCYQEvn6q/LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $CCFBE4EC
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $F1E5B79F
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $8BA80E0A
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $5A5DBE58
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $8BA80E0A
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $78EBE49A
Die überprüfte CRC32-Prüfsumme ist $B89AADDB
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/LANCOM Advanced VPN Client Installation

2024-12-01 12:55:56 : INFO  : lcadvancedvpnclient : Mounted: /Volumes/LANCOM Advanced VPN Client Installation 2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : Found pkg(s): /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg 2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : /Volumes/LANCOM Advanced VPN Client Installation/Uninstall.pkg 2024-12-01 12:55:56 : INFO  : lcadvancedvpnclient : found pkg: /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg 2024-12-01 12:55:56 : INFO  : lcadvancedvpnclient : Verifying: /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : File list: -rw-r--r--@ 1 savvas  staff    11M 24 Apr  2023 /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : File type: /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg: xar archive compressed TOC: 8760, SHA-1 checksum
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : spctlOut is /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg: accepted
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : source=Notarized Developer ID
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : override=security disabled
2024-12-01 12:55:56 : DEBUG : lcadvancedvpnclient : origin=Developer ID Installer: NCP engineering GmbH (LL3KBL2M3A)
2024-12-01 12:55:56 : INFO  : lcadvancedvpnclient : Team ID: LL3KBL2M3A (expected: LL3KBL2M3A )
2024-12-01 12:55:56 : INFO  : lcadvancedvpnclient : Installing /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg to /
2024-12-01 12:56:09 : DEBUG : lcadvancedvpnclient : Debugging enabled, installer output was:
Dec  1 12:55:56  installer[30718] <Info>: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel.
Dec  1 12:55:56  installer[30718] <Warning>: Architecture Translation: Process is about to get executed as Intel.
Dec  1 12:55:56  installer[30718] <Debug>: Product archive /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg trustLevel=350
Dec  1 12:55:56  installer[30718] <Debug>: External component packages (1) trustLevel=350
Dec  1 12:55:56  installer[30718] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost
Dec  1 12:55:56  installer[30718] <Debug>: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/LANCOM%20Advanced%20VPN%20Client%20Installation/LANCOM%20Advanced%20VPN%20Client.pkg#LANCOM_Advanced_VPN_Client.pkg
Dec  1 12:55:56  installer[30718] <Info>: Set authorization level to root for session
Dec  1 12:55:56  installer[30718] <Info>: Authorization is being checked, waiting until authorization arrives.
Dec  1 12:55:56  installer[30718] <Info>: Administrator authorization granted.
Dec  1 12:55:56  installer[30718] <Info>: Packages have been authorized for installation.
Dec  1 12:55:56  installer[30718] <Debug>: Will use PK session
Dec  1 12:55:56  installer[30718] <Debug>: Using authorization level of root for IFPKInstallElement
Dec  1 12:55:56  installer[30718] <Info>: Install request is requesting Rosetta translation.
Dec  1 12:55:57  installer[30718] <Info>: Starting installation:
Dec  1 12:55:57  installer[30718] <Notice>: Configuring volume "Macintosh HD"
Dec  1 12:55:57  installer[30718] <Info>: Preparing disk for local booted install.
Dec  1 12:55:57  installer[30718] <Notice>: Free space on "Macintosh HD": 311,36 GB (311356305408 bytes).
Dec  1 12:55:57  installer[30718] <Notice>: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.30718JDHVjH"
Dec  1 12:55:57  installer[30718] <Notice>: IFPKInstallElement (1 packages)
Dec  1 12:55:57  installer[30718] <Info>: Current Path: /usr/sbin/installer
Dec  1 12:55:57  installer[30718] <Info>: Current Path: /bin/zsh
Dec  1 12:55:57  installer[30718] <Info>: Current Path: /usr/bin/sudo
Dec  1 12:55:57  installer[30718] <Notice>: PackageKit: Enqueuing install with framework-specified quality of service (utility)
installer: Package name is LANCOM Advanced VPN Client
installer: Upgrading at base path /
installer: Installation vorbereiten ….....
installer: Volume vorbereiten ….....
installer: „LANCOM Advanced VPN Client“ vorbereiten ….....
installer: Warten, bis andere Installationen abgeschlossen werden ….....
installer: Installation konfigurieren ….....
installer:
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
Last Log repeated 2 times
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
#
installer: Paketskripte ausführen ….....
Last Log repeated 2 times
#
installer: Aktualisierte Komponenten registrieren ….....
#
installer: Aktualisierte Komponenten registrieren ….....
#
installer: Aktualisierte Komponenten registrieren ….....
#
installer: Aktualisierte Komponenten registrieren ….....
#
installer: Aktualisierte Komponenten registrieren ….....
#Dec  1 12:56:06  installer[30718] <Info>: PackageKit: Registered bundle file:///Library/Application%20Support/NCP/Secure%20Client/NCP%20Tracer.app/ for uid 0

installer: Aktualisierte Komponenten registrieren …..... Last Log repeated 2 times
installer: Pakete überprüfen ….....
#Dec  1 12:56:06  installer[30718] <Info>: PackageKit: Registered bundle file:///Applications/LANCOM%20Advanced%20VPN%20Client.app/ for uid 0

installer: Aktualisierte Programme registrieren …..... #Dec  1 12:56:07  installer[30718] <Notice>: Running install actions Dec  1 12:56:07  installer[30718] <Notice>: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.30718JDHVjH" Dec  1 12:56:07  installer[30718] <Notice>: Finalize disk "Macintosh HD" Dec  1 12:56:07  installer[30718] <Notice>: Notifying system of updated components Dec  1 12:56:07  installer[30718] <Notice>:
Dec  1 12:56:07  installer[30718] <Notice>: **** Summary Information ****
Dec  1 12:56:07  installer[30718] <Notice>:   Operation      Elapsed time
Dec  1 12:56:07  installer[30718] <Notice>: -----------------------------
Dec  1 12:56:07  installer[30718] <Notice>:        disk      0.01 seconds
Dec  1 12:56:07  installer[30718] <Notice>:      script      0.00 seconds
Dec  1 12:56:07  installer[30718] <Notice>:        zero      0.00 seconds
Dec  1 12:56:07  installer[30718] <Notice>:     install      10.07 seconds
Dec  1 12:56:07  installer[30718] <Notice>:     -total-      10.08 seconds
Dec  1 12:56:07  installer[30718] <Notice>:

installer: 	Installationsaktionen ausführen …
installer:
installer: Installation abschließen ….....
installer:
#
installer: Die Software wurde erfolgreich installiert...... installer: The upgrade was successful.
installer: The install requires restarting now.
Output of /var/log/install.log below this line.----------------------------------------------------------2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel. 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Architecture Translation: Distribution failed architecture check and is about to be re-executed as Intel. 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Architecture Translation: Process is about to get executed as Intel. 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Product archive /Volumes/LANCOM Advanced VPN Client Installation/LANCOM Advanced VPN Client.pkg trustLevel=350 Last Log repeated 2 times
2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: External component packages (1) trustLevel=350 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: location = file://localhost Last Log repeated 2 times
2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: -[IFDInstallController(Private) _buildInstallPlanReturningError:]: file://localhost/Volumes/LANCOM%20Advanced%20VPN%20Client%20Installation/LANCOM%20Advanced%20VPN%20Client.pkg#LANCOM_Advanced_VPN_Client.pkg 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Set authorization level to root for session Last Log repeated 2 times
2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Authorization is being checked, waiting until authorization arrives. 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Administrator authorization granted. Last Log repeated 2 times
2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Packages have been authorized for installation. 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Will use PK session Last Log repeated 2 times
2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Using authorization level of root for IFPKInstallElement 2024-12-01 12:55:56+01 savvasly25wvcx3 installer[30718]: Install request is requesting Rosetta translation. Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Starting installation: 2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Configuring volume "Macintosh HD" Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Preparing disk for local booted install. 2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Free space on "Macintosh HD": 311,36 GB (311356305408 bytes). Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Create temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.30718JDHVjH" 2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: IFPKInstallElement (1 packages) Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Current Path: /usr/sbin/installer 2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Current Path: /bin/zsh Last Log repeated 4 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: Current Path: /usr/bin/sudo 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Adding client PKInstallDaemonClient pid=30718, uid=0 (/usr/sbin/installer) Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installer[30718]: PackageKit: Enqueuing install with framework-specified quality of service (utility) 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Set reponsibility for install to 20609 Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Hosted team responsibility for install set to team:(LL3KBL2M3A) 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: ----- Begin install ----- Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: request=PKInstallRequest <1 packages, destination=/>
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: packages=( Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/156F18CF-27DF-44AE-B9E6-B44CDA41D20F.activeSandbox 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/B74B1466-ADF9-494E-8D4A-9D61E4731092.activeSandbox Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/32AA90C2-8717-4CE4-A0D6-A1313380B657.activeSandbox 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/AE2B4A2B-BAC9-4708-966B-B94DC18E2781.activeSandbox Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/968A49C8-FA71-4E0C-928B-21F55730403F.activeSandbox 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/A8E99944-B605-4006-AC35-DC74132FF9D7.activeSandbox Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/0BD34AEF-D776-4E4A-9B3C-52CA7C5F5977.activeSandbox 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Skipping stale sandbox at path /Library/InstallerSandboxes/.PKInstallSandboxManager/45C2D2B7-FFF5-45A6-82F3-AC326DD0CA1F.activeSandbox Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Will do receipt-based obsoleting for package identifier com.ncp-e.pkg.NCP Secure Client (prefix path=) 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: Extracting file:///Volumes/LANCOM%20Advanced%20VPN%20Client%20Installation/LANCOM%20Advanced%20VPN%20Client.pkg#LANCOM_Advanced_VPN_Client.pkg (destination=/Library/InstallerSandboxes/.PKInstallSandboxManager/0BAAC142-8F1A-4694-8443-8D9A892AB559.activeSandbox/Root, uid=0) Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: prevent user idle system sleep 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: suspending Spotlight indexing Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit: suspending backupd 2024-12-01 12:55:57+01 savvasly25wvcx3 installd[965]: PackageKit (package_script_service): Preparing to execute script "./preinstall" in /private/tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Preparing to execute script "preinstall" in /tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY 2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: Set responsibility to pid: 20609, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: Hosted team responsibility for script set to team:(LL3KBL2M3A) 2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY/preinstall' Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Executing script "preinstall" in /tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY 2024-12-01 12:55:57+01 savvasly25wvcx3 install_monitor[30719]: Temporarily excluding: /Applications, /Library, /System, /bin, /private, /sbin, /usr Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: ---- running ncp preflight script
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall:      stopping all active components of the VPN client
Last Log repeated 2 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - stopping GUI apps
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: No matching processes were found
Last Log repeated 8 times
2024-12-01 12:55:57+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - stopping VPN service
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: No matching processes were found
Last Log repeated 4 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Unload failed: 5: Input/output error
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Try running `launchctl bootout` as root for richer errors.
Last Log repeated 2 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - stopping update agent
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: No matching processes were found
Last Log repeated 4 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Unload failed: 5: Input/output error
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Try running `launchctl bootout` as root for richer errors.
Last Log repeated 2 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - stopping update service
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: No matching processes were found
Last Log repeated 4 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Unload failed: 5: Input/output error
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Try running `launchctl bootout` as root for richer errors.
Last Log repeated 2 times
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - unloading filter driver
2024-12-01 12:55:58+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Executing: /usr/bin/kmutil unload -b com.ncp-e.vpn.driver.ncplbmac
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: Error Domain=KMErrorDomain Code=3 "Error occurred unloading extensions: Missing extension with identifier com.ncp-e.vpn.driver.ncplbmac : Could not find: Extension with identifier 'com.ncp-e.vpn.driver.ncplbmac' not found" UserInfo={NSLocalizedDescription=Error occurred unloading extensions: Missing extension with identifier com.ncp-e.vpn.driver.ncplbmac : Could not find: Extension with identifier 'com.ncp-e.vpn.driver.ncplbmac' not found}
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: - additional cleanup
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./preinstall: ---- ncp preflight script finished
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Hosted team responsible for script has been cleared.
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: Responsibility set back to self.
2024-12-01 12:55:59+01 savvasly25wvcx3 installd[965]: PackageKit: Using trashcan path /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/PKInstallSandboxTrash/0BAAC142-8F1A-4694-8443-8D9A892AB559.sandboxTrash for sandbox /Library/InstallerSandboxes/.PKInstallSandboxManager/0BAAC142-8F1A-4694-8443-8D9A892AB559.activeSandbox
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 installd[965]: PackageKit: Shoving /Library/InstallerSandboxes/.PKInstallSandboxManager/0BAAC142-8F1A-4694-8443-8D9A892AB559.activeSandbox/Root (2 items) to /
2024-12-01 12:55:59+01 savvasly25wvcx3 installd[965]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: Set responsibility to pid: 20609, responsible_path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: Hosted team responsibility for script set to team:(LL3KBL2M3A)
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: Preparing to execute with Rosetta Intel Translation: '/tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY/postinstall'
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.f8ZMMv/Scripts/com.ncp-e.pkg.NCP Secure Client.m4BSMY
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: ---- running ncp postflight script
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall:      starting VPN client components
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - set installation directory permissions
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - create empty ncpphone.cfg file
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - copying additional files from ImportDir
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall:   nothing to import (directory "/Volumes/LANCOM Advanced VPN Client Installation/ImportDir" does not exist)
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - checking some file and directory permissions
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: stat: /Library/Extensions/ncplbmac.kext: stat: No such file or directory
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - removing no longer used support libraries from a previous version
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - checking if sample config files are needed
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: file '/Library/Application Support/NCP/ncppki.conf' exists
Last Log repeated 2 times
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: file '/Library/Preferences/com.ncp-e.vpn.rwsrsu.plist' exists
2024-12-01 12:55:59+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - allowing keychain access for VPN service
Last Log repeated 2 times
2024-12-01 12:56:00+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - adopting advanced setup settings
2024-12-01 12:56:00+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: no settings file to adopt --> skipping adoption
Last Log repeated 2 times
2024-12-01 12:56:00+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - loading VPN service
2024-12-01 12:56:00+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Load failed: 5: Input/output error
Last Log repeated 2 times
2024-12-01 12:56:00+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Try running `launchctl bootstrap` as root for richer errors.
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: - loading update service and starting agent
Last Log repeated 2 times
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Load failed: 5: Input/output error
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Try running `launchctl bootstrap` as root for richer errors.
Last Log repeated 2 times
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Warning: Expecting a LaunchDaemons path since the command was ran as root. Got LaunchAgents instead.
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: `launchctl bootstrap` is a recommended alternative.
Last Log repeated 2 times
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Load failed: 5: Input/output error
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: Try running `launchctl bootstrap` as root for richer errors.
Last Log repeated 2 times
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: ./postinstall: ---- ncp postflight script finished
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: PackageKit: Hosted team responsible for script has been cleared.
Last Log repeated 2 times
2024-12-01 12:56:01+01 savvasly25wvcx3 package_script_service[22054]: Responsibility set back to self.
2024-12-01 12:56:01+01 savvasly25wvcx3 installd[965]: PackageKit: Writing receipt for com.ncp-e.pkg.NCP Secure Client to /
Last Log repeated 2 times
2024-12-01 12:56:02+01 savvasly25wvcx3 installd[965]: oahd translated /Library/Application Support/NCP/Secure Client/NCP Tracer.app/Contents/MacOS/ncpTrace
2024-12-01 12:56:03+01 savvasly25wvcx3 installd[965]: oahd translated /Applications/LANCOM Advanced VPN Client.app/Contents/MacOS/ncpmon
Last Log repeated 2 times
2024-12-01 12:56:04+01 savvasly25wvcx3 installd[965]: oahd translated /Applications/LANCOM Advanced VPN Client.app/Contents/Resources/ext2ini
2024-12-01 12:56:04+01 savvasly25wvcx3 installd[965]: oahd translated /Applications/LANCOM Advanced VPN Client.app/Contents/Frameworks/ncpmacguiutils.framework/Versions/A/ncpmacguiutils
Last Log repeated 2 times
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: oahd translated /Library/Application Support/NCP/Secure Client/ncprwsmac
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: PackageKit: Translated 5 binaries.
Last Log repeated 2 times
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: PackageKit: Touched bundle /Library/Application Support/NCP/Secure Client/NCP Tracer.app
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: PackageKit: Touched bundle /Applications/LANCOM Advanced VPN Client.app
Last Log repeated 2 times
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: Installed "LANCOM Advanced VPN Client" ()
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: Successfully wrote install history to /Library/Receipts/InstallHistory.plist
Last Log repeated 2 times
2024-12-01 12:56:05+01 savvasly25wvcx3 installd[965]: PackageKit: releasing Spotlight indexing
2024-12-01 12:56:05+01 savvasly25wvcx3 install_monitor[30719]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: releasing backupd
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: allow user idle system sleep
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: ----- End install -----
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: 9.4s elapsed install time
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: Cleared responsibility for install from 30718.
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: Hosted team responsible for install has been cleared.
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: Running idle tasks
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: Done with sandbox removals
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installer[30718]: PackageKit: Registered bundle file:///Library/Application%20Support/NCP/Secure%20Client/NCP%20Tracer.app/ for uid 0
2024-12-01 12:56:06+01 savvasly25wvcx3 installer[30718]: PackageKit: Registered bundle file:///Applications/LANCOM%20Advanced%20VPN%20Client.app/ for uid 0
Last Log repeated 2 times
2024-12-01 12:56:06+01 savvasly25wvcx3 installd[965]: PackageKit: Removing client PKInstallDaemonClient pid=30718, uid=0 (/usr/sbin/installer)
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: Running install actions
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: Removing temporary directory "/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T//Install.30718JDHVjH"
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: Finalize disk "Macintosh HD"
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: Notifying system of updated components
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: **** Summary Information ****
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:   Operation      Elapsed time
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]: -----------------------------
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:        disk      0.01 seconds
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:      script      0.00 seconds
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:        zero      0.00 seconds
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:     install      10.07 seconds
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:     -total-      10.08 seconds
Last Log repeated 2 times
2024-12-01 12:56:07+01 savvasly25wvcx3 installer[30718]:

2024-12-01 12:56:09 : INFO  : lcadvancedvpnclient : Finishing... 2024-12-01 12:56:12 : INFO  : lcadvancedvpnclient : App(s) found: /Applications/LANCOM Advanced VPN Client.app 2024-12-01 12:56:12 : INFO  : lcadvancedvpnclient : found app at /Applications/LANCOM Advanced VPN Client.app, version 4.70, on versionKey CFBundleShortVersionString
2024-12-01 12:56:12 : REQ   : lcadvancedvpnclient : Installed LANCOM Advanced VPN Client, version 4.70
2024-12-01 12:56:12 : INFO  : lcadvancedvpnclient : notifying
ERROR: Notifications are not allowed for this application
2024-12-01 12:56:12 : DEBUG : lcadvancedvpnclient : Unmounting /Volumes/LANCOM Advanced VPN Client Installation
2024-12-01 12:56:13 : DEBUG : lcadvancedvpnclient : Debugging enabled, Unmounting output was:
"disk12" ejected.
2024-12-01 12:56:13 : DEBUG : lcadvancedvpnclient : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.RzCYQEvn6q
2024-12-01 12:56:13 : DEBUG : lcadvancedvpnclient : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.RzCYQEvn6q/LANCOM Advanced VPN Client.pkg
2024-12-01 12:56:13 : DEBUG : lcadvancedvpnclient : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.RzCYQEvn6q
2024-12-01 12:56:13 : INFO  : lcadvancedvpnclient : Installomator did not close any apps, so no need to reopen any apps.
2024-12-01 12:56:13 : REQ   : lcadvancedvpnclient : All done!
2024-12-01 12:56:13 : REQ   : lcadvancedvpnclient : ################## End Installomator, exit code 0