### PR TITLE
Update-espanso - TeamID change-ish

### DIFF
--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -9,6 +9,8 @@ espanso)
     else
         type="zip"
         downloadURL="https://github.com/espanso/espanso/releases/download/v2.2.1/Espanso-Mac-Intel.zip"
+        appNewVersion=2.2.1
         expectedTeamID="K839T4T5BY"
     fi
+    blockingProcesses=( "Espanso" "espanso" )
     ;;

--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -1,13 +1,14 @@
 espanso)
     name="Espanso"
-    type="zip"
     if [[ "$(arch)" == "arm64" ]]; then
-        archiveName="Espanso-Mac-M1.zip"
+        archiveName="Espanso-Mac-M1.dmg"
+        type="dmg"
+        downloadURL="$(downloadURLFromGit espanso espanso)"
+        appNewVersion="$(versionFromGit espanso espanso)"
+        expectedTeamID="6424323YUH"
     else
-        archiveName="Espanso-Mac-Intel.zip"
+        type="zip"
+        downloadURL="https://github.com/espanso/espanso/releases/download/v2.2.1/Espanso-Mac-Intel.zip"
+        expectedTeamID="K839T4T5BY"
     fi
-    downloadURL="$(downloadURLFromGit espanso espanso)"
-    appNewVersion="$(versionFromGit espanso espanso)"
-    blockingProcesses=( "Espanso" "espanso" )
-    expectedTeamID="K839T4T5BY"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
I'm sorry.

