### PR TITLE
New Label for DCP-o-matic 2

### DIFF
--- a/fragments/labels/DCP-o-matic.sh
+++ b/fragments/labels/DCP-o-matic.sh
@@ -1,0 +1,8 @@
+dcp-o-matic|dcpomatic|dcp-o-matic2|dcpomatic2)
+    name="DCP-o-matic 2"
+    type="dmg"
+    appNewVersion=$(curl -fs https://dcpomatic.com/download | grep "Stable release: " | awk -F '</p>' '{print $1}' | grep -o -e "[0-9.]*")
+    downloadURL="https://dcpomatic.com/dl.php?id=osx-10.10-main&version=$appNewVersion&paid=0"
+	versionKey="CFBundleVersion"
+    expectedTeamID="R82DXSR997"
+    ;;


### PR DESCRIPTION
Output for `./utils/assemble.sh dcpomatic2 DEBUG=0` 
```
2024-12-05 14:55:07 : REQ   : dcpomatic2 : ################## Start Installomator v. 10.6, date 2024-12-05
2024-12-05 14:55:07 : INFO  : dcpomatic2 : ################## Version: 10.6
2024-12-05 14:55:07 : INFO  : dcpomatic2 : ################## Date: 2024-12-05
2024-12-05 14:55:07 : INFO  : dcpomatic2 : ################## dcpomatic2
2024-12-05 14:55:07 : DEBUG : dcpomatic2 : DEBUG mode 1 enabled.
2024-12-05 14:55:08 : INFO  : dcpomatic2 : setting variable from argument DEBUG=0
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : name=DCP-o-matic 2
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : appName=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : type=dmg
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : archiveName=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : downloadURL=https://dcpomatic.com/dl.php?id=osx-10.10-main&version=2.16.98&paid=0
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : curlOptions=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : appNewVersion=2.16.98
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : appCustomVersion function: Not defined
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : versionKey=CFBundleVersion
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : packageID=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : pkgName=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : choiceChangesXML=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : expectedTeamID=R82DXSR997
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : blockingProcesses=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : installerTool=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : CLIInstaller=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : CLIArguments=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : updateTool=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : updateToolArguments=
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : updateToolRunAsCurrentUser=
2024-12-05 14:55:08 : INFO  : dcpomatic2 : BLOCKING_PROCESS_ACTION=tell_user
2024-12-05 14:55:08 : INFO  : dcpomatic2 : NOTIFY=success
2024-12-05 14:55:08 : INFO  : dcpomatic2 : LOGGING=DEBUG
2024-12-05 14:55:08 : INFO  : dcpomatic2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-05 14:55:08 : INFO  : dcpomatic2 : Label type: dmg
2024-12-05 14:55:08 : INFO  : dcpomatic2 : archiveName: DCP-o-matic 2.dmg
2024-12-05 14:55:08 : INFO  : dcpomatic2 : no blocking processes defined, using DCP-o-matic 2 as default
2024-12-05 14:55:08 : DEBUG : dcpomatic2 : Changing directory to /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.CZhiyTE1tt
2024-12-05 14:55:09 : INFO  : dcpomatic2 : name: DCP-o-matic 2, appName: DCP-o-matic 2.app
2024-12-05 14:55:09.037 mdfind[27507:5010910] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-12-05 14:55:09.038 mdfind[27507:5010910] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-12-05 14:55:09.137 mdfind[27507:5010910] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-05 14:55:09 : WARN  : dcpomatic2 : No previous app found
2024-12-05 14:55:09 : WARN  : dcpomatic2 : could not find DCP-o-matic 2.app
2024-12-05 14:55:09 : INFO  : dcpomatic2 : appversion: 
2024-12-05 14:55:09 : INFO  : dcpomatic2 : Latest version of DCP-o-matic 2 is 2.16.98
2024-12-05 14:55:09 : REQ   : dcpomatic2 : Downloading https://dcpomatic.com/dl.php?id=osx-10.10-main&version=2.16.98&paid=0 to DCP-o-matic 2.dmg
2024-12-05 14:55:09 : DEBUG : dcpomatic2 : No Dialog connection, just download
2024-12-05 14:56:16 : DEBUG : dcpomatic2 : File list: -rw-r--r--  1 testuser  staff   172M Dec  5 14:56 DCP-o-matic 2.dmg
2024-12-05 14:56:16 : DEBUG : dcpomatic2 : File type: DCP-o-matic 2.dmg: zlib compressed data
2024-12-05 14:56:16 : DEBUG : dcpomatic2 : curl output was:
* Host dcpomatic.com:443 was resolved.
* IPv6: (none)
* IPv4: 164.92.253.114
*   Trying 164.92.253.114:443...
* Connected to dcpomatic.com (164.92.253.114) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2631 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=carlh.net
*  start date: Oct 26 19:56:55 2024 GMT
*  expire date: Jan 24 19:56:54 2025 GMT
*  subjectAltName: host "dcpomatic.com" matched cert's "dcpomatic.com"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /dl.php?id=osx-10.10-main&version=2.16.98&paid=0 HTTP/1.1
> Host: dcpomatic.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off < HTTP/1.1 200 OK
< Date: Thu, 05 Dec 2024 20:55:09 GMT
< Server: Apache/2.4.62 (Debian)
< Strict-Transport-Security: max-age=63072000; includeSubdomains; < Set-Cookie: PHPSESSID=btmqqtmgkal3u214v028vo46ls; path=/ < Expires: 0
< Cache-Control: max-age=0
< Pragma: public
< Content-Description: File Transfer
< Content-Disposition: attachment; filename="DCP-o-matic 2.16.98 macOS10.10+.dmg" < Content-Transfer-Encoding: binary
< Last-Modified: Thu, 21 Nov 2024 07:43:57 GMT
< ETag: "ac61bd8-624811059c4a0"
< Content-Length: 180755416
< Content-Type: application/octet-stream
< 
{ [7631 bytes data]
* Connection #0 to host dcpomatic.com left intact

2024-12-05 14:56:16 : REQ   : dcpomatic2 : no more blocking processes, continue with update
2024-12-05 14:56:16 : REQ   : dcpomatic2 : Installing DCP-o-matic 2
2024-12-05 14:56:16 : INFO  : dcpomatic2 : Mounting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.CZhiyTE1tt/DCP-o-matic 2.dmg
2024-12-05 14:56:19 : DEBUG : dcpomatic2 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $10FA84A5
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B074E7B6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $21D24146
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $3F5C3864
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $21D24146
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CC692714
verified   CRC32 $612FF3E0
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/DCP-o-matic-2.16.98

2024-12-05 14:56:19 : INFO  : dcpomatic2 : Mounted: /Volumes/DCP-o-matic-2.16.98 2024-12-05 14:56:19 : INFO  : dcpomatic2 : Verifying: /Volumes/DCP-o-matic-2.16.98/DCP-o-matic 2.app 2024-12-05 14:56:19 : DEBUG : dcpomatic2 : App size: 477M	/Volumes/DCP-o-matic-2.16.98/DCP-o-matic 2.app 2024-12-05 14:56:23 : DEBUG : dcpomatic2 : Debugging enabled, App Verification output was: /Volumes/DCP-o-matic-2.16.98/DCP-o-matic 2.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Carl Hetherington (R82DXSR997)

2024-12-05 14:56:23 : INFO  : dcpomatic2 : Team ID matching: R82DXSR997 (expected: R82DXSR997 ) 2024-12-05 14:56:23 : INFO  : dcpomatic2 : Installing DCP-o-matic 2 version 2.16.98 on versionKey CFBundleVersion. 2024-12-05 14:56:23 : INFO  : dcpomatic2 : Copy /Volumes/DCP-o-matic-2.16.98/DCP-o-matic 2.app to /Applications 2024-12-05 14:56:24 : DEBUG : dcpomatic2 : Debugging enabled, App copy output was: Copying /Volumes/DCP-o-matic-2.16.98/DCP-o-matic 2.app

2024-12-05 14:56:24 : WARN  : dcpomatic2 : Changing owner to testuser 2024-12-05 14:56:24 : INFO  : dcpomatic2 : Finishing... 2024-12-05 14:56:27 : INFO  : dcpomatic2 : App(s) found: /Applications/DCP-o-matic 2.app 2024-12-05 14:56:27 : INFO  : dcpomatic2 : found app at /Applications/DCP-o-matic 2.app, version 2.16.98, on versionKey CFBundleVersion
2024-12-05 14:56:27 : REQ   : dcpomatic2 : Installed DCP-o-matic 2, version 2.16.98
2024-12-05 14:56:27 : INFO  : dcpomatic2 : notifying
2024-12-05 14:56:27 : DEBUG : dcpomatic2 : Unmounting /Volumes/DCP-o-matic-2.16.98
2024-12-05 14:56:27 : DEBUG : dcpomatic2 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-05 14:56:27 : DEBUG : dcpomatic2 : Deleting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.CZhiyTE1tt
2024-12-05 14:56:27 : DEBUG : dcpomatic2 : Debugging enabled, Deleting tmpDir output was:
/var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.CZhiyTE1tt/DCP-o-matic 2.dmg
2024-12-05 14:56:27 : DEBUG : dcpomatic2 : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.CZhiyTE1tt
2024-12-05 14:56:27 : INFO  : dcpomatic2 : Installomator did not close any apps, so no need to reopen any apps.
2024-12-05 14:56:27 : REQ   : dcpomatic2 : All done!
2024-12-05 14:56:27 : REQ   : dcpomatic2 : ################## End Installomator, exit code 0 
```