### PR TITLE
finalcutprocontent-new-label

### DIFF
--- a/fragments/labels/finalcutprocontent.sh
+++ b/fragments/labels/finalcutprocontent.sh
@@ -1,0 +1,7 @@
+finalcutprocontent)
+    name="FCPContent"
+    type="pkgInDmg"
+    downloadURL=$(curl -s "https://support.apple.com/en-us/106574" | grep -Eo 'https://updates\.cdn-apple\.com[^"]+FCPContent\.dmg' | head -n 1)
+    packageID="com.apple.pkg.FCPContent"
+    expectedTeamID="Software Update"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

Creating a new label for  [Final Cut Pro Content](https://support.apple.com/en-us/106574)

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.
Nope

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
sudo Installomator/utils/assemble.sh finalcutprocontent DEBUG=0  
2025-05-28 15:37:27 : INFO  : finalcutprocontent : setting variable from argument DEBUG=0
2025-05-28 15:37:27 : INFO  : finalcutprocontent : Total items in argumentsArray: 1
2025-05-28 15:37:27 : INFO  : finalcutprocontent : argumentsArray: DEBUG=0
2025-05-28 15:37:27 : REQ   : finalcutprocontent : ################## Start Installomator v. 10.9beta, date 2025-05-28
2025-05-28 15:37:27 : INFO  : finalcutprocontent : ################## Version: 10.9beta
2025-05-28 15:37:27 : INFO  : finalcutprocontent : ################## Date: 2025-05-28
2025-05-28 15:37:27 : INFO  : finalcutprocontent : ################## finalcutprocontent
2025-05-28 15:37:27 : INFO  : finalcutprocontent : Reading arguments again: DEBUG=0
2025-05-28 15:37:28 : INFO  : finalcutprocontent : BLOCKING_PROCESS_ACTION=tell_user
2025-05-28 15:37:28 : INFO  : finalcutprocontent : NOTIFY=success
2025-05-28 15:37:28 : INFO  : finalcutprocontent : LOGGING=INFO
2025-05-28 15:37:28 : INFO  : finalcutprocontent : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-28 15:37:28 : INFO  : finalcutprocontent : Label type: pkgInDmg
2025-05-28 15:37:28 : INFO  : finalcutprocontent : archiveName: FCPContent.dmg
2025-05-28 15:37:28 : INFO  : finalcutprocontent : no blocking processes defined, using FCPContent as default
2025-05-28 15:37:28 : INFO  : finalcutprocontent : No version found using packageID com.apple.pkg.FCPContent
2025-05-28 15:37:28 : INFO  : finalcutprocontent : name: FCPContent, appName: FCPContent.app
2025-05-28 15:37:29 : WARN  : finalcutprocontent : No previous app found
2025-05-28 15:37:29 : WARN  : finalcutprocontent : could not find FCPContent.app
2025-05-28 15:37:29 : INFO  : finalcutprocontent : appversion: 
2025-05-28 15:37:29 : INFO  : finalcutprocontent : Latest version not specified.
2025-05-28 15:37:29 : REQ   : finalcutprocontent : Downloading https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg to FCPContent.dmg
2025-05-28 15:37:35 : INFO  : finalcutprocontent : Downloaded FCPContent.dmg – Type is  zlib compressed data – SHA is 16b5010c6720eb085053037c33949f20c8cdc58f – Size is 633040 kB
2025-05-28 15:37:36 : REQ   : finalcutprocontent : no more blocking processes, continue with update
2025-05-28 15:37:36 : REQ   : finalcutprocontent : Installing FCPContent
2025-05-28 15:37:36 : INFO  : finalcutprocontent : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.k9VwNEguUr/FCPContent.dmg
2025-05-28 15:37:39 : INFO  : finalcutprocontent : Mounted: /Volumes/FCP Content
2025-05-28 15:37:39 : INFO  : finalcutprocontent : found pkg: /Volumes/FCP Content/FCPContent.pkg
2025-05-28 15:37:39 : INFO  : finalcutprocontent : Verifying: /Volumes/FCP Content/FCPContent.pkg
2025-05-28 15:37:39 : INFO  : finalcutprocontent : Team ID: Software Update (expected: Software Update )
2025-05-28 15:37:39 : INFO  : finalcutprocontent : Installing /Volumes/FCP Content/FCPContent.pkg to /
2025-05-28 15:37:41 : INFO  : finalcutprocontent : Finishing...
2025-05-28 15:37:44 : INFO  : finalcutprocontent : No version found using packageID com.apple.pkg.FCPContent
2025-05-28 15:37:44 : INFO  : finalcutprocontent : name: FCPContent, appName: FCPContent.app
2025-05-28 15:37:44 : WARN  : finalcutprocontent : No previous app found
2025-05-28 15:37:44 : WARN  : finalcutprocontent : could not find FCPContent.app
2025-05-28 15:37:44 : REQ   : finalcutprocontent : Installed FCPContent
2025-05-28 15:37:44 : INFO  : finalcutprocontent : notifying
2025-05-28 15:37:45 : INFO  : finalcutprocontent : Installomator did not close any apps, so no need to reopen any apps.
2025-05-28 15:37:45 : REQ   : finalcutprocontent : All done!
2025-05-28 15:37:45 : REQ   : finalcutprocontent : ################## End Installomator, exit code 0
```