### PR TITLE
Splitting 2 chemdoodle labels submitted in 1 label file

### DIFF
--- a/fragments/labels/chemdoodle.sh
+++ b/fragments/labels/chemdoodle.sh
@@ -1,23 +1,12 @@
 chemdoodle|\
 chemdoodle2d)
-     name="ChemDoodle"
-     type="dmg"
-     [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
-     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
-     expectedTeamID="9XP397UW95"
-     folderName="ChemDoodle"
-     appName="${folderName}/ChemDoodle.app"
-     appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
-     versionKey="CFBundleVersion"
-     ;;
-chemdoodle3d)
-     name="ChemDoodle3D"
-     type="dmg"
-     [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
-     downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle3D-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
-     expectedTeamID="9XP397UW95"
-     folderName="ChemDoodle3D"
-     appName="${folderName}/ChemDoodle3D.app"
-     appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
-     versionKey="CFBundleVersion"
-     ;;
+    name="ChemDoodle"
+    type="dmg"
+    [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
+    downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
+    expectedTeamID="9XP397UW95"
+    folderName="ChemDoodle"
+    appName="${folderName}/ChemDoodle.app"
+    appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
+    versionKey="CFBundleVersion"
+    ;;

--- a/fragments/labels/chemdoodle3d.sh
+++ b/fragments/labels/chemdoodle3d.sh
@@ -1,0 +1,11 @@
+chemdoodle3d)
+    name="ChemDoodle3D"
+    type="dmg"
+    [[ $(arch) == "arm64" ]] && cpu_arch="aarch64" || cpu_arch="x64"
+    downloadURL="https://www.ichemlabs.com$(curl -s -L https://www.ichemlabs.com/download | grep -oE '[^"]*Doodle3D-[^"]*'$cpu_arch'[^"]*\.dmg' | head -1)"
+    expectedTeamID="9XP397UW95"
+    folderName="ChemDoodle3D"
+    appName="${folderName}/ChemDoodle3D.app"
+    appNewVersion=$(sed -E 's/.*-(.*).dmg/\1/g' <<< $downloadURL )
+    versionKey="CFBundleVersion"
+    ;;


### PR DESCRIPTION
The labels for chemdoodle were both submitted in one label file. These should be in separate sh files.

- chemdoodle
- chemdoodle3d

No other changes made, other than splitting the labels