### PR TITLE
Cleanup of the zoomrooms label

### DIFF
--- a/fragments/labels/zoomrooms.sh
+++ b/fragments/labels/zoomrooms.sh
@@ -1,9 +1,8 @@
+zoompresence|\
 zoomrooms)
-    name="ZoomRooms"
+    name="ZoomPresence"
     type="pkg"
-    packageID="us.zoom.pkg.zp"
     downloadURL="https://zoom.us/client/latest/ZoomRooms.pkg"
     appNewVersion="$(curl -fsIL ${downloadURL} | grep -i location | cut -d "/" -f5)"
     expectedTeamID="BJ4HAAB9B3"
-    blockingProcesses=( "ZoomPresence" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Removed the unnecessary packageID and blockingProcesses keys. Updated the name key to reflect the current real name.

Would you prefer the file name also be renamed? I wasn't sure on that. I can make that change if need be.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh zoompresence
2025-01-16 21:58:01 : REQ   : zoompresence : ################## Start Installomator v. 10.7beta, date 2025-01-16
2025-01-16 21:58:01 : INFO  : zoompresence : ################## Version: 10.7beta
2025-01-16 21:58:01 : INFO  : zoompresence : ################## Date: 2025-01-16
2025-01-16 21:58:01 : INFO  : zoompresence : ################## zoompresence
2025-01-16 21:58:01 : DEBUG : zoompresence : DEBUG mode 1 enabled.
2025-01-16 21:58:02 : DEBUG : zoompresence : name=ZoomPresence
2025-01-16 21:58:02 : DEBUG : zoompresence : appName=
2025-01-16 21:58:02 : DEBUG : zoompresence : type=pkg
2025-01-16 21:58:02 : DEBUG : zoompresence : archiveName=
2025-01-16 21:58:02 : DEBUG : zoompresence : downloadURL=https://zoom.us/client/latest/ZoomRooms.pkg
2025-01-16 21:58:02 : DEBUG : zoompresence : curlOptions=
2025-01-16 21:58:02 : DEBUG : zoompresence : appNewVersion=6.3.5.8405
2025-01-16 21:58:02 : DEBUG : zoompresence : appCustomVersion function: Not defined
2025-01-16 21:58:02 : DEBUG : zoompresence : versionKey=CFBundleShortVersionString
2025-01-16 21:58:02 : DEBUG : zoompresence : packageID=
2025-01-16 21:58:02 : DEBUG : zoompresence : pkgName=
2025-01-16 21:58:02 : DEBUG : zoompresence : choiceChangesXML=
2025-01-16 21:58:02 : DEBUG : zoompresence : expectedTeamID=BJ4HAAB9B3
2025-01-16 21:58:02 : DEBUG : zoompresence : blockingProcesses=
2025-01-16 21:58:02 : DEBUG : zoompresence : installerTool=
2025-01-16 21:58:02 : DEBUG : zoompresence : CLIInstaller=
2025-01-16 21:58:02 : DEBUG : zoompresence : CLIArguments=
2025-01-16 21:58:02 : DEBUG : zoompresence : updateTool=
2025-01-16 21:58:02 : DEBUG : zoompresence : updateToolArguments=
2025-01-16 21:58:02 : DEBUG : zoompresence : updateToolRunAsCurrentUser=
2025-01-16 21:58:02 : INFO  : zoompresence : BLOCKING_PROCESS_ACTION=tell_user
2025-01-16 21:58:02 : INFO  : zoompresence : NOTIFY=success
2025-01-16 21:58:02 : INFO  : zoompresence : LOGGING=DEBUG
2025-01-16 21:58:02 : INFO  : zoompresence : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-16 21:58:02 : INFO  : zoompresence : Label type: pkg
2025-01-16 21:58:02 : INFO  : zoompresence : archiveName: ZoomPresence.pkg
2025-01-16 21:58:02 : INFO  : zoompresence : no blocking processes defined, using ZoomPresence as default
2025-01-16 21:58:02 : DEBUG : zoompresence : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-16 21:58:02 : INFO  : zoompresence : name: ZoomPresence, appName: ZoomPresence.app
2025-01-16 21:58:02.296 mdfind[91959:51301864] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-16 21:58:02.297 mdfind[91959:51301864] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-16 21:58:02.383 mdfind[91959:51301864] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-16 21:58:02 : WARN  : zoompresence : No previous app found
2025-01-16 21:58:02 : WARN  : zoompresence : could not find ZoomPresence.app
2025-01-16 21:58:02 : INFO  : zoompresence : appversion: 
2025-01-16 21:58:02 : INFO  : zoompresence : Latest version of ZoomPresence is 6.3.5.8405
2025-01-16 21:58:02 : REQ   : zoompresence : Downloading https://zoom.us/client/latest/ZoomRooms.pkg to ZoomPresence.pkg
2025-01-16 21:58:02 : DEBUG : zoompresence : No Dialog connection, just download
2025-01-16 21:59:49 : DEBUG : zoompresence : File list: -rw-r--r--  1 gilburns  staff   519M Jan 16 21:59 ZoomPresence.pkg
2025-01-16 21:59:49 : DEBUG : zoompresence : File type: ZoomPresence.pkg: xar archive compressed TOC: 7874, SHA-1 checksum
2025-01-16 21:59:49 : DEBUG : zoompresence : curl output was:
* Host zoom.us:443 was resolved.
* IPv6: 2407:30c0:182::aa72:3402
* IPv4: 170.114.52.2
*   Trying 170.114.52.2:443...
* Connected to zoom.us (170.114.52.2) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [312 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3059 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Zoom Video Communications, Inc.; CN=*.zoom.us
*  start date: Mar 28 00:00:00 2024 GMT
*  expire date: Apr  5 23:59:59 2025 GMT
*  subjectAltName: host "zoom.us" matched cert's "zoom.us"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://zoom.us/client/latest/ZoomRooms.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: zoom.us]
* [HTTP/2] [1] [:path: /client/latest/ZoomRooms.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /client/latest/ZoomRooms.pkg HTTP/2
> Host: zoom.us
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Fri, 17 Jan 2025 03:58:02 GMT
< content-length: 0
< location: https://cdn.zoom.us/prod/6.3.5.8405/ZoomRooms.pkg
< x-zm-trackingid: v=2.0;clid=aw1;rid=WEB_54a2a46f332c1fa7a3ab5bc79d52795b
< x-content-type-options: nosniff
< content-security-policy: upgrade-insecure-requests; default-src https://*.zoom.us https://zoom.us blob: 'self'; img-src https: about: blob: data: 'self'; style-src https: safari-extension: chrome-extension: 'unsafe-inline' data: 'self'; font-src https: safari-extension: chrome-extension: blob: data: 'self'; connect-src * about: blob: data: 'self'; media-src * rtmp: blob: data: 'self'; frame-src https: ms-appx-web: zoommtg: zoomus: wvjbscheme: zoomprc: data: blob: 'self'; object-src 'none'; base-uri 'none';
< x-frame-options: SAMEORIGIN
< set-cookie: _zm_feature=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Secure; HttpOnly
< x-zm-zoneid: VA
< strict-transport-security: max-age=31536000; includeSubDomains
< x-xss-protection: 1; mode=block
< referrer-policy: strict-origin-when-cross-origin
< cf-cache-status: DYNAMIC
< set-cookie: zm_aid=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: zm_haid=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: zm_tmaid=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: zm_htmaid=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: _zm_ssid=aw1_c_mLZcd_mfRomIaTFA7XcItg; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: cred=A79A33B238F88206E85B93FDA54AF3E9; Path=/; Secure; HttpOnly
< set-cookie: _zm_ctaid=8wO1FDe3TA6KfUUPa1JrPw.1737086282554.f34d50964e7bfaa2fc0eda43f0e1a869; Max-Age=7200; Expires=Fri, 17 Jan 2025 05:58:02 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: _zm_chtaid=736; Max-Age=7200; Expires=Fri, 17 Jan 2025 05:58:02 GMT; Domain=zoom.us; Path=/; Secure; HttpOnly
< set-cookie: _zm_mtk_guid=5b4c53a26394465ab58a46981e37ed5a; Max-Age=63072000; Expires=Sun, 17 Jan 2027 03:58:02 GMT; Domain=zoom.us; Path=/; Secure
< set-cookie: __cf_bm=mhIpKa4zBuYEZ0eD6O8tAKGKOGhP09ln07AlcJZFof0-1737086282-1.0.1.1-QKafv.P_ptP_rbHco3Jx5U5uzmlkEfWMepE7sfiignmetsuopuOpgsOrCTbvktouSYeEm67VDhaKmDP_ps_mYA; path=/; expires=Fri, 17-Jan-25 04:28:02 GMT; domain=.zoom.us; HttpOnly; Secure; SameSite=None
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=Iny7U8oHrk2XuO%2F0hbjSeuqqYOxe7wl249pq8ih%2FcyFPf4uU37i9S5NzLNGyjw1HCtsfUCwWhDb%2B2Wr2%2Fus%2BikwH7PXgoEIZPVUZu0V0gjY8kzora3%2B6PV8%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
< cf-ray: 90336cb1ca3c6315-ORD
< alt-svc: h3=":443"; ma=86400
< 
* Ignoring the response-body
* Connection #0 to host zoom.us left intact
* Issue another request to this URL: 'https://cdn.zoom.us/prod/6.3.5.8405/ZoomRooms.pkg'
* Host cdn.zoom.us:443 was resolved.
* IPv6: 2407:30c0:180::1, 2407:30c0:181::1
* IPv4: 170.114.46.1, 170.114.45.1
*   Trying 170.114.46.1:443...
* Connected to cdn.zoom.us (170.114.46.1) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [316 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3059 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: C=US; ST=California; L=San Jose; O=Zoom Video Communications, Inc.; CN=*.zoom.us
*  start date: Mar 28 00:00:00 2024 GMT
*  expire date: Apr  5 23:59:59 2025 GMT
*  subjectAltName: host "cdn.zoom.us" matched cert's "*.zoom.us"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cdn.zoom.us/prod/6.3.5.8405/ZoomRooms.pkg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cdn.zoom.us]
* [HTTP/2] [1] [:path: /prod/6.3.5.8405/ZoomRooms.pkg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /prod/6.3.5.8405/ZoomRooms.pkg HTTP/2
> Host: cdn.zoom.us
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Fri, 17 Jan 2025 03:58:02 GMT
< content-type: application/vnd.apple.installer+xml
< content-length: 544489886
< cf-cache-status: HIT
< accept-ranges: bytes
< access-control-allow-origin: *
< age: 337645
< cache-control: public, max-age=31536000
< etag: "71effa3beed8231124c93a8bd3c8cc54-65"
< expires: Sat, 17 Jan 2026 03:58:02 GMT
< last-modified: Mon, 13 Jan 2025 05:33:56 GMT
< strict-transport-security: max-age=15552000; includeSubDomains
< vary: Origin
< access-control-request-method: GET
< cross-origin-resource-policy: cross-origin
< x-amz-server-side-encryption: AES256
< set-cookie: __cf_bm=5yFgTLHjd._GqqdwKqNeaa1T1mcj3faRjWUnCHLkapg-1737086282-1.0.1.1-cjVqkAgERd1m7Eeqyh6k_STzcKDSWkU92jctVsSTV7IBGemtpPOVfF0FGh8Jcu6HxvNpF76z2UUfTh.1O4KSKA; path=/; expires=Fri, 17-Jan-25 04:28:02 GMT; domain=.cdn.zoom.us; HttpOnly; Secure; SameSite=None
< server: cloudflare
< cf-ray: 90336cb28d44f15d-ORD
< alt-svc: h3=":443"; ma=86400
< 
{ [1360 bytes data]
* Connection #1 to host cdn.zoom.us left intact

2025-01-16 21:59:49 : DEBUG : zoompresence : DEBUG mode 1, not checking for blocking processes
2025-01-16 21:59:49 : REQ   : zoompresence : Installing ZoomPresence
2025-01-16 21:59:49 : INFO  : zoompresence : Verifying: ZoomPresence.pkg
2025-01-16 21:59:49 : DEBUG : zoompresence : File list: -rw-r--r--  1 gilburns  staff   519M Jan 16 21:59 ZoomPresence.pkg
2025-01-16 21:59:49 : DEBUG : zoompresence : File type: ZoomPresence.pkg: xar archive compressed TOC: 7874, SHA-1 checksum
2025-01-16 21:59:49 : DEBUG : zoompresence : spctlOut is ZoomPresence.pkg: accepted
2025-01-16 21:59:49 : DEBUG : zoompresence : source=Notarized Developer ID
2025-01-16 21:59:49 : DEBUG : zoompresence : origin=Developer ID Installer: Zoom Video Communications, Inc. (BJ4HAAB9B3)
2025-01-16 21:59:49 : INFO  : zoompresence : Team ID: BJ4HAAB9B3 (expected: BJ4HAAB9B3 )
2025-01-16 21:59:49 : DEBUG : zoompresence : DEBUG enabled, skipping installation
2025-01-16 21:59:49 : INFO  : zoompresence : Finishing...
2025-01-16 21:59:52 : INFO  : zoompresence : name: ZoomPresence, appName: ZoomPresence.app
2025-01-16 21:59:52.610 mdfind[98817:51315374] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-16 21:59:52.610 mdfind[98817:51315374] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-16 21:59:52.656 mdfind[98817:51315374] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-16 21:59:52 : WARN  : zoompresence : No previous app found
2025-01-16 21:59:52 : WARN  : zoompresence : could not find ZoomPresence.app
2025-01-16 21:59:52 : REQ   : zoompresence : Installed ZoomPresence, version 6.3.5.8405
2025-01-16 21:59:52 : INFO  : zoompresence : notifying
ERROR: Notifications are not allowed for this application
2025-01-16 21:59:52 : DEBUG : zoompresence : DEBUG mode 1, not reopening anything
2025-01-16 21:59:52 : REQ   : zoompresence : All done!
2025-01-16 21:59:52 : REQ   : zoompresence : ################## End Installomator, exit code 0 

```
