### PR TITLE
Update depnotify.sh to use appNewVersion

### DIFF
--- a/fragments/labels/depnotify.sh
+++ b/fragments/labels/depnotify.sh
@@ -1,8 +1,8 @@
 depnotify)
     name="DEPNotify"
     type="pkg"
-    #packageID="menu.nomad.depnotify"
-    downloadURL="https://files.nomad.menu/DEPNotify.pkg"
-    #appNewVersion=$()
+    packageID="menu.nomad.depnotify"
+    downloadURL="https://files.jamfconnect.com/DEPNotify.pkg"
+    appNewVersion="$(versionFromGit jamf DEPNotify)"
     expectedTeamID="VRPY9KHGX6"
     ;;


### PR DESCRIPTION
PKG is not published on github, but release notes and latest source are. Using that for appNewVersion to avoid reinstalling over current release.

Also updated URL to Jamf site, since nomad.menu was less reliable while testing.