### PR TITLE
add blackmagicwebpresenter

### DIFF
--- a/fragments/labels/blackmagicwebpresenter.sh
+++ b/fragments/labels/blackmagicwebpresenter.sh
@@ -1,0 +1,15 @@
+blackmagicwebpresenter)
+    name="Blackmagic Web Presenter"
+    appName="/Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app"
+    type="pkgInDmgInZip"
+    downloadURL=$(curl --compressed --location --header "Content-Type: application/json;charset=UTF-8" --header "User-Agent: Mozilla/5.0" --data '{"country": "us", "platform": "Mac OS X", "product": "Videohub"}' \
+        "$(curl -fs https://www.blackmagicdesign.com/api/support/us/downloads.json | /usr/bin/osascript -l 'JavaScript' \
+		-e "let json = $.NSString.alloc.initWithDataEncoding($.NSFileHandle.fileHandleWithStandardInput.readDataToEndOfFile$(/usr/bin/uname -r | /usr/bin/awk -F '.' '($1 > 18) { print "AndReturnError(ObjC.wrap())" }'), $.NSUTF8StringEncoding)" \
+		-e 'if ($.NSFileManager.defaultManager.fileExistsAtPath(json)) json = $.NSString.stringWithContentsOfFileEncodingError(json, $.NSUTF8StringEncoding, ObjC.wrap())' \
+		-e 'parsed = JSON.parse(json.js)' \
+        -e "update = parsed.downloads.filter((download) => download.name.match(/^Blackmagic Web Presenter/))[0]" \
+        -e 'download_id = update.urls["Mac OS X"][0].downloadId' \
+	    -e '"https://www.blackmagicdesign.com/api/register/us/download/" + download_id')")
+    appNewVersion=$(echo ${downloadURL} | grep -oE '/v([0-9.]+)' | cut -d'v' -f2)
+    expectedTeamID="9ZGFBWLSYP"
+    ;;

--- a/fragments/labels/blackmagicwebpresenter.sh
+++ b/fragments/labels/blackmagicwebpresenter.sh
@@ -11,5 +11,6 @@ blackmagicwebpresenter)
         -e 'download_id = update.urls["Mac OS X"][0].downloadId' \
 	    -e '"https://www.blackmagicdesign.com/api/register/us/download/" + download_id')")
     appNewVersion=$(echo ${downloadURL} | grep -oE '/v([0-9.]+)' | cut -d'v' -f2)
+    blockingProcesses=( "Blackmagic Web Presenter Setup" )
     expectedTeamID="9ZGFBWLSYP"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** 
