### PR TITLE
New label for Hudl Sportscode

### DIFF
--- a/fragments/labels/HudlSportscode.sh
+++ b/fragments/labels/HudlSportscode.sh
@@ -1,0 +1,8 @@
+hudlsportscode)
+    name="Hudl Sportscode"
+    type="appInDmgInZip"
+    appNewVersion=$(curl -fs https://www.hudl.com/downloads/elite | grep -A 1 "Download Hudl Sportscode" | grep -o -e "[0-9.]*")
+    downloadURL="https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-$appNewVersion.dmg.zip"
+	versionKey="CFBundleVersion"
+    expectedTeamID="4M6T2C723P"
+    ;;


### PR DESCRIPTION
Output of `./utils/assemble.sh hudlsportscode DEBUG=0`

```
2024-12-05 14:44:04 : REQ   : hudlsportscode : ################## Start Installomator v. 10.6, date 2024-12-05
2024-12-05 14:44:04 : INFO  : hudlsportscode : ################## Version: 10.6
2024-12-05 14:44:04 : INFO  : hudlsportscode : ################## Date: 2024-12-05
2024-12-05 14:44:04 : INFO  : hudlsportscode : ################## hudlsportscode
2024-12-05 14:44:04 : DEBUG : hudlsportscode : DEBUG mode 1 enabled.
2024-12-05 14:44:05 : INFO  : hudlsportscode : setting variable from argument DEBUG=0
2024-12-05 14:44:05 : DEBUG : hudlsportscode : name=Hudl Sportscode
2024-12-05 14:44:05 : DEBUG : hudlsportscode : appName=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : type=appInDmgInZip
2024-12-05 14:44:05 : DEBUG : hudlsportscode : archiveName=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : downloadURL=https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-12.46.0.dmg.zip
2024-12-05 14:44:05 : DEBUG : hudlsportscode : curlOptions=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : appNewVersion=12.46.0
2024-12-05 14:44:05 : DEBUG : hudlsportscode : appCustomVersion function: Not defined
2024-12-05 14:44:05 : DEBUG : hudlsportscode : versionKey=CFBundleVersion
2024-12-05 14:44:05 : DEBUG : hudlsportscode : packageID=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : pkgName=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : choiceChangesXML=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : expectedTeamID=4M6T2C723P
2024-12-05 14:44:05 : DEBUG : hudlsportscode : blockingProcesses=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : installerTool=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : CLIInstaller=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : CLIArguments=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : updateTool=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : updateToolArguments=
2024-12-05 14:44:05 : DEBUG : hudlsportscode : updateToolRunAsCurrentUser=
2024-12-05 14:44:05 : INFO  : hudlsportscode : BLOCKING_PROCESS_ACTION=tell_user
2024-12-05 14:44:05 : INFO  : hudlsportscode : NOTIFY=success
2024-12-05 14:44:05 : INFO  : hudlsportscode : LOGGING=DEBUG
2024-12-05 14:44:05 : INFO  : hudlsportscode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-05 14:44:05 : INFO  : hudlsportscode : Label type: appInDmgInZip
2024-12-05 14:44:05 : INFO  : hudlsportscode : archiveName: Hudl Sportscode.zip
2024-12-05 14:44:05 : INFO  : hudlsportscode : no blocking processes defined, using Hudl Sportscode as default
2024-12-05 14:44:05 : DEBUG : hudlsportscode : Changing directory to /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7
2024-12-05 14:44:05 : INFO  : hudlsportscode : name: Hudl Sportscode, appName: Hudl Sportscode.app
2024-12-05 14:44:05.921 mdfind[26552:4992174] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-12-05 14:44:05.921 mdfind[26552:4992174] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-12-05 14:44:05.974 mdfind[26552:4992174] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-05 14:44:06 : WARN  : hudlsportscode : No previous app found
2024-12-05 14:44:06 : WARN  : hudlsportscode : could not find Hudl Sportscode.app
2024-12-05 14:44:06 : INFO  : hudlsportscode : appversion: 
2024-12-05 14:44:06 : INFO  : hudlsportscode : Latest version of Hudl Sportscode is 12.46.0
2024-12-05 14:44:06 : REQ   : hudlsportscode : Downloading https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-12.46.0.dmg.zip to Hudl Sportscode.zip
2024-12-05 14:44:06 : DEBUG : hudlsportscode : No Dialog connection, just download
2024-12-05 14:44:38 : DEBUG : hudlsportscode : File list: -rw-r--r--  1 testuser  staff   114M Dec  5 14:44 Hudl Sportscode.zip
2024-12-05 14:44:38 : DEBUG : hudlsportscode : File type: Hudl Sportscode.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2024-12-05 14:44:38 : DEBUG : hudlsportscode : curl output was:
* Host sportscode64-updates.s3.amazonaws.com:443 was resolved.
* IPv6: (none)
* IPv4: 52.217.199.81, 54.231.236.145, 3.5.27.235, 52.217.233.233, 52.216.29.252, 16.182.41.73, 3.5.0.29, 3.5.10.223
*   Trying 52.217.199.81:443...
* Connected to sportscode64-updates.s3.amazonaws.com (52.217.199.81) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [342 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4980 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.amazonaws.com
*  start date: Apr 22 00:00:00 2024 GMT
*  expire date: Apr  7 23:59:59 2025 GMT
*  subjectAltName: host "sportscode64-updates.s3.amazonaws.com" matched cert's "*.s3.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /PublicReleaseDmgs/HudlSportscode-12.46.0.dmg.zip HTTP/1.1
> Host: sportscode64-updates.s3.amazonaws.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< x-amz-id-2: i6Mn6bm13iWkJ8YAsuFUh7uty9BIg8R7gfnS9cYM+cTP6MUWUWMcMto0QiG4swTYVZa5LgmwEiE=
< x-amz-request-id: 4ZMXJMNKXS1BQCX2
< Date: Thu, 05 Dec 2024 20:44:07 GMT
< Last-Modified: Tue, 26 Nov 2024 15:55:24 GMT
< ETag: "7529a7e99fb81b6a693e1c1265ad0494-15"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: OzqUKstSHYHSMgZkfBEcSVkp4YR3q22l
< Accept-Ranges: bytes
< Content-Type: application/zip
< Content-Length: 119371651
< Server: AmazonS3
< 
{ [16384 bytes data]
* Connection #0 to host sportscode64-updates.s3.amazonaws.com left intact

2024-12-05 14:44:38 : REQ   : hudlsportscode : no more blocking processes, continue with update
2024-12-05 14:44:38 : REQ   : hudlsportscode : Installing Hudl Sportscode
2024-12-05 14:44:38 : INFO  : hudlsportscode : Unzipping Hudl Sportscode.zip
2024-12-05 14:44:38 : INFO  : hudlsportscode : found dmg: /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7/HudlSportscode.dmg
2024-12-05 14:44:38 : INFO  : hudlsportscode : Mounting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7/HudlSportscode.dmg
2024-12-05 14:44:42 : DEBUG : hudlsportscode : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D2E71997
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1AE4D80E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2065878D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $9EC2BF6A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2065878D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $37056EEB
verified   CRC32 $491A700B
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Hudl Sportscode

2024-12-05 14:44:42 : INFO  : hudlsportscode : Mounted: /Volumes/Hudl Sportscode
2024-12-05 14:44:42 : INFO  : hudlsportscode : Verifying: /Volumes/Hudl Sportscode/Hudl Sportscode.app
2024-12-05 14:44:42 : DEBUG : hudlsportscode : App size: 300M	/Volumes/Hudl Sportscode/Hudl Sportscode.app
2024-12-05 14:44:45 : DEBUG : hudlsportscode : Debugging enabled, App Verification output was:
/Volumes/Hudl Sportscode/Hudl Sportscode.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Agile Sports Technologies (4M6T2C723P)

2024-12-05 14:44:45 : INFO  : hudlsportscode : Team ID matching: 4M6T2C723P (expected: 4M6T2C723P )
2024-12-05 14:44:45 : INFO  : hudlsportscode : Installing Hudl Sportscode version 56598.bd01df2 on versionKey CFBundleVersion.
2024-12-05 14:44:45 : INFO  : hudlsportscode : App has LSMinimumSystemVersion: 13.0
2024-12-05 14:44:45 : INFO  : hudlsportscode : Copy /Volumes/Hudl Sportscode/Hudl Sportscode.app to /Applications
2024-12-05 14:44:48 : DEBUG : hudlsportscode : Debugging enabled, App copy output was:
Copying /Volumes/Hudl Sportscode/Hudl Sportscode.app

2024-12-05 14:44:48 : WARN  : hudlsportscode : Changing owner to testuser
2024-12-05 14:44:48 : INFO  : hudlsportscode : Finishing...
2024-12-05 14:44:51 : INFO  : hudlsportscode : App(s) found: /Applications/Hudl Sportscode.app
2024-12-05 14:44:51 : INFO  : hudlsportscode : found app at /Applications/Hudl Sportscode.app, version 56598.bd01df2, on versionKey CFBundleVersion
2024-12-05 14:44:51 : REQ   : hudlsportscode : Installed Hudl Sportscode, version 56598.bd01df2
2024-12-05 14:44:51 : INFO  : hudlsportscode : notifying
2024-12-05 14:44:51 : DEBUG : hudlsportscode : Unmounting /Volumes/Hudl Sportscode
2024-12-05 14:44:52 : DEBUG : hudlsportscode : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-05 14:44:52 : DEBUG : hudlsportscode : Deleting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7
2024-12-05 14:44:52 : DEBUG : hudlsportscode : Debugging enabled, Deleting tmpDir output was:
/var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7/HudlSportscode.dmg
2024-12-05 14:44:52 : DEBUG : hudlsportscode : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7/Hudl Sportscode.zip
2024-12-05 14:44:52 : DEBUG : hudlsportscode : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.PGuANTfds7
2024-12-05 14:44:52 : INFO  : hudlsportscode : Installomator did not close any apps, so no need to reopen any apps.
2024-12-05 14:44:52 : REQ   : hudlsportscode : All done!
2024-12-05 14:44:52 : REQ   : hudlsportscode : ################## End Installomator, exit code 0 
```