### PR TITLE
Update ringcentralapp

### DIFF
--- a/fragments/labels/ringcentralapp.sh
+++ b/fragments/labels/ringcentralapp.sh
@@ -1,6 +1,8 @@
 ringcentralapp)
     # credit: Isaac Ordonez, Mann consulting (@mannconsulting)
     name="RingCentral"
+    appNewVersion=$(curl -fs https://support.ringcentral.com/gb/en/release-notes/ringex/desktop.html | grep -i -m1 "<div>Version" | sed 's/[^0-9\.]//g')
+    appCustomVersion() { defaults read /Applications/RingCentral.app/Contents/Info.plist CFBundleShortVersionString  | cut -c-7 }
     type="pkg"
     if [[ $(arch) != "i386" ]]; then
         downloadURL="https://app.ringcentral.com/download/RingCentral-arm64.pkg"
@@ -8,5 +10,4 @@ ringcentralapp)
         downloadURL="https://app.ringcentral.com/download/RingCentral.pkg"
     fi
     expectedTeamID="M932RC5J66"
-    blockingProcesses=( "RingCentral" )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `blockingProcess`
Added `appNewVersion`
Addded `appCustomVersion`. The version number online is 7 characters long. The `CFBundleShortVersionString` is 14 characters long. I used `appCustomVersion` to get the first 7 characters

**Installomator log**
````
./assemble.sh ringcentralapp
2025-03-22 23:04:44 : INFO  : ringcentralapp : Total items in argumentsArray: 0
2025-03-22 23:04:44 : INFO  : ringcentralapp : argumentsArray:
2025-03-22 23:04:44 : REQ   : ringcentralapp : ################## Start Installomator v. 10.8beta, date 2025-03-22
2025-03-22 23:04:44 : INFO  : ringcentralapp : ################## Version: 10.8beta
2025-03-22 23:04:44 : INFO  : ringcentralapp : ################## Date: 2025-03-22
2025-03-22 23:04:44 : INFO  : ringcentralapp : ################## ringcentralapp
2025-03-22 23:04:44 : DEBUG : ringcentralapp : DEBUG mode 1 enabled.
2025-03-22 23:04:45 : INFO  : ringcentralapp : Reading arguments again:
2025-03-22 23:04:45 : DEBUG : ringcentralapp : name=RingCentral
2025-03-22 23:04:45 : DEBUG : ringcentralapp : appName=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : type=pkg
2025-03-22 23:04:45 : DEBUG : ringcentralapp : archiveName=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : downloadURL=https://app.ringcentral.com/download/RingCentral-arm64.pkg
2025-03-22 23:04:45 : DEBUG : ringcentralapp : curlOptions=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : appNewVersion=25.1.30
2025-03-22 23:04:45 : DEBUG : ringcentralapp : appCustomVersion function: Defined.
2025-03-22 23:04:45 : DEBUG : ringcentralapp : versionKey=CFBundleShortVersionString
2025-03-22 23:04:45 : DEBUG : ringcentralapp : packageID=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : pkgName=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : choiceChangesXML=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : expectedTeamID=M932RC5J66
2025-03-22 23:04:45 : DEBUG : ringcentralapp : blockingProcesses=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : installerTool=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : CLIInstaller=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : CLIArguments=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : updateTool=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : updateToolArguments=
2025-03-22 23:04:45 : DEBUG : ringcentralapp : updateToolRunAsCurrentUser=
2025-03-22 23:04:45 : INFO  : ringcentralapp : BLOCKING_PROCESS_ACTION=tell_user
2025-03-22 23:04:45 : INFO  : ringcentralapp : NOTIFY=success
2025-03-22 23:04:45 : INFO  : ringcentralapp : LOGGING=DEBUG
2025-03-22 23:04:45 : INFO  : ringcentralapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-22 23:04:45 : INFO  : ringcentralapp : Label type: pkg
2025-03-22 23:04:45 : INFO  : ringcentralapp : archiveName: RingCentral.pkg
2025-03-22 23:04:45 : INFO  : ringcentralapp : no blocking processes defined, using RingCentral as default
2025-03-22 23:04:45 : DEBUG : ringcentralapp : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-22 23:04:45 : INFO  : ringcentralapp : Custom App Version detection is used, found 25.1.30
2025-03-22 23:04:45 : INFO  : ringcentralapp : appversion: 25.1.30
2025-03-22 23:04:45 : INFO  : ringcentralapp : Latest version of RingCentral is 25.1.30
2025-03-22 23:04:45 : WARN  : ringcentralapp : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-03-22 23:04:45 : REQ   : ringcentralapp : Downloading https://app.ringcentral.com/download/RingCentral-arm64.pkg to RingCentral.pkg
2025-03-22 23:04:45 : DEBUG : ringcentralapp : No Dialog connection, just download
2025-03-22 23:05:23 : INFO  : ringcentralapp : Downloaded RingCentral.pkg – Type is  xar archive compressed TOC – SHA is 58a3db9a246ce55aa70915f018b042f177aecd29 – Size is 426540 kB
2025-03-22 23:05:23 : DEBUG : ringcentralapp : DEBUG mode 1, not checking for blocking processes
2025-03-22 23:05:23 : REQ   : ringcentralapp : Installing RingCentral
2025-03-22 23:05:23 : INFO  : ringcentralapp : Verifying: RingCentral.pkg
2025-03-22 23:05:23 : DEBUG : ringcentralapp : File list: -rw-r--r--@ 1 h.lans  admin   409M Mar 22 23:05 RingCentral.pkg
2025-03-22 23:05:23 : DEBUG : ringcentralapp : File type: RingCentral.pkg: xar archive compressed TOC: 4503, SHA-1 checksum
2025-03-22 23:05:23 : DEBUG : ringcentralapp : spctlOut is RingCentral.pkg: accepted
2025-03-22 23:05:23 : DEBUG : ringcentralapp : source=Notarized Developer ID
2025-03-22 23:05:23 : DEBUG : ringcentralapp : origin=Developer ID Installer: RingCentral, Inc. (M932RC5J66)
2025-03-22 23:05:23 : INFO  : ringcentralapp : Team ID: M932RC5J66 (expected: M932RC5J66 )
2025-03-22 23:05:23 : DEBUG : ringcentralapp : DEBUG enabled, skipping installation
2025-03-22 23:05:23 : INFO  : ringcentralapp : Finishing...
2025-03-22 23:05:26 : INFO  : ringcentralapp : Custom App Version detection is used, found 25.1.30
2025-03-22 23:05:26 : REQ   : ringcentralapp : Installed RingCentral, version 25.1.30
2025-03-22 23:05:26 : INFO  : ringcentralapp : notifying
2025-03-22 23:05:26 : DEBUG : ringcentralapp : DEBUG mode 1, not reopening anything
2025-03-22 23:05:26 : REQ   : ringcentralapp : All done!
2025-03-22 23:05:26 : REQ   : ringcentralapp : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