`arm64` moved from .zip to .dmg, [because](https://github.com/espanso/espanso/releases/tag/v2.2.3): _I could sign a macOS silicon (M-arch) package and i went a step further and created a .dmg image._ The arm64 version had a TeamID change: from K839T4T5BY to Auca Coyan Maillot (6424323YUH)

`i386` stayed on .zip and an older version, and the previous TeamID (K839T4T5BY), [because](https://github.com/espanso/espanso/releases/tag/v2.2.3): _macOS Intel is missing, I know, I'm figuring out how to sign it with my M-arch mac so you can have it signed_
Removed unneccessary `blockinProcessess`


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2344 

````
### i386
./assemble.sh espanso
2025-05-28 23:47:24 : INFO  : espanso : Total items in argumentsArray: 0
2025-05-28 23:47:24 : INFO  : espanso : argumentsArray:
2025-05-28 23:47:24 : REQ   : espanso : ################## Start Installomator v. 10.9beta, date 2025-05-28
2025-05-28 23:47:24 : INFO  : espanso : ################## Version: 10.9beta
2025-05-28 23:47:24 : INFO  : espanso : ################## Date: 2025-05-28
2025-05-28 23:47:24 : INFO  : espanso : ################## espanso
2025-05-28 23:47:24 : DEBUG : espanso : DEBUG mode 1 enabled.
2025-05-28 23:47:25 : INFO  : espanso : Reading arguments again:
2025-05-28 23:47:25 : DEBUG : espanso : name=Espanso
2025-05-28 23:47:25 : DEBUG : espanso : appName=
2025-05-28 23:47:25 : DEBUG : espanso : type=zip
2025-05-28 23:47:25 : DEBUG : espanso : archiveName=
2025-05-28 23:47:25 : DEBUG : espanso : downloadURL=https://github.com/espanso/espanso/releases/download/v2.2.1/Espanso-Mac-Intel.zip
2025-05-28 23:47:25 : DEBUG : espanso : curlOptions=
2025-05-28 23:47:25 : DEBUG : espanso : appNewVersion=
2025-05-28 23:47:25 : DEBUG : espanso : appCustomVersion function: Not defined
2025-05-28 23:47:25 : DEBUG : espanso : versionKey=CFBundleShortVersionString
2025-05-28 23:47:25 : DEBUG : espanso : packageID=
2025-05-28 23:47:25 : DEBUG : espanso : pkgName=
2025-05-28 23:47:25 : DEBUG : espanso : choiceChangesXML=
2025-05-28 23:47:25 : DEBUG : espanso : expectedTeamID=K839T4T5BY
2025-05-28 23:47:25 : DEBUG : espanso : blockingProcesses=
2025-05-28 23:47:25 : DEBUG : espanso : installerTool=
2025-05-28 23:47:25 : DEBUG : espanso : CLIInstaller=
2025-05-28 23:47:25 : DEBUG : espanso : CLIArguments=
2025-05-28 23:47:25 : DEBUG : espanso : updateTool=
2025-05-28 23:47:25 : DEBUG : espanso : updateToolArguments=
2025-05-28 23:47:25 : DEBUG : espanso : updateToolRunAsCurrentUser=
2025-05-28 23:47:25 : INFO  : espanso : BLOCKING_PROCESS_ACTION=tell_user
2025-05-28 23:47:25 : INFO  : espanso : NOTIFY=success
2025-05-28 23:47:25 : INFO  : espanso : LOGGING=DEBUG
2025-05-28 23:47:25 : INFO  : espanso : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-28 23:47:25 : INFO  : espanso : Label type: zip
2025-05-28 23:47:25 : INFO  : espanso : archiveName: Espanso.zip
2025-05-28 23:47:25 : INFO  : espanso : no blocking processes defined, using Espanso as default
2025-05-28 23:47:25 : DEBUG : espanso : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-05-28 23:47:25 : INFO  : espanso : name: Espanso, appName: Espanso.app
2025-05-28 23:47:25 : WARN  : espanso : No previous app found
2025-05-28 23:47:25 : WARN  : espanso : could not find Espanso.app
2025-05-28 23:47:25 : INFO  : espanso : appversion:
2025-05-28 23:47:25 : INFO  : espanso : Latest version not specified.
2025-05-28 23:47:25 : REQ   : espanso : Downloading https://github.com/espanso/espanso/releases/download/v2.2.1/Espanso-Mac-Intel.zip to Espanso.zip
2025-05-28 23:47:25 : DEBUG : espanso : No Dialog connection, just download
2025-05-28 23:47:26 : INFO  : espanso : Downloaded Espanso.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is f3b0febbe7e84696f83ab45792999096920b7558 – Size is 7376 kB
2025-05-28 23:47:26 : DEBUG : espanso : DEBUG mode 1, not checking for blocking processes
2025-05-28 23:47:26 : REQ   : espanso : Installing Espanso
2025-05-28 23:47:26 : INFO  : espanso : Unzipping Espanso.zip
2025-05-28 23:47:26 : INFO  : espanso : Verifying: /Users/h.lans/Documents/GitHub/Installomator/build/Espanso.app
2025-05-28 23:47:26 : DEBUG : espanso : App size:  18M	/Users/h.lans/Documents/GitHub/Installomator/build/Espanso.app
2025-05-28 23:47:27 : DEBUG : espanso : Debugging enabled, App Verification output was:
/Users/h.lans/Documents/GitHub/Installomator/build/Espanso.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Federico Terzi (K839T4T5BY)

2025-05-28 23:47:27 : INFO  : espanso : Team ID matching: K839T4T5BY (expected: K839T4T5BY )
2025-05-28 23:47:27 : INFO  : espanso : Installing Espanso version 2.2.1 on versionKey CFBundleShortVersionString.
2025-05-28 23:47:27 : DEBUG : espanso : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-28 23:47:27 : INFO  : espanso : Finishing...
2025-05-28 23:47:30 : INFO  : espanso : name: Espanso, appName: Espanso.app
2025-05-28 23:47:30 : INFO  : espanso : App(s) found: /Users/h.lans/Documents/GitHub/Installomator/build/Espanso.app
2025-05-28 23:47:30 : WARN  : espanso : could not determine location of Espanso.app
2025-05-28 23:47:30 : REQ   : espanso : Installed Espanso, version 2.2.1
2025-05-28 23:47:30 : INFO  : espanso : notifying
2025-05-28 23:47:30 : DEBUG : espanso : DEBUG mode 1, not reopening anything
2025-05-28 23:47:30 : REQ   : espanso : All done!
2025-05-28 23:47:30 : REQ   : espanso : ################## End Installomator, exit code 0


### arm64
./assemble.sh espanso
2025-05-28 23:48:32 : INFO  : espanso : Total items in argumentsArray: 0
2025-05-28 23:48:32 : INFO  : espanso : argumentsArray:
2025-05-28 23:48:32 : REQ   : espanso : ################## Start Installomator v. 10.9beta, date 2025-05-28
2025-05-28 23:48:32 : INFO  : espanso : ################## Version: 10.9beta
2025-05-28 23:48:32 : INFO  : espanso : ################## Date: 2025-05-28
2025-05-28 23:48:32 : INFO  : espanso : ################## espanso
2025-05-28 23:48:32 : DEBUG : espanso : DEBUG mode 1 enabled.
2025-05-28 23:48:34 : INFO  : espanso : Reading arguments again:
2025-05-28 23:48:34 : DEBUG : espanso : name=Espanso
2025-05-28 23:48:34 : DEBUG : espanso : appName=
2025-05-28 23:48:34 : DEBUG : espanso : type=dmg
2025-05-28 23:48:34 : DEBUG : espanso : archiveName=Espanso-Mac-M1.dmg
2025-05-28 23:48:34 : DEBUG : espanso : downloadURL=https://github.com/espanso/espanso/releases/download/v2.2.3/Espanso-Mac-M1.dmg
2025-05-28 23:48:34 : DEBUG : espanso : curlOptions=
2025-05-28 23:48:34 : DEBUG : espanso : appNewVersion=2.2.3
2025-05-28 23:48:34 : DEBUG : espanso : appCustomVersion function: Not defined
2025-05-28 23:48:34 : DEBUG : espanso : versionKey=CFBundleShortVersionString
2025-05-28 23:48:34 : DEBUG : espanso : packageID=
2025-05-28 23:48:34 : DEBUG : espanso : pkgName=
2025-05-28 23:48:34 : DEBUG : espanso : choiceChangesXML=
2025-05-28 23:48:34 : DEBUG : espanso : expectedTeamID=6424323YUH
2025-05-28 23:48:34 : DEBUG : espanso : blockingProcesses=
2025-05-28 23:48:34 : DEBUG : espanso : installerTool=
2025-05-28 23:48:34 : DEBUG : espanso : CLIInstaller=
2025-05-28 23:48:34 : DEBUG : espanso : CLIArguments=
2025-05-28 23:48:34 : DEBUG : espanso : updateTool=
2025-05-28 23:48:34 : DEBUG : espanso : updateToolArguments=
2025-05-28 23:48:34 : DEBUG : espanso : updateToolRunAsCurrentUser=
2025-05-28 23:48:34 : INFO  : espanso : BLOCKING_PROCESS_ACTION=tell_user
2025-05-28 23:48:34 : INFO  : espanso : NOTIFY=success
2025-05-28 23:48:34 : INFO  : espanso : LOGGING=DEBUG
2025-05-28 23:48:34 : INFO  : espanso : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-28 23:48:34 : INFO  : espanso : Label type: dmg
2025-05-28 23:48:34 : INFO  : espanso : archiveName: Espanso-Mac-M1.dmg
2025-05-28 23:48:34 : INFO  : espanso : no blocking processes defined, using Espanso as default
2025-05-28 23:48:34 : DEBUG : espanso : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-05-28 23:48:34 : INFO  : espanso : name: Espanso, appName: Espanso.app
2025-05-28 23:48:34 : WARN  : espanso : No previous app found
2025-05-28 23:48:34 : WARN  : espanso : could not find Espanso.app
2025-05-28 23:48:34 : INFO  : espanso : appversion:
2025-05-28 23:48:34 : INFO  : espanso : Latest version of Espanso is 2.2.3
2025-05-28 23:48:34 : REQ   : espanso : Downloading https://github.com/espanso/espanso/releases/download/v2.2.3/Espanso-Mac-M1.dmg to Espanso-Mac-M1.dmg
2025-05-28 23:48:34 : DEBUG : espanso : No Dialog connection, just download
2025-05-28 23:48:35 : INFO  : espanso : Downloaded Espanso-Mac-M1.dmg – Type is  zlib compressed data – SHA is 33e5188796afc91bfecc9195d15f35d7a6773733 – Size is 7412 kB
2025-05-28 23:48:35 : DEBUG : espanso : DEBUG mode 1, not checking for blocking processes
2025-05-28 23:48:35 : REQ   : espanso : Installing Espanso
2025-05-28 23:48:35 : INFO  : espanso : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Espanso-Mac-M1.dmg
2025-05-28 23:48:39 : DEBUG : espanso : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $C2ED7E31
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $5E292E8B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $3699C8E4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $00149A58
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $3699C8E4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $578DED69
verified CRC32 $D28CCE55
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Espanso.app

2025-05-28 23:48:39 : INFO  : espanso : Mounted: /Volumes/Espanso.app
2025-05-28 23:48:39 : INFO  : espanso : Verifying: /Volumes/Espanso.app/Espanso.app
2025-05-28 23:48:39 : DEBUG : espanso : App size:  16M	/Volumes/Espanso.app/Espanso.app
2025-05-28 23:48:39 : DEBUG : espanso : Debugging enabled, App Verification output was:
/Volumes/Espanso.app/Espanso.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Auca Coyan Maillot (6424323YUH)

2025-05-28 23:48:39 : INFO  : espanso : Team ID matching: 6424323YUH (expected: 6424323YUH )
2025-05-28 23:48:39 : INFO  : espanso : Installing Espanso version 2.2.3 on versionKey CFBundleShortVersionString.
2025-05-28 23:48:39 : DEBUG : espanso : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-05-28 23:48:39 : INFO  : espanso : Finishing...
2025-05-28 23:48:42 : INFO  : espanso : name: Espanso, appName: Espanso.app
2025-05-28 23:48:42 : WARN  : espanso : No previous app found
2025-05-28 23:48:42 : WARN  : espanso : could not find Espanso.app
2025-05-28 23:48:42 : REQ   : espanso : Installed Espanso, version 2.2.3
2025-05-28 23:48:42 : INFO  : espanso : notifying
2025-05-28 23:48:42 : DEBUG : espanso : Unmounting /Volumes/Espanso.app
2025-05-28 23:48:42 : DEBUG : espanso : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-28 23:48:42 : DEBUG : espanso : DEBUG mode 1, not reopening anything
2025-05-28 23:48:42 : REQ   : espanso : All done!
2025-05-28 23:48:42 : REQ   : espanso : ################## End Installomator, exit code 0
````