### PR TITLE
Update gdevelop

### DIFF
--- a/fragments/labels/gdevelop.sh
+++ b/fragments/labels/gdevelop.sh
@@ -1,11 +1,7 @@
 gdevelop)
     name="GDevelop 5"
     type="dmg"
-    if [[ $(arch) == arm64 ]]; then
-        archiveName="GDevelop-5-[0-9.]*-arm64.dmg"
-    elif [[ $(arch) == i386 ]]; then
-        archiveName="GDevelop-5-[0-9.]*.dmg" 
-    fi
+    archiveName="GDevelop-5-[0-9.]*-universal.dmg"
     appNewVersion="$(versionFromGit 4ian GDevelop)"
     downloadURL="$(downloadURLFromGit 4ian GDevelop)"
     expectedTeamID="5CG65LEVUK"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
App is universal since Jul 24, 2023

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh gdevelop
2025-05-22 22:30:10 : INFO  : gdevelop : Total items in argumentsArray: 0
2025-05-22 22:30:10 : INFO  : gdevelop : argumentsArray:
2025-05-22 22:30:10 : REQ   : gdevelop : ################## Start Installomator v. 10.9beta, date 2025-05-22
2025-05-22 22:30:10 : INFO  : gdevelop : ################## Version: 10.9beta
2025-05-22 22:30:10 : INFO  : gdevelop : ################## Date: 2025-05-22
2025-05-22 22:30:10 : INFO  : gdevelop : ################## gdevelop
2025-05-22 22:30:10 : DEBUG : gdevelop : DEBUG mode 1 enabled.
2025-05-22 22:30:11 : INFO  : gdevelop : Reading arguments again:
2025-05-22 22:30:11 : DEBUG : gdevelop : name=GDevelop 5
2025-05-22 22:30:11 : DEBUG : gdevelop : appName=
2025-05-22 22:30:11 : DEBUG : gdevelop : type=dmg
2025-05-22 22:30:11 : DEBUG : gdevelop : archiveName=GDevelop-5-[0-9.]*-universal.dmg
2025-05-22 22:30:11 : DEBUG : gdevelop : downloadURL=https://github.com/4ian/GDevelop/releases/download/v5.5.231/GDevelop-5-5.5.231-universal.dmg
2025-05-22 22:30:11 : DEBUG : gdevelop : curlOptions=
2025-05-22 22:30:11 : DEBUG : gdevelop : appNewVersion=5.5.231
2025-05-22 22:30:11 : DEBUG : gdevelop : appCustomVersion function: Not defined
2025-05-22 22:30:11 : DEBUG : gdevelop : versionKey=CFBundleShortVersionString
2025-05-22 22:30:11 : DEBUG : gdevelop : packageID=
2025-05-22 22:30:11 : DEBUG : gdevelop : pkgName=
2025-05-22 22:30:11 : DEBUG : gdevelop : choiceChangesXML=
2025-05-22 22:30:11 : DEBUG : gdevelop : expectedTeamID=5CG65LEVUK
2025-05-22 22:30:11 : DEBUG : gdevelop : blockingProcesses=
2025-05-22 22:30:11 : DEBUG : gdevelop : installerTool=
2025-05-22 22:30:11 : DEBUG : gdevelop : CLIInstaller=
2025-05-22 22:30:11 : DEBUG : gdevelop : CLIArguments=
2025-05-22 22:30:11 : DEBUG : gdevelop : updateTool=
2025-05-22 22:30:11 : DEBUG : gdevelop : updateToolArguments=
2025-05-22 22:30:11 : DEBUG : gdevelop : updateToolRunAsCurrentUser=
2025-05-22 22:30:12 : INFO  : gdevelop : BLOCKING_PROCESS_ACTION=tell_user
2025-05-22 22:30:12 : INFO  : gdevelop : NOTIFY=success
2025-05-22 22:30:12 : INFO  : gdevelop : LOGGING=DEBUG
2025-05-22 22:30:12 : INFO  : gdevelop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-22 22:30:12 : INFO  : gdevelop : Label type: dmg
2025-05-22 22:30:12 : INFO  : gdevelop : archiveName: GDevelop-5-[0-9.]*-universal.dmg
2025-05-22 22:30:12 : INFO  : gdevelop : no blocking processes defined, using GDevelop 5 as default
2025-05-22 22:30:12 : DEBUG : gdevelop : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-05-22 22:30:12 : INFO  : gdevelop : name: GDevelop 5, appName: GDevelop 5.app
2025-05-22 22:30:12 : WARN  : gdevelop : No previous app found
2025-05-22 22:30:12 : WARN  : gdevelop : could not find GDevelop 5.app
2025-05-22 22:30:12 : INFO  : gdevelop : appversion:
2025-05-22 22:30:12 : INFO  : gdevelop : Latest version of GDevelop 5 is 5.5.231
2025-05-22 22:30:12 : REQ   : gdevelop : Downloading https://github.com/4ian/GDevelop/releases/download/v5.5.231/GDevelop-5-5.5.231-universal.dmg to GDevelop-5-[0-9.]*-universal.dmg
2025-05-22 22:30:12 : DEBUG : gdevelop : No Dialog connection, just download
2025-05-22 22:30:42 : INFO  : gdevelop : Downloaded GDevelop-5-[0-9.]*-universal.dmg – Type is  zlib compressed data – SHA is 0a3cd5f490c6d602a3c7afb1bf4d8d12f5d012ca – Size is 246556 kB
2025-05-22 22:30:42 : DEBUG : gdevelop : DEBUG mode 1, not checking for blocking processes
2025-05-22 22:30:42 : REQ   : gdevelop : Installing GDevelop 5
2025-05-22 22:30:42 : INFO  : gdevelop : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/GDevelop-5-[0-9.]*-universal.dmg
2025-05-22 22:30:46 : DEBUG : gdevelop : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $0911D657
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $FA98A5BF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $49457884
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $5B760C68
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $49457884
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $0C37CC0C
verified CRC32 $CFF86E9E
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/GDevelop 5 5.5.231-universal

