### PR TITLE
Fixed Tidal

### DIFF
--- a/fragments/labels/tidal.sh
+++ b/fragments/labels/tidal.sh
@@ -1,7 +1,11 @@
 tidal)
     name="TIDAL"
     type="dmg"
-    downloadURL="https://download.tidal.com/desktop/TIDAL.dmg"
-    appNewVersion=$(curl -fs https://update.tidal.com/updates/latest\?v\=1 | cut -d '"' -f4 | sed -E 's/https.*\/TIDAL\.([0-9.]*)\.zip/\1/g')
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://download.tidal.com/desktop/TIDAL.x64.dmg
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://download.tidal.com/desktop/TIDAL.arm64.dmg
+    fi
+    appNewVersion=$(curl -fs https://support.datajar.co.uk/hc/en-us/articles/360010333638-Jamf-Auto-Update-Application-Catalog | grep -ozpEi ">TIDAL<\/td>\n<td>(.*)<" | grep -oE "((?:[0-9]+\.?)+)" | head -1)
     expectedTeamID="GK2243L7KB"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
App version is grabbed from JAMF which might break, but I can't get it from anywhere else

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2311 


```
❯ ./assemble.sh tidal
2025-04-04 09:43:20 : INFO  : tidal : Total items in argumentsArray: 0
2025-04-04 09:43:20 : INFO  : tidal : argumentsArray: 
2025-04-04 09:43:20 : REQ   : tidal : ################## Start Installomator v. 10.9beta, date 2025-04-04
2025-04-04 09:43:20 : INFO  : tidal : ################## Version: 10.9beta
2025-04-04 09:43:20 : INFO  : tidal : ################## Date: 2025-04-04
2025-04-04 09:43:20 : INFO  : tidal : ################## tidal
2025-04-04 09:43:20 : DEBUG : tidal : DEBUG mode 1 enabled.
2025-04-04 09:43:20 : INFO  : tidal : Reading arguments again: 
2025-04-04 09:43:20 : DEBUG : tidal : name=TIDAL
2025-04-04 09:43:20 : DEBUG : tidal : appName=
2025-04-04 09:43:20 : DEBUG : tidal : type=dmg
2025-04-04 09:43:20 : DEBUG : tidal : archiveName=
2025-04-04 09:43:20 : DEBUG : tidal : downloadURL=https://download.tidal.com/desktop/TIDAL.arm64.dmg
2025-04-04 09:43:20 : DEBUG : tidal : curlOptions=
2025-04-04 09:43:20 : DEBUG : tidal : appNewVersion=2.38.5
2025-04-04 09:43:20 : DEBUG : tidal : appCustomVersion function: Not defined
2025-04-04 09:43:20 : DEBUG : tidal : versionKey=CFBundleShortVersionString
2025-04-04 09:43:20 : DEBUG : tidal : packageID=
2025-04-04 09:43:20 : DEBUG : tidal : pkgName=
2025-04-04 09:43:20 : DEBUG : tidal : choiceChangesXML=
2025-04-04 09:43:20 : DEBUG : tidal : expectedTeamID=GK2243L7KB
2025-04-04 09:43:20 : DEBUG : tidal : blockingProcesses=
2025-04-04 09:43:20 : DEBUG : tidal : installerTool=
2025-04-04 09:43:20 : DEBUG : tidal : CLIInstaller=
2025-04-04 09:43:20 : DEBUG : tidal : CLIArguments=
2025-04-04 09:43:20 : DEBUG : tidal : updateTool=
2025-04-04 09:43:20 : DEBUG : tidal : updateToolArguments=
2025-04-04 09:43:20 : DEBUG : tidal : updateToolRunAsCurrentUser=
2025-04-04 09:43:20 : INFO  : tidal : BLOCKING_PROCESS_ACTION=tell_user
2025-04-04 09:43:20 : INFO  : tidal : NOTIFY=success
2025-04-04 09:43:20 : INFO  : tidal : LOGGING=DEBUG
2025-04-04 09:43:20 : INFO  : tidal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-04 09:43:20 : INFO  : tidal : Label type: dmg
2025-04-04 09:43:20 : INFO  : tidal : archiveName: TIDAL.dmg
2025-04-04 09:43:20 : INFO  : tidal : no blocking processes defined, using TIDAL as default
2025-04-04 09:43:20 : DEBUG : tidal : Changing directory to /Users/pavel.kuzminov/code/Installomator-BN/build
2025-04-04 09:43:20 : INFO  : tidal : name: TIDAL, appName: TIDAL.app
2025-04-04 09:43:20 : WARN  : tidal : No previous app found
2025-04-04 09:43:20 : WARN  : tidal : could not find TIDAL.app
2025-04-04 09:43:20 : INFO  : tidal : appversion: 
2025-04-04 09:43:20 : INFO  : tidal : Latest version of TIDAL is 2.38.5
2025-04-04 09:43:20 : REQ   : tidal : Downloading https://download.tidal.com/desktop/TIDAL.arm64.dmg to TIDAL.dmg
2025-04-04 09:43:20 : DEBUG : tidal : No Dialog connection, just download
2025-04-04 09:43:27 : INFO  : tidal : Downloaded TIDAL.dmg – Type is  zlib compressed data – SHA is 763835d5188508649c23f4ef6893457f2aa022ff – Size is 131872 kB
2025-04-04 09:43:27 : DEBUG : tidal : DEBUG mode 1, not checking for blocking processes
2025-04-04 09:43:27 : REQ   : tidal : Installing TIDAL
2025-04-04 09:43:27 : INFO  : tidal : Mounting /Users/pavel.kuzminov/code/Installomator-BN/build/TIDAL.dmg
2025-04-04 09:43:32 : DEBUG : tidal : Debugging enabled, dmgmount output was:
Beräknar kontrollsumma för Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verifierade   CRC32 $C908D4C6
Beräknar kontrollsumma för GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verifierade   CRC32 $B70995B5
Beräknar kontrollsumma för GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verifierade   CRC32 $FF3E5DC1
Beräknar kontrollsumma för  (Apple_Free : 3)…
(Apple_Free : 3): verifierade   CRC32 $00000000
Beräknar kontrollsumma för disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verifierade   CRC32 $D48AF9AF
Beräknar kontrollsumma för  (Apple_Free : 5)…
(Apple_Free : 5): verifierade   CRC32 $00000000
Beräknar kontrollsumma för GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verifierade   CRC32 $FF3E5DC1
Beräknar kontrollsumma för GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verifierade   CRC32 $FAF59501
verifierade   CRC32 $1E9E16C7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/TIDAL.-arm64

2025-04-04 09:43:32 : INFO  : tidal : Mounted: /Volumes/TIDAL.-arm64
2025-04-04 09:43:32 : INFO  : tidal : Verifying: /Volumes/TIDAL.-arm64/TIDAL.app
2025-04-04 09:43:32 : DEBUG : tidal : App size: 320M	/Volumes/TIDAL.-arm64/TIDAL.app
2025-04-04 09:43:33 : DEBUG : tidal : Debugging enabled, App Verification output was:
/Volumes/TIDAL.-arm64/TIDAL.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TIDAL Music AS (GK2243L7KB)

2025-04-04 09:43:33 : INFO  : tidal : Team ID matching: GK2243L7KB (expected: GK2243L7KB )
2025-04-04 09:43:33 : INFO  : tidal : Installing TIDAL version 2.38.5 on versionKey CFBundleShortVersionString.
2025-04-04 09:43:33 : INFO  : tidal : App has LSMinimumSystemVersion: 10.15
2025-04-04 09:43:33 : DEBUG : tidal : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-04-04 09:43:33 : INFO  : tidal : Finishing...
2025-04-04 09:43:36 : INFO  : tidal : name: TIDAL, appName: TIDAL.app
2025-04-04 09:43:36 : WARN  : tidal : No previous app found
2025-04-04 09:43:37 : WARN  : tidal : could not find TIDAL.app
2025-04-04 09:43:37 : REQ   : tidal : Installed TIDAL, version 2.38.5
2025-04-04 09:43:37 : INFO  : tidal : notifying
2025-04-04 09:43:37 : DEBUG : tidal : Unmounting /Volumes/TIDAL.-arm64
2025-04-04 09:43:37 : DEBUG : tidal : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-04-04 09:43:37 : DEBUG : tidal : DEBUG mode 1, not reopening anything
2025-04-04 09:43:37 : REQ   : tidal : All done!
2025-04-04 09:43:37 : REQ   : tidal : ################## End Installomator, exit code 0
```