### PR TITLE
Update chatgpt to prevent installation on Intel based Macs

### DIFF
--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -1,7 +1,11 @@
 chatgpt)
     name="ChatGPT"
     type="dmg"
-    downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
+    else
+        downloadURL="" # Apple Silicon only
+    fi
     appNewVersion="$(curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xpath '(//rss/channel/item/title)[1]/text()' 2>/dev/null)"
     expectedTeamID="2DC432GLL2"
     ;;

--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -4,7 +4,7 @@ chatgpt)
     if [[ $(arch) == arm64 ]]; then
         downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
     else
-        downloadURL="" # Apple Silicon only
+        cleanupandexit 2 "No Intel-compatible download URL found. $appLabel is not Intel-compatible. Could not install app." ERROR
     fi
     appNewVersion="$(curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xpath '(//rss/channel/item/title)[1]/text()' 2>/dev/null)"
     expectedTeamID="2DC432GLL2"


### PR DESCRIPTION
Only Apple Silicon is supported by CharGPT. Attempts to install on Intel based Macs will fail. I feel like that is what we should want to happen.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Only Apple Silicon is supported by CharGPT. Attempts to install on Intel based Macs will fail. I feel like that is what we should want to happen.


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
~/GitHub/Installomator/utils/assemble.sh chatgpt
2025-05-26 15:02:41 : INFO  : chatgpt : Total items in argumentsArray: 0
2025-05-26 15:02:41 : INFO  : chatgpt : argumentsArray: 
2025-05-26 15:02:41 : REQ   : chatgpt : ################## Start Installomator v. 10.9beta, date 2025-05-26
2025-05-26 15:02:41 : INFO  : chatgpt : ################## Version: 10.9beta
2025-05-26 15:02:41 : INFO  : chatgpt : ################## Date: 2025-05-26
2025-05-26 15:02:41 : INFO  : chatgpt : ################## chatgpt
2025-05-26 15:02:41 : DEBUG : chatgpt : DEBUG mode 1 enabled.
2025-05-26 15:02:41 : INFO  : chatgpt : Reading arguments again: 
2025-05-26 15:02:41 : DEBUG : chatgpt : name=ChatGPT
2025-05-26 15:02:41 : DEBUG : chatgpt : appName=
2025-05-26 15:02:41 : DEBUG : chatgpt : type=dmg
2025-05-26 15:02:41 : DEBUG : chatgpt : archiveName=
2025-05-26 15:02:41 : DEBUG : chatgpt : downloadURL=https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg
2025-05-26 15:02:41 : DEBUG : chatgpt : curlOptions=
2025-05-26 15:02:41 : DEBUG : chatgpt : appNewVersion=1.2025.133
2025-05-26 15:02:41 : DEBUG : chatgpt : appCustomVersion function: Not defined
2025-05-26 15:02:41 : DEBUG : chatgpt : versionKey=CFBundleShortVersionString
2025-05-26 15:02:41 : DEBUG : chatgpt : packageID=
2025-05-26 15:02:41 : DEBUG : chatgpt : pkgName=
2025-05-26 15:02:41 : DEBUG : chatgpt : choiceChangesXML=
2025-05-26 15:02:41 : DEBUG : chatgpt : expectedTeamID=2DC432GLL2
2025-05-26 15:02:41 : DEBUG : chatgpt : blockingProcesses=
2025-05-26 15:02:41 : DEBUG : chatgpt : installerTool=
2025-05-26 15:02:41 : DEBUG : chatgpt : CLIInstaller=
2025-05-26 15:02:41 : DEBUG : chatgpt : CLIArguments=
2025-05-26 15:02:41 : DEBUG : chatgpt : updateTool=
2025-05-26 15:02:41 : DEBUG : chatgpt : updateToolArguments=
2025-05-26 15:02:41 : DEBUG : chatgpt : updateToolRunAsCurrentUser=
2025-05-26 15:02:41 : INFO  : chatgpt : BLOCKING_PROCESS_ACTION=tell_user
2025-05-26 15:02:41 : INFO  : chatgpt : NOTIFY=success
2025-05-26 15:02:41 : INFO  : chatgpt : LOGGING=DEBUG
2025-05-26 15:02:41 : INFO  : chatgpt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-26 15:02:41 : INFO  : chatgpt : Label type: dmg
2025-05-26 15:02:41 : INFO  : chatgpt : archiveName: ChatGPT.dmg
2025-05-26 15:02:41 : INFO  : chatgpt : no blocking processes defined, using ChatGPT as default
2025-05-26 15:02:41 : DEBUG : chatgpt : Changing directory to /Users/gilburns/GitHub/Installomator/build
2025-05-26 15:02:41 : INFO  : chatgpt : App(s) found: /Applications/ChatGPT.app
2025-05-26 15:02:42 : INFO  : chatgpt : found app at /Applications/ChatGPT.app, version 1.2025.133, on versionKey CFBundleShortVersionString
2025-05-26 15:02:42 : INFO  : chatgpt : appversion: 1.2025.133
2025-05-26 15:02:42 : INFO  : chatgpt : Latest version of ChatGPT is 1.2025.133
2025-05-26 15:02:42 : WARN  : chatgpt : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-05-26 15:02:42 : REQ   : chatgpt : Downloading https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg to ChatGPT.dmg
2025-05-26 15:02:42 : DEBUG : chatgpt : No Dialog connection, just download
2025-05-26 15:02:52 : INFO  : chatgpt : Downloaded ChatGPT.dmg – Type is  zlib compressed data – SHA is 02fd38e3364b0640ae76cf619f5fdcb1ba8c0af8 – Size is 57452 kB
2025-05-26 15:02:52 : DEBUG : chatgpt : DEBUG mode 1, not checking for blocking processes
2025-05-26 15:02:52 : REQ   : chatgpt : Installing ChatGPT
2025-05-26 15:02:52 : INFO  : chatgpt : Mounting /Users/gilburns/GitHub/Installomator/build/ChatGPT.dmg
2025-05-26 15:02:56 : DEBUG : chatgpt : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $897D3A1C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $C99CA685
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $B199AB86
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $25972CCA
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $B199AB86
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $8F3FDCF8
verified   CRC32 $68655172
/dev/disk25         	GUID_partition_scheme
/dev/disk25s1       	Apple_HFS                      	/Volumes/ChatGPT Installer

