### PR TITLE
Create rokokostudio.sh

### DIFF
--- a/fragments/labels/rokokostudio.sh
+++ b/fragments/labels/rokokostudio.sh
@@ -1,0 +1,9 @@
+rokokostudio)
+    name="RokokoStudio"
+    type="pkg"
+    packageID="com.rokoko.pkg.rokokostudio"
+    downloadURL="https://downloads.rokoko.com/studio-mac"
+    appNewVersion=$(curl -Ls -o /dev/null -w %{url_effective} https://downloads.rokoko.com/studio-mac | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+    versionKey="CFBundleVersion"
+    expectedTeamID="5K4RZM8SUS"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Log:

```
2025-04-03 14:08:19 : INFO  : rokokostudio : Total items in argumentsArray: 0
2025-04-03 14:08:19 : INFO  : rokokostudio : argumentsArray: 
2025-04-03 14:08:19 : REQ   : rokokostudio : ################## Start Installomator v. 10.9beta, date 2025-04-03
2025-04-03 14:08:19 : INFO  : rokokostudio : ################## Version: 10.9beta
2025-04-03 14:08:19 : INFO  : rokokostudio : ################## Date: 2025-04-03
2025-04-03 14:08:19 : INFO  : rokokostudio : ################## rokokostudio
2025-04-03 14:08:19 : DEBUG : rokokostudio : DEBUG mode 1 enabled.
2025-04-03 14:08:30 : INFO  : rokokostudio : Reading arguments again: 
2025-04-03 14:08:30 : DEBUG : rokokostudio : name=RokokoStudio
2025-04-03 14:08:30 : DEBUG : rokokostudio : appName=
2025-04-03 14:08:30 : DEBUG : rokokostudio : type=pkg
2025-04-03 14:08:30 : DEBUG : rokokostudio : archiveName=
2025-04-03 14:08:30 : DEBUG : rokokostudio : downloadURL=https://downloads.rokoko.com/studio-mac
2025-04-03 14:08:30 : DEBUG : rokokostudio : curlOptions=
2025-04-03 14:08:30 : DEBUG : rokokostudio : appNewVersion=2.4.8.0
2025-04-03 14:08:30 : DEBUG : rokokostudio : appCustomVersion function: Not defined
2025-04-03 14:08:30 : DEBUG : rokokostudio : versionKey=CFBundleVersion
2025-04-03 14:08:30 : DEBUG : rokokostudio : packageID=com.rokoko.pkg.rokokostudio
2025-04-03 14:08:30 : DEBUG : rokokostudio : pkgName=
2025-04-03 14:08:30 : DEBUG : rokokostudio : choiceChangesXML=
2025-04-03 14:08:30 : DEBUG : rokokostudio : expectedTeamID=5K4RZM8SUS
2025-04-03 14:08:30 : DEBUG : rokokostudio : blockingProcesses=
2025-04-03 14:08:30 : DEBUG : rokokostudio : installerTool=
2025-04-03 14:08:30 : DEBUG : rokokostudio : CLIInstaller=
2025-04-03 14:08:30 : DEBUG : rokokostudio : CLIArguments=
2025-04-03 14:08:30 : DEBUG : rokokostudio : updateTool=
2025-04-03 14:08:30 : DEBUG : rokokostudio : updateToolArguments=
2025-04-03 14:08:30 : DEBUG : rokokostudio : updateToolRunAsCurrentUser=
2025-04-03 14:08:30 : INFO  : rokokostudio : BLOCKING_PROCESS_ACTION=tell_user
2025-04-03 14:08:30 : INFO  : rokokostudio : NOTIFY=success
2025-04-03 14:08:30 : INFO  : rokokostudio : LOGGING=DEBUG
2025-04-03 14:08:30 : INFO  : rokokostudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-03 14:08:30 : INFO  : rokokostudio : Label type: pkg
2025-04-03 14:08:30 : INFO  : rokokostudio : archiveName: RokokoStudio.pkg
2025-04-03 14:08:30 : INFO  : rokokostudio : no blocking processes defined, using RokokoStudio as default
2025-04-03 14:08:30 : DEBUG : rokokostudio : Changing directory to /Users/coreyg/Documents/GitHub/Installomator/build
2025-04-03 14:08:31 : INFO  : rokokostudio : found packageID com.rokoko.pkg.rokokostudio installed, version 2.4.8.0
2025-04-03 14:08:31 : INFO  : rokokostudio : appversion: 2.4.8.0
2025-04-03 14:08:31 : INFO  : rokokostudio : Latest version of RokokoStudio is 2.4.8.0
2025-04-03 14:08:31 : WARN  : rokokostudio : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-04-03 14:08:31 : REQ   : rokokostudio : Downloading https://downloads.rokoko.com/studio-mac to RokokoStudio.pkg
2025-04-03 14:08:31 : DEBUG : rokokostudio : No Dialog connection, just download
2025-04-03 14:08:37 : INFO  : rokokostudio : Downloaded RokokoStudio.pkg – Type is  xar archive compressed TOC – SHA is 5e5ef66f1427f6211fe51195148763478be48848 – Size is 115408 kB
2025-04-03 14:08:37 : DEBUG : rokokostudio : DEBUG mode 1, not checking for blocking processes
2025-04-03 14:08:37 : REQ   : rokokostudio : Installing RokokoStudio
2025-04-03 14:08:37 : INFO  : rokokostudio : Verifying: RokokoStudio.pkg
2025-04-03 14:08:37 : DEBUG : rokokostudio : File list: -rw-r--r--  1 root  staff   108M Apr  3 14:08 RokokoStudio.pkg
2025-04-03 14:08:37 : DEBUG : rokokostudio : File type: RokokoStudio.pkg: xar archive compressed TOC: 5769, SHA-1 checksum
2025-04-03 14:08:37 : DEBUG : rokokostudio : spctlOut is RokokoStudio.pkg: accepted
2025-04-03 14:08:37 : DEBUG : rokokostudio : source=Notarized Developer ID
2025-04-03 14:08:37 : DEBUG : rokokostudio : origin=Developer ID Installer: Rokoko Electronics ApS (5K4RZM8SUS)
2025-04-03 14:08:37 : INFO  : rokokostudio : Team ID: 5K4RZM8SUS (expected: 5K4RZM8SUS )
2025-04-03 14:08:37 : INFO  : rokokostudio : Checking package version.
2025-04-03 14:08:38 : INFO  : rokokostudio : Downloaded package com.rokoko.pkg.rokokostudio version 2.4.8.0
2025-04-03 14:08:38 : INFO  : rokokostudio : Downloaded version of RokokoStudio is the same as installed.
2025-04-03 14:08:38 : DEBUG : rokokostudio : DEBUG mode 1, not reopening anything
2025-04-03 14:08:38 : REQ   : rokokostudio : No new version to install
2025-04-03 14:08:38 : REQ   : rokokostudio : ################## End Installomator, exit code 0 
```
