### PR TITLE
Better appNewVersion for 1Password8

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -3,8 +3,7 @@
     type="pkg"
     packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
-    relBuildVer=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | grep -v Beta | head -n 1 | grep href | cut -d = -f 3 | cut -d / -f 3)
-    appNewVersion=$(curl -s "https://releases.1password.com/mac/$relBuildVer/" | grep "Updated to" | cut -d \> -f 78 | cut -d \  -f 3)
+    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | grep -v Beta | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]-" | cut -d - -f 1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -3,7 +3,7 @@
     type="pkg"
     packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
-    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | grep -v Beta | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]" | cut -d - -f 1)
+    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]" | cut -d - -f 1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -3,7 +3,7 @@
     type="pkg"
     packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
-    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | grep -v Beta | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]-" | cut -d - -f 1)
+    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | grep -v Beta | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]" | cut -d - -f 1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
I found it was possible to get the appNewVersion directly, instead of using the intermediate $relBuildVer.
This fixes #2099 (which is the sole reason for this PR)

**Installomator log** 
```
2025-01-23 08:42:01 : REQ   : 1password8 : ################## Start Installomator v. 10.7beta, date 2025-01-23
2025-01-23 08:42:01 : INFO  : 1password8 : ################## Version: 10.7beta
2025-01-23 08:42:01 : INFO  : 1password8 : ################## Date: 2025-01-23
2025-01-23 08:42:01 : INFO  : 1password8 : ################## 1password8
2025-01-23 08:42:01 : DEBUG : 1password8 : DEBUG mode 1 enabled.
2025-01-23 08:42:01 : INFO  : 1password8 : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2025-01-23 08:42:01 : INFO  : 1password8 : setting variable from argument NOTIFY=success
2025-01-23 08:42:02 : INFO  : 1password8 : setting variable from argument swiftDialogNotification=notification
2025-01-23 08:42:02 : INFO  : 1password8 : setting variable from argument SYSTEMOWNER=1
2025-01-23 08:42:02 : INFO  : 1password8 : setting variable from argument DEBUG=0
2025-01-23 08:42:02 : DEBUG : 1password8 : name=1Password
2025-01-23 08:42:02 : DEBUG : 1password8 : appName=
2025-01-23 08:42:02 : DEBUG : 1password8 : type=pkg
2025-01-23 08:42:02 : DEBUG : 1password8 : archiveName=
2025-01-23 08:42:02 : DEBUG : 1password8 : downloadURL=https://downloads.1password.com/mac/1Password.pkg
2025-01-23 08:42:02 : DEBUG : 1password8 : curlOptions=
2025-01-23 08:42:02 : DEBUG : 1password8 : appNewVersion=8.10.58
2025-01-23 08:42:02 : DEBUG : 1password8 : appCustomVersion function: Not defined
2025-01-23 08:42:02 : DEBUG : 1password8 : versionKey=CFBundleShortVersionString
2025-01-23 08:42:02 : DEBUG : 1password8 : packageID=com.1password.1password
2025-01-23 08:42:02 : DEBUG : 1password8 : pkgName=
2025-01-23 08:42:02 : DEBUG : 1password8 : choiceChangesXML=
2025-01-23 08:42:02 : DEBUG : 1password8 : expectedTeamID=2BUA8C4S2C
2025-01-23 08:42:02 : DEBUG : 1password8 : blockingProcesses=1Password Extension Helper 1Password 7 1Password 8 1Password 1PasswordNativeMessageHost 1PasswordSafariAppExtension
2025-01-23 08:42:02 : DEBUG : 1password8 : installerTool=
2025-01-23 08:42:02 : DEBUG : 1password8 : CLIInstaller=
2025-01-23 08:42:02 : DEBUG : 1password8 : CLIArguments=
2025-01-23 08:42:02 : DEBUG : 1password8 : updateTool=
2025-01-23 08:42:02 : DEBUG : 1password8 : updateToolArguments=
2025-01-23 08:42:02 : DEBUG : 1password8 : updateToolRunAsCurrentUser=
2025-01-23 08:42:02 : INFO  : 1password8 : BLOCKING_PROCESS_ACTION=tell_user
2025-01-23 08:42:02 : INFO  : 1password8 : NOTIFY=success
2025-01-23 08:42:02 : INFO  : 1password8 : LOGGING=DEBUG
2025-01-23 08:42:02 : INFO  : 1password8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-23 08:42:02 : INFO  : 1password8 : Label type: pkg
2025-01-23 08:42:02 : INFO  : 1password8 : archiveName: 1Password.pkg
2025-01-23 08:42:02 : DEBUG : 1password8 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AsOYLf0R0q
2025-01-23 08:42:02 : INFO  : 1password8 : found packageID com.1password.1password installed, version 8.10.58
2025-01-23 08:42:02 : INFO  : 1password8 : appversion: 8.10.58
2025-01-23 08:42:02 : INFO  : 1password8 : Latest version of 1Password is 8.10.58
2025-01-23 08:42:02 : INFO  : 1password8 : There is no newer version available.
2025-01-23 08:42:02 : DEBUG : 1password8 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AsOYLf0R0q
2025-01-23 08:42:02 : DEBUG : 1password8 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AsOYLf0R0q
2025-01-23 08:42:02 : INFO  : 1password8 : Installomator did not close any apps, so no need to reopen any apps.
2025-01-23 08:42:02 : REQ   : 1password8 : No newer version.
2025-01-23 08:42:02 : REQ   : 1password8 : ################## End Installomator, exit code 0
```