### PR TITLE
Update rocket label to use xml feed for download and new version

### DIFF
--- a/fragments/labels/rocket.sh
+++ b/fragments/labels/rocket.sh
@@ -1,6 +1,8 @@
 rocket)
     name="Rocket"
     type="dmg"
-    downloadURL="https://macrelease.matthewpalmer.net/Rocket.dmg"
+    rocketFeed=$(curl -fsL "https://macrelease.matthewpalmer.net/distribution/appcasts/rocket.xml")
+    appNewVersion=$(echo "${rocketFeed}" | xpath 'string(//rss/channel/item[last()]/title)' 2>/dev/null)
+    downloadURL=$(echo "${rocketFeed}" | xpath 'string(//rss/channel/item[last()]/enclosure/@url)' 2>/dev/null)
     expectedTeamID="Z4JV2M65MH"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update rocket label to use xml feed for download and new version

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh rocket
2025-01-20 20:23:36 : REQ   : rocket : ################## Start Installomator v. 10.7beta, date 2025-01-20
2025-01-20 20:23:36 : INFO  : rocket : ################## Version: 10.7beta
2025-01-20 20:23:36 : INFO  : rocket : ################## Date: 2025-01-20
2025-01-20 20:23:36 : INFO  : rocket : ################## rocket
2025-01-20 20:23:36 : DEBUG : rocket : DEBUG mode 1 enabled.
2025-01-20 20:23:36 : DEBUG : rocket : name=Rocket
2025-01-20 20:23:36 : DEBUG : rocket : appName=
2025-01-20 20:23:36 : DEBUG : rocket : type=dmg
2025-01-20 20:23:36 : DEBUG : rocket : archiveName=
2025-01-20 20:23:36 : DEBUG : rocket : downloadURL=https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-85.dmg
2025-01-20 20:23:36 : DEBUG : rocket : curlOptions=
2025-01-20 20:23:36 : DEBUG : rocket : appNewVersion=1.9.3
2025-01-20 20:23:36 : DEBUG : rocket : appCustomVersion function: Not defined
2025-01-20 20:23:36 : DEBUG : rocket : versionKey=CFBundleShortVersionString
2025-01-20 20:23:36 : DEBUG : rocket : packageID=
2025-01-20 20:23:36 : DEBUG : rocket : pkgName=
2025-01-20 20:23:36 : DEBUG : rocket : choiceChangesXML=
2025-01-20 20:23:36 : DEBUG : rocket : expectedTeamID=Z4JV2M65MH
2025-01-20 20:23:36 : DEBUG : rocket : blockingProcesses=
2025-01-20 20:23:36 : DEBUG : rocket : installerTool=
2025-01-20 20:23:36 : DEBUG : rocket : CLIInstaller=
2025-01-20 20:23:36 : DEBUG : rocket : CLIArguments=
2025-01-20 20:23:36 : DEBUG : rocket : updateTool=
2025-01-20 20:23:36 : DEBUG : rocket : updateToolArguments=
2025-01-20 20:23:36 : DEBUG : rocket : updateToolRunAsCurrentUser=
2025-01-20 20:23:36 : INFO  : rocket : BLOCKING_PROCESS_ACTION=tell_user
2025-01-20 20:23:36 : INFO  : rocket : NOTIFY=success
2025-01-20 20:23:36 : INFO  : rocket : LOGGING=DEBUG
2025-01-20 20:23:36 : INFO  : rocket : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-20 20:23:36 : INFO  : rocket : Label type: dmg
2025-01-20 20:23:36 : INFO  : rocket : archiveName: Rocket.dmg
2025-01-20 20:23:36 : INFO  : rocket : no blocking processes defined, using Rocket as default
2025-01-20 20:23:36 : DEBUG : rocket : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-20 20:23:36 : INFO  : rocket : name: Rocket, appName: Rocket.app
2025-01-20 20:23:36.632 mdfind[33237:23462744] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:23:36.632 mdfind[33237:23462744] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:23:36.664 mdfind[33237:23462744] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:23:36 : WARN  : rocket : No previous app found
2025-01-20 20:23:36 : WARN  : rocket : could not find Rocket.app
2025-01-20 20:23:36 : INFO  : rocket : appversion: 
2025-01-20 20:23:36 : INFO  : rocket : Latest version of Rocket is 1.9.3
2025-01-20 20:23:36 : REQ   : rocket : Downloading https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-85.dmg to Rocket.dmg
2025-01-20 20:23:36 : DEBUG : rocket : No Dialog connection, just download
2025-01-20 20:23:39 : DEBUG : rocket : File list: -rw-r--r--  1 gilburns  staff    15M Jan 20 20:23 Rocket.dmg
2025-01-20 20:23:39 : DEBUG : rocket : File type: Rocket.dmg: zlib compressed data
2025-01-20 20:23:39 : DEBUG : rocket : curl output was:
* Host macrelease.matthewpalmer.net:443 was resolved.
* IPv6: 2606:4700:3034::6815:4304, 2606:4700:3031::ac43:a769
* IPv4: 172.67.167.105, 104.21.67.4
*   Trying 172.67.167.105:443...
* Connected to macrelease.matthewpalmer.net (172.67.167.105) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [333 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2548 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=matthewpalmer.net
*  start date: Dec 25 13:28:03 2024 GMT
*  expire date: Mar 25 14:26:46 2025 GMT
*  subjectAltName: host "macrelease.matthewpalmer.net" matched cert's "*.matthewpalmer.net"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://macrelease.matthewpalmer.net/distribution/appcasts/Rocket-85.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: macrelease.matthewpalmer.net]
* [HTTP/2] [1] [:path: /distribution/appcasts/Rocket-85.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /distribution/appcasts/Rocket-85.dmg HTTP/2
> Host: macrelease.matthewpalmer.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< date: Tue, 21 Jan 2025 02:23:36 GMT
< content-type: text/plain; charset=utf-8
< content-length: 90
< location: https://db879acd-macrelease.s3.us-east-2.amazonaws.com/Rocket-85.dmg
< x-powered-by: Express
< vary: Accept
< cf-cache-status: BYPASS
< report-to: {"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=o51FKiWJJs3a1IM3CKrpIQWoCGXt47P5UG1eApCzXwxxcqrT2PCYrYyMNVwEC7quPgjLHHFVA7KaUh6vTPEUttr8uH%2BHNDad0nHgLRdfo9BADpK4eXrWFp5nHu7GR289%2BmMqs5H7dAtBdWaK55tA"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< server: cloudflare
< cf-ray: 9053d7df5c3eacb1-ORD
< alt-svc: h3=":443"; ma=86400
< server-timing: cfL4;desc="?proto=TCP&rtt=34445&min_rtt=28270&rtt_var=12434&sent=5&recv=10&lost=0&retrans=0&sent_bytes=2908&recv_bytes=617&delivery_rate=102440&cwnd=208&unsent_bytes=0&cid=0456223d041e4386&ts=94&x=0"
< 
* Ignoring the response-body
* Connection #0 to host macrelease.matthewpalmer.net left intact
* Issue another request to this URL: 'https://db879acd-macrelease.s3.us-east-2.amazonaws.com/Rocket-85.dmg'
* Host db879acd-macrelease.s3.us-east-2.amazonaws.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.5.131.158, 3.5.132.170, 3.5.129.2, 52.219.178.154, 52.219.111.18, 3.5.131.174, 3.5.129.112, 3.5.132.183
*   Trying 3.5.131.158:443...
* Connected to db879acd-macrelease.s3.us-east-2.amazonaws.com (3.5.131.158) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [351 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [5512 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=*.s3.us-east-2.amazonaws.com
*  start date: Jan  9 00:00:00 2025 GMT
*  expire date: Jan  4 23:59:59 2026 GMT
*  subjectAltName: host "db879acd-macrelease.s3.us-east-2.amazonaws.com" matched cert's "*.s3.us-east-2.amazonaws.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /Rocket-85.dmg HTTP/1.1
> Host: db879acd-macrelease.s3.us-east-2.amazonaws.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< x-amz-id-2: +9T+FsplAMpfASqw7/1erEs/puq4p3gtALF+UIqH1yyRFE3kLqb/M1XO3oRHNEj3/9EXskCeILL02JZltA6r/A==
< x-amz-request-id: RF59ZT01GZ0RDT8K
< Date: Tue, 21 Jan 2025 02:23:38 GMT
< Last-Modified: Fri, 28 Apr 2023 02:38:08 GMT
< ETag: "f951ff2724c0a48870c1a621ea317244-2"
< x-amz-server-side-encryption: AES256
< Accept-Ranges: bytes
< Content-Type: application/x-apple-diskimage
< Content-Length: 15777706
< Server: AmazonS3
< 
{ [16384 bytes data]
* Connection #1 to host db879acd-macrelease.s3.us-east-2.amazonaws.com left intact

2025-01-20 20:23:39 : DEBUG : rocket : DEBUG mode 1, not checking for blocking processes
2025-01-20 20:23:39 : REQ   : rocket : Installing Rocket
2025-01-20 20:23:39 : INFO  : rocket : Mounting /Users/gilburns/GitHub/Installomator/build/Rocket.dmg
2025-01-20 20:23:43 : DEBUG : rocket : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $451F091C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $F62522AF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DABCDE4B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $23A4E481
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DABCDE4B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FE57AF75
verified   CRC32 $5D3B17E0
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_HFS                      	/Volumes/Rocket 1

2025-01-20 20:23:43 : INFO  : rocket : Mounted: /Volumes/Rocket 1
2025-01-20 20:23:43 : INFO  : rocket : Verifying: /Volumes/Rocket 1/Rocket.app
2025-01-20 20:23:43 : DEBUG : rocket : App size:  31M	/Volumes/Rocket 1/Rocket.app
2025-01-20 20:23:44 : DEBUG : rocket : Debugging enabled, App Verification output was:
/Volumes/Rocket 1/Rocket.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Matthew Palmer (Z4JV2M65MH)

2025-01-20 20:23:44 : INFO  : rocket : Team ID matching: Z4JV2M65MH (expected: Z4JV2M65MH )
2025-01-20 20:23:44 : INFO  : rocket : Installing Rocket version 1.9.3 on versionKey CFBundleShortVersionString.
2025-01-20 20:23:44 : INFO  : rocket : App has LSMinimumSystemVersion: 10.12
2025-01-20 20:23:44 : DEBUG : rocket : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-20 20:23:44 : INFO  : rocket : Finishing...
2025-01-20 20:23:47 : INFO  : rocket : name: Rocket, appName: Rocket.app
2025-01-20 20:23:47.118 mdfind[33566:23463523] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:23:47.118 mdfind[33566:23463523] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:23:47.155 mdfind[33566:23463523] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:23:47 : WARN  : rocket : No previous app found
2025-01-20 20:23:47 : WARN  : rocket : could not find Rocket.app
2025-01-20 20:23:47 : REQ   : rocket : Installed Rocket, version 1.9.3
2025-01-20 20:23:47 : INFO  : rocket : notifying
ERROR: Notifications are not allowed for this application
2025-01-20 20:23:47 : DEBUG : rocket : Unmounting /Volumes/Rocket 1
2025-01-20 20:23:47 : DEBUG : rocket : Debugging enabled, Unmounting output was:
"disk13" ejected.
2025-01-20 20:23:47 : DEBUG : rocket : DEBUG mode 1, not reopening anything
2025-01-20 20:23:47 : REQ   : rocket : All done!
2025-01-20 20:23:47 : REQ   : rocket : ################## End Installomator, exit code 0 
```
