### PR TITLE
New label: githubcopilotforxcode

### DIFF
--- a/fragments/labels/githubcopilotforxcode.sh
+++ b/fragments/labels/githubcopilotforxcode.sh
@@ -1,0 +1,8 @@
+githubcopilotforxcode)
+    name="GitHub Copilot for Xcode"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit github CopilotForXcode)"
+    appNewVersion="$(versionFromGit github CopilotForXcode)"
+    expectedTeamID="VEKTX9H2N7"
+    blockingProcesses=( "GitHub Copilot for Xcode" "GitHub Copilot for Xcode Extension" "Copilot" )
+    ;;


### PR DESCRIPTION
```sh
$ ./assemble.sh githubcopilotforxcode

2025-01-09 16:06:36 : REQ   : githubcopilotforxcode : ################## Start Installomator v. 10.7beta, date 2025-01-09
2025-01-09 16:06:36 : INFO  : githubcopilotforxcode : ################## Version: 10.7beta
2025-01-09 16:06:36 : INFO  : githubcopilotforxcode : ################## Date: 2025-01-09
2025-01-09 16:06:36 : INFO  : githubcopilotforxcode : ################## githubcopilotforxcode
2025-01-09 16:06:36 : DEBUG : githubcopilotforxcode : DEBUG mode 1 enabled.
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : name=GitHub Copilot for Xcode
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : appName=
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : type=dmg
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : archiveName=
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : downloadURL=https://github.com/github/CopilotForXcode/releases/download/0.29.0/GitHubCopilotForXcode.dmg
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : curlOptions=
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : appNewVersion=0.29.0
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : appCustomVersion function: Not defined
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : versionKey=CFBundleShortVersionString
2025-01-09 16:06:37 : DEBUG : githubcopilotforxcode : packageID=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : pkgName=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : choiceChangesXML=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : expectedTeamID=VEKTX9H2N7
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : blockingProcesses=GitHub Copilot for Xcode GitHub Copilot for Xcode Extension Copilot
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : installerTool=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : CLIInstaller=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : CLIArguments=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : updateTool=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : updateToolArguments=
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : updateToolRunAsCurrentUser=
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : BLOCKING_PROCESS_ACTION=tell_user
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : NOTIFY=success
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : LOGGING=DEBUG
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : Label type: dmg
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : archiveName: GitHub Copilot for Xcode.dmg
2025-01-09 16:06:38 : DEBUG : githubcopilotforxcode : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : name: GitHub Copilot for Xcode, appName: GitHub Copilot for Xcode.app
2025-01-09 16:06:38.270 mdfind[57814:15965020] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2025-01-09 16:06:38.271 mdfind[57814:15965020] [UserQueryParser] Loading keywords and predicates for locale "ja"
2025-01-09 16:06:38.640 mdfind[57814:15965020] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : App(s) found: /Users/kenchan0130/Applications/GitHub Copilot for Xcode.app/Users/kenchan0130/Applications/GitHub Copilot for Xcode.app/Contents/Applications/GitHub Copilot for Xcode Extension.app
2025-01-09 16:06:38 : WARN  : githubcopilotforxcode : could not determine location of GitHub Copilot for Xcode.app
2025-01-09 16:06:38 : INFO  : githubcopilotforxcode : appversion:
2025-01-09 16:06:39 : INFO  : githubcopilotforxcode : Latest version of GitHub Copilot for Xcode is 0.29.0
2025-01-09 16:06:39 : REQ   : githubcopilotforxcode : Downloading https://github.com/github/CopilotForXcode/releases/download/0.29.0/GitHubCopilotForXcode.dmg to GitHub Copilot for Xcode.dmg
2025-01-09 16:06:39 : DEBUG : githubcopilotforxcode : No Dialog connection, just download
2025-01-09 16:06:43 : DEBUG : githubcopilotforxcode : File list: -rw-r--r--  1 kenchan0130  staff   137M  1  9 16:06 GitHub Copilot for Xcode.dmg
2025-01-09 16:06:43 : DEBUG : githubcopilotforxcode : File type: GitHub Copilot for Xcode.dmg: zlib compressed data
2025-01-09 16:06:43 : DEBUG : githubcopilotforxcode : curl output was:
* Host github.com:443 was resolved.
* IPv6: (none)
* IPv4: 20.27.177.113
*   Trying 20.27.177.113:443...
* Connected to github.com (20.27.177.113) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3137 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=github.com
*  start date: Mar  7 00:00:00 2024 GMT
*  expire date: Mar  7 23:59:59 2025 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo ECC Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://github.com/github/CopilotForXcode/releases/download/0.29.0/GitHubCopilotForXcode.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: github.com]
* [HTTP/2] [1] [:path: /github/CopilotForXcode/releases/download/0.29.0/GitHubCopilotForXcode.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github/CopilotForXcode/releases/download/0.29.0/GitHubCopilotForXcode.dmg HTTP/2
> Host: github.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 302
< server: GitHub.com
< date: Thu, 09 Jan 2025 07:06:39 GMT
< content-type: text/html; charset=utf-8
< vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
< location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/860035177/2db905e4-0e83-4db5-803f-502cc86015cc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250109T070639Z&X-Amz-Expires=300&X-Amz-Signature=11ef64d73f7595b2ed2a160c49ba4dfd95106af7f19929f417f6f138227be9a3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DGitHubCopilotForXcode.dmg&response-content-type=application%2Foctet-stream
< cache-control: no-cache
< strict-transport-security: max-age=31536000; includeSubdomains; preload
< x-frame-options: deny
< x-content-type-options: nosniff
< x-xss-protection: 0
< referrer-policy: no-referrer-when-downgrade
< content-security-policy: default-src 'none'; base-uri 'self'; child-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.com/assets-cdn/worker/ github.com/webpack/ github.com/assets/ gist.github.com/assets-cdn/worker/
< content-length: 0
< x-github-request-id: EC55:3F9B0C:5CEF61:70903B:677F757F
<
* Ignoring the response-body
* Connection #0 to host github.com left intact
* Issue another request to this URL: 'https://objects.githubusercontent.com/github-production-release-asset-2e65be/860035177/2db905e4-0e83-4db5-803f-502cc86015cc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250109T070639Z&X-Amz-Expires=300&X-Amz-Signature=11ef64d73f7595b2ed2a160c49ba4dfd95106af7f19929f417f6f138227be9a3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DGitHubCopilotForXcode.dmg&response-content-type=application%2Foctet-stream'
* Host objects.githubusercontent.com:443 was resolved.
* IPv6: (none)
* IPv4: 185.199.108.133, 185.199.109.133, 185.199.110.133, 185.199.111.133
*   Trying 185.199.108.133:443...
* Connected to objects.githubusercontent.com (185.199.108.133) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [334 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3099 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=*.github.io
*  start date: Mar 15 00:00:00 2024 GMT
*  expire date: Mar 14 23:59:59 2025 GMT
*  subjectAltName: host "objects.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://objects.githubusercontent.com/github-production-release-asset-2e65be/860035177/2db905e4-0e83-4db5-803f-502cc86015cc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250109T070639Z&X-Amz-Expires=300&X-Amz-Signature=11ef64d73f7595b2ed2a160c49ba4dfd95106af7f19929f417f6f138227be9a3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DGitHubCopilotForXcode.dmg&response-content-type=application%2Foctet-stream
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: objects.githubusercontent.com]
* [HTTP/2] [1] [:path: /github-production-release-asset-2e65be/860035177/2db905e4-0e83-4db5-803f-502cc86015cc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250109T070639Z&X-Amz-Expires=300&X-Amz-Signature=11ef64d73f7595b2ed2a160c49ba4dfd95106af7f19929f417f6f138227be9a3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DGitHubCopilotForXcode.dmg&response-content-type=application%2Foctet-stream]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /github-production-release-asset-2e65be/860035177/2db905e4-0e83-4db5-803f-502cc86015cc?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250109T070639Z&X-Amz-Expires=300&X-Amz-Signature=11ef64d73f7595b2ed2a160c49ba4dfd95106af7f19929f417f6f138227be9a3&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3DGitHubCopilotForXcode.dmg&response-content-type=application%2Foctet-stream HTTP/2
> Host: objects.githubusercontent.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: application/octet-stream
< last-modified: Thu, 14 Nov 2024 16:16:08 GMT
< etag: "0x8DD04C7A5D98E70"
< server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
< x-ms-request-id: f55809d6-101e-0009-304a-5da486000000
< x-ms-version: 2024-11-04
< x-ms-creation-time: Thu, 14 Nov 2024 16:16:08 GMT
< x-ms-lease-status: unlocked
< x-ms-lease-state: available
< x-ms-blob-type: BlockBlob
< content-disposition: attachment; filename=GitHubCopilotForXcode.dmg
< x-ms-server-encrypted: true
< via: 1.1 varnish, 1.1 varnish
< fastly-restarts: 1
< accept-ranges: bytes
< age: 21
< date: Thu, 09 Jan 2025 07:06:40 GMT
< x-served-by: cache-iad-kcgs7200022-IAD, cache-nrt-rjtf7700069-NRT
< x-cache: HIT, HIT
< x-cache-hits: 331, 0
< x-timer: S1736406399.347163,VS0,VE174
< content-length: 143507908
<
{ [1369 bytes data]
* Connection #1 to host objects.githubusercontent.com left intact

2025-01-09 16:06:43 : DEBUG : githubcopilotforxcode : DEBUG mode 1, not checking for blocking processes
2025-01-09 16:06:43 : REQ   : githubcopilotforxcode : Installing GitHub Copilot for Xcode
2025-01-09 16:06:43 : INFO  : githubcopilotforxcode : Mounting /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build/GitHub Copilot for Xcode.dmg
2025-01-09 16:06:46 : DEBUG : githubcopilotforxcode : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $466BBF5A
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $D044BB4C
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $BAF50856
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
disk image (Apple_APFS : 4)のチェックサムを計算中…
disk image (Apple_APFS : 4): 検証済み CRC32 $BDE4681C
(Apple_Free : 5)のチェックサムを計算中…
(Apple_Free : 5): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 6)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $BAF50856
GPT Header (Backup GPT Header : 7)のチェックサムを計算中…
GPT Header (Backup GPT Header : 7): 検証済み CRC32 $54F88090
検証済み CRC32 $23C970CE
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/GitHub Copilot for Xcode 1

2025-01-09 16:06:46 : INFO  : githubcopilotforxcode : Mounted: /Volumes/GitHub Copilot for Xcode 1
2025-01-09 16:06:46 : INFO  : githubcopilotforxcode : Verifying: /Volumes/GitHub Copilot for Xcode 1/GitHub Copilot for Xcode.app
2025-01-09 16:06:46 : DEBUG : githubcopilotforxcode : App size: 297M	/Volumes/GitHub Copilot for Xcode 1/GitHub Copilot for Xcode.app
2025-01-09 16:06:48 : DEBUG : githubcopilotforxcode : Debugging enabled, App Verification output was:
/Volumes/GitHub Copilot for Xcode 1/GitHub Copilot for Xcode.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: GitHub (VEKTX9H2N7)

2025-01-09 16:06:48 : INFO  : githubcopilotforxcode : Team ID matching: VEKTX9H2N7 (expected: VEKTX9H2N7 )
2025-01-09 16:06:48 : INFO  : githubcopilotforxcode : Installing GitHub Copilot for Xcode version 0.29.0 on versionKey CFBundleShortVersionString.
2025-01-09 16:06:48 : INFO  : githubcopilotforxcode : App has LSMinimumSystemVersion: 12.0
2025-01-09 16:06:48 : DEBUG : githubcopilotforxcode : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-09 16:06:48 : INFO  : githubcopilotforxcode : Finishing...
2025-01-09 16:06:51 : INFO  : githubcopilotforxcode : name: GitHub Copilot for Xcode, appName: GitHub Copilot for Xcode.app
2025-01-09 16:06:51.323 mdfind[57985:15965730] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2025-01-09 16:06:51.324 mdfind[57985:15965730] [UserQueryParser] Loading keywords and predicates for locale "ja"
2025-01-09 16:06:51.459 mdfind[57985:15965730] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-09 16:06:51 : INFO  : githubcopilotforxcode : App(s) found: /Users/kenchan0130/Applications/GitHub Copilot for Xcode.app/Users/kenchan0130/Applications/GitHub Copilot for Xcode.app/Contents/Applications/GitHub Copilot for Xcode Extension.app
2025-01-09 16:06:51 : WARN  : githubcopilotforxcode : could not determine location of GitHub Copilot for Xcode.app
2025-01-09 16:06:51 : REQ   : githubcopilotforxcode : Installed GitHub Copilot for Xcode, version 0.29.0
2025-01-09 16:06:51 : INFO  : githubcopilotforxcode : notifying
2025-01-09 16:06:52 : DEBUG : githubcopilotforxcode : Unmounting /Volumes/GitHub Copilot for Xcode 1
2025-01-09 16:06:52 : DEBUG : githubcopilotforxcode : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-01-09 16:06:52 : DEBUG : githubcopilotforxcode : DEBUG mode 1, not reopening anything
2025-01-09 16:06:52 : REQ   : githubcopilotforxcode : All done!
2025-01-09 16:06:52 : REQ   : githubcopilotforxcode : ################## End Installomator, exit code 0
```