### PR TITLE
Create fierycommandworkstation.sh

### DIFF
--- a/fragments/labels/fierycommandworkstation.sh
+++ b/fragments/labels/fierycommandworkstation.sh
@@ -1,0 +1,44 @@
+fierycommandworkstation)
+    name="FieryCommandWorkStation"
+    #appName="Fiery Command WorkStation Package.app"
+    pkgName="/OSX/CWS Wrapper.pkg"
+    type="pkgInDmg"
+
+    latest=$(curl -s -H "Content-Type: text/xml; charset=utf-8" \
+        -H "SOAPAction: http://updates.efi.com/des/newSoftware" \
+        -d '<?xml version="1.0" encoding="utf-8"?>
+    <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+            <newSoftware xmlns="http://updates.efi.com/des/">
+                <product_identifier>10001069</product_identifier>
+                <host_id>12345</host_id>
+                <os_name>Mac OS X</os_name>
+                <os_version>12</os_version>
+                <software_version>0.0.0.0</software_version>
+                <software_language>EN</software_language>
+                <custom_attribute1>CodeBase</custom_attribute1>
+                <installed_updates/>
+            </newSoftware>
+        </soap:Body>
+    </soap:Envelope>' \
+    http://liveupdate.efi.com/des/hypatia.asmx | xmllint --format - 2>/dev/null |
+    awk '
+    /<version>/ {
+        gsub(/<\/?version>/, "")
+        ver=$0
+    }
+    /<location_download>/ {
+        gsub(/<\/?location_download>/, "")
+        if ($0 ~ /\.dmg$/) {
+            print ver "|" $0
+        }
+    }' |
+    sort -t. -k1,1n -k2,2n -k3,3n -k4,4n |
+    tail -n1)
+
+    downloadURL="$(echo "$latest" | cut -d"|" -f2 | tr -d '[:space:]')"
+    appNewVersion="$(echo "$latest" | cut -d"|" -f1 | tr -d '[:space:]')"
+    expectedTeamID="5N677U7DA8"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**: Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**: Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**: Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

