### PR TITLE
Add appNewVersion key to Pacifist

### DIFF
--- a/fragments/labels/pacifist.sh
+++ b/fragments/labels/pacifist.sh
@@ -2,5 +2,6 @@ pacifist)
     name="Pacifist"
     type="dmg"
     downloadURL="https://charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg"
+    appNewVersion="$(curl -fsL "https://www.charlessoft.com/cgi-bin/pacifist_sparkle.cgi" | xpath 'string(//rss/channel/item[last()]/enclosure/@sparkle:shortVersionString)' 2>/dev/null)"
     expectedTeamID="HRLUCP7QP4"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Add **appNewVersion** key to Pacifist

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh pacifist
2025-01-18 07:42:13 : REQ   : pacifist : ################## Start Installomator v. 10.7beta, date 2025-01-18
2025-01-18 07:42:13 : INFO  : pacifist : ################## Version: 10.7beta
2025-01-18 07:42:13 : INFO  : pacifist : ################## Date: 2025-01-18
2025-01-18 07:42:13 : INFO  : pacifist : ################## pacifist
2025-01-18 07:42:13 : DEBUG : pacifist : DEBUG mode 1 enabled.
2025-01-18 07:42:14 : DEBUG : pacifist : name=Pacifist
2025-01-18 07:42:14 : DEBUG : pacifist : appName=
2025-01-18 07:42:14 : DEBUG : pacifist : type=dmg
2025-01-18 07:42:14 : DEBUG : pacifist : archiveName=
2025-01-18 07:42:14 : DEBUG : pacifist : downloadURL=https://charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg
2025-01-18 07:42:14 : DEBUG : pacifist : curlOptions=
2025-01-18 07:42:14 : DEBUG : pacifist : appNewVersion=4.1.3
2025-01-18 07:42:14 : DEBUG : pacifist : appCustomVersion function: Not defined
2025-01-18 07:42:14 : DEBUG : pacifist : versionKey=CFBundleShortVersionString
2025-01-18 07:42:14 : DEBUG : pacifist : packageID=
2025-01-18 07:42:14 : DEBUG : pacifist : pkgName=
2025-01-18 07:42:14 : DEBUG : pacifist : choiceChangesXML=
2025-01-18 07:42:14 : DEBUG : pacifist : expectedTeamID=HRLUCP7QP4
2025-01-18 07:42:14 : DEBUG : pacifist : blockingProcesses=
2025-01-18 07:42:14 : DEBUG : pacifist : installerTool=
2025-01-18 07:42:14 : DEBUG : pacifist : CLIInstaller=
2025-01-18 07:42:14 : DEBUG : pacifist : CLIArguments=
2025-01-18 07:42:14 : DEBUG : pacifist : updateTool=
2025-01-18 07:42:14 : DEBUG : pacifist : updateToolArguments=
2025-01-18 07:42:14 : DEBUG : pacifist : updateToolRunAsCurrentUser=
2025-01-18 07:42:14 : INFO  : pacifist : BLOCKING_PROCESS_ACTION=tell_user
2025-01-18 07:42:14 : INFO  : pacifist : NOTIFY=success
2025-01-18 07:42:14 : INFO  : pacifist : LOGGING=DEBUG
2025-01-18 07:42:14 : INFO  : pacifist : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-18 07:42:14 : INFO  : pacifist : Label type: dmg
2025-01-18 07:42:14 : INFO  : pacifist : archiveName: Pacifist.dmg
2025-01-18 07:42:14 : INFO  : pacifist : no blocking processes defined, using Pacifist as default
2025-01-18 07:42:14 : DEBUG : pacifist : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-18 07:42:14 : INFO  : pacifist : name: Pacifist, appName: Pacifist.app
2025-01-18 07:42:14.467 mdfind[26670:61824760] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 07:42:14.467 mdfind[26670:61824760] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 07:42:14.505 mdfind[26670:61824760] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 07:42:14 : INFO  : pacifist : App(s) found: /Users/gilburns/Applications/Pacifist.app
2025-01-18 07:42:14 : WARN  : pacifist : could not determine location of Pacifist.app
2025-01-18 07:42:14 : INFO  : pacifist : appversion: 
2025-01-18 07:42:14 : INFO  : pacifist : Latest version of Pacifist is 4.1.3
2025-01-18 07:42:14 : REQ   : pacifist : Downloading https://charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg to Pacifist.dmg
2025-01-18 07:42:14 : DEBUG : pacifist : No Dialog connection, just download
2025-01-18 07:42:22 : DEBUG : pacifist : File list: -rw-r--r--  1 gilburns  staff    36M Jan 18 07:42 Pacifist.dmg
2025-01-18 07:42:22 : DEBUG : pacifist : File type: Pacifist.dmg: bzip2 compressed data, block size = 100k
2025-01-18 07:42:22 : DEBUG : pacifist : curl output was:
* Host charlessoft.com:443 was resolved.
* IPv6: (none)
* IPv4: 158.106.129.172
*   Trying 158.106.129.172:443...
* Connected to charlessoft.com (158.106.129.172) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5217 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=charlessoft.com
*  start date: May 28 00:00:00 2024 GMT
*  expire date: May 28 23:59:59 2025 GMT
*  subjectAltName: host "charlessoft.com" matched cert's "charlessoft.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=RapidSSL TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: charlessoft.com]
* [HTTP/2] [1] [:path: /cgi-bin/pacifist_download.cgi?type=dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /cgi-bin/pacifist_download.cgi?type=dmg HTTP/2
> Host: charlessoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 301 
< location: https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg
< content-length: 274
< content-type: text/html; charset=iso-8859-1
< date: Sat, 18 Jan 2025 13:42:14 GMT
< server: Apache/2
< 
* Ignoring the response-body
* Connection #0 to host charlessoft.com left intact
* Issue another request to this URL: 'https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg'
* Host www.charlessoft.com:443 was resolved.
* IPv6: (none)
* IPv4: 158.106.129.172
*   Trying 158.106.129.172:443...
* Connected to www.charlessoft.com (158.106.129.172) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5217 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=charlessoft.com
*  start date: May 28 00:00:00 2024 GMT
*  expire date: May 28 23:59:59 2025 GMT
*  subjectAltName: host "www.charlessoft.com" matched cert's "www.charlessoft.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=RapidSSL TLS RSA CA G1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.charlessoft.com/cgi-bin/pacifist_download.cgi?type=dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.charlessoft.com]
* [HTTP/2] [1] [:path: /cgi-bin/pacifist_download.cgi?type=dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /cgi-bin/pacifist_download.cgi?type=dmg HTTP/2
> Host: www.charlessoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< expires: Sat, 18 Jan 2025 13:43:15 GMT
< date: Sat, 18 Jan 2025 13:42:14 GMT
< cache-control: max-age=60
< location: https://www.charlessoft.com/pacifist_download/Pacifist_4.1.3.dmg
< vary: User-Agent
< content-length: 0
< server: Apache/2
< 
* Ignoring the response-body
* Connection #1 to host www.charlessoft.com left intact
* Issue another request to this URL: 'https://www.charlessoft.com/pacifist_download/Pacifist_4.1.3.dmg'
* Found bundle for host: 0x6000005aff60 [can multiplex]
* Re-using existing connection with host www.charlessoft.com
* [HTTP/2] [3] OPENED stream for https://www.charlessoft.com/pacifist_download/Pacifist_4.1.3.dmg
* [HTTP/2] [3] [:method: GET]
* [HTTP/2] [3] [:scheme: https]
* [HTTP/2] [3] [:authority: www.charlessoft.com]
* [HTTP/2] [3] [:path: /pacifist_download/Pacifist_4.1.3.dmg]
* [HTTP/2] [3] [user-agent: curl/8.7.1]
* [HTTP/2] [3] [accept: */*]
> GET /pacifist_download/Pacifist_4.1.3.dmg HTTP/2
> Host: www.charlessoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< last-modified: Thu, 09 Jan 2025 02:27:36 GMT
< etag: "2406849-62b3cb8afc8af"
< accept-ranges: bytes
< content-length: 37775433
< vary: Accept-Encoding,User-Agent
< content-type: application/octet-stream
< date: Sat, 18 Jan 2025 13:42:15 GMT
< server: Apache/2
< 
{ [16241 bytes data]
* Connection #1 to host www.charlessoft.com left intact

2025-01-18 07:42:22 : DEBUG : pacifist : DEBUG mode 1, not checking for blocking processes
2025-01-18 07:42:22 : REQ   : pacifist : Installing Pacifist
2025-01-18 07:42:22 : INFO  : pacifist : Mounting /Users/gilburns/GitHub/Installomator/build/Pacifist.dmg
2025-01-18 07:42:25 : DEBUG : pacifist : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $13D81963
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $37B5D71F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CFF054B7
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $20741DD8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CFF054B7
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CB92EF61
verified   CRC32 $FA2ED2E0
/dev/disk17         	GUID_partition_scheme
/dev/disk17s1       	Apple_APFS
/dev/disk18         	EF57347C-0000-11AA-AA11-0030654
/dev/disk18s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Pacifist

2025-01-18 07:42:25 : INFO  : pacifist : Mounted: /Volumes/Pacifist
2025-01-18 07:42:25 : INFO  : pacifist : Verifying: /Volumes/Pacifist/Pacifist.app
2025-01-18 07:42:25 : DEBUG : pacifist : App size:  58M	/Volumes/Pacifist/Pacifist.app
2025-01-18 07:42:27 : DEBUG : pacifist : Debugging enabled, App Verification output was:
/Volumes/Pacifist/Pacifist.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Charles Srstka (HRLUCP7QP4)

2025-01-18 07:42:27 : INFO  : pacifist : Team ID matching: HRLUCP7QP4 (expected: HRLUCP7QP4 )
2025-01-18 07:42:27 : INFO  : pacifist : Installing Pacifist version 4.1.3 on versionKey CFBundleShortVersionString.
2025-01-18 07:42:27 : INFO  : pacifist : App has LSMinimumSystemVersion: 10.14.6
2025-01-18 07:42:27 : DEBUG : pacifist : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-18 07:42:27 : INFO  : pacifist : Finishing...
2025-01-18 07:42:30 : INFO  : pacifist : name: Pacifist, appName: Pacifist.app
2025-01-18 07:42:30.331 mdfind[30207:61831107] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 07:42:30.332 mdfind[30207:61831107] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 07:42:30.377 mdfind[30207:61831107] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 07:42:30 : INFO  : pacifist : App(s) found: /Users/gilburns/Applications/Pacifist.app
2025-01-18 07:42:30 : WARN  : pacifist : could not determine location of Pacifist.app
2025-01-18 07:42:30 : REQ   : pacifist : Installed Pacifist, version 4.1.3
2025-01-18 07:42:30 : INFO  : pacifist : notifying
ERROR: Notifications are not allowed for this application
2025-01-18 07:42:30 : DEBUG : pacifist : Unmounting /Volumes/Pacifist
2025-01-18 07:42:30 : DEBUG : pacifist : Debugging enabled, Unmounting output was:
"disk17" ejected.
2025-01-18 07:42:30 : DEBUG : pacifist : DEBUG mode 1, not reopening anything
2025-01-18 07:42:30 : REQ   : pacifist : All done!
2025-01-18 07:42:30 : REQ   : pacifist : ################## End Installomator, exit code 0 

```