### PR TITLE
Update garminexpress

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -6,5 +6,4 @@ garminexpress)
     garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')
     appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print}').0"
     expectedTeamID="72ES32VZUA"
-    appName="Garmin Express.app"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `appname`

**Installomator log**
````
./assemble.sh garminexpress
2025-03-16 01:18:34 : INFO  : garminexpress : Total items in argumentsArray: 0
2025-03-16 01:18:34 : INFO  : garminexpress : argumentsArray:
2025-03-16 01:18:34 : REQ   : garminexpress : ################## Start Installomator v. 10.8beta, date 2025-03-16
2025-03-16 01:18:34 : INFO  : garminexpress : ################## Version: 10.8beta
2025-03-16 01:18:34 : INFO  : garminexpress : ################## Date: 2025-03-16
2025-03-16 01:18:34 : INFO  : garminexpress : ################## garminexpress
2025-03-16 01:18:34 : DEBUG : garminexpress : DEBUG mode 1 enabled.
2025-03-16 01:18:35 : INFO  : garminexpress : Reading arguments again:
2025-03-16 01:18:35 : DEBUG : garminexpress : name=Garmin Express
2025-03-16 01:18:35 : DEBUG : garminexpress : appName=
2025-03-16 01:18:35 : DEBUG : garminexpress : type=pkgInDmg
2025-03-16 01:18:35 : DEBUG : garminexpress : archiveName=
2025-03-16 01:18:35 : DEBUG : garminexpress : downloadURL=https://download.garmin.com/omt/express/GarminExpress.dmg
2025-03-16 01:18:35 : DEBUG : garminexpress : curlOptions=
2025-03-16 01:18:35 : DEBUG : garminexpress : appNewVersion=7.24.0.0
2025-03-16 01:18:35 : DEBUG : garminexpress : appCustomVersion function: Not defined
2025-03-16 01:18:35 : DEBUG : garminexpress : versionKey=CFBundleShortVersionString
2025-03-16 01:18:35 : DEBUG : garminexpress : packageID=
2025-03-16 01:18:35 : DEBUG : garminexpress : pkgName=
2025-03-16 01:18:35 : DEBUG : garminexpress : choiceChangesXML=
2025-03-16 01:18:35 : DEBUG : garminexpress : expectedTeamID=72ES32VZUA
2025-03-16 01:18:35 : DEBUG : garminexpress : blockingProcesses=Garmin Express Garmin Express Service
2025-03-16 01:18:35 : DEBUG : garminexpress : installerTool=
2025-03-16 01:18:35 : DEBUG : garminexpress : CLIInstaller=
2025-03-16 01:18:35 : DEBUG : garminexpress : CLIArguments=
2025-03-16 01:18:35 : DEBUG : garminexpress : updateTool=
2025-03-16 01:18:35 : DEBUG : garminexpress : updateToolArguments=
2025-03-16 01:18:35 : DEBUG : garminexpress : updateToolRunAsCurrentUser=
2025-03-16 01:18:35 : INFO  : garminexpress : BLOCKING_PROCESS_ACTION=tell_user
2025-03-16 01:18:35 : INFO  : garminexpress : NOTIFY=success
2025-03-16 01:18:35 : INFO  : garminexpress : LOGGING=DEBUG
2025-03-16 01:18:35 : INFO  : garminexpress : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-16 01:18:35 : INFO  : garminexpress : Label type: pkgInDmg
2025-03-16 01:18:35 : INFO  : garminexpress : archiveName: Garmin Express.dmg
2025-03-16 01:18:35 : DEBUG : garminexpress : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-16 01:18:35 : INFO  : garminexpress : name: Garmin Express, appName: Garmin Express.app
2025-03-16 01:18:35 : WARN  : garminexpress : No previous app found
2025-03-16 01:18:35 : WARN  : garminexpress : could not find Garmin Express.app
2025-03-16 01:18:35 : INFO  : garminexpress : appversion:
2025-03-16 01:18:35 : INFO  : garminexpress : Latest version of Garmin Express is 7.24.0.0
2025-03-16 01:18:35 : INFO  : garminexpress : Garmin Express.dmg exists and DEBUG mode 1 enabled, skipping download
2025-03-16 01:18:35 : DEBUG : garminexpress : DEBUG mode 1, not checking for blocking processes
2025-03-16 01:18:35 : REQ   : garminexpress : Installing Garmin Express
2025-03-16 01:18:35 : INFO  : garminexpress : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Garmin Express.dmg
2025-03-16 01:18:35 : DEBUG : garminexpress : Debugging enabled, dmgmount output was:
expected CRC32 $D6921E28
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Garmin Express

2025-03-16 01:18:35 : INFO  : garminexpress : Mounted: /Volumes/Garmin Express
2025-03-16 01:18:35 : DEBUG : garminexpress : Found pkg(s):
/Volumes/Garmin Express/Install Garmin Express.pkg
2025-03-16 01:18:35 : INFO  : garminexpress : found pkg: /Volumes/Garmin Express/Install Garmin Express.pkg
2025-03-16 01:18:35 : INFO  : garminexpress : Verifying: /Volumes/Garmin Express/Install Garmin Express.pkg
2025-03-16 01:18:35 : DEBUG : garminexpress : File list: -rw-r--r--@ 1 h.lans  2094862921    43M Nov  5 21:49 /Volumes/Garmin Express/Install Garmin Express.pkg
2025-03-16 01:18:35 : DEBUG : garminexpress : File type: /Volumes/Garmin Express/Install Garmin Express.pkg: xar archive compressed TOC: 9583, SHA-1 checksum
2025-03-16 01:18:35 : DEBUG : garminexpress : spctlOut is /Volumes/Garmin Express/Install Garmin Express.pkg: accepted
2025-03-16 01:18:35 : DEBUG : garminexpress : source=Notarized Developer ID
2025-03-16 01:18:35 : DEBUG : garminexpress : origin=Developer ID Installer: Garmin International (72ES32VZUA)
2025-03-16 01:18:35 : INFO  : garminexpress : Team ID: 72ES32VZUA (expected: 72ES32VZUA )
2025-03-16 01:18:35 : DEBUG : garminexpress : DEBUG enabled, skipping installation
2025-03-16 01:18:35 : INFO  : garminexpress : Finishing...
2025-03-16 01:18:38 : INFO  : garminexpress : name: Garmin Express, appName: Garmin Express.app
2025-03-16 01:18:38 : WARN  : garminexpress : No previous app found
2025-03-16 01:18:38 : WARN  : garminexpress : could not find Garmin Express.app
2025-03-16 01:18:38 : REQ   : garminexpress : Installed Garmin Express, version 7.24.0.0
2025-03-16 01:18:38 : INFO  : garminexpress : notifying
2025-03-16 01:18:38 : DEBUG : garminexpress : Unmounting /Volumes/Garmin Express
2025-03-16 01:18:38 : DEBUG : garminexpress : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-16 01:18:38 : DEBUG : garminexpress : DEBUG mode 1, not reopening anything
2025-03-16 01:18:38 : REQ   : garminexpress : All done!
2025-03-16 01:18:38 : REQ   : garminexpress : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
