### PR TITLE
Update todoist

### DIFF
--- a/fragments/labels/todoist.sh
+++ b/fragments/labels/todoist.sh
@@ -1,7 +1,11 @@
 todoist)
     name="Todoist"
     type="dmg"
-    downloadURL="https://todoist.com/mac_app"
-    appNewVersion="$(curl -fsIL https://todoist.com/mac_app | grep -i ^location | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')"
+    if [[ $(arch) == arm64 ]]; then
+	    downloadURL=$(curl -fsLI "https://todoist.com/mac_app?arch=arm" | grep -i ^location | sed -E 's/.*(https.*\.dmg).*/\1/g')
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL=$(curl -fsLI "https://todoist.com/mac_app?arch=x64" | grep -i ^location | sed -E 's/.*(https.*\.dmg).*/\1/g')
+    fi
+    appNewVersion="$(curl -fsIL https://todoist.com/mac_app | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/')"
     expectedTeamID="S3DD273774"
     ;;

--- a/fragments/labels/todoist.sh
+++ b/fragments/labels/todoist.sh
@@ -2,7 +2,7 @@ todoist)
     name="Todoist"
     type="dmg"
     if [[ $(arch) == arm64 ]]; then
-	    downloadURL=$(curl -fsLI "https://todoist.com/mac_app?arch=arm" | grep -i ^location | sed -E 's/.*(https.*\.dmg).*/\1/g')
+    downloadURL=$(curl -fsLI "https://todoist.com/mac_app?arch=arm" | grep -i ^location | sed -E 's/.*(https.*\.dmg).*/\1/g')
     elif [[ $(arch) == i386 ]]; then
         downloadURL=$(curl -fsLI "https://todoist.com/mac_app?arch=x64" | grep -i ^location | sed -E 's/.*(https.*\.dmg).*/\1/g')
     fi


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Updated `appNewVersion`
Added `arch` check and urls

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2368 


````
./assemble.sh todoist
2025-05-16 00:41:19 : INFO  : todoist : Total items in argumentsArray: 0
2025-05-16 00:41:19 : INFO  : todoist : argumentsArray:
2025-05-16 00:41:19 : REQ   : todoist : ################## Start Installomator v. 10.9beta, date 2025-05-16
2025-05-16 00:41:19 : INFO  : todoist : ################## Version: 10.9beta
2025-05-16 00:41:19 : INFO  : todoist : ################## Date: 2025-05-16
2025-05-16 00:41:19 : INFO  : todoist : ################## todoist
2025-05-16 00:41:19 : DEBUG : todoist : DEBUG mode 1 enabled.
2025-05-16 00:41:20 : INFO  : todoist : Reading arguments again:
2025-05-16 00:41:20 : DEBUG : todoist : name=Todoist
2025-05-16 00:41:20 : DEBUG : todoist : appName=
2025-05-16 00:41:20 : DEBUG : todoist : type=dmg
2025-05-16 00:41:20 : DEBUG : todoist : archiveName=
2025-05-16 00:41:20 : DEBUG : todoist : downloadURL=https://electron-dl.todoist.net/mac/Todoist-darwin-9.14.0-arm64-latest.dmg
2025-05-16 00:41:20 : DEBUG : todoist : curlOptions=
2025-05-16 00:41:20 : DEBUG : todoist : appNewVersion=9.14.0
2025-05-16 00:41:20 : DEBUG : todoist : appCustomVersion function: Not defined
2025-05-16 00:41:20 : DEBUG : todoist : versionKey=CFBundleShortVersionString
2025-05-16 00:41:20 : DEBUG : todoist : packageID=
2025-05-16 00:41:20 : DEBUG : todoist : pkgName=
2025-05-16 00:41:20 : DEBUG : todoist : choiceChangesXML=
2025-05-16 00:41:20 : DEBUG : todoist : expectedTeamID=S3DD273774
2025-05-16 00:41:20 : DEBUG : todoist : blockingProcesses=
2025-05-16 00:41:20 : DEBUG : todoist : installerTool=
2025-05-16 00:41:20 : DEBUG : todoist : CLIInstaller=
2025-05-16 00:41:20 : DEBUG : todoist : CLIArguments=
2025-05-16 00:41:20 : DEBUG : todoist : updateTool=
2025-05-16 00:41:20 : DEBUG : todoist : updateToolArguments=
2025-05-16 00:41:21 : DEBUG : todoist : updateToolRunAsCurrentUser=
2025-05-16 00:41:21 : INFO  : todoist : BLOCKING_PROCESS_ACTION=tell_user
2025-05-16 00:41:21 : INFO  : todoist : NOTIFY=success
2025-05-16 00:41:21 : INFO  : todoist : LOGGING=DEBUG
2025-05-16 00:41:21 : INFO  : todoist : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-16 00:41:21 : INFO  : todoist : Label type: dmg
2025-05-16 00:41:21 : INFO  : todoist : archiveName: Todoist.dmg
2025-05-16 00:41:21 : INFO  : todoist : no blocking processes defined, using Todoist as default
2025-05-16 00:41:21 : DEBUG : todoist : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-05-16 00:41:21 : INFO  : todoist : name: Todoist, appName: Todoist.app
2025-05-16 00:41:21 : WARN  : todoist : No previous app found
2025-05-16 00:41:21 : WARN  : todoist : could not find Todoist.app
2025-05-16 00:41:21 : INFO  : todoist : appversion:
2025-05-16 00:41:21 : INFO  : todoist : Latest version of Todoist is 9.14.0
2025-05-16 00:41:21 : REQ   : todoist : Downloading https://electron-dl.todoist.net/mac/Todoist-darwin-9.14.0-arm64-latest.dmg to Todoist.dmg
2025-05-16 00:41:21 : DEBUG : todoist : No Dialog connection, just download
2025-05-16 00:41:30 : INFO  : todoist : Downloaded Todoist.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 4e631d9628c825d30f688ce123e580854dff51ca – Size is 114812 kB
2025-05-16 00:41:30 : DEBUG : todoist : DEBUG mode 1, not checking for blocking processes
2025-05-16 00:41:30 : REQ   : todoist : Installing Todoist
2025-05-16 00:41:30 : INFO  : todoist : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Todoist.dmg
2025-05-16 00:41:37 : DEBUG : todoist : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $2E099BA1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $689A427E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $A2A3B93D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $4E6F5846
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $A2A3B93D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $9FC510CC
verified CRC32 $394EF1F4
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Todoist 9.14.0-arm64

