### PR TITLE
'testnav' added to the labels.

### DIFF
--- a/fragments/labels/testnav.sh
+++ b/fragments/labels/testnav.sh
@@ -1,0 +1,8 @@
+testnav)
+    name="TestNav"
+    type="dmg"
+    fileName=$(getJSONValue "$(curl -fs "https://download.testnav.com/installerVersions.json")" 'mac')
+    downloadURL="https://download.testnav.com/_testnavinstallers/${fileName}"
+    appNewVersion=$(echo "$fileName" | sed -E 's/^.*-([0-9]+(\.[0-9]+)+)\.dmg$/\1/')
+    expectedTeamID="9EGT93JZWD"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

Output:
```
2025-04-21 11:59:37 : INFO  : testnav : setting variable from argument DEBUG=0 2025-04-21 11:59:37 : INFO  : testnav : Total items in argumentsArray: 1 2025-04-21 11:59:37 : INFO  : testnav : argumentsArray: DEBUG=0
2025-04-21 11:59:37 : REQ   : testnav : ################## Start Installomator v. 10.9beta, date 2025-04-21
2025-04-21 11:59:37 : INFO  : testnav : ################## Version: 10.9beta
2025-04-21 11:59:37 : INFO  : testnav : ################## Date: 2025-04-21
2025-04-21 11:59:37 : INFO  : testnav : ################## testnav
2025-04-21 11:59:38 : INFO  : testnav : Reading arguments again: DEBUG=0
2025-04-21 11:59:38 : INFO  : testnav : BLOCKING_PROCESS_ACTION=tell_user
2025-04-21 11:59:38 : INFO  : testnav : NOTIFY=success
2025-04-21 11:59:38 : INFO  : testnav : LOGGING=INFO
2025-04-21 11:59:38 : INFO  : testnav : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-04-21 11:59:38 : INFO  : testnav : Label type: dmg
2025-04-21 11:59:38 : INFO  : testnav : archiveName: TestNav.dmg
2025-04-21 11:59:38 : INFO  : testnav : no blocking processes defined, using TestNav as default
2025-04-21 11:59:38 : INFO  : testnav : name: TestNav, appName: TestNav.app
2025-04-21 11:59:38 : WARN  : testnav : No previous app found
2025-04-21 11:59:38 : WARN  : testnav : could not find TestNav.app
2025-04-21 11:59:38 : INFO  : testnav : appversion:
2025-04-21 11:59:38 : INFO  : testnav : Latest version of TestNav is 1.13.3
2025-04-21 11:59:38 : REQ   : testnav : Downloading https://download.testnav.com/_testnavinstallers/testnav-1.13.3.dmg to TestNav.dmg
2025-04-21 12:00:21 : INFO  : testnav : Downloaded TestNav.dmg – Type is  zlib compressed data – SHA is 812d991f8d2883b0becac98349121a6ad9827c71 – Size is 180312 kB
2025-04-21 12:00:21 : REQ   : testnav : no more blocking processes, continue with update
2025-04-21 12:00:21 : REQ   : testnav : Installing TestNav
2025-04-21 12:00:21 : INFO  : testnav : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Rw6HNK9OwR/TestNav.dmg
2025-04-21 12:00:26 : INFO  : testnav : Mounted: /Volumes/TestNav
2025-04-21 12:00:26 : INFO  : testnav : Verifying: /Volumes/TestNav/TestNav.app
2025-04-21 12:00:27 : INFO  : testnav : Team ID matching: 9EGT93JZWD (expected: 9EGT93JZWD )
2025-04-21 12:00:27 : INFO  : testnav : Installing TestNav version 1.13.3 on versionKey CFBundleShortVersionString.
2025-04-21 12:00:27 : INFO  : testnav : App has LSMinimumSystemVersion: 10.9
2025-04-21 12:00:27 : INFO  : testnav : Copy /Volumes/TestNav/TestNav.app to /Applications
2025-04-21 12:00:28 : WARN  : testnav : Changing owner to rbond
2025-04-21 12:00:28 : INFO  : testnav : Finishing...
2025-04-21 12:00:31 : INFO  : testnav : App(s) found: /Applications/TestNav.app
2025-04-21 12:00:31 : INFO  : testnav : found app at /Applications/TestNav.app, version 1.13.3, on versionKey CFBundleShortVersionString
2025-04-21 12:00:31 : REQ   : testnav : Installed TestNav, version 1.13.3
2025-04-21 12:00:31 : INFO  : testnav : notifying
2025-04-21 12:00:31 : INFO  : testnav : Installomator did not close any apps, so no need to reopen any apps.
2025-04-21 12:00:31 : REQ   : testnav : All done!
2025-04-21 12:00:31 : REQ   : testnav : ################## End Installomator, exit code 0
```