### PR TITLE
New Label for Synergy Video Express

### DIFF
--- a/fragments/labels/SynergyVideoExpress.sh
+++ b/fragments/labels/SynergyVideoExpress.sh
@@ -1,0 +1,10 @@
+synergyvideoexpress)
+    name="Synergy Video Express"
+    type="dmg"
+    relativeDownloadURL="$(curl -fsL https://www.synergysportstech.com/apps/videoexpress/production/macOS/default.htm | grep -Eo 'Synergy_Video_Express_[^"]+\.dmg' | head -1)"
+    downloadURL="https://www.synergysportstech.com/apps/videoexpress/production/macOS/${relativeDownloadURL}"
+    appNewVersion=$(echo "$relativeDownloadURL" | sed -E 's/.*_([0-9]+_[0-9]+_[0-9]+_[0-9]+)\.dmg/\1/' | tr '_' '.')
+    expectedTeamID="BATB6XS52B"
+    appName="Synergy Video Express.app"
+    blockingProcesses=( "Synergy Video Express" )
+    ;;


### PR DESCRIPTION
Output of `./utils/assemble.sh synergyvideoexpress DEBUG=0`
```
2024-12-05 15:39:56 : REQ   : synergyvideoexpress : ################## Start Installomator v. 10.6, date 2024-12-05
2024-12-05 15:39:56 : INFO  : synergyvideoexpress : ################## Version: 10.6
2024-12-05 15:39:56 : INFO  : synergyvideoexpress : ################## Date: 2024-12-05
2024-12-05 15:39:56 : INFO  : synergyvideoexpress : ################## synergyvideoexpress
2024-12-05 15:39:56 : DEBUG : synergyvideoexpress : DEBUG mode 1 enabled.
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : setting variable from argument DEBUG=0
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : name=Synergy Video Express
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : appName=Synergy Video Express.app
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : type=dmg
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : archiveName=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : downloadURL=https://www.synergysportstech.com/apps/videoexpress/production/macOS/Synergy_Video_Express_1_1_4_121.dmg
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : curlOptions=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : appNewVersion=1.1.4.121
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : appCustomVersion function: Not defined
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : versionKey=CFBundleShortVersionString
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : packageID=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : pkgName=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : choiceChangesXML=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : expectedTeamID=BATB6XS52B
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : blockingProcesses=Synergy Video Express
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : installerTool=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : CLIInstaller=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : CLIArguments=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : updateTool=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : updateToolArguments=
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : updateToolRunAsCurrentUser=
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : BLOCKING_PROCESS_ACTION=tell_user
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : NOTIFY=success
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : LOGGING=DEBUG
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : Label type: dmg
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : archiveName: Synergy Video Express.dmg
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : Changing directory to /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.s5WXmnCnWO
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : name: Synergy Video Express, appName: Synergy Video Express.app
2024-12-05 15:39:57.358 mdfind[31684:5087038] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2024-12-05 15:39:57.358 mdfind[31684:5087038] [UserQueryParser] Loading keywords and predicates for locale "en"
2024-12-05 15:39:57.463 mdfind[31684:5087038] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-05 15:39:57 : WARN  : synergyvideoexpress : No previous app found
2024-12-05 15:39:57 : WARN  : synergyvideoexpress : could not find Synergy Video Express.app
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : appversion: 
2024-12-05 15:39:57 : INFO  : synergyvideoexpress : Latest version of Synergy Video Express is 1.1.4.121
2024-12-05 15:39:57 : REQ   : synergyvideoexpress : Downloading https://www.synergysportstech.com/apps/videoexpress/production/macOS/Synergy_Video_Express_1_1_4_121.dmg to Synergy Video Express.dmg
2024-12-05 15:39:57 : DEBUG : synergyvideoexpress : No Dialog connection, just download
2024-12-05 15:40:09 : DEBUG : synergyvideoexpress : File list: -rw-r--r--  1 testuser  staff    55M Dec  5 15:40 Synergy Video Express.dmg
2024-12-05 15:40:09 : DEBUG : synergyvideoexpress : File type: Synergy Video Express.dmg: lzfse encoded, lzvn compressed
2024-12-05 15:40:09 : DEBUG : synergyvideoexpress : curl output was:
* Host www.synergysportstech.com:443 was resolved.
* IPv6: (none)
* IPv4: 99.84.160.84, 99.84.160.89, 99.84.160.105, 99.84.160.51
*   Trying 99.84.160.84:443...
* Connected to www.synergysportstech.com (99.84.160.84) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [330 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5158 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.synergysportstech.com
*  start date: Nov 14 17:15:30 2024 GMT
*  expire date: Dec 16 17:15:30 2025 GMT
*  subjectAltName: host "www.synergysportstech.com" matched cert's "*.synergysportstech.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.synergysportstech.com/apps/videoexpress/production/macOS/Synergy_Video_Express_1_1_4_121.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.synergysportstech.com]
* [HTTP/2] [1] [:path: /apps/videoexpress/production/macOS/Synergy_Video_Express_1_1_4_121.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /apps/videoexpress/production/macOS/Synergy_Video_Express_1_1_4_121.dmg HTTP/2
> Host: www.synergysportstech.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/octet-stream
< content-length: 57708023
< last-modified: Mon, 11 Nov 2024 11:48:56 GMT
< x-amz-server-side-encryption: AES256
< accept-ranges: bytes
< server: AmazonS3
< date: Thu, 05 Dec 2024 03:48:09 GMT
< etag: "d10f62119cb12521c460c08efcff7dd1-12"
< x-cache: Hit from cloudfront
< via: 1.1 8aaf7991e324696a1356521b2694d9b4.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD52-C2
< x-amz-cf-id: LmvxAcM9LE07cOsK-dI_T2aR_mUKFA8fT1L1OkpoY--w17amZo2MAg==
< age: 64309
< 
{ [3198 bytes data]
* Connection #0 to host www.synergysportstech.com left intact

2024-12-05 15:40:09 : REQ   : synergyvideoexpress : no more blocking processes, continue with update
2024-12-05 15:40:09 : REQ   : synergyvideoexpress : Installing Synergy Video Express
2024-12-05 15:40:09 : INFO  : synergyvideoexpress : Mounting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.s5WXmnCnWO/Synergy Video Express.dmg
2024-12-05 15:40:12 : DEBUG : synergyvideoexpress : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C7C286DB
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $6676EDE6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9478EFC2
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $A5D1F930
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9478EFC2
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $B6F0C9D1
verified   CRC32 $32AD53D3
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Synergy Video Express

2024-12-05 15:40:12 : INFO  : synergyvideoexpress : Mounted: /Volumes/Synergy Video Express
2024-12-05 15:40:12 : INFO  : synergyvideoexpress : Verifying: /Volumes/Synergy Video Express/Synergy Video Express.app
2024-12-05 15:40:12 : DEBUG : synergyvideoexpress : App size: 130M	/Volumes/Synergy Video Express/Synergy Video Express.app
2024-12-05 15:40:14 : DEBUG : synergyvideoexpress : Debugging enabled, App Verification output was:
/Volumes/Synergy Video Express/Synergy Video Express.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Synergy Sports Technology, LLC (BATB6XS52B)

2024-12-05 15:40:14 : INFO  : synergyvideoexpress : Team ID matching: BATB6XS52B (expected: BATB6XS52B )
2024-12-05 15:40:14 : INFO  : synergyvideoexpress : Installing Synergy Video Express version 1.1.4.121 on versionKey CFBundleShortVersionString.
2024-12-05 15:40:14 : INFO  : synergyvideoexpress : App has LSMinimumSystemVersion: 10.13
2024-12-05 15:40:14 : INFO  : synergyvideoexpress : Copy /Volumes/Synergy Video Express/Synergy Video Express.app to /Applications
2024-12-05 15:40:14 : DEBUG : synergyvideoexpress : Debugging enabled, App copy output was:
Copying /Volumes/Synergy Video Express/Synergy Video Express.app

2024-12-05 15:40:14 : WARN  : synergyvideoexpress : Changing owner to testuser
2024-12-05 15:40:14 : INFO  : synergyvideoexpress : Finishing...
2024-12-05 15:40:17 : INFO  : synergyvideoexpress : App(s) found: /Applications/Synergy Video Express.app
2024-12-05 15:40:18 : INFO  : synergyvideoexpress : found app at /Applications/Synergy Video Express.app, version 1.1.4.121, on versionKey CFBundleShortVersionString
2024-12-05 15:40:18 : REQ   : synergyvideoexpress : Installed Synergy Video Express, version 1.1.4.121
2024-12-05 15:40:18 : INFO  : synergyvideoexpress : notifying
2024-12-05 15:40:18 : DEBUG : synergyvideoexpress : Unmounting /Volumes/Synergy Video Express
2024-12-05 15:40:18 : DEBUG : synergyvideoexpress : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-05 15:40:18 : DEBUG : synergyvideoexpress : Deleting /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.s5WXmnCnWO
2024-12-05 15:40:18 : DEBUG : synergyvideoexpress : Debugging enabled, Deleting tmpDir output was:
/var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.s5WXmnCnWO/Synergy Video Express.dmg
2024-12-05 15:40:18 : DEBUG : synergyvideoexpress : /var/folders/dw/l8d118ms5ll8tgl771y4p4g80000gp/T/tmp.s5WXmnCnWO
2024-12-05 15:40:18 : INFO  : synergyvideoexpress : Installomator did not close any apps, so no need to reopen any apps.
2024-12-05 15:40:18 : REQ   : synergyvideoexpress : All done!
2024-12-05 15:40:18 : REQ   : synergyvideoexpress : ################## End Installomator, exit code 0 
```