### PR TITLE
Overhauling Oracle SQL Developer

### DIFF
--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -1,7 +1,23 @@
-sqldeveloper)
+sqldeveloper|\
+oraclesqldeveloper)
+    # This label does not support killing blocking processes
+    # The name of the process that needs to be killed is 'java'. Killing that may have unintended consequences.
     name="SQLDeveloper"
     type="zip"
-    downloadURL="https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip"
-    appNewVersion="$(plutil -p /Applications/SQLDeveloper.app/Contents/Info.plist | grep CFBundleShortVersionString | awk -F'"' '{print $4}')"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -oE "download.oracle.com.*macos-aarch64.app.zip")
+    else
+        downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -oE "download.oracle.com.*macos-x64.app.zip")
+    fi
+    downloadURL="https://${downloadURL}"
+    # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The custom version gives 5 numbers and matches the version in downloadURL.
+    appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}')
+    versionKey="CFBundleVersion"
+    appCustomVersion() {
+        sql_version_file="/Applications/SQLDeveloper.app/Contents/Resources/sqldeveloper/sqldeveloper/bin/version.properties"
+        if [[ -f "${sql_version_file}" ]]; then
+            /usr/bin/grep VER_FULL "${sql_version_file}" | /usr/bin/cut -d = -f 2
+        fi
+    }
     expectedTeamID="VB5E2TV963"
     ;;

--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -15,9 +15,7 @@ oraclesqldeveloper)
     versionKey="CFBundleVersion"
     appCustomVersion() {
         sql_version_file="/Applications/SQLDeveloper.app/Contents/Resources/sqldeveloper/sqldeveloper/bin/version.properties"
-        if [[ -f "${sql_version_file}" ]]; then
-            /usr/bin/grep VER_FULL "${sql_version_file}" | /usr/bin/cut -d = -f 2
-        fi
+        [[ -f "${sql_version_file}" ]] && /usr/bin/grep VER_FULL "${sql_version_file}" | /usr/bin/cut -d = -f 2
     }
     expectedTeamID="VB5E2TV963"
     ;;

--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -4,12 +4,10 @@ oraclesqldeveloper)
     # The name of the process that needs to be killed is 'java'. Killing that may have unintended consequences.
     name="SQLDeveloper"
     type="zip"
+    downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -o 'https://download\.oracle\.com[^"]*macos-x64\.app\.zip')
     if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -oE "download.oracle.com.*macos-aarch64.app.zip")
-    else
-        downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -oE "download.oracle.com.*macos-x64.app.zip")
+        downloadURL=$(echo "$downloadURL" | sed 's/x64/aarch64/')
     fi
-    downloadURL="https://${downloadURL}"
     # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The custom version gives 5 numbers and matches the version in downloadURL.
     appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}')
     versionKey="CFBundleVersion"


