### PR TITLE
New Label teamwire.sh

### DIFF
--- a/fragments/labels/teamwire.sh
+++ b/fragments/labels/teamwire.sh
@@ -1,0 +1,12 @@
+teamwire)
+    name="Teamwire"
+    type="dmg"
+    packageID="eu.teamwire.app"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://desktop.teamwire.eu/download.php?platform=darwinArm64"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://desktop.teamwire.eu/download.php?platform=darwinX64"
+    fi
+    appNewVersion=$(curl -fsI $downloadURL | grep -i 'Location' | cut -d ' ' -f2 | sed 's|.*dist/v\([^/]*\).*|\1|')
+    expectedTeamID="2JCSJ44B3U"
+    ;;


### PR DESCRIPTION
create label for teamwire messenger download + update

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** Add any other context about the label or fix here.
Teamwire is a Business Messenger in the EU.
The new Version is parsed from the download URL because its just a path with the version key like https://desktop.teamwire.eu/dist/v4.1.2/ 
Versions are published here: https://desktop.teamwire.eu/dist/ (older Versions are available for testing)

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

`2025-01-31 17:33:00 : INFO  : teamwire : setting variable from argument DEBUG=1
2025-01-31 17:33:00 : INFO  : teamwire : Total items in argumentsArray: 1
2025-01-31 17:33:00 : INFO  : teamwire : argumentsArray: DEBUG=1
2025-01-31 17:33:00 : REQ   : teamwire : ################## Start Installomator v. 10.8beta, date 2025-01-31
2025-01-31 17:33:00 : INFO  : teamwire : ################## Version: 10.8beta
2025-01-31 17:33:00 : INFO  : teamwire : ################## Date: 2025-01-31
2025-01-31 17:33:00 : INFO  : teamwire : ################## teamwire
2025-01-31 17:33:00 : DEBUG : teamwire : DEBUG mode 1 enabled.
2025-01-31 17:33:00 : INFO  : teamwire : Reading arguments again: DEBUG=1
2025-01-31 17:33:00 : DEBUG : teamwire : argument: DEBUG=1
2025-01-31 17:33:00 : DEBUG : teamwire : name=Teamwire
2025-01-31 17:33:00 : DEBUG : teamwire : appName=
2025-01-31 17:33:00 : DEBUG : teamwire : type=dmg
2025-01-31 17:33:00 : DEBUG : teamwire : archiveName=
2025-01-31 17:33:00 : DEBUG : teamwire : downloadURL=https://desktop.teamwire.eu/download.php?platform=darwinArm64
2025-01-31 17:33:00 : DEBUG : teamwire : curlOptions=
2025-01-31 17:33:00 : DEBUG : teamwire : appNewVersion=4.1.2
2025-01-31 17:33:00 : DEBUG : teamwire : appCustomVersion function: Not defined
2025-01-31 17:33:00 : DEBUG : teamwire : versionKey=CFBundleShortVersionString
2025-01-31 17:33:00 : DEBUG : teamwire : packageID=eu.teamwire.app
2025-01-31 17:33:00 : DEBUG : teamwire : pkgName=
2025-01-31 17:33:00 : DEBUG : teamwire : choiceChangesXML=
2025-01-31 17:33:00 : DEBUG : teamwire : expectedTeamID=2JCSJ44B3U
2025-01-31 17:33:00 : DEBUG : teamwire : blockingProcesses=
2025-01-31 17:33:00 : DEBUG : teamwire : installerTool=
2025-01-31 17:33:00 : DEBUG : teamwire : CLIInstaller=
2025-01-31 17:33:00 : DEBUG : teamwire : CLIArguments=
2025-01-31 17:33:00 : DEBUG : teamwire : updateTool=
2025-01-31 17:33:00 : DEBUG : teamwire : updateToolArguments=
2025-01-31 17:33:00 : DEBUG : teamwire : updateToolRunAsCurrentUser=
2025-01-31 17:33:00 : INFO  : teamwire : BLOCKING_PROCESS_ACTION=tell_user
2025-01-31 17:33:00 : INFO  : teamwire : NOTIFY=success
2025-01-31 17:33:00 : INFO  : teamwire : LOGGING=DEBUG
2025-01-31 17:33:00 : INFO  : teamwire : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-01-31 17:33:00 : INFO  : teamwire : Label type: dmg
2025-01-31 17:33:00 : INFO  : teamwire : archiveName: Teamwire.dmg
2025-01-31 17:33:00 : INFO  : teamwire : no blocking processes defined, using Teamwire as default
2025-01-31 17:33:00 : DEBUG : teamwire : Changing directory to /Users/UserName/Documents/GitHub/Installomator/build
2025-01-31 17:33:00 : INFO  : teamwire : No version found using packageID eu.teamwire.app
2025-01-31 17:33:00 : INFO  : teamwire : App(s) found: /Applications/Teamwire.app
2025-01-31 17:33:00 : INFO  : teamwire : found app at /Applications/Teamwire.app, version 4.1.2, on versionKey CFBundleShortVersionString
2025-01-31 17:33:00 : INFO  : teamwire : appversion: 4.1.2
2025-01-31 17:33:00 : INFO  : teamwire : Latest version of Teamwire is 4.1.2
2025-01-31 17:33:00 : WARN  : teamwire : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-01-31 17:33:00 : REQ   : teamwire : Downloading https://desktop.teamwire.eu/download.php?platform=darwinArm64 to Teamwire.dmg
2025-01-31 17:33:00 : DEBUG : teamwire : No Dialog connection, just download
2025-01-31 17:33:08 : INFO  : teamwire : Downloaded Teamwire.dmg – Type is  zlib compressed data – SHA is 9aadd13fe027bb1e78918bbd5557c5e7dcef077e – Size is 181180 kB
2025-01-31 17:33:08 : DEBUG : teamwire : DEBUG mode 1, not checking for blocking processes
2025-01-31 17:33:08 : REQ   : teamwire : Installing Teamwire
2025-01-31 17:33:08 : INFO  : teamwire : Mounting /Users/UserName/Documents/GitHub/Installomator/build/Teamwire.dmg
2025-01-31 17:33:12 : DEBUG : teamwire : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $7410A226
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $819052A7
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $AD0799CB
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_APFS : 4) berechnen …
disk image (Apple_APFS : 4): Die überprüfte CRC32-Prüfsumme ist $79D24537
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $AD0799CB
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $5D602263
Die überprüfte CRC32-Prüfsumme ist $20AC3CC6
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Teamwire 4.1.2-arm64

2025-01-31 17:33:12 : INFO  : teamwire : Mounted: /Volumes/Teamwire 4.1.2-arm64
2025-01-31 17:33:12 : INFO  : teamwire : Verifying: /Volumes/Teamwire 4.1.2-arm64/Teamwire.app
2025-01-31 17:33:12 : DEBUG : teamwire : App size: 493M	/Volumes/Teamwire 4.1.2-arm64/Teamwire.app
2025-01-31 17:33:14 : DEBUG : teamwire : Debugging enabled, App Verification output was:
/Volumes/Teamwire 4.1.2-arm64/Teamwire.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Teamwire GmbH (2JCSJ44B3U)

2025-01-31 17:33:14 : INFO  : teamwire : Team ID matching: 2JCSJ44B3U (expected: 2JCSJ44B3U )
2025-01-31 17:33:14 : INFO  : teamwire : Downloaded version of Teamwire is 4.1.2 on versionKey CFBundleShortVersionString, same as installed.
2025-01-31 17:33:14 : DEBUG : teamwire : Unmounting /Volumes/Teamwire 4.1.2-arm64
2025-01-31 17:33:14 : DEBUG : teamwire : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-01-31 17:33:14 : DEBUG : teamwire : DEBUG mode 1, not reopening anything
2025-01-31 17:33:14 : REG   : teamwire : No new version to install
2025-01-31 17:33:14 : REQ   : teamwire : ################## End Installomator, exit code 0`

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
nothing found