### PR TITLE
Update igv for Apple Silicon

### DIFF
--- a/fragments/labels/igv.sh
+++ b/fragments/labels/igv.sh
@@ -1,8 +1,13 @@
 igv)
     name="IGV"
     type="zip"
-    downloadURL="$(curl -fs "https://igv.org/doc/desktop/DownloadPage/" | grep -oE "https://data.broadinstitute.org/igv/projects/downloads/.*/IGV_MacApp_.*_WithJava\.zip")"
-    appNewVersion="$(echo $downloadURL | sed -E 's/.*IGV_MacApp_([0-9]+(\.[0-9]+)*).*/\1/')"
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="$(curl -fs "https://igv.org/doc/desktop/DownloadPage/" | grep -m1 -oE "https://data.broadinstitute.org/igv/projects/downloads/.*/IGV_MacApp_.*_WithJava\.zip")"
+        appNewVersion="$(echo $downloadURL | sed -E 's/.*IGV_MacApp_([0-9]+(\.[0-9]+)*).*/\1/')"
+    else
+        downloadURL="$(curl -fs "https://igv.org/doc/desktop/DownloadPage/" | grep -m1 -oE "https://data.broadinstitute.org/igv/projects/downloads/.*/IGV_MacAppIntel_.*_WithJava\.zip")"
+        appNewVersion="$(echo $downloadURL | sed -E 's/.*IGV_MacAppIntel_([0-9]+(\.[0-9]+)*).*/\1/')"
+    fi
     appName="${name}_${appNewVersion}.app"
     expectedTeamID="R787A9V6VV"
     ;;


