### PR TITLE
Update deepl.sh

### DIFF
--- a/fragments/labels/deepl.sh
+++ b/fragments/labels/deepl.sh
@@ -1,7 +1,7 @@
 deepl)
     name="DeepL"
     type="dmg"
-    downloadURL="https://www.deepl.com/macos/download/bigsur/DeepL.dmg"
-    appNewVersion=""
+    downloadURL="https://appdownload.deepl.com/macos/$(curl -fs https://appdownload.deepl.com/macos/ | grep -o "[0-9]\+\.[0-9]\+/[0-9]\+/DeepL\.dmg" | sort -t'/' -k1,1V -k2,2n | tail -n 1)"
+    appNewVersion="$(curl -fs https://appdownload.deepl.com/macos/ | grep -o "[0-9]\+\.[0-9]\+/[0-9]\+/DeepL\.dmg" | sort -t'/' -k1,1V -k2,2n | tail -n 1 | awk -F'/' '{print $1 "." $2}')"
     expectedTeamID="4N8BGCG336"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes, didn't need it though

**Additional context** Add any other context about the label or fix here.
Adds appNewVersion and uses the same download URL specified in appNewVersion instead of an ambiguous link for what appears to be the latest version of Deepl.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Script exit code: 0
Script result: 2025-02-07 09:30:25 : REQ   :  : shifting arguments for Jamf
2025-02-07 09:30:25 : INFO  : deepl : setting variable from argument DEBUG=1
2025-02-07 09:30:25 : INFO  : deepl : setting variable from argument LOGGING=INFO
2025-02-07 09:30:25 : INFO  : deepl : Total items in argumentsArray: 2
2025-02-07 09:30:25 : INFO  : deepl : argumentsArray: DEBUG=1 LOGGING=INFO
2025-02-07 09:30:25 : REQ   : deepl : ################## Start Installomator v. 10.8beta, date 2025-02-01
2025-02-07 09:30:25 : INFO  : deepl : ################## Version: 10.8beta
2025-02-07 09:30:25 : INFO  : deepl : ################## Date: 2025-02-01
2025-02-07 09:30:25 : INFO  : deepl : ################## deepl
2025-02-07 09:30:25 : DEBUG : deepl : DEBUG mode 1 enabled.
2025-02-07 09:30:25 : INFO  : deepl : Reading arguments again: DEBUG=1 LOGGING=INFO
2025-02-07 09:30:25 : DEBUG : deepl : argument: DEBUG=1
2025-02-07 09:30:25 : DEBUG : deepl : argument: LOGGING=INFO
2025-02-07 09:30:25 : INFO  : deepl : BLOCKING_PROCESS_ACTION=tell_user
2025-02-07 09:30:26 : INFO  : deepl : NOTIFY=success
2025-02-07 09:30:26 : INFO  : deepl : LOGGING=INFO
2025-02-07 09:30:26 : INFO  : deepl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-07 09:30:26 : INFO  : deepl : Label type: dmg
2025-02-07 09:30:26 : INFO  : deepl : archiveName: DeepL.dmg
2025-02-07 09:30:26 : INFO  : deepl : no blocking processes defined, using DeepL as default
2025-02-07 09:30:26 : INFO  : deepl : App(s) found: /Applications/DeepL.app
2025-02-07 09:30:26 : INFO  : deepl : found app at /Applications/DeepL.app, version 25.1.11615133, on versionKey CFBundleShortVersionString
2025-02-07 09:30:26 : INFO  : deepl : appversion: 25.1.11615133
2025-02-07 09:30:26 : INFO  : deepl : Latest version of DeepL is 25.1.11615133
2025-02-07 09:30:26 : WARN  : deepl : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-02-07 09:30:26 : INFO  : deepl : DeepL.dmg exists and DEBUG mode 1 enabled, skipping download
2025-02-07 09:30:26 : REQ   : deepl : Installing DeepL
2025-02-07 09:30:26 : INFO  : deepl : Mounting /Library/Application Support/JAMF/tmp/DeepL.dmg
2025-02-07 09:30:26 : INFO  : deepl : Mounted: /Volumes/DeepL
2025-02-07 09:30:26 : INFO  : deepl : Verifying: /Volumes/DeepL/DeepL.app
2025-02-07 09:30:27 : INFO  : deepl : Team ID matching: 4N8BGCG336 (expected: 4N8BGCG336 )
2025-02-07 09:30:27 : INFO  : deepl : Downloaded version of DeepL is 25.1.11615133 on versionKey CFBundleShortVersionString, same as installed.
2025-02-07 09:30:27 : REQ   : deepl : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Superseeds #2176 
#1453 can already be closed, as Deepl has already been added with #1372