### PR TITLE
New Label for Synergy Editor Basketball

### DIFF
--- a/fragments/labels/SynergyEditorBasketball.sh
+++ b/fragments/labels/SynergyEditorBasketball.sh
@@ -1,0 +1,12 @@
+synergyeditor|synergyeditorbasketball)
+    name="Synergy Editor"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$( echo https://www.synergysportstech.com/apps/editor/basketball/macos/$(curl -s https://www.synergysportstech.com/apps/editor/basketball/macos/ | grep arm64.dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}' ))
+    else
+        downloadURL=$( echo https://www.synergysportstech.com/apps/editor/basketball/macos/$(curl -s https://www.synergysportstech.com/apps/editor/basketball/macos/ | grep x64.dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}' ))
+    fi
+    appNewVersion=$(curl -fs https://www.synergysportstech.com/apps/editor/basketball/macos/default.html | grep Version: | grep -o -e "[0-9.]*")
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="BATB6XS52B"
+    ;;


### PR DESCRIPTION
Output of `./utils/assemble.sh synergyeditorbasketball DEBUG=0`
```
2024-12-05 15:14:39 : REQ   : synergyeditorbasketball : ################## Start Installomator v. 10.6, date 2024-12-05
2024-12-05 15:14:39 : INFO  : synergyeditorbasketball : ################## Version: 10.6
2024-12-05 15:14:39 : INFO  : synergyeditorbasketball : ################## Date: 2024-12-05
2024-12-05 15:14:39 : INFO  : synergyeditorbasketball : ################## synergyeditorbasketball
2024-12-05 15:14:39 : DEBUG : synergyeditorbasketball : DEBUG mode 1 enabled.
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : setting variable from argument DEBUG=0
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : name=Synergy Editor
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : appName=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : type=dmg
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : archiveName=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : downloadURL=https://www.synergysportstech.com/apps/editor/basketball/macos/arm64/Synergy_Editor_12_4_1_46_arm64.dmg
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : curlOptions=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : appNewVersion=12.4.1.46
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : appCustomVersion function: Not defined
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : versionKey=CFBundleShortVersionString
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : packageID=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : pkgName=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : choiceChangesXML=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : expectedTeamID=BATB6XS52B
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : blockingProcesses=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : installerTool=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : CLIInstaller=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : CLIArguments=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : updateTool=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : updateToolArguments=
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : updateToolRunAsCurrentUser=
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : BLOCKING_PROCESS_ACTION=tell_user
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : NOTIFY=success
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : LOGGING=DEBUG
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : Label type: dmg
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : archiveName: Synergy Editor.dmg
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : no blocking processes defined, using Synergy Editor as default
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : Changing directory to /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.ctBSY7SsXa
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : name: Synergy Editor, appName: Synergy Editor.app
2024-12-05 15:14:40.677 mdfind[29977:5047389] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-12-05 15:14:40.678 mdfind[29977:5047389] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-12-05 15:14:40.738 mdfind[29977:5047389] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-05 15:14:40 : WARN  : synergyeditorbasketball : No previous app found
2024-12-05 15:14:40 : WARN  : synergyeditorbasketball : could not find Synergy Editor.app
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : appversion: 
2024-12-05 15:14:40 : INFO  : synergyeditorbasketball : Latest version of Synergy Editor is 12.4.1.46
2024-12-05 15:14:40 : REQ   : synergyeditorbasketball : Downloading https://www.synergysportstech.com/apps/editor/basketball/macos/arm64/Synergy_Editor_12_4_1_46_arm64.dmg to Synergy Editor.dmg
2024-12-05 15:14:40 : DEBUG : synergyeditorbasketball : No Dialog connection, just download
2024-12-05 15:15:00 : DEBUG : synergyeditorbasketball : File list: -rw-r--r--  1 testuser  staff    88M Dec  5 15:15 Synergy Editor.dmg
2024-12-05 15:15:00 : DEBUG : synergyeditorbasketball : File type: Synergy Editor.dmg: lzfse encoded, lzvn compressed
2024-12-05 15:15:00 : DEBUG : synergyeditorbasketball : curl output was:
* Host www.synergysportstech.com:443 was resolved.
* IPv6: (none)
* IPv4: 99.84.160.89, 99.84.160.105, 99.84.160.51, 99.84.160.84
*   Trying 99.84.160.89:443...
* Connected to www.synergysportstech.com (99.84.160.89) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [330 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5158 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.synergysportstech.com
*  start date: Nov 14 17:15:30 2024 GMT
*  expire date: Dec 16 17:15:30 2025 GMT
*  subjectAltName: host "www.synergysportstech.com" matched cert's "*.synergysportstech.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.synergysportstech.com/apps/editor/basketball/macos/arm64/Synergy_Editor_12_4_1_46_arm64.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.synergysportstech.com]
* [HTTP/2] [1] [:path: /apps/editor/basketball/macos/arm64/Synergy_Editor_12_4_1_46_arm64.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /apps/editor/basketball/macos/arm64/Synergy_Editor_12_4_1_46_arm64.dmg HTTP/2
> Host: www.synergysportstech.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 92711509
< last-modified: Wed, 13 Nov 2024 16:29:28 GMT
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< date: Wed, 04 Dec 2024 21:54:55 GMT
< etag: "d707d2b9bd9ecd58972f20a02f353a94-18"
< x-cache: Hit from cloudfront
< via: 1.1 e385fbaea7c648ad7e4ea77cdc0acd94.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD52-C2
< x-amz-cf-id: 0PR3FtR2AKNSJdC-GVLhTR7V24FGGAIynsj5PauLkJLdMZ6ICRieTw==
< age: 83987
< 
{ [8192 bytes data]
* Connection #0 to host www.synergysportstech.com left intact

2024-12-05 15:15:00 : REQ   : synergyeditorbasketball : no more blocking processes, continue with update
2024-12-05 15:15:00 : REQ   : synergyeditorbasketball : Installing Synergy Editor
2024-12-05 15:15:00 : INFO  : synergyeditorbasketball : Mounting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.ctBSY7SsXa/Synergy Editor.dmg
2024-12-05 15:15:01 : DEBUG : synergyeditorbasketball : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7EEE950A
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E524970A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DB8A9333
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $B4913E54
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DB8A9333
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $C3D3A19F
verified   CRC32 $D03D2C3B
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Synergy Editor

2024-12-05 15:15:01 : INFO  : synergyeditorbasketball : Mounted: /Volumes/Synergy Editor
2024-12-05 15:15:01 : INFO  : synergyeditorbasketball : Verifying: /Volumes/Synergy Editor/Synergy Editor.app
2024-12-05 15:15:01 : DEBUG : synergyeditorbasketball : App size: 239M	/Volumes/Synergy Editor/Synergy Editor.app
2024-12-05 15:15:02 : DEBUG : synergyeditorbasketball : Debugging enabled, App Verification output was:
/Volumes/Synergy Editor/Synergy Editor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Synergy Sports Technology, LLC (BATB6XS52B)

2024-12-05 15:15:02 : INFO  : synergyeditorbasketball : Team ID matching: BATB6XS52B (expected: BATB6XS52B )
2024-12-05 15:15:02 : INFO  : synergyeditorbasketball : Installing Synergy Editor version 12.4.1.46 on versionKey CFBundleShortVersionString.
2024-12-05 15:15:02 : INFO  : synergyeditorbasketball : App has LSMinimumSystemVersion: 10.15
2024-12-05 15:15:02 : INFO  : synergyeditorbasketball : Copy /Volumes/Synergy Editor/Synergy Editor.app to /Applications
2024-12-05 15:15:02 : DEBUG : synergyeditorbasketball : Debugging enabled, App copy output was:
Copying /Volumes/Synergy Editor/Synergy Editor.app

2024-12-05 15:15:02 : WARN  : synergyeditorbasketball : Changing owner to testuser
2024-12-05 15:15:02 : INFO  : synergyeditorbasketball : Finishing...
2024-12-05 15:15:05 : INFO  : synergyeditorbasketball : App(s) found: /Applications/Synergy Editor.app
2024-12-05 15:15:05 : INFO  : synergyeditorbasketball : found app at /Applications/Synergy Editor.app, version 12.4.1.46, on versionKey CFBundleShortVersionString
2024-12-05 15:15:05 : REQ   : synergyeditorbasketball : Installed Synergy Editor, version 12.4.1.46
2024-12-05 15:15:05 : INFO  : synergyeditorbasketball : notifying
2024-12-05 15:15:06 : DEBUG : synergyeditorbasketball : Unmounting /Volumes/Synergy Editor
2024-12-05 15:15:06 : DEBUG : synergyeditorbasketball : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-05 15:15:06 : DEBUG : synergyeditorbasketball : Deleting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.ctBSY7SsXa
2024-12-05 15:15:06 : DEBUG : synergyeditorbasketball : Debugging enabled, Deleting tmpDir output was:
/var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.ctBSY7SsXa/Synergy Editor.dmg
2024-12-05 15:15:06 : DEBUG : synergyeditorbasketball : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.ctBSY7SsXa
2024-12-05 15:15:06 : INFO  : synergyeditorbasketball : Installomator did not close any apps, so no need to reopen any apps.
2024-12-05 15:15:06 : REQ   : synergyeditorbasketball : All done!
2024-12-05 15:15:06 : REQ   : synergyeditorbasketball : ################## End Installomator, exit code 0 
```