### PR TITLE
Splitting 2 realvnc labels submitted in 1 label file

### DIFF
--- a/fragments/labels/realvncserver.sh
+++ b/fragments/labels/realvncserver.sh
@@ -1,12 +1,3 @@
-realvncviewer)
-    name="Real VNC Viewer"
-    appName="VNC Viewer.app"
-    type="dmg"
-    downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/viewer/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"
-    appNewVersion="$(echo $downloadURL | sed -n 's:.*VNC-Viewer-\(.*\)-MacOSX.*:\1:p')"
-    expectedTeamID="ZNCQ8JEH7X"
-    ;;
-
 vncconnect|\
 realvncserver)
     name="Real VNC Server"
@@ -17,4 +8,3 @@ realvncserver)
     appNewVersion="$(echo ${downloadURL} | sed -n 's:.*VNC-Server-\(.*\)-MacOSX.*:\1:p')"
     expectedTeamID="ZNCQ8JEH7X"
     ;;
-

--- a/fragments/labels/realvncviewer.sh
+++ b/fragments/labels/realvncviewer.sh
@@ -1,0 +1,8 @@
+realvncviewer)
+    name="Real VNC Viewer"
+    appName="VNC Viewer.app"
+    type="dmg"
+    downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/viewer/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"
+    appNewVersion="$(echo $downloadURL | sed -n 's:.*VNC-Viewer-\(.*\)-MacOSX.*:\1:p')"
+    expectedTeamID="ZNCQ8JEH7X"
+    ;;


### PR DESCRIPTION
The labels for realvnc were both submitted in one label file. These should be in separate sh files.

- realvncserver
- realvncviewer

No other changes made, other than splitting the labels