### PR TITLE
Update citrixworkspace.sh appNewVersion

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -13,7 +13,7 @@ citrixworkspace)
         htmlDocument=$(curl -fs $urlToParse)
         xmllint --html --xpath 'string(//p[contains(., "Version")])' 2> /dev/null <(print $htmlDocument)
     }
-    appNewVersion=$(newVersionString | cut -d ' ' -f2 )
+    appNewVersion=$(newVersionString | cut -d ' ' -f2 | cut -d '(' -f1)
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;


### PR DESCRIPTION
Removes build number from AppNewVersion to fix version compare.

Before:
````
2024-12-04 11:45:51 : INFO  : citrixworkspace : appversion: 24.09.10.26
2024-12-04 11:45:51 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 24.09.10.26(2409.10)
2024-12-04 11:45:51 : REQ   : citrixworkspace : Downloading https://downloads.citrix.com/23004/CitrixWorkspaceApp.dmg?__gda__=exp=1733312749~acl=/*~hmac=08a96ce8c2e77a75afc76a727b09310d932162bb32c8a2bb82fff95218fb55e4 to Citrix Workspace.dmg
````
After:
````
2024-12-04 12:03:24 : REQ   : citrixworkspace : ################## Start Installomator v. 10.6.1, date 2024-09-06
2024-12-04 12:03:24 : INFO  : citrixworkspace : ################## Version: 10.6.1
2024-12-04 12:03:24 : INFO  : citrixworkspace : ################## Date: 2024-09-06
2024-12-04 12:03:24 : INFO  : citrixworkspace : ################## citrixworkspace
2024-12-04 12:03:24 : DEBUG : citrixworkspace : DEBUG mode 1 enabled.
2024-12-04 12:03:24 : INFO  : citrixworkspace : SwiftDialog is not installed, clear cmd file var
2024-12-04 12:03:44 : INFO  : citrixworkspace : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2024-12-04 12:03:44 : INFO  : citrixworkspace : setting variable from argument NOTIFY=silent
2024-12-04 12:03:44 : INFO  : citrixworkspace : setting variable from argument LOGO=/usr/local/sbin/FileWave.app/Contents/Resources/fwGUI.app/Contents/Resources/kiosk.icns
2024-12-04 12:03:44 : INFO  : citrixworkspace : setting variable from argument DEBUG=0
2024-12-04 12:03:44 : DEBUG : citrixworkspace : name=Citrix Workspace
2024-12-04 12:03:44 : DEBUG : citrixworkspace : appName=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : type=pkgInDmg
2024-12-04 12:03:44 : DEBUG : citrixworkspace : archiveName=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : downloadURL=https://downloads.citrix.com/23004/CitrixWorkspaceApp.dmg?__gda__=exp=1733313816~acl=/*~hmac=820a53a75643be579b530fdd85adaba8bc7138788c459b759af4cd23569e087b
2024-12-04 12:03:44 : DEBUG : citrixworkspace : curlOptions=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : appNewVersion=24.09.10.26
2024-12-04 12:03:44 : DEBUG : citrixworkspace : appCustomVersion function: Not defined
2024-12-04 12:03:44 : DEBUG : citrixworkspace : versionKey=CitrixVersionString
2024-12-04 12:03:44 : DEBUG : citrixworkspace : packageID=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : pkgName=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : choiceChangesXML=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : expectedTeamID=S272Y5R93J
2024-12-04 12:03:44 : DEBUG : citrixworkspace : blockingProcesses=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : installerTool=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : CLIInstaller=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : CLIArguments=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : updateTool=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : updateToolArguments=
2024-12-04 12:03:44 : DEBUG : citrixworkspace : updateToolRunAsCurrentUser=
2024-12-04 12:03:44 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=prompt_user_then_kill
2024-12-04 12:03:44 : INFO  : citrixworkspace : NOTIFY=silent
2024-12-04 12:03:44 : INFO  : citrixworkspace : LOGGING=DEBUG
2024-12-04 12:03:44 : INFO  : citrixworkspace : LOGO=/usr/local/sbin/FileWave.app/Contents/Resources/fwGUI.app/Contents/Resources/kiosk.icns
2024-12-04 12:03:44 : INFO  : citrixworkspace : Label type: pkgInDmg
2024-12-04 12:03:44 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2024-12-04 12:03:44 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2024-12-04 12:03:44 : DEBUG : citrixworkspace : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YAHBhhTFkt
2024-12-04 12:03:44 : INFO  : citrixworkspace : App(s) found: /Applications/Citrix Workspace.app
2024-12-04 12:03:44 : INFO  : citrixworkspace : found app at /Applications/Citrix Workspace.app, version 24.09.10.26, on versionKey CitrixVersionString
2024-12-04 12:03:44 : INFO  : citrixworkspace : appversion: 24.09.10.26
2024-12-04 12:03:44 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 24.09.10.26
2024-12-04 12:03:44 : INFO  : citrixworkspace : There is no newer version available.
2024-12-04 12:03:44 : DEBUG : citrixworkspace : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YAHBhhTFkt
2024-12-04 12:03:44 : DEBUG : citrixworkspace : Debugging enabled, Deleting tmpDir output was:
2024-12-04 12:03:44 : INFO  : citrixworkspace : Installomator did not close any apps, so no need to reopen any apps.
2024-12-04 12:03:45 : REQ   : citrixworkspace : No newer version.
2024-12-04 12:03:45 : REQ   : citrixworkspace : ################## End Installomator, exit code 0 
````

https://github.com/Installomator/Installomator/pull/1987 is also required to make the label work.