2025-05-16 00:41:37 : INFO  : todoist : Mounted: /Volumes/Todoist 9.14.0-arm64
2025-05-16 00:41:37 : INFO  : todoist : Verifying: /Volumes/Todoist 9.14.0-arm64/Todoist.app
2025-05-16 00:41:37 : DEBUG : todoist : App size: 282M	/Volumes/Todoist 9.14.0-arm64/Todoist.app
2025-05-16 00:41:44 : DEBUG : todoist : Debugging enabled, App Verification output was:
/Volumes/Todoist 9.14.0-arm64/Todoist.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Doist Inc. (S3DD273774)

2025-05-16 00:41:44 : INFO  : todoist : Team ID matching: S3DD273774 (expected: S3DD273774 )
2025-05-16 00:41:44 : INFO  : todoist : Installing Todoist version 9.14.0 on versionKey CFBundleShortVersionString.
2025-05-16 00:41:44 : INFO  : todoist : App has LSMinimumSystemVersion: 11.0
2025-05-16 00:41:44 : DEBUG : todoist : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-16 00:41:44 : INFO  : todoist : Finishing...
2025-05-16 00:41:47 : INFO  : todoist : name: Todoist, appName: Todoist.app
2025-05-16 00:41:47 : WARN  : todoist : No previous app found
2025-05-16 00:41:47 : WARN  : todoist : could not find Todoist.app
2025-05-16 00:41:47 : REQ   : todoist : Installed Todoist, version 9.14.0
2025-05-16 00:41:47 : INFO  : todoist : notifying
2025-05-16 00:41:48 : DEBUG : todoist : Unmounting /Volumes/Todoist 9.14.0-arm64
2025-05-16 00:41:48 : DEBUG : todoist : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-16 00:41:48 : DEBUG : todoist : DEBUG mode 1, not reopening anything
2025-05-16 00:41:48 : REQ   : todoist : All done!
2025-05-16 00:41:48 : REQ   : todoist : ################## End Installomator, exit code 0
````