### PR TITLE
Update cisdem-documentreader

### DIFF
--- a/fragments/labels/cisdem-documentreader.sh
+++ b/fragments/labels/cisdem-documentreader.sh
@@ -1,6 +1,8 @@
 cisdem-documentreader)
     name="cisdem-documentreader"
     type="dmg"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" )
+    appNewVersion=$(curl -sf $curlOptons https://www.cisdem.com/document-reader-mac.html | grep -i "Latest Version:" | sed 's/[^0-9\.]//g')
     downloadURL="https://download.cisdem.com/cisdem-documentreader.dmg"
     expectedTeamID="5HGV8EX6BQ"
     appName="Cisdem Document Reader.app"

--- a/fragments/labels/cisdemdocumentreader.sh
+++ b/fragments/labels/cisdemdocumentreader.sh
@@ -1,4 +1,4 @@
-cisdem-documentreader)
+cisdemdocumentreader)
     name="cisdem-documentreader"
     type="dmg"
     curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" )


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Added `curlOption` to nudge the download.
Added `appNewVersion`. Latest version is from 2021-07-29...

**Installomator log** 
````
./assemble.sh cisdem-documentreader
2025-03-26 16:18:51 : INFO  : cisdem-documentreader : Total items in argumentsArray: 0
2025-03-26 16:18:51 : INFO  : cisdem-documentreader : argumentsArray:
2025-03-26 16:18:51 : REQ   : cisdem-documentreader : ################## Start Installomator v. 10.8beta, date 2025-03-26
2025-03-26 16:18:51 : INFO  : cisdem-documentreader : ################## Version: 10.8beta
2025-03-26 16:18:51 : INFO  : cisdem-documentreader : ################## Date: 2025-03-26
2025-03-26 16:18:51 : INFO  : cisdem-documentreader : ################## cisdem-documentreader
2025-03-26 16:18:51 : DEBUG : cisdem-documentreader : DEBUG mode 1 enabled.
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : Reading arguments again:
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : name=cisdem-documentreader
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : appName=Cisdem Document Reader.app
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : type=dmg
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : archiveName=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : downloadURL=https://download.cisdem.com/cisdem-documentreader.dmg
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : appNewVersion=5.5.1
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : appCustomVersion function: Not defined
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : versionKey=CFBundleShortVersionString
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : packageID=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : pkgName=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : choiceChangesXML=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : expectedTeamID=5HGV8EX6BQ
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : blockingProcesses=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : installerTool=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : CLIInstaller=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : CLIArguments=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : updateTool=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : updateToolArguments=
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : updateToolRunAsCurrentUser=
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : BLOCKING_PROCESS_ACTION=tell_user
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : NOTIFY=success
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : LOGGING=DEBUG
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : Label type: dmg
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : archiveName: cisdem-documentreader.dmg
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : no blocking processes defined, using cisdem-documentreader as default
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : name: cisdem-documentreader, appName: Cisdem Document Reader.app
2025-03-26 16:18:52 : WARN  : cisdem-documentreader : No previous app found
2025-03-26 16:18:52 : WARN  : cisdem-documentreader : could not find Cisdem Document Reader.app
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : appversion:
2025-03-26 16:18:52 : INFO  : cisdem-documentreader : Latest version of cisdem-documentreader is 5.5.1
2025-03-26 16:18:52 : REQ   : cisdem-documentreader : Downloading https://download.cisdem.com/cisdem-documentreader.dmg to cisdem-documentreader.dmg
2025-03-26 16:18:52 : DEBUG : cisdem-documentreader : No Dialog connection, just download
2025-03-26 16:18:55 : INFO  : cisdem-documentreader : Downloaded cisdem-documentreader.dmg – Type is  zlib compressed data – SHA is af660162283ed648faba3480dff63ff4b02d90e7 – Size is 23556 kB
2025-03-26 16:18:55 : DEBUG : cisdem-documentreader : DEBUG mode 1, not checking for blocking processes
2025-03-26 16:18:55 : REQ   : cisdem-documentreader : Installing cisdem-documentreader
2025-03-26 16:18:55 : INFO  : cisdem-documentreader : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/cisdem-documentreader.dmg
2025-03-26 16:18:59 : DEBUG : cisdem-documentreader : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $66102D3B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $0FD2D8B2
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $7CB7BA8A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $4363C471
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $7CB7BA8A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $857F0476
verified CRC32 $322B15B8
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Cisdem Document Reader

2025-03-26 16:18:59 : INFO  : cisdem-documentreader : Mounted: /Volumes/Cisdem Document Reader
2025-03-26 16:18:59 : INFO  : cisdem-documentreader : Verifying: /Volumes/Cisdem Document Reader/Cisdem Document Reader.app
2025-03-26 16:18:59 : DEBUG : cisdem-documentreader : App size:  68M	/Volumes/Cisdem Document Reader/Cisdem Document Reader.app
2025-03-26 16:18:59 : DEBUG : cisdem-documentreader : Debugging enabled, App Verification output was:
/Volumes/Cisdem Document Reader/Cisdem Document Reader.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: ENOL INTERNATIONAL CO., LIMITED (5HGV8EX6BQ)

2025-03-26 16:18:59 : INFO  : cisdem-documentreader : Team ID matching: 5HGV8EX6BQ (expected: 5HGV8EX6BQ )
2025-03-26 16:18:59 : INFO  : cisdem-documentreader : Installing cisdem-documentreader version 5.5.1 on versionKey CFBundleShortVersionString.
2025-03-26 16:18:59 : INFO  : cisdem-documentreader : App has LSMinimumSystemVersion: 10.10
2025-03-26 16:18:59 : DEBUG : cisdem-documentreader : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-03-26 16:18:59 : INFO  : cisdem-documentreader : Finishing...
2025-03-26 16:19:02 : INFO  : cisdem-documentreader : name: cisdem-documentreader, appName: Cisdem Document Reader.app
2025-03-26 16:19:02 : WARN  : cisdem-documentreader : No previous app found
2025-03-26 16:19:02 : WARN  : cisdem-documentreader : could not find Cisdem Document Reader.app
2025-03-26 16:19:02 : REQ   : cisdem-documentreader : Installed cisdem-documentreader, version 5.5.1
2025-03-26 16:19:02 : INFO  : cisdem-documentreader : notifying
2025-03-26 16:19:02 : DEBUG : cisdem-documentreader : Unmounting /Volumes/Cisdem Document Reader
2025-03-26 16:19:03 : DEBUG : cisdem-documentreader : Debugging enabled, Unmounting output was:
"disk5" ejected.
2025-03-26 16:19:03 : DEBUG : cisdem-documentreader : DEBUG mode 1, not reopening anything
2025-03-26 16:19:03 : REQ   : cisdem-documentreader : All done!
2025-03-26 16:19:03 : REQ   : cisdem-documentreader : ################## End Installomator, exit code 0
````

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
