### PR TITLE
Update island.sh downloadURL

### DIFF
--- a/fragments/labels/island.sh
+++ b/fragments/labels/island.sh
@@ -1,8 +1,8 @@
 island)
     name="Island"
     type="dmg"
-    downloadURL="https://d3qqq7lqx3rf23.internal.island.io/E5QCaudFDx5FE5OX4INk/stable/latest/mac/IslandX64.dmg"
+    downloadURL="" # Customers MUST request a dedicated URL from the vendor to use this label. ie. https://your_tenant_id.internal.island.io/id_provided_by_vendor/stable/latest/mac/IslandX64.dmg
     appCustomVersion() { echo "$(defaults read /Applications/Island.app/Contents/Info.plist CFBundleShortVersionString | sed 's/[^.]*.//' | sed -e 's/*\.//')" }
-    appNewVersion=$(curl -fsLIXGET "https://d3qqq7lqx3rf23.internal.island.io/E5QCaudFDx5FE5OX4INk/stable/latest/mac/IslandX64.dmg" | grep -i "^x-amz-meta-version" | sed -e 's/x-amz-meta-version\: //' | tr -d '\r')
+    appNewVersion=$(curl -fsLIXGET ${downloadURL} | grep -i "^x-amz-meta-version" | sed -e 's/x-amz-meta-version\: //' | tr -d '\r')
     expectedTeamID="38ZC4T8AWY"
     ;;


### PR DESCRIPTION
Address Issue #1891 by removing the existing broken `downloadURL` and provide details via comment around needing to contact Island Support to get a dedicated installer URL that is associated with your Island Tenant. Added `downloadURL` variable into `appNewVersion`. 