2025-05-22 22:30:46 : INFO  : gdevelop : Mounted: /Volumes/GDevelop 5 5.5.231-universal
2025-05-22 22:30:46 : INFO  : gdevelop : Verifying: /Volumes/GDevelop 5 5.5.231-universal/GDevelop 5.app
2025-05-22 22:30:46 : DEBUG : gdevelop : App size: 729M	/Volumes/GDevelop 5 5.5.231-universal/GDevelop 5.app
2025-05-22 22:30:49 : DEBUG : gdevelop : Debugging enabled, App Verification output was:
/Volumes/GDevelop 5 5.5.231-universal/GDevelop 5.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Florian Rival (5CG65LEVUK)

2025-05-22 22:30:49 : INFO  : gdevelop : Team ID matching: 5CG65LEVUK (expected: 5CG65LEVUK )
2025-05-22 22:30:49 : INFO  : gdevelop : Installing GDevelop 5 version 5.5.231 on versionKey CFBundleShortVersionString.
2025-05-22 22:30:49 : INFO  : gdevelop : App has LSMinimumSystemVersion: 10.11.0
2025-05-22 22:30:49 : DEBUG : gdevelop : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-22 22:30:49 : INFO  : gdevelop : Finishing...
2025-05-22 22:30:52 : INFO  : gdevelop : name: GDevelop 5, appName: GDevelop 5.app
2025-05-22 22:30:52 : WARN  : gdevelop : No previous app found
2025-05-22 22:30:52 : WARN  : gdevelop : could not find GDevelop 5.app
2025-05-22 22:30:52 : REQ   : gdevelop : Installed GDevelop 5, version 5.5.231
2025-05-22 22:30:52 : INFO  : gdevelop : notifying
2025-05-22 22:30:52 : DEBUG : gdevelop : Unmounting /Volumes/GDevelop 5 5.5.231-universal
2025-05-22 22:30:53 : DEBUG : gdevelop : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-22 22:30:53 : DEBUG : gdevelop : DEBUG mode 1, not reopening anything
2025-05-22 22:30:53 : REQ   : gdevelop : All done!
2025-05-22 22:30:53 : REQ   : gdevelop : ################## End Installomator, exit code 0
````
