### PR TITLE
Add Owncloud client

### DIFF
--- a/fragments/labels/owncloud.sh
+++ b/fragments/labels/owncloud.sh
@@ -1,0 +1,12 @@
+    owncloud)
+    name="ownCloud"
+    type="pkg"
+    downloadPage="https://download.owncloud.com/desktop/ownCloud/stable/latest/mac/"
+    appNewVersion=$(curl -fsL "$downloadPage" | grep -oE 'ownCloud-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-(arm64|x86_64)\.pkg' | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="${downloadPage}ownCloud-${appNewVersion}-arm64.pkg"
+    else
+        downloadURL="${downloadPage}ownCloud-${appNewVersion}-x86_64.pkg"
+    fi
+    expectedTeamID="4AP2STM4H5"
+    ;;


### PR DESCRIPTION

**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
A label for the Owncloud client for mac, supports both Intel and Apple Silicon.
 
**Installomator log** 
./assemble.sh owncloud
2025-03-07 15:00:15 : INFO  : owncloud : Total items in argumentsArray: 0 2025-03-07 15:00:15 : INFO  : owncloud : argumentsArray:
2025-03-07 15:00:15 : REQ   : owncloud : ################## Start Installomator v. 10.8beta, date 2025-03-07
2025-03-07 15:00:15 : INFO  : owncloud : ################## Version: 10.8beta
2025-03-07 15:00:15 : INFO  : owncloud : ################## Date: 2025-03-07
2025-03-07 15:00:15 : INFO  : owncloud : ################## owncloud
2025-03-07 15:00:15 : DEBUG : owncloud : DEBUG mode 1 enabled.
2025-03-07 15:00:15 : INFO  : owncloud : SwiftDialog is not installed, clear cmd file var
2025-03-07 15:00:16 : INFO  : owncloud : Reading arguments again:
2025-03-07 15:00:16 : DEBUG : owncloud : name=ownCloud
2025-03-07 15:00:16 : DEBUG : owncloud : appName=
2025-03-07 15:00:16 : DEBUG : owncloud : type=pkg
2025-03-07 15:00:16 : DEBUG : owncloud : archiveName=
2025-03-07 15:00:16 : DEBUG : owncloud : downloadURL=https://download.owncloud.com/desktop/ownCloud/stable/latest/mac/ownCloud-5.3.2.15463-x86_64.pkg
2025-03-07 15:00:16 : DEBUG : owncloud : curlOptions=
2025-03-07 15:00:16 : DEBUG : owncloud : appNewVersion=5.3.2.15463
2025-03-07 15:00:16 : DEBUG : owncloud : appCustomVersion function: Not defined
2025-03-07 15:00:16 : DEBUG : owncloud : versionKey=CFBundleShortVersionString
2025-03-07 15:00:16 : DEBUG : owncloud : packageID=
2025-03-07 15:00:16 : DEBUG : owncloud : pkgName=
2025-03-07 15:00:16 : DEBUG : owncloud : choiceChangesXML=
2025-03-07 15:00:16 : DEBUG : owncloud : expectedTeamID=4AP2STM4H5
2025-03-07 15:00:16 : DEBUG : owncloud : blockingProcesses=
2025-03-07 15:00:16 : DEBUG : owncloud : installerTool=
2025-03-07 15:00:16 : DEBUG : owncloud : CLIInstaller=
2025-03-07 15:00:16 : DEBUG : owncloud : CLIArguments=
2025-03-07 15:00:16 : DEBUG : owncloud : updateTool=
2025-03-07 15:00:16 : DEBUG : owncloud : updateToolArguments=
2025-03-07 15:00:16 : DEBUG : owncloud : updateToolRunAsCurrentUser=
2025-03-07 15:00:16 : INFO  : owncloud : BLOCKING_PROCESS_ACTION=tell_user
2025-03-07 15:00:16 : INFO  : owncloud : NOTIFY=success
2025-03-07 15:00:16 : INFO  : owncloud : LOGGING=DEBUG
2025-03-07 15:00:17 : INFO  : owncloud : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-07 15:00:17 : INFO  : owncloud : Label type: pkg
2025-03-07 15:00:17 : INFO  : owncloud : archiveName: ownCloud.pkg
2025-03-07 15:00:17 : INFO  : owncloud : no blocking processes defined, using ownCloud as default
2025-03-07 15:00:17 : DEBUG : owncloud : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2025-03-07 15:00:17 : INFO  : owncloud : name: ownCloud, appName: ownCloud.app
2025-03-07 15:00:18 : WARN  : owncloud : No previous app found
2025-03-07 15:00:18 : WARN  : owncloud : could not find ownCloud.app
2025-03-07 15:00:18 : INFO  : owncloud : appversion:
2025-03-07 15:00:18 : INFO  : owncloud : Latest version of ownCloud is 5.3.2.15463
2025-03-07 15:00:18 : REQ   : owncloud : Downloading https://download.owncloud.com/desktop/ownCloud/stable/latest/mac/ownCloud-5.3.2.15463-x86_64.pkg to ownCloud.pkg
2025-03-07 15:00:18 : DEBUG : owncloud : No Dialog connection, just download
2025-03-07 15:00:19 : INFO  : owncloud : Downloaded ownCloud.pkg – Type is  xar archive compressed TOC – SHA is da9c0d07c332de0abb72d643020d2bb721710568 – Size is 30444 kB
2025-03-07 15:00:19 : DEBUG : owncloud : DEBUG mode 1, not checking for blocking processes
2025-03-07 15:00:19 : REQ   : owncloud : Installing ownCloud
2025-03-07 15:00:19 : INFO  : owncloud : Verifying: ownCloud.pkg
2025-03-07 15:00:19 : DEBUG : owncloud : File list: -rw-r--r--  1 admin  staff    30M Mar  7 15:00 ownCloud.pkg
2025-03-07 15:00:19 : DEBUG : owncloud : File type: ownCloud.pkg: xar archive compressed TOC: 5335, SHA-1 checksum
2025-03-07 15:00:20 : DEBUG : owncloud : spctlOut is ownCloud.pkg: accepted
2025-03-07 15:00:20 : DEBUG : owncloud : source=Notarized Developer ID
2025-03-07 15:00:20 : DEBUG : owncloud : origin=Developer ID Installer: ownCloud GmbH (4AP2STM4H5)
2025-03-07 15:00:20 : INFO  : owncloud : Team ID: 4AP2STM4H5 (expected: 4AP2STM4H5 )
2025-03-07 15:00:20 : DEBUG : owncloud : DEBUG enabled, skipping installation
2025-03-07 15:00:20 : INFO  : owncloud : Finishing...
2025-03-07 15:00:23 : INFO  : owncloud : name: ownCloud, appName: ownCloud.app
2025-03-07 15:00:24 : WARN  : owncloud : No previous app found
2025-03-07 15:00:24 : WARN  : owncloud : could not find ownCloud.app
2025-03-07 15:00:24 : REQ   : owncloud : Installed ownCloud, version 5.3.2.15463
2025-03-07 15:00:24 : INFO  : owncloud : notifying
displaynotification:7: permission denied: /usr/local/bin/dialog
2025-03-07 15:00:24 : DEBUG : owncloud : DEBUG mode 1, not reopening anything
2025-03-07 15:00:24 : REQ   : owncloud : All done!
2025-03-07 15:00:24 : REQ   : owncloud : ################## End Installomator, exit code 0

