### PR TITLE
More reliable appNewVersion and downloadURL

### DIFF
--- a/fragments/labels/topazgigapixel.sh
+++ b/fragments/labels/topazgigapixel.sh
@@ -3,9 +3,9 @@ topazgigapixelai)
     # credit: Tully Jagoe
     name="Topaz Gigapixel AI"
     type="pkg"
-    appNewVersion=$(curl -fsL https://community.topazlabs.com/c/gigapixel-ai/gigapixel-ai/66 | grep -o "raw-topic-link'>.*<" | grep -o "v.*<" | sed -E 's/[v|<]//g' | head -1)
+    appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'gigaVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
     versionKey="CFBundleShortVersionString"
-    downloadURL="https://downloads.topazlabs.com/deploy/TopazGigapixelAI/${appNewVersion}/TopazGigapixelAI-${appNewVersion}.pkg"
+    downloadURL="https://topazlabs.com/d/gigapixel/latest/mac/full"
     archiveName="TopazGigapixelAI-${appNewVersion}.pkg"
     expectedTeamID="3G3JE37ZHF"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
On the downloads page, the only version number is the latest.
Same goes for using the direct download url instead of using the appNewVersion

**Installomator log** 

Upgrading installed version:
```
2025-03-21 09:16:43 : INFO  : topazgigapixel : setting variable from argument DEBUG=0
2025-03-21 09:16:43 : INFO  : topazgigapixel : Total items in argumentsArray: 1
2025-03-21 09:16:43 : INFO  : topazgigapixel : argumentsArray: DEBUG=0
2025-03-21 09:16:43 : REQ   : topazgigapixel : ################## Start Installomator v. 10.8beta, date 2025-03-21
2025-03-21 09:16:43 : INFO  : topazgigapixel : ################## Version: 10.8beta
2025-03-21 09:16:43 : INFO  : topazgigapixel : ################## Date: 2025-03-21
2025-03-21 09:16:43 : INFO  : topazgigapixel : ################## topazgigapixel
2025-03-21 09:16:44 : INFO  : topazgigapixel : Reading arguments again: DEBUG=0
2025-03-21 09:16:44 : INFO  : topazgigapixel : BLOCKING_PROCESS_ACTION=tell_user
2025-03-21 09:16:44 : INFO  : topazgigapixel : NOTIFY=success
2025-03-21 09:16:44 : INFO  : topazgigapixel : LOGGING=INFO
2025-03-21 09:16:44 : INFO  : topazgigapixel : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-21 09:16:44 : INFO  : topazgigapixel : Label type: pkg
2025-03-21 09:16:44 : INFO  : topazgigapixel : archiveName: TopazGigapixelAI-8.3.0.pkg
2025-03-21 09:16:44 : INFO  : topazgigapixel : no blocking processes defined, using Topaz Gigapixel AI as default
2025-03-21 09:16:44 : INFO  : topazgigapixel : App(s) found: /Applications/Topaz Gigapixel AI.app
2025-03-21 09:16:44 : INFO  : topazgigapixel : found app at /Applications/Topaz Gigapixel AI.app, version 8.2.0, on versionKey CFBundleShortVersionString
2025-03-21 09:16:44 : INFO  : topazgigapixel : appversion: 8.2.0
2025-03-21 09:16:44 : INFO  : topazgigapixel : Latest version of Topaz Gigapixel AI is 8.3.0
2025-03-21 09:16:44 : REQ   : topazgigapixel : Downloading https://topazlabs.com/d/gigapixel/latest/mac/full to TopazGigapixelAI-8.3.0.pkg
2025-03-21 09:16:58 : INFO  : topazgigapixel : Downloaded TopazGigapixelAI-8.3.0.pkg – Type is  xar archive compressed TOC – SHA is 8d8c2b2a7b74b88e1dc65c5f9aed8682907ff33d – Size is 377436 kB
2025-03-21 09:16:59 : REQ   : topazgigapixel : no more blocking processes, continue with update
2025-03-21 09:16:59 : REQ   : topazgigapixel : Installing Topaz Gigapixel AI
2025-03-21 09:16:59 : INFO  : topazgigapixel : Verifying: TopazGigapixelAI-8.3.0.pkg
2025-03-21 09:16:59 : INFO  : topazgigapixel : Team ID: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2025-03-21 09:16:59 : INFO  : topazgigapixel : Installing TopazGigapixelAI-8.3.0.pkg to /
2025-03-21 09:17:13 : INFO  : topazgigapixel : Finishing...
2025-03-21 09:17:16 : INFO  : topazgigapixel : App(s) found: /Applications/Topaz Gigapixel AI.app
2025-03-21 09:17:16 : INFO  : topazgigapixel : found app at /Applications/Topaz Gigapixel AI.app, version 8.3.0, on versionKey CFBundleShortVersionString
2025-03-21 09:17:16 : REQ   : topazgigapixel : Installed Topaz Gigapixel AI, version 8.3.0
2025-03-21 09:17:16 : INFO  : topazgigapixel : notifying
2025-03-21 09:17:16 : INFO  : topazgigapixel : Installomator did not close any apps, so no need to reopen any apps.
2025-03-21 09:17:16 : REQ   : topazgigapixel : All done!
2025-03-21 09:17:16 : REQ   : topazgigapixel : ################## End Installomator, exit code 0 
```

With correct version installed:
```
2025-03-21 09:22:55 : INFO  : topazgigapixel : setting variable from argument DEBUG=0
2025-03-21 09:22:55 : INFO  : topazgigapixel : Total items in argumentsArray: 1
2025-03-21 09:22:55 : INFO  : topazgigapixel : argumentsArray: DEBUG=0
2025-03-21 09:22:55 : REQ   : topazgigapixel : ################## Start Installomator v. 10.8beta, date 2025-03-21
2025-03-21 09:22:55 : INFO  : topazgigapixel : ################## Version: 10.8beta
2025-03-21 09:22:55 : INFO  : topazgigapixel : ################## Date: 2025-03-21
2025-03-21 09:22:55 : INFO  : topazgigapixel : ################## topazgigapixel
2025-03-21 09:22:56 : INFO  : topazgigapixel : Reading arguments again: DEBUG=0
2025-03-21 09:22:56 : INFO  : topazgigapixel : BLOCKING_PROCESS_ACTION=tell_user
2025-03-21 09:22:56 : INFO  : topazgigapixel : NOTIFY=success
2025-03-21 09:22:56 : INFO  : topazgigapixel : LOGGING=INFO
2025-03-21 09:22:56 : INFO  : topazgigapixel : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-21 09:22:56 : INFO  : topazgigapixel : Label type: pkg
2025-03-21 09:22:56 : INFO  : topazgigapixel : archiveName: TopazGigapixelAI-8.3.0.pkg
2025-03-21 09:22:56 : INFO  : topazgigapixel : no blocking processes defined, using Topaz Gigapixel AI as default
2025-03-21 09:22:56 : INFO  : topazgigapixel : App(s) found: /Applications/Topaz Gigapixel AI.app
2025-03-21 09:22:56 : INFO  : topazgigapixel : found app at /Applications/Topaz Gigapixel AI.app, version 8.3.0, on versionKey CFBundleShortVersionString
2025-03-21 09:22:56 : INFO  : topazgigapixel : appversion: 8.3.0
2025-03-21 09:22:56 : INFO  : topazgigapixel : Latest version of Topaz Gigapixel AI is 8.3.0
2025-03-21 09:22:56 : INFO  : topazgigapixel : There is no newer version available.
2025-03-21 09:22:56 : INFO  : topazgigapixel : Installomator did not close any apps, so no need to reopen any apps.
2025-03-21 09:22:56 : REQ   : topazgigapixel : No newer version.
2025-03-21 09:22:56 : REQ   : topazgigapixel : ################## End Installomator, exit code 0
```