### PR TITLE
Create warp.sh

### DIFF
--- a/fragments/labels/warp.sh
+++ b/fragments/labels/warp.sh
@@ -2,6 +2,6 @@ warp)
     name="Warp"
     type="dmg"
     downloadURL="https://app.warp.dev/download"
-    appNewVersion="$(curl -s https://releases.warp.dev/channel_versions.json | grep -A 3 '"stable"' | grep '"version"' | head -n 1 | sed -E 's/.*"version": *"v([^"]+)".*/\1/')"
+    appNewVersion=$(curl -s https://releases.warp.dev/channel_versions.json | grep -A 3 '"stable"' | grep '"version"' | head -n 1 | sed -E 's/.*"version": *"v([^"]+)".*/\1/')
     expectedTeamID="2BBY89MBSN"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-05-25 07:00:28 : INFO  : warp : Total items in argumentsArray: 0
2025-05-25 07:00:28 : INFO  : warp : argumentsArray:
2025-05-25 07:00:28 : REQ   : warp : ################## Start Installomator v. 10.9beta, date 2025-05-25
2025-05-25 07:00:28 : INFO  : warp : ################## Version: 10.9beta
2025-05-25 07:00:28 : INFO  : warp : ################## Date: 2025-05-25
2025-05-25 07:00:28 : INFO  : warp : ################## warp
2025-05-25 07:00:28 : DEBUG : warp : DEBUG mode 1 enabled.
2025-05-25 07:00:28 : INFO  : warp : SwiftDialog is not installed, clear cmd file var
2025-05-25 07:00:29 : INFO  : warp : Reading arguments again:
2025-05-25 07:00:29 : DEBUG : warp : name=Warp
2025-05-25 07:00:29 : DEBUG : warp : appName=
2025-05-25 07:00:29 : DEBUG : warp : type=dmg
2025-05-25 07:00:29 : DEBUG : warp : archiveName=
2025-05-25 07:00:29 : DEBUG : warp : downloadURL=https://app.warp.dev/download
2025-05-25 07:00:29 : DEBUG : warp : curlOptions=
2025-05-25 07:00:29 : DEBUG : warp : appNewVersion=0.2025.05.21.08.11.stable_01
2025-05-25 07:00:29 : DEBUG : warp : appCustomVersion function: Not defined
2025-05-25 07:00:29 : DEBUG : warp : versionKey=CFBundleShortVersionString
2025-05-25 07:00:29 : DEBUG : warp : packageID=
2025-05-25 07:00:29 : DEBUG : warp : pkgName=
2025-05-25 07:00:29 : DEBUG : warp : choiceChangesXML=
2025-05-25 07:00:29 : DEBUG : warp : expectedTeamID=2BBY89MBSN
2025-05-25 07:00:29 : DEBUG : warp : blockingProcesses=
2025-05-25 07:00:29 : DEBUG : warp : installerTool=
2025-05-25 07:00:29 : DEBUG : warp : CLIInstaller=
2025-05-25 07:00:29 : DEBUG : warp : CLIArguments=
2025-05-25 07:00:29 : DEBUG : warp : updateTool=
2025-05-25 07:00:29 : DEBUG : warp : updateToolArguments=
2025-05-25 07:00:29 : DEBUG : warp : updateToolRunAsCurrentUser=
2025-05-25 07:00:29 : INFO  : warp : BLOCKING_PROCESS_ACTION=tell_user
2025-05-25 07:00:29 : INFO  : warp : NOTIFY=success
2025-05-25 07:00:29 : INFO  : warp : LOGGING=DEBUG
2025-05-25 07:00:29 : INFO  : warp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-25 07:00:29 : INFO  : warp : Label type: dmg
2025-05-25 07:00:29 : INFO  : warp : archiveName: Warp.dmg
2025-05-25 07:00:29 : INFO  : warp : no blocking processes defined, using Warp as default
2025-05-25 07:00:29 : DEBUG : warp : Changing directory to /Users/malte.kiefer/Entwicklung/Installomator/build
2025-05-25 07:00:29 : INFO  : warp : App(s) found: /Applications/Warp.app
2025-05-25 07:00:29 : INFO  : warp : found app at /Applications/Warp.app, version 0.2025.05.14.08.11.03, on versionKey CFBundleShortVersionString
2025-05-25 07:00:29 : INFO  : warp : appversion: 0.2025.05.14.08.11.03
2025-05-25 07:00:29 : INFO  : warp : Latest version of Warp is 0.2025.05.21.08.11.stable_01
2025-05-25 07:00:29 : INFO  : warp : Warp.dmg exists and DEBUG mode 1 enabled, skipping download
2025-05-25 07:00:29 : DEBUG : warp : DEBUG mode 1, not checking for blocking processes
2025-05-25 07:00:29 : REQ   : warp : Installing Warp
2025-05-25 07:00:29 : INFO  : warp : Mounting /Users/malte.kiefer/Entwicklung/Installomator/build/Warp.dmg
2025-05-25 07:00:30 : DEBUG : warp : Debugging enabled, dmgmount output was:
expected   CRC32 $D9C8D465
/dev/disk10         	GUID_partition_scheme
/dev/disk10s1       	Apple_HFS                      	/Volumes/Warp

2025-05-25 07:00:30 : INFO  : warp : Mounted: /Volumes/Warp
2025-05-25 07:00:30 : INFO  : warp : Verifying: /Volumes/Warp/Warp.app
2025-05-25 07:00:30 : DEBUG : warp : App size: 331M	/Volumes/Warp/Warp.app
2025-05-25 07:00:32 : DEBUG : warp : Debugging enabled, App Verification output was:
/Volumes/Warp/Warp.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Denver Technologies, Inc (2BBY89MBSN)

2025-05-25 07:00:32 : INFO  : warp : Team ID matching: 2BBY89MBSN (expected: 2BBY89MBSN )
2025-05-25 07:00:32 : INFO  : warp : Downloaded version of Warp is 0.2025.05.21.08.11.01 on versionKey CFBundleShortVersionString (replacing version 0.2025.05.14.08.11.03).
2025-05-25 07:00:32 : DEBUG : warp : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-25 07:00:32 : INFO  : warp : Finishing...
2025-05-25 07:00:35 : INFO  : warp : App(s) found: /Applications/Warp.app
2025-05-25 07:00:35 : INFO  : warp : found app at /Applications/Warp.app, version 0.2025.05.14.08.11.03, on versionKey CFBundleShortVersionString
2025-05-25 07:00:35 : REQ   : warp : Installed Warp, version 0.2025.05.21.08.11.01
2025-05-25 07:00:35 : INFO  : warp : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-05-25 07:00:35 : DEBUG : warp : Unmounting /Volumes/Warp
2025-05-25 07:00:35 : DEBUG : warp : Debugging enabled, Unmounting output was:
"disk10" ejected.
2025-05-25 07:00:35 : DEBUG : warp : DEBUG mode 1, not reopening anything
2025-05-25 07:00:35 : REQ   : warp : All done!
2025-05-25 07:00:35 : REQ   : warp : ################## End Installomator, exit code 0

```
