### PR TITLE
Snagit2025 label

### DIFF
--- a/fragments/labels/snagit2024.sh
+++ b/fragments/labels/snagit2024.sh
@@ -1,4 +1,3 @@
-snagit|\
 snagit2024)
     name="Snagit 2024"
     type="dmg"

--- a/fragments/labels/snagit2025.sh
+++ b/fragments/labels/snagit2025.sh
@@ -1,0 +1,12 @@
+snagit|\
+snagit2025)
+    name="Snagit"
+    type="dmg"
+    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" \
+        -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" |\
+        grep -A 3 "Snagit (Mac) 2025" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" \
+        -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" |\
+        grep "Snagit (Mac) 2025" | sed -e 's/.*Snagit (Mac) //' -e 's/<\/td>.*//' -e 's/<\/p>//')
+    expectedTeamID="7TQL462TU8"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
In order to be more consistent with camtasia and other labels with different years I renamed the current snagit label to snagit 2024, and then added a snagit 2025 label. I also made snagit 2025 the default snagit installer (when it's invoked simply as 'snagit') and removed that from the snagit 2024 label.


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
bowmanj17@S23156-CIT Installomator % sudo ./build/Installomator.sh snagit DEBUG=0
2025-03-10 14:28:39 : INFO  : snagit : setting variable from argument DEBUG=0
2025-03-10 14:28:39 : INFO  : snagit : Total items in argumentsArray: 1
2025-03-10 14:28:39 : INFO  : snagit : argumentsArray: DEBUG=0
2025-03-10 14:28:39 : REQ   : snagit : ################## Start Installomator v. 10.8beta, date 2025-03-10
2025-03-10 14:28:39 : INFO  : snagit : ################## Version: 10.8beta
2025-03-10 14:28:39 : INFO  : snagit : ################## Date: 2025-03-10
2025-03-10 14:28:39 : INFO  : snagit : ################## snagit
2025-03-10 14:28:40 : INFO  : snagit : Reading arguments again: DEBUG=0
2025-03-10 14:28:40 : INFO  : snagit : BLOCKING_PROCESS_ACTION=tell_user
2025-03-10 14:28:40 : INFO  : snagit : NOTIFY=success
2025-03-10 14:28:40 : INFO  : snagit : LOGGING=INFO
2025-03-10 14:28:40 : INFO  : snagit : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-10 14:28:40 : INFO  : snagit : Label type: dmg
2025-03-10 14:28:40 : INFO  : snagit : archiveName: Snagit.dmg
2025-03-10 14:28:40 : INFO  : snagit : no blocking processes defined, using Snagit as default
2025-03-10 14:28:40 : INFO  : snagit : App(s) found: /Applications/Snagit.app
2025-03-10 14:28:40 : INFO  : snagit : found app at /Applications/Snagit.app, version 2025.0.0, on versionKey CFBundleShortVersionString
2025-03-10 14:28:40 : INFO  : snagit : appversion: 2025.0.0
2025-03-10 14:28:40 : INFO  : snagit : Latest version of Snagit is 2025.0.0
2025-03-10 14:28:40 : INFO  : snagit : There is no newer version available.
2025-03-10 14:28:40 : INFO  : snagit : Installomator did not close any apps, so no need to reopen any apps.
2025-03-10 14:28:40 : REQ   : snagit : No newer version.
2025-03-10 14:28:40 : REQ   : snagit : ################## End Installomator, exit code 0 
```
