### PR TITLE
Update label mamp

### DIFF
--- a/fragments/labels/mamp.sh
+++ b/fragments/labels/mamp.sh
@@ -1,7 +1,13 @@
 mamp)
-    name="MAMP"
+    name="MAMP PRO"
     type="pkg"
-    downloadURL="$(curl -fsL 'https://www.mamp.info/en/downloads/' | grep -o 'https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-[^"]*.pkg' | head -1)"
+    if [[ $(arch) != "i386" ]]; then
+        printlog "Architecture: arm64 (not i386)"
+        downloadURL="$(curl -fsL 'https://www.mamp.info/en/downloads/' | grep -o 'https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-[^"]*Apple-chip.pkg' | head -1)"
+    else
+        printlog "Architecture: i386"
+        downloadURL="$(curl -fsL 'https://www.mamp.info/en/downloads/' | grep -o 'https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-[^"]*Intel-x86.pkg' | head -1)"
+    fi
     appNewVersion="$(echo "${downloadURL}" | grep -o 'MAMP-MAMP-PRO-[0-9]*\.[0-9]*' | sed 's/MAMP-MAMP-PRO-//')"
     expectedTeamID="5KCB5KHK77"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Updated the Application Name to enhance  installed version detection.

Updated downloadURL section to properly detect the correct Apple Silicon and Intel specific architecture download.  

