### PR TITLE
New Label for Hudl Studio

### DIFF
--- a/fragments/labels/HudlStudio.sh
+++ b/fragments/labels/HudlStudio.sh
@@ -1,0 +1,8 @@
+hudlstudio)
+    name="Studio"
+    type="dmg"
+    appNewVersion=$(curl -fs https://www.hudl.com/downloads/elite | grep -A 1 "Download Studio" | grep -o -e "[0-9.]*")
+    downloadURL="https://studio-releases.s3.amazonaws.com/Studio-$appNewVersion.dmg"
+	versionKey="CFBundleVersion"
+    expectedTeamID="2YLQ7PASUE"
+    ;;


### PR DESCRIPTION
Output of `./utils/assemble.sh hudlstudio DEBUG=0`

```
2024-12-05 14:36:13 : REQ   : hudlstudio : ################## Start Installomator v. 10.6, date 2024-12-05
2024-12-05 14:36:13 : INFO  : hudlstudio : ################## Version: 10.6
2024-12-05 14:36:13 : INFO  : hudlstudio : ################## Date: 2024-12-05
2024-12-05 14:36:13 : INFO  : hudlstudio : ################## hudlstudio
2024-12-05 14:36:13 : DEBUG : hudlstudio : DEBUG mode 1 enabled.
2024-12-05 14:36:14 : INFO  : hudlstudio : setting variable from argument DEBUG=0
2024-12-05 14:36:14 : DEBUG : hudlstudio : name=Studio
2024-12-05 14:36:14 : DEBUG : hudlstudio : appName=
2024-12-05 14:36:14 : DEBUG : hudlstudio : type=dmg
2024-12-05 14:36:14 : DEBUG : hudlstudio : archiveName=
2024-12-05 14:36:14 : DEBUG : hudlstudio : downloadURL=https://studio-releases.s3.amazonaws.com/Studio-2.2.7.dmg
2024-12-05 14:36:14 : DEBUG : hudlstudio : curlOptions=
2024-12-05 14:36:14 : DEBUG : hudlstudio : appNewVersion=2.2.7
2024-12-05 14:36:14 : DEBUG : hudlstudio : appCustomVersion function: Not defined
2024-12-05 14:36:14 : DEBUG : hudlstudio : versionKey=CFBundleVersion
2024-12-05 14:36:14 : DEBUG : hudlstudio : packageID=
2024-12-05 14:36:14 : DEBUG : hudlstudio : pkgName=
2024-12-05 14:36:14 : DEBUG : hudlstudio : choiceChangesXML=
2024-12-05 14:36:14 : DEBUG : hudlstudio : expectedTeamID=2YLQ7PASUE
2024-12-05 14:36:14 : DEBUG : hudlstudio : blockingProcesses=
2024-12-05 14:36:14 : DEBUG : hudlstudio : installerTool=
2024-12-05 14:36:14 : DEBUG : hudlstudio : CLIInstaller=
2024-12-05 14:36:14 : DEBUG : hudlstudio : CLIArguments=
2024-12-05 14:36:14 : DEBUG : hudlstudio : updateTool=
2024-12-05 14:36:14 : DEBUG : hudlstudio : updateToolArguments=
2024-12-05 14:36:14 : DEBUG : hudlstudio : updateToolRunAsCurrentUser=
2024-12-05 14:36:14 : INFO  : hudlstudio : BLOCKING_PROCESS_ACTION=tell_user
2024-12-05 14:36:14 : INFO  : hudlstudio : NOTIFY=success
2024-12-05 14:36:14 : INFO  : hudlstudio : LOGGING=DEBUG
2024-12-05 14:36:14 : INFO  : hudlstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-05 14:36:14 : INFO  : hudlstudio : Label type: dmg
2024-12-05 14:36:14 : INFO  : hudlstudio : archiveName: Studio.dmg
2024-12-05 14:36:14 : INFO  : hudlstudio : no blocking processes defined, using Studio as default
2024-12-05 14:36:14 : DEBUG : hudlstudio : Changing directory to /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.yh4m5E9MCV
2024-12-05 14:36:14 : INFO  : hudlstudio : name: Studio, appName: Studio.app
2024-12-05 14:36:15.023 mdfind[25519:4978152] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-12-05 14:36:15.024 mdfind[25519:4978152] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-12-05 14:36:15.158 mdfind[25519:4978152] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-05 14:36:15 : WARN  : hudlstudio : No previous app found
2024-12-05 14:36:15 : WARN  : hudlstudio : could not find Studio.app
2024-12-05 14:36:15 : INFO  : hudlstudio : appversion: 
2024-12-05 14:36:15 : INFO  : hudlstudio : Latest version of Studio is 2.2.7
2024-12-05 14:36:15 : REQ   : hudlstudio : Downloading https://studio-releases.s3.amazonaws.com/Studio-2.2.7.dmg to Studio.dmg
2024-12-05 14:36:15 : DEBUG : hudlstudio : No Dialog connection, just download
2024-12-05 14:37:50 : DEBUG : hudlstudio : File list: -rw-r--r--  1 testuser  staff   246M Dec  5 14:37 Studio.dmg
2024-12-05 14:37:50 : DEBUG : hudlstudio : File type: Studio.dmg: zlib compressed data
2024-12-05 14:37:50 : DEBUG : hudlstudio : curl output was:
* Host studio-releases.s3.amazonaws.com:443 was resolved.
* IPv6: (none)
* IPv4: 52.218.110.2, 52.92.3.129, 52.218.100.34, 3.5.71.134, 52.218.100.242, 52.218.100.130, 52.92.19.225, 52.218.45.129
*   Trying 52.218.110.2:443...
* Connected to studio-releases.s3.amazonaws.com (52.218.110.2) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [337 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4980 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Apr 22 00:00:00 2024 GMT
*  expire date: Apr  7 23:59:59 2025 GMT
*  subjectAltName: host "studio-releases.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /Studio-2.2.7.dmg HTTP/1.1
> Host: studio-releases.s3.amazonaws.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off < HTTP/1.1 200 OK
< x-amz-id-2: LS4hb1X2+X32akHAveRXw+4dhZ/nQiOb60Cq6+a4/4EhfXppq/j36XIcTo8KB05l7scdbLXUR4I= < x-amz-request-id: 1Z01JRKR6HC30B1C
< Date: Thu, 05 Dec 2024 20:36:16 GMT
< Last-Modified: Fri, 24 May 2024 13:28:04 GMT
< ETag: "0ce1001bb8f08e0ce11610ee1775815a-50"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Content-Type: application/x-apple-diskimage
< Content-Length: 257607550
< Server: AmazonS3
< 
{ [16384 bytes data]
* Connection #0 to host studio-releases.s3.amazonaws.com left intact

2024-12-05 14:37:50 : REQ   : hudlstudio : no more blocking processes, continue with update
2024-12-05 14:37:50 : REQ   : hudlstudio : Installing Studio
2024-12-05 14:37:50 : INFO  : hudlstudio : Mounting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.yh4m5E9MCV/Studio.dmg
2024-12-05 14:37:54 : DEBUG : hudlstudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $4699C6C1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0B45F0F1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $76C6ED97
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $C1F23674
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $76C6ED97
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $7512B8B3
verified   CRC32 $810832D9
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Studio 2.2.7-universal

2024-12-05 14:37:54 : INFO  : hudlstudio : Mounted: /Volumes/Studio 2.2.7-universal 2024-12-05 14:37:54 : INFO  : hudlstudio : Verifying: /Volumes/Studio 2.2.7-universal/Studio.app 2024-12-05 14:37:54 : DEBUG : hudlstudio : App size: 651M	/Volumes/Studio 2.2.7-universal/Studio.app 2024-12-05 14:37:58 : DEBUG : hudlstudio : Debugging enabled, App Verification output was: /Volumes/Studio 2.2.7-universal/Studio.app: accepted source=Notarized Developer ID
origin=Developer ID Application: WY SRL (2YLQ7PASUE)

2024-12-05 14:37:58 : INFO  : hudlstudio : Team ID matching: 2YLQ7PASUE (expected: 2YLQ7PASUE ) 2024-12-05 14:37:58 : INFO  : hudlstudio : Installing Studio version 2.2.7 on versionKey CFBundleVersion. 2024-12-05 14:37:58 : INFO  : hudlstudio : App has LSMinimumSystemVersion: 10.13 2024-12-05 14:37:58 : INFO  : hudlstudio : Copy /Volumes/Studio 2.2.7-universal/Studio.app to /Applications 2024-12-05 14:38:05 : DEBUG : hudlstudio : Debugging enabled, App copy output was: Copying /Volumes/Studio 2.2.7-universal/Studio.app

2024-12-05 14:38:05 : WARN  : hudlstudio : Changing owner to testuser 2024-12-05 14:38:06 : INFO  : hudlstudio : Finishing... 2024-12-05 14:38:09 : INFO  : hudlstudio : App(s) found: /Applications/Studio.app 2024-12-05 14:38:09 : INFO  : hudlstudio : found app at /Applications/Studio.app, version 2.2.7, on versionKey CFBundleVersion
2024-12-05 14:38:09 : REQ   : hudlstudio : Installed Studio, version 2.2.7
2024-12-05 14:38:09 : INFO  : hudlstudio : notifying
2024-12-05 14:38:10 : DEBUG : hudlstudio : Unmounting /Volumes/Studio 2.2.7-universal
2024-12-05 14:38:10 : DEBUG : hudlstudio : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-05 14:38:10 : DEBUG : hudlstudio : Deleting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.yh4m5E9MCV
2024-12-05 14:38:10 : DEBUG : hudlstudio : Debugging enabled, Deleting tmpDir output was:
/var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.yh4m5E9MCV/Studio.dmg
2024-12-05 14:38:10 : DEBUG : hudlstudio : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.yh4m5E9MCV
2024-12-05 14:38:10 : INFO  : hudlstudio : Installomator did not close any apps, so no need to reopen any apps.
2024-12-05 14:38:10 : REQ   : hudlstudio : All done!
```