### PR TITLE
Update mmhmm-studio

### DIFF
--- a/fragments/labels/mmhmm-studio.sh
+++ b/fragments/labels/mmhmm-studio.sh
@@ -1,6 +1,5 @@
 mmhmm-studio)
     name="mmhmm Studio"
-    appName="mmhmm Studio.app"
     type="pkg"
     downloadURL="https://updates.mmhmm.app/mac/mmhmmStudio.pkg"
     curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15" )


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `appName`

**Installomator log** 
````
./assemble.sh mmhmm-studio
2025-03-17 17:38:19 : INFO  : mmhmm-studio : Total items in argumentsArray: 0
2025-03-17 17:38:19 : INFO  : mmhmm-studio : argumentsArray:
2025-03-17 17:38:19 : REQ   : mmhmm-studio : ################## Start Installomator v. 10.8beta, date 2025-03-17
2025-03-17 17:38:19 : INFO  : mmhmm-studio : ################## Version: 10.8beta
2025-03-17 17:38:19 : INFO  : mmhmm-studio : ################## Date: 2025-03-17
2025-03-17 17:38:19 : INFO  : mmhmm-studio : ################## mmhmm-studio
2025-03-17 17:38:19 : DEBUG : mmhmm-studio : DEBUG mode 1 enabled.
2025-03-17 17:38:20 : INFO  : mmhmm-studio : Reading arguments again:
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : name=mmhmm Studio
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : appName=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : type=pkg
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : archiveName=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : downloadURL=https://updates.mmhmm.app/mac/mmhmmStudio.pkg
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : appNewVersion=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : appCustomVersion function: Not defined
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : versionKey=CFBundleShortVersionString
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : packageID=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : pkgName=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : choiceChangesXML=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : expectedTeamID=M3KUT44L48
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : blockingProcesses=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : installerTool=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : CLIInstaller=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : CLIArguments=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : updateTool=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : updateToolArguments=
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : updateToolRunAsCurrentUser=
2025-03-17 17:38:20 : INFO  : mmhmm-studio : BLOCKING_PROCESS_ACTION=tell_user
2025-03-17 17:38:20 : INFO  : mmhmm-studio : NOTIFY=success
2025-03-17 17:38:20 : INFO  : mmhmm-studio : LOGGING=DEBUG
2025-03-17 17:38:20 : INFO  : mmhmm-studio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-17 17:38:20 : INFO  : mmhmm-studio : Label type: pkg
2025-03-17 17:38:20 : INFO  : mmhmm-studio : archiveName: mmhmm Studio.pkg
2025-03-17 17:38:20 : INFO  : mmhmm-studio : no blocking processes defined, using mmhmm Studio as default
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-17 17:38:20 : INFO  : mmhmm-studio : name: mmhmm Studio, appName: mmhmm Studio.app
2025-03-17 17:38:20 : WARN  : mmhmm-studio : No previous app found
2025-03-17 17:38:20 : WARN  : mmhmm-studio : could not find mmhmm Studio.app
2025-03-17 17:38:20 : INFO  : mmhmm-studio : appversion:
2025-03-17 17:38:20 : INFO  : mmhmm-studio : Latest version not specified.
2025-03-17 17:38:20 : REQ   : mmhmm-studio : Downloading https://updates.mmhmm.app/mac/mmhmmStudio.pkg to mmhmm Studio.pkg
2025-03-17 17:38:20 : DEBUG : mmhmm-studio : No Dialog connection, just download
2025-03-17 17:38:44 : INFO  : mmhmm-studio : Downloaded mmhmm Studio.pkg – Type is  xar archive compressed TOC – SHA is 57f7b532869e035c5283bd0c99861bf06e42e5e4 – Size is 147832 kB
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : DEBUG mode 1, not checking for blocking processes
2025-03-17 17:38:44 : REQ   : mmhmm-studio : Installing mmhmm Studio
2025-03-17 17:38:44 : INFO  : mmhmm-studio : Verifying: mmhmm Studio.pkg
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : File list: -rw-r--r--@ 1 h.lans  admin   139M Mar 17 17:38 mmhmm Studio.pkg
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : File type: mmhmm Studio.pkg: xar archive compressed TOC: 4240, SHA-1 checksum
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : spctlOut is mmhmm Studio.pkg: accepted
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : source=Notarized Developer ID
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : origin=Developer ID Installer: mmhmm inc. (M3KUT44L48)
2025-03-17 17:38:44 : INFO  : mmhmm-studio : Team ID: M3KUT44L48 (expected: M3KUT44L48 )
2025-03-17 17:38:44 : DEBUG : mmhmm-studio : DEBUG enabled, skipping installation
2025-03-17 17:38:44 : INFO  : mmhmm-studio : Finishing...
2025-03-17 17:38:47 : INFO  : mmhmm-studio : name: mmhmm Studio, appName: mmhmm Studio.app
2025-03-17 17:38:47 : WARN  : mmhmm-studio : No previous app found
2025-03-17 17:38:47 : WARN  : mmhmm-studio : could not find mmhmm Studio.app
2025-03-17 17:38:47 : REQ   : mmhmm-studio : Installed mmhmm Studio
2025-03-17 17:38:47 : INFO  : mmhmm-studio : notifying
2025-03-17 17:38:47 : DEBUG : mmhmm-studio : DEBUG mode 1, not reopening anything
2025-03-17 17:38:47 : REQ   : mmhmm-studio : All done!
2025-03-17 17:38:47 : REQ   : mmhmm-studio : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
