### PR TITLE
Add appNewVersion to universaltypeclient

### DIFF
--- a/fragments/labels/universaltypeclient.sh
+++ b/fragments/labels/universaltypeclient.sh
@@ -1,7 +1,7 @@
 universaltypeclient)
     name="Universal Type Client"
     type="pkgInZip"
-    #packageID="com.extensis.UniversalTypeClient.universalTypeClient70.Info.pkg" # Does not contain the real version of the download
     downloadURL=https://bin.extensis.com/$( curl -fs https://www.extensis.com/support/universal-type-server-7/ | grep -o "UTC-[0-9].*M.zip" )
+    appNewVersion=$(echo "$downloadURL" | awk -F'UTC-' '{split($2, a, "-M"); print a[1]}' | tr '-' '.')
     expectedTeamID="J6MMHGD9D6"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Add **appNewVersion** to universaltypeclient

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh universaltypeclient
2025-01-18 09:13:27 : REQ   : universaltypeclient : ################## Start Installomator v. 10.7beta, date 2025-01-18
2025-01-18 09:13:27 : INFO  : universaltypeclient : ################## Version: 10.7beta
2025-01-18 09:13:27 : INFO  : universaltypeclient : ################## Date: 2025-01-18
2025-01-18 09:13:27 : INFO  : universaltypeclient : ################## universaltypeclient
2025-01-18 09:13:27 : DEBUG : universaltypeclient : DEBUG mode 1 enabled.
2025-01-18 09:13:27 : DEBUG : universaltypeclient : name=Universal Type Client
2025-01-18 09:13:27 : DEBUG : universaltypeclient : appName=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : type=pkgInZip
2025-01-18 09:13:27 : DEBUG : universaltypeclient : archiveName=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : downloadURL=https://bin.extensis.com/UTC-7-0-13-M.zip
2025-01-18 09:13:27 : DEBUG : universaltypeclient : curlOptions=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : appNewVersion=7.0.13
2025-01-18 09:13:27 : DEBUG : universaltypeclient : appCustomVersion function: Not defined
2025-01-18 09:13:27 : DEBUG : universaltypeclient : versionKey=CFBundleShortVersionString
2025-01-18 09:13:27 : DEBUG : universaltypeclient : packageID=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : pkgName=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : choiceChangesXML=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : expectedTeamID=J6MMHGD9D6
2025-01-18 09:13:27 : DEBUG : universaltypeclient : blockingProcesses=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : installerTool=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : CLIInstaller=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : CLIArguments=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : updateTool=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : updateToolArguments=
2025-01-18 09:13:27 : DEBUG : universaltypeclient : updateToolRunAsCurrentUser=
2025-01-18 09:13:27 : INFO  : universaltypeclient : BLOCKING_PROCESS_ACTION=tell_user
2025-01-18 09:13:27 : INFO  : universaltypeclient : NOTIFY=success
2025-01-18 09:13:27 : INFO  : universaltypeclient : LOGGING=DEBUG
2025-01-18 09:13:27 : INFO  : universaltypeclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-18 09:13:27 : INFO  : universaltypeclient : Label type: pkgInZip
2025-01-18 09:13:27 : INFO  : universaltypeclient : archiveName: Universal Type Client.zip
2025-01-18 09:13:27 : INFO  : universaltypeclient : no blocking processes defined, using Universal Type Client as default
2025-01-18 09:13:27 : DEBUG : universaltypeclient : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-18 09:13:27 : INFO  : universaltypeclient : name: Universal Type Client, appName: Universal Type Client.app
2025-01-18 09:13:27.990 mdfind[62776:544747] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 09:13:27.990 mdfind[62776:544747] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 09:13:28.030 mdfind[62776:544747] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 09:13:28 : WARN  : universaltypeclient : No previous app found
2025-01-18 09:13:28 : WARN  : universaltypeclient : could not find Universal Type Client.app
2025-01-18 09:13:28 : INFO  : universaltypeclient : appversion: 
2025-01-18 09:13:28 : INFO  : universaltypeclient : Latest version of Universal Type Client is 7.0.13
2025-01-18 09:13:28 : REQ   : universaltypeclient : Downloading https://bin.extensis.com/UTC-7-0-13-M.zip to Universal Type Client.zip
2025-01-18 09:13:28 : DEBUG : universaltypeclient : No Dialog connection, just download
2025-01-18 09:13:36 : DEBUG : universaltypeclient : File list: -rw-r--r--  1 gilburns  staff    64M Jan 18 09:13 Universal Type Client.zip
2025-01-18 09:13:36 : DEBUG : universaltypeclient : File type: Universal Type Client.zip: Zip archive data, at least v2.0 to extract, compression method=deflate
2025-01-18 09:13:36 : DEBUG : universaltypeclient : curl output was:
* Host bin.extensis.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.154.185.37, 18.154.185.64, 18.154.185.18, 18.154.185.72
*   Trying 18.154.185.37:443...
* Connected to bin.extensis.com (18.154.185.37) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [10 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3803 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=*.extensis.com
*  start date: Oct  7 00:00:00 2024 GMT
*  expire date: Nov  5 23:59:59 2025 GMT
*  subjectAltName: host "bin.extensis.com" matched cert's "*.extensis.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /UTC-7-0-13-M.zip HTTP/1.1
> Host: bin.extensis.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/x-zip-compressed
< Content-Length: 67504964
< Connection: keep-alive
< Date: Fri, 17 Jan 2025 15:21:08 GMT
< Last-Modified: Mon, 18 Jul 2022 17:56:34 GMT
< ETag: "25ad7cdf8b5c81c4a9e1963c1ba6bf38"
< x-amz-meta-cb-modifiedtime: Mon, 18 Jul 2022 17:53:50 GMT
< Accept-Ranges: bytes
< Server: AmazonS3
< X-Cache: Hit from cloudfront
< Via: 1.1 0424dcdedb0e45d57a9099e5691e583a.cloudfront.net (CloudFront)
< X-Amz-Cf-Pop: ORD58-P7
< X-Amz-Cf-Id: 0E-XQ3rjDW3qcV8WLsLDbbe1m8pDX77Yv3u8IyoyIVeRZ1Z4usqYtA==
< Age: 85941
< 
{ [16384 bytes data]
* Connection #0 to host bin.extensis.com left intact

2025-01-18 09:13:36 : DEBUG : universaltypeclient : DEBUG mode 1, not checking for blocking processes
2025-01-18 09:13:36 : REQ   : universaltypeclient : Installing Universal Type Client
2025-01-18 09:13:36 : INFO  : universaltypeclient : Unzipping Universal Type Client.zip
2025-01-18 09:13:36 : DEBUG : universaltypeclient : Found pkg(s):
/Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg
2025-01-18 09:13:36 : DEBUG : universaltypeclient : /Users/gilburns/GitHub/Installomator/build/ZoomPresence.pkg
2025-01-18 09:13:36 : INFO  : universaltypeclient : found pkg: /Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg
2025-01-18 09:13:36 : INFO  : universaltypeclient : Verifying: /Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg
2025-01-18 09:13:36 : DEBUG : universaltypeclient : File list: -rw-r--r--  1 gilburns  staff    65M Jul 15  2022 /Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg
2025-01-18 09:13:36 : DEBUG : universaltypeclient : File type: /Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg: xar archive compressed TOC: 7242, SHA-1 checksum
2025-01-18 09:13:36 : DEBUG : universaltypeclient : spctlOut is /Users/gilburns/GitHub/Installomator/build/Universal Type Client 7.0.13.pkg: accepted
2025-01-18 09:13:36 : DEBUG : universaltypeclient : source=Notarized Developer ID
2025-01-18 09:13:36 : DEBUG : universaltypeclient : origin=Developer ID Installer: Extensis (J6MMHGD9D6)
2025-01-18 09:13:36 : INFO  : universaltypeclient : Team ID: J6MMHGD9D6 (expected: J6MMHGD9D6 )
2025-01-18 09:13:36 : DEBUG : universaltypeclient : DEBUG enabled, skipping installation
2025-01-18 09:13:36 : INFO  : universaltypeclient : Finishing...
2025-01-18 09:13:39 : INFO  : universaltypeclient : name: Universal Type Client, appName: Universal Type Client.app
2025-01-18 09:13:39.632 mdfind[62843:545029] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 09:13:39.632 mdfind[62843:545029] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 09:13:39.674 mdfind[62843:545029] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 09:13:39 : WARN  : universaltypeclient : No previous app found
2025-01-18 09:13:39 : WARN  : universaltypeclient : could not find Universal Type Client.app
2025-01-18 09:13:39 : REQ   : universaltypeclient : Installed Universal Type Client, version 7.0.13
2025-01-18 09:13:39 : INFO  : universaltypeclient : notifying
ERROR: Notifications are not allowed for this application
2025-01-18 09:13:39 : DEBUG : universaltypeclient : DEBUG mode 1, not reopening anything
2025-01-18 09:13:39 : REQ   : universaltypeclient : All done!
2025-01-18 09:13:39 : REQ   : universaltypeclient : ################## End Installomator, exit code 0 

```