### PR TITLE
New OneDrive labels that pull from the same feed as the OneDrive StandaloneUpdater tool

### DIFF
--- a/fragments/labels/microsoftonedrivesuinsiders.sh
+++ b/fragments/labels/microsoftonedrivesuinsiders.sh
@@ -1,0 +1,10 @@
+microsoftonedrivesuinsiders)
+    # This label uses the same XML feed that the OneDrive StandaloneUpdater tool uses to find the Insiders version of OneDrive updates.
+    # Microsoft OneDrive StandaloneUpdater Insiders
+    name="OneDrive"
+    type="pkg"
+    onedriveFeed="https://g.live.com/0USSDMC_W5T/MacODSUInsiders"
+    downloadURL="$(curl -fsL "${onedriveFeed}" | grep -A1 "UniversalPkgBinaryURL" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
+    appNewVersion="$(curl -fsL "${onedriveFeed}" | grep -A1 "CFBundleShortVersionString" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
+    expectedTeamID="UBF8T346G9"
+    ;;

--- a/fragments/labels/microsoftonedrivesuprod.sh
+++ b/fragments/labels/microsoftonedrivesuprod.sh
@@ -1,0 +1,10 @@
+microsoftonedrivesuprod)
+    # This label uses the same XML feed that the OneDrive StandaloneUpdater tool uses to find the production version of OneDrive updates.
+    # Microsoft OneDrive StandaloneUpdater Production
+    name="OneDrive"
+    type="pkg"
+    onedriveFeed="https://g.live.com/0USSDMC_W5T/MacODSUProduction"
+    downloadURL="$(curl -fsL "${onedriveFeed}" | grep -A1 "UniversalPkgBinaryURL" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
+    appNewVersion="$(curl -fsL "${onedriveFeed}" | grep -A1 "CFBundleShortVersionString" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
+    expectedTeamID="UBF8T346G9"
+    ;;


### PR DESCRIPTION
This uses the same XML feeds that the OneDrive StandaloneUpdater tool uses to update the app. Two labels included. One for the Production feed, the other for the Insiders feed.