### PR TITLE
Support zipInTBZ

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -859,6 +859,20 @@ installAppInDmgInZip() {
     installFromDMG
 }
 
+installZipInTBZ() {
+    # unzip the archive
+    printlog "Unzipping $archiveName"
+    tar -xf "$archiveName"
+
+    findfiles=$(find "$tmpDir" -iname "*.zip" -maxdepth 1)
+    filearray=( ${(f)findfiles} )
+    if [[ ${#filearray} -eq 0 ]]; then
+        cleanupAndExit 22 "couldn't find zip in tbz $archiveName" ERROR
+    fi
+    archiveName=$(basename ${filearray[1]})
+    installFromZIP
+}
+
 runUpdateTool() {
     printlog "Function called: runUpdateTool"
     if [[ -x $updateTool ]]; then

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -192,6 +192,7 @@ NOTIFY_DIALOG=0
 #     - pkgInDmg
 #     - pkgInZip
 #     - appInDmgInZip
+#     - zipInTBZ
 #     - updateronly     This last one is for labels that should only run an updateTool (see below)
 #
 # - packageID: (optional)

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -156,6 +156,9 @@ if [ -z "$archiveName" ]; then
         *InZip)
             archiveName="${name}.zip"
             ;;
+        *InTBZ|*InBZ2)
+            archiveName="${name}.tbz"
+            ;;
         updateronly)
             ;;
         *)
@@ -369,6 +372,9 @@ case $type in
         ;;
     appInDmgInZip)
         installAppInDmgInZip
+        ;;
+    zipInTBZ|zipInBZ2)
+        installZipInTBZ
         ;;
     *)
         cleanupAndExit 99 "Cannot handle type $type" ERROR

--- a/utils/checkLabels.sh
+++ b/utils/checkLabels.sh
@@ -211,6 +211,9 @@ for fixedArch in i386 arm64; do
                 *InZip)
                     expectedExtension="zip"
                     ;;
+                *InTBZ|*InBZ2)
+                    expectedExtension="tbz"
+                    ;;
                 *)
                     echo "Cannot handle type $type"
                     ;;


### PR DESCRIPTION
There are cases where the tar is unzipped and zipped as in https://github.com/Installomator/Installomator/pull/2105.
Due to the tricky process in the relevant PR, I have received comments from maintainers like that the process is complicated.
I agree with this.

Therefore, I have made it official to support zip in tar so that such a tricky process is not necessary.

Related: https://github.com/Installomator/Installomator/pull/2105