### PR TITLE
Update flexoptixapp.sh

### DIFF
--- a/fragments/labels/flexoptixapp.sh
+++ b/fragments/labels/flexoptixapp.sh
@@ -2,6 +2,6 @@ flexoptixapp)
     name="FLEXOPTIX App"
     type="dmg"
     downloadURL="https://flexbox.reconfigure.me/download/electron/mac/x64/current"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*-([0-9.]*)\.dmg/\1/g')
+    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*App-(.*)\.dmg/\1/g')
     expectedTeamID="C5JETSFPHL"
     ;;


### PR DESCRIPTION
Changed AppNewVersion to get correct latest version information

2024-12-01 15:39:34 : REQ   : flexoptixapp : ################## Start Installomator v. 10.6, date 2024-12-01
2024-12-01 15:39:34 : INFO  : flexoptixapp : ################## Version: 10.6
2024-12-01 15:39:34 : INFO  : flexoptixapp : ################## Date: 2024-12-01
2024-12-01 15:39:34 : INFO  : flexoptixapp : ################## flexoptixapp
2024-12-01 15:39:34 : DEBUG : flexoptixapp : DEBUG mode 1 enabled.
2024-12-01 15:39:34 : INFO  : flexoptixapp : setting variable from argument DEBUG=0
2024-12-01 15:39:34 : DEBUG : flexoptixapp : name=FLEXOPTIX App
2024-12-01 15:39:34 : DEBUG : flexoptixapp : appName=
2024-12-01 15:39:34 : DEBUG : flexoptixapp : type=dmg
2024-12-01 15:39:35 : DEBUG : flexoptixapp : archiveName=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : downloadURL=https://flexbox.reconfigure.me/download/electron/mac/x64/current
2024-12-01 15:39:35 : DEBUG : flexoptixapp : curlOptions=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : appNewVersion=5.26.0-latest
2024-12-01 15:39:35 : DEBUG : flexoptixapp : appCustomVersion function: Not defined
2024-12-01 15:39:35 : DEBUG : flexoptixapp : versionKey=CFBundleShortVersionString
2024-12-01 15:39:35 : DEBUG : flexoptixapp : packageID=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : pkgName=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : choiceChangesXML=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : expectedTeamID=C5JETSFPHL
2024-12-01 15:39:35 : DEBUG : flexoptixapp : blockingProcesses=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : installerTool=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : CLIInstaller=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : CLIArguments=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : updateTool=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : updateToolArguments=
2024-12-01 15:39:35 : DEBUG : flexoptixapp : updateToolRunAsCurrentUser=
2024-12-01 15:39:35 : INFO  : flexoptixapp : BLOCKING_PROCESS_ACTION=tell_user
2024-12-01 15:39:35 : INFO  : flexoptixapp : NOTIFY=success
2024-12-01 15:39:35 : INFO  : flexoptixapp : LOGGING=DEBUG
2024-12-01 15:39:35 : INFO  : flexoptixapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-01 15:39:35 : INFO  : flexoptixapp : Label type: dmg
2024-12-01 15:39:35 : INFO  : flexoptixapp : archiveName: FLEXOPTIX App.dmg
2024-12-01 15:39:35 : INFO  : flexoptixapp : no blocking processes defined, using FLEXOPTIX App as default
2024-12-01 15:39:35 : DEBUG : flexoptixapp : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x82ioRr5sC
2024-12-01 15:39:35 : INFO  : flexoptixapp : name: FLEXOPTIX App, appName: FLEXOPTIX App.app
2024-12-01 15:39:35.304 mdfind[37639:910733] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2024-12-01 15:39:35.305 mdfind[37639:910733] [UserQueryParser] Loading keywords and predicates for locale "de"
2024-12-01 15:39:35.374 mdfind[37639:910733] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-01 15:39:35 : WARN  : flexoptixapp : No previous app found
2024-12-01 15:39:35 : WARN  : flexoptixapp : could not find FLEXOPTIX App.app
2024-12-01 15:39:35 : INFO  : flexoptixapp : appversion:
2024-12-01 15:39:35 : INFO  : flexoptixapp : Latest version of FLEXOPTIX App is 5.26.0-latest
2024-12-01 15:39:35 : REQ   : flexoptixapp : Downloading https://flexbox.reconfigure.me/download/electron/mac/x64/current to FLEXOPTIX App.dmg
2024-12-01 15:39:35 : DEBUG : flexoptixapp : No Dialog connection, just download
2024-12-01 15:39:40 : DEBUG : flexoptixapp : File list: -rw-r--r--  1 root  wheel   107M  1 Dez 15:39 FLEXOPTIX App.dmg
2024-12-01 15:39:40 : DEBUG : flexoptixapp : File type: FLEXOPTIX App.dmg: zlib compressed data
2024-12-01 15:39:40 : DEBUG : flexoptixapp : curl output was:
* Host flexbox.reconfigure.me:443 was resolved.
* IPv6: (none)
* IPv4: 162.55.184.232
*   Trying 162.55.184.232:443...
* Connected to flexbox.reconfigure.me (162.55.184.232) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [327 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2756 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=reconfigure.me
*  start date: Oct 19 21:54:08 2024 GMT
*  expire date: Jan 17 21:54:07 2025 GMT
*  subjectAltName: host "flexbox.reconfigure.me" matched cert's "flexbox.reconfigure.me"
*  issuer: C=US; O=Let's Encrypt; CN=R11
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://flexbox.reconfigure.me/download/electron/mac/x64/current
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: flexbox.reconfigure.me]
* [HTTP/2] [1] [:path: /download/electron/mac/x64/current]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /download/electron/mac/x64/current HTTP/2
> Host: flexbox.reconfigure.me
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 302
< server: nginx
< date: Sun, 01 Dec 2024 14:39:35 GMT
< content-type: text/html
< content-length: 138
< location: /download/electron/mac/x64/FLEXOPTIX App-5.26.0-latest.dmg <
* Ignoring the response-body
* Connection #0 to host flexbox.reconfigure.me left intact
* Issue another request to this URL: 'https://flexbox.reconfigure.me/download/electron/mac/x64/FLEXOPTIX%20App-5.26.0-latest.dmg'
* Found bundle for host: 0x60000092ca50 [can multiplex]
* Re-using existing connection with host flexbox.reconfigure.me
* [HTTP/2] [3] OPENED stream for https://flexbox.reconfigure.me/download/electron/mac/x64/FLEXOPTIX%20App-5.26.0-latest.dmg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: flexbox.reconfigure.me]
* [HTTP/2] [3] [:path: /download/electron/mac/x64/FLEXOPTIX%20App-5.26.0-latest.dmg]
* [HTTP/2] [3] [user-agent: curl/8.7.1]
* [HTTP/2] [3] [accept: */*]
> GET /download/electron/mac/x64/FLEXOPTIX%20App-5.26.0-latest.dmg HTTP/2
> Host: flexbox.reconfigure.me
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< server: nginx
< date: Sun, 01 Dec 2024 14:39:35 GMT
< content-type: application/octet-stream
< content-length: 111837048
< last-modified: Thu, 21 Nov 2024 15:37:55 GMT
< etag: "673f53d3-6aa7f78"
< accept-ranges: bytes
<
{ [8192 bytes data]
* Connection #0 to host flexbox.reconfigure.me left intact

2024-12-01 15:39:40 : REQ   : flexoptixapp : no more blocking processes, continue with update
2024-12-01 15:39:40 : REQ   : flexoptixapp : Installing FLEXOPTIX App
2024-12-01 15:39:40 : INFO  : flexoptixapp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x82ioRr5sC/FLEXOPTIX App.dmg
2024-12-01 15:39:43 : DEBUG : flexoptixapp : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $0248D3DD
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $91BD1A3A
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $E2F56137
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_HFS : 4) berechnen …
disk image (Apple_HFS : 4): Die überprüfte CRC32-Prüfsumme ist $7F6CFC80
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $E2F56137
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $725C56A1
Die überprüfte CRC32-Prüfsumme ist $4DFEE7A0
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_HFS                      	/Volumes/FLEXOPTIX App 5.26.0-latest 1

2024-12-01 15:39:43 : INFO  : flexoptixapp : Mounted: /Volumes/FLEXOPTIX App 5.26.0-latest 1 2024-12-01 15:39:43 : INFO  : flexoptixapp : Verifying: /Volumes/FLEXOPTIX App 5.26.0-latest 1/FLEXOPTIX App.app 2024-12-01 15:39:43 : DEBUG : flexoptixapp : App size: 261M	/Volumes/FLEXOPTIX App 5.26.0-latest 1/FLEXOPTIX App.app 2024-12-01 15:39:44 : DEBUG : flexoptixapp : Debugging enabled, App Verification output was: /Volumes/FLEXOPTIX App 5.26.0-latest 1/FLEXOPTIX App.app: accepted source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Flexoptix GmbH (C5JETSFPHL)

2024-12-01 15:39:44 : INFO  : flexoptixapp : Team ID matching: C5JETSFPHL (expected: C5JETSFPHL ) 2024-12-01 15:39:44 : INFO  : flexoptixapp : Installing FLEXOPTIX App version 5.26.0-latest on versionKey CFBundleShortVersionString. 2024-12-01 15:39:44 : INFO  : flexoptixapp : App has LSMinimumSystemVersion: 10.15 2024-12-01 15:39:44 : INFO  : flexoptixapp : Copy /Volumes/FLEXOPTIX App 5.26.0-latest 1/FLEXOPTIX App.app to /Applications 2024-12-01 15:39:45 : DEBUG : flexoptixapp : Debugging enabled, App copy output was: Copying /Volumes/FLEXOPTIX App 5.26.0-latest 1/FLEXOPTIX App.app

2024-12-01 15:39:45 : WARN  : flexoptixapp : Changing owner to savvas 2024-12-01 15:39:45 : INFO  : flexoptixapp : Finishing... 2024-12-01 15:39:48 : INFO  : flexoptixapp : App(s) found: /Applications/FLEXOPTIX App.app 2024-12-01 15:39:48 : INFO  : flexoptixapp : found app at /Applications/FLEXOPTIX App.app, version 5.26.0-latest, on versionKey CFBundleShortVersionString
2024-12-01 15:39:48 : REQ   : flexoptixapp : Installed FLEXOPTIX App, version 5.26.0-latest
2024-12-01 15:39:48 : INFO  : flexoptixapp : notifying
ERROR: Notifications are not allowed for this application
2024-12-01 15:39:48 : DEBUG : flexoptixapp : Unmounting /Volumes/FLEXOPTIX App 5.26.0-latest 1
2024-12-01 15:39:49 : DEBUG : flexoptixapp : Debugging enabled, Unmounting output was:
"disk13" ejected.
2024-12-01 15:39:49 : DEBUG : flexoptixapp : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x82ioRr5sC
2024-12-01 15:39:49 : DEBUG : flexoptixapp : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x82ioRr5sC/FLEXOPTIX App.dmg
2024-12-01 15:39:49 : DEBUG : flexoptixapp : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x82ioRr5sC
2024-12-01 15:39:49 : INFO  : flexoptixapp : Installomator did not close any apps, so no need to reopen any apps.
2024-12-01 15:39:49 : REQ   : flexoptixapp : All done!
2024-12-01 15:39:49 : REQ   : flexoptixapp : ################## End Installomator, exit code 0