### PR TITLE
Synologydriveclient update

### DIFF
--- a/fragments/labels/synologydriveclient.sh
+++ b/fragments/labels/synologydriveclient.sh
@@ -1,10 +1,9 @@
 synologydriveclient)
     name="Synology Drive Client"
     type="pkgInDmg"
-    # packageID="com.synology.CloudStation"
     versionKey="CFBundleVersion"
-    downloadURL=$(appVersion=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)<.*|\\1|"` && appShortVersion=`sed 's#.*-\(\)#\1#' <<< $appVersion` && echo https://global.download.synology.com/download/Utility/SynologyDriveClient/"$appVersion"/Mac/Installer/synology-drive-client-"${appShortVersion}".dmg)
-    # appNewVersion=$(appVersionP1=`curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)-.*|\\1|"` && sed 's/\(.\{0\}\)./\17/' <<< $appVersionP1)
-    appNewVersion=$(curl -sf https://archive.synology.com/download/Utility/SynologyDriveClient | grep -m 1 /download/Utility/SynologyDriveClient/ | sed "s|.*>\(.*\)<.*|\\1|" | sed "s#.*-\(\)#\1#")
+    appFullVersion="$( curl -sf "https://archive.synology.com/download/Utility/SynologyDriveClient" | grep -m 1 "/download/Utility/SynologyDriveClient/" | sed "s|.*>\(.*\)<.*|\\1|" )"
+    appNewVersion="$( echo $appFullVersion | sed 's#.*-\(\)#\1#' )"
+    downloadURL="https://global.download.synology.com/download/Utility/SynologyDriveClient/$appFullVersion/Mac/Installer/synology-drive-client-$appNewVersion.dmg"
     expectedTeamID="X85BAK35Y4"
     ;;

--- a/fragments/labels/synologydriveclient.sh
+++ b/fragments/labels/synologydriveclient.sh
@@ -3,7 +3,7 @@ synologydriveclient)
     type="pkgInDmg"
     versionKey="CFBundleVersion"
     appFullVersion="$( curl -sf "https://archive.synology.com/download/Utility/SynologyDriveClient" | grep -m 1 "/download/Utility/SynologyDriveClient/" | sed "s|.*>\(.*\)<.*|\\1|" )"
-    appNewVersion="$( echo $appFullVersion | sed 's#.*-\(\)#\1#' )"
+    appNewVersion="$( echo $appFullVersion | sed "s|.*-\(\)|\\1|" )"
     downloadURL="https://global.download.synology.com/download/Utility/SynologyDriveClient/$appFullVersion/Mac/Installer/synology-drive-client-$appNewVersion.dmg"
     expectedTeamID="X85BAK35Y4"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes, modifying a label.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
No, edited original in Github.

**Additional context** Add any other context about the label or fix here.
Label required clean up, and was download and processing the same information twice.

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Downloads and process version information once. Removed comments.

