### PR TITLE
Update Aircall label to include appNewVersion key

### DIFF
--- a/fragments/labels/aircall.sh
+++ b/fragments/labels/aircall.sh
@@ -1,7 +1,8 @@
 aircall)
-    # credit: @kris-anderson
     name="Aircall"
-    type="dmg"
-    downloadURL="https://electron.aircall.io/download/osx"
+    type="zip"
+    aircallUpdate=$(curl -fsL "https://electron.aircall.io/update/osx/1.0.0?channel=stable")
+    downloadURL=$(echo "${aircallUpdate}" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+    appNewVersion=$(echo "${aircallUpdate}" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')
     expectedTeamID="3ML357Q795"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update Aircall label to include **appNewVersion** key

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh aircall
2025-01-19 16:35:12 : REQ   : aircall : ################## Start Installomator v. 10.7beta, date 2025-01-19
2025-01-19 16:35:12 : INFO  : aircall : ################## Version: 10.7beta
2025-01-19 16:35:12 : INFO  : aircall : ################## Date: 2025-01-19
2025-01-19 16:35:12 : INFO  : aircall : ################## aircall
2025-01-19 16:35:12 : DEBUG : aircall : DEBUG mode 1 enabled.
2025-01-19 16:35:13 : DEBUG : aircall : name=Aircall
2025-01-19 16:35:13 : DEBUG : aircall : appName=
2025-01-19 16:35:13 : DEBUG : aircall : type=zip
2025-01-19 16:35:13 : DEBUG : aircall : archiveName=
2025-01-19 16:35:13 : DEBUG : aircall : downloadURL=https://download-electron.aircall.io/Aircall-3.1.66.zip
2025-01-19 16:35:13 : DEBUG : aircall : curlOptions=
2025-01-19 16:35:13 : DEBUG : aircall : appNewVersion=3.1.66
2025-01-19 16:35:13 : DEBUG : aircall : appCustomVersion function: Not defined
2025-01-19 16:35:13 : DEBUG : aircall : versionKey=CFBundleShortVersionString
2025-01-19 16:35:13 : DEBUG : aircall : packageID=
2025-01-19 16:35:13 : DEBUG : aircall : pkgName=
2025-01-19 16:35:13 : DEBUG : aircall : choiceChangesXML=
2025-01-19 16:35:13 : DEBUG : aircall : expectedTeamID=3ML357Q795
2025-01-19 16:35:13 : DEBUG : aircall : blockingProcesses=
2025-01-19 16:35:13 : DEBUG : aircall : installerTool=
2025-01-19 16:35:13 : DEBUG : aircall : CLIInstaller=
2025-01-19 16:35:13 : DEBUG : aircall : CLIArguments=
2025-01-19 16:35:13 : DEBUG : aircall : updateTool=
2025-01-19 16:35:13 : DEBUG : aircall : updateToolArguments=
2025-01-19 16:35:13 : DEBUG : aircall : updateToolRunAsCurrentUser=
2025-01-19 16:35:13 : INFO  : aircall : BLOCKING_PROCESS_ACTION=tell_user
2025-01-19 16:35:13 : INFO  : aircall : NOTIFY=success
2025-01-19 16:35:13 : INFO  : aircall : LOGGING=DEBUG
2025-01-19 16:35:13 : INFO  : aircall : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-19 16:35:13 : INFO  : aircall : Label type: zip
2025-01-19 16:35:13 : INFO  : aircall : archiveName: Aircall.zip
2025-01-19 16:35:13 : INFO  : aircall : no blocking processes defined, using Aircall as default
2025-01-19 16:35:13 : DEBUG : aircall : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-19 16:35:13 : INFO  : aircall : name: Aircall, appName: Aircall.app
2025-01-19 16:35:13.508 mdfind[70818:12488020] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-19 16:35:13.508 mdfind[70818:12488020] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-19 16:35:13.553 mdfind[70818:12488020] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-19 16:35:13 : INFO  : aircall : App(s) found: /Users/gilburns/Applications/Aircall.app
2025-01-19 16:35:13 : WARN  : aircall : could not determine location of Aircall.app
2025-01-19 16:35:13 : INFO  : aircall : appversion: 
2025-01-19 16:35:13 : INFO  : aircall : Latest version of Aircall is 3.1.66
2025-01-19 16:35:13 : REQ   : aircall : Downloading https://download-electron.aircall.io/Aircall-3.1.66.zip to Aircall.zip
2025-01-19 16:35:13 : DEBUG : aircall : No Dialog connection, just download
2025-01-19 16:35:50 : DEBUG : aircall : File list: -rw-r--r--  1 gilburns  staff   169M Jan 19 16:35 Aircall.zip
2025-01-19 16:35:50 : DEBUG : aircall : File type: Aircall.zip: Zip archive data, at least v2.0 to extract, compression method=store
2025-01-19 16:35:50 : DEBUG : aircall : curl output was:
* Host download-electron.aircall.io:443 was resolved.
* IPv6: (none)
* IPv4: 18.172.122.77, 18.172.122.56, 18.172.122.76, 18.172.122.122
*   Trying 18.172.122.77:443...
* Connected to download-electron.aircall.io (18.172.122.77) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3836 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=aircall.io
*  start date: Nov  7 00:00:00 2024 GMT
*  expire date: Dec  5 23:59:59 2025 GMT
*  subjectAltName: host "download-electron.aircall.io" matched cert's "*.aircall.io"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download-electron.aircall.io/Aircall-3.1.66.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download-electron.aircall.io]
* [HTTP/2] [1] [:path: /Aircall-3.1.66.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Aircall-3.1.66.zip HTTP/2
> Host: download-electron.aircall.io
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: application/zip
< content-length: 176912888
< date: Mon, 13 Jan 2025 20:48:56 GMT
< last-modified: Mon, 30 Dec 2024 13:50:42 GMT
< etag: "f430b08dc8d5bb4fa9ba603affcbab43-34"
< x-amz-server-side-encryption: AES256
< cache-control: max-age=31536000
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 49359653c83aba064c5552e90ff15b76.cloudfront.net (CloudFront)
< x-amz-cf-pop: ORD56-P6
< x-amz-cf-id: OUxbUcWGVDYbMEZo9Uf_WyfP2uQa98HRiM1Gypb-lolntn7KEHXiVA==
< age: 524778
< 
{ [8192 bytes data]
* Connection #0 to host download-electron.aircall.io left intact

2025-01-19 16:35:50 : DEBUG : aircall : DEBUG mode 1, not checking for blocking processes
2025-01-19 16:35:50 : REQ   : aircall : Installing Aircall
2025-01-19 16:35:50 : INFO  : aircall : Unzipping Aircall.zip
2025-01-19 16:35:51 : INFO  : aircall : Verifying: /Users/gilburns/GitHub/Installomator/build/Aircall.app
2025-01-19 16:35:51 : DEBUG : aircall : App size: 421M	/Users/gilburns/GitHub/Installomator/build/Aircall.app
2025-01-19 16:35:52 : DEBUG : aircall : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/Aircall.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Aircall.io Inc. (3ML357Q795)

2025-01-19 16:35:52 : INFO  : aircall : Team ID matching: 3ML357Q795 (expected: 3ML357Q795 )
2025-01-19 16:35:52 : INFO  : aircall : Installing Aircall version 3.1.66 on versionKey CFBundleShortVersionString.
2025-01-19 16:35:52 : INFO  : aircall : App has LSMinimumSystemVersion: 10.12.0
2025-01-19 16:35:52 : DEBUG : aircall : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-19 16:35:52 : INFO  : aircall : Finishing...
2025-01-19 16:35:55 : INFO  : aircall : name: Aircall, appName: Aircall.app
2025-01-19 16:35:55.444 mdfind[70894:12488851] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-19 16:35:55.445 mdfind[70894:12488851] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-19 16:35:55.488 mdfind[70894:12488851] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-19 16:35:55 : WARN  : aircall : could not determine location of Aircall.app
2025-01-19 16:35:55 : REQ   : aircall : Installed Aircall, version 3.1.66
2025-01-19 16:35:55 : INFO  : aircall : notifying
ERROR: Notifications are not allowed for this application
2025-01-19 16:35:55 : DEBUG : aircall : DEBUG mode 1, not reopening anything
2025-01-19 16:35:55 : REQ   : aircall : All done!
2025-01-19 16:35:55 : REQ   : aircall : ################## End Installomator, exit code 0 

```