### PR TITLE
Add Cinema 4D 2025

### DIFF
--- a/fragments/labels/cinema4d2025.sh
+++ b/fragments/labels/cinema4d2025.sh
@@ -1,0 +1,16 @@
+cinema4d2025)
+    name="Cinema 4D"
+    type="dmg"
+    appCustomVersion(){
+      defaults read "/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "2025+\.[0-9]+\.[0-9]+"
+    }
+    productDownloadsPage=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*downloads/cinema-4d-2025[^"]*' | head -1)
+    downloadURL=$(curl -fsL $productDownloadsPage | grep -oE 'https://[^"]*\.dmg' | head -1)
+    appNewVersion=$(sed -E 's/.*_([0-9.]*)_Mac\.dmg/\1/g' <<< $downloadURL)
+    targetDir="/Applications/Maxon Cinema 4D 2025"
+    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/${appNewVersion}/Cinema4D_2025_${appNewVersion}_Mac.dmg"
+    installerTool="Maxon Cinema 4D Installer.app"
+    CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=(--mode unattended --unattendedmodeui none)
+    expectedTeamID="4ZY22YGXQG"
+    ;;


### PR DESCRIPTION
I continue my quest for separate C4D labels (#1607).

assemble.sh without installed app:
```➜  Installomator git:(add_cinema4d_2025) ✗ sudo utils/assemble.sh cinema4d2025
Password:
2024-12-10 14:49:23 : REQ   : cinema4d2025 : ################## Start Installomator v. 10.7beta, date 2024-12-10
2024-12-10 14:49:23 : INFO  : cinema4d2025 : ################## Version: 10.7beta
2024-12-10 14:49:23 : INFO  : cinema4d2025 : ################## Date: 2024-12-10
2024-12-10 14:49:23 : INFO  : cinema4d2025 : ################## cinema4d2025
2024-12-10 14:49:23 : DEBUG : cinema4d2025 : DEBUG mode 1 enabled.
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : name=Cinema 4D
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : appName=
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : type=dmg
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : archiveName=
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2025.1.0/Cinema4D_2025_2025.1.0_Mac.dmg
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : curlOptions=
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : appNewVersion=2025.1.0
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : appCustomVersion function: Defined. 
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : versionKey=CFBundleShortVersionString
2024-12-10 14:49:27 : DEBUG : cinema4d2025 : packageID=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : pkgName=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : choiceChangesXML=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : expectedTeamID=4ZY22YGXQG
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : blockingProcesses=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : installerTool=Maxon Cinema 4D Installer.app
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : CLIInstaller=Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : CLIArguments=--mode unattended --unattendedmodeui none
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : updateTool=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : updateToolArguments=
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : updateToolRunAsCurrentUser=
2024-12-10 14:49:28 : INFO  : cinema4d2025 : BLOCKING_PROCESS_ACTION=tell_user
2024-12-10 14:49:28 : INFO  : cinema4d2025 : NOTIFY=success
2024-12-10 14:49:28 : INFO  : cinema4d2025 : LOGGING=DEBUG
2024-12-10 14:49:28 : INFO  : cinema4d2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-10 14:49:28 : INFO  : cinema4d2025 : Label type: dmg
2024-12-10 14:49:28 : INFO  : cinema4d2025 : archiveName: Cinema 4D.dmg
2024-12-10 14:49:28 : INFO  : cinema4d2025 : no blocking processes defined, using Cinema 4D as default
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : Changing directory to /path/to/git/repo/Installomator/build
2024-12-10 14:49:28.322 defaults[23099:58525073] 
The domain/default pair of (/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/Info.plist, CFBundleGetInfoString) does not exist
2024-12-10 14:49:28 : INFO  : cinema4d2025 : Custom App Version detection is used, found 
2024-12-10 14:49:28 : INFO  : cinema4d2025 : appversion: 
2024-12-10 14:49:28 : INFO  : cinema4d2025 : Latest version of Cinema 4D is 2025.1.0
2024-12-10 14:49:28 : INFO  : cinema4d2025 : Cinema 4D.dmg exists and DEBUG mode 1 enabled, skipping download
2024-12-10 14:49:28 : DEBUG : cinema4d2025 : DEBUG mode 1, not checking for blocking processes
2024-12-10 14:49:28 : REQ   : cinema4d2025 : Installing Cinema 4D
2024-12-10 14:49:28 : REQ   : cinema4d2025 : installerTool used: Maxon Cinema 4D Installer.app
2024-12-10 14:49:28 : INFO  : cinema4d2025 : Mounting /path/to/git/repo/Installomator/build/Cinema 4D.dmg
2024-12-10 14:49:29 : DEBUG : cinema4d2025 : Debugging enabled, dmgmount output was:
förväntade   CRC32 $73206996
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            EFI
/dev/disk4s2            Apple_HFS                       /Volumes/Maxon Cinema 4D

2024-12-10 14:49:29 : INFO  : cinema4d2025 : Mounted: /Volumes/Maxon Cinema 4D
2024-12-10 14:49:29 : INFO  : cinema4d2025 : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-12-10 14:49:29 : DEBUG : cinema4d2025 : App size: 1.1G     /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-12-10 14:49:30 : DEBUG : cinema4d2025 : Debugging enabled, App Verification output was:
/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-12-10 14:49:30 : INFO  : cinema4d2025 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-12-10 14:49:30 : INFO  : cinema4d2025 : Installing Cinema 4D version 2025.1.0 on versionKey CFBundleShortVersionString.
2024-12-10 14:49:30 : DEBUG : cinema4d2025 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2024-12-10 14:49:30 : INFO  : cinema4d2025 : Finishing...
2024-12-10 14:49:33.905 defaults[23231:58525600] 
The domain/default pair of (/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/Info.plist, CFBundleGetInfoString) does not exist
2024-12-10 14:49:33 : INFO  : cinema4d2025 : Custom App Version detection is used, found 
2024-12-10 14:49:33 : REQ   : cinema4d2025 : Installed Cinema 4D, version 2025.1.0
2024-12-10 14:49:33 : INFO  : cinema4d2025 : notifying
2024-12-10 14:49:34 : DEBUG : cinema4d2025 : Unmounting /Volumes/Maxon Cinema 4D
2024-12-10 14:49:35 : DEBUG : cinema4d2025 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-10 14:49:35 : DEBUG : cinema4d2025 : DEBUG mode 1, not reopening anything
2024-12-10 14:49:35 : REQ   : cinema4d2025 : All done!
2024-12-10 14:49:35 : REQ   : cinema4d2025 : ################## End Installomator, exit code 0 
```

And assemble.sh after app is installed:
```➜  Installomator git:(add_cinema4d_2025) ✗ sudo utils/assemble.sh cinema4d2025        
2024-12-10 14:53:23 : REQ   : cinema4d2025 : ################## Start Installomator v. 10.7beta, date 2024-12-10
2024-12-10 14:53:23 : INFO  : cinema4d2025 : ################## Version: 10.7beta
2024-12-10 14:53:23 : INFO  : cinema4d2025 : ################## Date: 2024-12-10
2024-12-10 14:53:23 : INFO  : cinema4d2025 : ################## cinema4d2025
2024-12-10 14:53:23 : DEBUG : cinema4d2025 : DEBUG mode 1 enabled.
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : name=Cinema 4D
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : appName=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : type=dmg
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : archiveName=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2025.1.0/Cinema4D_2025_2025.1.0_Mac.dmg
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : curlOptions=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : appNewVersion=2025.1.0
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : appCustomVersion function: Defined. 
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : versionKey=CFBundleShortVersionString
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : packageID=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : pkgName=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : choiceChangesXML=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : expectedTeamID=4ZY22YGXQG
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : blockingProcesses=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : installerTool=Maxon Cinema 4D Installer.app
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : CLIInstaller=Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : CLIArguments=--mode unattended --unattendedmodeui none
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : updateTool=
2024-12-10 14:53:27 : DEBUG : cinema4d2025 : updateToolArguments=
2024-12-10 14:53:28 : DEBUG : cinema4d2025 : updateToolRunAsCurrentUser=
2024-12-10 14:53:28 : INFO  : cinema4d2025 : BLOCKING_PROCESS_ACTION=tell_user
2024-12-10 14:53:28 : INFO  : cinema4d2025 : NOTIFY=success
2024-12-10 14:53:28 : INFO  : cinema4d2025 : LOGGING=DEBUG
2024-12-10 14:53:28 : INFO  : cinema4d2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-10 14:53:28 : INFO  : cinema4d2025 : Label type: dmg
2024-12-10 14:53:28 : INFO  : cinema4d2025 : archiveName: Cinema 4D.dmg
2024-12-10 14:53:28 : INFO  : cinema4d2025 : no blocking processes defined, using Cinema 4D as default
2024-12-10 14:53:28 : DEBUG : cinema4d2025 : Changing directory to /path/to/git/repo/Installomator/build
2024-12-10 14:53:28 : INFO  : cinema4d2025 : Custom App Version detection is used, found 2025.1.0
2024-12-10 14:53:28 : INFO  : cinema4d2025 : appversion: 2025.1.0
2024-12-10 14:53:28 : INFO  : cinema4d2025 : Latest version of Cinema 4D is 2025.1.0
2024-12-10 14:53:28 : WARN  : cinema4d2025 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-12-10 14:53:28 : INFO  : cinema4d2025 : Cinema 4D.dmg exists and DEBUG mode 1 enabled, skipping download
2024-12-10 14:53:28 : DEBUG : cinema4d2025 : DEBUG mode 1, not checking for blocking processes
2024-12-10 14:53:28 : REQ   : cinema4d2025 : Installing Cinema 4D
2024-12-10 14:53:28 : REQ   : cinema4d2025 : installerTool used: Maxon Cinema 4D Installer.app
2024-12-10 14:53:28 : INFO  : cinema4d2025 : Mounting /path/to/git/repo/Installomator/build/Cinema 4D.dmg
2024-12-10 14:53:29 : DEBUG : cinema4d2025 : Debugging enabled, dmgmount output was:
förväntade   CRC32 $73206996
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            EFI
/dev/disk4s2            Apple_HFS                       /Volumes/Maxon Cinema 4D

2024-12-10 14:53:29 : INFO  : cinema4d2025 : Mounted: /Volumes/Maxon Cinema 4D
2024-12-10 14:53:29 : INFO  : cinema4d2025 : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-12-10 14:53:29 : DEBUG : cinema4d2025 : App size: 1.1G     /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2024-12-10 14:53:31 : DEBUG : cinema4d2025 : Debugging enabled, App Verification output was:
/Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2024-12-10 14:53:31 : INFO  : cinema4d2025 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2024-12-10 14:53:31 : INFO  : cinema4d2025 : Downloaded version of Cinema 4D is 2025.1.0 on versionKey CFBundleShortVersionString, same as installed.
2024-12-10 14:53:31 : DEBUG : cinema4d2025 : Unmounting /Volumes/Maxon Cinema 4D
2024-12-10 14:53:31 : DEBUG : cinema4d2025 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2024-12-10 14:53:31 : DEBUG : cinema4d2025 : DEBUG mode 1, not reopening anything
2024-12-10 14:53:32 : REG   : cinema4d2025 : No new version to install
2024-12-10 14:53:32 : REQ   : cinema4d2025 : ################## End Installomator, exit code 0 
```