### PR TITLE
Firefox ESR version fix

### DIFF
--- a/fragments/labels/firefoxesr.sh
+++ b/fragments/labels/firefoxesr.sh
@@ -5,6 +5,7 @@ firefoxesrpkg)
     downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx"
     firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
     appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
+    appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
     blockingProcesses=( firefox )
     ;;

--- a/fragments/labels/firefoxesr_intl.sh
+++ b/fragments/labels/firefoxesr_intl.sh
@@ -20,7 +20,8 @@ firefoxesr_intl)
         downloadURL="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx"
     fi
     firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
-    appNewVersion=$(getJSONValue "$firefoxVersions" "LATEST_FIREFOX_VERSION")
+    appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
+    appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
     blockingProcesses=( firefox )
     printlog "WARNING for ERROR: Label firefox and firefox_intl should not be used. Instead use firefoxpkg and firefoxpkg_intl as per recommendations from Firefox. It's not fully certain that the app actually gets updated here. firefoxpkg and firefoxpkg_intl will have built in updates and make sure the client is updated in the future." REQ

--- a/fragments/labels/firefoxesrpkg_intl
+++ b/fragments/labels/firefoxesrpkg_intl
@@ -1,0 +1,27 @@
+firefoxesrpkg_intl)
+    # This label will try to figure out the selected language of the user,
+    # and install corrosponding version of Firefox ESR PKG
+    name="Firefox"
+    type="pkg"
+    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-')
+    printlog "Found language $userLanguage to be used for $name."
+    releaseURL="https://ftp.mozilla.org/pub/firefox/releases/latest-esr/README.txt"
+    until curl -fs $releaseURL | grep -q "=$userLanguage"; do
+        if [ ${#userLanguage} -eq 2 ]; then
+            break
+        fi
+        printlog "No locale matching '$userLanguage', trying '${userLanguage:0:2}'"
+        userLanguage=${userLanguage:0:2}
+    done
+    printlog "Using language '$userLanguage' for download."
+    downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx&lang=$userLanguage"
+    if ! curl -sfL --output /dev/null -r 0-0 $downloadURL; then
+        printlog "Download not found for '$userLanguage', using default ('en-US')."
+        downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx"
+    fi
+    firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
+    appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
+    appNewVersion=${appNewVersion:0:-3}
+    expectedTeamID="43AQ936H96"
+    blockingProcesses=( firefox )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

Firefox ESR uses the esr suffix in the version string but the Firefox.app does not. Therefore the version compare always says the versions are different. This is fixed for firefoxesr/firefoxesrpkg label and firefoxesr_intl label. For the firefoxesr_intl label also the version for the normal firefox version was picked from the firefox_versions.json from the Mozilla website.

In Addition I created a new label firefoxesrpkg_intl that is based on the firefoxesr_intl label but downloads the PKG instead of the DMG for Firefox ESR.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](`https:`//docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
`2025-03-03 08:46:59 : REQ   : firefoxesrpkg : ################## Start Installomator v. 10.7, date 2025-01-24
2025-03-03 08:46:59 : INFO  : firefoxesrpkg : ################## Version: 10.7
2025-03-03 08:46:59 : INFO  : firefoxesrpkg : ################## Date: 2025-01-24
2025-03-03 08:46:59 : INFO  : firefoxesrpkg : ################## firefoxesrpkg
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : setting variable from argument DEBUG=2
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : BLOCKING_PROCESS_ACTION=tell_user
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : NOTIFY=success
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : LOGGING=INFO
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : Label type: pkg
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : archiveName: Firefox.pkg
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : name: Firefox, appName: Firefox.app
2025-03-03 08:47:00 : WARN  : firefoxesrpkg : No previous app found
2025-03-03 08:47:00 : WARN  : firefoxesrpkg : could not find Firefox.app
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : appversion: 
2025-03-03 08:47:00 : INFO  : firefoxesrpkg : Latest version of Firefox is 128.7.0
2025-03-03 08:47:00 : REQ   : firefoxesrpkg : Downloading https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx to Firefox.pkg
2025-03-03 08:47:36 : REQ   : firefoxesrpkg : no more blocking processes, continue with update
2025-03-03 08:47:36 : REQ   : firefoxesrpkg : Installing Firefox
2025-03-03 08:47:36 : INFO  : firefoxesrpkg : Verifying: Firefox.pkg
2025-03-03 08:47:36 : INFO  : firefoxesrpkg : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2025-03-03 08:47:36 : INFO  : firefoxesrpkg : Installomator did not close any apps, so no need to reopen any apps.
2025-03-03 08:47:36 : REQ   : firefoxesrpkg : ################## End Installomator, exit code 0 `

`2025-03-03 08:48:05 : REQ   : firefoxesr_intl : ################## Start Installomator v. 10.7, date 2025-01-24
2025-03-03 08:48:05 : INFO  : firefoxesr_intl : ################## Version: 10.7
2025-03-03 08:48:05 : INFO  : firefoxesr_intl : ################## Date: 2025-01-24
2025-03-03 08:48:05 : INFO  : firefoxesr_intl : ################## firefoxesr_intl
2025-03-03 08:48:05 : INFO  : firefoxesr_intl : Found language de-DE to be used for Firefox.
2025-03-03 08:48:05 : INFO  : firefoxesr_intl : No locale matching 'de-DE', trying 'de'
2025-03-03 08:48:06 : INFO  : firefoxesr_intl : Using language 'de' for download.
2025-03-03 08:48:07 : REQ   : firefoxesr_intl : WARNING for ERROR: Label firefox and firefox_intl should not be used. Instead use firefoxpkg and firefoxpkg_intl as per recommendations from Firefox. It's not fully certain that the app actually gets updated here. firefoxpkg and firefoxpkg_intl will have built in updates and make sure the client is updated in the future.
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : setting variable from argument DEBUG=2
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : BLOCKING_PROCESS_ACTION=tell_user
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : NOTIFY=success
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : LOGGING=INFO
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : Label type: dmg
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : archiveName: Firefox.dmg
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : name: Firefox, appName: Firefox.app
2025-03-03 08:48:07 : WARN  : firefoxesr_intl : No previous app found
2025-03-03 08:48:07 : WARN  : firefoxesr_intl : could not find Firefox.app
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : appversion: 
2025-03-03 08:48:07 : INFO  : firefoxesr_intl : Latest version of Firefox is 128.7.0
2025-03-03 08:48:07 : REQ   : firefoxesr_intl : Downloading https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=de to Firefox.dmg
2025-03-03 08:48:33 : REQ   : firefoxesr_intl : no more blocking processes, continue with update
2025-03-03 08:48:33 : REQ   : firefoxesr_intl : Installing Firefox
2025-03-03 08:48:33 : INFO  : firefoxesr_intl : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7ZxUnlU7By/Firefox.dmg
2025-03-03 08:48:41 : INFO  : firefoxesr_intl : Mounted: /Volumes/Firefox
2025-03-03 08:48:41 : INFO  : firefoxesr_intl : Verifying: /Volumes/Firefox/Firefox.app
2025-03-03 08:48:50 : INFO  : firefoxesr_intl : Team ID matching: 43AQ936H96 (expected: 43AQ936H96 )
2025-03-03 08:48:50 : INFO  : firefoxesr_intl : Installing Firefox version 128.7.0 on versionKey CFBundleShortVersionString.
2025-03-03 08:48:50 : INFO  : firefoxesr_intl : App has LSMinimumSystemVersion: 10.15.0
2025-03-03 08:48:50 : INFO  : firefoxesr_intl : Installomator did not close any apps, so no need to reopen any apps.
2025-03-03 08:48:50 : INFO  : firefoxesr_intl : 
2025-03-03 08:48:50 : REQ   : firefoxesr_intl : ################## End Installomator, exit code 0 `

`2025-03-03 15:04:55 : REQ   : firefoxesrpkg_intl : ################## Start Installomator v. 10.7, date 2025-01-24
2025-03-03 15:04:55 : INFO  : firefoxesrpkg_intl : ################## Version: 10.7
2025-03-03 15:04:55 : INFO  : firefoxesrpkg_intl : ################## Date: 2025-01-24
2025-03-03 15:04:55 : INFO  : firefoxesrpkg_intl : ################## firefoxesrpkg_intl
2025-03-03 15:04:56 : INFO  : firefoxesrpkg_intl : Found language de-DE to be used for Firefox.
2025-03-03 15:04:56 : INFO  : firefoxesrpkg_intl : No locale matching 'de-DE', trying 'de'
2025-03-03 15:04:56 : INFO  : firefoxesrpkg_intl : Using language 'de' for download.
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : setting variable from argument DEBUG=2
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : BLOCKING_PROCESS_ACTION=tell_user
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : NOTIFY=success
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : LOGGING=INFO
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : Label type: pkg
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : archiveName: Firefox.pkg
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : name: Firefox, appName: Firefox.app
2025-03-03 15:04:58 : WARN  : firefoxesrpkg_intl : No previous app found
2025-03-03 15:04:58 : WARN  : firefoxesrpkg_intl : could not find Firefox.app
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : appversion: 
2025-03-03 15:04:58 : INFO  : firefoxesrpkg_intl : Latest version of Firefox is 128.7.0
2025-03-03 15:04:58 : REQ   : firefoxesrpkg_intl : Downloading https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx&lang=de to Firefox.pkg
2025-03-03 15:05:24 : REQ   : firefoxesrpkg_intl : no more blocking processes, continue with update
2025-03-03 15:05:24 : REQ   : firefoxesrpkg_intl : Installing Firefox
2025-03-03 15:05:24 : INFO  : firefoxesrpkg_intl : Verifying: Firefox.pkg
2025-03-03 15:05:25 : INFO  : firefoxesrpkg_intl : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2025-03-03 15:05:25 : INFO  : firefoxesrpkg_intl : Installomator did not close any apps, so no need to reopen any apps.
2025-03-03 15:05:25 : REQ   : firefoxesrpkg_intl : ################## End Installomator, exit code 0 `

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
