### PR TITLE
Add kDrive

### DIFF
--- a/fragments/labels/kdrive.sh
+++ b/fragments/labels/kdrive.sh
@@ -1,0 +1,9 @@
+kdrive)
+    name="kDrive"
+    type="pkg"
+    packageID="com.infomaniak.drive.desktopclient"
+    jsonData=$(curl -sf https://www.infomaniak.com/drive/latest)
+    downloadURL=$(getJSONValue "$jsonData" "macos.downloadurl")
+    appNewVersion=$(getJSONValue "$jsonData" "macos.version")
+    expectedTeamID="864VDCS2QY"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** 
````
./assemble.sh kdrive
2025-03-18 23:06:35 : INFO  : kdrive : Total items in argumentsArray: 0
2025-03-18 23:06:35 : INFO  : kdrive : argumentsArray:
2025-03-18 23:06:35 : REQ   : kdrive : ################## Start Installomator v. 10.8beta, date 2025-03-18
2025-03-18 23:06:35 : INFO  : kdrive : ################## Version: 10.8beta
2025-03-18 23:06:35 : INFO  : kdrive : ################## Date: 2025-03-18
2025-03-18 23:06:35 : INFO  : kdrive : ################## kdrive
2025-03-18 23:06:35 : DEBUG : kdrive : DEBUG mode 1 enabled.
2025-03-18 23:06:35 : INFO  : kdrive : Reading arguments again:
2025-03-18 23:06:35 : DEBUG : kdrive : name=kDrive
2025-03-18 23:06:35 : DEBUG : kdrive : appName=
2025-03-18 23:06:35 : DEBUG : kdrive : type=pkg
2025-03-18 23:06:35 : DEBUG : kdrive : archiveName=
2025-03-18 23:06:35 : DEBUG : kdrive : downloadURL=https://download.storage.infomaniak.com/drive/desktopclient/kDrive-3.6.9.20250304.pkg
2025-03-18 23:06:35 : DEBUG : kdrive : curlOptions=
2025-03-18 23:06:35 : DEBUG : kdrive : appNewVersion=3.6.9.20250304
2025-03-18 23:06:35 : DEBUG : kdrive : appCustomVersion function: Not defined
2025-03-18 23:06:35 : DEBUG : kdrive : versionKey=CFBundleShortVersionString
2025-03-18 23:06:35 : DEBUG : kdrive : packageID=com.infomaniak.drive.desktopclient
2025-03-18 23:06:35 : DEBUG : kdrive : pkgName=
2025-03-18 23:06:35 : DEBUG : kdrive : choiceChangesXML=
2025-03-18 23:06:35 : DEBUG : kdrive : expectedTeamID=864VDCS2QY
2025-03-18 23:06:35 : DEBUG : kdrive : blockingProcesses=
2025-03-18 23:06:35 : DEBUG : kdrive : installerTool=
2025-03-18 23:06:35 : DEBUG : kdrive : CLIInstaller=
2025-03-18 23:06:35 : DEBUG : kdrive : CLIArguments=
2025-03-18 23:06:35 : DEBUG : kdrive : updateTool=
2025-03-18 23:06:35 : DEBUG : kdrive : updateToolArguments=
2025-03-18 23:06:35 : DEBUG : kdrive : updateToolRunAsCurrentUser=
2025-03-18 23:06:35 : INFO  : kdrive : BLOCKING_PROCESS_ACTION=tell_user
2025-03-18 23:06:35 : INFO  : kdrive : NOTIFY=success
2025-03-18 23:06:35 : INFO  : kdrive : LOGGING=DEBUG
2025-03-18 23:06:35 : INFO  : kdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-18 23:06:36 : INFO  : kdrive : Label type: pkg
2025-03-18 23:06:36 : INFO  : kdrive : archiveName: kDrive.pkg
2025-03-18 23:06:36 : INFO  : kdrive : no blocking processes defined, using kDrive as default
2025-03-18 23:06:36 : DEBUG : kdrive : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-18 23:06:36 : INFO  : kdrive : No version found using packageID com.infomaniak.drive.desktopclient
2025-03-18 23:06:36 : INFO  : kdrive : name: kDrive, appName: kDrive.app
2025-03-18 23:06:36 : WARN  : kdrive : No previous app found
2025-03-18 23:06:36 : WARN  : kdrive : could not find kDrive.app
2025-03-18 23:06:36 : INFO  : kdrive : appversion:
2025-03-18 23:06:36 : INFO  : kdrive : Latest version of kDrive is 3.6.9.20250304
2025-03-18 23:06:36 : REQ   : kdrive : Downloading https://download.storage.infomaniak.com/drive/desktopclient/kDrive-3.6.9.20250304.pkg to kDrive.pkg
2025-03-18 23:06:36 : DEBUG : kdrive : No Dialog connection, just download
2025-03-18 23:07:09 : INFO  : kdrive : Downloaded kDrive.pkg – Type is  xar archive compressed TOC – SHA is 2fc580fc3d145f208dbcc99053a183613fc29c16 – Size is 213960 kB
2025-03-18 23:07:09 : DEBUG : kdrive : DEBUG mode 1, not checking for blocking processes
2025-03-18 23:07:09 : REQ   : kdrive : Installing kDrive
2025-03-18 23:07:09 : INFO  : kdrive : Verifying: kDrive.pkg
2025-03-18 23:07:09 : DEBUG : kdrive : File list: -rw-r--r--@ 1 h.lans  admin   209M Mar 18 23:07 kDrive.pkg
2025-03-18 23:07:09 : DEBUG : kdrive : File type: kDrive.pkg: xar archive compressed TOC: 6175, SHA-1 checksum
2025-03-18 23:07:09 : DEBUG : kdrive : spctlOut is kDrive.pkg: accepted
2025-03-18 23:07:09 : DEBUG : kdrive : source=Notarized Developer ID
2025-03-18 23:07:09 : DEBUG : kdrive : origin=Developer ID Installer: Infomaniak Network SA (864VDCS2QY)
2025-03-18 23:07:09 : INFO  : kdrive : Team ID: 864VDCS2QY (expected: 864VDCS2QY )
2025-03-18 23:07:09 : DEBUG : kdrive : DEBUG enabled, skipping installation
2025-03-18 23:07:09 : INFO  : kdrive : Finishing...
2025-03-18 23:07:12 : INFO  : kdrive : No version found using packageID com.infomaniak.drive.desktopclient
2025-03-18 23:07:12 : INFO  : kdrive : name: kDrive, appName: kDrive.app
2025-03-18 23:07:12 : WARN  : kdrive : No previous app found
2025-03-18 23:07:12 : WARN  : kdrive : could not find kDrive.app
2025-03-18 23:07:12 : REQ   : kdrive : Installed kDrive, version 3.6.9.20250304
2025-03-18 23:07:12 : INFO  : kdrive : notifying
2025-03-18 23:07:12 : DEBUG : kdrive : DEBUG mode 1, not reopening anything
2025-03-18 23:07:12 : REQ   : kdrive : All done!
2025-03-18 23:07:12 : REQ   : kdrive : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2212 