### PR TITLE
Update remotedesktopmanagerfree.sh

### DIFF
--- a/fragments/labels/remotedesktopmanagerfree.sh
+++ b/fragments/labels/remotedesktopmanagerfree.sh
@@ -1,7 +1,7 @@
 remotedesktopmanagerfree)
     name="Remote Desktop Manager"
     type="dmg"
-    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacbin/ | grep -oe "http.*\.dmg" | head -1)
+    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/download/thank-you/ | sed -n 's/.*"RDMMacFreebin\.Url":"\([^"]*\)".*/\1/p' | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
     expectedTeamID="N592S9ASDB"
     ;;


### PR DESCRIPTION
Fix downloadURL extraction.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
Fixes downloadURL extraction for remotedesktopmanagerfree.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
N/A
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes downloadURL extraction for remotedesktopmanagerfree.