### PR TITLE
Update flowjo

### DIFF
--- a/fragments/labels/flowjo.sh
+++ b/fragments/labels/flowjo.sh
@@ -1,7 +1,7 @@
 flowjo)
     name="FlowJo"
     type="dmg"
-    downloadURL="$(curl -fs "https://www.flowjo.com/solutions/flowjo/downloads" | grep -i -o -E "https.*\.dmg")"
+    downloadURL="$(curl -fs "https://www.flowjo.com/flowjo/download" | grep -i -o -E "https.*\.dmg")"
     appNewVersion=$(echo "${downloadURL}" | tr "-" "\n" | grep dmg | sed -E 's/([0-9.]*)\.dmg/\1/g')
     expectedTeamID="C79HU5AD9V"
     ;;

--- a/fragments/labels/flowjo.sh
+++ b/fragments/labels/flowjo.sh
@@ -1,7 +1,11 @@
 flowjo)
-    name="FlowJo"
+    name="FlowJo 11"
     type="dmg"
-    downloadURL="$(curl -fs "https://www.flowjo.com/flowjo/download" | grep -i -o -E "https.*\.dmg")"
-    appNewVersion=$(echo "${downloadURL}" | tr "-" "\n" | grep dmg | sed -E 's/([0-9.]*)\.dmg/\1/g')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="$(curl -fs "https://www.flowjo.com/flowjo/download" | grep -i -o -E "https.*\.dmg" | grep -m 1 'arm64')"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="$(curl -fs "https://www.flowjo.com/flowjo/download" | grep -i -o -E "https.*\.dmg" | grep -m 1 'x64')"
+    fi
+    appNewVersion=$(echo "${downloadURL}" | cut -d "-" -f2 )
     expectedTeamID="C79HU5AD9V"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Updated `downloadURL`

**Installomator log**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh flowjo
2025-03-31 21:32:00 : INFO  : flowjo : Total items in argumentsArray: 0
2025-03-31 21:32:00 : INFO  : flowjo : argumentsArray:
2025-03-31 21:32:00 : REQ   : flowjo : ################## Start Installomator v. 10.9beta, date 2025-03-31
2025-03-31 21:32:00 : INFO  : flowjo : ################## Version: 10.9beta
2025-03-31 21:32:00 : INFO  : flowjo : ################## Date: 2025-03-31
2025-03-31 21:32:00 : INFO  : flowjo : ################## flowjo
2025-03-31 21:32:00 : DEBUG : flowjo : DEBUG mode 1 enabled.
2025-03-31 21:32:01 : INFO  : flowjo : Reading arguments again:
2025-03-31 21:32:01 : DEBUG : flowjo : name=FlowJo
2025-03-31 21:32:01 : DEBUG : flowjo : appName=
2025-03-31 21:32:01 : DEBUG : flowjo : type=dmg
2025-03-31 21:32:01 : DEBUG : flowjo : archiveName=
2025-03-31 21:32:01 : DEBUG : flowjo : downloadURL=https://fjinstallers.s3.amazonaws.com/FlowJo/FlowJo-OSX64-10.10.0.dmg
2025-03-31 21:32:01 : DEBUG : flowjo : curlOptions=
2025-03-31 21:32:01 : DEBUG : flowjo : appNewVersion=10.10.0
2025-03-31 21:32:01 : DEBUG : flowjo : appCustomVersion function: Not defined
2025-03-31 21:32:01 : DEBUG : flowjo : versionKey=CFBundleShortVersionString
2025-03-31 21:32:01 : DEBUG : flowjo : packageID=
2025-03-31 21:32:01 : DEBUG : flowjo : pkgName=
2025-03-31 21:32:01 : DEBUG : flowjo : choiceChangesXML=
2025-03-31 21:32:01 : DEBUG : flowjo : expectedTeamID=C79HU5AD9V
2025-03-31 21:32:01 : DEBUG : flowjo : blockingProcesses=
2025-03-31 21:32:01 : DEBUG : flowjo : installerTool=
2025-03-31 21:32:01 : DEBUG : flowjo : CLIInstaller=
2025-03-31 21:32:01 : DEBUG : flowjo : CLIArguments=
2025-03-31 21:32:01 : DEBUG : flowjo : updateTool=
2025-03-31 21:32:01 : DEBUG : flowjo : updateToolArguments=
2025-03-31 21:32:01 : DEBUG : flowjo : updateToolRunAsCurrentUser=
2025-03-31 21:32:01 : INFO  : flowjo : BLOCKING_PROCESS_ACTION=tell_user
2025-03-31 21:32:01 : INFO  : flowjo : NOTIFY=success
2025-03-31 21:32:01 : INFO  : flowjo : LOGGING=DEBUG
2025-03-31 21:32:01 : INFO  : flowjo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-31 21:32:01 : INFO  : flowjo : Label type: dmg
2025-03-31 21:32:01 : INFO  : flowjo : archiveName: FlowJo.dmg
2025-03-31 21:32:01 : INFO  : flowjo : no blocking processes defined, using FlowJo as default
2025-03-31 21:32:01 : DEBUG : flowjo : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-03-31 21:32:01 : INFO  : flowjo : name: FlowJo, appName: FlowJo.app
2025-03-31 21:32:01 : WARN  : flowjo : No previous app found
2025-03-31 21:32:01 : WARN  : flowjo : could not find FlowJo.app
2025-03-31 21:32:01 : INFO  : flowjo : appversion:
2025-03-31 21:32:01 : INFO  : flowjo : Latest version of FlowJo is 10.10.0
2025-03-31 21:32:01 : REQ   : flowjo : Downloading https://fjinstallers.s3.amazonaws.com/FlowJo/FlowJo-OSX64-10.10.0.dmg to FlowJo.dmg
2025-03-31 21:32:01 : DEBUG : flowjo : No Dialog connection, just download
2025-03-31 21:33:19 : INFO  : flowjo : Downloaded FlowJo.dmg – Type is  zlib compressed data – SHA is 0e75441ba767fb186ca2ff4f4c5fcf9a9a7a453a – Size is 262436 kB
2025-03-31 21:33:19 : DEBUG : flowjo : DEBUG mode 1, not checking for blocking processes
2025-03-31 21:33:19 : REQ   : flowjo : Installing FlowJo
2025-03-31 21:33:19 : INFO  : flowjo : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/FlowJo.dmg
2025-03-31 21:33:22 : DEBUG : flowjo : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $91F761BF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $DF282B6F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $1880D591
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $F808F41C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $1880D591
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $7E0A8041
verified CRC32 $821A943F
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/FlowJo Installer

