### PR TITLE
Harmony SASE / Perimeter81 fix / update

### DIFF
--- a/fragments/labels/harmonysase.sh
+++ b/fragments/labels/harmonysase.sh
@@ -1,7 +1,9 @@
-perimeter81)
-    name="Perimeter 81"
+perimeter81|\
+harmonysase)
+    name="Harmony SASE"
+    #name="Perimeter 81"
     type="pkg"
-    pkgURL=$(curl -sL https://support.perimeter81.com/docs/downloading-the-agent | grep -o "Perimeter81.*.pkg")
+    pkgURL=$(curl -sL https://support.perimeter81.com/docs/downloading-the-agent | grep -o 'Harmony[^"]*.pkg')
     downloadURL="https://static.perimeter81.com/agents/mac/$pkgURL"
     appNewVersion="$(curl -fsIL "${downloadURL}" | grep -i ^x-amz-meta-version | sed -E 's/x-amz-meta-version: //' | cut -d"." -f1-3)"
     expectedTeamID="924635PD62"


### PR DESCRIPTION
Perimeter81 has rebranded as Harmony SASE, this PR adds a new trigger and fixes the pkgurl logic as the package name has changed.

Fix pkgURL for new product name
Rename fragment to new product name
Add new product name to case trigger

Fixes #1988