### PR TITLE
Update namiral

### DIFF
--- a/fragments/labels/namiral.sh
+++ b/fragments/labels/namiral.sh
@@ -3,5 +3,4 @@ namiral)
     type="dmg"
     downloadURL="https://sign-be.namirial.app/download/macos"
     expectedTeamID="V7PV54FASQ"
-    appName="Namirial Sign.app"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Remove unnecessary `appName`
Label has a different name than the app: namiral vs Namirial.

**Installomator log**
````
./assemble.sh namiral
2025-03-17 17:55:25 : INFO  : namiral : Total items in argumentsArray: 0
2025-03-17 17:55:25 : INFO  : namiral : argumentsArray:
2025-03-17 17:55:25 : REQ   : namiral : ################## Start Installomator v. 10.8beta, date 2025-03-17
2025-03-17 17:55:25 : INFO  : namiral : ################## Version: 10.8beta
2025-03-17 17:55:25 : INFO  : namiral : ################## Date: 2025-03-17
2025-03-17 17:55:25 : INFO  : namiral : ################## namiral
2025-03-17 17:55:25 : DEBUG : namiral : DEBUG mode 1 enabled.
2025-03-17 17:55:26 : INFO  : namiral : Reading arguments again:
2025-03-17 17:55:26 : DEBUG : namiral : name=Namirial Sign
2025-03-17 17:55:26 : DEBUG : namiral : appName=
2025-03-17 17:55:26 : DEBUG : namiral : type=dmg
2025-03-17 17:55:26 : DEBUG : namiral : archiveName=
2025-03-17 17:55:26 : DEBUG : namiral : downloadURL=https://sign-be.namirial.app/download/macos
2025-03-17 17:55:26 : DEBUG : namiral : curlOptions=
2025-03-17 17:55:26 : DEBUG : namiral : appNewVersion=
2025-03-17 17:55:26 : DEBUG : namiral : appCustomVersion function: Not defined
2025-03-17 17:55:26 : DEBUG : namiral : versionKey=CFBundleShortVersionString
2025-03-17 17:55:26 : DEBUG : namiral : packageID=
2025-03-17 17:55:26 : DEBUG : namiral : pkgName=
2025-03-17 17:55:26 : DEBUG : namiral : choiceChangesXML=
2025-03-17 17:55:26 : DEBUG : namiral : expectedTeamID=V7PV54FASQ
2025-03-17 17:55:26 : DEBUG : namiral : blockingProcesses=
2025-03-17 17:55:26 : DEBUG : namiral : installerTool=
2025-03-17 17:55:26 : DEBUG : namiral : CLIInstaller=
2025-03-17 17:55:26 : DEBUG : namiral : CLIArguments=
2025-03-17 17:55:26 : DEBUG : namiral : updateTool=
2025-03-17 17:55:26 : DEBUG : namiral : updateToolArguments=
2025-03-17 17:55:26 : DEBUG : namiral : updateToolRunAsCurrentUser=
2025-03-17 17:55:26 : INFO  : namiral : BLOCKING_PROCESS_ACTION=tell_user
2025-03-17 17:55:26 : INFO  : namiral : NOTIFY=success
2025-03-17 17:55:26 : INFO  : namiral : LOGGING=DEBUG
2025-03-17 17:55:26 : INFO  : namiral : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-17 17:55:26 : INFO  : namiral : Label type: dmg
2025-03-17 17:55:26 : INFO  : namiral : archiveName: Namirial Sign.dmg
2025-03-17 17:55:26 : INFO  : namiral : no blocking processes defined, using Namirial Sign as default
2025-03-17 17:55:26 : DEBUG : namiral : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-17 17:55:26 : INFO  : namiral : name: Namirial Sign, appName: Namirial Sign.app
2025-03-17 17:55:26 : WARN  : namiral : No previous app found
2025-03-17 17:55:26 : WARN  : namiral : could not find Namirial Sign.app
2025-03-17 17:55:26 : INFO  : namiral : appversion:
2025-03-17 17:55:26 : INFO  : namiral : Latest version not specified.
2025-03-17 17:55:26 : REQ   : namiral : Downloading https://sign-be.namirial.app/download/macos to Namirial Sign.dmg
2025-03-17 17:55:26 : DEBUG : namiral : No Dialog connection, just download
2025-03-17 17:55:55 : INFO  : namiral : Downloaded Namirial Sign.dmg – Type is  zlib compressed data – SHA is 0654eb61cf18bd39047b420182c9bc9701d02f13 – Size is 213816 kB
2025-03-17 17:55:55 : DEBUG : namiral : DEBUG mode 1, not checking for blocking processes
2025-03-17 17:55:55 : REQ   : namiral : Installing Namirial Sign
2025-03-17 17:55:55 : INFO  : namiral : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Namirial Sign.dmg
2025-03-17 17:55:59 : DEBUG : namiral : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $4B6AF318
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $2B7BCA1C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $B167D8DE
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $B3E26567
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $B167D8DE
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $CDCE576F
verified CRC32 $A6C93CD6
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Namirial Sign

2025-03-17 17:55:59 : INFO  : namiral : Mounted: /Volumes/Namirial Sign
2025-03-17 17:55:59 : INFO  : namiral : Verifying: /Volumes/Namirial Sign/Namirial Sign.app
2025-03-17 17:55:59 : DEBUG : namiral : App size: 357M	/Volumes/Namirial Sign/Namirial Sign.app
2025-03-17 17:56:00 : DEBUG : namiral : Debugging enabled, App Verification output was:
/Volumes/Namirial Sign/Namirial Sign.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Namirial Spa (V7PV54FASQ)

2025-03-17 17:56:00 : INFO  : namiral : Team ID matching: V7PV54FASQ (expected: V7PV54FASQ )
2025-03-17 17:56:00 : INFO  : namiral : Installing Namirial Sign version 1.1.9 on versionKey CFBundleShortVersionString.
2025-03-17 17:56:00 : INFO  : namiral : App has LSMinimumSystemVersion: 10.11.0
2025-03-17 17:56:00 : DEBUG : namiral : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-03-17 17:56:00 : INFO  : namiral : Finishing...
2025-03-17 17:56:03 : INFO  : namiral : name: Namirial Sign, appName: Namirial Sign.app
2025-03-17 17:56:03 : WARN  : namiral : No previous app found
2025-03-17 17:56:03 : WARN  : namiral : could not find Namirial Sign.app
2025-03-17 17:56:03 : REQ   : namiral : Installed Namirial Sign, version 1.1.9
2025-03-17 17:56:03 : INFO  : namiral : notifying
2025-03-17 17:56:04 : DEBUG : namiral : Unmounting /Volumes/Namirial Sign
2025-03-17 17:56:04 : DEBUG : namiral : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-17 17:56:04 : DEBUG : namiral : DEBUG mode 1, not reopening anything
2025-03-17 17:56:04 : REQ   : namiral : All done!
2025-03-17 17:56:04 : REQ   : namiral : ################## End Installomator, exit code 0
```` 

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
