### PR TITLE
Create label Python version 3.12

### DIFF
--- a/fragments/labels/python312.sh
+++ b/fragments/labels/python312.sh
@@ -1,0 +1,17 @@
+python312)
+    name="Python312"
+    type="pkg"
+    appNewVersion="$( curl --compressed -s "https://www.python.org/downloads/macos/" | awk -F'[<>]' '/Python 3.12./{print $3}' | awk -F' ' '{print $2}' | head -n 1 )"
+    archiveName="$( curl -s "https://www.python.org/ftp/python/$appNewVersion/" | grep -om 1 "\"python.*macos.*\.pkg\"" | tr -d \" )"
+    downloadURL="https://www.python.org/ftp/python/$appNewVersion/$archiveName"
+    shortVersion=$( cut -d '.' -f1,2 <<< $appNewVersion )
+    packageID="org.python.Python.PythonFramework-$shortVersion"
+    expectedTeamID="BMM5U3QVKW"
+    blockingProcesses=( "IDLE" "Python Launcher" )
+    versionKey="CFBundleVersion"
+    appCustomVersion() {
+        if [ -d "/Library/Frameworks/Python.framework/Versions/$shortVersion/Resources/Python.app/" ]; then
+            /usr/bin/defaults read "/Library/Frameworks/Python.framework/Versions/$shortVersion/Resources/Python.app/Contents/Info" CFBundleVersion
+        fi
+    }
+    ;;


### PR DESCRIPTION
We need Python version 3.12 specific and can't use version 3.13 (latest). Since version 3.12 is in the "bugfix" fase this version is still supported. As this might help someone else, I created this PR.