### PR TITLE
Update 4kvideodownloader

### DIFF
--- a/fragments/labels/4kvideodownloader.sh
+++ b/fragments/labels/4kvideodownloader.sh
@@ -1,8 +1,8 @@
 4kvideodownloader)
     name="4K Video Downloader"
     type="dmg"
-    downloadURL="$(curl -fsL "https://www.4kdownload.com/products/product-videodownloader" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.dmg\?source=website" | head -1)"
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[0-9a-zA-Z]*_([0-9.]*)\.dmg.*/\1/g')
+    appNewVersion=$(curl -fsL "https://www.4kdownload.com/downloads/34" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.exe\?source=website" | head -1 | cut -d "_" -f2)
+    downloadURL="https://dl.4kdownload.com/app/4kvideodownloader_${appNewVersion}_x64.dmg?source=website"
 	versionKey="CFBundleVersion"
     expectedTeamID="GHQ37VJF83"
     ;;

--- a/fragments/labels/4kvideodownloader.sh
+++ b/fragments/labels/4kvideodownloader.sh
@@ -1,8 +1,9 @@
 4kvideodownloader)
     name="4K Video Downloader"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://www.4kdownload.com/downloads/34" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.exe\?source=website" | head -1 | cut -d "_" -f2)
+    videoDownloaderXML=$(curl -fsL https://dl.4kdownload.com/app/appcast/videodownloader.xml)
+    appNewVersion=$(echo "$videoDownloaderXML" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' | cut -d "." -f1-3)
     downloadURL="https://dl.4kdownload.com/app/4kvideodownloader_${appNewVersion}_x64.dmg?source=website"
-	versionKey="CFBundleVersion"
+    versionKey="CFBundleVersion"
     expectedTeamID="GHQ37VJF83"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
I'm sorry.
Old label did not work anymore ([Mac Admins Slack](https://macadmins.slack.com/archives/C013HFTFQ13/p1741652450055519)). There is no download URL in the source webpage, just an 'onclick=' attribute. The version number for 4K Video Downloader is the same across all operating systems. I've filtered for the Windows version and used that number for `appNewVersion` and `downloadURL`.

**Installomator log** 
````
./assemble.sh 4kvideodownloader
2025-03-24 23:00:47 : INFO  : 4kvideodownloader : Total items in argumentsArray: 0
2025-03-24 23:00:47 : INFO  : 4kvideodownloader : argumentsArray:
2025-03-24 23:00:47 : REQ   : 4kvideodownloader : ################## Start Installomator v. 10.8beta, date 2025-03-24
2025-03-24 23:00:47 : INFO  : 4kvideodownloader : ################## Version: 10.8beta
2025-03-24 23:00:47 : INFO  : 4kvideodownloader : ################## Date: 2025-03-24
2025-03-24 23:00:47 : INFO  : 4kvideodownloader : ################## 4kvideodownloader
2025-03-24 23:00:47 : DEBUG : 4kvideodownloader : DEBUG mode 1 enabled.
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : Reading arguments again:
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : name=4K Video Downloader
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : appName=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : type=dmg
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : archiveName=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : downloadURL=https://dl.4kdownload.com/app/4kvideodownloader_4.33.5_x64.dmg?source=website
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : curlOptions=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : appNewVersion=4.33.5
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : appCustomVersion function: Not defined
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : versionKey=CFBundleVersion
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : packageID=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : pkgName=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : choiceChangesXML=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : expectedTeamID=GHQ37VJF83
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : blockingProcesses=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : installerTool=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : CLIInstaller=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : CLIArguments=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : updateTool=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : updateToolArguments=
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : updateToolRunAsCurrentUser=
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : BLOCKING_PROCESS_ACTION=tell_user
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : NOTIFY=success
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : LOGGING=DEBUG
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : Label type: dmg
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : archiveName: 4K Video Downloader.dmg
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : no blocking processes defined, using 4K Video Downloader as default
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : name: 4K Video Downloader, appName: 4K Video Downloader.app
2025-03-24 23:00:49 : WARN  : 4kvideodownloader : No previous app found
2025-03-24 23:00:49 : WARN  : 4kvideodownloader : could not find 4K Video Downloader.app
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : appversion:
2025-03-24 23:00:49 : INFO  : 4kvideodownloader : Latest version of 4K Video Downloader is 4.33.5
2025-03-24 23:00:49 : REQ   : 4kvideodownloader : Downloading https://dl.4kdownload.com/app/4kvideodownloader_4.33.5_x64.dmg?source=website to 4K Video Downloader.dmg
2025-03-24 23:00:49 : DEBUG : 4kvideodownloader : No Dialog connection, just download
2025-03-24 23:01:15 : INFO  : 4kvideodownloader : Downloaded 4K Video Downloader.dmg – Type is  zlib compressed data – SHA is f869fa78a7294cba8212e8378d11459678b780e2 – Size is 131244 kB
2025-03-24 23:01:15 : DEBUG : 4kvideodownloader : DEBUG mode 1, not checking for blocking processes
2025-03-24 23:01:15 : REQ   : 4kvideodownloader : Installing 4K Video Downloader
2025-03-24 23:01:15 : INFO  : 4kvideodownloader : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/4K Video Downloader.dmg
2025-03-24 23:01:17 : DEBUG : 4kvideodownloader : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $247C9704
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $7673149D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $5F4C2CBB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $DCD21FA4
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $5F4C2CBB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $C4AD0885
verified CRC32 $5552F37C
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/4K Video Downloader

2025-03-24 23:01:17 : INFO  : 4kvideodownloader : Mounted: /Volumes/4K Video Downloader
2025-03-24 23:01:17 : INFO  : 4kvideodownloader : Verifying: /Volumes/4K Video Downloader/4K Video Downloader.app
2025-03-24 23:01:17 : DEBUG : 4kvideodownloader : App size: 357M	/Volumes/4K Video Downloader/4K Video Downloader.app
2025-03-24 23:01:19 : DEBUG : 4kvideodownloader : Debugging enabled, App Verification output was:
/Volumes/4K Video Downloader/4K Video Downloader.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Open Media OOO (GHQ37VJF83)

2025-03-24 23:01:19 : INFO  : 4kvideodownloader : Team ID matching: GHQ37VJF83 (expected: GHQ37VJF83 )
2025-03-24 23:01:19 : INFO  : 4kvideodownloader : Installing 4K Video Downloader version 4.33.5 on versionKey CFBundleVersion.
2025-03-24 23:01:19 : INFO  : 4kvideodownloader : App has LSMinimumSystemVersion: 10.13.0
2025-03-24 23:01:19 : DEBUG : 4kvideodownloader : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-03-24 23:01:19 : INFO  : 4kvideodownloader : Finishing...
2025-03-24 23:01:22 : INFO  : 4kvideodownloader : name: 4K Video Downloader, appName: 4K Video Downloader.app
2025-03-24 23:01:22 : WARN  : 4kvideodownloader : No previous app found
2025-03-24 23:01:22 : WARN  : 4kvideodownloader : could not find 4K Video Downloader.app
2025-03-24 23:01:22 : REQ   : 4kvideodownloader : Installed 4K Video Downloader, version 4.33.5
2025-03-24 23:01:22 : INFO  : 4kvideodownloader : notifying
2025-03-24 23:01:22 : DEBUG : 4kvideodownloader : Unmounting /Volumes/4K Video Downloader
2025-03-24 23:01:22 : DEBUG : 4kvideodownloader : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-24 23:01:22 : DEBUG : 4kvideodownloader : DEBUG mode 1, not reopening anything
2025-03-24 23:01:22 : REQ   : 4kvideodownloader : All done!
2025-03-24 23:01:22 : REQ   : 4kvideodownloader : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
