### PR TITLE
Create anotherredisdesktopmanager.sh

### DIFF
--- a/fragments/labels/anotherredisdesktopmanager.sh
+++ b/fragments/labels/anotherredisdesktopmanager.sh
@@ -1,0 +1,7 @@
+anotherredisdesktopmanager)
+    name="Another Redis Desktop Manager"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit qishibo AnotherRedisDesktopManager)"
+    appNewVersion="$(versionFromGit qishibo AnotherRedisDesktopManager)"
+    expectedTeamID="68JN8DV835"
+    ;;


### PR DESCRIPTION
Output

2025-01-15 16:46:09 : REQ   : anotherredisdesktopmanager : ################## Start Installomator v. 10.7beta, date 2025-01-15
2025-01-15 16:46:09 : INFO  : anotherredisdesktopmanager : ################## Version: 10.7beta
2025-01-15 16:46:09 : INFO  : anotherredisdesktopmanager : ################## Date: 2025-01-15
2025-01-15 16:46:09 : INFO  : anotherredisdesktopmanager : ################## anotherredisdesktopmanager
2025-01-15 16:46:09 : DEBUG : anotherredisdesktopmanager : DEBUG mode 1 enabled.
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : setting variable from argument DEBUG=1
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : name=Another Redis Desktop Manager
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : appName=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : type=dmg
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : archiveName=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : downloadURL=https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.7.1/Another-Redis-Desktop-Manager-mac-1.7.1-arm64.dmg
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : curlOptions=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : appNewVersion=1.7.1
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : appCustomVersion function: Not defined
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : versionKey=CFBundleShortVersionString
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : packageID=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : pkgName=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : choiceChangesXML=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : expectedTeamID=68JN8DV835
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : blockingProcesses=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : installerTool=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : CLIInstaller=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : CLIArguments=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : updateTool=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : updateToolArguments=
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : updateToolRunAsCurrentUser=
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : BLOCKING_PROCESS_ACTION=tell_user
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : NOTIFY=success
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : LOGGING=DEBUG
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : Label type: dmg
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : archiveName: Another Redis Desktop Manager.dmg
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : no blocking processes defined, using Another Redis Desktop Manager as default
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : Changing directory to /Users/j.garcia/GitHub/Installomator/build
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : name: Another Redis Desktop Manager, appName: Another Redis Desktop Manager.app
2025-01-15 16:46:10.725 mdfind[11752:136458] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-15 16:46:10.725 mdfind[11752:136458] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-15 16:46:10.764 mdfind[11752:136458] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-15 16:46:10 : WARN  : anotherredisdesktopmanager : No previous app found
2025-01-15 16:46:10 : WARN  : anotherredisdesktopmanager : could not find Another Redis Desktop Manager.app
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : appversion:
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : Latest version of Another Redis Desktop Manager is 1.7.1
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : Another Redis Desktop Manager.dmg exists and DEBUG mode 1 enabled, skipping download
2025-01-15 16:46:10 : DEBUG : anotherredisdesktopmanager : DEBUG mode 1, not checking for blocking processes
2025-01-15 16:46:10 : REQ   : anotherredisdesktopmanager : Installing Another Redis Desktop Manager
2025-01-15 16:46:10 : INFO  : anotherredisdesktopmanager : Mounting /Users/j.garcia/GitHub/Installomator/build/Another Redis Desktop Manager.dmg
2025-01-15 16:46:11 : DEBUG : anotherredisdesktopmanager : Debugging enabled, dmgmount output was:
expected   CRC32 $638DCAD7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Another Redis Desktop Manager 1.7.1-arm64

2025-01-15 16:46:11 : INFO  : anotherredisdesktopmanager : Mounted: /Volumes/Another Redis Desktop Manager 1.7.1-arm64 2025-01-15 16:46:11 : INFO  : anotherredisdesktopmanager : Verifying: /Volumes/Another Redis Desktop Manager 1.7.1-arm64/Another Redis Desktop Manager.app 2025-01-15 16:46:11 : DEBUG : anotherredisdesktopmanager : App size: 199M	/Volumes/Another Redis Desktop Manager 1.7.1-arm64/Another Redis Desktop Manager.app 2025-01-15 16:46:12 : DEBUG : anotherredisdesktopmanager : Debugging enabled, App Verification output was: /Volumes/Another Redis Desktop Manager 1.7.1-arm64/Another Redis Desktop Manager.app: accepted source=Notarized Developer ID
origin=Developer ID Application: shibo qi (68JN8DV835)

2025-01-15 16:46:12 : INFO  : anotherredisdesktopmanager : Team ID matching: 68JN8DV835 (expected: 68JN8DV835 ) 2025-01-15 16:46:12 : INFO  : anotherredisdesktopmanager : Installing Another Redis Desktop Manager version 1.7.1 on versionKey CFBundleShortVersionString. 2025-01-15 16:46:12 : INFO  : anotherredisdesktopmanager : App has LSMinimumSystemVersion: 10.11.0 2025-01-15 16:46:12 : DEBUG : anotherredisdesktopmanager : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2025-01-15 16:46:12 : INFO  : anotherredisdesktopmanager : Finishing... 2025-01-15 16:46:15 : INFO  : anotherredisdesktopmanager : name: Another Redis Desktop Manager, appName: Another Redis Desktop Manager.app 2025-01-15 16:46:15.462 mdfind[11862:136790] [UserQueryParser] Loading keywords and predicates for locale "en_US" 2025-01-15 16:46:15.463 mdfind[11862:136790] [UserQueryParser] Loading keywords and predicates for locale "en" 2025-01-15 16:46:15.503 mdfind[11862:136790] Couldn't determine the mapping between prefab keywords and predicates. 2025-01-15 16:46:15 : WARN  : anotherredisdesktopmanager : No previous app found 2025-01-15 16:46:15 : WARN  : anotherredisdesktopmanager : could not find Another Redis Desktop Manager.app
2025-01-15 16:46:15 : REQ   : anotherredisdesktopmanager : Installed Another Redis Desktop Manager, version 1.7.1
2025-01-15 16:46:15 : INFO  : anotherredisdesktopmanager : notifying
2025-01-15 16:46:15 : DEBUG : anotherredisdesktopmanager : Unmounting /Volumes/Another Redis Desktop Manager 1.7.1-arm64
2025-01-15 16:46:15 : DEBUG : anotherredisdesktopmanager : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-01-15 16:46:15 : DEBUG : anotherredisdesktopmanager : DEBUG mode 1, not reopening anything
2025-01-15 16:46:15 : REQ   : anotherredisdesktopmanager : All done!
2025-01-15 16:46:15 : REQ   : anotherredisdesktopmanager : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