**Installomator log**:
```
2025-05-07 11:48:39 : REQ   : fierycommandworkstation : ################## Start Installomator v. 10.9beta, date 2025-05-07
2025-05-07 11:48:39 : INFO  : fierycommandworkstation : ################## Version: 10.9beta
2025-05-07 11:48:39 : INFO  : fierycommandworkstation : ################## Date: 2025-05-07
2025-05-07 11:48:39 : INFO  : fierycommandworkstation : ################## fierycommandworkstation
2025-05-07 11:48:39 : DEBUG : fierycommandworkstation : DEBUG mode 1 enabled.
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : Reading arguments again: 
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : name=FieryCommandWorkStation
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : appName=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : type=pkgInDmg
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : archiveName=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : downloadURL=https://d1umxs9ckzarso.cloudfront.net/Products/CWSP/71/DCenter/471_Apr/FieryCommandWorkStation7_1.dmg
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : curlOptions=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : appNewVersion=7.1.0.471
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : appCustomVersion function: Not defined
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : versionKey=CFBundleShortVersionString
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : packageID=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : pkgName=/OSX/CWS Wrapper.pkg
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : choiceChangesXML=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : expectedTeamID=5N677U7DA8
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : blockingProcesses=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : installerTool=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : CLIInstaller=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : CLIArguments=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : updateTool=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : updateToolArguments=
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : updateToolRunAsCurrentUser=
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : BLOCKING_PROCESS_ACTION=tell_user
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : NOTIFY=success
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : LOGGING=DEBUG
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : Label type: pkgInDmg
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : archiveName: FieryCommandWorkStation.dmg
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : no blocking processes defined, using FieryCommandWorkStation as default
2025-05-07 11:48:40 : DEBUG : fierycommandworkstation : Changing directory to .
2025-05-07 11:48:40 : INFO  : fierycommandworkstation : name: FieryCommandWorkStation, appName: FieryCommandWorkStation.app
2025-05-07 11:48:41 : WARN  : fierycommandworkstation : No previous app found
2025-05-07 11:48:41 : WARN  : fierycommandworkstation : could not find FieryCommandWorkStation.app
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : appversion: 
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : Latest version of FieryCommandWorkStation is 7.1.0.471
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : FieryCommandWorkStation.dmg exists and DEBUG mode 1 enabled, skipping download
2025-05-07 11:48:41 : DEBUG : fierycommandworkstation : DEBUG mode 1, not checking for blocking processes
2025-05-07 11:48:41 : REQ   : fierycommandworkstation : Installing FieryCommandWorkStation
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : Mounting ./FieryCommandWorkStation.dmg
2025-05-07 11:48:41 : DEBUG : fierycommandworkstation : Debugging enabled, dmgmount output was:
Die erwartete CRC32-Prüfsumme ist $2A5A21D1
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            EFI
/dev/disk4s2            Apple_HFS                       /Volumes/FieryCommandWorkStation

2025-05-07 11:48:41 : INFO  : fierycommandworkstation : Mounted: /Volumes/FieryCommandWorkStation
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : found pkg: /Volumes/FieryCommandWorkStation//OSX/CWS Wrapper.pkg
2025-05-07 11:48:41 : INFO  : fierycommandworkstation : Verifying: /Volumes/FieryCommandWorkStation//OSX/CWS Wrapper.pkg
2025-05-07 11:48:41 : DEBUG : fierycommandworkstation : File list: -rwxr-xr-x  1 b.kollmer  staff    26K 16 Sep  2024 /Volumes/FieryCommandWorkStation//OSX/CWS Wrapper.pkg
2025-05-07 11:48:41 : DEBUG : fierycommandworkstation : File type: /Volumes/FieryCommandWorkStation//OSX/CWS Wrapper.pkg: xar archive compressed TOC: 4369, SHA-1 checksum
2025-05-07 11:48:42 : DEBUG : fierycommandworkstation : spctlOut is /Volumes/FieryCommandWorkStation//OSX/CWS Wrapper.pkg: accepted
2025-05-07 11:48:42 : DEBUG : fierycommandworkstation : source=Notarized Developer ID
2025-05-07 11:48:42 : DEBUG : fierycommandworkstation : origin=Developer ID Installer: Fiery, LLC (5N677U7DA8)
2025-05-07 11:48:42 : INFO  : fierycommandworkstation : Team ID: 5N677U7DA8 (expected: 5N677U7DA8 )
2025-05-07 11:48:42 : DEBUG : fierycommandworkstation : DEBUG enabled, skipping installation
2025-05-07 11:48:42 : INFO  : fierycommandworkstation : Finishing...
2025-05-07 11:48:45 : INFO  : fierycommandworkstation : name: FieryCommandWorkStation, appName: FieryCommandWorkStation.app
2025-05-07 11:48:45 : WARN  : fierycommandworkstation : No previous app found
2025-05-07 11:48:45 : WARN  : fierycommandworkstation : could not find FieryCommandWorkStation.app
2025-05-07 11:48:45 : REQ   : fierycommandworkstation : Installed FieryCommandWorkStation, version 7.1.0.471
2025-05-07 11:48:45 : INFO  : fierycommandworkstation : notifying
2025-05-07 11:48:45 : DEBUG : fierycommandworkstation : Unmounting /Volumes/FieryCommandWorkStation
2025-05-07 11:48:45 : DEBUG : fierycommandworkstation : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-07 11:48:45 : DEBUG : fierycommandworkstation : DEBUG mode 1, not reopening anything
2025-05-07 11:48:45 : REQ   : fierycommandworkstation : All done!
2025-05-07 11:48:45 : REQ   : fierycommandworkstation : ################## End Installomator, exit code 0 
```