### PR TITLE
Create sqldeveloper.sh

### DIFF
--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -1,0 +1,7 @@
+sqldeveloper)
+    name="SQLDeveloper"
+    type="zip"
+    downloadURL="https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip"
+    appNewVersion="$(plutil -p /Applications/SQLDeveloper.app/Contents/Info.plist | grep CFBundleShortVersionString | awk -F'"' '{print $4}')"
+    expectedTeamID="VB5E2TV963"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

2025-03-17 15:36:43 : INFO  : sqldeveloper : setting variable from argument DEBUG=1 2025-03-17 15:36:43 : INFO  : sqldeveloper : Total items in argumentsArray: 1 2025-03-17 15:36:43 : INFO  : sqldeveloper : argumentsArray: DEBUG=1
2025-03-17 15:36:43 : REQ   : sqldeveloper : ################## Start Installomator v. 10.8beta, date 2025-03-17
2025-03-17 15:36:43 : INFO  : sqldeveloper : ################## Version: 10.8beta
2025-03-17 15:36:43 : INFO  : sqldeveloper : ################## Date: 2025-03-17
2025-03-17 15:36:43 : INFO  : sqldeveloper : ################## sqldeveloper
2025-03-17 15:36:43 : DEBUG : sqldeveloper : DEBUG mode 1 enabled.
2025-03-17 15:36:43 : INFO  : sqldeveloper : Reading arguments again: DEBUG=1
2025-03-17 15:36:43 : DEBUG : sqldeveloper : argument: DEBUG=1
2025-03-17 15:36:43 : DEBUG : sqldeveloper : name=SQLDeveloper
2025-03-17 15:36:43 : DEBUG : sqldeveloper : appName=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : type=zip
2025-03-17 15:36:43 : DEBUG : sqldeveloper : archiveName=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : downloadURL=https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip
2025-03-17 15:36:43 : DEBUG : sqldeveloper : curlOptions=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : appNewVersion=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : appCustomVersion function: Not defined
2025-03-17 15:36:43 : DEBUG : sqldeveloper : versionKey=CFBundleShortVersionString
2025-03-17 15:36:43 : DEBUG : sqldeveloper : packageID=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : pkgName=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : choiceChangesXML=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : expectedTeamID=VB5E2TV963
2025-03-17 15:36:43 : DEBUG : sqldeveloper : blockingProcesses=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : installerTool=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : CLIInstaller=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : CLIArguments=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : updateTool=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : updateToolArguments=
2025-03-17 15:36:43 : DEBUG : sqldeveloper : updateToolRunAsCurrentUser=
2025-03-17 15:36:44 : INFO  : sqldeveloper : BLOCKING_PROCESS_ACTION=tell_user
2025-03-17 15:36:44 : INFO  : sqldeveloper : NOTIFY=success
2025-03-17 15:36:44 : INFO  : sqldeveloper : LOGGING=DEBUG
2025-03-17 15:36:44 : INFO  : sqldeveloper : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-17 15:36:44 : INFO  : sqldeveloper : Label type: zip
2025-03-17 15:36:44 : INFO  : sqldeveloper : archiveName: SQLDeveloper.zip
2025-03-17 15:36:44 : INFO  : sqldeveloper : no blocking processes defined, using SQLDeveloper as default
2025-03-17 15:36:44 : DEBUG : sqldeveloper : Changing directory to /Users/daniel.ross/GitHub/Installomator/build
2025-03-17 15:36:44 : INFO  : sqldeveloper : name: SQLDeveloper, appName: SQLDeveloper.app
2025-03-17 15:36:44 : INFO  : sqldeveloper : App(s) found: /Users/daniel.ross/GitHub/Installomator/build/SQLDeveloper.app
2025-03-17 15:36:44 : WARN  : sqldeveloper : could not determine location of SQLDeveloper.app
2025-03-17 15:36:44 : INFO  : sqldeveloper : appversion:
2025-03-17 15:36:44 : INFO  : sqldeveloper : Latest version not specified.
2025-03-17 15:36:44 : REQ   : sqldeveloper : Downloading https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip to SQLDeveloper.zip
2025-03-17 15:36:44 : DEBUG : sqldeveloper : No Dialog connection, just download
2025-03-17 15:37:01 : INFO  : sqldeveloper : Downloaded SQLDeveloper.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is d4838de3cf62320e96f289f94b854391f8cd8077 – Size is 540824 kB
2025-03-17 15:37:01 : DEBUG : sqldeveloper : DEBUG mode 1, not checking for blocking processes
2025-03-17 15:37:01 : REQ   : sqldeveloper : Installing SQLDeveloper
2025-03-17 15:37:01 : INFO  : sqldeveloper : Unzipping SQLDeveloper.zip
2025-03-17 15:37:05 : INFO  : sqldeveloper : Verifying: /Users/daniel.ross/GitHub/Installomator/build/SQLDeveloper.app
2025-03-17 15:37:05 : DEBUG : sqldeveloper : App size: 770M	/Users/daniel.ross/GitHub/Installomator/build/SQLDeveloper.app
2025-03-17 15:37:05 : DEBUG : sqldeveloper : Debugging enabled, App Verification output was:
/Users/daniel.ross/GitHub/Installomator/build/SQLDeveloper.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Oracle America, Inc. (VB5E2TV963)