### PR TITLE
Add appNewVersion to diskdrill label

### DIFF
--- a/fragments/labels/diskdrill.sh
+++ b/fragments/labels/diskdrill.sh
@@ -3,6 +3,6 @@ diskdrill)
     type="dmg"
     appname="Disk Drill.app"
     downloadURL="https://dl.cleverfiles.com/diskdrill.dmg"
+    appNewVersion=$( curl -fsL "https://www.cleverfiles.com/releases/auto-update/dd5-newestr.xml" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null)
     expectedTeamID="A3W62KZY8Z"
-    blockingProcesses=( Disk Drill )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Add **appNewVersion** to diskdrill label
Removed unnecessary blockingProcesses

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh diskdrill
2025-01-18 18:47:46 : REQ   : diskdrill : ################## Start Installomator v. 10.7beta, date 2025-01-18
2025-01-18 18:47:46 : INFO  : diskdrill : ################## Version: 10.7beta
2025-01-18 18:47:46 : INFO  : diskdrill : ################## Date: 2025-01-18
2025-01-18 18:47:46 : INFO  : diskdrill : ################## diskdrill
2025-01-18 18:47:46 : DEBUG : diskdrill : DEBUG mode 1 enabled.
2025-01-18 18:47:46 : DEBUG : diskdrill : name=Disk Drill
2025-01-18 18:47:46 : DEBUG : diskdrill : appName=
2025-01-18 18:47:46 : DEBUG : diskdrill : type=dmg
2025-01-18 18:47:46 : DEBUG : diskdrill : archiveName=
2025-01-18 18:47:46 : DEBUG : diskdrill : downloadURL=https://dl.cleverfiles.com/diskdrill.dmg
2025-01-18 18:47:46 : DEBUG : diskdrill : curlOptions=
2025-01-18 18:47:46 : DEBUG : diskdrill : appNewVersion=5.7.1704
2025-01-18 18:47:46 : DEBUG : diskdrill : appCustomVersion function: Not defined
2025-01-18 18:47:46 : DEBUG : diskdrill : versionKey=CFBundleShortVersionString
2025-01-18 18:47:46 : DEBUG : diskdrill : packageID=
2025-01-18 18:47:46 : DEBUG : diskdrill : pkgName=
2025-01-18 18:47:46 : DEBUG : diskdrill : choiceChangesXML=
2025-01-18 18:47:46 : DEBUG : diskdrill : expectedTeamID=A3W62KZY8Z
2025-01-18 18:47:46 : DEBUG : diskdrill : blockingProcesses=
2025-01-18 18:47:46 : DEBUG : diskdrill : installerTool=
2025-01-18 18:47:46 : DEBUG : diskdrill : CLIInstaller=
2025-01-18 18:47:46 : DEBUG : diskdrill : CLIArguments=
2025-01-18 18:47:46 : DEBUG : diskdrill : updateTool=
2025-01-18 18:47:46 : DEBUG : diskdrill : updateToolArguments=
2025-01-18 18:47:46 : DEBUG : diskdrill : updateToolRunAsCurrentUser=
2025-01-18 18:47:46 : INFO  : diskdrill : BLOCKING_PROCESS_ACTION=tell_user
2025-01-18 18:47:46 : INFO  : diskdrill : NOTIFY=success
2025-01-18 18:47:46 : INFO  : diskdrill : LOGGING=DEBUG
2025-01-18 18:47:46 : INFO  : diskdrill : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-18 18:47:46 : INFO  : diskdrill : Label type: dmg
2025-01-18 18:47:46 : INFO  : diskdrill : archiveName: Disk Drill.dmg
2025-01-18 18:47:46 : INFO  : diskdrill : no blocking processes defined, using Disk Drill as default
2025-01-18 18:47:46 : DEBUG : diskdrill : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-18 18:47:46 : INFO  : diskdrill : name: Disk Drill, appName: Disk Drill.app
2025-01-18 18:47:46.716 mdfind[28869:4202386] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 18:47:46.716 mdfind[28869:4202386] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 18:47:46.767 mdfind[28869:4202386] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 18:47:46 : WARN  : diskdrill : No previous app found
2025-01-18 18:47:46 : WARN  : diskdrill : could not find Disk Drill.app
2025-01-18 18:47:46 : INFO  : diskdrill : appversion: 
2025-01-18 18:47:46 : INFO  : diskdrill : Latest version of Disk Drill is 5.7.1704
2025-01-18 18:47:46 : REQ   : diskdrill : Downloading https://dl.cleverfiles.com/diskdrill.dmg to Disk Drill.dmg
2025-01-18 18:47:46 : DEBUG : diskdrill : No Dialog connection, just download
2025-01-18 18:48:01 : DEBUG : diskdrill : File list: -rw-r--r--  1 gilburns  staff    61M Jan 18 18:48 Disk Drill.dmg
2025-01-18 18:48:01 : DEBUG : diskdrill : File type: Disk Drill.dmg: lzfse encoded, lzvn compressed
2025-01-18 18:48:01 : DEBUG : diskdrill : curl output was:
* Host dl.cleverfiles.com:443 was resolved.
* IPv6: 2a02:6ea0:c600::25, 2a02:6ea0:c600::26
* IPv4: 89.187.180.93, 89.187.180.102
*   Trying 89.187.180.93:443...
* Connected to dl.cleverfiles.com (89.187.180.93) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [6002 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: serialNumber=11054861; jurisdictionCountryName=US; jurisdictionStateOrProvinceName=Georgia; businessCategory=Private Organization; C=US; ST=Virginia; O=508 Software LLC; CN=cleverfiles.com
*  start date: Sep 16 00:00:00 2024 GMT
*  expire date: Oct 17 23:59:59 2025 GMT
*  subjectAltName: host "dl.cleverfiles.com" matched cert's "dl.cleverfiles.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Extended Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.cleverfiles.com/diskdrill.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.cleverfiles.com]
* [HTTP/2] [1] [:path: /diskdrill.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /diskdrill.dmg HTTP/2
> Host: dl.cleverfiles.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Sun, 19 Jan 2025 00:47:47 GMT
< content-type: binary/octet-stream
< content-length: 64394230
< last-modified: Mon, 09 Dec 2024 15:54:32 GMT
< x-rgw-object-type: Normal
< etag: "5d0ec00d07c9ff203be85567f76817d2-13"
< x-amz-request-id: tx000001e1b3d9d2467c88f-00675713c8-9f56a4c-nyc
< x-77-nzt: FAwBWbu0WwHXcHUAAAwBWbu3EQH3uCYAAAwBnJI76AG3UAUAAAgBz9PUZgAA
< x-77-nzt-ray: c029d62960c4e7e6d84b8c67682a4d06
< x-77-cache: HIT
< x-77-age: 30064
< server: CDN77-Turbo
< x-77-pop: chicagoUSIL
< accept-ranges: bytes
< 
{ [8183 bytes data]
* Connection #0 to host dl.cleverfiles.com left intact

2025-01-18 18:48:01 : DEBUG : diskdrill : DEBUG mode 1, not checking for blocking processes
2025-01-18 18:48:01 : REQ   : diskdrill : Installing Disk Drill
2025-01-18 18:48:01 : INFO  : diskdrill : Mounting /Users/gilburns/GitHub/Installomator/build/Disk Drill.dmg
2025-01-18 18:48:02 : DEBUG : diskdrill : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $9AD3D33B
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $18755945
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $5AF65FB1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $0C4AFAD9
/dev/disk14         	Apple_partition_scheme
/dev/disk14s1       	Apple_partition_map
/dev/disk14s2       	Apple_HFS                      	/Volumes/DiskDrill 1

2025-01-18 18:48:02 : INFO  : diskdrill : Mounted: /Volumes/DiskDrill 1
2025-01-18 18:48:02 : INFO  : diskdrill : Verifying: /Volumes/DiskDrill 1/Disk Drill.app
2025-01-18 18:48:02 : DEBUG : diskdrill : App size: 133M	/Volumes/DiskDrill 1/Disk Drill.app
2025-01-18 18:48:03 : DEBUG : diskdrill : Debugging enabled, App Verification output was:
/Volumes/DiskDrill 1/Disk Drill.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Justin Johnson (A3W62KZY8Z)

2025-01-18 18:48:03 : INFO  : diskdrill : Team ID matching: A3W62KZY8Z (expected: A3W62KZY8Z )
2025-01-18 18:48:03 : INFO  : diskdrill : Installing Disk Drill version 5.7 on versionKey CFBundleShortVersionString.
2025-01-18 18:48:03 : INFO  : diskdrill : App has LSMinimumSystemVersion: 10.15
2025-01-18 18:48:03 : DEBUG : diskdrill : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-18 18:48:03 : INFO  : diskdrill : Finishing...
2025-01-18 18:48:06 : INFO  : diskdrill : name: Disk Drill, appName: Disk Drill.app
2025-01-18 18:48:06.441 mdfind[28977:4203071] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 18:48:06.441 mdfind[28977:4203071] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 18:48:06.486 mdfind[28977:4203071] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 18:48:06 : WARN  : diskdrill : No previous app found
2025-01-18 18:48:06 : WARN  : diskdrill : could not find Disk Drill.app
2025-01-18 18:48:06 : REQ   : diskdrill : Installed Disk Drill, version 5.7
2025-01-18 18:48:06 : INFO  : diskdrill : notifying
ERROR: Notifications are not allowed for this application
2025-01-18 18:48:06 : DEBUG : diskdrill : Unmounting /Volumes/DiskDrill 1
2025-01-18 18:48:06 : DEBUG : diskdrill : Debugging enabled, Unmounting output was:
"disk14" ejected.
2025-01-18 18:48:06 : DEBUG : diskdrill : DEBUG mode 1, not reopening anything
2025-01-18 18:48:06 : REQ   : diskdrill : All done!
2025-01-18 18:48:06 : REQ   : diskdrill : ################## End Installomator, exit code 0 

```