### PR TITLE
Update dragonframe5

### DIFF
--- a/fragments/labels/dragonframe5.sh
+++ b/fragments/labels/dragonframe5.sh
@@ -4,6 +4,5 @@ dragonframe5)
     packageID="com.dzed.Dragonframe5"
     expectedTeamID="PG7SM8SD8M"
     curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
-    downloadURL="$( curl -s "https://www.dragonframe.com/downloads/" $curlOptions | tr '"' '\n' | grep -m1 "_5.*pkg" )"
-    appNewVersion="$( echo "$downloadURL" | cut -d '_' -f 2 | cut -d '.' -f 1-3 )"
+    downloadURL="https://www.dragonframe.com/download/Dragonframe_5.2.8.pkg"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Hardcoded `downloadURL`, removed `appNewVersion`. There was a name change somewhere in 2024. `dragonframe5` was the last version 5 [release](https://www.dragonframe.com/downloads/). New versions are named per year, see #2269 and #2270. 

**Installomator log**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh dragonframe5
2025-03-30 00:31:25 : INFO  : dragonframe5 : Total items in argumentsArray: 0
2025-03-30 00:31:25 : INFO  : dragonframe5 : argumentsArray:
2025-03-30 00:31:25 : REQ   : dragonframe5 : ################## Start Installomator v. 10.8, date 2025-03-30
2025-03-30 00:31:25 : INFO  : dragonframe5 : ################## Version: 10.8
2025-03-30 00:31:25 : INFO  : dragonframe5 : ################## Date: 2025-03-30
2025-03-30 00:31:25 : INFO  : dragonframe5 : ################## dragonframe5
2025-03-30 00:31:25 : DEBUG : dragonframe5 : DEBUG mode 1 enabled.
2025-03-30 00:31:25 : INFO  : dragonframe5 : Reading arguments again:
2025-03-30 00:31:25 : DEBUG : dragonframe5 : name=DragonFrame 5
2025-03-30 00:31:25 : DEBUG : dragonframe5 : appName=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : type=pkg
2025-03-30 00:31:25 : DEBUG : dragonframe5 : archiveName=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : downloadURL=https://www.dragonframe.com/download/Dragonframe_5.2.8.pkg
2025-03-30 00:31:25 : DEBUG : dragonframe5 : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
2025-03-30 00:31:25 : DEBUG : dragonframe5 : appNewVersion=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : appCustomVersion function: Not defined
2025-03-30 00:31:25 : DEBUG : dragonframe5 : versionKey=CFBundleShortVersionString
2025-03-30 00:31:25 : DEBUG : dragonframe5 : packageID=com.dzed.Dragonframe5
2025-03-30 00:31:25 : DEBUG : dragonframe5 : pkgName=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : choiceChangesXML=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : expectedTeamID=PG7SM8SD8M
2025-03-30 00:31:25 : DEBUG : dragonframe5 : blockingProcesses=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : installerTool=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : CLIInstaller=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : CLIArguments=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : updateTool=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : updateToolArguments=
2025-03-30 00:31:25 : DEBUG : dragonframe5 : updateToolRunAsCurrentUser=
2025-03-30 00:31:25 : INFO  : dragonframe5 : BLOCKING_PROCESS_ACTION=tell_user
2025-03-30 00:31:25 : INFO  : dragonframe5 : NOTIFY=success
2025-03-30 00:31:25 : INFO  : dragonframe5 : LOGGING=DEBUG
2025-03-30 00:31:26 : INFO  : dragonframe5 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-30 00:31:26 : INFO  : dragonframe5 : Label type: pkg
2025-03-30 00:31:26 : INFO  : dragonframe5 : archiveName: DragonFrame 5.pkg
2025-03-30 00:31:26 : INFO  : dragonframe5 : no blocking processes defined, using DragonFrame 5 as default
2025-03-30 00:31:26 : DEBUG : dragonframe5 : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-30 00:31:26 : INFO  : dragonframe5 : No version found using packageID com.dzed.Dragonframe5
2025-03-30 00:31:26 : INFO  : dragonframe5 : name: DragonFrame 5, appName: DragonFrame 5.app
2025-03-30 00:31:26 : WARN  : dragonframe5 : No previous app found
2025-03-30 00:31:26 : WARN  : dragonframe5 : could not find DragonFrame 5.app
2025-03-30 00:31:26 : INFO  : dragonframe5 : appversion:
2025-03-30 00:31:26 : INFO  : dragonframe5 : Latest version not specified.
2025-03-30 00:31:26 : REQ   : dragonframe5 : Downloading https://www.dragonframe.com/download/Dragonframe_5.2.8.pkg to DragonFrame 5.pkg
2025-03-30 00:31:26 : DEBUG : dragonframe5 : No Dialog connection, just download
2025-03-30 00:31:36 : INFO  : dragonframe5 : Downloaded DragonFrame 5.pkg – Type is  xar archive compressed TOC
2025-03-30 00:31:36 : INFO  : dragonframe5 : - OpenPGP Public Key – SHA is 581b92de095e31e1136dae66e8d7722c68fbea84 – Size is 115452 kB
2025-03-30 00:31:36 : DEBUG : dragonframe5 : DEBUG mode 1, not checking for blocking processes
2025-03-30 00:31:36 : REQ   : dragonframe5 : Installing DragonFrame 5
2025-03-30 00:31:36 : INFO  : dragonframe5 : Verifying: DragonFrame 5.pkg
2025-03-30 00:31:36 : DEBUG : dragonframe5 : File list: -rw-r--r--@ 1 h.lans  admin   103M Mar 30 00:31 DragonFrame 5.pkg
2025-03-30 00:31:36 : DEBUG : dragonframe5 : File type: DragonFrame 5.pkg: xar archive compressed TOC: 4811, SHA-1 checksum, contains
2025-03-30 00:31:36 : DEBUG : dragonframe5 : - OpenPGP Public Key
2025-03-30 00:31:36 : DEBUG : dragonframe5 : spctlOut is DragonFrame 5.pkg: accepted
2025-03-30 00:31:36 : DEBUG : dragonframe5 : source=Notarized Developer ID
2025-03-30 00:31:36 : DEBUG : dragonframe5 : origin=Developer ID Installer: DZED Systems LLC (PG7SM8SD8M)
2025-03-30 00:31:36 : INFO  : dragonframe5 : Team ID: PG7SM8SD8M (expected: PG7SM8SD8M )
2025-03-30 00:31:36 : DEBUG : dragonframe5 : DEBUG enabled, skipping installation
2025-03-30 00:31:36 : INFO  : dragonframe5 : Finishing...
2025-03-30 00:31:39 : INFO  : dragonframe5 : No version found using packageID com.dzed.Dragonframe5
2025-03-30 00:31:39 : INFO  : dragonframe5 : name: DragonFrame 5, appName: DragonFrame 5.app
2025-03-30 00:31:40 : WARN  : dragonframe5 : No previous app found
2025-03-30 00:31:40 : WARN  : dragonframe5 : could not find DragonFrame 5.app
2025-03-30 00:31:40 : REQ   : dragonframe5 : Installed DragonFrame 5
2025-03-30 00:31:40 : INFO  : dragonframe5 : notifying
2025-03-30 00:31:40 : DEBUG : dragonframe5 : DEBUG mode 1, not reopening anything
2025-03-30 00:31:40 : REQ   : dragonframe5 : All done!
2025-03-30 00:31:40 : REQ   : dragonframe5 : ################## End Installomator, exit code 0
````