This label is dependent on pkgInDmgInZip being added in #1865
(credit to @gazzer82 who laid the groundwork in #1223)

**Installomator log** 
```
sudo utils/assemble.sh blackmagicwebpresenter DEBUG=0

2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : setting variable from argument DEBUG=0
2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : Total items in argumentsArray: 1
2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : argumentsArray: DEBUG=0
2025-02-18 10:24:54 : REQ   : blackmagicwebpresenter : ################## Start Installomator v. 10.8beta, date 2025-02-18
2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : ################## Version: 10.8beta
2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : ################## Date: 2025-02-18
2025-02-18 10:24:54 : INFO  : blackmagicwebpresenter : ################## blackmagicwebpresenter
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   232  100   168  100    64    580    221 --:--:-- --:--:-- --:--:--   802
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : Reading arguments again: DEBUG=0
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : BLOCKING_PROCESS_ACTION=tell_user
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : NOTIFY=success
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : LOGGING=INFO
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : Label type: pkgInDmgInZip
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : archiveName: Blackmagic Web Presenter.zip
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : no blocking processes defined, using Blackmagic Web Presenter as default
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : name: Blackmagic Web Presenter, appName: /Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app
2025-02-18 10:24:56 : WARN  : blackmagicwebpresenter : No previous app found
2025-02-18 10:24:56 : WARN  : blackmagicwebpresenter : could not find /Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : appversion: 
2025-02-18 10:24:56 : INFO  : blackmagicwebpresenter : Latest version of Blackmagic Web Presenter is 3.5
2025-02-18 10:24:56 : REQ   : blackmagicwebpresenter : Downloading https://swr.cloud.blackmagicdesign.com/WebPresenter/v3.5/Blackmagic_Web_Presenter_Macintosh_3.5.zip?verify=1739870696-EhnrWI3i3Ehnt20XoK42na2nRCwxMTkTc0RTlzfK%2B%2FY%3D to Blackmagic Web Presenter.zip
2025-02-18 10:25:02 : INFO  : blackmagicwebpresenter : Downloaded Blackmagic Web Presenter.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is 0a79ee6eb7c0096d4d6ac30270ba7dcfca2e4d38 – Size is 448284 kB
2025-02-18 10:25:02 : REQ   : blackmagicwebpresenter : no more blocking processes, continue with update
2025-02-18 10:25:02 : REQ   : blackmagicwebpresenter : Installing Blackmagic Web Presenter
2025-02-18 10:25:02 : INFO  : blackmagicwebpresenter : Unzipping Blackmagic Web Presenter.zip
2025-02-18 10:25:03 : INFO  : blackmagicwebpresenter : found dmg: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gjK02QdGvs/Blackmagic_Web_Presenter_3.5.dmg
2025-02-18 10:25:03 : INFO  : blackmagicwebpresenter : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.gjK02QdGvs/Blackmagic_Web_Presenter_3.5.dmg
2025-02-18 10:25:07 : INFO  : blackmagicwebpresenter : Mounted: /Volumes/Web Presenter
2025-02-18 10:25:07 : INFO  : blackmagicwebpresenter : found pkg: /Volumes/Web Presenter/Install Web Presenter 3.5.pkg
2025-02-18 10:25:07 : INFO  : blackmagicwebpresenter : Verifying: /Volumes/Web Presenter/Install Web Presenter 3.5.pkg
2025-02-18 10:25:07 : INFO  : blackmagicwebpresenter : Team ID: 9ZGFBWLSYP (expected: 9ZGFBWLSYP )
2025-02-18 10:25:07 : INFO  : blackmagicwebpresenter : Installing /Volumes/Web Presenter/Install Web Presenter 3.5.pkg to /
2025-02-18 10:25:16 : INFO  : blackmagicwebpresenter : Finishing...
2025-02-18 10:25:19 : INFO  : blackmagicwebpresenter : App(s) found: /Applications//Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app
2025-02-18 10:25:19 : INFO  : blackmagicwebpresenter : found app at /Applications//Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app, version 3.5, on versionKey CFBundleShortVersionString
2025-02-18 10:25:19 : REQ   : blackmagicwebpresenter : Installed Blackmagic Web Presenter, version 3.5
2025-02-18 10:25:19 : INFO  : blackmagicwebpresenter : notifying
2025-02-18 10:25:20 : INFO  : blackmagicwebpresenter : Installomator did not close any apps, so no need to reopen any apps.
2025-02-18 10:25:20 : REQ   : blackmagicwebpresenter : All done!
2025-02-18 10:25:20 : REQ   : blackmagicwebpresenter : ################## End Installomator, exit code 0 
```
Second run (latest version installed):
```
sudo utils/assemble.sh blackmagicwebpresenter DEBUG=0

2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : setting variable from argument DEBUG=0
2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : Total items in argumentsArray: 1
2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : argumentsArray: DEBUG=0
2025-02-18 10:25:49 : REQ   : blackmagicwebpresenter : ################## Start Installomator v. 10.8beta, date 2025-02-18
2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : ################## Version: 10.8beta
2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : ################## Date: 2025-02-18
2025-02-18 10:25:49 : INFO  : blackmagicwebpresenter : ################## blackmagicwebpresenter
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   234  100   170  100    64    493    185 --:--:-- --:--:-- --:--:--   680
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : Reading arguments again: DEBUG=0
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : BLOCKING_PROCESS_ACTION=tell_user
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : NOTIFY=success
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : LOGGING=INFO
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : Label type: pkgInDmgInZip
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : archiveName: Blackmagic Web Presenter.zip
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : no blocking processes defined, using Blackmagic Web Presenter as default
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : App(s) found: /Applications//Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : found app at /Applications//Blackmagic Web Presenter/Blackmagic Web Presenter Setup.app, version 3.5, on versionKey CFBundleShortVersionString
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : appversion: 3.5
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : Latest version of Blackmagic Web Presenter is 3.5
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : There is no newer version available.
2025-02-18 10:25:51 : INFO  : blackmagicwebpresenter : Installomator did not close any apps, so no need to reopen any apps.
2025-02-18 10:25:51 : REQ   : blackmagicwebpresenter : No newer version.
2025-02-18 10:25:51 : REQ   : blackmagicwebpresenter : ################## End Installomator, exit code 0
```