### PR TITLE
Add appNewVersion to cloudflarewarp

### DIFF
--- a/fragments/labels/cloudflarewarp.sh
+++ b/fragments/labels/cloudflarewarp.sh
@@ -3,6 +3,6 @@ cloudflarewarp)
     type="pkg"
     packageID="com.cloudflare.1dot1dot1dot1.macos"
     downloadURL="https://1111-releases.cloudflareclient.com/mac/latest"
-    appNewVersion=""
+    appNewVersion="$(curl -SLI ${downloadURL} | grep -i "^location.*version" | awk -F "version/" '{print$2}' | awk -F "." '{print$1"."$2"."$3}')"
     expectedTeamID="68WVV388M8"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context**
Label had an empty appNewVersion, causing it to reinstall even when not needed.
In this fixed label, the version pulled from the download url is cropped, since the pkg receipt version lacks the last part.
(Best would be to use customAppVersion, checking the installed app, so that it will work on installations without receipts. That just rendered a constant reinstallation, bringing me back to square one)
**Installomator log** 
Without installed app:
```
sudo utils/assemble.sh cloudflarewarp DEBUG=0
2025-03-03 14:50:32 : INFO  : cloudflarewarp : setting variable from argument DEBUG=0
2025-03-03 14:50:32 : INFO  : cloudflarewarp : Total items in argumentsArray: 1
2025-03-03 14:50:32 : INFO  : cloudflarewarp : argumentsArray: DEBUG=0
2025-03-03 14:50:32 : REQ   : cloudflarewarp : ################## Start Installomator v. 10.8beta, date 2025-03-03
2025-03-03 14:50:32 : INFO  : cloudflarewarp : ################## Version: 10.8beta
2025-03-03 14:50:32 : INFO  : cloudflarewarp : ################## Date: 2025-03-03
2025-03-03 14:50:32 : INFO  : cloudflarewarp : ################## cloudflarewarp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0 88.0M    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
2025-03-03 14:50:34 : INFO  : cloudflarewarp : Reading arguments again: DEBUG=0
2025-03-03 14:50:34 : INFO  : cloudflarewarp : BLOCKING_PROCESS_ACTION=tell_user
2025-03-03 14:50:34 : INFO  : cloudflarewarp : NOTIFY=success
2025-03-03 14:50:34 : INFO  : cloudflarewarp : LOGGING=INFO
2025-03-03 14:50:34 : INFO  : cloudflarewarp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-03 14:50:34 : INFO  : cloudflarewarp : Label type: pkg
2025-03-03 14:50:34 : INFO  : cloudflarewarp : archiveName: Cloudflare WARP.pkg
2025-03-03 14:50:34 : INFO  : cloudflarewarp : no blocking processes defined, using Cloudflare WARP as default
2025-03-03 14:50:34 : INFO  : cloudflarewarp : No version found using packageID com.cloudflare.1dot1dot1dot1.macos
2025-03-03 14:50:35 : INFO  : cloudflarewarp : name: Cloudflare WARP, appName: Cloudflare WARP.app
2025-03-03 14:50:35 : WARN  : cloudflarewarp : No previous app found
2025-03-03 14:50:35 : WARN  : cloudflarewarp : could not find Cloudflare WARP.app
2025-03-03 14:50:35 : INFO  : cloudflarewarp : appversion: 
2025-03-03 14:50:35 : INFO  : cloudflarewarp : Latest version of Cloudflare WARP is 2025.1.861
2025-03-03 14:50:35 : REQ   : cloudflarewarp : Downloading https://1111-releases.cloudflareclient.com/mac/latest to Cloudflare WARP.pkg
2025-03-03 14:50:38 : INFO  : cloudflarewarp : Downloaded Cloudflare WARP.pkg – Type is  xar archive compressed TOC – SHA is aa8b431c20fdbe0a77ca44a31e6aa405bef3f3c0 – Size is 90196 kB
2025-03-03 14:50:38 : REQ   : cloudflarewarp : no more blocking processes, continue with update
2025-03-03 14:50:38 : REQ   : cloudflarewarp : Installing Cloudflare WARP
2025-03-03 14:50:38 : INFO  : cloudflarewarp : Verifying: Cloudflare WARP.pkg
2025-03-03 14:50:38 : INFO  : cloudflarewarp : Team ID: 68WVV388M8 (expected: 68WVV388M8 )
2025-03-03 14:50:38 : INFO  : cloudflarewarp : Installing Cloudflare WARP.pkg to /
2025-03-03 14:51:25 : INFO  : cloudflarewarp : Finishing...
2025-03-03 14:51:28 : INFO  : cloudflarewarp : found packageID com.cloudflare.1dot1dot1dot1.macos installed, version 2025.1.861
2025-03-03 14:51:28 : REQ   : cloudflarewarp : Installed Cloudflare WARP, version 2025.1.861
2025-03-03 14:51:28 : INFO  : cloudflarewarp : notifying
2025-03-03 14:51:29 : INFO  : cloudflarewarp : Installomator did not close any apps, so no need to reopen any apps.
2025-03-03 14:51:29 : REQ   : cloudflarewarp : All done!
2025-03-03 14:51:29 : REQ   : cloudflarewarp : ################## End Installomator, exit code 0 
```

