### PR TITLE
Create foxitpdfeditor.sh

### DIFF
--- a/fragments/labels/foxitpdeditor.sh
+++ b/fragments/labels/foxitpdeditor.sh
@@ -1,0 +1,7 @@
+foxitpdfeditor)
+    name="Foxit PDF Editor"
+    type="pkg"
+    downloadURL="https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language"
+    appNewVersion=$(curl -fsSL "https://www.foxit.com/pdf-editor/version-history.html" | awk '/<div class="tab-product hide" id="tab-editor-suite-mac">/,/<\/div>/' | sed -n 's/.*<h3>Version \([0-9.]*\)<\/h3>.*/\1/p' | head -n 1)
+    expectedTeamID="8GN47HTP75"
+    ;;


### PR DESCRIPTION
2025-01-16 10:43:04 : REQ   : foxitpdfeditor : ################## Start Installomator v. 10.7beta, date 2025-01-16
2025-01-16 10:43:04 : INFO  : foxitpdfeditor : ################## Version: 10.7beta
2025-01-16 10:43:04 : INFO  : foxitpdfeditor : ################## Date: 2025-01-16
2025-01-16 10:43:04 : INFO  : foxitpdfeditor : ################## foxitpdfeditor
2025-01-16 10:43:04 : DEBUG : foxitpdfeditor : DEBUG mode 1 enabled.
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : name=Foxit PDF Editor
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : appName=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : type=pkg
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : archiveName=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : downloadURL=https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : curlOptions=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : appNewVersion=2024.4.1.66479
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : appCustomVersion function: Not defined
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : versionKey=CFBundleShortVersionString
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : packageID=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : pkgName=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : choiceChangesXML=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : expectedTeamID=8GN47HTP75
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : blockingProcesses=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : installerTool=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : CLIInstaller=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : CLIArguments=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : updateTool=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : updateToolArguments=
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : updateToolRunAsCurrentUser=
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : BLOCKING_PROCESS_ACTION=tell_user
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : NOTIFY=success
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : LOGGING=DEBUG
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : Label type: pkg
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : archiveName: Foxit PDF Editor.pkg
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : no blocking processes defined, using Foxit PDF Editor as default
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : Changing directory to .
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : App(s) found: /Applications/Foxit PDF Editor.app
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : found app at /Applications/Foxit PDF Editor.app, version 2024.4.1.66479, on versionKey CFBundleShortVersionString
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : appversion: 2024.4.1.66479
2025-01-16 10:43:05 : INFO  : foxitpdfeditor : Latest version of Foxit PDF Editor is 2024.4.1.66479
2025-01-16 10:43:05 : WARN  : foxitpdfeditor : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-01-16 10:43:05 : REQ   : foxitpdfeditor : Downloading https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language to Foxit PDF Editor.pkg
2025-01-16 10:43:05 : DEBUG : foxitpdfeditor : No Dialog connection, just download
2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : File list: -rw-r--r--@ 1 root  staff   1,3G 16 Jan 10:53 Foxit PDF Editor.pkg
2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : File type: Foxit PDF Editor.pkg: xar archive compressed TOC: 7375, SHA-1 checksum
2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : curl output was:
* Host www.foxit.com:443 was resolved.
* IPv6: 2606:4700::6812:1c5d, 2606:4700::6812:1d5d
* IPv4: 104.18.29.93, 104.18.28.93
*   Trying 104.18.29.93:443...
* Connected to www.foxit.com (104.18.29.93) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2517 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=www.foxit.com
*  start date: Dec  2 03:30:20 2024 GMT
*  expire date: Mar  2 03:30:19 2025 GMT
*  subjectAltName: host "www.foxit.com" matched cert's "www.foxit.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.foxit.com]
* [HTTP/2] [1] [:path: /downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac&platform=Mac-OS-X&language=Multi%20Language HTTP/2
> Host: www.foxit.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/2 302
< date: Thu, 16 Jan 2025 09:43:06 GMT
< content-type: text/html; charset=UTF-8
< location: https://cdn01.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/2024.x/2024.4/FoxitPDFEditor202441.L10N.Setup.pkg < set-cookie: AWSALB=fMtuka2tHUsj+/3uwqhFOU0riEHpAQ+YuRsgjawP1BPfcaXfR6oEP/NBVZNGVKLRcEKVMCnTuLiIChqxyGsxNDMbwMqqdum9s3H2E6imNWEej7l4dmR6RpJ7sz8B; Expires=Thu, 23 Jan 2025 09:43:05 GMT; Path=/ < x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< x-frame-options: sameorigin
< x-frame-options: SAMEORIGIN
< expires: Thu, 19 Nov 1981 08:52:00 GMT
< cache-control: no-store, no-cache, must-revalidate < pragma: no-cache
< content-security-policy: default-src https: wss: blob: 'self' 'unsafe-inline' *.demandbase.com *.evergage.com foxit.us-6.evergage.com *.visualwebsiteoptimizer.com app.vwo.com; img-src 'self' data: www.google.com www.google-analytics.com optimize.google.com www.googletagmanager.com *.stripe.com *.clarity.ms tribl.io px.ads.linkedin.com www.linkedin.com cc.swiftype.com *.bing.com images.g2crowd.com *.g2.com *.outbrain.com *.adroll.com alb.reddit.com 11145320.fls.doubleclick.net www.facebook.com sealserver.trustwave.com i.imgur.com *.checkout.visa.com *.mastercard.com *.discovercard.com *.discover.com *.online-metrix.net q.quora.com d.adroll.com accounts.zendesk.com hero.kingpinkton.com ct.capterra.com tracking.g2crowd.com aorta.clickagy.com googleads.g.doubleclick.net srv.stackadapt.com pixel-sync.sitescout.com id.rlcdn.com *.gravatar.com secure.gravatar.com *.paypal.com www.google.com.hk www.google.com.tw segments.company-target.com tags.srv.stackadapt.com dev.visualwebsiteoptimizer.com cdn-cookieyes.com *.visualwebsiteoptimizer.com chart.googleapis.com app.vwo.com useruploads.vwo.io www.paypalobjects.com fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.cloudflare.com static.cloudflareinsights.com kit.fontawesome.com www.google.com www.googletagmanager.com *.googleadservices.com www.google-analytics.com www.googleanalytics.com www.googleoptimize.com optimize.google.com googleads.g.doubleclick.net static.addtoany.com platform.twitter.com pi.pardot.com static.hotjar.com script.hotjar.com bat.bing.com s.swiftypecdn.com go.foxitinfo.com widget.trustpilot.com amplify.outbrain.com tr.outbrain.com q.quora.com 11145320.fls.doubleclick.net c.sf-syn.com scout-cdn.salesloft.com static.zdassets.com api.smooch.io widget-mediator.zopim.com tracking.g2crowd.com tags.srv.stackadapt.com *.zoominfo.com *.chilipiper.com www.redditstatic.com d.adroll.mgr.consensu.org d.adroll.com s.adroll.com snap.licdn.com connect.facebook.net static.ads-twitter.com sealserver.trustwave.com *.clarity.ms tribl.io *.stripe.com m.stripe.network *.paypal.com *.checkout.visa.com *.mastercard.com *.discovercard.com *.discover.com h.online-metrix.net www.aexp-static.com www.paypalobjects.com www.youtube.com villain.kingpinkton.com hero.kingpinkton.com unpkg.com *.cloudfront.net tags.clickagy.com public.profitwell.com *.demandbase.com apis.google.com www.google.com.hk js.driftt.com t.usermaven.com *.doubleclick.net google.com.tw paapi8916.d41.co cdn-0.d41.co a.quora.com *.rlcdn.com *.d41.co *.recaptcha.net *.gstatic.com cdn.evgnet.com *.company-target.com foxit.us-6.evergage.com *.evergage.com dev.visualwebsiteoptimizer.com cdn-cookieyes.com *.visualwebsiteoptimizer.com app.vwo.com *.gstatic.cn *.amazon-adsystem.com www.foxit.com ipinfo.io pagead2.googlesyndication.com; style-src 'self' 'unsafe-inline' https: www.google-analytics.com www.googletagmanager.com optimize.google.com s.swiftypecdn.com fonts.googleapis.com *.cloudflare.com tags.srv.stackadapt.com *.demandbase.com foxit.us-6.evergage.com *.visualwebsiteoptimizer.com www.foxit.com app.vwo.com; font-src 'self' fonts.gstatic.com fonts.googleapis.com ka-f.fontawesome.com script.hotjar.com foxit.us-6.evergage.com at.alicdn.com; object-src 'self' *.foxitsoftware.com; worker-src 'unsafe-inline' 'self' blob:; frame-src app.vwo.com *.visualwebsiteoptimizer.com *.foxitsoftware.com td.doubleclick.net js.driftt.com s.company-target.com js.stripe.com www.sandbox.paypal.com www.recaptcha.net www.youtube.com www.foxit.com www.paypal.com na1.foxitesign.foxit.com www.google.com www.googletagmanager.com; < access-control-allow-methods: GET, POST, OPTIONS < access-control-allow-headers: DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization < strict-transport-security: max-age=31536000; includeSubDomains; preload < cf-cache-status: DYNAMIC
< set-cookie: AWSALBCORS=fMtuka2tHUsj+/3uwqhFOU0riEHpAQ+YuRsgjawP1BPfcaXfR6oEP/NBVZNGVKLRcEKVMCnTuLiIChqxyGsxNDMbwMqqdum9s3H2E6imNWEej7l4dmR6RpJ7sz8B; Expires=Thu, 23 Jan 2025 09:43:05 GMT; Path=/; SameSite=None; Secure < set-cookie: PHPSESSID=bu3feii7cf4f9qc4vkafd5a421; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: first_landing_page=%2Fdownloads%2Flatest.html; path=/; domain=.foxit.com; secure < set-cookie: eid=-1; expires=Thu, 16-Jan-2025 10:43:06 GMT; Max-Age=3600; path=/ < set-cookie: ename=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/ < set-cookie: last_referrer_page=Direct; path=/; domain=.foxit.com; secure Last Log repeated 2 times
< set-cookie: FoxitWebsiteLang=en-us; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: fx_uid=251UsZWnJ-c9tMb3B-163; expires=Thu, 17-Dec-2026 09:43:06 GMT; Max-Age=60480000; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b3VyaXN0X2lkIjoiZTIxMTlkNmFmYzQ1OTM2NjczZGY4NGRmNzNjMmFkYTEiLCJicm93c2VyX2ZpbmdlcnByaW50IjoiMDI2MDEzYmY3ZmQwOTBmNDcwZTRiOWQ1MjEyZTRjNDUiLCJ0aW1lIjoxNzM3MDIwNTg2LCJpcCI6IjE0NS4yMjQuNzQuNjQifQ.lt4bDc913OlKLCg0RUt78tc95gm1FbxH4OEBt1oLcxM; expires=Thu, 16-Jan-2025 21:43:06 GMT; Max-Age=43200; path=/ < set-cookie: CLIENT_STATUS=tourist; expires=Thu, 16-Jan-2025 21:43:06 GMT; Max-Age=43200; path=/ < set-cookie: client_id=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; domain=.foxit.com; secure < set-cookie: session_id=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; domain=.foxit.com; secure < set-cookie: last_type_of_visits=Direct%2B; expires=Sun, 19-Jan-2025 09:43:06 GMT; Max-Age=259200; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: number_of_visits=1; expires=Sun, 19-Jan-2025 09:43:06 GMT; Max-Age=259200; path=/; domain=.foxit.com; secure < set-cookie: source=Direct%2B; expires=Sun, 19-Jan-2025 09:43:06 GMT; Max-Age=259200; path=/; domain=.foxit.com; secure < set-cookie: had_view_cookie_policy=1; expires=Fri, 16-Jan-2026 09:43:06 GMT; Max-Age=31536000; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: CMSFoxitWebsiteCC=cd19STHmmUvExBqBe1N%2FpXTheJTk8d5sEVXQcf34s0Se%2BXUTc90q8pTgGi%2BKVlBQzzOGjf1D7%2BGaTKU1781C20R9qWIsUMoX5rvnNmxGQlZ6lloijrr3wFbOtEctEVJbwM75P07vYVFUYOFstKwOeck9QaY01TFBxehlDz1xj3kv9yxJhGRs; expires=Fri, 17-Jan-2025 09:43:06 GMT; Max-Age=86400; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: countrycode=US; path=/; domain=.foxit.com; secure < set-cookie: needGTMTracking=7559qSjkhrO2BpysEtdw%2BFWqKnB4n3IqZD8NXrUs; expires=Fri, 17-Jan-2025 09:43:06 GMT; Max-Age=86400; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: rate_info=%7B%22count%22%3A0%2C%22point%22%3A0%7D; expires=Fri, 17-Jan-2025 09:43:06 GMT; Max-Age=86400; path=/; domain=.foxit.com; secure; HttpOnly < set-cookie: __cf_bm=VhsI4836_kv8o2wmXUTE5FS6MuS4aSGarO3KIdmAQq4-1737020586-1.0.1.1-ZbW7cZHtVdGUVlOXyD3frtyN2UamM62iJRvK7Y0KJPzVXpWu2wM7Gs2BVyp4bZ3WgIjmJx0Uc95yNa3xj7LRGw; path=/; expires=Thu, 16-Jan-25 10:13:06 GMT; domain=.foxit.com; HttpOnly; Secure; SameSite=None < server: cloudflare
< cf-ray: 902d28c5eb9c1e4c-FRA
<
* Ignoring the response-body
* Connection #0 to host www.foxit.com left intact
* Issue another request to this URL: 'https://cdn01.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/2024.x/2024.4/FoxitPDFEditor202441.L10N.Setup.pkg'
* Host cdn01.foxitsoftware.com:443 was resolved.
* IPv6: (none)
* IPv4: 64.62.208.5, 184.105.233.248, 64.62.194.29, 64.62.208.6, 64.62.208.4, 64.62.208.2, 64.62.153.144, 64.62.194.28
*   Trying 64.62.208.5:443...
* Connected to cdn01.foxitsoftware.com (64.62.208.5) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [328 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5147 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.foxitsoftware.com
*  start date: Jan 14 01:48:31 2025 GMT
*  expire date: Feb  5 19:43:43 2026 GMT
*  subjectAltName: host "cdn01.foxitsoftware.com" matched cert's "*.foxitsoftware.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /pub/foxit/phantomPDF/desktop/mac/2024.x/2024.4/FoxitPDFEditor202441.L10N.Setup.pkg HTTP/1.1
> Host: cdn01.foxitsoftware.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off < HTTP/1.1 200 OK
< Date: Thu, 16 Jan 2025 09:43:06 GMT
< Server: Apache/2.4.58 (Debian)
< Strict-Transport-Security: max-age=31536000
< Last-Modified: Sun, 12 Jan 2025 03:39:33 GMT
< ETag: "56648019-62b7a137db89b"
< Accept-Ranges: bytes
< Content-Length: 1449426969
< Content-Type: application/vnd.apple.installer+xml <
{ [7880 bytes data]
* Connection #1 to host cdn01.foxitsoftware.com left intact

2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : DEBUG mode 1, not checking for blocking processes
2025-01-16 10:53:54 : REQ   : foxitpdfeditor : Installing Foxit PDF Editor
2025-01-16 10:53:54 : INFO  : foxitpdfeditor : Verifying: Foxit PDF Editor.pkg
2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : File list: -rw-r--r--@ 1 root  staff   1,3G 16 Jan 10:53 Foxit PDF Editor.pkg
2025-01-16 10:53:54 : DEBUG : foxitpdfeditor : File type: Foxit PDF Editor.pkg: xar archive compressed TOC: 7375, SHA-1 checksum
2025-01-16 10:53:55 : DEBUG : foxitpdfeditor : spctlOut is Foxit PDF Editor.pkg: accepted
2025-01-16 10:53:55 : DEBUG : foxitpdfeditor : source=Notarized Developer ID
2025-01-16 10:53:55 : DEBUG : foxitpdfeditor : origin=Developer ID Installer: Foxit Corporation (8GN47HTP75)
2025-01-16 10:53:55 : INFO  : foxitpdfeditor : Team ID: 8GN47HTP75 (expected: 8GN47HTP75 )
2025-01-16 10:53:55 : DEBUG : foxitpdfeditor : DEBUG enabled, skipping installation
2025-01-16 10:53:55 : INFO  : foxitpdfeditor : Finishing...
2025-01-16 10:53:58 : INFO  : foxitpdfeditor : App(s) found: /Applications/Foxit PDF Editor.app
2025-01-16 10:53:58 : INFO  : foxitpdfeditor : found app at /Applications/Foxit PDF Editor.app, version 2024.4.1.66479, on versionKey CFBundleShortVersionString
2025-01-16 10:53:58 : REQ   : foxitpdfeditor : Installed Foxit PDF Editor, version 2024.4.1.66479
2025-01-16 10:53:58 : INFO  : foxitpdfeditor : notifying
2025-01-16 10:53:58 : DEBUG : foxitpdfeditor : DEBUG mode 1, not reopening anything
2025-01-16 10:53:58 : REQ   : foxitpdfeditor : All done!
2025-01-16 10:53:58 : REQ   : foxitpdfeditor : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
