### PR TITLE
fix(soapuiopensource): add installation dir

### DIFF
--- a/fragments/labels/soapuiopensource.sh
+++ b/fragments/labels/soapuiopensource.sh
@@ -15,5 +15,6 @@ soapuiopensource)
     installerTool="SoapUI ${appNewVersion} Installer.app"
     CLIInstaller="${installerTool}/Contents/MacOS/JavaApplicationStub"
     CLIArguments=(-q)
+    CLIArguments+=(-dir /Applications)
     expectedTeamID="HVA5GNL2LF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

it was not needed for this change

**Additional context** Add any other context about the label or fix here.

introduces `-dir /Applications` in `CLIArguments` to install the resulting .app File in `/Applications`
which in turn solves issues, installing this software through Jamf.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-05-27 12:35:43 : INFO  : soapuiopensource : Total items in argumentsArray: 0
2025-05-27 12:35:43 : INFO  : soapuiopensource : argumentsArray:
2025-05-27 12:35:43 : REQ   : soapuiopensource : ################## Start Installomator v. 10.9beta, date 2025-04-22
2025-05-27 12:35:43 : INFO  : soapuiopensource : ################## Version: 10.9beta
2025-05-27 12:35:43 : INFO  : soapuiopensource : ################## Date: 2025-04-22
2025-05-27 12:35:43 : INFO  : soapuiopensource : ################## soapuiopensource
2025-05-27 12:35:43 : DEBUG : soapuiopensource : DEBUG mode 1 enabled.
2025-05-27 12:35:44 : INFO  : soapuiopensource : Reading arguments again:
2025-05-27 12:35:44 : DEBUG : soapuiopensource : name=SoapUI
2025-05-27 12:35:44 : DEBUG : soapuiopensource : appName=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : type=dmg
2025-05-27 12:35:44 : DEBUG : soapuiopensource : archiveName=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : downloadURL=https://dl.eviware.com/soapuios/5.8.0/SoapUI-x64-5.8.0.dmg
2025-05-27 12:35:44 : DEBUG : soapuiopensource : curlOptions=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : appNewVersion=5.8.0
2025-05-27 12:35:44 : DEBUG : soapuiopensource : appCustomVersion function: Defined.
2025-05-27 12:35:44 : DEBUG : soapuiopensource : versionKey=CFBundleShortVersionString
2025-05-27 12:35:44 : DEBUG : soapuiopensource : packageID=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : pkgName=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : choiceChangesXML=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : expectedTeamID=HVA5GNL2LF
2025-05-27 12:35:44 : DEBUG : soapuiopensource : blockingProcesses=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : installerTool=SoapUI 5.8.0 Installer.app
2025-05-27 12:35:44 : DEBUG : soapuiopensource : CLIInstaller=SoapUI 5.8.0 Installer.app/Contents/MacOS/JavaApplicationStub
2025-05-27 12:35:44 : DEBUG : soapuiopensource : CLIArguments=-q -dir /Applications
2025-05-27 12:35:44 : DEBUG : soapuiopensource : updateTool=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : updateToolArguments=
2025-05-27 12:35:44 : DEBUG : soapuiopensource : updateToolRunAsCurrentUser=
2025-05-27 12:35:44 : INFO  : soapuiopensource : BLOCKING_PROCESS_ACTION=tell_user
2025-05-27 12:35:44 : INFO  : soapuiopensource : NOTIFY=success
2025-05-27 12:35:44 : INFO  : soapuiopensource : LOGGING=DEBUG
2025-05-27 12:35:44 : INFO  : soapuiopensource : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-27 12:35:44 : INFO  : soapuiopensource : Label type: dmg
2025-05-27 12:35:44 : INFO  : soapuiopensource : archiveName: SoapUI.dmg
2025-05-27 12:35:44 : INFO  : soapuiopensource : no blocking processes defined, using SoapUI as default
2025-05-27 12:35:45 : DEBUG : soapuiopensource : Changing directory to .
2025-05-27 12:35:45 : INFO  : soapuiopensource : Custom App Version detection is used, found
2025-05-27 12:35:45 : INFO  : soapuiopensource : appversion:
2025-05-27 12:35:45 : INFO  : soapuiopensource : Latest version of SoapUI is 5.8.0
2025-05-27 12:35:45 : REQ   : soapuiopensource : Downloading https://dl.eviware.com/soapuios/5.8.0/SoapUI-x64-5.8.0.dmg to SoapUI.dmg
2025-05-27 12:35:45 : DEBUG : soapuiopensource : No Dialog connection, just download
2025-05-27 12:35:47 : INFO  : soapuiopensource : Downloaded SoapUI.dmg – Type is  Apple Driver Map, blocksize 512, blockcount 377464, devtype 0, devid 0, driver count 0, contains[@0x200] – SHA is 762841180732ebef6a5ccd10a0f087ab1d0fa614 – Size is 188800 kB
2025-05-27 12:35:47 : DEBUG : soapuiopensource : DEBUG mode 1, not checking for blocking processes
2025-05-27 12:35:47 : REQ   : soapuiopensource : Installing SoapUI
2025-05-27 12:35:47 : REQ   : soapuiopensource : installerTool used: SoapUI 5.8.0 Installer.app
2025-05-27 12:35:47 : INFO  : soapuiopensource : Mounting ./SoapUI.dmg
2025-05-27 12:35:47 : DEBUG : soapuiopensource : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $22AB2281
verified   CRC32 $C35FFFBE
/dev/disk4              Apple_partition_scheme
/dev/disk4s1            Apple_partition_map
/dev/disk4s2            Apple_HFS                       /Volumes/SoapUI

2025-05-27 12:35:47 : INFO  : soapuiopensource : Mounted: /Volumes/SoapUI
2025-05-27 12:35:47 : INFO  : soapuiopensource : Verifying: /Volumes/SoapUI/SoapUI 5.8.0 Installer.app
2025-05-27 12:35:47 : DEBUG : soapuiopensource : App size: 184M /Volumes/SoapUI/SoapUI 5.8.0 Installer.app
2025-05-27 12:35:48 : DEBUG : soapuiopensource : Debugging enabled, App Verification output was:
/Volumes/SoapUI/SoapUI 5.8.0 Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Smart Bear Software, Inc. (HVA5GNL2LF)

2025-05-27 12:35:48 : INFO  : soapuiopensource : Team ID matching: HVA5GNL2LF (expected: HVA5GNL2LF )
2025-05-27 12:35:48 : INFO  : soapuiopensource : Installing SoapUI version 5.8.0 on versionKey CFBundleShortVersionString.
2025-05-27 12:35:48 : INFO  : soapuiopensource : App has LSMinimumSystemVersion: 10.11
2025-05-27 12:35:48 : DEBUG : soapuiopensource : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-27 12:35:48 : INFO  : soapuiopensource : Finishing...
2025-05-27 12:35:51 : INFO  : soapuiopensource : Custom App Version detection is used, found
2025-05-27 12:35:51 : REQ   : soapuiopensource : Installed SoapUI, version 5.8.0
2025-05-27 12:35:51 : INFO  : soapuiopensource : notifying
2025-05-27 12:35:51 : DEBUG : soapuiopensource : Unmounting /Volumes/SoapUI
2025-05-27 12:35:51 : DEBUG : soapuiopensource : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-27 12:35:51 : DEBUG : soapuiopensource : DEBUG mode 1, not reopening anything
2025-05-27 12:35:51 : REQ   : soapuiopensource : All done!
2025-05-27 12:35:51 : REQ   : soapuiopensource : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

n/a