After app is installed:
```
sudo utils/assemble.sh cloudflarewarp DEBUG=0
2025-03-03 14:51:41 : INFO  : cloudflarewarp : setting variable from argument DEBUG=0
2025-03-03 14:51:41 : INFO  : cloudflarewarp : Total items in argumentsArray: 1
2025-03-03 14:51:41 : INFO  : cloudflarewarp : argumentsArray: DEBUG=0
2025-03-03 14:51:41 : REQ   : cloudflarewarp : ################## Start Installomator v. 10.8beta, date 2025-03-03
2025-03-03 14:51:41 : INFO  : cloudflarewarp : ################## Version: 10.8beta
2025-03-03 14:51:41 : INFO  : cloudflarewarp : ################## Date: 2025-03-03
2025-03-03 14:51:41 : INFO  : cloudflarewarp : ################## cloudflarewarp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0 88.0M    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
2025-03-03 14:51:44 : INFO  : cloudflarewarp : Reading arguments again: DEBUG=0
2025-03-03 14:51:44 : INFO  : cloudflarewarp : BLOCKING_PROCESS_ACTION=tell_user
2025-03-03 14:51:44 : INFO  : cloudflarewarp : NOTIFY=success
2025-03-03 14:51:44 : INFO  : cloudflarewarp : LOGGING=INFO
2025-03-03 14:51:44 : INFO  : cloudflarewarp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-03 14:51:44 : INFO  : cloudflarewarp : Label type: pkg
2025-03-03 14:51:44 : INFO  : cloudflarewarp : archiveName: Cloudflare WARP.pkg
2025-03-03 14:51:44 : INFO  : cloudflarewarp : no blocking processes defined, using Cloudflare WARP as default
2025-03-03 14:51:44 : INFO  : cloudflarewarp : found packageID com.cloudflare.1dot1dot1dot1.macos installed, version 2025.1.861
2025-03-03 14:51:44 : INFO  : cloudflarewarp : appversion: 2025.1.861
2025-03-03 14:51:44 : INFO  : cloudflarewarp : Latest version of Cloudflare WARP is 2025.1.861
2025-03-03 14:51:44 : INFO  : cloudflarewarp : There is no newer version available.
2025-03-03 14:51:44 : INFO  : cloudflarewarp : Installomator did not close any apps, so no need to reopen any apps.
2025-03-03 14:51:44 : REQ   : cloudflarewarp : No newer version.
2025-03-03 14:51:44 : REQ   : cloudflarewarp : ################## End Installomator, exit code 0 
```