### PR DESCRIPTION
```% utils/assemble.sh igv
2025-01-10 13:19:42 : REQ   : igv : ################## Start Installomator v. 10.7beta, date 2025-01-10
2025-01-10 13:19:42 : INFO  : igv : ################## Version: 10.7beta
2025-01-10 13:19:42 : INFO  : igv : ################## Date: 2025-01-10
2025-01-10 13:19:42 : INFO  : igv : ################## igv
2025-01-10 13:19:42 : DEBUG : igv : DEBUG mode 1 enabled.
2025-01-10 13:19:42 : DEBUG : igv : name=IGV
2025-01-10 13:19:42 : DEBUG : igv : appName=IGV_2.19.1.app
2025-01-10 13:19:42 : DEBUG : igv : type=zip
2025-01-10 13:19:42 : DEBUG : igv : archiveName=
2025-01-10 13:19:42 : DEBUG : igv : downloadURL=https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_MacApp_2.19.1_WithJava.zip
2025-01-10 13:19:42 : DEBUG : igv : curlOptions=
2025-01-10 13:19:42 : DEBUG : igv : appNewVersion=2.19.1
2025-01-10 13:19:42 : DEBUG : igv : appCustomVersion function: Not defined
2025-01-10 13:19:42 : DEBUG : igv : versionKey=CFBundleShortVersionString
2025-01-10 13:19:43 : DEBUG : igv : packageID=
2025-01-10 13:19:43 : DEBUG : igv : pkgName=
2025-01-10 13:19:43 : DEBUG : igv : choiceChangesXML=
2025-01-10 13:19:43 : DEBUG : igv : expectedTeamID=R787A9V6VV
2025-01-10 13:19:43 : DEBUG : igv : blockingProcesses=
2025-01-10 13:19:43 : DEBUG : igv : installerTool=
2025-01-10 13:19:43 : DEBUG : igv : CLIInstaller=
2025-01-10 13:19:43 : DEBUG : igv : CLIArguments=
2025-01-10 13:19:43 : DEBUG : igv : updateTool=
2025-01-10 13:19:43 : DEBUG : igv : updateToolArguments=
2025-01-10 13:19:43 : DEBUG : igv : updateToolRunAsCurrentUser=
2025-01-10 13:19:43 : INFO  : igv : BLOCKING_PROCESS_ACTION=tell_user
2025-01-10 13:19:43 : INFO  : igv : NOTIFY=success
2025-01-10 13:19:43 : INFO  : igv : LOGGING=DEBUG
2025-01-10 13:19:43 : INFO  : igv : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-10 13:19:43 : INFO  : igv : Label type: zip
2025-01-10 13:19:43 : INFO  : igv : archiveName: IGV.zip
2025-01-10 13:19:43 : INFO  : igv : no blocking processes defined, using IGV as default
2025-01-10 13:19:43 : DEBUG : igv : Changing directory to /Users/hessf/Git/Installomator/build
2025-01-10 13:19:43 : INFO  : igv : name: IGV, appName: IGV_2.19.1.app
2025-01-10 13:19:43.270 mdfind[57303:2175491] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-10 13:19:43.270 mdfind[57303:2175491] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-10 13:19:43.302 mdfind[57303:2175491] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-10 13:19:43 : WARN  : igv : No previous app found
2025-01-10 13:19:43 : WARN  : igv : could not find IGV_2.19.1.app
2025-01-10 13:19:43 : INFO  : igv : appversion:
2025-01-10 13:19:43 : INFO  : igv : Latest version of IGV is 2.19.1
2025-01-10 13:19:43 : REQ   : igv : Downloading https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_MacApp_2.19.1_WithJava.zip to IGV.zip
2025-01-10 13:19:43 : DEBUG : igv : No Dialog connection, just download
2025-01-10 13:19:48 : DEBUG : igv : File list: -rw-r--r--  1 hessf  staff    77M Jan 10 13:19 IGV.zip
2025-01-10 13:19:48 : DEBUG : igv : File type: IGV.zip: Zip archive data, at least v1.0 to extract, compression method=store
2025-01-10 13:19:48 : DEBUG : igv : curl output was:
* Host data.broadinstitute.org:443 was resolved.
* IPv6: (none)
* IPv4: 69.173.68.137
*   Trying 69.173.68.137:443...
* Connected to data.broadinstitute.org (69.173.68.137) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4817 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Massachusetts; O=The Broad Institute, Inc.; CN=data.broadinstitute.org
*  start date: Jun 26 00:00:00 2024 GMT
*  expire date: Jun 26 23:59:59 2025 GMT
*  subjectAltName: host "data.broadinstitute.org" matched cert's "data.broadinstitute.org"
*  issuer: C=US; O=Internet2; CN=InCommon RSA Server CA 2
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /igv/projects/downloads/2.19/IGV_MacApp_2.19.1_WithJava.zip HTTP/1.1
> Host: data.broadinstitute.org
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Fri, 10 Jan 2025 20:19:43 GMT
< Server: Apache
< Last-Modified: Thu, 05 Dec 2024 00:14:23 GMT
< ETag: "4cdabcf-6287ac7cadae7"
< Accept-Ranges: bytes
< Content-Length: 80587727
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET,POST,PUT,OPTIONS
< Access-Control-Allow-Headers: RANGE, Cache-control, If-None-Match, Content-Type
< Access-Control-Expose-Headers: Content-Length
< Content-Type: application/zip
<
{ [14920 bytes data]
* Connection #0 to host data.broadinstitute.org left intact

2025-01-10 13:19:48 : DEBUG : igv : DEBUG mode 1, not checking for blocking processes
2025-01-10 13:19:48 : REQ   : igv : Installing IGV
2025-01-10 13:19:48 : INFO  : igv : Unzipping IGV.zip
2025-01-10 13:19:48 : INFO  : igv : Verifying: /Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:19:48 : DEBUG : igv : App size: 185M	/Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:19:48 : DEBUG : igv : Debugging enabled, App Verification output was:
/Users/hessf/Git/Installomator/build/IGV_2.19.1.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: THE BROAD INSTITUTE INC (R787A9V6VV)

2025-01-10 13:19:49 : INFO  : igv : Team ID matching: R787A9V6VV (expected: R787A9V6VV )
2025-01-10 13:19:49 : INFO  : igv : Installing IGV version 2.19.1 on versionKey CFBundleShortVersionString.
2025-01-10 13:19:49 : DEBUG : igv : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-10 13:19:49 : INFO  : igv : Finishing...
2025-01-10 13:19:52 : INFO  : igv : name: IGV, appName: IGV_2.19.1.app
2025-01-10 13:19:52.119 mdfind[57362:2175758] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-10 13:19:52.120 mdfind[57362:2175758] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-10 13:19:52.158 mdfind[57362:2175758] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-10 13:19:52 : INFO  : igv : App(s) found: /Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:19:52 : WARN  : igv : could not determine location of IGV_2.19.1.app
2025-01-10 13:19:52 : REQ   : igv : Installed IGV, version 2.19.1
2025-01-10 13:19:52 : INFO  : igv : notifying
2025-01-10 13:19:52 : DEBUG : igv : DEBUG mode 1, not reopening anything
2025-01-10 13:19:52 : REQ   : igv : All done!
2025-01-10 13:19:52 : REQ   : igv : ################## End Installomator, exit code 0

hessf@b22088 ~/Git/Installomator % arch -arch x86_64 utils/assemble.sh igv
2025-01-10 13:20:01 : REQ   : igv : ################## Start Installomator v. 10.7beta, date 2025-01-10
2025-01-10 13:20:01 : INFO  : igv : ################## Version: 10.7beta
2025-01-10 13:20:01 : INFO  : igv : ################## Date: 2025-01-10
2025-01-10 13:20:01 : INFO  : igv : ################## igv
2025-01-10 13:20:01 : DEBUG : igv : DEBUG mode 1 enabled.
2025-01-10 13:20:02 : DEBUG : igv : name=IGV
2025-01-10 13:20:02 : DEBUG : igv : appName=IGV_2.19.1.app
2025-01-10 13:20:02 : DEBUG : igv : type=zip
2025-01-10 13:20:02 : DEBUG : igv : archiveName=
2025-01-10 13:20:02 : DEBUG : igv : downloadURL=https://data.broadinstitute.org/igv/projects/downloads/2.19/IGV_MacAppIntel_2.19.1_WithJava.zip
2025-01-10 13:20:02 : DEBUG : igv : curlOptions=
2025-01-10 13:20:02 : DEBUG : igv : appNewVersion=2.19.1
2025-01-10 13:20:02 : DEBUG : igv : appCustomVersion function: Not defined
2025-01-10 13:20:02 : DEBUG : igv : versionKey=CFBundleShortVersionString
2025-01-10 13:20:02 : DEBUG : igv : packageID=
2025-01-10 13:20:02 : DEBUG : igv : pkgName=
2025-01-10 13:20:02 : DEBUG : igv : choiceChangesXML=
2025-01-10 13:20:02 : DEBUG : igv : expectedTeamID=R787A9V6VV
2025-01-10 13:20:02 : DEBUG : igv : blockingProcesses=
2025-01-10 13:20:02 : DEBUG : igv : installerTool=
2025-01-10 13:20:02 : DEBUG : igv : CLIInstaller=
2025-01-10 13:20:02 : DEBUG : igv : CLIArguments=
2025-01-10 13:20:02 : DEBUG : igv : updateTool=
2025-01-10 13:20:02 : DEBUG : igv : updateToolArguments=
2025-01-10 13:20:02 : DEBUG : igv : updateToolRunAsCurrentUser=
2025-01-10 13:20:02 : INFO  : igv : BLOCKING_PROCESS_ACTION=tell_user
2025-01-10 13:20:02 : INFO  : igv : NOTIFY=success
2025-01-10 13:20:02 : INFO  : igv : LOGGING=DEBUG
2025-01-10 13:20:02 : INFO  : igv : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-10 13:20:03 : INFO  : igv : Label type: zip
2025-01-10 13:20:03 : INFO  : igv : archiveName: IGV.zip
2025-01-10 13:20:03 : INFO  : igv : no blocking processes defined, using IGV as default
2025-01-10 13:20:03 : DEBUG : igv : Changing directory to /Users/hessf/Git/Installomator/build
2025-01-10 13:20:03 : INFO  : igv : name: IGV, appName: IGV_2.19.1.app
2025-01-10 13:20:03.223 mdfind[57498:2176511] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-10 13:20:03.224 mdfind[57498:2176511] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-10 13:20:03.267 mdfind[57498:2176511] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-10 13:20:03 : INFO  : igv : App(s) found: /Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:20:03 : WARN  : igv : could not determine location of IGV_2.19.1.app
2025-01-10 13:20:03 : INFO  : igv : appversion:
2025-01-10 13:20:03 : INFO  : igv : Latest version of IGV is 2.19.1
2025-01-10 13:20:03 : INFO  : igv : IGV.zip exists and DEBUG mode 1 enabled, skipping download
2025-01-10 13:20:03 : DEBUG : igv : DEBUG mode 1, not checking for blocking processes
2025-01-10 13:20:03 : REQ   : igv : Installing IGV
2025-01-10 13:20:03 : INFO  : igv : Unzipping IGV.zip
2025-01-10 13:20:03 : INFO  : igv : Verifying: /Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:20:03 : DEBUG : igv : App size: 185M	/Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:20:04 : DEBUG : igv : Debugging enabled, App Verification output was:
/Users/hessf/Git/Installomator/build/IGV_2.19.1.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: THE BROAD INSTITUTE INC (R787A9V6VV)

2025-01-10 13:20:04 : INFO  : igv : Team ID matching: R787A9V6VV (expected: R787A9V6VV )
2025-01-10 13:20:04 : INFO  : igv : Installing IGV version 2.19.1 on versionKey CFBundleShortVersionString.
2025-01-10 13:20:04 : DEBUG : igv : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-10 13:20:04 : INFO  : igv : Finishing...
2025-01-10 13:20:07 : INFO  : igv : name: IGV, appName: IGV_2.19.1.app
2025-01-10 13:20:07.466 mdfind[57612:2176919] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-10 13:20:07.466 mdfind[57612:2176919] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-10 13:20:07.512 mdfind[57612:2176919] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-10 13:20:07 : INFO  : igv : App(s) found: /Users/hessf/Git/Installomator/build/IGV_2.19.1.app
2025-01-10 13:20:07 : WARN  : igv : could not determine location of IGV_2.19.1.app
2025-01-10 13:20:07 : REQ   : igv : Installed IGV, version 2.19.1
2025-01-10 13:20:07 : INFO  : igv : notifying
2025-01-10 13:20:07 : DEBUG : igv : DEBUG mode 1, not reopening anything
2025-01-10 13:20:07 : REQ   : igv : All done!
2025-01-10 13:20:07 : REQ   : igv : ################## End Installomator, exit code 0```