### PR TITLE
New label Oktaverifyorgurl

### DIFF
--- a/fragments/labels/oktaverifyorgurl.sh
+++ b/fragments/labels/oktaverifyorgurl.sh
@@ -1,11 +1,11 @@
-oktaverify)
+oktaverifyorgurl)
     name="Okta Verify"
     type="pkg"
     oktaTenant=$(defaults read /Library/Managed\ Preferences/com.okta.mobile.plist OktaVerify.OrgUrl)
     if [[ -z "$oktaTenant" ]]; then
       cleanupAndExit "Okta Tenant not set" ERROR
     fi
-    downloadURL="https://$oktaTenant/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA"
+    downloadURL="$oktaTenant/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA"
     appNewVersion=$(curl -is "$downloadURL" | grep ocation: | grep -o "OktaVerify.*pkg" | cut -d "-" -f 2)
     expectedTeamID="B7F62B65BN"
     ;;

--- a/fragments/labels/oktaverifyorgurl.sh
+++ b/fragments/labels/oktaverifyorgurl.sh
@@ -9,3 +9,4 @@ oktaverifyorgurl)
     appNewVersion=$(curl -is "$downloadURL" | grep ocation: | grep -o "OktaVerify.*pkg" | cut -d "-" -f 2)
     expectedTeamID="B7F62B65BN"
     ;;
+    

--- a/fragments/labels/oktaverifyyourorg.sh
+++ b/fragments/labels/oktaverifyyourorg.sh
@@ -1,0 +1,11 @@
+oktaverify)
+    name="Okta Verify"
+    type="pkg"
+    oktaTenant=$(defaults read /Library/Managed\ Preferences/com.okta.mobile.plist OktaVerify.OrgUrl)
+    if [[ -z "$oktaTenant" ]]; then
+      cleanupAndExit "Okta Tenant not set" ERROR
+    fi
+    downloadURL="https://$oktaTenant/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA"
+    appNewVersion=$(curl -is "$downloadURL" | grep ocation: | grep -o "OktaVerify.*pkg" | cut -d "-" -f 2)
+    expectedTeamID="B7F62B65BN"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes - slightly different from oktaverify.
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
Different from oktaverify as it's not using okta's tenant (okta.okta.com) to pull the installer - it's using the MDM set orgurl in the plist. Meaning it will use your org's tenant to pull down the latest installer.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

sudo Installomator/utils/assemble.sh oktaverifyorgurl DEBUG=0



2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : setting variable from argument DEBUG=0
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : Total items in argumentsArray: 1
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : argumentsArray: DEBUG=0
2025-04-07 12:56:46 : REQ   : oktaverifyorgurl : ################## Start Installomator v. 10.9beta, date 2025-04-07
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : ################## Version: 10.9beta
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : ################## Date: 2025-04-07
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : ################## oktaverifyorgurl
2025-04-07 12:56:46 : INFO  : oktaverifyorgurl : SwiftDialog is not installed, clear cmd file var
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : Reading arguments again: DEBUG=0
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : BLOCKING_PROCESS_ACTION=tell_user
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : NOTIFY=success
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : LOGGING=INFO
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : Label type: pkg
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : archiveName: Okta Verify.pkg
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : no blocking processes defined, using Okta Verify as default
2025-04-07 12:56:47 : INFO  : oktaverifyorgurl : name: Okta Verify, appName: Okta Verify.app
2025-04-07 12:56:48 : WARN  : oktaverifyorgurl : No previous app found
2025-04-07 12:56:48 : WARN  : oktaverifyorgurl : could not find Okta Verify.app
2025-04-07 12:56:48 : INFO  : oktaverifyorgurl : appversion: 
2025-04-07 12:56:48 : INFO  : oktaverifyorgurl : Latest version of Okta Verify is 9.37.0
2025-04-07 12:56:48 : REQ   : oktaverifyorgurl : Downloading https://okta.okta.com/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA to Okta Verify.pkg
2025-04-07 12:56:52 : INFO  : oktaverifyorgurl : Downloaded Okta Verify.pkg – Type is  xar archive compressed TOC – SHA is ddb4ba8c0a64bf96a1f6fe112f8d75cd97c0b412 – Size is 65148 kB
2025-04-07 12:56:52 : REQ   : oktaverifyorgurl : no more blocking processes, continue with update
2025-04-07 12:56:52 : REQ   : oktaverifyorgurl : Installing Okta Verify
2025-04-07 12:56:52 : INFO  : oktaverifyorgurl : Verifying: Okta Verify.pkg
2025-04-07 12:56:53 : INFO  : oktaverifyorgurl : Team ID: B7F62B65BN (expected: B7F62B65BN )
2025-04-07 12:56:53 : INFO  : oktaverifyorgurl : Installing Okta Verify.pkg to /
2025-04-07 12:56:54 : INFO  : oktaverifyorgurl : Finishing...
2025-04-07 12:56:57 : INFO  : oktaverifyorgurl : name: Okta Verify, appName: Okta Verify.app
2025-04-07 12:56:57 : WARN  : oktaverifyorgurl : No previous app found
2025-04-07 12:56:57 : WARN  : oktaverifyorgurl : could not find Okta Verify.app
2025-04-07 12:56:57 : REQ   : oktaverifyorgurl : Installed Okta Verify, version 9.37.0
2025-04-07 12:56:57 : INFO  : oktaverifyorgurl : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-04-07 12:56:58 : INFO  : oktaverifyorgurl : Installomator did not close any apps, so no need to reopen any apps.
2025-04-07 12:56:58 : REQ   : oktaverifyorgurl : All done!
2025-04-07 12:56:58 : REQ   : oktaverifyorgurl : ################## End Installomator, exit code 0 


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
