### PR TITLE
Update r.sh

### DIFF
--- a/fragments/labels/r.sh
+++ b/fragments/labels/r.sh
@@ -9,4 +9,5 @@ r)
         appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     fi
     expectedTeamID="VZLD955F6P"
+    appCustomVersion() { defaults read /Applications/r.app/Contents/Info.plist CFBundleShortVersionString | awk '{print $2}' }
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

Whenever an update check is run for the application R, it compares the full CFBundleShortVersionString (version R 4.4.2 GUI 1.81 Big Sur ARM build) to the latest version (4.4.2). This results in it re-downloading R every time Installomator is run.
```
2025-02-13 09:51:57 : INFO  : r : found app at /Applications/R.app, version R 4.4.2 GUI 1.81 Big Sur ARM build, on versionKey CFBundleShortVersionString
2025-02-13 09:51:57 : INFO  : r : appversion: R 4.4.2 GUI 1.81 Big Sur ARM build
2025-02-13 09:51:57 : INFO  : r : Latest version of R is 4.4.2
2025-02-13 09:51:57 : REQ   : r : Downloading https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-4.4.2-arm64.pkg to R.pkg
```

The appCustomVersion returns the correct value, so R is not re-downloaded when checking for an update.

**Installomator log** 
```
2025-02-13 09:55:09 : REQ   : r : ################## Start Installomator v. 10.7, date 2025-01-24
2025-02-13 09:55:09 : INFO  : r : ################## Version: 10.7
2025-02-13 09:55:09 : INFO  : r : ################## Date: 2025-01-24
2025-02-13 09:55:09 : INFO  : r : ################## r
2025-02-13 09:55:09 : INFO  : r : BLOCKING_PROCESS_ACTION=tell_user
2025-02-13 09:55:09 : INFO  : r : NOTIFY=success
2025-02-13 09:55:10 : INFO  : r : LOGGING=INFO
2025-02-13 09:55:10 : INFO  : r : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-13 09:55:10 : INFO  : r : Label type: pkg
2025-02-13 09:55:10 : INFO  : r : archiveName: R.pkg
2025-02-13 09:55:10 : INFO  : r : no blocking processes defined, using R as default
2025-02-13 09:55:10 : INFO  : r : Custom App Version detection is used, found 4.4.2
2025-02-13 09:55:10 : INFO  : r : appversion: 4.4.2
2025-02-13 09:55:10 : INFO  : r : Latest version of R is 4.4.2
2025-02-13 09:55:10 : INFO  : r : There is no newer version available.
2025-02-13 09:55:10 : INFO  : r : Installomator did not close any apps, so no need to reopen any apps.
2025-02-13 09:55:10 : REQ   : r : No newer version.
2025-02-13 09:55:10 : REQ   : r : ################## End Installomator, exit code 0
```
