### PR TITLE
acroniscyberprotectconnectagent.sh: Update Team ID

### DIFF
--- a/fragments/labels/acroniscyberprotectconnectagent.sh
+++ b/fragments/labels/acroniscyberprotectconnectagent.sh
@@ -6,6 +6,6 @@ remotixagent)
     downloadURL="https://go.acronis.com/AcronisCyberProtectConnect_AgentForMac"
     versionKey="CFBundleVersion"
     appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | sed -E 's/.*\/[a-zA-Z]*-[0-9.]*-([0-9.]*)\.pkg/\1/g')
-    expectedTeamID="H629V387SY"
+    expectedTeamID="ZU2TV78AA6"
     blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
Unsure when team ID changed. But verifying the PKG shows the following:
```sh
# $ pkgutil --check-signature AcronisCyberProtectConnectAgent-1.2.3-24916.pkg
Package "AcronisCyberProtectConnectAgent-1.2.3-24916.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2024-06-18 09:59:54 +0000
   Certificate Chain:
    1. Developer ID Installer: Acronis International GmbH (ZU2TV78AA6)
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           3D 0D C8 4F 85 19 A7 5D 9D 57 3D A2 B0 FF E1 91 55 FB 86 99 36 86 
           37 8C B9 03 E0 0C 72 CC CC 8E
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
           68 C5 BE 91 B5 A1 10 01 F0 24
```