### PR TITLE
Update and rename snapgeneviewer.sh to snapgene.sh

### DIFF
--- a/fragments/labels/snapgene.sh
+++ b/fragments/labels/snapgene.sh
@@ -1,7 +1,7 @@
 snapgene|snapgeneviewer)
     name="SnapGene"
     type="dmg"
-    downloadURL="https://www.snapgene.com/local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest"
+    downloadURL="https://www.snapgene.com/local/targets/download.php?os=mac&majorRelease=latest&minorRelease=latest"
     appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | tr '/' '\n' | grep -i "dmg" | sed -E 's/[a-zA-Z_]*_([0-9.]*)_mac\.dmg/\1/g' )
     expectedTeamID="WVCV9Q8Y78"
     ;;

--- a/fragments/labels/snapgene.sh
+++ b/fragments/labels/snapgene.sh
@@ -1,5 +1,5 @@
-snapgeneviewer)
-    name="SnapGene Viewer"
+snapgene|snapgeneviewer)
+    name="SnapGene"
     type="dmg"
     downloadURL="https://www.snapgene.com/local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest"
     appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | tr '/' '\n' | grep -i "dmg" | sed -E 's/[a-zA-Z_]*_([0-9.]*)_mac\.dmg/\1/g' )


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
SnapGene Viewer was merged into SnapGene.  Updating the label for SnapGene Viewer to pull the new unified application.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
testuser Installomator-10.6 % sudo sh ./assemble.sh snapgeneviewer DEBUG=0
./assemble.sh: line 16: zparseopts: command not found
./assemble.sh: line 18: (I)(-h|--help): syntax error in expression (error token is "(-h|--help)")
./assemble.sh: line 23: (I)(-s|--script): syntax error in expression (error token is "(-s|--script)")
./assemble.sh: line 25: (I)(-p|--pkg): syntax error in expression (error token is "(-p|--pkg)")
./assemble.sh: line 27: (I)(-n|--notarize): syntax error in expression (error token is "(-n|--notarize)")
./assemble.sh: line 30: (I)(-r|--run): syntax error in expression (error token is "(-r|--run)")
2025-01-21 17:14:39 : REQ   : snapgeneviewer : ################## Start Installomator v. 10.6, date 2025-01-21
2025-01-21 17:14:39 : INFO  : snapgeneviewer : ################## Version: 10.6
2025-01-21 17:14:39 : INFO  : snapgeneviewer : ################## Date: 2025-01-21
2025-01-21 17:14:39 : INFO  : snapgeneviewer : ################## snapgeneviewer
2025-01-21 17:14:39 : DEBUG : snapgeneviewer : DEBUG mode 1 enabled.
2025-01-21 17:14:40 : INFO  : snapgeneviewer : setting variable from argument DEBUG=0
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : name=SnapGene
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : appName=
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : type=dmg
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : archiveName=
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : downloadURL=https://www.snapgene.com/local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : curlOptions=
2025-01-21 17:14:40 : DEBUG : snapgeneviewer : appNewVersion=8.0.1
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : appCustomVersion function: Not defined
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : versionKey=CFBundleShortVersionString
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : packageID=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : pkgName=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : choiceChangesXML=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : expectedTeamID=WVCV9Q8Y78
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : blockingProcesses=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : installerTool=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : CLIInstaller=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : CLIArguments=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : updateTool=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : updateToolArguments=
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : updateToolRunAsCurrentUser=
2025-01-21 17:14:41 : INFO  : snapgeneviewer : BLOCKING_PROCESS_ACTION=tell_user
2025-01-21 17:14:41 : INFO  : snapgeneviewer : NOTIFY=success
2025-01-21 17:14:41 : INFO  : snapgeneviewer : LOGGING=DEBUG
2025-01-21 17:14:41 : INFO  : snapgeneviewer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-21 17:14:41 : INFO  : snapgeneviewer : Label type: dmg
2025-01-21 17:14:41 : INFO  : snapgeneviewer : archiveName: SnapGene.dmg
2025-01-21 17:14:41 : INFO  : snapgeneviewer : no blocking processes defined, using SnapGene as default
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MuoNo4vBu2
2025-01-21 17:14:41 : INFO  : snapgeneviewer : name: SnapGene, appName: SnapGene.app
2025-01-21 17:14:41.314 mdfind[30277:733194] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-01-21 17:14:41.314 mdfind[30277:733194] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-01-21 17:14:41.377 mdfind[30277:733194] Couldn't determine the mapping between prefab keywords and predicates.
2025-01-21 17:14:41 : WARN  : snapgeneviewer : No previous app found
2025-01-21 17:14:41 : WARN  : snapgeneviewer : could not find SnapGene.app
2025-01-21 17:14:41 : INFO  : snapgeneviewer : appversion: 
2025-01-21 17:14:41 : INFO  : snapgeneviewer : Latest version of SnapGene is 8.0.1
2025-01-21 17:14:41 : REQ   : snapgeneviewer : Downloading https://www.snapgene.com/local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest to SnapGene.dmg
2025-01-21 17:14:41 : DEBUG : snapgeneviewer : No Dialog connection, just download
^[[C^[[C2025-01-21 17:15:40 : DEBUG : snapgeneviewer : File list: -rw-r--r--  1 root  wheel   253M Jan 21 17:15 SnapGene.dmg
2025-01-21 17:15:40 : DEBUG : snapgeneviewer : File type: SnapGene.dmg: bzip2 compressed data, block size = 100k
2025-01-21 17:15:40 : DEBUG : snapgeneviewer : curl output was:
* Host www.snapgene.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.166.96.109, 3.166.96.30, 3.166.96.40, 3.166.96.108
*   Trying 3.166.96.109:443...
* Connected to www.snapgene.com (3.166.96.109) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3956 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=graphpad.com
*  start date: Sep 12 00:00:00 2024 GMT
*  expire date: Oct 11 23:59:59 2025 GMT
*  subjectAltName: host "www.snapgene.com" matched cert's "*.snapgene.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://www.snapgene.com/local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: www.snapgene.com]
* [HTTP/2] [1] [:path: /local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /local/targets/download.php?variant=viewer&os=mac&majorRelease=latest&minorRelease=latest HTTP/2
> Host: www.snapgene.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 302 
< content-type: text/html; charset=UTF-8
< content-length: 0
< location: https://cdn.snapgene.com/downloads/SnapGene/8.x/8.0/8.0.1/snapgene_8.0.1_mac.dmg
< date: Tue, 21 Jan 2025 23:14:41 GMT
< server: Apache/2.4.41 (Ubuntu)
< x-cache: Miss from cloudfront
< via: 1.1 677da8877c7bdf46bc7577d17b7b5a00.cloudfront.net (CloudFront)
< x-amz-cf-pop: MCI50-P3
< x-amz-cf-id: t4fW6uZWnB6MATOcpbqGzymRWMIfQamDCR7L2Fl2_VQnDMvPH5GzZw==
< x-xss-protection: 1; mode=block
< x-frame-options: SAMEORIGIN
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< strict-transport-security: max-age=31536000
< vary: Origin
< 
* Ignoring the response-body
* Connection #0 to host www.snapgene.com left intact
* Issue another request to this URL: 'https://cdn.snapgene.com/downloads/SnapGene/8.x/8.0/8.0.1/snapgene_8.0.1_mac.dmg'
* Host cdn.snapgene.com:443 was resolved.
* IPv6: (none)
* IPv4: 3.166.96.109, 3.166.96.30, 3.166.96.40, 3.166.96.108
*   Trying 3.166.96.109:443...
* Connected to cdn.snapgene.com (3.166.96.109) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [321 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3956 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=graphpad.com
*  start date: Sep 12 00:00:00 2024 GMT
*  expire date: Oct 11 23:59:59 2025 GMT
*  subjectAltName: host "cdn.snapgene.com" matched cert's "*.snapgene.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M02
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://cdn.snapgene.com/downloads/SnapGene/8.x/8.0/8.0.1/snapgene_8.0.1_mac.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: cdn.snapgene.com]
* [HTTP/2] [1] [:path: /downloads/SnapGene/8.x/8.0/8.0.1/snapgene_8.0.1_mac.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /downloads/SnapGene/8.x/8.0/8.0.1/snapgene_8.0.1_mac.dmg HTTP/2
> Host: cdn.snapgene.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/2 200 
< content-type: binary/octet-stream
< content-length: 265376175
< date: Tue, 21 Jan 2025 23:00:59 GMT
< last-modified: Wed, 20 Nov 2024 19:33:22 GMT
< etag: "7be076c1c5b3c506a1c3483bbab71cda-32"
< x-amz-server-side-encryption: AES256
< cache-control: max-age=31536000
< x-amz-version-id: ZsUURHD3cDllwnXvaE8uH0omtsPm6a43
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 d0d601bbf0821b7fe380f6619ce78e6c.cloudfront.net (CloudFront)
< x-amz-cf-pop: MCI50-P3
< x-amz-cf-id: 7RXMnr5C84Zei-FknvTbLEAD67AECdKKgRiUXky20d2TMh5d2Kk-OQ==
< age: 823
< x-xss-protection: 1; mode=block
< x-frame-options: SAMEORIGIN
< referrer-policy: strict-origin-when-cross-origin
< x-content-type-options: nosniff
< strict-transport-security: max-age=31536000
< vary: Origin
< 
{ [8192 bytes data]
* Connection #1 to host cdn.snapgene.com left intact

2025-01-21 17:15:40 : REQ   : snapgeneviewer : no more blocking processes, continue with update
2025-01-21 17:15:40 : REQ   : snapgeneviewer : Installing SnapGene
2025-01-21 17:15:40 : INFO  : snapgeneviewer : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MuoNo4vBu2/SnapGene.dmg
2025-01-21 17:15:54 : DEBUG : snapgeneviewer : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $77FEAFF3
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $5A9B737F
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $225D391C
verified   CRC32 $AC5D8267
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/SnapGene

2025-01-21 17:15:54 : INFO  : snapgeneviewer : Mounted: /Volumes/SnapGene
2025-01-21 17:15:54 : INFO  : snapgeneviewer : Verifying: /Volumes/SnapGene/SnapGene.app
2025-01-21 17:15:54 : DEBUG : snapgeneviewer : App size: 669M	/Volumes/SnapGene/SnapGene.app
2025-01-21 17:16:14 : DEBUG : snapgeneviewer : Debugging enabled, App Verification output was:
/Volumes/SnapGene/SnapGene.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: GSL Biotech LLC (WVCV9Q8Y78)

2025-01-21 17:16:14 : INFO  : snapgeneviewer : Team ID matching: WVCV9Q8Y78 (expected: WVCV9Q8Y78 )
2025-01-21 17:16:14 : INFO  : snapgeneviewer : Installing SnapGene version 8.0.1 on versionKey CFBundleShortVersionString.
2025-01-21 17:16:14 : INFO  : snapgeneviewer : App has LSMinimumSystemVersion: 10.14
2025-01-21 17:16:14 : INFO  : snapgeneviewer : Copy /Volumes/SnapGene/SnapGene.app to /Applications
2025-01-21 17:16:28 : DEBUG : snapgeneviewer : Debugging enabled, App copy output was:
Copying /Volumes/SnapGene/SnapGene.app

2025-01-21 17:16:28 : WARN  : snapgeneviewer : Changing owner to testuser
2025-01-21 17:16:28 : INFO  : snapgeneviewer : Finishing...
2025-01-21 17:16:31 : INFO  : snapgeneviewer : App(s) found: /Applications/SnapGene.app
2025-01-21 17:16:31 : INFO  : snapgeneviewer : found app at /Applications/SnapGene.app, version 8.0.1, on versionKey CFBundleShortVersionString
2025-01-21 17:16:31 : REQ   : snapgeneviewer : Installed SnapGene, version 8.0.1
2025-01-21 17:16:31 : INFO  : snapgeneviewer : notifying
2025-01-21 17:16:31 : DEBUG : snapgeneviewer : Unmounting /Volumes/SnapGene
2025-01-21 17:16:31 : DEBUG : snapgeneviewer : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-01-21 17:16:31 : DEBUG : snapgeneviewer : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MuoNo4vBu2
2025-01-21 17:16:32 : DEBUG : snapgeneviewer : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MuoNo4vBu2/SnapGene.dmg
2025-01-21 17:16:32 : DEBUG : snapgeneviewer : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MuoNo4vBu2
2025-01-21 17:16:32 : INFO  : snapgeneviewer : Installomator did not close any apps, so no need to reopen any apps.
2025-01-21 17:16:32 : REQ   : snapgeneviewer : All done!
2025-01-21 17:16:32 : REQ   : snapgeneviewer : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")