### PR TITLE
Update citrixworkspace.sh

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -5,13 +5,13 @@ citrixworkspace)
     curlOptions=( --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36")
     parseURL() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html#ctx-dl-eula-external'
-        htmlDocument=$(curl -s -L $urlToParse  $curlOptions)
+        htmlDocument=$(curl -s -L $urlToParse $curlOptions)
         xmllint --html --xpath "string(//a[contains(@rel, 'downloads.citrix.com')]/@rel)" 2> /dev/null <(print $htmlDocument)
     }
     downloadURL="https:$(parseURL)"
     newVersionString() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
-        htmlDocument=$(curl -fs $urlToParse)
+        htmlDocument=$(curl -fs $urlToParse $curlOptions)
         xmllint --html --xpath 'string(//p[contains(., "Version")])' 2> /dev/null <(print $htmlDocument)
     }
     appNewVersion=$(newVersionString | cut -d ' ' -f2 | cut -d '(' -f1)

--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -5,7 +5,7 @@ citrixworkspace)
     curlOptions=( --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36")
     parseURL() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html#ctx-dl-eula-external'
-        htmlDocument=$(curl -s -L $urlToParse)
+        htmlDocument=$(curl -s -L $urlToParse  $curlOptions)
         xmllint --html --xpath "string(//a[contains(@rel, 'downloads.citrix.com')]/@rel)" 2> /dev/null <(print $htmlDocument)
     }
     downloadURL="https:$(parseURL)"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Fixes issue #2174 from details provided. Under parseURL(), htmlDocument is missing $curlOptions

**Installomator log** 
```
2025-02-10 09:26:11 : REQ   : citrixworkspace : ################## Start Installomator v. 10.7, date 2025-01-24
2025-02-10 09:26:11 : INFO  : citrixworkspace : ################## Version: 10.7
2025-02-10 09:26:11 : INFO  : citrixworkspace : ################## Date: 2025-01-24
2025-02-10 09:26:11 : INFO  : citrixworkspace : ################## citrixworkspace
2025-02-10 09:26:12 : INFO  : citrixworkspace : setting variable from argument DEBUG=0
2025-02-10 09:26:13 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2025-02-10 09:26:13 : INFO  : citrixworkspace : NOTIFY=success
2025-02-10 09:26:13 : INFO  : citrixworkspace : LOGGING=INFO
2025-02-10 09:26:13 : INFO  : citrixworkspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-10 09:26:13 : INFO  : citrixworkspace : Label type: pkgInDmg
2025-02-10 09:26:13 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2025-02-10 09:26:13 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2025-02-10 09:26:13 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2025-02-10 09:26:13.144 mdfind[7966:95071] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-02-10 09:26:13.144 mdfind[7966:95071] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-02-10 09:26:13.192 mdfind[7966:95071] Couldn't determine the mapping between prefab keywords and predicates.
2025-02-10 09:26:13 : WARN  : citrixworkspace : No previous app found
2025-02-10 09:26:13 : WARN  : citrixworkspace : could not find Citrix Workspace.app
2025-02-10 09:26:13 : INFO  : citrixworkspace : appversion:
2025-02-10 09:26:13 : INFO  : citrixworkspace : Latest version not specified.
2025-02-10 09:26:13 : REQ   : citrixworkspace : Downloading https://downloads.citrix.com/23247/CitrixWorkspaceApp.dmg?__gda__=exp=1739201172~acl=/*~hmac=b60334bac9faf07570da639519136312d49362b60ff84291a5a9de7705b44415 to Citrix Workspace.dmg
2025-02-10 09:26:19 : REQ   : citrixworkspace : no more blocking processes, continue with update
2025-02-10 09:26:19 : REQ   : citrixworkspace : Installing Citrix Workspace
2025-02-10 09:26:19 : INFO  : citrixworkspace : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x9JekR0BM6/Citrix Workspace.dmg
2025-02-10 09:26:20 : INFO  : citrixworkspace : Mounted: /Volumes/Citrix Workspace
2025-02-10 09:26:20 : INFO  : citrixworkspace : found pkg: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-02-10 09:26:20 : INFO  : citrixworkspace : Verifying: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-02-10 09:26:20 : INFO  : citrixworkspace : Team ID: S272Y5R93J (expected: S272Y5R93J )
2025-02-10 09:26:20 : INFO  : citrixworkspace : Installing /Volumes/Citrix Workspace/Install Citrix Workspace.pkg to /
2025-02-10 09:26:59 : INFO  : citrixworkspace : Finishing...
2025-02-10 09:27:02 : INFO  : citrixworkspace : App(s) found: /Applications/Citrix Workspace.app
2025-02-10 09:27:02 : INFO  : citrixworkspace : found app at /Applications/Citrix Workspace.app, version 24.11.10.22, on versionKey CitrixVersionString
2025-02-10 09:27:02 : REQ   : citrixworkspace : Installed Citrix Workspace
2025-02-10 09:27:02 : INFO  : citrixworkspace : notifying
2025-02-10 09:27:03 : INFO  : citrixworkspace : Installomator did not close any apps, so no need to reopen any apps.
2025-02-10 09:27:03 : REQ   : citrixworkspace : All done!
2025-02-10 09:27:03 : REQ   : citrixworkspace : ################## End Installomator, exit code 0
```
