### PR TITLE
Fix broken clickshare.sh label

### DIFF
--- a/fragments/labels/clickshare.sh
+++ b/fragments/labels/clickshare.sh
@@ -1,11 +1,9 @@
 clickshare)
     name="ClickShare"
-    type="appInDmgInZip"
-    clickshareAppInfo="$( curl -fs "https://www.barco.com/bin/barco/tde/details.json?fileNumber=R3306192&tdeType=3" )"
-    appNewVersion="$( expr $( getJSONValue "$clickshareAppInfo" majorVersion ) + 1 - 1 )"
-    appNewVersion+=".$( expr $( getJSONValue "$clickshareAppInfo" minorVersion ) + 1 - 1 )"
-    appNewVersion+=".$( expr $( getJSONValue "$clickshareAppInfo" patchVersion ) + 1 - 1 )"
-    appNewVersion+="-b$( expr $( getJSONValue "$clickshareAppInfo" buildVersion ) + 1 - 1 )"
-    downloadURL="$( getJSONValue "$( curl -fs "https://www.barco.com/bin/barco/tde/downloadUrl.json?fileNumber=R3306192&tdeType=3" )" downloadUrl )"
+    type="zip"
+    json_feed=$(curl -fsL "https://assets.cloud.barco.com/clickshare/release/release.mac")
+    appNewVersion=$(getJSONValue "${json_feed}" 'version')
+    file_name=$(getJSONValue "${json_feed}" 'name')
+    downloadURL="https://assets.cloud.barco.com/clickshare/release/${file_name}"
     expectedTeamID="P6CDJZR997"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Existing label doesn't work anymore.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh clickshare                   
2025-02-10 20:06:59 : INFO  : clickshare : Total items in argumentsArray: 0
2025-02-10 20:06:59 : INFO  : clickshare : argumentsArray: 
2025-02-10 20:06:59 : REQ   : clickshare : ################## Start Installomator v. 10.8beta, date 2025-02-10
2025-02-10 20:06:59 : INFO  : clickshare : ################## Version: 10.8beta
2025-02-10 20:06:59 : INFO  : clickshare : ################## Date: 2025-02-10
2025-02-10 20:06:59 : INFO  : clickshare : ################## clickshare
2025-02-10 20:06:59 : DEBUG : clickshare : DEBUG mode 1 enabled.
2025-02-10 20:07:00 : INFO  : clickshare : Reading arguments again: 
2025-02-10 20:07:00 : DEBUG : clickshare : name=ClickShare
2025-02-10 20:07:00 : DEBUG : clickshare : appName=
2025-02-10 20:07:00 : DEBUG : clickshare : type=zip
2025-02-10 20:07:00 : DEBUG : clickshare : archiveName=
2025-02-10 20:07:00 : DEBUG : clickshare : downloadURL=https://assets.cloud.barco.com/clickshare/release/ClickShare-4.43.0-b8_mac.zip
2025-02-10 20:07:00 : DEBUG : clickshare : curlOptions=
2025-02-10 20:07:00 : DEBUG : clickshare : appNewVersion=4.43.0-b8
2025-02-10 20:07:00 : DEBUG : clickshare : appCustomVersion function: Not defined
2025-02-10 20:07:00 : DEBUG : clickshare : versionKey=CFBundleShortVersionString
2025-02-10 20:07:00 : DEBUG : clickshare : packageID=
2025-02-10 20:07:00 : DEBUG : clickshare : pkgName=
2025-02-10 20:07:00 : DEBUG : clickshare : choiceChangesXML=
2025-02-10 20:07:00 : DEBUG : clickshare : expectedTeamID=P6CDJZR997
2025-02-10 20:07:00 : DEBUG : clickshare : blockingProcesses=
2025-02-10 20:07:00 : DEBUG : clickshare : installerTool=
2025-02-10 20:07:00 : DEBUG : clickshare : CLIInstaller=
2025-02-10 20:07:00 : DEBUG : clickshare : CLIArguments=
2025-02-10 20:07:00 : DEBUG : clickshare : updateTool=
2025-02-10 20:07:00 : DEBUG : clickshare : updateToolArguments=
2025-02-10 20:07:00 : DEBUG : clickshare : updateToolRunAsCurrentUser=
2025-02-10 20:07:00 : INFO  : clickshare : BLOCKING_PROCESS_ACTION=tell_user
2025-02-10 20:07:00 : INFO  : clickshare : NOTIFY=success
2025-02-10 20:07:00 : INFO  : clickshare : LOGGING=DEBUG
2025-02-10 20:07:00 : INFO  : clickshare : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-10 20:07:00 : INFO  : clickshare : Label type: zip
2025-02-10 20:07:00 : INFO  : clickshare : archiveName: ClickShare.zip
2025-02-10 20:07:00 : INFO  : clickshare : no blocking processes defined, using ClickShare as default
2025-02-10 20:07:00 : DEBUG : clickshare : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-02-10 20:07:00 : INFO  : clickshare : App(s) found: /Applications/ClickShare.app
2025-02-10 20:07:00 : INFO  : clickshare : found app at /Applications/ClickShare.app, version 4.43.0-b8, on versionKey CFBundleShortVersionString
2025-02-10 20:07:00 : INFO  : clickshare : appversion: 4.43.0-b8
2025-02-10 20:07:00 : INFO  : clickshare : Latest version of ClickShare is 4.43.0-b8
2025-02-10 20:07:00 : WARN  : clickshare : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-02-10 20:07:00 : REQ   : clickshare : Downloading https://assets.cloud.barco.com/clickshare/release/ClickShare-4.43.0-b8_mac.zip to ClickShare.zip
2025-02-10 20:07:00 : DEBUG : clickshare : No Dialog connection, just download
2025-02-10 20:07:17 : INFO  : clickshare : Downloaded ClickShare.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 0c877ba15bc2ddf9eef061e5c329c18fa2684f34 – Size is 148408 kB
2025-02-10 20:07:17 : DEBUG : clickshare : DEBUG mode 1, not checking for blocking processes
2025-02-10 20:07:17 : REQ   : clickshare : Installing ClickShare
2025-02-10 20:07:17 : INFO  : clickshare : Unzipping ClickShare.zip
2025-02-10 20:07:17 : INFO  : clickshare : Verifying: /Users/gilburns/GitHub/Installomator/build/ClickShare.app
2025-02-10 20:07:17 : DEBUG : clickshare : App size: 142M	/Users/gilburns/GitHub/Installomator/build/ClickShare.app
2025-02-10 20:07:18 : DEBUG : clickshare : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/ClickShare.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Barco NV (P6CDJZR997)

2025-02-10 20:07:18 : INFO  : clickshare : Team ID matching: P6CDJZR997 (expected: P6CDJZR997 )
2025-02-10 20:07:18 : INFO  : clickshare : Downloaded version of ClickShare is 4.43.0-b8 on versionKey CFBundleShortVersionString, same as installed.
2025-02-10 20:07:18 : DEBUG : clickshare : DEBUG mode 1, not reopening anything
2025-02-10 20:07:18 : REG   : clickshare : No new version to install
2025-02-10 20:07:18 : REQ   : clickshare : ################## End Installomator, exit code 0 
```