### PR TITLE
Fix: Check for dockutil

### DIFF
--- a/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -259,7 +259,7 @@ checkCmdOutput "${cmdOutput}"
 # Mark: dockutil stuff
 if [[ $addToDock -eq 1 ]]; then
     dialogUpdate "progresstext: Adding to Dock"
-    if [[ ! -d $dockutil ]]; then
+    if [[ ! -x $dockutil ]]; then
         echo "Cannot find dockutil at $dockutil, trying installation"
         # Install using Installlomator
         cmdOutput="$(${destFile} dockutil LOGO=$LOGO BLOCKING_PROCESS_ACTION=ignore LOGGING=REQ NOTIFY=silent || true)"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** NO

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** NO

**Additional context** Add any other context about the label or fix here.
dockutil is a file and not a directory. So it must be -x instead of -d. Otherwise the check will always fail.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
