### PR TITLE
Create mersivesolstice.sh

### DIFF
--- a/fragments/labels/mersivesolstice.sh
+++ b/fragments/labels/mersivesolstice.sh
@@ -1,0 +1,10 @@
+mersivesolstice)
+    name="Mersive Solstice"
+    type="dmg"
+    appNewVersion=$(curl -fsL "https://documentation.mersive.com/en/solstice/solstice-release-notes.html" | grep -Eo "Solstice Version [0-9]+\.[0-9]+\.[0-9]+" | head -n 1 | awk '{print $3}')
+    downloadURL="https://www.mersive.com/downloads/SolsticeClient-${appNewVersion}.dmg"
+    expectedTeamID="63B5A5WDNG"
+    appCustomVersion() {
+        defaults read "/Applications/Mersive Solstice.app/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null
+    }
+    ;;


### PR DESCRIPTION
Output:

2025-04-08 11:46:05 : INFO  : mersivesolstice : setting variable from argument INSTALL=force
2025-04-08 11:46:05 : INFO  : mersivesolstice : setting variable from argument DEBUG=0
2025-04-08 11:46:05 : INFO  : mersivesolstice : Total items in argumentsArray: 2
2025-04-08 11:46:05 : INFO  : mersivesolstice : argumentsArray: INSTALL=force DEBUG=0
2025-04-08 11:46:05 : REQ   : mersivesolstice : ################## Start Installomator v. 10.9beta, date 2025-04-08
2025-04-08 11:46:05 : INFO  : mersivesolstice : ################## Version: 10.9beta
2025-04-08 11:46:05 : INFO  : mersivesolstice : ################## Date: 2025-04-08
2025-04-08 11:46:05 : INFO  : mersivesolstice : ################## mersivesolstice
2025-04-08 11:46:06 : INFO  : mersivesolstice : Reading arguments again: INSTALL=force DEBUG=0
2025-04-08 11:46:06 : INFO  : mersivesolstice : BLOCKING_PROCESS_ACTION=tell_user
2025-04-08 11:46:06 : INFO  : mersivesolstice : NOTIFY=success
2025-04-08 11:46:06 : INFO  : mersivesolstice : LOGGING=INFO
2025-04-08 11:46:06 : INFO  : mersivesolstice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-08 11:46:06 : INFO  : mersivesolstice : Label type: dmg
2025-04-08 11:46:06 : INFO  : mersivesolstice : archiveName: Mersive Solstice.dmg
2025-04-08 11:46:06 : INFO  : mersivesolstice : no blocking processes defined, using Mersive Solstice as default
2025-04-08 11:46:06 : INFO  : mersivesolstice : Custom App Version detection is used, found
2025-04-08 11:46:06 : INFO  : mersivesolstice : appversion:
2025-04-08 11:46:06 : INFO  : mersivesolstice : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2025-04-08 11:46:06 : INFO  : mersivesolstice : Latest version of Mersive Solstice is 6.2.1
2025-04-08 11:46:06 : REQ   : mersivesolstice : Downloading https://www.mersive.com/downloads/SolsticeClient-6.2.1.dmg to Mersive Solstice.dmg
2025-04-08 11:46:08 : INFO  : mersivesolstice : Downloaded Mersive Solstice.dmg – Type is  zlib compressed data – SHA is 1d7caea72ad556f9f8013ab2a5cbee9e9386c5af – Size is 62628 kB
2025-04-08 11:46:08 : REQ   : mersivesolstice : no more blocking processes, continue with update
2025-04-08 11:46:08 : REQ   : mersivesolstice : Installing Mersive Solstice
2025-04-08 11:46:08 : INFO  : mersivesolstice : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XG8HjVrc4A/Mersive Solstice.dmg
2025-04-08 11:46:12 : INFO  : mersivesolstice : Mounted: /Volumes/Solstice Client Installer
2025-04-08 11:46:12 : INFO  : mersivesolstice : Verifying: /Volumes/Solstice Client Installer/Mersive Solstice.app
2025-04-08 11:46:14 : INFO  : mersivesolstice : Team ID matching: 63B5A5WDNG (expected: 63B5A5WDNG )
2025-04-08 11:46:14 : INFO  : mersivesolstice : Installing Mersive Solstice version 6.2.37754 on versionKey CFBundleShortVersionString.
2025-04-08 11:46:14 : INFO  : mersivesolstice : App has LSMinimumSystemVersion: 12.3
2025-04-08 11:46:14 : INFO  : mersivesolstice : Copy /Volumes/Solstice Client Installer/Mersive Solstice.app to /Applications
2025-04-08 11:46:15 : WARN  : mersivesolstice : Changing owner to daniel.ross
2025-04-08 11:46:15 : INFO  : mersivesolstice : Finishing...
2025-04-08 11:46:18 : INFO  : mersivesolstice : Custom App Version detection is used, found 6.2.37754
2025-04-08 11:46:18 : REQ   : mersivesolstice : Installed Mersive Solstice, version 6.2.37754
2025-04-08 11:46:18 : INFO  : mersivesolstice : notifying
2025-04-08 11:46:19 : INFO  : mersivesolstice : Installomator did not close any apps, so no need to reopen any apps.
2025-04-08 11:46:19 : REQ   : mersivesolstice : All done!
2025-04-08 11:46:19 : REQ   : mersivesolstice : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
