### PR TITLE
Update beyondcomparepro to use XML update feed

### DIFF
--- a/fragments/labels/beyondcomparepro.sh
+++ b/fragments/labels/beyondcomparepro.sh
@@ -1,7 +1,9 @@
 beyondcomparepro)
     name="Beyond Compare"
     type="zip"
-    downloadURL="https://www.scootersoftware.com"$(curl -fsL 'https://www.scootersoftware.com/download' | sed -nE 's/.*"(.*OSX-[^"]*)".*/\1/p')
-    appNewVersion=$( grep -oE '(\d+\.){2}(\d+)' <<< $downloadURL )
+    updateFeed=$(curl -fsL "https://www.scootersoftware.com/checkupdates.php?product=bc5&minor=0&edition=pro&platform=osx&lang=silent")
+    rawVersion=$(echo "${updateFeed}" | xpath 'string(/Update/@latestversion)' 2>/dev/null)
+    appNewVersion=${rawVersion// build /.}
+    downloadURL=$(echo "${updateFeed}" | xpath 'string(/Update/@download)' 2>/dev/null)
     expectedTeamID="BS29TEJF86"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Updated to use a XML feed instead of the previous scraping or a page.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
~/GitHub/Installomator/utils/assemble.sh beyondcomparepro
2025-05-10 10:52:27 : INFO  : beyondcomparepro : Total items in argumentsArray: 0
2025-05-10 10:52:27 : INFO  : beyondcomparepro : argumentsArray: 
2025-05-10 10:52:27 : REQ   : beyondcomparepro : ################## Start Installomator v. 10.9beta, date 2025-05-10
2025-05-10 10:52:27 : INFO  : beyondcomparepro : ################## Version: 10.9beta
2025-05-10 10:52:27 : INFO  : beyondcomparepro : ################## Date: 2025-05-10
2025-05-10 10:52:27 : INFO  : beyondcomparepro : ################## beyondcomparepro
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : DEBUG mode 1 enabled.
2025-05-10 10:52:27 : INFO  : beyondcomparepro : Reading arguments again: 
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : name=Beyond Compare
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : appName=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : type=zip
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : archiveName=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : downloadURL=https://www.scootersoftware.com/BCompareOSX-5.0.7.30840.zip
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : curlOptions=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : appNewVersion=5.0.7.30840
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : appCustomVersion function: Not defined
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : versionKey=CFBundleShortVersionString
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : packageID=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : pkgName=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : choiceChangesXML=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : expectedTeamID=BS29TEJF86
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : blockingProcesses=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : installerTool=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : CLIInstaller=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : CLIArguments=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : updateTool=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : updateToolArguments=
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : updateToolRunAsCurrentUser=
2025-05-10 10:52:27 : INFO  : beyondcomparepro : BLOCKING_PROCESS_ACTION=tell_user
2025-05-10 10:52:27 : INFO  : beyondcomparepro : NOTIFY=success
2025-05-10 10:52:27 : INFO  : beyondcomparepro : LOGGING=DEBUG
2025-05-10 10:52:27 : INFO  : beyondcomparepro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-10 10:52:27 : INFO  : beyondcomparepro : Label type: zip
2025-05-10 10:52:27 : INFO  : beyondcomparepro : archiveName: Beyond Compare.zip
2025-05-10 10:52:27 : INFO  : beyondcomparepro : no blocking processes defined, using Beyond Compare as default
2025-05-10 10:52:27 : DEBUG : beyondcomparepro : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-05-10 10:52:27 : INFO  : beyondcomparepro : name: Beyond Compare, appName: Beyond Compare.app
2025-05-10 10:52:28 : INFO  : beyondcomparepro : App(s) found: /Users/gilburns/Applications/Beyond Compare.app
2025-05-10 10:52:28 : WARN  : beyondcomparepro : could not determine location of Beyond Compare.app
2025-05-10 10:52:28 : INFO  : beyondcomparepro : appversion: 
2025-05-10 10:52:28 : INFO  : beyondcomparepro : Latest version of Beyond Compare is 5.0.7.30840
2025-05-10 10:52:28 : REQ   : beyondcomparepro : Downloading https://www.scootersoftware.com/BCompareOSX-5.0.7.30840.zip to Beyond Compare.zip
2025-05-10 10:52:28 : DEBUG : beyondcomparepro : No Dialog connection, just download
2025-05-10 10:52:35 : INFO  : beyondcomparepro : Downloaded Beyond Compare.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 56cb23e582bbc37cf3ca6f65436804c5516561df – Size is 56408 kB
2025-05-10 10:52:35 : DEBUG : beyondcomparepro : DEBUG mode 1, not checking for blocking processes
2025-05-10 10:52:35 : REQ   : beyondcomparepro : Installing Beyond Compare
2025-05-10 10:52:35 : INFO  : beyondcomparepro : Unzipping Beyond Compare.zip
2025-05-10 10:52:35 : INFO  : beyondcomparepro : Verifying: /Users/gilburns/GitHub/Installomator/build/Beyond Compare.app
2025-05-10 10:52:35 : DEBUG : beyondcomparepro : App size: 180M	/Users/gilburns/GitHub/Installomator/build/Beyond Compare.app
2025-05-10 10:52:36 : DEBUG : beyondcomparepro : Debugging enabled, App Verification output was:
/Users/gilburns/GitHub/Installomator/build/Beyond Compare.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Scooter Software Inc. (BS29TEJF86)

2025-05-10 10:52:36 : INFO  : beyondcomparepro : Team ID matching: BS29TEJF86 (expected: BS29TEJF86 )
2025-05-10 10:52:36 : INFO  : beyondcomparepro : Installing Beyond Compare version 5.0.7.30840 on versionKey CFBundleShortVersionString.
2025-05-10 10:52:36 : DEBUG : beyondcomparepro : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-10 10:52:36 : INFO  : beyondcomparepro : Finishing...
2025-05-10 10:52:39 : INFO  : beyondcomparepro : name: Beyond Compare, appName: Beyond Compare.app
2025-05-10 10:52:39 : INFO  : beyondcomparepro : App(s) found: /Users/gilburns/Applications/Beyond Compare.app/Users/gilburns/GitHub/Installomator/build/Beyond Compare.app
2025-05-10 10:52:39 : WARN  : beyondcomparepro : could not determine location of Beyond Compare.app
2025-05-10 10:52:39 : REQ   : beyondcomparepro : Installed Beyond Compare, version 5.0.7.30840
2025-05-10 10:52:39 : INFO  : beyondcomparepro : notifying
2025-05-10 10:52:39 : DEBUG : beyondcomparepro : DEBUG mode 1, not reopening anything
2025-05-10 10:52:39 : REQ   : beyondcomparepro : All done!
2025-05-10 10:52:39 : REQ   : beyondcomparepro : ################## End Installomator, exit code 0 

```