### PR TITLE
Add netbird.io label / Fix TeamID installFromPKG

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -662,7 +662,7 @@ installFromPKG() {
     spctlStatus=$(echo $?)
     printlog "spctlOut is $spctlOut" DEBUG
 
-    teamID=$(echo $spctlOut | awk -F '(' '/origin=/ {print $2 }' | tr -d '()' )
+    teamID=$(echo $spctlOut | awk -F '(' '/origin=/ {print $NF }' | tr -d '()' )
     # Apple signed software has no teamID, grab entire origin instead
     if [[ -z $teamID ]]; then
         teamID=$(echo $spctlOut | awk -F '=' '/origin=/ {print $NF }')

--- a/fragments/labels/netbird.sh
+++ b/fragments/labels/netbird.sh
@@ -1,0 +1,12 @@
+netbird)
+    name="NetBird"
+    type="pkg"
+    if [[ $(arch) == "arm64" ]]; then
+        dURL="https://pkgs.netbird.io/macos/arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        dURL="https://pkgs.netbird.io/macos/amd64"
+    fi
+    downloadURL=$dURL
+    appNewVersion=$(curl -LsI $downloadURL -o /dev/null -w '%{url_effective}' | grep -oE "\d+\.\d+\.\d+")
+    expectedTeamID="TA739QLA7A"
+    ;;


### PR DESCRIPTION
This add netbird.io as label.

This also fix installFromPKG retrieval of TeamID.

Failing example:
origin=Developer ID Installer: Wiretrustee UG (haftungsbeschrankt) (TA739QLA7A)

old installFromPKG will retrieve haftungsbeschrankt instead of TA739QLA7A