### PR TITLE
Create KeyShot Studio label

### DIFF
--- a/fragments/labels/keyshot2024.sh
+++ b/fragments/labels/keyshot2024.sh
@@ -1,8 +1,0 @@
-keyshot|\
-keyshot2024)
-    name="KeyShot"
-    type="pkg"
-    expectedTeamID="W7B24M74T3"
-    downloadURL="https://www.keyshot.com/download/370762/"
-    appNewVersion="$( curl -v "$downloadURL" 2>&1 | grep location | cut -d '_' -f 4 | cut -d '.' -f 1-2 )"
-    ;;

--- a/fragments/labels/keyshotstudio.sh
+++ b/fragments/labels/keyshotstudio.sh
@@ -1,0 +1,12 @@
+keyshotstudio)
+    name="KeyShot Studio"
+    type="pkg"
+    expectedTeamID="W7B24M74T3"
+    downloadURL="https://www.keyshot.com/download/370762/"
+    appNewVersion="$( curl -v "$downloadURL" 2>&1 | grep location | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )"
+    appCustomVersion() {
+        if [ -d "/Applications/KeyShot Studio.app/Contents/" ]; then
+            /usr/bin/defaults read "/Applications/KeyShot Studio.app/Contents/Info.plist" CFBundleVersion
+        fi
+    }
+    ;;

--- a/fragments/labels/keyshotstudio.sh
+++ b/fragments/labels/keyshotstudio.sh
@@ -2,8 +2,9 @@ keyshotstudio)
     name="KeyShot Studio"
     type="pkg"
     expectedTeamID="W7B24M74T3"
-    downloadURL="https://www.keyshot.com/download/370762/"
-    appNewVersion="$( curl -v "$downloadURL" 2>&1 | grep location | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )"
+    downloadURL="https://download.keyshot.com/keyshot2025/keyshot_studio_mac64_2025.2_14.1.1.5.pkg"
+    # appNewVersion="$( curl -v "$downloadURL" 2>&1 | grep location | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )"
+    appNewVersion=$( echo "$downloadURL" | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )
     appCustomVersion() {
         if [ -d "/Applications/KeyShot Studio.app/Contents/" ]; then
             /usr/bin/defaults read "/Applications/KeyShot Studio.app/Contents/Info.plist" CFBundleVersion

--- a/fragments/labels/keyshotstudio.sh
+++ b/fragments/labels/keyshotstudio.sh
@@ -3,11 +3,28 @@ keyshotstudio)
     type="pkg"
     expectedTeamID="W7B24M74T3"
     downloadURL="https://download.keyshot.com/keyshot2025/keyshot_studio_mac64_2025.2_14.1.1.5.pkg"
-    # appNewVersion="$( curl -v "$downloadURL" 2>&1 | grep location | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )"
     appNewVersion=$( echo "$downloadURL" | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )
     appCustomVersion() {
-        if [ -d "/Applications/KeyShot Studio.app/Contents/" ]; then
-            /usr/bin/defaults read "/Applications/KeyShot Studio.app/Contents/Info.plist" CFBundleVersion
+        # KeyShot Studio only contains the Major.minor.minor in the Info.plist
+        # We're going to use a hidden file to store the full Major.minor.minor.minor version number
+        customVersionFile="/Users/Shared/.KeyShotStudioInstalledVersion"
+
+        # Check it the hidden custom version file exists. If so, use that version number.
+        if [ -f "${customVersionFile}" ]; then
+            result=$(cat "${customVersionFile}")
+        elif [ -d "/Applications/KeyShot Studio.app/Contents/" ]; then
+            # Custom version file doesn't exist - use the Major.minor.minor found in the app's Info.plist
+            result=$(/usr/bin/defaults read "/Applications/KeyShot Studio.app/Contents/Info.plist" CFBundleVersion)
         fi
+
+        # Write the appNewVersion value to the custom version file.
+        # This assumes any run of this label executed successfully and the installed version was updated to the
+        #   latest version because Installomator doesn't provide that kind of feedback to the label fragment code.
+        #   This is a hack, but it solves the problem of the software being re-installed on every run because the
+        #   installed version doesn't accurately report it's full version.
+        echo $appNewVersion > "${customVersionFile}"
+
+        # Write out whichever installed version number we found into appCustomVersion
+        echo $result
     }
     ;;

