### PR TITLE
Update eastwestplay to use https

### DIFF
--- a/fragments/labels/eastwestplay.sh
+++ b/fragments/labels/eastwestplay.sh
@@ -1,7 +1,7 @@
 eastwestplay)
     name="Play"
     type="pkgInZip"
-    downloadXML="$(curl -fs 'http://s3.amazonaws.com/ic-resources/products/PLAY.xml')"
+    downloadXML="$(curl -fs 'https://s3.amazonaws.com/ic-resources/products/PLAY.xml')"
     downloadURL="$(echo "${downloadXML}" | xpath '(//product/files/file[@platform="mac"]/url/text())' 2>/dev/null)"
     appNewVersion="$(echo "${downloadXML}" | xpath '(//product/version/text())' 2>/dev/null)"
     appCustomVersion(){ /usr/bin/defaults read "/Library/Application Support/East West/Play.app/Contents/Info.plist" CFBundleShortVersionString }


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Changed link from http to https. No other changes 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh eastwestplay
2025-04-20 09:19:32 : INFO  : eastwestplay : Total items in argumentsArray: 0
2025-04-20 09:19:32 : INFO  : eastwestplay : argumentsArray: 
2025-04-20 09:19:32 : REQ   : eastwestplay : ################## Start Installomator v. 10.9beta, date 2025-04-20
2025-04-20 09:19:32 : INFO  : eastwestplay : ################## Version: 10.9beta
2025-04-20 09:19:32 : INFO  : eastwestplay : ################## Date: 2025-04-20
2025-04-20 09:19:32 : INFO  : eastwestplay : ################## eastwestplay
2025-04-20 09:19:32 : DEBUG : eastwestplay : DEBUG mode 1 enabled.
2025-04-20 09:19:32 : INFO  : eastwestplay : Reading arguments again: 
2025-04-20 09:19:32 : DEBUG : eastwestplay : name=Play
2025-04-20 09:19:32 : DEBUG : eastwestplay : appName=
2025-04-20 09:19:32 : DEBUG : eastwestplay : type=pkgInZip
2025-04-20 09:19:32 : DEBUG : eastwestplay : archiveName=
2025-04-20 09:19:32 : DEBUG : eastwestplay : downloadURL=https://software.soundsonline.com/Products/PLAY/Play_6.1.9_Mac.zip
2025-04-20 09:19:32 : DEBUG : eastwestplay : curlOptions=
2025-04-20 09:19:32 : DEBUG : eastwestplay : appNewVersion=6.1.9
2025-04-20 09:19:32 : DEBUG : eastwestplay : appCustomVersion function: Defined. 
2025-04-20 09:19:32 : DEBUG : eastwestplay : versionKey=CFBundleShortVersionString
2025-04-20 09:19:32 : DEBUG : eastwestplay : packageID=
2025-04-20 09:19:32 : DEBUG : eastwestplay : pkgName=Play Installer 6.1.9.pkg
2025-04-20 09:19:32 : DEBUG : eastwestplay : choiceChangesXML=
2025-04-20 09:19:32 : DEBUG : eastwestplay : expectedTeamID=TWK4WE76V9
2025-04-20 09:19:32 : DEBUG : eastwestplay : blockingProcesses=
2025-04-20 09:19:32 : DEBUG : eastwestplay : installerTool=
2025-04-20 09:19:32 : DEBUG : eastwestplay : CLIInstaller=
2025-04-20 09:19:32 : DEBUG : eastwestplay : CLIArguments=
2025-04-20 09:19:32 : DEBUG : eastwestplay : updateTool=
2025-04-20 09:19:32 : DEBUG : eastwestplay : updateToolArguments=
2025-04-20 09:19:32 : DEBUG : eastwestplay : updateToolRunAsCurrentUser=
2025-04-20 09:19:32 : INFO  : eastwestplay : BLOCKING_PROCESS_ACTION=tell_user
2025-04-20 09:19:32 : INFO  : eastwestplay : NOTIFY=success
2025-04-20 09:19:32 : INFO  : eastwestplay : LOGGING=DEBUG
2025-04-20 09:19:32 : INFO  : eastwestplay : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-20 09:19:32 : INFO  : eastwestplay : Label type: pkgInZip
2025-04-20 09:19:32 : INFO  : eastwestplay : archiveName: Play.zip
2025-04-20 09:19:32 : INFO  : eastwestplay : no blocking processes defined, using Play as default
2025-04-20 09:19:32 : DEBUG : eastwestplay : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-04-20 09:19:32.804 defaults[74940:316795581] 
The domain/default pair of (/Library/Application Support/East West/Play.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2025-04-20 09:19:32 : INFO  : eastwestplay : Custom App Version detection is used, found 
2025-04-20 09:19:32 : INFO  : eastwestplay : appversion: 
2025-04-20 09:19:32 : INFO  : eastwestplay : Latest version of Play is 6.1.9
2025-04-20 09:19:32 : REQ   : eastwestplay : Downloading https://software.soundsonline.com/Products/PLAY/Play_6.1.9_Mac.zip to Play.zip
2025-04-20 09:19:32 : DEBUG : eastwestplay : No Dialog connection, just download
2025-04-20 09:20:45 : INFO  : eastwestplay : Downloaded Play.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is 16b413a36dfe3bcc468b08d04b76ef5a61fc180f – Size is 574036 kB
2025-04-20 09:20:45 : DEBUG : eastwestplay : DEBUG mode 1, not checking for blocking processes
2025-04-20 09:20:45 : REQ   : eastwestplay : Installing Play
2025-04-20 09:20:45 : INFO  : eastwestplay : Unzipping Play.zip
2025-04-20 09:20:45 : INFO  : eastwestplay : Verifying: /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg
2025-04-20 09:20:45 : DEBUG : eastwestplay : File list: -rw-r--r--@ 1 gilburns  staff   555M Jul  7  2020 /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg
2025-04-20 09:20:45 : DEBUG : eastwestplay : File type: /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg: xar archive compressed TOC: 12565, SHA-1 checksum
2025-04-20 09:20:46 : DEBUG : eastwestplay : spctlOut is /Users/gilburns/GitHub/Installomator/build/Play Installer 6.1.9.pkg: accepted
2025-04-20 09:20:46 : DEBUG : eastwestplay : source=Notarized Developer ID
2025-04-20 09:20:46 : DEBUG : eastwestplay : origin=Developer ID Installer: EASTWEST (TWK4WE76V9)
2025-04-20 09:20:46 : INFO  : eastwestplay : Team ID: TWK4WE76V9 (expected: TWK4WE76V9 )
2025-04-20 09:20:46 : DEBUG : eastwestplay : DEBUG enabled, skipping installation
2025-04-20 09:20:46 : INFO  : eastwestplay : Finishing...
2025-04-20 09:20:49.114 defaults[93212:316827625] 
The domain/default pair of (/Library/Application Support/East West/Play.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2025-04-20 09:20:49 : INFO  : eastwestplay : Custom App Version detection is used, found 
2025-04-20 09:20:49 : REQ   : eastwestplay : Installed Play, version 6.1.9
2025-04-20 09:20:49 : INFO  : eastwestplay : notifying
2025-04-20 09:20:49 : DEBUG : eastwestplay : DEBUG mode 1, not reopening anything
2025-04-20 09:20:49 : REQ   : eastwestplay : All done!
2025-04-20 09:20:49 : REQ   : eastwestplay : ################## End Installomator, exit code 0 

```