### PR TITLE
Update origin label to include appNewVersion key

### DIFF
--- a/fragments/labels/origin.sh
+++ b/fragments/labels/origin.sh
@@ -2,6 +2,6 @@ origin)
      name="Origin"
      type="dmg"
      downloadURL="https://www.dm.origin.com/mac/download/Origin.dmg"
+     appNewVersion=$(curl -fsL 'https://api1.origin.com/autopatch/2/upgradeFrom/9.0.000.00000/en_US/PROD?platform=MAC&osVersion=10.16.0' | xpath 'string(//version)' 2>/dev/null)
      expectedTeamID="TSTV75T6Q5"
-     blockingProcesses=( "Origin" )
      ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.

- Update origin label to include appNewVersion key
- Remove unnecessary blockingProcesses key

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh origin
2025-01-20 20:53:40 : REQ   : origin : ################## Start Installomator v. 10.7beta, date 2025-01-20
2025-01-20 20:53:40 : INFO  : origin : ################## Version: 10.7beta
2025-01-20 20:53:40 : INFO  : origin : ################## Date: 2025-01-20
2025-01-20 20:53:40 : INFO  : origin : ################## origin
2025-01-20 20:53:40 : DEBUG : origin : DEBUG mode 1 enabled.
2025-01-20 20:53:40 : DEBUG : origin : name=Origin
2025-01-20 20:53:40 : DEBUG : origin : appName=
2025-01-20 20:53:40 : DEBUG : origin : type=dmg
2025-01-20 20:53:40 : DEBUG : origin : archiveName=
2025-01-20 20:53:40 : DEBUG : origin : downloadURL=https://www.dm.origin.com/mac/download/Origin.dmg
2025-01-20 20:53:40 : DEBUG : origin : curlOptions=
2025-01-20 20:53:40 : DEBUG : origin : appNewVersion=10.5.128.55504
2025-01-20 20:53:40 : DEBUG : origin : appCustomVersion function: Not defined
2025-01-20 20:53:40 : DEBUG : origin : versionKey=CFBundleShortVersionString
2025-01-20 20:53:40 : DEBUG : origin : packageID=
2025-01-20 20:53:40 : DEBUG : origin : pkgName=
2025-01-20 20:53:40 : DEBUG : origin : choiceChangesXML=
2025-01-20 20:53:40 : DEBUG : origin : expectedTeamID=TSTV75T6Q5
2025-01-20 20:53:40 : DEBUG : origin : blockingProcesses=
2025-01-20 20:53:40 : DEBUG : origin : installerTool=
2025-01-20 20:53:40 : DEBUG : origin : CLIInstaller=
2025-01-20 20:53:40 : DEBUG : origin : CLIArguments=
2025-01-20 20:53:40 : DEBUG : origin : updateTool=
2025-01-20 20:53:40 : DEBUG : origin : updateToolArguments=
2025-01-20 20:53:40 : DEBUG : origin : updateToolRunAsCurrentUser=
2025-01-20 20:53:40 : INFO  : origin : BLOCKING_PROCESS_ACTION=tell_user
2025-01-20 20:53:40 : INFO  : origin : NOTIFY=success
2025-01-20 20:53:40 : INFO  : origin : LOGGING=DEBUG
2025-01-20 20:53:40 : INFO  : origin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-20 20:53:40 : INFO  : origin : Label type: dmg
2025-01-20 20:53:40 : INFO  : origin : archiveName: Origin.dmg
2025-01-20 20:53:40 : INFO  : origin : no blocking processes defined, using Origin as default
2025-01-20 20:53:40 : DEBUG : origin : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-01-20 20:53:41 : INFO  : origin : name: Origin, appName: Origin.app
2025-01-20 20:53:41.008 mdfind[44759:23687526] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:53:41.009 mdfind[44759:23687526] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:53:41.110 mdfind[44759:23687526] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:53:41 : INFO  : origin : App(s) found: /Users/gilburns/Applications/Origin.app/Users/gilburns/Applications/Origin.app/Contents/Applications/OriginER.app
2025-01-20 20:53:41 : WARN  : origin : could not determine location of Origin.app
2025-01-20 20:53:41 : INFO  : origin : appversion: 
2025-01-20 20:53:41 : INFO  : origin : Latest version of Origin is 10.5.128.55504
2025-01-20 20:53:41 : REQ   : origin : Downloading https://www.dm.origin.com/mac/download/Origin.dmg to Origin.dmg
2025-01-20 20:53:41 : DEBUG : origin : No Dialog connection, just download
2025-01-20 20:54:09 : DEBUG : origin : File list: -rw-r--r--  1 gilburns  staff   110M Jan 20 20:54 Origin.dmg
2025-01-20 20:54:09 : DEBUG : origin : File type: Origin.dmg: zlib compressed data
2025-01-20 20:54:09 : DEBUG : origin : curl output was:
* Host www.dm.origin.com:443 was resolved.
* IPv6: (none)
* IPv4: 54.165.196.185, 44.196.201.214, 34.194.83.135
*   Trying 54.165.196.185:443...
* Connected to www.dm.origin.com (54.165.196.185) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [322 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [3953 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [333 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [70 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=California; L=Redwood City; O=Electronic Arts Inc.; CN=www.dm.origin.com
*  start date: Dec 29 00:00:00 2024 GMT
*  expire date: Jan 29 23:59:59 2026 GMT
*  subjectAltName: host "www.dm.origin.com" matched cert's "www.dm.origin.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert SHA2 Secure Server CA
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /mac/download/Origin.dmg HTTP/1.1
> Host: www.dm.origin.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 302 Moved Temporarily
< Content-Type: text/html
< Date: Tue, 21 Jan 2025 02:53:41 GMT
< Location: https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/Origin.dmg
< Server: nginx
< Content-Length: 154
< Connection: keep-alive
< 
* Ignoring the response-body
* Connection #0 to host www.dm.origin.com left intact
* Issue another request to this URL: 'https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/Origin.dmg'
* Host origin-a.akamaihd.net:443 was resolved.
* IPv6: (none)
* IPv4: 2.18.190.75, 2.18.190.83
*   Trying 2.18.190.75:443...
* Connected to origin-a.akamaihd.net (2.18.190.75) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [35 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2854 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [78 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=US; ST=Massachusetts; L=Cambridge; O=Akamai Technologies, Inc.; CN=a248.e.akamai.net
*  start date: Apr 18 00:00:00 2024 GMT
*  expire date: Apr 19 23:59:59 2025 GMT
*  subjectAltName: host "origin-a.akamaihd.net" matched cert's "*.akamaihd.net"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /Origin-Client-Download/origin/mac/live/Origin.dmg HTTP/1.1
> Host: origin-a.akamaihd.net
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< x-amz-id-2: MSwwHzIX3q9ym4Y0W6SONOCkn2blzP85pkEOFdV6S8gtjfaP7wJM+Th9RlG7a5otfxwgokowxms=
< x-amz-request-id: E7X3A8H9DPMNZ4FE
< x-amz-server-side-encryption: AES256
< x-amz-version-id: bfkWB6GD8.96vRh6L0kC3iFCneUzc_JT
< Accept-Ranges: bytes
< Content-Type: binary/octet-stream
< Server: AmazonS3
< Last-Modified: Mon, 09 Sep 2024 22:33:57 GMT
< ETag: "d112a77487f7bc04eff0a942fe25f6ee-14"
< Content-Length: 115735192
< Cache-Control: public, max-age=1
< Date: Tue, 21 Jan 2025 02:53:41 GMT
< Connection: keep-alive
< Alt-Svc: h3-Q050=":443"; ma=93600,quic=":443"; ma=93600; v="46,43"
< 
{ [15793 bytes data]
* Connection #1 to host origin-a.akamaihd.net left intact

2025-01-20 20:54:09 : DEBUG : origin : DEBUG mode 1, not checking for blocking processes
2025-01-20 20:54:09 : REQ   : origin : Installing Origin
2025-01-20 20:54:09 : INFO  : origin : Mounting /Users/gilburns/GitHub/Installomator/build/Origin.dmg
2025-01-20 20:54:13 : DEBUG : origin : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $89AA0AE6
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8CCA94E2
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7691F8CC
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $D44CD127
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7691F8CC
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E463676A
verified   CRC32 $2869580A
/dev/disk12         	GUID_partition_scheme
/dev/disk12s1       	Apple_HFS                      	/Volumes/Origin

2025-01-20 20:54:13 : INFO  : origin : Mounted: /Volumes/Origin
2025-01-20 20:54:13 : INFO  : origin : Verifying: /Volumes/Origin/Origin.app
2025-01-20 20:54:13 : DEBUG : origin : App size: 286M	/Volumes/Origin/Origin.app
2025-01-20 20:54:14 : DEBUG : origin : Debugging enabled, App Verification output was:
/Volumes/Origin/Origin.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: EA Swiss Sarl (TSTV75T6Q5)

2025-01-20 20:54:14 : INFO  : origin : Team ID matching: TSTV75T6Q5 (expected: TSTV75T6Q5 )
2025-01-20 20:54:14 : INFO  : origin : Installing Origin version 10.5.128.55504 on versionKey CFBundleShortVersionString.
2025-01-20 20:54:14 : INFO  : origin : App has LSMinimumSystemVersion: 10.6
2025-01-20 20:54:14 : DEBUG : origin : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-01-20 20:54:14 : INFO  : origin : Finishing...
2025-01-20 20:54:17 : INFO  : origin : name: Origin, appName: Origin.app
2025-01-20 20:54:17.937 mdfind[44865:23688322] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-20 20:54:17.937 mdfind[44865:23688322] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-20 20:54:17.992 mdfind[44865:23688322] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-20 20:54:18 : INFO  : origin : App(s) found: /Users/gilburns/Applications/Origin.app/Users/gilburns/Applications/Origin.app/Contents/Applications/OriginER.app
2025-01-20 20:54:18 : WARN  : origin : could not determine location of Origin.app
2025-01-20 20:54:18 : REQ   : origin : Installed Origin, version 10.5.128.55504
2025-01-20 20:54:18 : INFO  : origin : notifying
ERROR: Notifications are not allowed for this application
2025-01-20 20:54:18 : DEBUG : origin : Unmounting /Volumes/Origin
2025-01-20 20:54:18 : DEBUG : origin : Debugging enabled, Unmounting output was:
"disk12" ejected.
2025-01-20 20:54:18 : DEBUG : origin : DEBUG mode 1, not reopening anything
2025-01-20 20:54:18 : REQ   : origin : All done!
2025-01-20 20:54:18 : REQ   : origin : ################## End Installomator, exit code 0 

```