### PR TITLE
Create dragonframe2025.sh

### DIFF
--- a/fragments/labels/dragonframe2025.sh
+++ b/fragments/labels/dragonframe2025.sh
@@ -1,0 +1,11 @@
+dragonframe2025)
+    name="DragonFrame 2025"
+    type="pkg"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
+    appNewVersion=$(curl -s -A "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" https://www.dragonframe.com/downloads/ | grep -o 'Dragonframe [0-9]\+\.[0-9]\+\.[0-9]\+' | sed 's/Dragonframe //' | head -n 1)
+    downloadURL="https://www.dragonframe.com/download/Dragonframe_${appNewVersion}.pkg"
+    appName="Applications/Dragonframe 2025/Dragonframe 2025.app"
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="PG7SM8SD8M"
+    ;;
+


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Log: 

```
2025-03-21 13:25:41 : INFO  : dragonframe2025 : Total items in argumentsArray: 0
2025-03-21 13:25:41 : INFO  : dragonframe2025 : argumentsArray: 
2025-03-21 13:25:41 : REQ   : dragonframe2025 : ################## Start Installomator v. 10.8beta, date 2025-03-21
2025-03-21 13:25:41 : INFO  : dragonframe2025 : ################## Version: 10.8beta
2025-03-21 13:25:41 : INFO  : dragonframe2025 : ################## Date: 2025-03-21
2025-03-21 13:25:41 : INFO  : dragonframe2025 : ################## dragonframe2025
2025-03-21 13:25:41 : DEBUG : dragonframe2025 : DEBUG mode 1 enabled.
2025-03-21 13:25:42 : INFO  : dragonframe2025 : Reading arguments again: 
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : name=DragonFrame 2025
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : appName=Applications/Dragonframe 2025/Dragonframe 2025.app
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : type=pkg
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : archiveName=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : downloadURL=https://www.dragonframe.com/download/Dragonframe_2025.01.3.pkg
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : appNewVersion=2025.01.3
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : appCustomVersion function: Not defined
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : versionKey=CFBundleShortVersionString
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : packageID=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : pkgName=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : choiceChangesXML=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : expectedTeamID=PG7SM8SD8M
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : blockingProcesses=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : installerTool=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : CLIInstaller=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : CLIArguments=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : updateTool=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : updateToolArguments=
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : updateToolRunAsCurrentUser=
2025-03-21 13:25:42 : INFO  : dragonframe2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-03-21 13:25:42 : INFO  : dragonframe2025 : NOTIFY=success
2025-03-21 13:25:42 : INFO  : dragonframe2025 : LOGGING=DEBUG
2025-03-21 13:25:42 : INFO  : dragonframe2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-21 13:25:42 : INFO  : dragonframe2025 : Label type: pkg
2025-03-21 13:25:42 : INFO  : dragonframe2025 : archiveName: DragonFrame 2025.pkg
2025-03-21 13:25:42 : INFO  : dragonframe2025 : no blocking processes defined, using DragonFrame 2025 as default
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : Changing directory to /Users/coreyg/Documents/GitHub/Installomator/build
2025-03-21 13:25:42 : INFO  : dragonframe2025 : App(s) found: //Applications/Dragonframe 2025/Dragonframe 2025.app
2025-03-21 13:25:42 : INFO  : dragonframe2025 : found app at //Applications/Dragonframe 2025/Dragonframe 2025.app, version 2025.01.3, on versionKey CFBundleShortVersionString
2025-03-21 13:25:42 : INFO  : dragonframe2025 : appversion: 2025.01.3
2025-03-21 13:25:42 : INFO  : dragonframe2025 : Latest version of DragonFrame 2025 is 2025.01.3
2025-03-21 13:25:42 : WARN  : dragonframe2025 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-03-21 13:25:42 : REQ   : dragonframe2025 : Downloading https://www.dragonframe.com/download/Dragonframe_2025.01.3.pkg to DragonFrame 2025.pkg
2025-03-21 13:25:42 : DEBUG : dragonframe2025 : No Dialog connection, just download
2025-03-21 13:25:46 : INFO  : dragonframe2025 : Downloaded DragonFrame 2025.pkg – Type is  xar archive compressed TOC – SHA is 600f2dcc82f2ad6a1a6f3c81adc630b79c2d93af – Size is 147484 kB
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : DEBUG mode 1, not checking for blocking processes
2025-03-21 13:25:46 : REQ   : dragonframe2025 : Installing DragonFrame 2025
2025-03-21 13:25:46 : INFO  : dragonframe2025 : Verifying: DragonFrame 2025.pkg
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : File list: -rw-r--r--  1 root  staff   132M Mar 21 13:25 DragonFrame 2025.pkg
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : File type: DragonFrame 2025.pkg: xar archive compressed TOC: 4816, SHA-1 checksum
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : spctlOut is DragonFrame 2025.pkg: accepted
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : source=Notarized Developer ID
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : origin=Developer ID Installer: DZED Systems LLC (PG7SM8SD8M)
2025-03-21 13:25:46 : INFO  : dragonframe2025 : Team ID: PG7SM8SD8M (expected: PG7SM8SD8M )
2025-03-21 13:25:46 : DEBUG : dragonframe2025 : DEBUG enabled, skipping installation
2025-03-21 13:25:47 : INFO  : dragonframe2025 : Finishing...
2025-03-21 13:25:50 : INFO  : dragonframe2025 : App(s) found: //Applications/Dragonframe 2025/Dragonframe 2025.app
2025-03-21 13:25:50 : INFO  : dragonframe2025 : found app at //Applications/Dragonframe 2025/Dragonframe 2025.app, version 2025.01.3, on versionKey CFBundleShortVersionString
2025-03-21 13:25:50 : REQ   : dragonframe2025 : Installed DragonFrame 2025, version 2025.01.3
2025-03-21 13:25:50 : INFO  : dragonframe2025 : notifying
2025-03-21 13:25:50 : DEBUG : dragonframe2025 : DEBUG mode 1, not reopening anything
2025-03-21 13:25:50 : REQ   : dragonframe2025 : All done!
2025-03-21 13:25:50 : REQ   : dragonframe2025 : ################## End Installomator, exit code 0 
```
