### PR TITLE
Update mysqlworkbenchce to use https

### DIFF
--- a/fragments/labels/mysqlworkbenchce.sh
+++ b/fragments/labels/mysqlworkbenchce.sh
@@ -6,6 +6,6 @@ mysqlworkbenchce)
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://dev.mysql.com/get/Downloads/MySQLGUITools/$(curl -fsL "https://dev.mysql.com/downloads/workbench/?os=33" | grep -o "mysql-workbench-community-.*-macos-x86_64.dmg" | head -1)"
     fi
-    appNewVersion="$(curl -fsL 'http://workbench.mysql.com/current-release' | grep fullversion | cut -d\" -f4).CE"
+    appNewVersion="$(curl -fsL 'https://workbench.mysql.com/current-release' | grep fullversion | cut -d\" -f4).CE"
     expectedTeamID="VB5E2TV963"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Changed the http link to https

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
assemble.sh mysqlworkbenchce                    
2025-04-20 09:27:26 : INFO  : mysqlworkbenchce : Total items in argumentsArray: 0
2025-04-20 09:27:26 : INFO  : mysqlworkbenchce : argumentsArray: 
2025-04-20 09:27:26 : REQ   : mysqlworkbenchce : ################## Start Installomator v. 10.9beta, date 2025-04-20
2025-04-20 09:27:26 : INFO  : mysqlworkbenchce : ################## Version: 10.9beta
2025-04-20 09:27:26 : INFO  : mysqlworkbenchce : ################## Date: 2025-04-20
2025-04-20 09:27:26 : INFO  : mysqlworkbenchce : ################## mysqlworkbenchce
2025-04-20 09:27:26 : DEBUG : mysqlworkbenchce : DEBUG mode 1 enabled.
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : Reading arguments again: 
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : name=MySQLWorkbench
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : appName=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : type=dmg
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : archiveName=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : downloadURL=https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.42-macos-arm64.dmg
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : curlOptions=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : appNewVersion=8.0.42.CE
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : appCustomVersion function: Not defined
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : versionKey=CFBundleShortVersionString
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : packageID=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : pkgName=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : choiceChangesXML=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : expectedTeamID=VB5E2TV963
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : blockingProcesses=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : installerTool=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : CLIInstaller=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : CLIArguments=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : updateTool=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : updateToolArguments=
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : updateToolRunAsCurrentUser=
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : BLOCKING_PROCESS_ACTION=tell_user
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : NOTIFY=success
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : LOGGING=DEBUG
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : Label type: dmg
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : archiveName: MySQLWorkbench.dmg
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : no blocking processes defined, using MySQLWorkbench as default
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : name: MySQLWorkbench, appName: MySQLWorkbench.app
2025-04-20 09:27:27 : WARN  : mysqlworkbenchce : No previous app found
2025-04-20 09:27:27 : WARN  : mysqlworkbenchce : could not find MySQLWorkbench.app
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : appversion: 
2025-04-20 09:27:27 : INFO  : mysqlworkbenchce : Latest version of MySQLWorkbench is 8.0.42.CE
2025-04-20 09:27:27 : REQ   : mysqlworkbenchce : Downloading https://dev.mysql.com/get/Downloads/MySQLGUITools/mysql-workbench-community-8.0.42-macos-arm64.dmg to MySQLWorkbench.dmg
2025-04-20 09:27:27 : DEBUG : mysqlworkbenchce : No Dialog connection, just download
2025-04-20 09:27:43 : INFO  : mysqlworkbenchce : Downloaded MySQLWorkbench.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is 163b532b7b62f067e2dcec912528f1190b7be295 – Size is 131104 kB
2025-04-20 09:27:43 : DEBUG : mysqlworkbenchce : DEBUG mode 1, not checking for blocking processes
2025-04-20 09:27:43 : REQ   : mysqlworkbenchce : Installing MySQLWorkbench
2025-04-20 09:27:43 : INFO  : mysqlworkbenchce : Mounting /Users/gilburns/GitHub/Installomator/build/MySQLWorkbench.dmg
2025-04-20 09:27:49 : DEBUG : mysqlworkbenchce : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $D29C1205
verified   CRC32 $518E6BC6
/dev/disk16         	                               	/Volumes/MySQL Workbench community-8.0.42

2025-04-20 09:27:49 : INFO  : mysqlworkbenchce : Mounted: /Volumes/MySQL Workbench community-8.0.42
2025-04-20 09:27:49 : INFO  : mysqlworkbenchce : Verifying: /Volumes/MySQL Workbench community-8.0.42/MySQLWorkbench.app
2025-04-20 09:27:49 : DEBUG : mysqlworkbenchce : App size: 228M	/Volumes/MySQL Workbench community-8.0.42/MySQLWorkbench.app
2025-04-20 09:28:10 : DEBUG : mysqlworkbenchce : Debugging enabled, App Verification output was:
/Volumes/MySQL Workbench community-8.0.42/MySQLWorkbench.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Oracle America, Inc. (VB5E2TV963)

2025-04-20 09:28:10 : INFO  : mysqlworkbenchce : Team ID matching: VB5E2TV963 (expected: VB5E2TV963 )
2025-04-20 09:28:10 : INFO  : mysqlworkbenchce : Installing MySQLWorkbench version 8.0.42.CE on versionKey CFBundleShortVersionString.
2025-04-20 09:28:10 : INFO  : mysqlworkbenchce : App has LSMinimumSystemVersion: 13.0
2025-04-20 09:28:10 : DEBUG : mysqlworkbenchce : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-04-20 09:28:10 : INFO  : mysqlworkbenchce : Finishing...
2025-04-20 09:28:13 : INFO  : mysqlworkbenchce : name: MySQLWorkbench, appName: MySQLWorkbench.app
2025-04-20 09:28:13 : WARN  : mysqlworkbenchce : No previous app found
2025-04-20 09:28:13 : WARN  : mysqlworkbenchce : could not find MySQLWorkbench.app
2025-04-20 09:28:13 : REQ   : mysqlworkbenchce : Installed MySQLWorkbench, version 8.0.42.CE
2025-04-20 09:28:13 : INFO  : mysqlworkbenchce : notifying
2025-04-20 09:28:13 : DEBUG : mysqlworkbenchce : Unmounting /Volumes/MySQL Workbench community-8.0.42
2025-04-20 09:28:13 : DEBUG : mysqlworkbenchce : Debugging enabled, Unmounting output was:
"disk16" ejected.
2025-04-20 09:28:13 : DEBUG : mysqlworkbenchce : DEBUG mode 1, not reopening anything
2025-04-20 09:28:13 : REQ   : mysqlworkbenchce : All done!
2025-04-20 09:28:13 : REQ   : mysqlworkbenchce : ################## End Installomator, exit code 0 

```