### PR TITLE
Add Epson EPPT

### DIFF
--- a/fragments/labels/epsoneppt.sh
+++ b/fragments/labels/epsoneppt.sh
@@ -1,0 +1,11 @@
+epsoneppt)
+    name="Epson EPPT"
+    appName="Epson Projector Professional Tool/EPPT.app"
+    type="pkgInDmg"
+    blockingProcesses=( "EPPT" )
+    userAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10"
+    pageURL="https://epson.com/Support/Other-Products/Epson-Software/Epson-Projector-Professional-Tool-Software/s/SPT_Epson-PJ-Pro-Tool?review-filter=macOS+10.15.x"
+    downloadURL=$(curl -A $userAgent -fs $pageURL | xmllint --html -xpath "string((//a[contains(@href, '.dmg')])[1]/@href)" - 2> /dev/null)
+    appNewVersion=$( echo "${downloadURL}" | grep -oE '_([0-9.]+)' | sed 's/.$//' | cut -d'_' -f2)
+    expectedTeamID="TXAEAV5RN4"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-02-18 13:11:37 : REQ   : epsoneppt : ################## Start Installomator v. 10.6, date 2025-02-18
2025-02-18 13:11:37 : INFO  : epsoneppt : ################## Version: 10.6
2025-02-18 13:11:37 : INFO  : epsoneppt : ################## Date: 2025-02-18
2025-02-18 13:11:37 : INFO  : epsoneppt : ################## epsoneppt
2025-02-18 13:11:37 : DEBUG : epsoneppt : DEBUG mode 1 enabled.
2025-02-18 13:11:37 : INFO  : epsoneppt : SwiftDialog is not installed, clear cmd file var
2025-02-18 13:11:38 : INFO  : epsoneppt : setting variable from argument LOGGING=INFO
2025-02-18 13:11:38 : INFO  : epsoneppt : BLOCKING_PROCESS_ACTION=tell_user
2025-02-18 13:11:38 : INFO  : epsoneppt : NOTIFY=success
2025-02-18 13:11:38 : INFO  : epsoneppt : LOGGING=INFO
2025-02-18 13:11:38 : INFO  : epsoneppt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-18 13:11:38 : INFO  : epsoneppt : Label type: pkgInDmg
2025-02-18 13:11:38 : INFO  : epsoneppt : archiveName: Epson EPPT.dmg
2025-02-18 13:11:38 : INFO  : epsoneppt : name: Epson EPPT, appName: Epson Projector Professional Tool/EPPT.app
2025-02-18 13:11:38.519 mdfind[26715:8916766] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2025-02-18 13:11:38.569 mdfind[26715:8916766] Couldn't determine the mapping between prefab keywords and predicates.
2025-02-18 13:11:38 : WARN  : epsoneppt : No previous app found
2025-02-18 13:11:38 : WARN  : epsoneppt : could not find Epson Projector Professional Tool/EPPT.app
2025-02-18 13:11:38 : INFO  : epsoneppt : appversion: 
2025-02-18 13:11:38 : INFO  : epsoneppt : Latest version of Epson EPPT is 1.52
2025-02-18 13:11:38 : REQ   : epsoneppt : Downloading https://ftp.epson.com/drivers/EPPT_1.52.dmg to Epson EPPT.dmg
2025-02-18 13:11:40 : REQ   : epsoneppt : Installing Epson EPPT
2025-02-18 13:11:40 : INFO  : epsoneppt : Mounting ./Epson EPPT.dmg
2025-02-18 13:11:41 : INFO  : epsoneppt : Mounted: /Volumes/“EPPT152_MacOSX”
2025-02-18 13:11:41 : INFO  : epsoneppt : found pkg: /Volumes/“EPPT152_MacOSX”/Epson Projector Professional Tool Installer.pkg
2025-02-18 13:11:41 : INFO  : epsoneppt : Verifying: /Volumes/“EPPT152_MacOSX”/Epson Projector Professional Tool Installer.pkg
2025-02-18 13:11:41 : INFO  : epsoneppt : Team ID: TXAEAV5RN4 (expected: TXAEAV5RN4 )
2025-02-18 13:11:41 : INFO  : epsoneppt : Finishing...
2025-02-18 13:11:44 : INFO  : epsoneppt : name: Epson EPPT, appName: Epson Projector Professional Tool/EPPT.app
2025-02-18 13:11:44.441 mdfind[26863:8917266] [UserQueryParser] Loading keywords and predicates for locale "en_GB"
2025-02-18 13:11:44.483 mdfind[26863:8917266] Couldn't determine the mapping between prefab keywords and predicates.
2025-02-18 13:11:44 : WARN  : epsoneppt : No previous app found
2025-02-18 13:11:44 : WARN  : epsoneppt : could not find Epson Projector Professional Tool/EPPT.app
2025-02-18 13:11:44 : REQ   : epsoneppt : Installed Epson EPPT, version 1.52
2025-02-18 13:11:44 : INFO  : epsoneppt : notifying
displaynotification:23: no such file or directory: /usr/local/bin/dialog
displaynotification:27: no such file or directory: /Applications/IBM Notifier.app/Contents/MacOS/IBM Notifier
2025-02-18 13:11:44 : INFO  : epsoneppt : AppleScript notification fallback
2025-02-18 13:11:44 : REQ   : epsoneppt : All done!
2025-02-18 13:11:44 : REQ   : epsoneppt : ################## End Installomator, exit code 0 
```
