### PR TITLE
Update defaultfolderx to use sparkle feed for downloadURL and appNewVersion

### DIFF
--- a/fragments/labels/defaultfolderx.sh
+++ b/fragments/labels/defaultfolderx.sh
@@ -1,7 +1,8 @@
 defaultfolderx)
-    # credit: Gabe Marchan (gabemarchan.com - @darklink87)
     name="Default Folder X"
     type="dmg"
-    downloadURL=$(curl -fs "https://www.stclairsoft.com/cgi-bin/dl.cgi?DX" | awk -F '"' "/dmg/ {print \$4}" | head -2 | tail -1)
+    sparkleFeed="$(curl -fsL "https://www.stclairsoft.com/cgi-bin/sparkle.cgi?DX5")"
+    downloadURL="$(echo $sparkleFeed | xpath 'string(//rss/channel/item/enclosure/@url)' 2>/dev/null)"
+    appNewVersion="$(echo $sparkleFeed | xpath 'string(//rss/channel/item/enclosure/@sparkle:shortVersionString)' 2>/dev/null)"
     expectedTeamID="7HK42V8R9D"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update defaultfolderx to use sparkle feed for downloadURL and appNewVersion

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
assemble.sh defaultfolderx
2025-01-18 08:32:32 : REQ   : defaultfolderx : ################## Start Installomator v. 10.7beta, date 2025-01-18
2025-01-18 08:32:32 : INFO  : defaultfolderx : ################## Version: 10.7beta
2025-01-18 08:32:32 : INFO  : defaultfolderx : ################## Date: 2025-01-18
2025-01-18 08:32:32 : INFO  : defaultfolderx : ################## defaultfolderx
2025-01-18 08:32:32 : DEBUG : defaultfolderx : DEBUG mode 1 enabled.
2025-01-18 08:32:33 : DEBUG : defaultfolderx : name=Default Folder X
2025-01-18 08:32:33 : DEBUG : defaultfolderx : appName=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : type=dmg
2025-01-18 08:32:33 : DEBUG : defaultfolderx : archiveName=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : downloadURL=https://www.stclairsoft.com/download/DefaultFolderX-6.1.4.dmg
2025-01-18 08:32:33 : DEBUG : defaultfolderx : curlOptions=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : appNewVersion=6.1.4
2025-01-18 08:32:33 : DEBUG : defaultfolderx : appCustomVersion function: Not defined
2025-01-18 08:32:33 : DEBUG : defaultfolderx : versionKey=CFBundleShortVersionString
2025-01-18 08:32:33 : DEBUG : defaultfolderx : packageID=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : pkgName=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : choiceChangesXML=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : expectedTeamID=7HK42V8R9D
2025-01-18 08:32:33 : DEBUG : defaultfolderx : blockingProcesses=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : installerTool=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : CLIInstaller=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : CLIArguments=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : updateTool=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : updateToolArguments=
2025-01-18 08:32:33 : DEBUG : defaultfolderx : updateToolRunAsCurrentUser=
2025-01-18 08:32:33 : INFO  : defaultfolderx : BLOCKING_PROCESS_ACTION=tell_user
2025-01-18 08:32:33 : INFO  : defaultfolderx : NOTIFY=success
2025-01-18 08:32:33 : INFO  : defaultfolderx : LOGGING=DEBUG
2025-01-18 08:32:33 : INFO  : defaultfolderx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-18 08:32:33 : INFO  : defaultfolderx : Label type: dmg
2025-01-18 08:32:33 : INFO  : defaultfolderx : archiveName: Default Folder X.dmg
2025-01-18 08:32:33 : INFO  : defaultfolderx : no blocking processes defined, using Default Folder X as default
2025-01-18 08:32:33 : DEBUG : defaultfolderx : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-18 08:32:33 : INFO  : defaultfolderx : name: Default Folder X, appName: Default Folder X.app
2025-01-18 08:32:33.240 mdfind[22305:266582] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 08:32:33.240 mdfind[22305:266582] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 08:32:33.266 mdfind[22305:266582] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 08:32:33 : WARN  : defaultfolderx : No previous app found
2025-01-18 08:32:33 : WARN  : defaultfolderx : could not find Default Folder X.app
2025-01-18 08:32:33 : INFO  : defaultfolderx : appversion: 
2025-01-18 08:32:33 : INFO  : defaultfolderx : Latest version of Default Folder X is 6.1.4
2025-01-18 08:32:33 : REQ   : defaultfolderx : Downloading https://www.stclairsoft.com/download/DefaultFolderX-6.1.4.dmg to Default Folder X.dmg
2025-01-18 08:32:33 : DEBUG : defaultfolderx : No Dialog connection, just download
2025-01-18 08:32:35 : DEBUG : defaultfolderx : File list: -rw-r--r--  1 gilburns  staff    17M Jan 18 08:32 Default Folder X.dmg
2025-01-18 08:32:35 : DEBUG : defaultfolderx : File type: Default Folder X.dmg: bzip2 compressed data, block size = 100k
2025-01-18 08:32:35 : DEBUG : defaultfolderx : curl output was:
* Host www.stclairsoft.com:443 was resolved.
* IPv6: (none)
* IPv4: 66.39.85.53
*   Trying 66.39.85.53:443...
* Connected to www.stclairsoft.com (66.39.85.53) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5677 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=stclairsoft.com
*  start date: Mar  6 00:00:00 2024 GMT
*  expire date: Apr  6 23:59:59 2025 GMT
*  subjectAltName: host "www.stclairsoft.com" matched cert's "www.stclairsoft.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.stclairsoft.com/download/DefaultFolderX-6.1.4.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.stclairsoft.com]
* [HTTP/2] [1] [:path: /download/DefaultFolderX-6.1.4.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /download/DefaultFolderX-6.1.4.dmg HTTP/2
> Host: www.stclairsoft.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< last-modified: Mon, 06 Jan 2025 20:32:43 GMT
< etag: "10cc4f1-62b0f87cb10c0"
< accept-ranges: bytes
< content-length: 17614065
< content-type: application/x-apple-diskimage
< date: Sat, 18 Jan 2025 14:32:33 GMT
< server: Apache
< 
{ [16252 bytes data]
* Connection #0 to host www.stclairsoft.com left intact

2025-01-18 08:32:35 : DEBUG : defaultfolderx : DEBUG mode 1, not checking for blocking processes
2025-01-18 08:32:35 : REQ   : defaultfolderx : Installing Default Folder X
2025-01-18 08:32:35 : INFO  : defaultfolderx : Mounting /Users/gilburns/GitHub/Installomator/build/Default Folder X.dmg
2025-01-18 08:32:36 : DEBUG : defaultfolderx : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $6D1AFC4E
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $EE526A4E
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $8061257F
verified   CRC32 $7DE82DFB
/dev/disk13         	Apple_partition_scheme
/dev/disk13s1       	Apple_partition_map
/dev/disk13s2       	Apple_HFS                      	/Volumes/Default Folder X 1

2025-01-18 08:32:36 : INFO  : defaultfolderx : Mounted: /Volumes/Default Folder X 1
2025-01-18 08:32:36 : INFO  : defaultfolderx : Verifying: /Volumes/Default Folder X 1/Default Folder X.app
2025-01-18 08:32:36 : DEBUG : defaultfolderx : App size:  32M	/Volumes/Default Folder X 1/Default Folder X.app
2025-01-18 08:32:38 : DEBUG : defaultfolderx : Debugging enabled, App Verification output was:
/Volumes/Default Folder X 1/Default Folder X.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: St. Clair Software (7HK42V8R9D)

2025-01-18 08:32:38 : INFO  : defaultfolderx : Team ID matching: 7HK42V8R9D (expected: 7HK42V8R9D )
2025-01-18 08:32:38 : INFO  : defaultfolderx : Installing Default Folder X version 6.1.4 on versionKey CFBundleShortVersionString.
2025-01-18 08:32:38 : INFO  : defaultfolderx : App has LSMinimumSystemVersion: 10.13
2025-01-18 08:32:38 : DEBUG : defaultfolderx : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-18 08:32:38 : INFO  : defaultfolderx : Finishing...
2025-01-18 08:32:41 : INFO  : defaultfolderx : name: Default Folder X, appName: Default Folder X.app
2025-01-18 08:32:41.898 mdfind[22394:266930] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 08:32:41.898 mdfind[22394:266930] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 08:32:41.939 mdfind[22394:266930] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 08:32:41 : WARN  : defaultfolderx : No previous app found
2025-01-18 08:32:41 : WARN  : defaultfolderx : could not find Default Folder X.app
2025-01-18 08:32:41 : REQ   : defaultfolderx : Installed Default Folder X, version 6.1.4
2025-01-18 08:32:41 : INFO  : defaultfolderx : notifying
ERROR: Notifications are not allowed for this application
2025-01-18 08:32:42 : DEBUG : defaultfolderx : Unmounting /Volumes/Default Folder X 1
2025-01-18 08:32:42 : DEBUG : defaultfolderx : Debugging enabled, Unmounting output was:
"disk13" ejected.
2025-01-18 08:32:42 : DEBUG : defaultfolderx : DEBUG mode 1, not reopening anything
2025-01-18 08:32:42 : REQ   : defaultfolderx : All done!
2025-01-18 08:32:42 : REQ   : defaultfolderx : ################## End Installomator, exit code 0 

```