2025-05-26 15:02:56 : INFO  : chatgpt : Mounted: /Volumes/ChatGPT Installer
2025-05-26 15:02:56 : INFO  : chatgpt : Verifying: /Volumes/ChatGPT Installer/ChatGPT.app
2025-05-26 15:02:56 : DEBUG : chatgpt : App size: 127M	/Volumes/ChatGPT Installer/ChatGPT.app
2025-05-26 15:02:57 : DEBUG : chatgpt : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Installer/ChatGPT.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI, L.L.C. (2DC432GLL2)

2025-05-26 15:02:57 : INFO  : chatgpt : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2025-05-26 15:02:57 : INFO  : chatgpt : Downloaded version of ChatGPT is 1.2025.133 on versionKey CFBundleShortVersionString, same as installed.
2025-05-26 15:02:57 : DEBUG : chatgpt : Unmounting /Volumes/ChatGPT Installer
2025-05-26 15:02:57 : DEBUG : chatgpt : Debugging enabled, Unmounting output was:
hdiutil: couldn't unmount "disk25" - Undefined error: 0
2025-05-26 15:02:57 : DEBUG : chatgpt : Busy
2025-05-26 15:02:57 : DEBUG : chatgpt : DEBUG mode 1, not reopening anything
2025-05-26 15:02:57 : REG   : chatgpt : No new version to install
2025-05-26 15:02:57 : REQ   : chatgpt : ################## End Installomator, exit code 0 

```