### PR TITLE
Update Apple SF Symbols to fix detection to match the current app version

### DIFF
--- a/fragments/labels/applesfsymbols.sh
+++ b/fragments/labels/applesfsymbols.sh
@@ -3,6 +3,11 @@ sfsymbols)
     name="SF Symbols"
     type="pkgInDmg"
     downloadURL=$( curl -fs "https://developer.apple.com/sf-symbols/" | grep -oe "https.*Symbols.*\.dmg" | head -1 )
-    appNewVersion=$( echo "$downloadURL" | sed -E 's/.*SF-Symbols-([0-9.]*)\..*/\1/g')
+    ver=${downloadURL##*SF-Symbols-}
+    ver=${ver%.dmg}
+    if [[ $ver != *.* ]]; then
+        ver=$ver.0
+    fi
+    appNewVersion=$ver
     expectedTeamID="Software Update"
     ;;


### PR DESCRIPTION
With the current label it only returns '6' as the version number, but the app is '6.0'. So, it will constantly download. The fixes that issue and should be future proof if 6 changes to 6.1 or something else.


All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Now matches the version number of the installed app and prevents redownloading.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./assemble.sh applesfsymbols
2025-05-25 21:17:44 : INFO  : applesfsymbols : Total items in argumentsArray: 0
2025-05-25 21:17:44 : INFO  : applesfsymbols : argumentsArray: 
2025-05-25 21:17:44 : REQ   : applesfsymbols : ################## Start Installomator v. 10.9beta, date 2025-05-25
2025-05-25 21:17:44 : INFO  : applesfsymbols : ################## Version: 10.9beta
2025-05-25 21:17:44 : INFO  : applesfsymbols : ################## Date: 2025-05-25
2025-05-25 21:17:44 : INFO  : applesfsymbols : ################## applesfsymbols
2025-05-25 21:17:44 : DEBUG : applesfsymbols : DEBUG mode 1 enabled.
2025-05-25 21:17:45 : INFO  : applesfsymbols : Reading arguments again: 
2025-05-25 21:17:45 : DEBUG : applesfsymbols : name=SF Symbols
2025-05-25 21:17:45 : DEBUG : applesfsymbols : appName=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : type=pkgInDmg
2025-05-25 21:17:45 : DEBUG : applesfsymbols : archiveName=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : downloadURL=https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-6.dmg
2025-05-25 21:17:45 : DEBUG : applesfsymbols : curlOptions=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : appNewVersion=6.0
2025-05-25 21:17:45 : DEBUG : applesfsymbols : appCustomVersion function: Not defined
2025-05-25 21:17:45 : DEBUG : applesfsymbols : versionKey=CFBundleShortVersionString
2025-05-25 21:17:45 : DEBUG : applesfsymbols : packageID=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : pkgName=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : choiceChangesXML=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : expectedTeamID=Software Update
2025-05-25 21:17:45 : DEBUG : applesfsymbols : blockingProcesses=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : installerTool=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : CLIInstaller=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : CLIArguments=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : updateTool=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : updateToolArguments=
2025-05-25 21:17:45 : DEBUG : applesfsymbols : updateToolRunAsCurrentUser=
2025-05-25 21:17:45 : INFO  : applesfsymbols : BLOCKING_PROCESS_ACTION=tell_user
2025-05-25 21:17:45 : INFO  : applesfsymbols : NOTIFY=success
2025-05-25 21:17:45 : INFO  : applesfsymbols : LOGGING=DEBUG
2025-05-25 21:17:45 : INFO  : applesfsymbols : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-25 21:17:45 : INFO  : applesfsymbols : Label type: pkgInDmg
2025-05-25 21:17:45 : INFO  : applesfsymbols : archiveName: SF Symbols.dmg
2025-05-25 21:17:45 : INFO  : applesfsymbols : no blocking processes defined, using SF Symbols as default
2025-05-25 21:17:45 : DEBUG : applesfsymbols : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-05-25 21:17:45 : INFO  : applesfsymbols : App(s) found: /Applications/SF Symbols.app
2025-05-25 21:17:45 : INFO  : applesfsymbols : found app at /Applications/SF Symbols.app, version 6.0, on versionKey CFBundleShortVersionString
2025-05-25 21:17:45 : INFO  : applesfsymbols : appversion: 6.0
2025-05-25 21:17:45 : INFO  : applesfsymbols : Latest version of SF Symbols is 6.0
2025-05-25 21:17:45 : WARN  : applesfsymbols : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-05-25 21:17:45 : REQ   : applesfsymbols : Downloading https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-6.dmg to SF Symbols.dmg
2025-05-25 21:17:45 : DEBUG : applesfsymbols : No Dialog connection, just download
2025-05-25 21:19:00 : INFO  : applesfsymbols : Downloaded SF Symbols.dmg – Type is  zlib compressed data – SHA is 8d5f89f5f791a55fcb36805d1b334c1599b4a86f – Size is 377452 kB
2025-05-25 21:19:00 : DEBUG : applesfsymbols : DEBUG mode 1, not checking for blocking processes
2025-05-25 21:19:00 : REQ   : applesfsymbols : Installing SF Symbols
2025-05-25 21:19:00 : INFO  : applesfsymbols : Mounting /Users/gilburns/GitHub/Installomator/build/SF Symbols.dmg
2025-05-25 21:19:03 : DEBUG : applesfsymbols : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $F087347A
Checksumming  (Apple_Free : 1)…
(Apple_Free : 1): verified   CRC32 $00000000
Checksumming Apple (Apple_partition_map : 2)…
Apple (Apple_partition_map : 2): verified   CRC32 $6172CA64
Checksumming disk image (Apple_HFS : 3)…
disk image (Apple_HFS : 3): verified   CRC32 $D4090C51
Checksumming  (Apple_Free : 4)…
(Apple_Free : 4): verified   CRC32 $00000000
verified   CRC32 $4BC96F26
/dev/disk18         	Apple_partition_scheme
/dev/disk18s1       	Apple_partition_map
/dev/disk18s2       	Apple_HFS                      	/Volumes/SFSymbols

2025-05-25 21:19:03 : INFO  : applesfsymbols : Mounted: /Volumes/SFSymbols
2025-05-25 21:19:03 : DEBUG : applesfsymbols : Found pkg(s):
/Volumes/SFSymbols/SF Symbols.pkg
2025-05-25 21:19:03 : INFO  : applesfsymbols : found pkg: /Volumes/SFSymbols/SF Symbols.pkg
2025-05-25 21:19:03 : INFO  : applesfsymbols : Verifying: /Volumes/SFSymbols/SF Symbols.pkg
2025-05-25 21:19:03 : DEBUG : applesfsymbols : File list: -rw-r--r--  1 gilburns  staff   367M Sep 20  2024 /Volumes/SFSymbols/SF Symbols.pkg
2025-05-25 21:19:03 : DEBUG : applesfsymbols : File type: /Volumes/SFSymbols/SF Symbols.pkg: xar archive compressed TOC: 14640, SHA-1 checksum
2025-05-25 21:19:03 : DEBUG : applesfsymbols : spctlOut is /Volumes/SFSymbols/SF Symbols.pkg: accepted
2025-05-25 21:19:03 : DEBUG : applesfsymbols : source=Apple Installer
2025-05-25 21:19:03 : DEBUG : applesfsymbols : origin=Software Update
2025-05-25 21:19:03 : INFO  : applesfsymbols : Team ID: Software Update (expected: Software Update )
2025-05-25 21:19:03 : DEBUG : applesfsymbols : DEBUG enabled, skipping installation
2025-05-25 21:19:03 : INFO  : applesfsymbols : Finishing...
2025-05-25 21:19:06 : INFO  : applesfsymbols : App(s) found: /Applications/SF Symbols.app
2025-05-25 21:19:06 : INFO  : applesfsymbols : found app at /Applications/SF Symbols.app, version 6.0, on versionKey CFBundleShortVersionString
2025-05-25 21:19:06 : REQ   : applesfsymbols : Installed SF Symbols, version 6.0
2025-05-25 21:19:06 : INFO  : applesfsymbols : notifying
2025-05-25 21:19:07 : DEBUG : applesfsymbols : Unmounting /Volumes/SFSymbols
2025-05-25 21:19:07 : DEBUG : applesfsymbols : Debugging enabled, Unmounting output was:
hdiutil: couldn't unmount "disk18" - Undefined error: 0
2025-05-25 21:19:07 : DEBUG : applesfsymbols : Busy
2025-05-25 21:19:07 : DEBUG : applesfsymbols : DEBUG mode 1, not reopening anything
2025-05-25 21:19:07 : REQ   : applesfsymbols : All done!
2025-05-25 21:19:07 : REQ   : applesfsymbols : ################## End Installomator, exit code 0 

```