### PR TITLE
Update DEPNotify download URL

### DIFF
--- a/fragments/labels/depnotify.sh
+++ b/fragments/labels/depnotify.sh
@@ -2,7 +2,7 @@ depnotify)
     name="DEPNotify"
     type="pkg"
     #packageID="menu.nomad.depnotify"
-    downloadURL="https://files.nomad.menu/DEPNotify.pkg"
+    downloadURL="https://files.jamfconnect.com/DEPNotify.pkg"
     #appNewVersion=$()
     expectedTeamID="VRPY9KHGX6"
     ;;

--- a/fragments/labels/depnotify.sh
+++ b/fragments/labels/depnotify.sh
@@ -1,8 +1,6 @@
 depnotify)
     name="DEPNotify"
     type="pkg"
-    #packageID="menu.nomad.depnotify"
     downloadURL="https://files.jamfconnect.com/DEPNotify.pkg"
-    #appNewVersion=$()
     expectedTeamID="VRPY9KHGX6"
     ;;


### PR DESCRIPTION
The old domain's SSL certificate has expired. Updating the domain to a new supported home with a valid SSL cert.

https://macadmins.slack.com/archives/C1Y2Y14QG/p1734470818166909?thread_ts=1734308012.355699&cid=C1Y2Y14QG

### Before

```
./Installomator.sh depnotify
2024-12-18 09:41:51 : REQ   : depnotify : ################## Start Installomator v. 10.7beta, date 2024-11-21
2024-12-18 09:41:51 : INFO  : depnotify : ################## Version: 10.7beta
2024-12-18 09:41:51 : INFO  : depnotify : ################## Date: 2024-11-21
2024-12-18 09:41:51 : INFO  : depnotify : ################## depnotify
2024-12-18 09:41:51 : DEBUG : depnotify : DEBUG mode 1 enabled.
2024-12-18 09:41:51 : DEBUG : depnotify : name=DEPNotify
2024-12-18 09:41:51 : DEBUG : depnotify : appName=
2024-12-18 09:41:51 : DEBUG : depnotify : type=pkg
2024-12-18 09:41:51 : DEBUG : depnotify : archiveName=
2024-12-18 09:41:51 : DEBUG : depnotify : downloadURL=https://files.nomad.menu/DEPNotify.pkg
2024-12-18 09:41:51 : DEBUG : depnotify : curlOptions=
2024-12-18 09:41:51 : DEBUG : depnotify : appNewVersion=
2024-12-18 09:41:51 : DEBUG : depnotify : appCustomVersion function: Not defined
2024-12-18 09:41:51 : DEBUG : depnotify : versionKey=CFBundleShortVersionString
2024-12-18 09:41:51 : DEBUG : depnotify : packageID=
2024-12-18 09:41:51 : DEBUG : depnotify : pkgName=
2024-12-18 09:41:51 : DEBUG : depnotify : choiceChangesXML=
2024-12-18 09:41:51 : DEBUG : depnotify : expectedTeamID=VRPY9KHGX6
2024-12-18 09:41:51 : DEBUG : depnotify : blockingProcesses=
2024-12-18 09:41:51 : DEBUG : depnotify : installerTool=
2024-12-18 09:41:51 : DEBUG : depnotify : CLIInstaller=
2024-12-18 09:41:51 : DEBUG : depnotify : CLIArguments=
2024-12-18 09:41:51 : DEBUG : depnotify : updateTool=
2024-12-18 09:41:51 : DEBUG : depnotify : updateToolArguments=
2024-12-18 09:41:51 : DEBUG : depnotify : updateToolRunAsCurrentUser=
2024-12-18 09:41:51 : INFO  : depnotify : BLOCKING_PROCESS_ACTION=tell_user
2024-12-18 09:41:51 : INFO  : depnotify : NOTIFY=success
2024-12-18 09:41:51 : INFO  : depnotify : LOGGING=DEBUG
2024-12-18 09:41:51 : INFO  : depnotify : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-18 09:41:51 : INFO  : depnotify : Label type: pkg
2024-12-18 09:41:51 : INFO  : depnotify : archiveName: DEPNotify.pkg
2024-12-18 09:41:51 : INFO  : depnotify : no blocking processes defined, using DEPNotify as default
2024-12-18 09:41:51 : DEBUG : depnotify : Changing directory to .
2024-12-18 09:41:51 : INFO  : depnotify : name: DEPNotify, appName: DEPNotify.app
2024-12-18 09:41:51.896 mdfind[45481:6410898] [UserQueryParser] Loading keywords and predicates for locale "en_AU"
2024-12-18 09:41:52.044 mdfind[45481:6410898] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-18 09:41:52 : WARN  : depnotify : No previous app found
2024-12-18 09:41:52 : WARN  : depnotify : could not find DEPNotify.app
2024-12-18 09:41:52 : INFO  : depnotify : appversion:
2024-12-18 09:41:52 : INFO  : depnotify : Latest version not specified.
2024-12-18 09:41:52 : REQ   : depnotify : Downloading https://files.nomad.menu/DEPNotify.pkg to DEPNotify.pkg
2024-12-18 09:41:52 : DEBUG : depnotify : No Dialog connection, just download
2024-12-18 09:41:52 : ERROR : depnotify : error downloading https://files.nomad.menu/DEPNotify.pkg
ls: DEPNotify.pkg: No such file or directory
2024-12-18 09:41:52 : ERROR : depnotify : File list:
2024-12-18 09:41:52 : ERROR : depnotify : File type: DEPNotify.pkg: cannot open `DEPNotify.pkg' (No such file or directory)
2024-12-18 09:41:52 : DEBUG : depnotify : DEBUG mode 1, not reopening anything
2024-12-18 09:41:52 : ERROR : depnotify : ERROR: Error downloading https://files.nomad.menu/DEPNotify.pkg error:
* Host files.nomad.menu:443 was resolved.
* IPv6: 2600:9000:277c:9800:12:3667:4f40:93a1, 2600:9000:277c:c600:12:3667:4f40:93a1, 2600:9000:277c:b000:12:3667:4f40:93a1, 2600:9000:277c:6a00:12:3667:4f40:93a1, 2600:9000:277c:5200:12:3667:4f40:93a1, 2600:9000:277c:1e00:12:3667:4f40:93a1, 2600:9000:277c:ce00:12:3667:4f40:93a1
* IPv4: 108.158.32.17, 108.158.32.75, 108.158.32.58, 108.158.32.53
*   Trying 108.158.32.17:443...
* Connected to files.nomad.menu (108.158.32.17) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3190 bytes data]
* SSL certificate problem: unable to get local issuer certificate
* Closing connection
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