2025-03-31 21:33:22 : INFO  : flowjo : Mounted: /Volumes/FlowJo Installer
2025-03-31 21:33:22 : INFO  : flowjo : Verifying: /Volumes/FlowJo Installer/FlowJo.app
2025-03-31 21:33:22 : DEBUG : flowjo : App size: 445M	/Volumes/FlowJo Installer/FlowJo.app
2025-03-31 21:33:23 : DEBUG : flowjo : Debugging enabled, App Verification output was:
/Volumes/FlowJo Installer/FlowJo.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: FlowJo LLC (C79HU5AD9V)

2025-03-31 21:33:23 : INFO  : flowjo : Team ID matching: C79HU5AD9V (expected: C79HU5AD9V )
2025-03-31 21:33:23 : INFO  : flowjo : Installing FlowJo version 10.10.0 on versionKey CFBundleShortVersionString.
2025-03-31 21:33:23 : DEBUG : flowjo : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-03-31 21:33:24 : INFO  : flowjo : Finishing...
2025-03-31 21:33:27 : INFO  : flowjo : name: FlowJo, appName: FlowJo.app
2025-03-31 21:33:27 : WARN  : flowjo : No previous app found
2025-03-31 21:33:27 : WARN  : flowjo : could not find FlowJo.app
2025-03-31 21:33:27 : REQ   : flowjo : Installed FlowJo, version 10.10.0
2025-03-31 21:33:27 : INFO  : flowjo : notifying
2025-03-31 21:33:27 : DEBUG : flowjo : Unmounting /Volumes/FlowJo Installer
2025-03-31 21:33:27 : DEBUG : flowjo : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-03-31 21:33:27 : DEBUG : flowjo : DEBUG mode 1, not reopening anything
2025-03-31 21:33:27 : REQ   : flowjo : All done!
2025-03-31 21:33:27 : REQ   : flowjo : ################## End Installomator, exit code 0
````