### PR TITLE
Create ultracompare.sh

### DIFF
--- a/fragments/labels/ultracompare.sh
+++ b/fragments/labels/ultracompare.sh
@@ -1,0 +1,7 @@
+ultracompare)
+    name="UltraCompare"
+    type="dmg"
+    downloadURL="https://downloads.ultraedit.com/main/uc/mac/UltraCompare.dmg"
+    appNewVersion=""
+    expectedTeamID="2T4C9Y59FF"
+    ;;


### PR DESCRIPTION
Downloading https://downloads.ultraedit.com/main/uc/mac/UltraCompare.dmg UltraCompare.dmg
Redirecting to (maybe this can help us with version): HTTP/2 200
date: Fri, 03 Jan 2025 05:28:38 GMT
content-type: application/octet-stream
content-length: 56427266
x-guploader-uploadid: AFiumC5yINTFfNV-j9pMcveGCk4HcjsX4mhcdsbs27j2xGgL3Bwq0aaf3OKR7lIgO2bcIaiq expires: Thu, 02 Jan 2025 14:55:17 GMT
cache-control: public, max-age=86400
last-modified: Wed, 15 May 2024 12:44:20 GMT
etag: "a8d83cce5d56e7765e8491b7a92480c7"
x-goog-generation: 1715777060277392
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 56427266
x-goog-hash: crc32c=UhY4qg==
x-goog-hash: md5=qNg8zl1W53ZehJG3qSSAxw==
x-goog-storage-class: REGIONAL
cf-cache-status: HIT
accept-ranges: bytes
vary: Accept-Encoding
strict-transport-security: max-age=0
x-content-type-options: nosniff
server: cloudflare
cf-ray: 8fc09625d97de759-DEN

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 53.8M  100 53.8M    0     0  23.1M      0  0:00:02  0:00:02 --:--:-- 23.1M
archiveTempName: UltraCompare.dmg
archivePath: https://downloads.ultraedit.com/main/uc/mac/UltraCompare.dmg
Calculated archiveName: UltraCompare.dmg
name: UltraCompare
archiveExt: dmg
Diskimage found
DMG investigation.
Mounting UltraCompare.dmg
Mounted: /Volumes/UltraCompare Setup
App found: /Volumes/UltraCompare Setup/UltraCompare.app
Application investigation.
Team ID found for app: 2T4C9Y59FF
"disk4" ejected.
identifier: ultracompare

**********

Labels should be named in small caps, numbers 0-9, “-”, and “_”. No other characters allowed.

appNewVersion is often difficult to find. Can sometimes be found in the filename, sometimes as part of the download redirects, but also on a web page. See redirect and archivePath above if link contains information about this. That is a good place to start

ultracompare)
    name="UltraCompare"
    type="dmg"
    downloadURL="https://downloads.ultraedit.com/main/uc/mac/UltraCompare.dmg"
    appNewVersion=""
    expectedTeamID="2T4C9Y59FF"
    ;;

Above should be saved in a file with exact same name as label, and given extension “.sh”. Put this file in folder “fragments/labels”.