### PR TITLE
Update theunarchiver

### DIFF
--- a/fragments/labels/theunarchiver.sh
+++ b/fragments/labels/theunarchiver.sh
@@ -4,5 +4,4 @@ theunarchiver)
     downloadURL="https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg"
     appNewVersion="$(curl -fs "https://theunarchiver.com" | grep -i "Latest version" | head -1 | sed -E 's/.*> ([0-9.]*) .*/\1/g')"
     expectedTeamID="S8EX82NJP6"
-    appName="The Unarchiver.app"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `appName`

**Installomator log** 
````
./assemble.sh theunarchiver
2025-03-18 21:33:58 : INFO  : theunarchiver : Total items in argumentsArray: 0
2025-03-18 21:33:58 : INFO  : theunarchiver : argumentsArray:
2025-03-18 21:33:58 : REQ   : theunarchiver : ################## Start Installomator v. 10.8beta, date 2025-03-18
2025-03-18 21:33:58 : INFO  : theunarchiver : ################## Version: 10.8beta
2025-03-18 21:33:58 : INFO  : theunarchiver : ################## Date: 2025-03-18
2025-03-18 21:33:58 : INFO  : theunarchiver : ################## theunarchiver
2025-03-18 21:33:58 : DEBUG : theunarchiver : DEBUG mode 1 enabled.
2025-03-18 21:33:59 : INFO  : theunarchiver : Reading arguments again:
2025-03-18 21:33:59 : DEBUG : theunarchiver : name=The Unarchiver
2025-03-18 21:33:59 : DEBUG : theunarchiver : appName=
2025-03-18 21:33:59 : DEBUG : theunarchiver : type=dmg
2025-03-18 21:33:59 : DEBUG : theunarchiver : archiveName=
2025-03-18 21:33:59 : DEBUG : theunarchiver : downloadURL=https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg
2025-03-18 21:33:59 : DEBUG : theunarchiver : curlOptions=
2025-03-18 21:33:59 : DEBUG : theunarchiver : appNewVersion=4.3.8
2025-03-18 21:33:59 : DEBUG : theunarchiver : appCustomVersion function: Not defined
2025-03-18 21:33:59 : DEBUG : theunarchiver : versionKey=CFBundleShortVersionString
2025-03-18 21:33:59 : DEBUG : theunarchiver : packageID=
2025-03-18 21:33:59 : DEBUG : theunarchiver : pkgName=
2025-03-18 21:33:59 : DEBUG : theunarchiver : choiceChangesXML=
2025-03-18 21:33:59 : DEBUG : theunarchiver : expectedTeamID=S8EX82NJP6
2025-03-18 21:33:59 : DEBUG : theunarchiver : blockingProcesses=
2025-03-18 21:33:59 : DEBUG : theunarchiver : installerTool=
2025-03-18 21:33:59 : DEBUG : theunarchiver : CLIInstaller=
2025-03-18 21:33:59 : DEBUG : theunarchiver : CLIArguments=
2025-03-18 21:33:59 : DEBUG : theunarchiver : updateTool=
2025-03-18 21:33:59 : DEBUG : theunarchiver : updateToolArguments=
2025-03-18 21:33:59 : DEBUG : theunarchiver : updateToolRunAsCurrentUser=
2025-03-18 21:33:59 : INFO  : theunarchiver : BLOCKING_PROCESS_ACTION=tell_user
2025-03-18 21:33:59 : INFO  : theunarchiver : NOTIFY=success
2025-03-18 21:33:59 : INFO  : theunarchiver : LOGGING=DEBUG
2025-03-18 21:33:59 : INFO  : theunarchiver : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-18 21:33:59 : INFO  : theunarchiver : Label type: dmg
2025-03-18 21:33:59 : INFO  : theunarchiver : archiveName: The Unarchiver.dmg
2025-03-18 21:33:59 : INFO  : theunarchiver : no blocking processes defined, using The Unarchiver as default
2025-03-18 21:33:59 : DEBUG : theunarchiver : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-18 21:33:59 : INFO  : theunarchiver : name: The Unarchiver, appName: The Unarchiver.app
2025-03-18 21:33:59 : WARN  : theunarchiver : No previous app found
2025-03-18 21:33:59 : WARN  : theunarchiver : could not find The Unarchiver.app
2025-03-18 21:33:59 : INFO  : theunarchiver : appversion:
2025-03-18 21:33:59 : INFO  : theunarchiver : Latest version of The Unarchiver is 4.3.8
2025-03-18 21:33:59 : REQ   : theunarchiver : Downloading https://dl.devmate.com/com.macpaw.site.theunarchiver/TheUnarchiver.dmg to The Unarchiver.dmg
2025-03-18 21:33:59 : DEBUG : theunarchiver : No Dialog connection, just download
2025-03-18 21:34:01 : INFO  : theunarchiver : Downloaded The Unarchiver.dmg – Type is  zlib compressed data – SHA is 7c07e762d0dae4f6b77a2ec2f6101c2c17083b50 – Size is 22652 kB
2025-03-18 21:34:01 : DEBUG : theunarchiver : DEBUG mode 1, not checking for blocking processes
2025-03-18 21:34:01 : REQ   : theunarchiver : Installing The Unarchiver
2025-03-18 21:34:01 : INFO  : theunarchiver : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/The Unarchiver.dmg
2025-03-18 21:34:04 : DEBUG : theunarchiver : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $02E67733
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $DDDB4227
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $10D1BDFB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $903A4C25
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $10D1BDFB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $B956C145
verified CRC32 $11E387C4
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/The Unarchiver

2025-03-18 21:34:04 : INFO  : theunarchiver : Mounted: /Volumes/The Unarchiver
2025-03-18 21:34:04 : INFO  : theunarchiver : Verifying: /Volumes/The Unarchiver/The Unarchiver.app
2025-03-18 21:34:04 : DEBUG : theunarchiver : App size:  46M	/Volumes/The Unarchiver/The Unarchiver.app
2025-03-18 21:34:04 : DEBUG : theunarchiver : Debugging enabled, App Verification output was:
/Volumes/The Unarchiver/The Unarchiver.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: MacPaw Inc. (S8EX82NJP6)

2025-03-18 21:34:04 : INFO  : theunarchiver : Team ID matching: S8EX82NJP6 (expected: S8EX82NJP6 )
2025-03-18 21:34:04 : INFO  : theunarchiver : Installing The Unarchiver version 4.3.8 on versionKey CFBundleShortVersionString.
2025-03-18 21:34:04 : INFO  : theunarchiver : App has LSMinimumSystemVersion: 10.13
2025-03-18 21:34:04 : DEBUG : theunarchiver : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-03-18 21:34:04 : INFO  : theunarchiver : Finishing...
2025-03-18 21:34:08 : INFO  : theunarchiver : name: The Unarchiver, appName: The Unarchiver.app
2025-03-18 21:34:08 : WARN  : theunarchiver : No previous app found
2025-03-18 21:34:08 : WARN  : theunarchiver : could not find The Unarchiver.app
2025-03-18 21:34:08 : REQ   : theunarchiver : Installed The Unarchiver, version 4.3.8
2025-03-18 21:34:08 : INFO  : theunarchiver : notifying
2025-03-18 21:34:08 : DEBUG : theunarchiver : Unmounting /Volumes/The Unarchiver
2025-03-18 21:34:08 : DEBUG : theunarchiver : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-18 21:34:08 : DEBUG : theunarchiver : DEBUG mode 1, not reopening anything
2025-03-18 21:34:08 : REQ   : theunarchiver : All done!
2025-03-18 21:34:08 : REQ   : theunarchiver : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