Previously the downloadURL would provide Apple Silicon version package regardless of actual architecture, resulting in no install or update on Intel based computers.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-05-24 13:46:00 : INFO  : mamp : setting variable from argument DIALOG_CMD_FILE=
2025-05-24 13:46:00 : INFO  : mamp : setting variable from argument NOTIFY=silent
2025-05-24 13:46:00 : INFO  : mamp : setting variable from argument DEBUG=1
2025-05-24 13:46:00 : INFO  : mamp : Total items in argumentsArray: 3
2025-05-24 13:46:00 : INFO  : mamp : argumentsArray: DIALOG_CMD_FILE= NOTIFY=silent DEBUG=1
2025-05-24 13:46:00 : REQ   : mamp : ################## Start Installomator v. 10.9beta, date 2025-04-22
2025-05-24 13:46:00 : INFO  : mamp : ################## Version: 10.9beta
2025-05-24 13:46:00 : INFO  : mamp : ################## Date: 2025-04-22
2025-05-24 13:46:00 : INFO  : mamp : ################## mamp
2025-05-24 13:46:00 : DEBUG : mamp : DEBUG mode 1 enabled.
2025-05-24 13:46:01 : INFO  : mamp : Architecture: arm64 (not i386)
2025-05-24 13:46:01 : INFO  : mamp : Reading arguments again: DIALOG_CMD_FILE= NOTIFY=silent DEBUG=1
2025-05-24 13:46:01 : DEBUG : mamp : argument: DIALOG_CMD_FILE=
2025-05-24 13:46:01 : DEBUG : mamp : argument: NOTIFY=silent
2025-05-24 13:46:01 : DEBUG : mamp : argument: DEBUG=1
2025-05-24 13:46:01 : DEBUG : mamp : name=MAMP PRO
2025-05-24 13:46:01 : DEBUG : mamp : appName=
2025-05-24 13:46:01 : DEBUG : mamp : type=pkg
2025-05-24 13:46:02 : DEBUG : mamp : archiveName=
2025-05-24 13:46:02 : DEBUG : mamp : downloadURL=https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.2-Apple-chip.pkg
2025-05-24 13:46:02 : DEBUG : mamp : curlOptions=
2025-05-24 13:46:02 : DEBUG : mamp : appNewVersion=7.2
2025-05-24 13:46:02 : DEBUG : mamp : appCustomVersion function: Not defined
2025-05-24 13:46:02 : DEBUG : mamp : versionKey=CFBundleShortVersionString
2025-05-24 13:46:02 : DEBUG : mamp : packageID=
2025-05-24 13:46:02 : DEBUG : mamp : pkgName=
2025-05-24 13:46:02 : DEBUG : mamp : choiceChangesXML=
2025-05-24 13:46:02 : DEBUG : mamp : expectedTeamID=5KCB5KHK77
2025-05-24 13:46:02 : DEBUG : mamp : blockingProcesses=
2025-05-24 13:46:02 : DEBUG : mamp : installerTool=
2025-05-24 13:46:02 : DEBUG : mamp : CLIInstaller=
2025-05-24 13:46:02 : DEBUG : mamp : CLIArguments=
2025-05-24 13:46:02 : DEBUG : mamp : updateTool=
2025-05-24 13:46:02 : DEBUG : mamp : updateToolArguments=
2025-05-24 13:46:02 : DEBUG : mamp : updateToolRunAsCurrentUser=
2025-05-24 13:46:02 : INFO  : mamp : BLOCKING_PROCESS_ACTION=tell_user
2025-05-24 13:46:02 : INFO  : mamp : NOTIFY=silent
2025-05-24 13:46:02 : INFO  : mamp : LOGGING=DEBUG
2025-05-24 13:46:02 : INFO  : mamp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-24 13:46:02 : INFO  : mamp : Label type: pkg
2025-05-24 13:46:02 : INFO  : mamp : archiveName: MAMP PRO.pkg
2025-05-24 13:46:02 : INFO  : mamp : no blocking processes defined, using MAMP PRO as default
2025-05-24 13:46:02 : DEBUG : mamp : Changing directory to /Library/Application Support/JAMF/tmp
2025-05-24 13:46:02 : INFO  : mamp : App(s) found: /Applications/MAMP PRO.app
2025-05-24 13:46:02 : INFO  : mamp : found app at /Applications/MAMP PRO.app, version 7.2, on versionKey CFBundleShortVersionString
2025-05-24 13:46:02 : INFO  : mamp : appversion: 7.2
2025-05-24 13:46:02 : INFO  : mamp : Latest version of MAMP PRO is 7.2
2025-05-24 13:46:02 : WARN  : mamp : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-05-24 13:46:02 : REQ   : mamp : Downloading https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-7.2-Apple-chip.pkg to MAMP PRO.pkg
2025-05-24 13:46:02 : DEBUG : mamp : No Dialog connection, just download
2025-05-24 13:46:51 : INFO  : mamp : Downloaded MAMP PRO.pkg – Type is  xar archive compressed TOC
2025-05-24 13:46:51 : INFO  : mamp : - OpenPGP Secret Key – SHA is 8ca6cf7cd60b60d7fa5b792db2f9c92fea2b0747 – Size is 754108 kB
2025-05-24 13:46:51 : DEBUG : mamp : DEBUG mode 1, not checking for blocking processes
2025-05-24 13:46:51 : REQ   : mamp : Installing MAMP PRO
2025-05-24 13:46:51 : INFO  : mamp : Verifying: MAMP PRO.pkg
2025-05-24 13:46:51 : DEBUG : mamp : File list: -rw-r--r--  1 root  admin   721M May 24 13:46 MAMP PRO.pkg
2025-05-24 13:46:52 : DEBUG : mamp : File type: MAMP PRO.pkg: xar archive compressed TOC: 7124, SHA-1 checksum, contains 
2025-05-24 13:46:52 : DEBUG : mamp : - OpenPGP Secret Key
2025-05-24 13:46:52 : DEBUG : mamp : spctlOut is MAMP PRO.pkg: accepted
2025-05-24 13:46:52 : DEBUG : mamp : source=Notarized Developer ID
2025-05-24 13:46:52 : DEBUG : mamp : origin=Developer ID Installer: MAMP GmbH (5KCB5KHK77)
2025-05-24 13:46:52 : INFO  : mamp : Team ID: 5KCB5KHK77 (expected: 5KCB5KHK77 )
2025-05-24 13:46:52 : DEBUG : mamp : DEBUG enabled, skipping installation
2025-05-24 13:46:52 : INFO  : mamp : Finishing...
2025-05-24 13:46:55 : INFO  : mamp : App(s) found: /Applications/MAMP PRO.app
2025-05-24 13:46:55 : INFO  : mamp : found app at /Applications/MAMP PRO.app, version 7.2, on versionKey CFBundleShortVersionString
2025-05-24 13:46:55 : REQ   : mamp : Installed MAMP PRO, version 7.2
2025-05-24 13:46:55 : DEBUG : mamp : DEBUG mode 1, not reopening anything
2025-05-24 13:46:55 : REQ   : mamp : All done!
2025-05-24 13:46:55 : REQ   : mamp : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
No issue was recorded for this label.