--- a/fragments/labels/keyshotstudio.sh
+++ b/fragments/labels/keyshotstudio.sh
@@ -5,26 +5,13 @@ keyshotstudio)
     downloadURL="https://download.keyshot.com/keyshot2025/keyshot_studio_mac64_2025.2_14.1.1.5.pkg"
     appNewVersion=$( echo "$downloadURL" | cut -d '_' -f 5 | rev | cut -d '.' -f2- | rev )
     appCustomVersion() {
-        # KeyShot Studio only contains the Major.minor.minor in the Info.plist
-        # We're going to use a hidden file to store the full Major.minor.minor.minor version number
         customVersionFile="/Users/Shared/.KeyShotStudioInstalledVersion"
-
-        # Check it the hidden custom version file exists. If so, use that version number.
         if [ -f "${customVersionFile}" ]; then
             result=$(cat "${customVersionFile}")
         elif [ -d "/Applications/KeyShot Studio.app/Contents/" ]; then
-            # Custom version file doesn't exist - use the Major.minor.minor found in the app's Info.plist
             result=$(/usr/bin/defaults read "/Applications/KeyShot Studio.app/Contents/Info.plist" CFBundleVersion)
         fi
-
-        # Write the appNewVersion value to the custom version file.
-        # This assumes any run of this label executed successfully and the installed version was updated to the
-        #   latest version because Installomator doesn't provide that kind of feedback to the label fragment code.
-        #   This is a hack, but it solves the problem of the software being re-installed on every run because the
-        #   installed version doesn't accurately report it's full version.
         echo $appNewVersion > "${customVersionFile}"
-
-        # Write out whichever installed version number we found into appCustomVersion
         echo $result
     }
     ;;


### PR DESCRIPTION
Also remove keyshot/keyshot2024 label. The download link is the same - the product has been renamed.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes.

**Additional context** Add any other context about the label or fix here.

