### PR TITLE
Add appNewVersion to fsmonitor label

### DIFF
--- a/fragments/labels/fsmonitor.sh
+++ b/fragments/labels/fsmonitor.sh
@@ -1,6 +1,7 @@
 fsmonitor)
     name="FSMonitor"
     type="zip"
-    downloadURL=$(curl --location --fail --silent "https://fsmonitor.com/FSMonitor/Archives/appcast2.xml" | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null  | cut -d '"' -f 2)
+    downloadURL=$(curl -fsL "https://fsmonitor.com/FSMonitor/Archives/appcast2.xml" | xpath 'string(//rss/channel/item[last()]/enclosure/@url)' 2>/dev/null)
+    appNewVersion=$(curl -fsL "https://fsmonitor.com/FSMonitor/Archives/appcast2.xml" | xpath 'string(//rss/channel/item[last()]/enclosure/@sparkle:shortVersionString)' 2>/dev/null)
     expectedTeamID="V85GBYB7B9"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Add appNewVersion to fsmonitor label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh fsmonitor
2025-01-18 18:57:24 : REQ   : fsmonitor : ################## Start Installomator v. 10.7beta, date 2025-01-18
2025-01-18 18:57:24 : INFO  : fsmonitor : ################## Version: 10.7beta
2025-01-18 18:57:24 : INFO  : fsmonitor : ################## Date: 2025-01-18
2025-01-18 18:57:24 : INFO  : fsmonitor : ################## fsmonitor
2025-01-18 18:57:24 : DEBUG : fsmonitor : DEBUG mode 1 enabled.
2025-01-18 18:57:25 : DEBUG : fsmonitor : name=FSMonitor
2025-01-18 18:57:25 : DEBUG : fsmonitor : appName=
2025-01-18 18:57:25 : DEBUG : fsmonitor : type=zip
2025-01-18 18:57:25 : DEBUG : fsmonitor : archiveName=
2025-01-18 18:57:25 : DEBUG : fsmonitor : downloadURL=https://tristan-software.ch/FSMonitor/Archives/FSMonitor_1.2(137).zip
2025-01-18 18:57:25 : DEBUG : fsmonitor : curlOptions=
2025-01-18 18:57:25 : DEBUG : fsmonitor : appNewVersion=1.2
2025-01-18 18:57:25 : DEBUG : fsmonitor : appCustomVersion function: Not defined
2025-01-18 18:57:25 : DEBUG : fsmonitor : versionKey=CFBundleShortVersionString
2025-01-18 18:57:25 : DEBUG : fsmonitor : packageID=
2025-01-18 18:57:25 : DEBUG : fsmonitor : pkgName=
2025-01-18 18:57:25 : DEBUG : fsmonitor : choiceChangesXML=
2025-01-18 18:57:25 : DEBUG : fsmonitor : expectedTeamID=V85GBYB7B9
2025-01-18 18:57:25 : DEBUG : fsmonitor : blockingProcesses=
2025-01-18 18:57:25 : DEBUG : fsmonitor : installerTool=
2025-01-18 18:57:25 : DEBUG : fsmonitor : CLIInstaller=
2025-01-18 18:57:25 : DEBUG : fsmonitor : CLIArguments=
2025-01-18 18:57:25 : DEBUG : fsmonitor : updateTool=
2025-01-18 18:57:25 : DEBUG : fsmonitor : updateToolArguments=
2025-01-18 18:57:25 : DEBUG : fsmonitor : updateToolRunAsCurrentUser=
2025-01-18 18:57:25 : INFO  : fsmonitor : BLOCKING_PROCESS_ACTION=tell_user
2025-01-18 18:57:25 : INFO  : fsmonitor : NOTIFY=success
2025-01-18 18:57:25 : INFO  : fsmonitor : LOGGING=DEBUG
2025-01-18 18:57:25 : INFO  : fsmonitor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-18 18:57:25 : INFO  : fsmonitor : Label type: zip
2025-01-18 18:57:25 : INFO  : fsmonitor : archiveName: FSMonitor.zip
2025-01-18 18:57:25 : INFO  : fsmonitor : no blocking processes defined, using FSMonitor as default
2025-01-18 18:57:25 : DEBUG : fsmonitor : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-18 18:57:25 : INFO  : fsmonitor : name: FSMonitor, appName: FSMonitor.app
2025-01-18 18:57:25.888 mdfind[60786:4266833] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 18:57:25.888 mdfind[60786:4266833] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 18:57:25.921 mdfind[60786:4266833] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 18:57:25 : INFO  : fsmonitor : App(s) found: /Users/gilburns/Downloads/FSMonitor.app
2025-01-18 18:57:25 : WARN  : fsmonitor : could not determine location of FSMonitor.app
2025-01-18 18:57:25 : INFO  : fsmonitor : appversion: 
2025-01-18 18:57:25 : INFO  : fsmonitor : Latest version of FSMonitor is 1.2
2025-01-18 18:57:25 : REQ   : fsmonitor : Downloading https://tristan-software.ch/FSMonitor/Archives/FSMonitor_1.2(137).zip to FSMonitor.zip
2025-01-18 18:57:25 : DEBUG : fsmonitor : No Dialog connection, just download
2025-01-18 18:57:31 : DEBUG : fsmonitor : File list: -rw-r--r--  1 gilburns  staff   9.6M Jan 18 18:57 FSMonitor.zip
2025-01-18 18:57:31 : DEBUG : fsmonitor : File type: FSMonitor.zip: Zip archive data, at least v1.0 to extract, compression method=store
2025-01-18 18:57:31 : DEBUG : fsmonitor : curl output was:
* Host tristan-software.ch:443 was resolved.
* IPv6: (none)
* IPv4: 80.74.139.25
*   Trying 80.74.139.25:443...
* Connected to tristan-software.ch (80.74.139.25) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [324 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2695 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=tristan-software.ch
*  start date: Nov 21 01:03:54 2024 GMT
*  expire date: Feb 19 01:03:53 2025 GMT
*  subjectAltName: host "tristan-software.ch" matched cert's "tristan-software.ch"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://tristan-software.ch/FSMonitor/Archives/FSMonitor_1.2(137).zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: tristan-software.ch]
* [HTTP/2] [1] [:path: /FSMonitor/Archives/FSMonitor_1.2(137).zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /FSMonitor/Archives/FSMonitor_1.2(137).zip HTTP/2
> Host: tristan-software.ch
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< server: nginx
< date: Sun, 19 Jan 2025 00:57:26 GMT
< content-type: application/zip
< content-length: 10027060
< last-modified: Wed, 08 Jul 2020 19:54:27 GMT
< etag: "5f062473-990034"
< accept-ranges: bytes
< 
{ [8192 bytes data]
* Connection #0 to host tristan-software.ch left intact

2025-01-18 18:57:31 : DEBUG : fsmonitor : DEBUG mode 1, not checking for blocking processes
2025-01-18 18:57:31 : REQ   : fsmonitor : Installing FSMonitor
2025-01-18 18:57:31 : INFO  : fsmonitor : Unzipping FSMonitor.zip
2025-01-18 18:57:31 : INFO  : fsmonitor : Verifying: /Users/gilburns/GitHub/Installomator/build/FSMonitor.app
2025-01-18 18:57:31 : DEBUG : fsmonitor : App size:  26M	/Users/gilburns/GitHub/Installomator/build/FSMonitor.app
2025-01-18 18:57:31 : DEBUG : fsmonitor : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/FSMonitor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Matthias Keiser (V85GBYB7B9)

2025-01-18 18:57:31 : INFO  : fsmonitor : Team ID matching: V85GBYB7B9 (expected: V85GBYB7B9 )
2025-01-18 18:57:31 : INFO  : fsmonitor : Installing FSMonitor version 1.2 on versionKey CFBundleShortVersionString.
2025-01-18 18:57:31 : INFO  : fsmonitor : App has LSMinimumSystemVersion: 10.11
2025-01-18 18:57:31 : DEBUG : fsmonitor : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-18 18:57:31 : INFO  : fsmonitor : Finishing...
2025-01-18 18:57:34 : INFO  : fsmonitor : name: FSMonitor, appName: FSMonitor.app
2025-01-18 18:57:34.680 mdfind[60853:4267174] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-18 18:57:34.680 mdfind[60853:4267174] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-18 18:57:34.721 mdfind[60853:4267174] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-18 18:57:34 : INFO  : fsmonitor : App(s) found: /Users/gilburns/Downloads/FSMonitor.app/Users/gilburns/GitHub/Installomator/build/FSMonitor.app
2025-01-18 18:57:34 : WARN  : fsmonitor : could not determine location of FSMonitor.app
2025-01-18 18:57:34 : REQ   : fsmonitor : Installed FSMonitor, version 1.2
2025-01-18 18:57:34 : INFO  : fsmonitor : notifying
ERROR: Notifications are not allowed for this application
2025-01-18 18:57:34 : DEBUG : fsmonitor : DEBUG mode 1, not reopening anything
2025-01-18 18:57:34 : REQ   : fsmonitor : All done!
2025-01-18 18:57:34 : REQ   : fsmonitor : ################## End Installomator, exit code 0 

```