### PR TITLE
Add LiveReplayer

### DIFF
--- a/fragments/labels/livereplayer.sh
+++ b/fragments/labels/livereplayer.sh
@@ -1,0 +1,7 @@
+livereplayer)
+    name="LiveReplayer"
+    type="pkg"
+    downloadURL=$(curl -fsL https://s3-eu-west-1.amazonaws.com/fsm-livereplayer/update/stable/latest.json | grep package-url | grep -o "https:.*.pkg")
+    appNewVersion=$(echo ${downloadURL} | grep -o "LiveReplayer-.*" | grep -o "[0-9].*[0-9]")
+    expectedTeamID="2H7P9E934F"
+    ;;

--- a/fragments/labels/livereplayer.sh
+++ b/fragments/labels/livereplayer.sh
@@ -1,7 +1,7 @@
 livereplayer)
     name="LiveReplayer"
     type="pkg"
-    downloadURL=$(curl -fsL https://s3-eu-west-1.amazonaws.com/fsm-livereplayer/update/stable/latest.json | grep package-url | grep -o "https:.*.pkg")
+    downloadURL=$(curl -fsL https://fsm-livereplayer.s3.amazonaws.com/update/stable/latest.json | grep package-url | grep -o "https:.*.pkg")
     appNewVersion=$(echo ${downloadURL} | grep -o "LiveReplayer-.*" | grep -o "[0-9].*[0-9]")
     expectedTeamID="2H7P9E934F"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
Good to know is that the download page doesn't show the latest version.
Found the url the app uses for checking latest version by going through the strings in the binary (so it might eventually change)

**Installomator log**
```
2025-01-23 10:38:34 : REQ   : livereplayer : ################## Start Installomator v. 10.7beta, date 2025-01-23
2025-01-23 10:38:34 : INFO  : livereplayer : ################## Version: 10.7beta
2025-01-23 10:38:34 : INFO  : livereplayer : ################## Date: 2025-01-23
2025-01-23 10:38:34 : INFO  : livereplayer : ################## livereplayer
2025-01-23 10:38:34 : DEBUG : livereplayer : DEBUG mode 1 enabled.
2025-01-23 10:38:35 : INFO  : livereplayer : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2025-01-23 10:38:35 : INFO  : livereplayer : setting variable from argument NOTIFY=success
2025-01-23 10:38:35 : INFO  : livereplayer : setting variable from argument swiftDialogNotification=notification
2025-01-23 10:38:35 : INFO  : livereplayer : setting variable from argument SYSTEMOWNER=1
2025-01-23 10:38:35 : INFO  : livereplayer : setting variable from argument DEBUG=0
2025-01-23 10:38:35 : DEBUG : livereplayer : name=LiveReplayer
2025-01-23 10:38:35 : DEBUG : livereplayer : appName=
2025-01-23 10:38:35 : DEBUG : livereplayer : type=pkg
2025-01-23 10:38:35 : DEBUG : livereplayer : archiveName=
2025-01-23 10:38:35 : DEBUG : livereplayer : downloadURL=https://s3-eu-west-1.amazonaws.com/fsm-livereplayer/update/stable/packages/LiveReplayer-1.11.7.pkg
2025-01-23 10:38:35 : DEBUG : livereplayer : curlOptions=
2025-01-23 10:38:35 : DEBUG : livereplayer : appNewVersion=1.11.7
2025-01-23 10:38:35 : DEBUG : livereplayer : appCustomVersion function: Not defined
2025-01-23 10:38:35 : DEBUG : livereplayer : versionKey=CFBundleShortVersionString
2025-01-23 10:38:35 : DEBUG : livereplayer : packageID=
2025-01-23 10:38:35 : DEBUG : livereplayer : pkgName=
2025-01-23 10:38:35 : DEBUG : livereplayer : choiceChangesXML=
2025-01-23 10:38:35 : DEBUG : livereplayer : expectedTeamID=2H7P9E934F
2025-01-23 10:38:35 : DEBUG : livereplayer : blockingProcesses=
2025-01-23 10:38:35 : DEBUG : livereplayer : installerTool=
2025-01-23 10:38:35 : DEBUG : livereplayer : CLIInstaller=
2025-01-23 10:38:35 : DEBUG : livereplayer : CLIArguments=
2025-01-23 10:38:35 : DEBUG : livereplayer : updateTool=
2025-01-23 10:38:35 : DEBUG : livereplayer : updateToolArguments=
2025-01-23 10:38:35 : DEBUG : livereplayer : updateToolRunAsCurrentUser=
2025-01-23 10:38:35 : INFO  : livereplayer : BLOCKING_PROCESS_ACTION=tell_user
2025-01-23 10:38:35 : INFO  : livereplayer : NOTIFY=success
2025-01-23 10:38:35 : INFO  : livereplayer : LOGGING=DEBUG
2025-01-23 10:38:35 : INFO  : livereplayer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-23 10:38:35 : INFO  : livereplayer : Label type: pkg
2025-01-23 10:38:35 : INFO  : livereplayer : archiveName: LiveReplayer.pkg
2025-01-23 10:38:35 : INFO  : livereplayer : no blocking processes defined, using LiveReplayer as default
2025-01-23 10:38:35 : DEBUG : livereplayer : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dRXSfAGHTw
2025-01-23 10:38:35 : INFO  : livereplayer : App(s) found: /Applications/LiveReplayer.app
2025-01-23 10:38:35 : INFO  : livereplayer : found app at /Applications/LiveReplayer.app, version 1.11.7, on versionKey CFBundleShortVersionString
2025-01-23 10:38:35 : INFO  : livereplayer : appversion: 1.11.7
2025-01-23 10:38:35 : INFO  : livereplayer : Latest version of LiveReplayer is 1.11.7
2025-01-23 10:38:35 : INFO  : livereplayer : There is no newer version available.
2025-01-23 10:38:35 : DEBUG : livereplayer : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dRXSfAGHTw
2025-01-23 10:38:35 : DEBUG : livereplayer : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dRXSfAGHTw
2025-01-23 10:38:35 : INFO  : livereplayer : Installomator did not close any apps, so no need to reopen any apps.
2025-01-23 10:38:35 : REQ   : livereplayer : No newer version.
2025-01-23 10:38:35 : REQ   : livereplayer : ################## End Installomator, exit code 0 
```