Keyshot changed the name of their app to KeyShot Studio. They also began using actual version numbers (13.2.1.1) instead of the poorly-implemented year-based version (2024.3). I adjusted the label to reflect this.


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
% ./build/Installomator.sh keyshotstudio DEBUG=1
2025-04-09 08:56:10 : INFO  : keyshotstudio : setting variable from argument DEBUG=1
2025-04-09 08:56:10 : INFO  : keyshotstudio : Total items in argumentsArray: 1
2025-04-09 08:56:10 : INFO  : keyshotstudio : argumentsArray: DEBUG=1
2025-04-09 08:56:10 : REQ   : keyshotstudio : ################## Start Installomator v. 10.9beta, date 2025-04-08
2025-04-09 08:56:10 : INFO  : keyshotstudio : ################## Version: 10.9beta
2025-04-09 08:56:10 : INFO  : keyshotstudio : ################## Date: 2025-04-08
2025-04-09 08:56:10 : INFO  : keyshotstudio : ################## keyshotstudio
2025-04-09 08:56:10 : DEBUG : keyshotstudio : DEBUG mode 1 enabled.
2025-04-09 08:56:10 : INFO  : keyshotstudio : Reading arguments again: DEBUG=1
2025-04-09 08:56:11 : DEBUG : keyshotstudio : argument: DEBUG=1
2025-04-09 08:56:11 : DEBUG : keyshotstudio : name=KeyShot Studio
2025-04-09 08:56:11 : DEBUG : keyshotstudio : appName=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : type=pkg
2025-04-09 08:56:11 : DEBUG : keyshotstudio : archiveName=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : downloadURL=https://www.keyshot.com/download/370762/
2025-04-09 08:56:11 : DEBUG : keyshotstudio : curlOptions=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : appNewVersion=13.2.1.1
2025-04-09 08:56:11 : DEBUG : keyshotstudio : appCustomVersion function: Defined. 
2025-04-09 08:56:11 : DEBUG : keyshotstudio : versionKey=CFBundleShortVersionString
2025-04-09 08:56:11 : DEBUG : keyshotstudio : packageID=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : pkgName=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : choiceChangesXML=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : expectedTeamID=W7B24M74T3
2025-04-09 08:56:11 : DEBUG : keyshotstudio : blockingProcesses=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : installerTool=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : CLIInstaller=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : CLIArguments=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : updateTool=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : updateToolArguments=
2025-04-09 08:56:11 : DEBUG : keyshotstudio : updateToolRunAsCurrentUser=
2025-04-09 08:56:11 : INFO  : keyshotstudio : BLOCKING_PROCESS_ACTION=tell_user
2025-04-09 08:56:11 : INFO  : keyshotstudio : NOTIFY=success
2025-04-09 08:56:11 : INFO  : keyshotstudio : LOGGING=DEBUG
2025-04-09 08:56:11 : INFO  : keyshotstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-09 08:56:11 : INFO  : keyshotstudio : Label type: pkg
2025-04-09 08:56:11 : INFO  : keyshotstudio : archiveName: KeyShot Studio.pkg
2025-04-09 08:56:11 : INFO  : keyshotstudio : no blocking processes defined, using KeyShot Studio as default
2025-04-09 08:56:11 : DEBUG : keyshotstudio : Changing directory to ./build
2025-04-09 08:56:11 : INFO  : keyshotstudio : Custom App Version detection is used, found 13.2.1
2025-04-09 08:56:11 : INFO  : keyshotstudio : appversion: 13.2.1
2025-04-09 08:56:11 : INFO  : keyshotstudio : Latest version of KeyShot Studio is 13.2.1.1
2025-04-09 08:56:11 : REQ   : keyshotstudio : Downloading https://www.keyshot.com/download/370762/ to KeyShot Studio.pkg
2025-04-09 08:56:11 : DEBUG : keyshotstudio : No Dialog connection, just download
2025-04-09 08:56:27 : INFO  : keyshotstudio : Downloaded KeyShot Studio.pkg – Type is  xar archive compressed TOC – SHA is 62b1597b988fc4ce1ba1b5a5eabf91b4d79b953d – Size is 1478632 kB
2025-04-09 08:56:27 : DEBUG : keyshotstudio : DEBUG mode 1, not checking for blocking processes
2025-04-09 08:56:27 : REQ   : keyshotstudio : Installing KeyShot Studio
2025-04-09 08:56:27 : INFO  : keyshotstudio : Verifying: KeyShot Studio.pkg
2025-04-09 08:56:27 : DEBUG : keyshotstudio : File list: -rw-r--r--  1 bowmanj17  MCC\Domain Users   1.4G Apr  9 08:56 KeyShot Studio.pkg
2025-04-09 08:56:27 : DEBUG : keyshotstudio : File type: KeyShot Studio.pkg: xar archive compressed TOC: 7136, SHA-1 checksum
2025-04-09 08:56:27 : DEBUG : keyshotstudio : spctlOut is KeyShot Studio.pkg: accepted
2025-04-09 08:56:27 : DEBUG : keyshotstudio : source=Notarized Developer ID
2025-04-09 08:56:27 : DEBUG : keyshotstudio : origin=Developer ID Installer: Luxion, Inc (W7B24M74T3)
2025-04-09 08:56:27 : INFO  : keyshotstudio : Team ID: W7B24M74T3 (expected: W7B24M74T3 )
2025-04-09 08:56:27 : DEBUG : keyshotstudio : DEBUG enabled, skipping installation
2025-04-09 08:56:27 : INFO  : keyshotstudio : Finishing...
2025-04-09 08:56:31 : INFO  : keyshotstudio : Custom App Version detection is used, found 13.2.1
2025-04-09 08:56:31 : REQ   : keyshotstudio : Installed KeyShot Studio, version 13.2.1.1
2025-04-09 08:56:31 : INFO  : keyshotstudio : notifying
2025-04-09 08:56:31 : DEBUG : keyshotstudio : DEBUG mode 1, not reopening anything
2025-04-09 08:56:31 : REQ   : keyshotstudio : All done!
2025-04-09 08:56:31 : REQ   : keyshotstudio : ################## End Installomator, exit code 0 
```