### PR TITLE
New label lunadisplay

### DIFF
--- a/fragments/labels/lunadisplay.sh
+++ b/fragments/labels/lunadisplay.sh
@@ -3,12 +3,12 @@ lunadisplay)
     type="dmg"
     downloadURL="https://downloads.astropad.com/luna/mac/latest"
     appNewVersion=$(curl -sI "${downloadURL}" | grep -o -E 'location:.*$' | grep -o -E '\d+\.\d+\.\d+\.\d+')
-    appCustomVersion(){ 
-        if [ -f "/Applications/Luna Display.app/Contents/Info.plist" ]; then 
+    appCustomVersion(){
+        if [ -f "/Applications/Luna Display.app/Contents/Info.plist" ]; then
             firstPart=$(/usr/bin/defaults read "/Applications/Luna Display.app/Contents/Info.plist" "CFBundleShortVersionString")
             secondPart=$(/usr/bin/defaults read "/Applications/Luna Display.app/Contents/Info.plist" "CFBundleVersion")
             echo "$firstPart.$secondPart"
-        fi 
+        fi
     }
     expectedTeamID="8356ZZ8Y5K"
     ;;

--- a/fragments/labels/lunadisplay.sh
+++ b/fragments/labels/lunadisplay.sh
@@ -1,0 +1,14 @@
+lunadisplay)
+    name="Luna Display"
+    type="dmg"
+    downloadURL="https://downloads.astropad.com/luna/mac/latest"
+    appNewVersion=$(curl -sI "${downloadURL}" | grep -o -E 'location:.*$' | grep -o -E '\d+\.\d+\.\d+\.\d+')
+    appCustomVersion(){ 
+        if [ -f "/Applications/Luna Display.app/Contents/Info.plist" ]; then 
+            firstPart=$(/usr/bin/defaults read "/Applications/Luna Display.app/Contents/Info.plist" "CFBundleShortVersionString")
+            secondPart=$(/usr/bin/defaults read "/Applications/Luna Display.app/Contents/Info.plist" "CFBundleVersion")
+            echo "$firstPart.$secondPart"
+        fi 
+    }
+    expectedTeamID="8356ZZ8Y5K"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
sudo build/Installomator.sh lunadisplay DEBUG=0
2025-01-27 15:28:14 : INFO  : lunadisplay : setting variable from argument DEBUG=0
2025-01-27 15:28:14 : INFO  : lunadisplay : Total items in argumentsArray: 1
2025-01-27 15:28:14 : INFO  : lunadisplay : argumentsArray: DEBUG=0
2025-01-27 15:28:14 : REQ   : lunadisplay : ################## Start Installomator v. 10.8beta, date 2025-01-27
2025-01-27 15:28:14 : INFO  : lunadisplay : ################## Version: 10.8beta
2025-01-27 15:28:14 : INFO  : lunadisplay : ################## Date: 2025-01-27
2025-01-27 15:28:14 : INFO  : lunadisplay : ################## lunadisplay
2025-01-27 15:28:15 : INFO  : lunadisplay : Reading arguments again: DEBUG=0
2025-01-27 15:28:15 : INFO  : lunadisplay : BLOCKING_PROCESS_ACTION=tell_user
2025-01-27 15:28:15 : INFO  : lunadisplay : NOTIFY=success
2025-01-27 15:28:15 : INFO  : lunadisplay : LOGGING=INFO
2025-01-27 15:28:15 : INFO  : lunadisplay : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-27 15:28:15 : INFO  : lunadisplay : Label type: dmg
2025-01-27 15:28:15 : INFO  : lunadisplay : archiveName: Luna Display.dmg
2025-01-27 15:28:15 : INFO  : lunadisplay : no blocking processes defined, using Luna Display as default
2025-01-27 15:28:15 : INFO  : lunadisplay : Custom App Version detection is used, found 5.3.3.4813
2025-01-27 15:28:15 : INFO  : lunadisplay : appversion: 5.3.3.4813
2025-01-27 15:28:15 : INFO  : lunadisplay : Latest version of Luna Display is 5.3.3.4813
2025-01-27 15:28:15 : INFO  : lunadisplay : There is no newer version available.
2025-01-27 15:28:15 : INFO  : lunadisplay : Installomator did not close any apps, so no need to reopen any apps.
2025-01-27 15:28:15 : REQ   : lunadisplay : No newer version.
2025-01-27 15:28:15 : REQ   : lunadisplay : ################## End Installomator, exit code 0 
```
