### PR TITLE
Clean up all Synergy* labels

### DIFF
--- a/fragments/labels/synergybaseball.sh
+++ b/fragments/labels/synergybaseball.sh
@@ -3,7 +3,6 @@ synergybaseball)
     type="dmg"
     downloadURL="$( echo https://www.synergysportstech.com/baseballclient/MacOS/$(curl -s https://www.synergysportstech.com/baseballclient/MacOS/default.htm | grep dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}') )"
     appNewVersion=$(curl -fs https://www.synergysportstech.com/baseballclient/MacOS/default.htm | grep Version: | grep -o -e "[0-9.]*")
-	versionKey="CFBundleVersion"
+    versionKey="CFBundleVersion"
     expectedTeamID="BATB6XS52B"
     ;;
-

--- a/fragments/labels/synergybasketball.sh
+++ b/fragments/labels/synergybasketball.sh
@@ -3,6 +3,6 @@ synergybasketball)
     type="dmg"
     downloadURL="$( echo https://www.synergysportstech.com/Apps/Basketball/production/macOS/$(curl -s https://www.synergysportstech.com/Apps/Basketball/production/macOS/default.htm | grep dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}') )"
     appNewVersion=$(curl -fs https://www.synergysportstech.com/Apps/Basketball/production/macOS/default.htm | grep Version: | grep -o -e "[0-9.]*")
-	versionKey="CFBundleVersion"
+    versionKey="CFBundleVersion"
     expectedTeamID="BATB6XS52B"
     ;;

--- a/fragments/labels/synergyeditorbasketball.sh
+++ b/fragments/labels/synergyeditorbasketball.sh
@@ -7,6 +7,5 @@ synergyeditor|synergyeditorbasketball)
         downloadURL=$( echo https://www.synergysportstech.com/apps/editor/basketball/macos/$(curl -s https://www.synergysportstech.com/apps/editor/basketball/macos/ | grep x64.dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}' ))
     fi
     appNewVersion=$(curl -fs https://www.synergysportstech.com/apps/editor/basketball/macos/default.html | grep Version: | grep -o -e "[0-9.]*")
-    versionKey="CFBundleShortVersionString"
     expectedTeamID="BATB6XS52B"
     ;;

--- a/fragments/labels/synergyvideoexpress.sh
+++ b/fragments/labels/synergyvideoexpress.sh
@@ -5,6 +5,4 @@ synergyvideoexpress)
     downloadURL="https://www.synergysportstech.com/apps/videoexpress/production/macOS/${relativeDownloadURL}"
     appNewVersion=$(echo "$relativeDownloadURL" | sed -E 's/.*_([0-9]+_[0-9]+_[0-9]+_[0-9]+)\.dmg/\1/' | tr '_' '.')
     expectedTeamID="BATB6XS52B"
-    appName="Synergy Video Express.app"
-    blockingProcesses=( "Synergy Video Express" )
     ;;


### PR DESCRIPTION
Various issues. All had filenames in the wrong case. Most had at least one line with tabs instead of spaces. Removed extra unnecessary keys for appName, blockingProcess, and versionKey

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Various issues. All had filenames in the wrong case. Most had at least one line with tabs instead of spaces. Removed extra unnecessary keys for appName, blockingProcess, and versionKey


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
