### PR TITLE
`mdfind` commands fixed

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -264,11 +264,10 @@ getAppVersion() {
 #            targetDir="/Applications/Utilities"
 #        fi
     else
-    #    applist=$(mdfind "kind:application $appName" -0 )
         printlog "name: $name, appName: $appName"
-        applist=$(mdfind "kind:application AND name:$name" -0 )
+        applist=$(mdfind -name "$name" 'kMDItemKind:"App"' -0)
+#        applist=$(mdfind -name "$appName" 'kMDItemKind:"App"' -0)
 #        printlog "App(s) found: ${applist}" DEBUG
-#        applist=$(mdfind "kind:application AND name:$appName" -0 )
     fi
     if [[ -z $applist ]]; then
         printlog "No previous app found" WARN

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -266,8 +266,8 @@ getAppVersion() {
     else
         printlog "name: $name, appName: $appName"
         # mdfind now handling if kind is either Application or App
-        applist=$(mdfind 'kMDItemContentType:com.apple.application AND kMDItemFSName:"'"$name"'"' -0 2>/dev/null)
-#        applist=$(mdfind 'kMDItemContentType:com.apple.application AND kMDItemFSName:"'"$appName"'"' -0 2>/dev/null)
+        applist=$(mdfind "kMDItemContentType:com.apple.application AND kMDItemFSName:\"$name\"" -0 2>/dev/null)
+#        applist=$(mdfind "kMDItemContentType:com.apple.application AND kMDItemFSName:\"$appName\"" -0 2>/dev/null)
 #        printlog "App(s) found: ${applist}" DEBUG
     fi
     if [[ -z $applist ]]; then

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -265,8 +265,9 @@ getAppVersion() {
 #        fi
     else
         printlog "name: $name, appName: $appName"
-        applist=$(mdfind -name "$name" 'kMDItemKind:"App"' -0)
-#        applist=$(mdfind -name "$appName" 'kMDItemKind:"App"' -0)
+        # mdfind now handling if kind is either Application or App
+        applist=$(mdfind 'kMDItemContentType:com.apple.application AND kMDItemFSName:"'"$name"'"' -0 2>/dev/null)
+#        applist=$(mdfind 'kMDItemContentType:com.apple.application AND kMDItemFSName:"'"$appName"'"' -0 2>/dev/null)
 #        printlog "App(s) found: ${applist}" DEBUG
     fi
     if [[ -z $applist ]]; then


### PR DESCRIPTION
We have to specify the `kind` in the query more precisely to make sure it only finds applications. And now it's not `Application`, but `App`.

This will find apps only:
```
mdfind -name "$name" 'kMDItemKind:"App"'
```
