### PR TITLE
Update googlechromepkg.sh

### DIFF
--- a/fragments/labels/googlechromepkg.sh
+++ b/fragments/labels/googlechromepkg.sh
@@ -6,7 +6,7 @@ googlechromepkg)
     # https://support.google.com/chrome/a/answer/9915669
     #
     downloadURL="https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg"
-    appNewVersion=$(getJSONValue "$(curl -fsL "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=fraction>0.01,endtime=none&order_by=version%20desc" )" "releases[0].version" )
+    appNewVersion=$(getJSONValue "$(curl -fsL "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=fraction%3E0.01,endtime=none&order_by=version%20desc" )" "releases[0].version" )
     expectedTeamID="EQHXZ8M8AV"
     updateTool="/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent"
     updateToolArguments=( -runMode oneshot -userInitiated YES )


### PR DESCRIPTION
fixes #2165

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
fixes url in AppNewVersion
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

`2025-02-06 11:49:18 : INFO  : googlechromepkg : setting variable from argument DEBUG=1
2025-02-06 11:49:18 : INFO  : googlechromepkg : Total items in argumentsArray: 1
2025-02-06 11:49:18 : INFO  : googlechromepkg : argumentsArray: DEBUG=1
2025-02-06 11:49:18 : REQ   : googlechromepkg : ################## Start Installomator v. 10.8beta, date 2025-02-06
2025-02-06 11:49:18 : INFO  : googlechromepkg : ################## Version: 10.8beta
2025-02-06 11:49:18 : INFO  : googlechromepkg : ################## Date: 2025-02-06
2025-02-06 11:49:18 : INFO  : googlechromepkg : ################## googlechromepkg
2025-02-06 11:49:18 : DEBUG : googlechromepkg : DEBUG mode 1 enabled.
2025-02-06 11:49:19 : INFO  : googlechromepkg : Reading arguments again: DEBUG=1
2025-02-06 11:49:19 : DEBUG : googlechromepkg : argument: DEBUG=1
2025-02-06 11:49:19 : DEBUG : googlechromepkg : name=Google Chrome
2025-02-06 11:49:19 : DEBUG : googlechromepkg : appName=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : type=pkg
2025-02-06 11:49:19 : DEBUG : googlechromepkg : archiveName=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : downloadURL=https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
2025-02-06 11:49:19 : DEBUG : googlechromepkg : curlOptions=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : appNewVersion=133.0.6943.54
2025-02-06 11:49:19 : DEBUG : googlechromepkg : appCustomVersion function: Not defined
2025-02-06 11:49:19 : DEBUG : googlechromepkg : versionKey=CFBundleShortVersionString
2025-02-06 11:49:19 : DEBUG : googlechromepkg : packageID=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : pkgName=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : choiceChangesXML=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : expectedTeamID=EQHXZ8M8AV
2025-02-06 11:49:19 : DEBUG : googlechromepkg : blockingProcesses=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : installerTool=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : CLIInstaller=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : CLIArguments=
2025-02-06 11:49:19 : DEBUG : googlechromepkg : updateTool=/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent
2025-02-06 11:49:19 : DEBUG : googlechromepkg : updateToolArguments=-runMode oneshot -userInitiated YES
2025-02-06 11:49:19 : DEBUG : googlechromepkg : updateToolRunAsCurrentUser=1
2025-02-06 11:49:19 : INFO  : googlechromepkg : BLOCKING_PROCESS_ACTION=tell_user
2025-02-06 11:49:19 : INFO  : googlechromepkg : NOTIFY=success
2025-02-06 11:49:19 : INFO  : googlechromepkg : LOGGING=DEBUG
2025-02-06 11:49:19 : INFO  : googlechromepkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-06 11:49:19 : INFO  : googlechromepkg : Label type: pkg
2025-02-06 11:49:19 : INFO  : googlechromepkg : archiveName: Google Chrome.pkg
2025-02-06 11:49:19 : INFO  : googlechromepkg : no blocking processes defined, using Google Chrome as default
2025-02-06 11:49:19 : DEBUG : googlechromepkg : Changing directory to /Users/p.sogl/Documents/GitHub/Installomator/build
2025-02-06 11:49:19 : INFO  : googlechromepkg : App(s) found: /Applications/Google Chrome.app
2025-02-06 11:49:19 : INFO  : googlechromepkg : found app at /Applications/Google Chrome.app, version 133.0.6943.54, on versionKey CFBundleShortVersionString
2025-02-06 11:49:19 : INFO  : googlechromepkg : appversion: 133.0.6943.54
2025-02-06 11:49:19 : INFO  : googlechromepkg : Latest version of Google Chrome is 133.0.6943.54
2025-02-06 11:49:19 : WARN  : googlechromepkg : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-02-06 11:49:19 : INFO  : googlechromepkg : App needs to be updated and uses /Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2025-02-06 11:49:19 : WARN  : googlechromepkg : DEBUG mode 1 enabled, not running update tool
2025-02-06 11:49:19 : REQ   : googlechromepkg : Downloading https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg to Google Chrome.pkg
2025-02-06 11:49:19 : DEBUG : googlechromepkg : No Dialog connection, just download
2025-02-06 11:49:24 : INFO  : googlechromepkg : Downloaded Google Chrome.pkg – Type is  xar archive compressed TOC – SHA is 0bd5e628e94e783412defe14cb2e59304073486d – Size is 213068 kB
2025-02-06 11:49:24 : DEBUG : googlechromepkg : DEBUG mode 1, not checking for blocking processes
2025-02-06 11:49:24 : REQ   : googlechromepkg : Installing Google Chrome
2025-02-06 11:49:24 : INFO  : googlechromepkg : Verifying: Google Chrome.pkg
2025-02-06 11:49:24 : DEBUG : googlechromepkg : File list: -rw-r--r--@ 1 p.sogl  staff   201M  6 Feb 11:49 Google Chrome.pkg
2025-02-06 11:49:24 : DEBUG : googlechromepkg : File type: Google Chrome.pkg: xar archive compressed TOC: 4512, SHA-1 checksum
2025-02-06 11:49:24 : DEBUG : googlechromepkg : spctlOut is Google Chrome.pkg: accepted
2025-02-06 11:49:24 : DEBUG : googlechromepkg : source=Notarized Developer ID
2025-02-06 11:49:24 : DEBUG : googlechromepkg : override=security disabled
2025-02-06 11:49:24 : DEBUG : googlechromepkg : origin=Developer ID Installer: Google LLC (EQHXZ8M8AV)
2025-02-06 11:49:24 : INFO  : googlechromepkg : Team ID: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2025-02-06 11:49:24 : DEBUG : googlechromepkg : DEBUG enabled, skipping installation
2025-02-06 11:49:25 : INFO  : googlechromepkg : Finishing...
2025-02-06 11:49:28 : INFO  : googlechromepkg : App(s) found: /Applications/Google Chrome.app
2025-02-06 11:49:28 : INFO  : googlechromepkg : found app at /Applications/Google Chrome.app, version 133.0.6943.54, on versionKey CFBundleShortVersionString
2025-02-06 11:49:28 : REQ   : googlechromepkg : Installed Google Chrome, version 133.0.6943.54
2025-02-06 11:49:28 : INFO  : googlechromepkg : notifying
2025-02-06 11:49:28 : DEBUG : googlechromepkg : DEBUG mode 1, not reopening anything
2025-02-06 11:49:28 : REQ   : googlechromepkg : All done!
2025-02-06 11:49:28 : REQ   : googlechromepkg : ################## End Installomator, exit code 0 
`