### PR TITLE
Update eastwestopus to use https

### DIFF
--- a/fragments/labels/eastwestopus.sh
+++ b/fragments/labels/eastwestopus.sh
@@ -2,7 +2,7 @@ eastwestopus)
     name="Opus"
     type="pkgInZip"
     packageID="com.eastwest.pkg.OpusInstaller"
-    downloadXML="$(curl -fs 'http://s3.amazonaws.com/ic-resources/products/OPUS.xml')"
+    downloadXML="$(curl -fs 'https://s3.amazonaws.com/ic-resources/products/OPUS.xml')"
     downloadURL="$(echo "${downloadXML}" | xpath '(//product/files/file[@platform="mac"]/url/text())' 2>/dev/null)"
     appNewVersion="$(echo "${downloadXML}" | xpath '(//product/version/text())' 2>/dev/null)"
     expectedTeamID="TWK4WE76V9"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Changed the URL from http to https. No other changes applied.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh eastwestopus              
2025-04-20 09:10:52 : INFO  : eastwestopus : Total items in argumentsArray: 0
2025-04-20 09:10:52 : INFO  : eastwestopus : argumentsArray: 
2025-04-20 09:10:52 : REQ   : eastwestopus : ################## Start Installomator v. 10.9beta, date 2025-04-20
2025-04-20 09:10:52 : INFO  : eastwestopus : ################## Version: 10.9beta
2025-04-20 09:10:52 : INFO  : eastwestopus : ################## Date: 2025-04-20
2025-04-20 09:10:52 : INFO  : eastwestopus : ################## eastwestopus
2025-04-20 09:10:52 : DEBUG : eastwestopus : DEBUG mode 1 enabled.
2025-04-20 09:10:52 : INFO  : eastwestopus : Reading arguments again: 
2025-04-20 09:10:52 : DEBUG : eastwestopus : name=Opus
2025-04-20 09:10:52 : DEBUG : eastwestopus : appName=
2025-04-20 09:10:52 : DEBUG : eastwestopus : type=pkgInZip
2025-04-20 09:10:52 : DEBUG : eastwestopus : archiveName=
2025-04-20 09:10:52 : DEBUG : eastwestopus : downloadURL=https://software.soundsonline.com/Products/OPUS/Opus_1.5.7_Mac.zip
2025-04-20 09:10:52 : DEBUG : eastwestopus : curlOptions=
2025-04-20 09:10:52 : DEBUG : eastwestopus : appNewVersion=1.5.7
2025-04-20 09:10:52 : DEBUG : eastwestopus : appCustomVersion function: Not defined
2025-04-20 09:10:52 : DEBUG : eastwestopus : versionKey=CFBundleShortVersionString
2025-04-20 09:10:52 : DEBUG : eastwestopus : packageID=com.eastwest.pkg.OpusInstaller
2025-04-20 09:10:52 : DEBUG : eastwestopus : pkgName=
2025-04-20 09:10:52 : DEBUG : eastwestopus : choiceChangesXML=
2025-04-20 09:10:52 : DEBUG : eastwestopus : expectedTeamID=TWK4WE76V9
2025-04-20 09:10:52 : DEBUG : eastwestopus : blockingProcesses=
2025-04-20 09:10:52 : DEBUG : eastwestopus : installerTool=
2025-04-20 09:10:52 : DEBUG : eastwestopus : CLIInstaller=
2025-04-20 09:10:52 : DEBUG : eastwestopus : CLIArguments=
2025-04-20 09:10:52 : DEBUG : eastwestopus : updateTool=
2025-04-20 09:10:52 : DEBUG : eastwestopus : updateToolArguments=
2025-04-20 09:10:52 : DEBUG : eastwestopus : updateToolRunAsCurrentUser=
2025-04-20 09:10:52 : INFO  : eastwestopus : BLOCKING_PROCESS_ACTION=tell_user
2025-04-20 09:10:52 : INFO  : eastwestopus : NOTIFY=success
2025-04-20 09:10:52 : INFO  : eastwestopus : LOGGING=DEBUG
2025-04-20 09:10:52 : INFO  : eastwestopus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-20 09:10:52 : INFO  : eastwestopus : Label type: pkgInZip
2025-04-20 09:10:52 : INFO  : eastwestopus : archiveName: Opus.zip
2025-04-20 09:10:52 : INFO  : eastwestopus : no blocking processes defined, using Opus as default
2025-04-20 09:10:52 : DEBUG : eastwestopus : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-04-20 09:10:52 : INFO  : eastwestopus : No version found using packageID com.eastwest.pkg.OpusInstaller
2025-04-20 09:10:52 : INFO  : eastwestopus : name: Opus, appName: Opus.app
2025-04-20 09:10:53 : WARN  : eastwestopus : No previous app found
2025-04-20 09:10:53 : WARN  : eastwestopus : could not find Opus.app
2025-04-20 09:10:53 : INFO  : eastwestopus : appversion: 
2025-04-20 09:10:53 : INFO  : eastwestopus : Latest version of Opus is 1.5.7
2025-04-20 09:10:53 : REQ   : eastwestopus : Downloading https://software.soundsonline.com/Products/OPUS/Opus_1.5.7_Mac.zip to Opus.zip
2025-04-20 09:10:53 : DEBUG : eastwestopus : No Dialog connection, just download
2025-04-20 09:12:38 : INFO  : eastwestopus : Downloaded Opus.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is 72da325e6f2822e7510085c93697d772c9dcca80 – Size is 803768 kB
2025-04-20 09:12:38 : DEBUG : eastwestopus : DEBUG mode 1, not checking for blocking processes
2025-04-20 09:12:38 : REQ   : eastwestopus : Installing Opus
2025-04-20 09:12:38 : INFO  : eastwestopus : Unzipping Opus.zip
2025-04-20 09:12:38 : DEBUG : eastwestopus : Found pkg(s):
/Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg
2025-04-20 09:12:38 : DEBUG : eastwestopus : /Users/gilburns/GitHub/Installomator/build/Opus Installer.pkg
2025-04-20 09:12:38 : INFO  : eastwestopus : found pkg: /Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg
2025-04-20 09:12:38 : INFO  : eastwestopus : Verifying: /Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg
2025-04-20 09:12:38 : DEBUG : eastwestopus : File list: -rw-r--r--@ 1 gilburns  staff   326M Aug 26  2024 /Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg
2025-04-20 09:12:38 : DEBUG : eastwestopus : File type: /Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg: xar archive compressed TOC: 5550, SHA-1 checksum
2025-04-20 09:12:39 : DEBUG : eastwestopus : spctlOut is /Users/gilburns/GitHub/Installomator/build/EW Installation Center-1.5.0.pkg: accepted
2025-04-20 09:12:39 : DEBUG : eastwestopus : source=Notarized Developer ID
2025-04-20 09:12:39 : DEBUG : eastwestopus : origin=Developer ID Installer: EASTWEST (TWK4WE76V9)
2025-04-20 09:12:39 : INFO  : eastwestopus : Team ID: TWK4WE76V9 (expected: TWK4WE76V9 )
2025-04-20 09:12:39 : DEBUG : eastwestopus : DEBUG enabled, skipping installation
2025-04-20 09:12:39 : INFO  : eastwestopus : Finishing...
2025-04-20 09:12:42 : INFO  : eastwestopus : No version found using packageID com.eastwest.pkg.OpusInstaller
2025-04-20 09:12:42 : INFO  : eastwestopus : name: Opus, appName: Opus.app
2025-04-20 09:12:42 : WARN  : eastwestopus : No previous app found
2025-04-20 09:12:42 : WARN  : eastwestopus : could not find Opus.app
2025-04-20 09:12:42 : REQ   : eastwestopus : Installed Opus, version 1.5.7
2025-04-20 09:12:42 : INFO  : eastwestopus : notifying
2025-04-20 09:12:42 : DEBUG : eastwestopus : DEBUG mode 1, not reopening anything
2025-04-20 09:12:42 : REQ   : eastwestopus : All done!
2025-04-20 09:12:42 : REQ   : eastwestopus : ################## End Installomator, exit code 0 

```