### PR TITLE
Updated url's for label surfdrive

### DIFF
--- a/fragments/labels/surfdrive.sh
+++ b/fragments/labels/surfdrive.sh
@@ -2,11 +2,11 @@ surfdrive)
     name="SURFdrive"
     type="pkg"
 	if [[ $(arch) == "arm64" ]]; then
-		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm64)
-		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm |cut -d- -f2)
+		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/74225443/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm64)
+		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/74225443/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep arm |cut -d -f2)
     elif [[ $(arch) == "i386" ]]; then
-		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86)
-		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/display/WIKI/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86 |cut -d- -f2)
+		downloadURL=$(curl -fs https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/74225443/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86)
+		appNewVersion=$(curl -fs https://servicedesk.surf.nl/wiki/spaces/WIKI/pages/74225443/Desktop+client+login|grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*" | grep pkg | grep x86|cut -d- -f2)
 	fi
     expectedTeamID="4AP2STM4H5"
     appName="surfdrive.app"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./Installomator/utils/assemble.sh surfdrive
2025-03-08 23:27:11 : INFO  : surfdrive : Total items in argumentsArray: 0
2025-03-08 23:27:11 : INFO  : surfdrive : argumentsArray:
2025-03-08 23:27:11 : REQ   : surfdrive : ################## Start Installomator v. 10.8beta, date 2025-03-08
2025-03-08 23:27:11 : INFO  : surfdrive : ################## Version: 10.8beta
2025-03-08 23:27:11 : INFO  : surfdrive : ################## Date: 2025-03-08
2025-03-08 23:27:11 : INFO  : surfdrive : ################## surfdrive
2025-03-08 23:27:11 : DEBUG : surfdrive : DEBUG mode 1 enabled.
cut: bad delimiter
2025-03-08 23:27:12 : INFO  : surfdrive : Reading arguments again:
2025-03-08 23:27:12 : DEBUG : surfdrive : name=SURFdrive
2025-03-08 23:27:12 : DEBUG : surfdrive : appName=surfdrive.app
2025-03-08 23:27:12 : DEBUG : surfdrive : type=pkg
2025-03-08 23:27:12 : DEBUG : surfdrive : archiveName=
2025-03-08 23:27:12 : DEBUG : surfdrive : downloadURL=https://surfdrive.surf.nl/downloads/surfdrive-5.3.2.15536-arm64.pkg
2025-03-08 23:27:12 : DEBUG : surfdrive : curlOptions=
2025-03-08 23:27:12 : DEBUG : surfdrive : appNewVersion=
2025-03-08 23:27:12 : DEBUG : surfdrive : appCustomVersion function: Not defined
2025-03-08 23:27:12 : DEBUG : surfdrive : versionKey=CFBundleShortVersionString
2025-03-08 23:27:12 : DEBUG : surfdrive : packageID=
2025-03-08 23:27:12 : DEBUG : surfdrive : pkgName=
2025-03-08 23:27:12 : DEBUG : surfdrive : choiceChangesXML=
2025-03-08 23:27:12 : DEBUG : surfdrive : expectedTeamID=4AP2STM4H5
2025-03-08 23:27:12 : DEBUG : surfdrive : blockingProcesses=surfdrive
2025-03-08 23:27:12 : DEBUG : surfdrive : installerTool=
2025-03-08 23:27:12 : DEBUG : surfdrive : CLIInstaller=
2025-03-08 23:27:12 : DEBUG : surfdrive : CLIArguments=
2025-03-08 23:27:12 : DEBUG : surfdrive : updateTool=
2025-03-08 23:27:12 : DEBUG : surfdrive : updateToolArguments=
2025-03-08 23:27:12 : DEBUG : surfdrive : updateToolRunAsCurrentUser=
2025-03-08 23:27:12 : INFO  : surfdrive : BLOCKING_PROCESS_ACTION=tell_user
2025-03-08 23:27:12 : INFO  : surfdrive : NOTIFY=success
2025-03-08 23:27:12 : INFO  : surfdrive : LOGGING=DEBUG
2025-03-08 23:27:12 : INFO  : surfdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-08 23:27:12 : INFO  : surfdrive : Label type: pkg
2025-03-08 23:27:12 : INFO  : surfdrive : archiveName: SURFdrive.pkg
2025-03-08 23:27:12 : DEBUG : surfdrive : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-08 23:27:12 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2025-03-08 23:27:12 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 5.3.2.15536, on versionKey CFBundleShortVersionString
2025-03-08 23:27:12 : INFO  : surfdrive : appversion: 5.3.2.15536
2025-03-08 23:27:12 : INFO  : surfdrive : Latest version not specified.
2025-03-08 23:27:12 : REQ   : surfdrive : Downloading https://surfdrive.surf.nl/downloads/surfdrive-5.3.2.15536-arm64.pkg to SURFdrive.pkg
2025-03-08 23:27:12 : DEBUG : surfdrive : No Dialog connection, just download
2025-03-08 23:27:22 : INFO  : surfdrive : Downloaded SURFdrive.pkg – Type is  xar archive compressed TOC – SHA is d1da7a9f35402f9f4a1a88f7eef37c2d43667b7c – Size is 29692 kB
2025-03-08 23:27:22 : DEBUG : surfdrive : DEBUG mode 1, not checking for blocking processes
2025-03-08 23:27:22 : REQ   : surfdrive : Installing SURFdrive
2025-03-08 23:27:22 : INFO  : surfdrive : Verifying: SURFdrive.pkg
2025-03-08 23:27:22 : DEBUG : surfdrive : File list: -rw-r--r--@ 1 h.lans  admin    28M Mar  8 23:27 SURFdrive.pkg
2025-03-08 23:27:22 : DEBUG : surfdrive : File type: SURFdrive.pkg: xar archive compressed TOC: 5337, SHA-1 checksum
2025-03-08 23:27:23 : DEBUG : surfdrive : spctlOut is SURFdrive.pkg: accepted
2025-03-08 23:27:23 : DEBUG : surfdrive : source=Notarized Developer ID
2025-03-08 23:27:23 : DEBUG : surfdrive : origin=Developer ID Installer: ownCloud GmbH (4AP2STM4H5)
2025-03-08 23:27:23 : INFO  : surfdrive : Team ID: 4AP2STM4H5 (expected: 4AP2STM4H5 )
2025-03-08 23:27:23 : DEBUG : surfdrive : DEBUG enabled, skipping installation
2025-03-08 23:27:23 : INFO  : surfdrive : Finishing...
2025-03-08 23:27:26 : INFO  : surfdrive : App(s) found: /Applications/surfdrive.app
2025-03-08 23:27:26 : INFO  : surfdrive : found app at /Applications/surfdrive.app, version 5.3.2.15536, on versionKey CFBundleShortVersionString
2025-03-08 23:27:26 : REQ   : surfdrive : Installed SURFdrive
2025-03-08 23:27:26 : INFO  : surfdrive : notifying
2025-03-08 23:27:26 : DEBUG : surfdrive : DEBUG mode 1, not reopening anything
2025-03-08 23:27:26 : REQ   : surfdrive : All done!
2025-03-08 23:27:26 : REQ   : surfdrive : ################## End Installomator, exit code 0
````