### PR TITLE
anydesk.sh: Update Team ID

### DIFF
--- a/fragments/labels/anydesk.sh
+++ b/fragments/labels/anydesk.sh
@@ -3,5 +3,5 @@ anydesk)
     type="dmg"
     downloadURL="https://download.anydesk.com/anydesk.dmg"
     appNewVersion="$(curl -fs https://anydesk.com/en/downloads/mac-os | grep -i "d-block" | grep -E -o ">v[0-9.]* .*MB" | sed -E 's/.*v([0-9.]*) .*/\1/g')"
-    expectedTeamID="KU6W3B6JMZ"
+    expectedTeamID="KHRWM533LU"
     ;;


### PR DESCRIPTION
Unsure when team ID changed. But verifying the app inside AnyDesk DMG shows the following:
```sh
# $ codesign -dvvv /Volumes/AnyDesk/AnyDesk.app 
Executable=/Volumes/AnyDesk/AnyDesk.app/Contents/MacOS/AnyDesk
Identifier=com.philandro.anydesk
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20500 size=82593 flags=0x10000(runtime) hashes=2570+7 location=embedded
Hash type=sha256 size=32
CandidateCDHash sha256=7e4cd1451027b76ea0ede4239563102703c1f395
CandidateCDHashFull sha256=7e4cd1451027b76ea0ede4239563102703c1f395c7e2ef6243960360d3bdfa6f
Hash choices=sha256
CMSDigest=7e4cd1451027b76ea0ede4239563102703c1f395c7e2ef6243960360d3bdfa6f
CMSDigestType=2
CDHash=7e4cd1451027b76ea0ede4239563102703c1f395
Signature size=9061
Authority=Developer ID Application: AnyDesk Software GmbH (KHRWM533LU)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Oct 30, 2024 at 8:20:39 AM
Info.plist entries=39
TeamIdentifier=KHRWM533LU
Runtime Version=14.4.0
Sealed Resources version=2 rules=13 files=126
Internal requirements count=1 size=184
```