### PR DESCRIPTION
Overhauling Oracle SQL Developer label to support Intel, variable version, correct local app version
```% utils/assemble.sh sqldeveloper
2025-05-02 09:45:30 : INFO  : sqldeveloper : Total items in argumentsArray: 0
2025-05-02 09:45:30 : INFO  : sqldeveloper : argumentsArray:
2025-05-02 09:45:30 : REQ   : sqldeveloper : ################## Start Installomator v. 10.9beta, date 2025-05-02
2025-05-02 09:45:30 : INFO  : sqldeveloper : ################## Version: 10.9beta
2025-05-02 09:45:30 : INFO  : sqldeveloper : ################## Date: 2025-05-02
2025-05-02 09:45:30 : INFO  : sqldeveloper : ################## sqldeveloper
2025-05-02 09:45:30 : DEBUG : sqldeveloper : DEBUG mode 1 enabled.
2025-05-02 09:45:31 : INFO  : sqldeveloper : Reading arguments again:
2025-05-02 09:45:31 : DEBUG : sqldeveloper : name=SQLDeveloper
2025-05-02 09:45:31 : DEBUG : sqldeveloper : appName=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : type=zip
2025-05-02 09:45:31 : DEBUG : sqldeveloper : archiveName=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : downloadURL=https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip
2025-05-02 09:45:31 : DEBUG : sqldeveloper : curlOptions=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : appNewVersion=24.3.1.347.1826
2025-05-02 09:45:31 : DEBUG : sqldeveloper : appCustomVersion function: Defined.
2025-05-02 09:45:31 : DEBUG : sqldeveloper : versionKey=CFBundleVersion
2025-05-02 09:45:31 : DEBUG : sqldeveloper : packageID=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : pkgName=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : choiceChangesXML=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : expectedTeamID=VB5E2TV963
2025-05-02 09:45:31 : DEBUG : sqldeveloper : blockingProcesses=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : installerTool=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : CLIInstaller=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : CLIArguments=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : updateTool=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : updateToolArguments=
2025-05-02 09:45:31 : DEBUG : sqldeveloper : updateToolRunAsCurrentUser=
2025-05-02 09:45:31 : INFO  : sqldeveloper : BLOCKING_PROCESS_ACTION=tell_user
2025-05-02 09:45:31 : INFO  : sqldeveloper : NOTIFY=success
2025-05-02 09:45:31 : INFO  : sqldeveloper : LOGGING=DEBUG
2025-05-02 09:45:31 : INFO  : sqldeveloper : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-02 09:45:31 : INFO  : sqldeveloper : Label type: zip
2025-05-02 09:45:31 : INFO  : sqldeveloper : archiveName: SQLDeveloper.zip
2025-05-02 09:45:31 : INFO  : sqldeveloper : no blocking processes defined, using SQLDeveloper as default
2025-05-02 09:45:31 : DEBUG : sqldeveloper : Changing directory to /Users/hessf/Git/Installomator/build
2025-05-02 09:45:31 : INFO  : sqldeveloper : Custom App Version detection is used, found
2025-05-02 09:45:31 : INFO  : sqldeveloper : appversion:
2025-05-02 09:45:31 : INFO  : sqldeveloper : Latest version of SQLDeveloper is 24.3.1.347.1826
2025-05-02 09:45:31 : REQ   : sqldeveloper : Downloading https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-24.3.1.347.1826-macos-aarch64.app.zip to SQLDeveloper.zip
2025-05-02 09:45:31 : DEBUG : sqldeveloper : No Dialog connection, just download
2025-05-02 09:45:42 : INFO  : sqldeveloper : Downloaded SQLDeveloper.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is d4838de3cf62320e96f289f94b854391f8cd8077 – Size is 541616 kB
2025-05-02 09:45:42 : DEBUG : sqldeveloper : DEBUG mode 1, not checking for blocking processes
2025-05-02 09:45:42 : REQ   : sqldeveloper : Installing SQLDeveloper
2025-05-02 09:45:42 : INFO  : sqldeveloper : Unzipping SQLDeveloper.zip
2025-05-02 09:45:43 : INFO  : sqldeveloper : Verifying: /Users/hessf/Git/Installomator/build/SQLDeveloper.app
2025-05-02 09:45:43 : DEBUG : sqldeveloper : App size: 770M	/Users/hessf/Git/Installomator/build/SQLDeveloper.app
2025-05-02 09:45:44 : DEBUG : sqldeveloper : Debugging enabled, App Verification output was:
/Users/hessf/Git/Installomator/build/SQLDeveloper.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Oracle America, Inc. (VB5E2TV963)

2025-05-02 09:45:44 : INFO  : sqldeveloper : Team ID matching: VB5E2TV963 (expected: VB5E2TV963 )
2025-05-02 09:45:44 : INFO  : sqldeveloper : Installing SQLDeveloper version 24.3.1.347 on versionKey CFBundleVersion.
2025-05-02 09:45:44 : DEBUG : sqldeveloper : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-02 09:45:44 : INFO  : sqldeveloper : Finishing...
2025-05-02 09:45:47 : INFO  : sqldeveloper : Custom App Version detection is used, found
2025-05-02 09:45:47 : REQ   : sqldeveloper : Installed SQLDeveloper, version 24.3.1.347
2025-05-02 09:45:47 : INFO  : sqldeveloper : notifying
2025-05-02 09:45:47 : DEBUG : sqldeveloper : DEBUG mode 1, not reopening anything
2025-05-02 09:45:47 : REQ   : sqldeveloper : All done!
2025-05-02 09:45:47 : REQ   : sqldeveloper : ################## End Installomator, exit code 0```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
