### PR TITLE
Added PackageInfo Version Check to installFromPKG function along with improved error handling

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -658,7 +658,16 @@ installFromPKG() {
         baseArchiveName=$(basename $archiveName)
         expandedPkg="$tmpDir/${baseArchiveName}_pkg"
         pkgutil --expand "$archiveName" "$expandedPkg"
-        appNewVersion=$(cat "$expandedPkg"/Distribution | xpath "string(//installer-gui-script/pkg-ref[@id='$packageID'][@version]/@version)" 2>/dev/null )
+
+        # Checks for valid info file to determine downloaded pkg version
+        if [ -f "$expandedPkg"/PackageInfo ]; then
+            appNewVersion=$(cat "$expandedPkg"/PackageInfo | grep -o 'version="[^"]*"' | sed 's/version="//; s/"//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' 2>/dev/null)
+        elif [ -f "$expandedPkg"/Distribution ]; then
+            appNewVersion=$(cat "$expandedPkg"/Distribution | xpath "string(//installer-gui-script/pkg-ref[@id='$packageID'][@version]/@version)" 2>/dev/null )
+        else
+            printlog "No method to extract version when using packageID"
+        fi
+
         rm -r "$expandedPkg"
         printlog "Downloaded package $packageID version $appNewVersion"
         if [[ $appversion == $appNewVersion ]]; then


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
No
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
Improves the installFromPKG function by including a PackageInfo check. This enables direct version verification of downloaded PKGs, particularly useful when traditional app version checks (e.g., via curl) are unreliable or unavailable (e.g., Amazon Workspaces Client where the hosted xml file for version checking doesn't actually contain the current version with the latest update). This addition also improves the install functionality by preventing unnecessary updates and provides better error handling by validating the presence of either the PackageInfo or Distribution file within the PKG.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./assemble.sh amazonworkspaces
2025-03-31 19:23:15 : INFO    : amazonworkspaces : Total items in argumentsArray: 0
2025-03-31 19:23:15 : INFO    : amazonworkspaces : argumentsArray:
2025-03-31 19:23:16 : REQ      : amazonworkspaces : ################## Start Installomator v. 10.9beta, date 2025-03-31
2025-03-31 19:23:16 : INFO    : amazonworkspaces : ################## Version: 10.9beta
2025-03-31 19:23:16 : INFO    : amazonworkspaces : ################## Date: 2025-03-31
2025-03-31 19:23:16 : INFO    : amazonworkspaces : ################## amazonworkspaces
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : DEBUG mode 1 enabled.
2025-03-31 19:23:16 : INFO    : amazonworkspaces : SwiftDialog is not installed, clear cmd file var
2025-03-31 19:23:16 : INFO    : amazonworkspaces : Reading arguments again:
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : name=Workspaces
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : appName=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : type=pkg
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : archiveName=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : downloadURL=https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : curlOptions=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : appNewVersion=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : appCustomVersion function: Not defined
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : versionKey=CFBundleShortVersionString
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : packageID=com.amazon.workspaces
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : pkgName=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : choiceChangesXML=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : expectedTeamID=94KV3E626L
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : blockingProcesses=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : installerTool=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : CLIInstaller=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : CLIArguments=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : updateTool=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : updateToolArguments=
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : updateToolRunAsCurrentUser=
2025-03-31 19:23:16 : INFO    : amazonworkspaces : BLOCKING_PROCESS_ACTION=tell_user
2025-03-31 19:23:16 : INFO    : amazonworkspaces : NOTIFY=success
2025-03-31 19:23:16 : INFO    : amazonworkspaces : LOGGING=DEBUG
2025-03-31 19:23:16 : INFO    : amazonworkspaces : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-03-31 19:23:16 : INFO    : amazonworkspaces : Label type: pkg
2025-03-31 19:23:16 : INFO    : amazonworkspaces : archiveName: Workspaces.pkg
2025-03-31 19:23:16 : INFO    : amazonworkspaces : no blocking processes defined, using Workspaces as default
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : Changing directory to /Users/searnhardt/Projects/Installomator/build
2025-03-31 19:23:16 : INFO    : amazonworkspaces : found packageID com.amazon.workspaces installed, version 5.26.2.5779
2025-03-31 19:23:16 : INFO    : amazonworkspaces : appversion: 5.26.2.5779
2025-03-31 19:23:16 : INFO    : amazonworkspaces : Latest version not specified.
2025-03-31 19:23:16 : REQ      : amazonworkspaces : Downloading https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg to Workspaces.pkg
2025-03-31 19:23:16 : DEBUG : amazonworkspaces : No Dialog connection, just download
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Downloaded Workspaces.pkg – Type is    xar archive compressed TOC – SHA is 6a2bc6af9dbf684527b5334eaf0eb3ce9a5d08ae – Size is 115668 kB
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : DEBUG mode 1, not checking for blocking processes
2025-03-31 19:23:21 : REQ      : amazonworkspaces : Installing Workspaces
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Verifying: Workspaces.pkg
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : File list: -rw-r--r--@ 1 searnhardt    staff      100M Mar 31 19:23 Workspaces.pkg
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : File type: Workspaces.pkg: xar archive compressed TOC: 4335, SHA-1 checksum
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : spctlOut is Workspaces.pkg: accepted
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : source=Notarized Developer ID
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : origin=Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Team ID: 94KV3E626L (expected: 94KV3E626L )
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Checking package version.
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Downloaded package com.amazon.workspaces version 5.26.2.5779
2025-03-31 19:23:21 : INFO    : amazonworkspaces : Downloaded version of Workspaces is the same as installed.
2025-03-31 19:23:21 : DEBUG : amazonworkspaces : DEBUG mode 1, not reopening anything
2025-03-31 19:23:21 : REQ      : amazonworkspaces : No new version to install
2025-03-31 19:23:21 : REQ      : amazonworkspaces : ################## End Installomator, exit code 0

```