### PR TITLE
New label: Jamf Printer Manager

### DIFF
--- a/fragments/labels/jamfprintermanager.sh
+++ b/fragments/labels/jamfprintermanager.sh
@@ -1,0 +1,7 @@
+jamfprintermanager)
+    name="Jamf Printer Manager"
+    type="zip"
+    downloadURL="$(downloadURLFromGit jamf jamf-printer-manager)"
+    appNewVersion="$(versionFromGit jamf jamf-printer-manager)"
+    expectedTeamID="483DWKW443"
+    ;;


### PR DESCRIPTION
Created a label for [Jamf Printer Manager](https://github.com/jamf/jamf-printer-manager) using `buildLabel.sh`.

Verified functionality with the following output when running `utils/assemble.sh jamfprintermanager`:
```
2024-12-23 14:17:09 : REQ   : jamfprintermanager : ################## Start Installomator v. 10.7beta, date 2024-12-23
2024-12-23 14:17:09 : INFO  : jamfprintermanager : ################## Version: 10.7beta
2024-12-23 14:17:09 : INFO  : jamfprintermanager : ################## Date: 2024-12-23
2024-12-23 14:17:09 : INFO  : jamfprintermanager : ################## jamfprintermanager
2024-12-23 14:17:09 : DEBUG : jamfprintermanager : DEBUG mode 1 enabled.
2024-12-23 14:17:09 : INFO  : jamfprintermanager : SwiftDialog is not installed, clear cmd file var
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : name=Jamf Printer Manager
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : appName=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : type=zip
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : archiveName=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : downloadURL=https://github.com/jamf/jamf-printer-manager/releases/download/v1.0.2/Jamf.Printer.Manager.zip
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : curlOptions=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : appNewVersion=1.0.2
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : appCustomVersion function: Not defined
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : versionKey=CFBundleShortVersionString
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : packageID=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : pkgName=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : choiceChangesXML=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : expectedTeamID=483DWKW443
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : blockingProcesses=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : installerTool=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : CLIInstaller=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : CLIArguments=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : updateTool=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : updateToolArguments=
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : updateToolRunAsCurrentUser=
2024-12-23 14:17:10 : INFO  : jamfprintermanager : BLOCKING_PROCESS_ACTION=tell_user
2024-12-23 14:17:10 : INFO  : jamfprintermanager : NOTIFY=success
2024-12-23 14:17:10 : INFO  : jamfprintermanager : LOGGING=DEBUG
2024-12-23 14:17:10 : INFO  : jamfprintermanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2024-12-23 14:17:10 : INFO  : jamfprintermanager : Label type: zip
2024-12-23 14:17:10 : INFO  : jamfprintermanager : archiveName: Jamf Printer Manager.zip
2024-12-23 14:17:10 : INFO  : jamfprintermanager : no blocking processes defined, using Jamf Printer Manager as default
2024-12-23 14:17:10 : DEBUG : jamfprintermanager : Changing directory to /Users/dombrant/Documents/Code/Shell Scripts/Installomator/build
2024-12-23 14:17:10 : INFO  : jamfprintermanager : App(s) found: /Applications/Jamf Printer Manager.app
2024-12-23 14:17:10 : INFO  : jamfprintermanager : found app at /Applications/Jamf Printer Manager.app, version 1.0.2, on versionKey CFBundleShortVersionString
2024-12-23 14:17:10 : INFO  : jamfprintermanager : appversion: 1.0.2
2024-12-23 14:17:10 : INFO  : jamfprintermanager : Latest version of Jamf Printer Manager is 1.0.2
2024-12-23 14:17:11 : WARN  : jamfprintermanager : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2024-12-23 14:17:11 : INFO  : jamfprintermanager : Jamf Printer Manager.zip exists and DEBUG mode 1 enabled, skipping download
2024-12-23 14:17:11 : DEBUG : jamfprintermanager : DEBUG mode 1, not checking for blocking processes
2024-12-23 14:17:11 : REQ   : jamfprintermanager : Installing Jamf Printer Manager
2024-12-23 14:17:11 : INFO  : jamfprintermanager : Unzipping Jamf Printer Manager.zip
2024-12-23 14:17:11 : INFO  : jamfprintermanager : Verifying: /Users/dombrant/Documents/Code/Shell Scripts/Installomator/build/Jamf Printer Manager.app
2024-12-23 14:17:11 : DEBUG : jamfprintermanager : App size: 2.4M	/Users/dombrant/Documents/Code/Shell Scripts/Installomator/build/Jamf Printer Manager.app
2024-12-23 14:17:11 : DEBUG : jamfprintermanager : Debugging enabled, App Verification output was:
/Users/dombrant/Documents/Code/Shell Scripts/Installomator/build/Jamf Printer Manager.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: JAMF Software (483DWKW443)

2024-12-23 14:17:11 : INFO  : jamfprintermanager : Team ID matching: 483DWKW443 (expected: 483DWKW443 )
2024-12-23 14:17:11 : INFO  : jamfprintermanager : Downloaded version of Jamf Printer Manager is 1.0.2 on versionKey CFBundleShortVersionString, same as installed.
2024-12-23 14:17:11 : DEBUG : jamfprintermanager : DEBUG mode 1, not reopening anything
2024-12-23 14:17:11 : REG   : jamfprintermanager : No new version to install
2024-12-23 14:17:11 : REQ   : jamfprintermanager : ################## End Installomator, exit code 0 
```