### PR TITLE
Update crashplan

### DIFF
--- a/fragments/labels/crashplan.sh
+++ b/fragments/labels/crashplan.sh
@@ -1,6 +1,5 @@
 crashplan)
     name="CrashPlan"
-    appName="CrashPlan.app"
     type="pkgInDmg"
     downloadURL="https://download.crashplan.com/installs/agent/latest-mac.dmg"
     appNewVersion=$( curl -sfI https://download.crashplan.com/installs/agent/latest-mac.dmg | awk -F'/' '/Location: /{print $7}' )


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `appname`
#1853 talks about merging `crashplan` and `crashplansmb`


**Installomator log**
````
./assemble.sh crashplan
2025-03-15 21:52:48 : INFO  : crashplan : Total items in argumentsArray: 0
2025-03-15 21:52:48 : INFO  : crashplan : argumentsArray:
2025-03-15 21:52:48 : REQ   : crashplan : ################## Start Installomator v. 10.8beta, date 2025-03-15
2025-03-15 21:52:48 : INFO  : crashplan : ################## Version: 10.8beta
2025-03-15 21:52:48 : INFO  : crashplan : ################## Date: 2025-03-15
2025-03-15 21:52:48 : INFO  : crashplan : ################## crashplan
2025-03-15 21:52:48 : DEBUG : crashplan : DEBUG mode 1 enabled.
2025-03-15 21:52:49 : INFO  : crashplan : Reading arguments again:
2025-03-15 21:52:49 : DEBUG : crashplan : name=CrashPlan
2025-03-15 21:52:49 : DEBUG : crashplan : appName=
2025-03-15 21:52:49 : DEBUG : crashplan : type=pkgInDmg
2025-03-15 21:52:49 : DEBUG : crashplan : archiveName=CrashPlan_11.5.0_445_Mac.dmg
2025-03-15 21:52:49 : DEBUG : crashplan : downloadURL=https://download.crashplan.com/installs/agent/latest-mac.dmg
2025-03-15 21:52:49 : DEBUG : crashplan : curlOptions=
2025-03-15 21:52:49 : DEBUG : crashplan : appNewVersion=11.5.0
2025-03-15 21:52:49 : DEBUG : crashplan : appCustomVersion function: Not defined
2025-03-15 21:52:49 : DEBUG : crashplan : versionKey=CFBundleShortVersionString
2025-03-15 21:52:49 : DEBUG : crashplan : packageID=com.crashplan.app.pkg
2025-03-15 21:52:49 : DEBUG : crashplan : pkgName=Install CrashPlan.pkg
2025-03-15 21:52:49 : DEBUG : crashplan : choiceChangesXML=
2025-03-15 21:52:49 : DEBUG : crashplan : expectedTeamID=UGHXR79U6M
2025-03-15 21:52:49 : DEBUG : crashplan : blockingProcesses=
2025-03-15 21:52:49 : DEBUG : crashplan : installerTool=
2025-03-15 21:52:49 : DEBUG : crashplan : CLIInstaller=
2025-03-15 21:52:49 : DEBUG : crashplan : CLIArguments=
2025-03-15 21:52:49 : DEBUG : crashplan : updateTool=
2025-03-15 21:52:49 : DEBUG : crashplan : updateToolArguments=
2025-03-15 21:52:49 : DEBUG : crashplan : updateToolRunAsCurrentUser=
2025-03-15 21:52:49 : INFO  : crashplan : BLOCKING_PROCESS_ACTION=tell_user
2025-03-15 21:52:49 : INFO  : crashplan : NOTIFY=success
2025-03-15 21:52:49 : INFO  : crashplan : LOGGING=DEBUG
2025-03-15 21:52:49 : INFO  : crashplan : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-15 21:52:49 : INFO  : crashplan : Label type: pkgInDmg
2025-03-15 21:52:49 : INFO  : crashplan : archiveName: CrashPlan_11.5.0_445_Mac.dmg
2025-03-15 21:52:49 : INFO  : crashplan : no blocking processes defined, using CrashPlan as default
2025-03-15 21:52:49 : DEBUG : crashplan : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-15 21:52:49 : INFO  : crashplan : No version found using packageID com.crashplan.app.pkg
2025-03-15 21:52:49 : INFO  : crashplan : name: CrashPlan, appName: CrashPlan.app
2025-03-15 21:52:50 : WARN  : crashplan : No previous app found
2025-03-15 21:52:50 : WARN  : crashplan : could not find CrashPlan.app
2025-03-15 21:52:50 : INFO  : crashplan : appversion:
2025-03-15 21:52:50 : INFO  : crashplan : Latest version of CrashPlan is 11.5.0
 exists and DEBUG mode 1 enabled, skipping download_11.5.0_445_Mac.dmg
2025-03-15 21:52:50 : DEBUG : crashplan : DEBUG mode 1, not checking for blocking processes
2025-03-15 21:52:50 : REQ   : crashplan : Installing CrashPlan
2025-03-15 21:52:50 : INFO  : crashplan : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/CrashPlan_11.5.0_445_Mac.dmg
2025-03-15 21:52:50 : DEBUG : crashplan : Debugging enabled, dmgmount output was:
expected CRC32 $10CACAAC
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/CrashPlan

2025-03-15 21:52:50 : INFO  : crashplan : Mounted: /Volumes/CrashPlan
2025-03-15 21:52:50 : INFO  : crashplan : found pkg: /Volumes/CrashPlan/Install CrashPlan.pkg
2025-03-15 21:52:50 : INFO  : crashplan : Verifying: /Volumes/CrashPlan/Install CrashPlan.pkg
2025-03-15 21:52:50 : DEBUG : crashplan : File list: -rw-r--r--@ 1 h.lans  2094862921   344M Nov  6 01:42 /Volumes/CrashPlan/Install CrashPlan.pkg
2025-03-15 21:52:50 : DEBUG : crashplan : File type: /Volumes/CrashPlan/Install CrashPlan.pkg: xar archive compressed TOC: 4713, SHA-1 checksum
2025-03-15 21:52:50 : DEBUG : crashplan : spctlOut is /Volumes/CrashPlan/Install CrashPlan.pkg: accepted
2025-03-15 21:52:50 : DEBUG : crashplan : source=Notarized Developer ID
2025-03-15 21:52:50 : DEBUG : crashplan : origin=Developer ID Installer: CrashPlan Group, LLC (UGHXR79U6M)
2025-03-15 21:52:50 : INFO  : crashplan : Team ID: UGHXR79U6M (expected: UGHXR79U6M )
2025-03-15 21:52:50 : DEBUG : crashplan : DEBUG enabled, skipping installation
2025-03-15 21:52:50 : INFO  : crashplan : Finishing...
2025-03-15 21:52:53 : INFO  : crashplan : No version found using packageID com.crashplan.app.pkg
2025-03-15 21:52:53 : INFO  : crashplan : name: CrashPlan, appName: CrashPlan.app
2025-03-15 21:52:53 : WARN  : crashplan : No previous app found
2025-03-15 21:52:53 : WARN  : crashplan : could not find CrashPlan.app
2025-03-15 21:52:53 : REQ   : crashplan : Installed CrashPlan, version 11.5.0
2025-03-15 21:52:53 : INFO  : crashplan : notifying
2025-03-15 21:52:53 : DEBUG : crashplan : Unmounting /Volumes/CrashPlan
2025-03-15 21:52:53 : DEBUG : crashplan : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-15 21:52:53 : DEBUG : crashplan : DEBUG mode 1, not reopening anything
2025-03-15 21:52:53 : REQ   : crashplan : All done!
2025-03-15 21:52:53 : REQ   : crashplan : ################## End Installomator, exit code 0
````
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
