### PR TITLE
Update flux label to include appNewVersion key

### DIFF
--- a/fragments/labels/flux.sh
+++ b/fragments/labels/flux.sh
@@ -1,7 +1,7 @@
 flux)
     name="Flux"
     type="zip"
+    appNewVersion=$(curl -fsL "https://justgetflux.com/mac/macflux.xml" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null)
     downloadURL="https://justgetflux.com/mac/Flux.zip"
     expectedTeamID="VZKSA7H9J9"
     ;;
-    


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update flux label to include appNewVersion key

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh flux
2025-01-20 19:47:19 : REQ   : flux : ################## Start Installomator v. 10.7beta, date 2025-01-20
2025-01-20 19:47:19 : INFO  : flux : ################## Version: 10.7beta
2025-01-20 19:47:19 : INFO  : flux : ################## Date: 2025-01-20
2025-01-20 19:47:19 : INFO  : flux : ################## flux
2025-01-20 19:47:19 : DEBUG : flux : DEBUG mode 1 enabled.
2025-01-20 19:47:19 : DEBUG : flux : name=Flux
2025-01-20 19:47:19 : DEBUG : flux : appName=
2025-01-20 19:47:19 : DEBUG : flux : type=zip
2025-01-20 19:47:20 : DEBUG : flux : archiveName=
2025-01-20 19:47:20 : DEBUG : flux : downloadURL=https://justgetflux.com/mac/Flux.zip
2025-01-20 19:47:20 : DEBUG : flux : curlOptions=
2025-01-20 19:47:20 : DEBUG : flux : appNewVersion=42.2
2025-01-20 19:47:20 : DEBUG : flux : appCustomVersion function: Not defined
2025-01-20 19:47:20 : DEBUG : flux : versionKey=CFBundleShortVersionString
2025-01-20 19:47:20 : DEBUG : flux : packageID=
2025-01-20 19:47:20 : DEBUG : flux : pkgName=
2025-01-20 19:47:20 : DEBUG : flux : choiceChangesXML=
2025-01-20 19:47:20 : DEBUG : flux : expectedTeamID=VZKSA7H9J9
2025-01-20 19:47:20 : DEBUG : flux : blockingProcesses=
2025-01-20 19:47:20 : DEBUG : flux : installerTool=
2025-01-20 19:47:20 : DEBUG : flux : CLIInstaller=
2025-01-20 19:47:20 : DEBUG : flux : CLIArguments=
2025-01-20 19:47:20 : DEBUG : flux : updateTool=
2025-01-20 19:47:20 : DEBUG : flux : updateToolArguments=
2025-01-20 19:47:20 : DEBUG : flux : updateToolRunAsCurrentUser=
2025-01-20 19:47:20 : INFO  : flux : BLOCKING_PROCESS_ACTION=tell_user
2025-01-20 19:47:20 : INFO  : flux : NOTIFY=success
2025-01-20 19:47:20 : INFO  : flux : LOGGING=DEBUG
2025-01-20 19:47:20 : INFO  : flux : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-20 19:47:20 : INFO  : flux : Label type: zip
2025-01-20 19:47:20 : INFO  : flux : archiveName: Flux.zip
2025-01-20 19:47:20 : INFO  : flux : no blocking processes defined, using Flux as default
2025-01-20 19:47:20 : DEBUG : flux : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-20 19:47:20 : INFO  : flux : name: Flux, appName: Flux.app
2025-01-20 19:47:20.114 mdfind[96459:23188501] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 19:47:20.114 mdfind[96459:23188501] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 19:47:20.170 mdfind[96459:23188501] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 19:47:20 : INFO  : flux : App(s) found: /Users/gilburns/Downloads/Flux.app
2025-01-20 19:47:20 : WARN  : flux : could not determine location of Flux.app
2025-01-20 19:47:20 : INFO  : flux : appversion: 
2025-01-20 19:47:20 : INFO  : flux : Latest version of Flux is 42.2
2025-01-20 19:47:20 : REQ   : flux : Downloading https://justgetflux.com/mac/Flux.zip to Flux.zip
2025-01-20 19:47:20 : DEBUG : flux : No Dialog connection, just download
2025-01-20 19:47:21 : DEBUG : flux : File list: -rw-r--r--  1 gilburns  staff   2.0M Jan 20 19:47 Flux.zip
2025-01-20 19:47:21 : DEBUG : flux : File type: Flux.zip: Zip archive data, at least v1.0 to extract, compression method=store
2025-01-20 19:47:21 : DEBUG : flux : curl output was:
* Host justgetflux.com:443 was resolved.
* IPv6: (none)
* IPv4: 216.176.200.22
*   Trying 216.176.200.22:443...
* Connected to justgetflux.com (216.176.200.22) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [320 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [108 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [4610 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=justgetflux.com
*  start date: Jan 27 00:00:00 2024 GMT
*  expire date: Feb 26 23:59:59 2025 GMT
*  subjectAltName: host "justgetflux.com" matched cert's "justgetflux.com"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /mac/Flux.zip HTTP/1.1
> Host: justgetflux.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Moved Temporarily
< Server: nginx
< Date: Tue, 21 Jan 2025 01:47:20 GMT
< Content-Type: text/html
< Transfer-Encoding: chunked
< Connection: keep-alive
< Keep-Alive: timeout=35
< Location: https://macflux.b-cdn.net/Flux.zip
< Set-Cookie: uid=2LDIFmeO/KgqLACCVUweAg==; expires=Wed, 21-Jan-26 01:47:20 GMT; path=/
< 
* Ignoring the response-body
* Connection #0 to host justgetflux.com left intact
* Issue another request to this URL: 'https://macflux.b-cdn.net/Flux.zip'
* Host macflux.b-cdn.net:443 was resolved.
* IPv6: 2400:52e0:1a00::1029:1
* IPv4: 169.150.236.97
*   Trying 169.150.236.97:443...
* Connected to macflux.b-cdn.net (169.150.236.97) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5660 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.b-cdn.net
*  start date: Nov  5 00:00:00 2024 GMT
*  expire date: Nov 11 23:59:59 2025 GMT
*  subjectAltName: host "macflux.b-cdn.net" matched cert's "*.b-cdn.net"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://macflux.b-cdn.net/Flux.zip
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: macflux.b-cdn.net]
* [HTTP/2] [1] [:path: /Flux.zip]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /Flux.zip HTTP/2
> Host: macflux.b-cdn.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Tue, 21 Jan 2025 01:47:20 GMT
< content-type: application/zip
< content-length: 2129307
< server: BunnyCDN-IL1-1067
< cdn-pullzone: 277462
< cdn-uid: a4dbc144-ce45-4f49-a651-2c2e7608da9c
< cdn-requestcountrycode: US
< cache-control: max-age=60
< expires: Tue, 19 Nov 2024 03:08:32 GMT
< last-modified: Wed, 17 May 2023 01:53:31 GMT
< cdn-proxyver: 1.06
< cdn-requestpullsuccess: True
< cdn-requestpullcode: 206
< cdn-cachedat: 11/19/2024 03:07:32
< cdn-edgestorageid: 1068
< cdn-status: 200
< cdn-requesttime: 1
< cdn-requestid: 8ac534d2b542e5db7c1d4bc656de93cf
< cdn-cache: REVALIDATED
< accept-ranges: bytes
< 
{ [15784 bytes data]
* Connection #1 to host macflux.b-cdn.net left intact

2025-01-20 19:47:21 : DEBUG : flux : DEBUG mode 1, not checking for blocking processes
2025-01-20 19:47:21 : REQ   : flux : Installing Flux
2025-01-20 19:47:21 : INFO  : flux : Unzipping Flux.zip
2025-01-20 19:47:21 : INFO  : flux : Verifying: /Users/gilburns/GitHub/Installomator/build/Flux.app
2025-01-20 19:47:21 : DEBUG : flux : App size: 5.5M	/Users/gilburns/GitHub/Installomator/build/Flux.app
2025-01-20 19:47:21 : DEBUG : flux : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/Flux.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Michael Herf (VZKSA7H9J9)

2025-01-20 19:47:21 : INFO  : flux : Team ID matching: VZKSA7H9J9 (expected: VZKSA7H9J9 )
2025-01-20 19:47:21 : INFO  : flux : Installing Flux version 42.2 on versionKey CFBundleShortVersionString.
2025-01-20 19:47:21 : INFO  : flux : App has LSMinimumSystemVersion: 10.9
2025-01-20 19:47:21 : DEBUG : flux : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-20 19:47:21 : INFO  : flux : Finishing...
2025-01-20 19:47:24 : INFO  : flux : name: Flux, appName: Flux.app
2025-01-20 19:47:24.984 mdfind[96524:23188812] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 19:47:24.984 mdfind[96524:23188812] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 19:47:25.023 mdfind[96524:23188812] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 19:47:25 : INFO  : flux : App(s) found: /Users/gilburns/Downloads/Flux.app/Users/gilburns/GitHub/Installomator/build/Flux.app
2025-01-20 19:47:25 : WARN  : flux : could not determine location of Flux.app
2025-01-20 19:47:25 : REQ   : flux : Installed Flux, version 42.2
2025-01-20 19:47:25 : INFO  : flux : notifying
ERROR: Notifications are not allowed for this application
2025-01-20 19:47:25 : DEBUG : flux : DEBUG mode 1, not reopening anything
2025-01-20 19:47:25 : REQ   : flux : All done!
2025-01-20 19:47:25 : REQ   : flux : ################## End Installomator, exit code 0 
```