### PR TITLE
Create ultraedit.sh

### DIFF
--- a/fragments/labels/ultraedit.sh
+++ b/fragments/labels/ultraedit.sh
@@ -1,0 +1,7 @@
+ultraedit)
+    name="UltraEdit"
+    type="dmg"
+    downloadURL="https://downloads.ultraedit.com/main/ue/mac/UltraEdit.dmg"
+    appNewVersion=$(plutil -p /Volumes/UltraEdit\ Setup/UltraEdit.app/Contents/Info.plist | grep CFBundleShortVersionString | awk -F'"' '{print $4}')
+    expectedTeamID="2T4C9Y59FF"
+    ;;


### PR DESCRIPTION
2025-01-02 16:05:03 : REQ   : ultraedit : ################## Start Installomator v. 10.7beta, date 2025-01-02
2025-01-02 16:05:03 : INFO  : ultraedit : ################## Version: 10.7beta
2025-01-02 16:05:03 : INFO  : ultraedit : ################## Date: 2025-01-02
2025-01-02 16:05:03 : INFO  : ultraedit : ################## ultraedit
2025-01-02 16:05:03 : DEBUG : ultraedit : DEBUG mode 1 enabled.
2025-01-02 16:05:03 : INFO  : ultraedit : setting variable from argument DEBUG=0
2025-01-02 16:05:03 : DEBUG : ultraedit : name=UltraEdit
2025-01-02 16:05:03 : DEBUG : ultraedit : appName=
2025-01-02 16:05:03 : DEBUG : ultraedit : type=dmg
2025-01-02 16:05:03 : DEBUG : ultraedit : archiveName=
2025-01-02 16:05:03 : DEBUG : ultraedit : downloadURL=https://downloads.ultraedit.com/main/ue/mac/UltraEdit.dmg
2025-01-02 16:05:03 : DEBUG : ultraedit : curlOptions=
2025-01-02 16:05:03 : DEBUG : ultraedit : appNewVersion=
2025-01-02 16:05:03 : DEBUG : ultraedit : appCustomVersion function: Not defined
2025-01-02 16:05:03 : DEBUG : ultraedit : versionKey=CFBundleShortVersionString
2025-01-02 16:05:03 : DEBUG : ultraedit : packageID=
2025-01-02 16:05:03 : DEBUG : ultraedit : pkgName=
2025-01-02 16:05:03 : DEBUG : ultraedit : choiceChangesXML=
2025-01-02 16:05:03 : DEBUG : ultraedit : expectedTeamID=2T4C9Y59FF
2025-01-02 16:05:03 : DEBUG : ultraedit : blockingProcesses=
2025-01-02 16:05:03 : DEBUG : ultraedit : installerTool=
2025-01-02 16:05:03 : DEBUG : ultraedit : CLIInstaller=
2025-01-02 16:05:03 : DEBUG : ultraedit : CLIArguments=
2025-01-02 16:05:03 : DEBUG : ultraedit : updateTool=
2025-01-02 16:05:03 : DEBUG : ultraedit : updateToolArguments=
2025-01-02 16:05:03 : DEBUG : ultraedit : updateToolRunAsCurrentUser=
2025-01-02 16:05:03 : INFO  : ultraedit : BLOCKING_PROCESS_ACTION=tell_user
2025-01-02 16:05:03 : INFO  : ultraedit : NOTIFY=success
2025-01-02 16:05:03 : INFO  : ultraedit : LOGGING=DEBUG
2025-01-02 16:05:04 : INFO  : ultraedit : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-02 16:05:04 : INFO  : ultraedit : Label type: dmg
2025-01-02 16:05:04 : INFO  : ultraedit : archiveName: UltraEdit.dmg
2025-01-02 16:05:04 : INFO  : ultraedit : no blocking processes defined, using UltraEdit as default
2025-01-02 16:05:04 : DEBUG : ultraedit : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.q9kuwHfpA5
2025-01-02 16:05:04 : INFO  : ultraedit : name: UltraEdit, appName: UltraEdit.app
2025-01-02 16:05:04.166 mdfind[27031:697383] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-02 16:05:04.166 mdfind[27031:697383] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-02 16:05:04.215 mdfind[27031:697383] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-02 16:05:04 : WARN  : ultraedit : No previous app found
2025-01-02 16:05:04 : WARN  : ultraedit : could not find UltraEdit.app
2025-01-02 16:05:04 : INFO  : ultraedit : appversion:
2025-01-02 16:05:04 : INFO  : ultraedit : Latest version not specified.
2025-01-02 16:05:04 : REQ   : ultraedit : Downloading https://downloads.ultraedit.com/main/ue/mac/UltraEdit.dmg to UltraEdit.dmg
2025-01-02 16:05:04 : DEBUG : ultraedit : No Dialog connection, just download
2025-01-02 16:05:05 : DEBUG : ultraedit : File list: -rw-r--r--  1 root  wheel    55M Jan  2 16:05 UltraEdit.dmg
2025-01-02 16:05:05 : DEBUG : ultraedit : File type: UltraEdit.dmg: zlib compressed data
2025-01-02 16:05:05 : DEBUG : ultraedit : curl output was:
* Host downloads.ultraedit.com:443 was resolved.
* IPv6: (none)
* IPv4: 104.22.74.73, 104.22.75.73, 172.67.28.62
*   Trying 104.22.74.73:443...
* Connected to downloads.ultraedit.com (104.22.74.73) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2533 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=ultraedit.com
*  start date: Nov 27 22:07:23 2024 GMT
*  expire date: Feb 25 22:07:22 2025 GMT
*  subjectAltName: host "downloads.ultraedit.com" matched cert's "*.ultraedit.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://downloads.ultraedit.com/main/ue/mac/UltraEdit.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: downloads.ultraedit.com]
* [HTTP/2] [1] [:path: /main/ue/mac/UltraEdit.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /main/ue/mac/UltraEdit.dmg HTTP/2
> Host: downloads.ultraedit.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 200
< date: Thu, 02 Jan 2025 23:05:04 GMT
< content-type: application/octet-stream
< content-length: 57411211
< expires: Sun, 08 Dec 2024 12:47:27 GMT
< cache-control: public, max-age=86400
< last-modified: Fri, 18 Oct 2024 14:06:37 GMT
< etag: "3cfdea468316d1cf70831c998a0b5b99"
< x-goog-generation: 1729260397286346
< x-goog-metageneration: 1
< x-goog-stored-content-encoding: identity
< x-goog-stored-content-length: 57411211
< x-goog-hash: crc32c=U6/RQA==
< x-goog-hash: md5=PP3qRoMW0c9wgxyZigtbmQ==
< x-goog-storage-class: REGIONAL
< x-guploader-uploadid: AFiumC7wniUeOBcwUE-kxmMSWLLssDhkXZiLvFWP8toFnuOuy2w_7ghEZ9uukArBFMhUm8pdVw < cf-cache-status: HIT
< age: 1248823
< accept-ranges: bytes
< strict-transport-security: max-age=0
< x-content-type-options: nosniff
< server: cloudflare
< cf-ray: 8fbe644b2bc3e652-DEN
<
{ [1360 bytes data]
* Connection #0 to host downloads.ultraedit.com left intact

2025-01-02 16:05:05 : REQ   : ultraedit : no more blocking processes, continue with update
2025-01-02 16:05:05 : REQ   : ultraedit : Installing UltraEdit
2025-01-02 16:05:05 : INFO  : ultraedit : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.q9kuwHfpA5/UltraEdit.dmg
2025-01-02 16:05:09 : DEBUG : ultraedit : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $90F990FA
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0F46194B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $6E2F9B67
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $6C681063
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $6E2F9B67
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $8BE26EA4
verified   CRC32 $5E9FE05C
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/UltraEdit Setup

2025-01-02 16:05:09 : INFO  : ultraedit : Mounted: /Volumes/UltraEdit Setup 2025-01-02 16:05:09 : INFO  : ultraedit : Verifying: /Volumes/UltraEdit Setup/UltraEdit.app 2025-01-02 16:05:09 : DEBUG : ultraedit : App size: 137M	/Volumes/UltraEdit Setup/UltraEdit.app 2025-01-02 16:05:10 : DEBUG : ultraedit : Debugging enabled, App Verification output was: /Volumes/UltraEdit Setup/UltraEdit.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: IDM Computer Solutions, Inc. (2T4C9Y59FF)

2025-01-02 16:05:10 : INFO  : ultraedit : Team ID matching: 2T4C9Y59FF (expected: 2T4C9Y59FF ) 2025-01-02 16:05:10 : INFO  : ultraedit : Installing UltraEdit version 23.0.0.22 on versionKey CFBundleShortVersionString. 2025-01-02 16:05:10 : INFO  : ultraedit : App has LSMinimumSystemVersion: 11.5 2025-01-02 16:05:10 : INFO  : ultraedit : Copy /Volumes/UltraEdit Setup/UltraEdit.app to /Applications 2025-01-02 16:05:11 : DEBUG : ultraedit : Debugging enabled, App copy output was: Copying /Volumes/UltraEdit Setup/UltraEdit.app

2025-01-02 16:05:11 : WARN  : ultraedit : Changing owner to daniel.ross 2025-01-02 16:05:11 : INFO  : ultraedit : Finishing... 2025-01-02 16:05:14 : INFO  : ultraedit : App(s) found: /Applications/UltraEdit.app 2025-01-02 16:05:14 : INFO  : ultraedit : found app at /Applications/UltraEdit.app, version 23.0.0.22, on versionKey CFBundleShortVersionString
2025-01-02 16:05:14 : REQ   : ultraedit : Installed UltraEdit, version 23.0.0.22
2025-01-02 16:05:14 : INFO  : ultraedit : notifying
2025-01-02 16:05:14 : DEBUG : ultraedit : Unmounting /Volumes/UltraEdit Setup
2025-01-02 16:05:14 : DEBUG : ultraedit : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-01-02 16:05:14 : DEBUG : ultraedit : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.q9kuwHfpA5
2025-01-02 16:05:14 : DEBUG : ultraedit : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.q9kuwHfpA5/UltraEdit.dmg
2025-01-02 16:05:14 : DEBUG : ultraedit : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.q9kuwHfpA5
2025-01-02 16:05:14 : INFO  : ultraedit : Installomator did not close any apps, so no need to reopen any apps.
2025-01-02 16:05:14 : REQ   : ultraedit : All done!
2025-01-02 16:05:14 : REQ   : ultraedit : ################## End Installomator, exit code 0