### PR TITLE
Update rodecentral.sh

### DIFF
--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -3,6 +3,6 @@ rodecentral)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
-    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | head -1 | cut -w -f2)
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | cut -w -f2 | tail -n +2 | head -1)
     expectedTeamID="Z9T72PWTJA"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** No

**Additional context** 

Fixes #2163

As mentioned, appNewVersion is not filled with the right values. This got fixed when changing ` head -1 | cut -w -f2` to ` cut -w -f2 | tail -n +2 | head -1` at the end of the curl command.

The new appNewVersion is now changed to this: 
`appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | cut -w -f2 | tail -n +2 | head -1)
`


**Installomator log** 

```
2025-01-29 11:06:22 : INFO  : rodecentral : Total items in argumentsArray: 0
2025-01-29 11:06:22 : INFO  : rodecentral : argumentsArray: 
2025-01-29 11:06:22 : REQ   : rodecentral : ################## Start Installomator v. 10.8beta, date 2025-01-29
2025-01-29 11:06:22 : INFO  : rodecentral : ################## Version: 10.8beta
2025-01-29 11:06:22 : INFO  : rodecentral : ################## Date: 2025-01-29
2025-01-29 11:06:22 : INFO  : rodecentral : ################## rodecentral
2025-01-29 11:06:22 : DEBUG : rodecentral : DEBUG mode 1 enabled.
2025-01-29 11:06:25 : INFO  : rodecentral : Reading arguments again: 
2025-01-29 11:06:25 : DEBUG : rodecentral : name=RODE Central
2025-01-29 11:06:25 : DEBUG : rodecentral : appName=
2025-01-29 11:06:25 : DEBUG : rodecentral : type=pkgInZip
2025-01-29 11:06:25 : DEBUG : rodecentral : archiveName=
2025-01-29 11:06:25 : DEBUG : rodecentral : downloadURL=https://update.rode.com/central/RODE_Central_MACOS.zip
2025-01-29 11:06:25 : DEBUG : rodecentral : curlOptions=
2025-01-29 11:06:25 : DEBUG : rodecentral : appNewVersion=2.0.62
2025-01-29 11:06:25 : DEBUG : rodecentral : appCustomVersion function: Not defined
2025-01-29 11:06:25 : DEBUG : rodecentral : versionKey=CFBundleShortVersionString
2025-01-29 11:06:25 : DEBUG : rodecentral : packageID=
2025-01-29 11:06:25 : DEBUG : rodecentral : pkgName=
2025-01-29 11:06:25 : DEBUG : rodecentral : choiceChangesXML=
2025-01-29 11:06:25 : DEBUG : rodecentral : expectedTeamID=Z9T72PWTJA
2025-01-29 11:06:25 : DEBUG : rodecentral : blockingProcesses=
2025-01-29 11:06:25 : DEBUG : rodecentral : installerTool=
2025-01-29 11:06:25 : DEBUG : rodecentral : CLIInstaller=
2025-01-29 11:06:25 : DEBUG : rodecentral : CLIArguments=
2025-01-29 11:06:25 : DEBUG : rodecentral : updateTool=
2025-01-29 11:06:25 : DEBUG : rodecentral : updateToolArguments=
2025-01-29 11:06:25 : DEBUG : rodecentral : updateToolRunAsCurrentUser=
2025-01-29 11:06:25 : INFO  : rodecentral : BLOCKING_PROCESS_ACTION=tell_user
2025-01-29 11:06:25 : INFO  : rodecentral : NOTIFY=success
2025-01-29 11:06:26 : INFO  : rodecentral : LOGGING=DEBUG
2025-01-29 11:06:26 : INFO  : rodecentral : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-29 11:06:26 : INFO  : rodecentral : Label type: pkgInZip
2025-01-29 11:06:26 : INFO  : rodecentral : archiveName: RODE Central.zip
2025-01-29 11:06:26 : INFO  : rodecentral : no blocking processes defined, using RODE Central as default
2025-01-29 11:06:26 : DEBUG : rodecentral : Changing directory to .
2025-01-29 11:06:26 : INFO  : rodecentral : App(s) found: /Applications/RODE Central.app
2025-01-29 11:06:26 : INFO  : rodecentral : found app at /Applications/RODE Central.app, version 2.0.62, on versionKey CFBundleShortVersionString
2025-01-29 11:06:26 : INFO  : rodecentral : appversion: 2.0.62
2025-01-29 11:06:26 : INFO  : rodecentral : Latest version of RODE Central is 2.0.62
2025-01-29 11:06:26 : WARN  : rodecentral : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-01-29 11:06:26 : INFO  : rodecentral : RODE Central.zip exists and DEBUG mode 1 enabled, skipping download
2025-01-29 11:06:26 : DEBUG : rodecentral : DEBUG mode 1, not checking for blocking processes
2025-01-29 11:06:26 : REQ   : rodecentral : Installing RODE Central
2025-01-29 11:06:26 : INFO  : rodecentral : Unzipping RODE Central.zip
2025-01-29 11:06:26 : DEBUG : rodecentral : Found pkg(s):
./RØDE Central Installer (2.0.62).pkg
2025-01-29 11:06:26 : INFO  : rodecentral : found pkg: ./RØDE Central Installer (2.0.62).pkg
2025-01-29 11:06:26 : INFO  : rodecentral : Verifying: ./RØDE Central Installer (2.0.62).pkg
2025-01-29 11:06:26 : DEBUG : rodecentral : File list: -rw-rw-r--@ 1 1001  1001    83M  2 Dez 22:34 ./RØDE Central Installer (2.0.62).pkg
2025-01-29 11:06:26 : DEBUG : rodecentral : File type: ./RØDE Central Installer (2.0.62).pkg: xar archive compressed TOC: 4759, SHA-1 checksum
2025-01-29 11:06:26 : DEBUG : rodecentral : spctlOut is ./RØDE Central Installer (2.0.62).pkg: accepted
2025-01-29 11:06:26 : DEBUG : rodecentral : source=Notarized Developer ID
2025-01-29 11:06:26 : DEBUG : rodecentral : origin=Developer ID Installer: FREEDMAN ELECTRONICS PTY LTD (Z9T72PWTJA)
2025-01-29 11:06:26 : INFO  : rodecentral : Team ID: Z9T72PWTJA (expected: Z9T72PWTJA )
2025-01-29 11:06:26 : DEBUG : rodecentral : DEBUG enabled, skipping installation
2025-01-29 11:06:26 : INFO  : rodecentral : Finishing...
2025-01-29 11:06:29 : INFO  : rodecentral : App(s) found: /Applications/RODE Central.app
2025-01-29 11:06:29 : INFO  : rodecentral : found app at /Applications/RODE Central.app, version 2.0.62, on versionKey CFBundleShortVersionString
2025-01-29 11:06:29 : REQ   : rodecentral : Installed RODE Central, version 2.0.62
2025-01-29 11:06:29 : INFO  : rodecentral : notifying
2025-01-29 11:06:29 : DEBUG : rodecentral : DEBUG mode 1, not reopening anything
2025-01-29 11:06:29 : REQ   : rodecentral : All done!
2025-01-29 11:06:29 : REQ   : rodecentral : ################## End Installomator, exit code 0 
``` 

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
