### PR TITLE
Added tableplus label

### DIFF
--- a/fragments/labels/tableplus.sh
+++ b/fragments/labels/tableplus.sh
@@ -1,0 +1,8 @@
+tableplus)
+    name="TablePlus"
+    type="dmg"
+    downloadURL="https://tableplus.com/release/osx/tableplus_latest"
+    appNewVersion=$(curl -fs https://tableplus.com/release/osx/tableplus_latest | grep -oE '[0-9]+/[^"]*TablePlus\.dmg' | grep -oE '^[0-9]+')
+    versionKey="CFBundleVersion"
+    expectedTeamID="3X57WP8E8V"
+    ;;


### PR DESCRIPTION

---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
This is adding the label TablePlus (https://tableplus.com)

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
admin@admins-Virtual-Machine utils % sudo ./assemble.sh tableplus DEBUG=1
2025-05-19 13:11:34 : INFO  : tableplus : setting variable from argument DEBUG=1
2025-05-19 13:11:34 : INFO  : tableplus : Total items in argumentsArray: 1
2025-05-19 13:11:34 : INFO  : tableplus : argumentsArray: DEBUG=1
2025-05-19 13:11:34 : REQ   : tableplus : ################## Start Installomator v. 10.9beta, date 2025-05-19
2025-05-19 13:11:34 : INFO  : tableplus : ################## Version: 10.9beta
2025-05-19 13:11:34 : INFO  : tableplus : ################## Date: 2025-05-19
2025-05-19 13:11:34 : INFO  : tableplus : ################## tableplus
2025-05-19 13:11:34 : DEBUG : tableplus : DEBUG mode 1 enabled.
2025-05-19 13:11:35 : INFO  : tableplus : Reading arguments again: DEBUG=1
2025-05-19 13:11:35 : DEBUG : tableplus : argument: DEBUG=1
2025-05-19 13:11:35 : DEBUG : tableplus : name=TablePlus
2025-05-19 13:11:35 : DEBUG : tableplus : appName=
2025-05-19 13:11:35 : DEBUG : tableplus : type=dmg
2025-05-19 13:11:35 : DEBUG : tableplus : archiveName=
2025-05-19 13:11:35 : DEBUG : tableplus : downloadURL=https://tableplus.com/release/osx/tableplus_latest
2025-05-19 13:11:35 : DEBUG : tableplus : curlOptions=
2025-05-19 13:11:35 : DEBUG : tableplus : appNewVersion=608
2025-05-19 13:11:35 : DEBUG : tableplus : appCustomVersion function: Not defined
2025-05-19 13:11:35 : DEBUG : tableplus : versionKey=CFBundleVersion
2025-05-19 13:11:35 : DEBUG : tableplus : packageID=
2025-05-19 13:11:35 : DEBUG : tableplus : pkgName=
2025-05-19 13:11:35 : DEBUG : tableplus : choiceChangesXML=
2025-05-19 13:11:35 : DEBUG : tableplus : expectedTeamID=3X57WP8E8V
2025-05-19 13:11:35 : DEBUG : tableplus : blockingProcesses=
2025-05-19 13:11:35 : DEBUG : tableplus : installerTool=
2025-05-19 13:11:35 : DEBUG : tableplus : CLIInstaller=
2025-05-19 13:11:35 : DEBUG : tableplus : CLIArguments=
2025-05-19 13:11:35 : DEBUG : tableplus : updateTool=
2025-05-19 13:11:35 : DEBUG : tableplus : updateToolArguments=
2025-05-19 13:11:35 : DEBUG : tableplus : updateToolRunAsCurrentUser=
2025-05-19 13:11:35 : INFO  : tableplus : BLOCKING_PROCESS_ACTION=tell_user
2025-05-19 13:11:35 : INFO  : tableplus : NOTIFY=success
2025-05-19 13:11:35 : INFO  : tableplus : LOGGING=DEBUG
2025-05-19 13:11:35 : INFO  : tableplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-19 13:11:35 : INFO  : tableplus : Label type: dmg
2025-05-19 13:11:35 : INFO  : tableplus : archiveName: TablePlus.dmg
2025-05-19 13:11:35 : INFO  : tableplus : no blocking processes defined, using TablePlus as default
2025-05-19 13:11:35 : DEBUG : tableplus : Changing directory to /Users/admin/Documents/GitHub/Installomator/build
2025-05-19 13:11:35 : INFO  : tableplus : name: TablePlus, appName: TablePlus.app
2025-05-19 13:11:36 : WARN  : tableplus : No previous app found
2025-05-19 13:11:36 : WARN  : tableplus : could not find TablePlus.app
2025-05-19 13:11:36 : INFO  : tableplus : appversion: 
2025-05-19 13:11:36 : INFO  : tableplus : Latest version of TablePlus is 608
2025-05-19 13:11:36 : REQ   : tableplus : Downloading https://tableplus.com/release/osx/tableplus_latest to TablePlus.dmg
2025-05-19 13:11:36 : DEBUG : tableplus : No Dialog connection, just download
2025-05-19 13:11:38 : INFO  : tableplus : Downloaded TablePlus.dmg – Type is  lzfse encoded, lzvn compressed – SHA is da769fe8ba995ec4a6bcc35f34b97016a2ad9858 – Size is 114716 kB
2025-05-19 13:11:38 : DEBUG : tableplus : DEBUG mode 1, not checking for blocking processes
2025-05-19 13:11:38 : REQ   : tableplus : Installing TablePlus
2025-05-19 13:11:38 : INFO  : tableplus : Mounting /Users/admin/Documents/GitHub/Installomator/build/TablePlus.dmg
2025-05-19 13:11:39 : DEBUG : tableplus : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $EA82A04B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $1A16E6EE
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $7EAE53EC
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $8864BC3F
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $7EAE53EC
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $FFDBF6A8
verified CRC32 $2DE989FC
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/TablePlus

2025-05-19 13:11:39 : INFO  : tableplus : Mounted: /Volumes/TablePlus
2025-05-19 13:11:39 : INFO  : tableplus : Verifying: /Volumes/TablePlus/TablePlus.app
2025-05-19 13:11:39 : DEBUG : tableplus : App size: 317M	/Volumes/TablePlus/TablePlus.app
2025-05-19 13:11:42 : DEBUG : tableplus : Debugging enabled, App Verification output was:
/Volumes/TablePlus/TablePlus.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TablePlus Inc (3X57WP8E8V)

2025-05-19 13:11:42 : INFO  : tableplus : Team ID matching: 3X57WP8E8V (expected: 3X57WP8E8V )
2025-05-19 13:11:42 : INFO  : tableplus : Installing TablePlus version 608 on versionKey CFBundleVersion.
2025-05-19 13:11:42 : INFO  : tableplus : App has LSMinimumSystemVersion: 10.13
2025-05-19 13:11:42 : DEBUG : tableplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-19 13:11:42 : INFO  : tableplus : Finishing...
2025-05-19 13:11:45 : INFO  : tableplus : name: TablePlus, appName: TablePlus.app
2025-05-19 13:11:45 : WARN  : tableplus : No previous app found
2025-05-19 13:11:45 : WARN  : tableplus : could not find TablePlus.app
2025-05-19 13:11:45 : REQ   : tableplus : Installed TablePlus, version 608
2025-05-19 13:11:45 : INFO  : tableplus : notifying
2025-05-19 13:11:46 : DEBUG : tableplus : Unmounting /Volumes/TablePlus
2025-05-19 13:11:46 : DEBUG : tableplus : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-05-19 13:11:46 : DEBUG : tableplus : DEBUG mode 1, not reopening anything
2025-05-19 13:11:46 : REQ   : tableplus : All done!
2025-05-19 13:11:46 : REQ   : tableplus : ################## End Installomator, exit code 0 
```
