### PR TITLE
Add appCustomVersion to wacomdrivers

### DIFF
--- a/fragments/labels/wacomdrivers.sh
+++ b/fragments/labels/wacomdrivers.sh
@@ -1,6 +1,7 @@
 wacomdrivers)
-    name="Wacom Desktop Center"
+    name="Wacom Center"
     type="pkgInDmg"
+    appCustomVersion(){defaults read "/Applications/Wacom Tablet.localized/Wacom Center.app/Contents/Info.plist" CFBundleShortVersionString}
     downloadURL="$(curl -fs https://www.wacom.com/en-us/support/product-support/drivers | grep -e "drivers/mac/professional.*dmg" | head -1 | tr '"' "\n" | grep -i http)"
     expectedTeamID="EG27766DY7"
     #pkgName="Install Wacom Tablet.pkg"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
App is renamed from Wacom Desktop Center to Wacom Center. Somehow the builtin function for reading the appversion fails, so I've added appCustomVersion, besides changing the name.
Fixes #2148


**Installomator log** 
```
2025-01-23 13:09:51 : REQ   : wacomdrivers : ################## Start Installomator v. 10.7beta, date 2025-01-23
2025-01-23 13:09:51 : INFO  : wacomdrivers : ################## Version: 10.7beta
2025-01-23 13:09:51 : INFO  : wacomdrivers : ################## Date: 2025-01-23
2025-01-23 13:09:51 : INFO  : wacomdrivers : ################## wacomdrivers
2025-01-23 13:09:56 : INFO  : wacomdrivers : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2025-01-23 13:09:56 : INFO  : wacomdrivers : setting variable from argument NOTIFY=success
2025-01-23 13:09:56 : INFO  : wacomdrivers : setting variable from argument swiftDialogNotification=notification
2025-01-23 13:09:56 : INFO  : wacomdrivers : setting variable from argument SYSTEMOWNER=1
2025-01-23 13:09:56 : INFO  : wacomdrivers : setting variable from argument DEBUG=0
2025-01-23 13:09:56 : INFO  : wacomdrivers : BLOCKING_PROCESS_ACTION=tell_user
2025-01-23 13:09:56 : INFO  : wacomdrivers : NOTIFY=success
2025-01-23 13:09:56 : INFO  : wacomdrivers : LOGGING=INFO
2025-01-23 13:09:56 : INFO  : wacomdrivers : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-23 13:09:56 : INFO  : wacomdrivers : Label type: pkgInDmg
2025-01-23 13:09:56 : INFO  : wacomdrivers : archiveName: Wacom Center.dmg
2025-01-23 13:09:56 : INFO  : wacomdrivers : no blocking processes defined, using Wacom Center as default
2025-01-23 13:09:56 : INFO  : wacomdrivers : Custom App Version detection is used, found 6.4.8-3
2025-01-23 13:09:56 : INFO  : wacomdrivers : appversion: 6.4.8-3
2025-01-23 13:09:56 : INFO  : wacomdrivers : Latest version of Wacom Center is 6.4.8-3
2025-01-23 13:09:56 : INFO  : wacomdrivers : There is no newer version available.
2025-01-23 13:09:56 : INFO  : wacomdrivers : Installomator did not close any apps, so no need to reopen any apps.
2025-01-23 13:09:56 : REQ   : wacomdrivers : No newer version.
2025-01-23 13:09:56 : REQ   : wacomdrivers : ################## End Installomator, exit code 0 
```