### PR TITLE
Add label: redgiant

### DIFF
--- a/fragments/labels/redgiant.sh
+++ b/fragments/labels/redgiant.sh
@@ -1,0 +1,16 @@
+redgiant)
+    name="Red Giant"
+    type="dmg"
+    downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redgiant/releases[^"]*\.dmg' | head -1)
+    appNewVersion=$(sed -E 's/.*-([0-9.]*)-Mac\.dmg/\1/g' <<< "${downloadURL}")
+    expectedTeamID="4ZY22YGXQG"
+    appCustomVersion(){
+        infoPlist="/Applications/Red Giant/Red Giant/uninstall.app/Contents/Info.plist"
+        if [ -f "${infoPlist}" ];then
+            defaults read "${infoPlist}" CFBundleVersion
+        fi
+    }
+    installerTool="Red Giant Installer.app"
+    CLIInstaller="Red Giant Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=( --mode unattended --unattendedmodeui none )
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
n/a

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```log
$ ./assemble.sh redgiant

2025-02-28 12:35:06 : INFO  : redgiant : Total items in argumentsArray: 0
2025-02-28 12:35:06 : INFO  : redgiant : argumentsArray:
2025-02-28 12:35:06 : REQ   : redgiant : ################## Start Installomator v. 10.8beta, date 2025-02-28
2025-02-28 12:35:06 : INFO  : redgiant : ################## Version: 10.8beta
2025-02-28 12:35:06 : INFO  : redgiant : ################## Date: 2025-02-28
2025-02-28 12:35:06 : INFO  : redgiant : ################## redgiant
2025-02-28 12:35:06 : DEBUG : redgiant : DEBUG mode 1 enabled.
2025-02-28 12:35:07 : INFO  : redgiant : Reading arguments again:
2025-02-28 12:35:07 : DEBUG : redgiant : name=Red Giant
2025-02-28 12:35:07 : DEBUG : redgiant : appName=
2025-02-28 12:35:07 : DEBUG : redgiant : type=dmg
2025-02-28 12:35:07 : DEBUG : redgiant : archiveName=
2025-02-28 12:35:07 : DEBUG : redgiant : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/redgiant/releases/2025.3.0/RedGiant-2025.3.0-Mac.dmg
2025-02-28 12:35:07 : DEBUG : redgiant : curlOptions=
2025-02-28 12:35:07 : DEBUG : redgiant : appNewVersion=2025.3.0
2025-02-28 12:35:07 : DEBUG : redgiant : appCustomVersion function: Defined.
2025-02-28 12:35:07 : DEBUG : redgiant : versionKey=CFBundleShortVersionString
2025-02-28 12:35:07 : DEBUG : redgiant : packageID=
2025-02-28 12:35:07 : DEBUG : redgiant : pkgName=
2025-02-28 12:35:07 : DEBUG : redgiant : choiceChangesXML=
2025-02-28 12:35:07 : DEBUG : redgiant : expectedTeamID=4ZY22YGXQG
2025-02-28 12:35:08 : DEBUG : redgiant : blockingProcesses=
2025-02-28 12:35:08 : DEBUG : redgiant : installerTool=Red Giant Installer.app
2025-02-28 12:35:08 : DEBUG : redgiant : CLIInstaller=Red Giant Installer.app/Contents/MacOS/installbuilder.sh
2025-02-28 12:35:08 : DEBUG : redgiant : CLIArguments=--mode unattended --unattendedmodeui none
2025-02-28 12:35:08 : DEBUG : redgiant : updateTool=
2025-02-28 12:35:08 : DEBUG : redgiant : updateToolArguments=
2025-02-28 12:35:08 : DEBUG : redgiant : updateToolRunAsCurrentUser=
2025-02-28 12:35:08 : INFO  : redgiant : BLOCKING_PROCESS_ACTION=tell_user
2025-02-28 12:35:08 : INFO  : redgiant : NOTIFY=success
2025-02-28 12:35:08 : INFO  : redgiant : LOGGING=DEBUG
2025-02-28 12:35:08 : INFO  : redgiant : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-02-28 12:35:08 : INFO  : redgiant : Label type: dmg
2025-02-28 12:35:08 : INFO  : redgiant : archiveName: Red Giant.dmg
2025-02-28 12:35:08 : INFO  : redgiant : no blocking processes defined, using Red Giant as default
2025-02-28 12:35:08 : DEBUG : redgiant : Changing directory to /Users/kechan0130/ghq/github.com/Installomator/Installomator/build
2025-02-28 12:35:08 : INFO  : redgiant : Custom App Version detection is used, found
2025-02-28 12:35:08 : INFO  : redgiant : appversion:
2025-02-28 12:35:08 : INFO  : redgiant : Latest version of Red Giant is 2025.3.0
2025-02-28 12:35:08 : REQ   : redgiant : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/redgiant/releases/2025.3.0/RedGiant-2025.3.0-Mac.dmg to Red Giant.dmg
2025-02-28 12:35:08 : DEBUG : redgiant : No Dialog connection, just download
2025-02-28 12:36:03 : INFO  : redgiant : Downloaded Red Giant.dmg – Type is  zlib compressed data – SHA is f1d3dd2588795981b4c5edaff2aa20a0f0dc3368 – Size is 1442164 kB
2025-02-28 12:36:03 : DEBUG : redgiant : DEBUG mode 1, not checking for blocking processes
2025-02-28 12:36:03 : REQ   : redgiant : Installing Red Giant
2025-02-28 12:36:03 : REQ   : redgiant : installerTool used: Red Giant Installer.app
2025-02-28 12:36:03 : INFO  : redgiant : Mounting /Users/kechan0130/ghq/github.com/Installomator/Installomator/build/Red Giant.dmg
2025-02-28 12:36:07 : DEBUG : redgiant : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $B0BD0E3B
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $7F6D580D
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $F90E9C08
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)のチェックサムを計算中…
EFI System Partition (C12A7328-F81F-: 検証済み CRC32 $B54B659C
disk image (Apple_HFS : 5)のチェックサムを計算中…
disk image (Apple_HFS : 5): 検証済み CRC32 $B90BBFEA
(Apple_Free : 6)のチェックサムを計算中…
(Apple_Free : 6): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 7)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $F90E9C08
GPT Header (Backup GPT Header : 8)のチェックサムを計算中…
GPT Header (Backup GPT Header : 8): 検証済み CRC32 $AC073DA3
検証済み CRC32 $3D1B9A7F
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	EFI
/dev/disk4s2        	Apple_HFS                      	/Volumes/Red Giant Installer

2025-02-28 12:36:07 : INFO  : redgiant : Mounted: /Volumes/Red Giant Installer
2025-02-28 12:36:07 : INFO  : redgiant : Verifying: /Volumes/Red Giant Installer/Red Giant Installer.app
2025-02-28 12:36:07 : DEBUG : redgiant : App size: 1.4G	/Volumes/Red Giant Installer/Red Giant Installer.app
2025-02-28 12:36:09 : DEBUG : redgiant : Debugging enabled, App Verification output was:
/Volumes/Red Giant Installer/Red Giant Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2025-02-28 12:36:09 : INFO  : redgiant : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2025-02-28 12:36:09 : INFO  : redgiant : Installing Red Giant version 2025.3.0 on versionKey CFBundleShortVersionString.
2025-02-28 12:36:09 : DEBUG : redgiant : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-02-28 12:36:10 : INFO  : redgiant : Finishing...
2025-02-28 12:36:13 : INFO  : redgiant : Custom App Version detection is used, found
2025-02-28 12:36:13 : REQ   : redgiant : Installed Red Giant, version 2025.3.0
2025-02-28 12:36:13 : INFO  : redgiant : notifying
2025-02-28 12:36:14 : DEBUG : redgiant : Unmounting /Volumes/Red Giant Installer
2025-02-28 12:36:14 : DEBUG : redgiant : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-02-28 12:36:14 : DEBUG : redgiant : DEBUG mode 1, not reopening anything
2025-02-28 12:36:14 : REQ   : redgiant : All done!
2025-02-28 12:36:14 : REQ   : redgiant : ################## End Installomator, exit code 0
```
