### PR TITLE
Create Label unityhub.sh

### DIFF
--- a/fragments/labels/unityhub.sh
+++ b/fragments/labels/unityhub.sh
@@ -5,3 +5,4 @@ unityhub)
     appNewVersion=$(curl -s https://unity.com/unity-hub/release-notes | grep -oE '>[0-9]+\.[0-9]+\.[0-9]+<' | head -1 | tr -d '<>')
     expectedTeamID="9QW8UQUTAA"
     ;;
+

--- a/fragments/labels/unityhub.sh
+++ b/fragments/labels/unityhub.sh
@@ -3,5 +3,5 @@ unityhub)
     type="dmg"
     downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg"
     appNewVersion=$(curl -s https://unity.com/unity-hub/release-notes | grep -oE '>[0-9]+\.[0-9]+\.[0-9]+<' | head -1 | tr -d '<>')
-    expectedTeamID="BVPN9UFA9B"
+    expectedTeamID="9QW8UQUTAA"
     ;;

--- a/fragments/labels/unityhub.sh
+++ b/fragments/labels/unityhub.sh
@@ -1,0 +1,7 @@
+unityhub)
+    name="Unity Hub"
+    type="dmg"
+    downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg"
+    appNewVersion=$(curl -s https://unity.com/unity-hub/release-notes | grep -oE '>[0-9]+\.[0-9]+\.[0-9]+<' | head -1 | tr -d '<>')
+    expectedTeamID="BVPN9UFA9B"
+    ;;


### PR DESCRIPTION
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

Software: https://docs.unity3d.com/hub/manual/InstallHub.html

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes issue with https://github.com/Installomator/Installomator/pull/1769 - Updated TeamID from BVPN9UFA9B / 'Unity Hub' to 9QW8UQUTAA / 'Unity Technologies SF' as Unity seems to have changed which one they're using in 3.11.0 which came out 1/15/24.

**Installomator log**
```
Script result: 2025-01-16 10:29:53 : REQ   :  : shifting arguments for Jamf
2025-01-16 10:29:53 : REQ   : unityhub : ################## Start Installomator v. 10.6beta, date 2024-04-23
2025-01-16 10:29:53 : INFO  : unityhub : ################## Version: 10.6beta
2025-01-16 10:29:53 : INFO  : unityhub : ################## Date: 2024-04-23
2025-01-16 10:29:53 : INFO  : unityhub : ################## unityhub
2025-01-16 10:30:05 : INFO  : unityhub : BLOCKING_PROCESS_ACTION=tell_user_then_kill
2025-01-16 10:30:05 : INFO  : unityhub : NOTIFY=silent
2025-01-16 10:30:05 : INFO  : unityhub : LOGGING=INFO
2025-01-16 10:30:05 : INFO  : unityhub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-16 10:30:05 : INFO  : unityhub : Label type: dmg
2025-01-16 10:30:05 : INFO  : unityhub : archiveName: Unity Hub.dmg
2025-01-16 10:30:05 : INFO  : unityhub : no blocking processes defined, using Unity Hub as default
2025-01-16 10:30:05 : INFO  : unityhub : name: Unity Hub, appName: Unity Hub.app
2025-01-16 10:30:05.592 mdfind[55227:1357238] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-16 10:30:05.593 mdfind[55227:1357238] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-16 10:30:05.738 mdfind[55227:1357238] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-16 10:30:05 : WARN  : unityhub : No previous app found
2025-01-16 10:30:05 : WARN  : unityhub : could not find Unity Hub.app
2025-01-16 10:30:05 : INFO  : unityhub : appversion: 
2025-01-16 10:30:05 : INFO  : unityhub : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2025-01-16 10:30:05 : INFO  : unityhub : Latest version of Unity Hub is 3.11.0
2025-01-16 10:30:05 : REQ   : unityhub : Downloading https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg to Unity Hub.dmg
2025-01-16 10:30:14 : REQ   : unityhub : no more blocking processes, continue with update
2025-01-16 10:30:14 : REQ   : unityhub : Installing Unity Hub
2025-01-16 10:30:14 : INFO  : unityhub : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.clk1gsDuhB/Unity Hub.dmg
2025-01-16 10:30:28 : INFO  : unityhub : Mounted: /Volumes/Unity Hub 3.11.0
2025-01-16 10:30:29 : INFO  : unityhub : Verifying: /Volumes/Unity Hub 3.11.0/Unity Hub.app
2025-01-16 10:30:51 : INFO  : unityhub : Team ID matching: 9QW8UQUTAA (expected: 9QW8UQUTAA )
2025-01-16 10:30:51 : INFO  : unityhub : Installing Unity Hub version 3.11.0 on versionKey CFBundleShortVersionString.
2025-01-16 10:30:51 : INFO  : unityhub : App has LSMinimumSystemVersion: 10.13
2025-01-16 10:30:52 : INFO  : unityhub : Copy /Volumes/Unity Hub 3.11.0/Unity Hub.app to /Applications
2025-01-16 10:31:07 : WARN  : unityhub : Changing owner to whiteb
2025-01-16 10:31:07 : INFO  : unityhub : Finishing...
2025-01-16 10:31:10 : INFO  : unityhub : App(s) found: /Applications/Unity Hub.app
2025-01-16 10:31:10 : INFO  : unityhub : found app at /Applications/Unity Hub.app, version 3.11.0, on versionKey CFBundleShortVersionString
2025-01-16 10:31:10 : REQ   : unityhub : Installed Unity Hub, version 3.11.0
2025-01-16 10:31:11 : INFO  : unityhub : Installomator did not close any apps, so no need to reopen any apps.
2025-01-16 10:31:11 : REQ   : unityhub : All done!
2025-01-16 10:31:11 : REQ   : unityhub : ################## End Installomator, exit code 0
```