### PR TITLE
Update masv label to include appNewVersion key

### DIFF
--- a/fragments/labels/masv.sh
+++ b/fragments/labels/masv.sh
@@ -2,5 +2,6 @@ masv)
     name="MASV"
     type="dmg"
     downloadURL="https://dl.massive.io/MASV.dmg"
+    appNewVersion=$(curl -fsL 'https://dl.massive.io/latest-mac.yml' | grep 'version:' | awk '{print $NF }')
     expectedTeamID="VHKX7RCAY7"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update masv label to include appNewVersion key

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh masv
2025-01-20 20:01:56 : REQ   : masv : ################## Start Installomator v. 10.7beta, date 2025-01-20
2025-01-20 20:01:56 : INFO  : masv : ################## Version: 10.7beta
2025-01-20 20:01:56 : INFO  : masv : ################## Date: 2025-01-20
2025-01-20 20:01:56 : INFO  : masv : ################## masv
2025-01-20 20:01:56 : DEBUG : masv : DEBUG mode 1 enabled.
2025-01-20 20:01:57 : DEBUG : masv : name=MASV
2025-01-20 20:01:57 : DEBUG : masv : appName=
2025-01-20 20:01:57 : DEBUG : masv : type=dmg
2025-01-20 20:01:57 : DEBUG : masv : archiveName=
2025-01-20 20:01:57 : DEBUG : masv : downloadURL=https://dl.massive.io/MASV.dmg
2025-01-20 20:01:57 : DEBUG : masv : curlOptions=
2025-01-20 20:01:57 : DEBUG : masv : appNewVersion=2.10.0
2025-01-20 20:01:57 : DEBUG : masv : appCustomVersion function: Not defined
2025-01-20 20:01:57 : DEBUG : masv : versionKey=CFBundleShortVersionString
2025-01-20 20:01:57 : DEBUG : masv : packageID=
2025-01-20 20:01:57 : DEBUG : masv : pkgName=
2025-01-20 20:01:57 : DEBUG : masv : choiceChangesXML=
2025-01-20 20:01:57 : DEBUG : masv : expectedTeamID=VHKX7RCAY7
2025-01-20 20:01:57 : DEBUG : masv : blockingProcesses=
2025-01-20 20:01:57 : DEBUG : masv : installerTool=
2025-01-20 20:01:57 : DEBUG : masv : CLIInstaller=
2025-01-20 20:01:57 : DEBUG : masv : CLIArguments=
2025-01-20 20:01:57 : DEBUG : masv : updateTool=
2025-01-20 20:01:57 : DEBUG : masv : updateToolArguments=
2025-01-20 20:01:57 : DEBUG : masv : updateToolRunAsCurrentUser=
2025-01-20 20:01:57 : INFO  : masv : BLOCKING_PROCESS_ACTION=tell_user
2025-01-20 20:01:57 : INFO  : masv : NOTIFY=success
2025-01-20 20:01:57 : INFO  : masv : LOGGING=DEBUG
2025-01-20 20:01:57 : INFO  : masv : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-20 20:01:57 : INFO  : masv : Label type: dmg
2025-01-20 20:01:57 : INFO  : masv : archiveName: MASV.dmg
2025-01-20 20:01:57 : INFO  : masv : no blocking processes defined, using MASV as default
2025-01-20 20:01:57 : DEBUG : masv : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-20 20:01:57 : INFO  : masv : name: MASV, appName: MASV.app
2025-01-20 20:01:57.320 mdfind[52170:23300412] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:01:57.321 mdfind[52170:23300412] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:01:57.378 mdfind[52170:23300412] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:01:57 : INFO  : masv : App(s) found: /Users/gilburns/Applications/MASV.app
2025-01-20 20:01:57 : WARN  : masv : could not determine location of MASV.app
2025-01-20 20:01:57 : INFO  : masv : appversion: 
2025-01-20 20:01:57 : INFO  : masv : Latest version of MASV is 2.10.0
2025-01-20 20:01:57 : REQ   : masv : Downloading https://dl.massive.io/MASV.dmg to MASV.dmg
2025-01-20 20:01:57 : DEBUG : masv : No Dialog connection, just download
2025-01-20 20:03:08 : DEBUG : masv : File list: -rw-r--r--  1 gilburns  staff   215M Jan 20 20:03 MASV.dmg
2025-01-20 20:03:08 : DEBUG : masv : File type: MASV.dmg: zlib compressed data
2025-01-20 20:03:08 : DEBUG : masv : curl output was:
* Host dl.massive.io:443 was resolved.
* IPv6: 2606:4700:20::681a:e88, 2606:4700:20::ac43:497d, 2606:4700:20::681a:f88
* IPv4: 172.67.73.125, 104.26.15.136, 104.26.14.136
*   Trying 172.67.73.125:443...
* Connected to dl.massive.io (172.67.73.125) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2516 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=dl.massive.io
*  start date: Jan 19 06:54:35 2025 GMT
*  expire date: Apr 19 07:54:29 2025 GMT
*  subjectAltName: host "dl.massive.io" matched cert's "dl.massive.io"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://dl.massive.io/MASV.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dl.massive.io]
* [HTTP/2] [1] [:path: /MASV.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /MASV.dmg HTTP/2
> Host: dl.massive.io
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< date: Tue, 21 Jan 2025 02:01:57 GMT
< content-type: application/x-apple-diskimage
< content-length: 225613009
< etag: "ab642e16c2407a70e2648670fdd73f87-2"
< last-modified: Thu, 10 Oct 2024 14:44:43 GMT
< vary: Accept-Encoding
< cache-control: max-age=14400
< cf-cache-status: HIT
< accept-ranges: bytes
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=kTAGVuvoTYhbUBLEspZpydzOQRwf2XpJwXs7PHjywAY5Ld2c4u3Yh%2B3omCdF2Hk0vZJB0obEdZ04T8ofVOlxfxw0w80mmw6nzvp50SaXPiUWCAGEcK0AKDYkMCwo79A%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< strict-transport-security: max-age=31536000
< server: cloudflare
< cf-ray: 9053b8266ff22232-ORD
< alt-svc: h3=":443"; ma=86400
< server-timing: cfL4;desc="?proto=TCP&rtt=27165&min_rtt=21603&rtt_var=9120&sent=7&recv=11&lost=0&retrans=0&sent_bytes=2898&recv_bytes=573&delivery_rate=114815&cwnd=225&unsent_bytes=0&cid=3120ba50aa617c78&ts=93&x=0"
< 
{ [1360 bytes data]
* Connection #0 to host dl.massive.io left intact

2025-01-20 20:03:08 : DEBUG : masv : DEBUG mode 1, not checking for blocking processes
2025-01-20 20:03:08 : REQ   : masv : Installing MASV
2025-01-20 20:03:08 : INFO  : masv : Mounting /Users/gilburns/GitHub/Installomator/build/MASV.dmg
2025-01-20 20:03:10 : DEBUG : masv : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1EAB6189
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B3DA0488
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $035934A9
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $F65ED95C
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $035934A9
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $7F5C5DF7
verified   CRC32 $C1F2CB9B
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/MASV 2.10.0-universal

2025-01-20 20:03:10 : INFO  : masv : Mounted: /Volumes/MASV 2.10.0-universal
2025-01-20 20:03:10 : INFO  : masv : Verifying: /Volumes/MASV 2.10.0-universal/MASV.app
2025-01-20 20:03:10 : DEBUG : masv : App size: 520M	/Volumes/MASV 2.10.0-universal/MASV.app
2025-01-20 20:03:13 : DEBUG : masv : Debugging enabled, App Verification output was:
/Volumes/MASV 2.10.0-universal/MASV.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: LiveQoS Incorporated (VHKX7RCAY7)

2025-01-20 20:03:13 : INFO  : masv : Team ID matching: VHKX7RCAY7 (expected: VHKX7RCAY7 )
2025-01-20 20:03:13 : INFO  : masv : Installing MASV version 2.10.0 on versionKey CFBundleShortVersionString.
2025-01-20 20:03:13 : INFO  : masv : App has LSMinimumSystemVersion: 10.15
2025-01-20 20:03:13 : DEBUG : masv : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-20 20:03:13 : INFO  : masv : Finishing...
2025-01-20 20:03:16 : INFO  : masv : name: MASV, appName: MASV.app
2025-01-20 20:03:16.130 mdfind[55933:23308230] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:03:16.130 mdfind[55933:23308230] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:03:16.174 mdfind[55933:23308230] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:03:16 : INFO  : masv : App(s) found: /Users/gilburns/Applications/MASV.app
2025-01-20 20:03:16 : WARN  : masv : could not determine location of MASV.app
2025-01-20 20:03:16 : REQ   : masv : Installed MASV, version 2.10.0
2025-01-20 20:03:16 : INFO  : masv : notifying
ERROR: Notifications are not allowed for this application
2025-01-20 20:03:16 : DEBUG : masv : Unmounting /Volumes/MASV 2.10.0-universal
2025-01-20 20:03:16 : DEBUG : masv : Debugging enabled, Unmounting output was:
"disk12" ejected.
2025-01-20 20:03:16 : DEBUG : masv : DEBUG mode 1, not reopening anything
2025-01-20 20:03:16 : REQ   : masv : All done!
2025-01-20 20:03:16 : REQ   : masv : ################## End Installomator, exit code 0 

```