### PR TITLE
new label: utiluti

### DIFF
--- a/fragments/labels/utiluti.sh
+++ b/fragments/labels/utiluti.sh
@@ -1,0 +1,9 @@
+utiluti)
+    name="utiluti"
+    type="pkg"
+    packageID="com.scriptingosx.utiluti"
+    downloadURL=$(downloadURLFromGit "scriptingosx" "utiluti")
+    appNewVersion=$(versionFromGit "scriptingosx" "utiluti")
+    expectedTeamID="JME5BW3F3R"
+    blockingProcesses=( NONE )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes ✅

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes ✅

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes ✅

**Additional context** Add any other context about the label or fix here.

New label: utiluti https://github.com/scriptingosx/utiluti

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-03-30 17:24:48 : INFO  : utiluti : Total items in argumentsArray: 0
2025-03-30 17:24:48 : INFO  : utiluti : argumentsArray: 
2025-03-30 17:24:48 : REQ   : utiluti : ################## Start Installomator v. 10.8, date 2025-03-30
2025-03-30 17:24:48 : INFO  : utiluti : ################## Version: 10.8
2025-03-30 17:24:48 : INFO  : utiluti : ################## Date: 2025-03-30
2025-03-30 17:24:48 : INFO  : utiluti : ################## utiluti
2025-03-30 17:24:48 : DEBUG : utiluti : DEBUG mode 1 enabled.
2025-03-30 17:24:49 : INFO  : utiluti : Reading arguments again: 
2025-03-30 17:24:49 : DEBUG : utiluti : name=utiluti
2025-03-30 17:24:49 : DEBUG : utiluti : appName=
2025-03-30 17:24:49 : DEBUG : utiluti : type=pkg
2025-03-30 17:24:49 : DEBUG : utiluti : archiveName=
2025-03-30 17:24:49 : DEBUG : utiluti : downloadURL=https://github.com/scriptingosx/utiluti/releases/download/v1.0/utiluti-1.0.pkg
2025-03-30 17:24:49 : DEBUG : utiluti : curlOptions=
2025-03-30 17:24:49 : DEBUG : utiluti : appNewVersion=1.0
2025-03-30 17:24:49 : DEBUG : utiluti : appCustomVersion function: Not defined
2025-03-30 17:24:49 : DEBUG : utiluti : versionKey=CFBundleShortVersionString
2025-03-30 17:24:49 : DEBUG : utiluti : packageID=com.scriptingosx.utiluti
2025-03-30 17:24:49 : DEBUG : utiluti : pkgName=
2025-03-30 17:24:49 : DEBUG : utiluti : choiceChangesXML=
2025-03-30 17:24:49 : DEBUG : utiluti : expectedTeamID=JME5BW3F3R
2025-03-30 17:24:49 : DEBUG : utiluti : blockingProcesses=NONE
2025-03-30 17:24:49 : DEBUG : utiluti : installerTool=
2025-03-30 17:24:49 : DEBUG : utiluti : CLIInstaller=
2025-03-30 17:24:49 : DEBUG : utiluti : CLIArguments=
2025-03-30 17:24:49 : DEBUG : utiluti : updateTool=
2025-03-30 17:24:50 : DEBUG : utiluti : updateToolArguments=
2025-03-30 17:24:50 : DEBUG : utiluti : updateToolRunAsCurrentUser=
2025-03-30 17:24:50 : INFO  : utiluti : BLOCKING_PROCESS_ACTION=tell_user
2025-03-30 17:24:50 : INFO  : utiluti : NOTIFY=success
2025-03-30 17:24:50 : INFO  : utiluti : LOGGING=DEBUG
2025-03-30 17:24:50 : INFO  : utiluti : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-30 17:24:50 : INFO  : utiluti : Label type: pkg
2025-03-30 17:24:50 : INFO  : utiluti : archiveName: utiluti.pkg
2025-03-30 17:24:50 : DEBUG : utiluti : Changing directory to /Users/armin/BTSync/Work/Projects/Installomator/build
2025-03-30 17:24:50 : INFO  : utiluti : No version found using packageID com.scriptingosx.utiluti
2025-03-30 17:24:50 : INFO  : utiluti : name: utiluti, appName: utiluti.app
2025-03-30 17:24:50 : WARN  : utiluti : No previous app found
2025-03-30 17:24:50 : WARN  : utiluti : could not find utiluti.app
2025-03-30 17:24:50 : INFO  : utiluti : appversion: 
2025-03-30 17:24:50 : INFO  : utiluti : Latest version of utiluti is 1.0
2025-03-30 17:24:50 : REQ   : utiluti : Downloading https://github.com/scriptingosx/utiluti/releases/download/v1.0/utiluti-1.0.pkg to utiluti.pkg
2025-03-30 17:24:50 : DEBUG : utiluti : No Dialog connection, just download
2025-03-30 17:24:51 : INFO  : utiluti : Downloaded utiluti.pkg – Type is  xar archive compressed TOC – SHA is ecae7ab87d3bdd0bca5506ca6f35ff0d773f99ab – Size is 580 kB
2025-03-30 17:24:51 : REQ   : utiluti : Installing utiluti
2025-03-30 17:24:51 : INFO  : utiluti : Verifying: utiluti.pkg
2025-03-30 17:24:51 : DEBUG : utiluti : File list: -rw-r--r--  1 armin  staff   580K Mar 30 17:24 utiluti.pkg
2025-03-30 17:24:51 : DEBUG : utiluti : File type: utiluti.pkg: xar archive compressed TOC: 4392, SHA-1 checksum
2025-03-30 17:24:52 : DEBUG : utiluti : spctlOut is utiluti.pkg: accepted
2025-03-30 17:24:52 : DEBUG : utiluti : source=Notarized Developer ID
2025-03-30 17:24:52 : DEBUG : utiluti : origin=Developer ID Installer: Armin Briegel (JME5BW3F3R)
2025-03-30 17:24:52 : INFO  : utiluti : Team ID: JME5BW3F3R (expected: JME5BW3F3R )
2025-03-30 17:24:52 : DEBUG : utiluti : DEBUG enabled, skipping installation
2025-03-30 17:24:52 : INFO  : utiluti : Finishing...
2025-03-30 17:24:55 : INFO  : utiluti : No version found using packageID com.scriptingosx.utiluti
2025-03-30 17:24:55 : INFO  : utiluti : name: utiluti, appName: utiluti.app
2025-03-30 17:24:55 : WARN  : utiluti : No previous app found
2025-03-30 17:24:55 : WARN  : utiluti : could not find utiluti.app
2025-03-30 17:24:55 : REQ   : utiluti : Installed utiluti, version 1.0
2025-03-30 17:24:55 : INFO  : utiluti : notifying
2025-03-30 17:24:55 : DEBUG : utiluti : DEBUG mode 1, not reopening anything
2025-03-30 17:24:55 : REQ   : utiluti : All done!
2025-03-30 17:24:55 : REQ   : utiluti : ################## End Installomator, exit code 0 
```
