### PR TITLE
Update ringcentralclassicapp

### DIFF
--- a/fragments/labels/ringcentralclassicapp.sh
+++ b/fragments/labels/ringcentralclassicapp.sh
@@ -3,6 +3,4 @@ ringcentralclassicapp)
     type="dmg"
     downloadURL="https://downloads.ringcentral.com/glip/rc/GlipForMac"
     expectedTeamID="M932RC5J66"
-    blockingProcesses=( "Glip" )
-    #blockingProcessesMaxCPU="5"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removed unnecessary `blockingProcess`
Removed commented line about `blockingProcessesMaxCPU`

**Installomator log**
````
./assemble.sh ringcentralclassicapp
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : Total items in argumentsArray: 0
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : argumentsArray:
2025-03-23 00:01:09 : REQ   : ringcentralclassicapp : ################## Start Installomator v. 10.8beta, date 2025-03-23
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : ################## Version: 10.8beta
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : ################## Date: 2025-03-23
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : ################## ringcentralclassicapp
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : DEBUG mode 1 enabled.
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : Reading arguments again:
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : name=Glip
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : appName=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : type=dmg
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : archiveName=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : downloadURL=https://downloads.ringcentral.com/glip/rc/GlipForMac
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : curlOptions=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : appNewVersion=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : appCustomVersion function: Not defined
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : versionKey=CFBundleShortVersionString
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : packageID=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : pkgName=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : choiceChangesXML=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : expectedTeamID=M932RC5J66
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : blockingProcesses=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : installerTool=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : CLIInstaller=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : CLIArguments=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : updateTool=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : updateToolArguments=
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : updateToolRunAsCurrentUser=
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : BLOCKING_PROCESS_ACTION=tell_user
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : NOTIFY=success
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : LOGGING=DEBUG
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : Label type: dmg
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : archiveName: Glip.dmg
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : no blocking processes defined, using Glip as default
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : App(s) found: /Applications/Glip.app
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : found app at /Applications/Glip.app, version 20.4.30, on versionKey CFBundleShortVersionString
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : appversion: 20.4.30
2025-03-23 00:01:09 : INFO  : ringcentralclassicapp : Latest version not specified.
2025-03-23 00:01:09 : REQ   : ringcentralclassicapp : Downloading https://downloads.ringcentral.com/glip/rc/GlipForMac to Glip.dmg
2025-03-23 00:01:09 : DEBUG : ringcentralclassicapp : No Dialog connection, just download
2025-03-23 00:01:22 : INFO  : ringcentralclassicapp : Downloaded Glip.dmg – Type is  zlib compressed data – SHA is 46326080eb5dfc1999e3fd78272a322f548d04c3 – Size is 164172 kB
2025-03-23 00:01:22 : DEBUG : ringcentralclassicapp : DEBUG mode 1, not checking for blocking processes
2025-03-23 00:01:22 : REQ   : ringcentralclassicapp : Installing Glip
2025-03-23 00:01:22 : INFO  : ringcentralclassicapp : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Glip.dmg
2025-03-23 00:01:25 : DEBUG : ringcentralclassicapp : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $9C802640
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $7E485750
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $72C51FEA
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $68EB83DF
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $72C51FEA
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $3D42D5D3
verified CRC32 $94C8BC8F
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/RingCentral Classic20.4.30

2025-03-23 00:01:25 : INFO  : ringcentralclassicapp : Mounted: /Volumes/RingCentral Classic20.4.30
2025-03-23 00:01:25 : INFO  : ringcentralclassicapp : Verifying: /Volumes/RingCentral Classic20.4.30/Glip.app
2025-03-23 00:01:25 : DEBUG : ringcentralclassicapp : App size: 468M	/Volumes/RingCentral Classic20.4.30/Glip.app
2025-03-23 00:01:27 : DEBUG : ringcentralclassicapp : Debugging enabled, App Verification output was:
/Volumes/RingCentral Classic20.4.30/Glip.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: RingCentral, Inc. (M932RC5J66)

2025-03-23 00:01:27 : INFO  : ringcentralclassicapp : Team ID matching: M932RC5J66 (expected: M932RC5J66 )
2025-03-23 00:01:27 : INFO  : ringcentralclassicapp : Downloaded version of Glip is 20.4.30 on versionKey CFBundleShortVersionString, same as installed.
2025-03-23 00:01:27 : DEBUG : ringcentralclassicapp : Unmounting /Volumes/RingCentral Classic20.4.30
2025-03-23 00:01:27 : DEBUG : ringcentralclassicapp : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-23 00:01:27 : DEBUG : ringcentralclassicapp : DEBUG mode 1, not reopening anything
2025-03-23 00:01:27 : REG   : ringcentralclassicapp : No new version to install
2025-03-23 00:01:27 : REQ   : ringcentralclassicapp : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
