### PR TITLE
Update keyaccess

### DIFF
--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,7 +1,7 @@
 keyaccess)
     name="KeyAccess"
     type="pkg"
-    downloadStore="$(curl -s "http://www.sassafras.com/client-download/" | tr '>' '\n')"
+    downloadStore="$(curl -sL "http://www.sassafras.com/client-download/" | tr '>' '\n')"
     downloadURL="$(echo "$downloadStore" | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
     appNewVersion="$(echo "$downloadStore" | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
     expectedTeamID="7Z2KSDFMVY"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
-L added to curl fixed the 'The document has moved' issue.

**Installomator log**
````
./assemble.sh keyaccess
2025-03-16 21:39:31 : INFO  : keyaccess : Total items in argumentsArray: 0
2025-03-16 21:39:31 : INFO  : keyaccess : argumentsArray:
2025-03-16 21:39:31 : REQ   : keyaccess : ################## Start Installomator v. 10.8beta, date 2025-03-16
2025-03-16 21:39:31 : INFO  : keyaccess : ################## Version: 10.8beta
2025-03-16 21:39:31 : INFO  : keyaccess : ################## Date: 2025-03-16
2025-03-16 21:39:31 : INFO  : keyaccess : ################## keyaccess
2025-03-16 21:39:31 : DEBUG : keyaccess : DEBUG mode 1 enabled.
2025-03-16 21:39:33 : INFO  : keyaccess : Reading arguments again:
2025-03-16 21:39:33 : DEBUG : keyaccess : name=KeyAccess
2025-03-16 21:39:33 : DEBUG : keyaccess : appName=Library/KeyAccess/KeyAccess.app
2025-03-16 21:39:33 : DEBUG : keyaccess : type=pkg
2025-03-16 21:39:33 : DEBUG : keyaccess : archiveName=
2025-03-16 21:39:33 : DEBUG : keyaccess : downloadURL=https://www.sassafras.com/links/ksp-client-80-latest.pkg
2025-03-16 21:39:33 : DEBUG : keyaccess : curlOptions=
2025-03-16 21:39:33 : DEBUG : keyaccess : appNewVersion=8.0.0.9
2025-03-16 21:39:33 : DEBUG : keyaccess : appCustomVersion function: Not defined
2025-03-16 21:39:33 : DEBUG : keyaccess : versionKey=CFBundleShortVersionString
2025-03-16 21:39:33 : DEBUG : keyaccess : packageID=
2025-03-16 21:39:33 : DEBUG : keyaccess : pkgName=
2025-03-16 21:39:33 : DEBUG : keyaccess : choiceChangesXML=
2025-03-16 21:39:33 : DEBUG : keyaccess : expectedTeamID=7Z2KSDFMVY
2025-03-16 21:39:33 : DEBUG : keyaccess : blockingProcesses=NONE
2025-03-16 21:39:33 : DEBUG : keyaccess : installerTool=
2025-03-16 21:39:33 : DEBUG : keyaccess : CLIInstaller=
2025-03-16 21:39:33 : DEBUG : keyaccess : CLIArguments=
2025-03-16 21:39:33 : DEBUG : keyaccess : updateTool=
2025-03-16 21:39:33 : DEBUG : keyaccess : updateToolArguments=
2025-03-16 21:39:33 : DEBUG : keyaccess : updateToolRunAsCurrentUser=
2025-03-16 21:39:33 : INFO  : keyaccess : BLOCKING_PROCESS_ACTION=ignore
2025-03-16 21:39:33 : INFO  : keyaccess : NOTIFY=success
2025-03-16 21:39:33 : INFO  : keyaccess : LOGGING=DEBUG
2025-03-16 21:39:33 : INFO  : keyaccess : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-16 21:39:33 : INFO  : keyaccess : Label type: pkg
2025-03-16 21:39:33 : INFO  : keyaccess : archiveName: KeyAccess.pkg
2025-03-16 21:39:33 : DEBUG : keyaccess : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-16 21:39:33 : INFO  : keyaccess : name: KeyAccess, appName: Library/KeyAccess/KeyAccess.app
2025-03-16 21:39:33 : WARN  : keyaccess : No previous app found
2025-03-16 21:39:33 : WARN  : keyaccess : could not find Library/KeyAccess/KeyAccess.app
2025-03-16 21:39:33 : INFO  : keyaccess : appversion:
2025-03-16 21:39:33 : INFO  : keyaccess : Latest version of KeyAccess is 8.0.0.9
2025-03-16 21:39:33 : REQ   : keyaccess : Downloading https://www.sassafras.com/links/ksp-client-80-latest.pkg to KeyAccess.pkg
2025-03-16 21:39:33 : DEBUG : keyaccess : No Dialog connection, just download
2025-03-16 21:39:35 : INFO  : keyaccess : Downloaded KeyAccess.pkg – Type is  xar archive compressed TOC – SHA is 27f6550c584dbd7f7196c53236e41286f0504213 – Size is 4156 kB
2025-03-16 21:39:35 : INFO  : keyaccess : ignoring blocking processes
2025-03-16 21:39:35 : REQ   : keyaccess : Installing KeyAccess
2025-03-16 21:39:35 : INFO  : keyaccess : Verifying: KeyAccess.pkg
2025-03-16 21:39:35 : DEBUG : keyaccess : File list: -rw-r--r--@ 1 h.lans  admin   3.3M Mar 16 21:39 KeyAccess.pkg
2025-03-16 21:39:35 : DEBUG : keyaccess : File type: KeyAccess.pkg: xar archive compressed TOC: 5922, SHA-1 checksum
2025-03-16 21:39:35 : DEBUG : keyaccess : spctlOut is KeyAccess.pkg: accepted
2025-03-16 21:39:35 : DEBUG : keyaccess : source=Notarized Developer ID
2025-03-16 21:39:35 : DEBUG : keyaccess : origin=Developer ID Installer: Sassafras Software, Inc. (7Z2KSDFMVY)
2025-03-16 21:39:35 : INFO  : keyaccess : Team ID: 7Z2KSDFMVY (expected: 7Z2KSDFMVY )
2025-03-16 21:39:35 : DEBUG : keyaccess : DEBUG enabled, skipping installation
2025-03-16 21:39:35 : INFO  : keyaccess : Finishing...
2025-03-16 21:39:38 : INFO  : keyaccess : name: KeyAccess, appName: Library/KeyAccess/KeyAccess.app
2025-03-16 21:39:38 : WARN  : keyaccess : No previous app found
2025-03-16 21:39:38 : WARN  : keyaccess : could not find Library/KeyAccess/KeyAccess.app
2025-03-16 21:39:38 : REQ   : keyaccess : Installed KeyAccess, version 8.0.0.9
2025-03-16 21:39:38 : INFO  : keyaccess : notifying
2025-03-16 21:39:39 : DEBUG : keyaccess : DEBUG mode 1, not reopening anything
2025-03-16 21:39:39 : REQ   : keyaccess : All done!
2025-03-16 21:39:39 : REQ   : keyaccess : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2214 