### PR TITLE
Add appCustomVersion to gpgsuite

### DIFF
--- a/fragments/labels/gpgsuite.sh
+++ b/fragments/labels/gpgsuite.sh
@@ -7,4 +7,5 @@ gpgsuite)
     appNewVersion=$(echo $downloadURL | cut -d "-" -f 2 | cut -d "." -f 1-2)
     expectedTeamID="PKV8ZPD836"
     blockingProcesses=( "GPG Keychain" )
+    appCustomVersion(){ defaults read /Library/Application\ Support/GPGTools/version.plist CFBundleShortVersionString }
     ;;


### PR DESCRIPTION
There's no app called "GPG Suite" (anymore?), but the installed version is written to a plist file in Application Support/GPGTools.
Theoretically the version could be read from "GPG Suite Updater.app" in the same directory but I believe that reading the plist will be more consistent over time.

```➜  Installomator git:(deploy) ✗ sudo ./assemble.sh gpgsuite
Password:
2024-12-13 08:46:19 : REQ   : gpgsuite : ################## Start Installomator v. 10.7beta, date 2024-12-13
2024-12-13 08:46:19 : INFO  : gpgsuite : ################## Version: 10.7beta
2024-12-13 08:46:19 : INFO  : gpgsuite : ################## Date: 2024-12-13
2024-12-13 08:46:19 : INFO  : gpgsuite : ################## gpgsuite
2024-12-13 08:46:20 : INFO  : gpgsuite : BLOCKING_PROCESS_ACTION=tell_user
2024-12-13 08:46:20 : INFO  : gpgsuite : NOTIFY=success
2024-12-13 08:46:20 : INFO  : gpgsuite : LOGGING=INFO
2024-12-13 08:46:20 : INFO  : gpgsuite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-13 08:46:20 : INFO  : gpgsuite : Label type: pkgInDmg
2024-12-13 08:46:20 : INFO  : gpgsuite : archiveName: GPG Suite.dmg
2024-12-13 08:46:20 : INFO  : gpgsuite : Custom App Version detection is used, found 2023.3
2024-12-13 08:46:20 : INFO  : gpgsuite : appversion: 2023.3
2024-12-13 08:46:20 : INFO  : gpgsuite : Latest version of GPG Suite is 2023.3
2024-12-13 08:46:20 : INFO  : gpgsuite : There is no newer version available.
2024-12-13 08:46:20 : INFO  : gpgsuite : Installomator did not close any apps, so no need to reopen any apps.
2024-12-13 08:46:20 : REQ   : gpgsuite : No newer version.
2024-12-13 08:46:20 : REQ   : gpgsuite : ################## End Installomator, exit code 0 
```