2024-12-18 09:41:52 : REQ   : depnotify : ################## End Installomator, exit code 2
```

### After

```
./Installomator.sh depnotify
2024-12-18 09:43:53 : REQ   : depnotify : ################## Start Installomator v. 10.7beta, date 2024-12-18
2024-12-18 09:43:53 : INFO  : depnotify : ################## Version: 10.7beta
2024-12-18 09:43:53 : INFO  : depnotify : ################## Date: 2024-12-18
2024-12-18 09:43:53 : INFO  : depnotify : ################## depnotify
2024-12-18 09:43:53 : DEBUG : depnotify : DEBUG mode 1 enabled.
2024-12-18 09:43:53 : DEBUG : depnotify : name=DEPNotify
2024-12-18 09:43:53 : DEBUG : depnotify : appName=
2024-12-18 09:43:53 : DEBUG : depnotify : type=pkg
2024-12-18 09:43:53 : DEBUG : depnotify : archiveName=
2024-12-18 09:43:53 : DEBUG : depnotify : downloadURL=https://files.jamfconnect.com/DEPNotify.pkg
2024-12-18 09:43:53 : DEBUG : depnotify : curlOptions=
2024-12-18 09:43:53 : DEBUG : depnotify : appNewVersion=
2024-12-18 09:43:53 : DEBUG : depnotify : appCustomVersion function: Not defined
2024-12-18 09:43:53 : DEBUG : depnotify : versionKey=CFBundleShortVersionString
2024-12-18 09:43:53 : DEBUG : depnotify : packageID=
2024-12-18 09:43:53 : DEBUG : depnotify : pkgName=
2024-12-18 09:43:53 : DEBUG : depnotify : choiceChangesXML=
2024-12-18 09:43:53 : DEBUG : depnotify : expectedTeamID=VRPY9KHGX6
2024-12-18 09:43:53 : DEBUG : depnotify : blockingProcesses=
2024-12-18 09:43:53 : DEBUG : depnotify : installerTool=
2024-12-18 09:43:53 : DEBUG : depnotify : CLIInstaller=
2024-12-18 09:43:53 : DEBUG : depnotify : CLIArguments=
2024-12-18 09:43:53 : DEBUG : depnotify : updateTool=
2024-12-18 09:43:53 : DEBUG : depnotify : updateToolArguments=
2024-12-18 09:43:53 : DEBUG : depnotify : updateToolRunAsCurrentUser=
2024-12-18 09:43:53 : INFO  : depnotify : BLOCKING_PROCESS_ACTION=tell_user
2024-12-18 09:43:53 : INFO  : depnotify : NOTIFY=success
2024-12-18 09:43:53 : INFO  : depnotify : LOGGING=DEBUG
2024-12-18 09:43:53 : INFO  : depnotify : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-18 09:43:53 : INFO  : depnotify : Label type: pkg
2024-12-18 09:43:53 : INFO  : depnotify : archiveName: DEPNotify.pkg
2024-12-18 09:43:53 : INFO  : depnotify : no blocking processes defined, using DEPNotify as default
2024-12-18 09:43:53 : DEBUG : depnotify : Changing directory to .
2024-12-18 09:43:53 : INFO  : depnotify : name: DEPNotify, appName: DEPNotify.app
2024-12-18 09:43:53.817 mdfind[45867:6414022] [UserQueryParser] Loading keywords and predicates for locale "en_AU"
2024-12-18 09:43:53.862 mdfind[45867:6414022] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-18 09:43:54 : WARN  : depnotify : No previous app found
2024-12-18 09:43:54 : WARN  : depnotify : could not find DEPNotify.app
2024-12-18 09:43:54 : INFO  : depnotify : appversion:
2024-12-18 09:43:54 : INFO  : depnotify : Latest version not specified.
2024-12-18 09:43:54 : REQ   : depnotify : Downloading https://files.jamfconnect.com/DEPNotify.pkg to DEPNotify.pkg
2024-12-18 09:43:54 : DEBUG : depnotify : No Dialog connection, just download
2024-12-18 09:43:57 : DEBUG : depnotify : File list: -rw-r--r--@ 1 nickf  staff   5.2M 18 Dec 09:43 DEPNotify.pkg
2024-12-18 09:43:57 : DEBUG : depnotify : File type: DEPNotify.pkg: xar archive compressed TOC: 4158, SHA-1 checksum
2024-12-18 09:43:57 : DEBUG : depnotify : curl output was:
* Host files.jamfconnect.com:443 was resolved.
* IPv6: 2600:9000:2083:3e00:3:32d:8fc0:93a1, 2600:9000:2083:ce00:3:32d:8fc0:93a1, 2600:9000:2083:6200:3:32d:8fc0:93a1, 2600:9000:2083:2a00:3:32d:8fc0:93a1, 2600:9000:2083:fa00:3:32d:8fc0:93a1, 2600:9000:2083:e800:3:32d:8fc0:93a1, 2600:9000:2083:d400:3:32d:8fc0:93a1
* IPv4: 13.35.147.12, 13.35.147.125, 13.35.147.113, 13.35.147.53
*   Trying 13.35.147.12:443...
* Connected to files.jamfconnect.com (13.35.147.12) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3818 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=files.jamfconnect.com
*  start date: Sep 19 00:00:00 2024 GMT
*  expire date: Oct 16 23:59:59 2025 GMT
*  subjectAltName: host "files.jamfconnect.com" matched cert's "files.jamfconnect.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://files.jamfconnect.com/DEPNotify.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: files.jamfconnect.com]
* [HTTP/2] [1] [:path: /DEPNotify.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /DEPNotify.pkg HTTP/2
> Host: files.jamfconnect.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 5466966
< date: Tue, 17 Dec 2024 22:43:56 GMT
< last-modified: Tue, 17 Dec 2024 21:14:52 GMT
< etag: "291d7d077f8b4f6ec5e76beb91e34503"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: P_X7izkadudLSsD5ig1LJl7pqhTivUVu
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 dc1a63a7a534969f09f5dd25ee1d95f2.cloudfront.net (CloudFront)
< x-amz-cf-pop: SYD1-C1
< x-amz-cf-id: 0ZwWMeWjQ-Au7r51stlHBspNfDWN4smL8jZzCRoNAdHovWHQ2mFrQA==
<
{ [8192 bytes data]
* Connection #0 to host files.jamfconnect.com left intact

2024-12-18 09:43:57 : DEBUG : depnotify : DEBUG mode 1, not checking for blocking processes
2024-12-18 09:43:57 : REQ   : depnotify : Installing DEPNotify
2024-12-18 09:43:57 : INFO  : depnotify : Verifying: DEPNotify.pkg
2024-12-18 09:43:57 : DEBUG : depnotify : File list: -rw-r--r--@ 1 nickf  staff   5.2M 18 Dec 09:43 DEPNotify.pkg
2024-12-18 09:43:57 : DEBUG : depnotify : File type: DEPNotify.pkg: xar archive compressed TOC: 4158, SHA-1 checksum
2024-12-18 09:43:57 : DEBUG : depnotify : spctlOut is DEPNotify.pkg: accepted
2024-12-18 09:43:57 : DEBUG : depnotify : source=Notarized Developer ID
2024-12-18 09:43:57 : DEBUG : depnotify : origin=Developer ID Installer: Orchard & Grove Inc. (VRPY9KHGX6)
2024-12-18 09:43:57 : INFO  : depnotify : Team ID: VRPY9KHGX6 (expected: VRPY9KHGX6 )
2024-12-18 09:43:57 : DEBUG : depnotify : DEBUG enabled, skipping installation
2024-12-18 09:43:57 : INFO  : depnotify : Finishing...
2024-12-18 09:44:00 : INFO  : depnotify : name: DEPNotify, appName: DEPNotify.app
2024-12-18 09:44:00.299 mdfind[45927:6414225] [UserQueryParser] Loading keywords and predicates for locale "en_AU"
2024-12-18 09:44:00.336 mdfind[45927:6414225] Couldn't determine the mapping between prefab keywords and predicates.
2024-12-18 09:44:00 : WARN  : depnotify : No previous app found
2024-12-18 09:44:00 : WARN  : depnotify : could not find DEPNotify.app
2024-12-18 09:44:00 : REQ   : depnotify : Installed DEPNotify
2024-12-18 09:44:00 : INFO  : depnotify : notifying
2024-12-18 09:44:00 : DEBUG : depnotify : DEBUG mode 1, not reopening anything
2024-12-18 09:44:00 : REQ   : depnotify : All done!
2024-12-18 09:44:00 : REQ   : depnotify : ################## End Installomator, exit code 0
```