**Installomator log** Provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
/usr/local/Installomator/Installomator.sh valuesfromarguments DEBUG=1 'name="Synology Drive Client"' 'type="pkgInDmg"' 'versionKey="CFBundleVersion"' 'appFullVersion="$( curl -sf "https://archive.synology.com/download/Utility/SynologyDriveClient" | grep -m 1 "/download/Utility/SynologyDriveClient/" | sed "s|.*>\(.*\)<.*|\\1|" )"' 'appNewVersion="$( echo $appFullVersion | sed "s|.*-\(\)|\\1|" )"' 'downloadURL="https://global.download.synology.com/download/Utility/SynologyDriveClient/$appFullVersion/Mac/Installer/synology-drive-client-$appNewVersion.dmg"' 'expectedTeamID="X85BAK35Y4"'
2025-04-14 13:39:48 : REQ   : valuesfromarguments : ################## Start Installomator v. 10.7, date 2025-01-24
2025-04-14 13:39:48 : INFO  : valuesfromarguments : ################## Version: 10.7
2025-04-14 13:39:48 : INFO  : valuesfromarguments : ################## Date: 2025-01-24
2025-04-14 13:39:48 : INFO  : valuesfromarguments : ################## valuesfromarguments
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument DEBUG=1
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument name="Synology Drive Client"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument type="pkgInDmg"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument versionKey="CFBundleVersion"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument appFullVersion="$( curl -sf "https://archive.synology.com/download/Utility/SynologyDriveClient" | grep -m 1 "/download/Utility/SynologyDriveClient/" | sed "s|.*>\(.*\)<.*|\1|" )"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument appNewVersion="$( echo $appFullVersion | sed "s|.*-\(\)|\1|" )"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument downloadURL="https://global.download.synology.com/download/Utility/SynologyDriveClient/$appFullVersion/Mac/Installer/synology-drive-client-$appNewVersion.dmg"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : setting variable from argument expectedTeamID="X85BAK35Y4"
2025-04-14 13:39:49 : INFO  : valuesfromarguments : BLOCKING_PROCESS_ACTION=tell_user
2025-04-14 13:39:49 : INFO  : valuesfromarguments : NOTIFY=success
2025-04-14 13:39:49 : INFO  : valuesfromarguments : LOGGING=INFO
2025-04-14 13:39:49 : INFO  : valuesfromarguments : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-14 13:39:49 : INFO  : valuesfromarguments : Label type: pkgInDmg
2025-04-14 13:39:49 : INFO  : valuesfromarguments : archiveName: Synology Drive Client.dmg
2025-04-14 13:39:49 : INFO  : valuesfromarguments : no blocking processes defined, using Synology Drive Client as default
2025-04-14 13:39:49 : INFO  : valuesfromarguments : name: Synology Drive Client, appName: Synology Drive Client.app
2025-04-14 13:39:50 : WARN  : valuesfromarguments : No previous app found
2025-04-14 13:39:50 : WARN  : valuesfromarguments : could not find Synology Drive Client.app
2025-04-14 13:39:50 : INFO  : valuesfromarguments : appversion: 
2025-04-14 13:39:50 : INFO  : valuesfromarguments : Latest version of Synology Drive Client is 16111
2025-04-14 13:39:50 : REQ   : valuesfromarguments : Downloading https://global.download.synology.com/download/Utility/SynologyDriveClient/3.5.2-16111/Mac/Installer/synology-drive-client-16111.dmg to Synology Drive Client.dmg
2025-04-14 13:39:52 : REQ   : valuesfromarguments : Installing Synology Drive Client
2025-04-14 13:39:52 : INFO  : valuesfromarguments : Mounting /usr/local/Installomator/Synology Drive Client.dmg
2025-04-14 13:40:02 : INFO  : valuesfromarguments : Mounted: /Volumes/Synology Drive Client
2025-04-14 13:40:02 : INFO  : valuesfromarguments : found pkg: /Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2025-04-14 13:40:02 : INFO  : valuesfromarguments : Verifying: /Volumes/Synology Drive Client/Install Synology Drive Client.pkg
2025-04-14 13:40:03 : INFO  : valuesfromarguments : Team ID: X85BAK35Y4 (expected: X85BAK35Y4 )
2025-04-14 13:40:03 : INFO  : valuesfromarguments : Finishing...
2025-04-14 13:40:06 : INFO  : valuesfromarguments : name: Synology Drive Client, appName: Synology Drive Client.app
2025-04-14 13:40:06 : WARN  : valuesfromarguments : No previous app found
2025-04-14 13:40:06 : WARN  : valuesfromarguments : could not find Synology Drive Client.app
2025-04-14 13:40:06 : REQ   : valuesfromarguments : Installed Synology Drive Client, version 16111
2025-04-14 13:40:06 : INFO  : valuesfromarguments : notifying
2025-04-14 13:40:17 : REQ   : valuesfromarguments : All done!
2025-04-14 13:40:17 : REQ   : valuesfromarguments : ################## End Installomator, exit code 0
```