### PR TITLE
Update wechat label to include appNewVersion key

### DIFF
--- a/fragments/labels/wechat.sh
+++ b/fragments/labels/wechat.sh
@@ -2,5 +2,6 @@ wechat)
     name="WeChat"
     type="dmg"
     downloadURL="https://dldir1.qq.com/weixin/mac/WeChatMac.dmg"
+    appNewVersion=$(curl -fsL 'https://dldir1.qq.com/weixin/mac/mac-release.xml' | xpath 'string(//rss/channel/item[1]/title)' 2>/dev/null)
     expectedTeamID="5A4RE8SF68"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Update wechat label to include appNewVersion key

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh wechat
2025-01-20 20:40:14 : REQ   : wechat : ################## Start Installomator v. 10.7beta, date 2025-01-20
2025-01-20 20:40:14 : INFO  : wechat : ################## Version: 10.7beta
2025-01-20 20:40:14 : INFO  : wechat : ################## Date: 2025-01-20
2025-01-20 20:40:14 : INFO  : wechat : ################## wechat
2025-01-20 20:40:14 : DEBUG : wechat : DEBUG mode 1 enabled.
2025-01-20 20:40:16 : DEBUG : wechat : name=WeChat
2025-01-20 20:40:16 : DEBUG : wechat : appName=
2025-01-20 20:40:16 : DEBUG : wechat : type=dmg
2025-01-20 20:40:16 : DEBUG : wechat : archiveName=
2025-01-20 20:40:16 : DEBUG : wechat : downloadURL=https://dldir1.qq.com/weixin/mac/WeChatMac.dmg
2025-01-20 20:40:16 : DEBUG : wechat : curlOptions=
2025-01-20 20:40:16 : DEBUG : wechat : appNewVersion=3.8.10.17
2025-01-20 20:40:16 : DEBUG : wechat : appCustomVersion function: Not defined
2025-01-20 20:40:16 : DEBUG : wechat : versionKey=CFBundleShortVersionString
2025-01-20 20:40:16 : DEBUG : wechat : packageID=
2025-01-20 20:40:16 : DEBUG : wechat : pkgName=
2025-01-20 20:40:16 : DEBUG : wechat : choiceChangesXML=
2025-01-20 20:40:16 : DEBUG : wechat : expectedTeamID=5A4RE8SF68
2025-01-20 20:40:16 : DEBUG : wechat : blockingProcesses=
2025-01-20 20:40:16 : DEBUG : wechat : installerTool=
2025-01-20 20:40:16 : DEBUG : wechat : CLIInstaller=
2025-01-20 20:40:16 : DEBUG : wechat : CLIArguments=
2025-01-20 20:40:16 : DEBUG : wechat : updateTool=
2025-01-20 20:40:16 : DEBUG : wechat : updateToolArguments=
2025-01-20 20:40:16 : DEBUG : wechat : updateToolRunAsCurrentUser=
2025-01-20 20:40:16 : INFO  : wechat : BLOCKING_PROCESS_ACTION=tell_user
2025-01-20 20:40:16 : INFO  : wechat : NOTIFY=success
2025-01-20 20:40:16 : INFO  : wechat : LOGGING=DEBUG
2025-01-20 20:40:16 : INFO  : wechat : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-20 20:40:16 : INFO  : wechat : Label type: dmg
2025-01-20 20:40:16 : INFO  : wechat : archiveName: WeChat.dmg
2025-01-20 20:40:16 : INFO  : wechat : no blocking processes defined, using WeChat as default
2025-01-20 20:40:16 : DEBUG : wechat : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-20 20:40:16 : INFO  : wechat : name: WeChat, appName: WeChat.app
2025-01-20 20:40:16.538 mdfind[92502:23581578] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:40:16.538 mdfind[92502:23581578] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:40:16.593 mdfind[92502:23581578] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:40:16 : INFO  : wechat : App(s) found: /Users/gilburns/Applications/WeChat.app
2025-01-20 20:40:16 : WARN  : wechat : could not determine location of WeChat.app
2025-01-20 20:40:16 : INFO  : wechat : appversion: 
2025-01-20 20:40:16 : INFO  : wechat : Latest version of WeChat is 3.8.10.17
2025-01-20 20:40:16 : REQ   : wechat : Downloading https://dldir1.qq.com/weixin/mac/WeChatMac.dmg to WeChat.dmg
2025-01-20 20:40:16 : DEBUG : wechat : No Dialog connection, just download
2025-01-20 20:41:36 : DEBUG : wechat : File list: -rw-r--r--  1 gilburns  staff   353M Jan 20 20:41 WeChat.dmg
2025-01-20 20:41:36 : DEBUG : wechat : File type: WeChat.dmg: zlib compressed data
2025-01-20 20:41:36 : DEBUG : wechat : curl output was:
* Host dldir1.qq.com:443 was resolved.
* IPv6: (none)
* IPv4: 43.152.15.39, 43.152.15.37
*   Trying 43.152.15.39:443...
* Connected to dldir1.qq.com (43.152.15.39) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [318 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [4743 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=CN; ST=Guangdong Province; L=Shenzhen; O=Shenzhen Tencent Computer Systems Company Limited; CN=dl.tcdntip.com
*  start date: Jul 30 00:00:00 2024 GMT
*  expire date: Jul 29 23:59:59 2025 GMT
*  subjectAltName: host "dldir1.qq.com" matched cert's "dldir1.qq.com"
*  issuer: C=US; O=DigiCert, Inc.; CN=DigiCert Secure Site OV G2 TLS CN RSA4096 SHA256 2022 CA1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /weixin/mac/WeChatMac.dmg HTTP/1.1
> Host: dldir1.qq.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Last-Modified: Thu, 16 Jan 2025 09:12:00 GMT
< Server: NWSs
< Date: Thu, 16 Jan 2025 09:16:07 GMT
< Content-Type: application/octet-stream
< x-cos-storage-class: STANDARD_IA
< x-cos-version-id: MTg0NDUwMDcwNTQ5ODg2NjQ5Njc
< x-cos-hash-crc64ecma: 4020453514187049730
< X-COS-META-MD5: f2d068df06390024415b5a402ad34478
< X-COS-META-MTIME: Thu, 16 01 2025 09:11:59 GMT
< x-cos-replication-status: Complete
< x-cos-object-type: normal
< Content-Length: 370574676
< Accept-Ranges: bytes
< X-NWS-LOG-UUID: 465895881097938582
< Connection: keep-alive
< X-Cache-Lookup: Cache Hit
< 
{ [16384 bytes data]
* Connection #0 to host dldir1.qq.com left intact

2025-01-20 20:41:36 : DEBUG : wechat : DEBUG mode 1, not checking for blocking processes
2025-01-20 20:41:36 : REQ   : wechat : Installing WeChat
2025-01-20 20:41:36 : INFO  : wechat : Mounting /Users/gilburns/GitHub/Installomator/build/WeChat.dmg
2025-01-20 20:41:39 : DEBUG : wechat : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8AA232D7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3FAAA2A0
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $A4374EEB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $BA9FC801
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $A4374EEB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $85930274
verified   CRC32 $055C9E60
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/微信 WeChat

2025-01-20 20:41:39 : INFO  : wechat : Mounted: /Volumes/微信 WeChat
2025-01-20 20:41:39 : INFO  : wechat : Verifying: /Volumes/微信 WeChat/WeChat.app
2025-01-20 20:41:39 : DEBUG : wechat : App size: 828M	/Volumes/微信 WeChat/WeChat.app
2025-01-20 20:41:44 : DEBUG : wechat : Debugging enabled, App Verification output was:
/Volumes/微信 WeChat/WeChat.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Tencent Mobile International Limited (5A4RE8SF68)

2025-01-20 20:41:44 : INFO  : wechat : Team ID matching: 5A4RE8SF68 (expected: 5A4RE8SF68 )
2025-01-20 20:41:44 : INFO  : wechat : Installing WeChat version 3.8.10.17 on versionKey CFBundleShortVersionString.
2025-01-20 20:41:44 : INFO  : wechat : App has LSMinimumSystemVersion: 10.13
2025-01-20 20:41:44 : DEBUG : wechat : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-20 20:41:44 : INFO  : wechat : Finishing...
2025-01-20 20:41:47 : INFO  : wechat : name: WeChat, appName: WeChat.app
2025-01-20 20:41:47.397 mdfind[99855:23595647] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:41:47.397 mdfind[99855:23595647] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:41:47.438 mdfind[99855:23595647] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:41:47 : INFO  : wechat : App(s) found: /Users/gilburns/Applications/WeChat.app
2025-01-20 20:41:47 : WARN  : wechat : could not determine location of WeChat.app
2025-01-20 20:41:47 : REQ   : wechat : Installed WeChat, version 3.8.10.17
2025-01-20 20:41:47 : INFO  : wechat : notifying
ERROR: Notifications are not allowed for this application
2025-01-20 20:41:47 : DEBUG : wechat : Unmounting /Volumes/微信 WeChat
2025-01-20 20:41:47 : DEBUG : wechat : Debugging enabled, Unmounting output was:
"disk12" ejected.
2025-01-20 20:41:47 : DEBUG : wechat : DEBUG mode 1, not reopening anything
2025-01-20 20:41:47 : REQ   : wechat : All done!
2025-01-20 20:41:47 : REQ   : wechat : ################## End Installomator, exit code 0 

```