### PR TITLE
new label: microsoftglobalsecureaccessclient

### DIFF
--- a/fragments/labels/microsoftglobalsecureaccessclient.sh
+++ b/fragments/labels/microsoftglobalsecureaccessclient.sh
@@ -1,0 +1,7 @@
+microsoftglobalsecureaccessclient)
+    name="Global Secure Access Client"
+    type="pkg"
+    packageID="com.microsoft.naas.globalsecure"
+    downloadURL="https://aka.ms/GlobalSecureAccess-macOS"
+    expectedTeamID="UBF8T346G9"
+    ;;

--- a/fragments/labels/microsoftglobalsecureaccessclient.sh
+++ b/fragments/labels/microsoftglobalsecureaccessclient.sh
@@ -1,7 +1,7 @@
 microsoftglobalsecureaccessclient)
     name="Global Secure Access Client"
     type="pkg"
-    packageID="com.microsoft.naas.globalsecure"
+    packageID="com.microsoft.globalsecureaccess"
     downloadURL="https://aka.ms/GlobalSecureAccess-macOS"
     expectedTeamID="UBF8T346G9"
     ;;

--- a/fragments/labels/microsoftglobalsecureaccessclient.sh
+++ b/fragments/labels/microsoftglobalsecureaccessclient.sh
@@ -4,4 +4,5 @@ microsoftglobalsecureaccessclient)
     packageID="com.microsoft.globalsecureaccess"
     downloadURL="https://aka.ms/GlobalSecureAccess-macOS"
     expectedTeamID="UBF8T346G9"
+    appNewVersion=$(curl -sfL https://raw.githubusercontent.com/MicrosoftDocs/entra-docs/refs/heads/main/docs/global-secure-access/reference-macos-client-release-history.md | grep -m1 -E "##.*Version" | grep -E -o "[0-9.]+")
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```sh
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : Total items in argumentsArray: 0
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : argumentsArray:
2026-05-21 22:38:09 : REQ   : microsoftglobalsecureaccessclient : ################## Start Installomator v. 10.9beta, date 2026-05-21
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : ################## Version: 10.9beta
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : ################## Date: 2026-05-21
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : ################## microsoftglobalsecureaccessclient
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : DEBUG mode 1 enabled.
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : SwiftDialog is not installed, clear cmd file var
2026-05-21 22:38:09 : INFO  : microsoftglobalsecureaccessclient : Reading arguments again:
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : name=Global Secure Access Client
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : appName=
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : type=pkg
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : archiveName=
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : downloadURL=https://aka.ms/GlobalSecureAccess-macOS
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : curlOptions=
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : appNewVersion=1.1.26030601
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : appCustomVersion function: Not defined
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : versionKey=CFBundleShortVersionString
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : packageID=com.microsoft.globalsecureaccess
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : pkgName=
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : choiceChangesXML=
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : expectedTeamID=UBF8T346G9
2026-05-21 22:38:09 : DEBUG : microsoftglobalsecureaccessclient : blockingProcesses=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : installerTool=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : CLIInstaller=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : CLIArguments=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : updateTool=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : updateToolArguments=
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : updateToolRunAsCurrentUser=
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : BLOCKING_PROCESS_ACTION=tell_user
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : NOTIFY=success
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : LOGGING=DEBUG
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : Label type: pkg
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : archiveName: Global Secure Access Client.pkg
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : no blocking processes defined, using Global Secure Access Client as default
2026-05-21 22:38:10 : DEBUG : microsoftglobalsecureaccessclient : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : No version found using packageID com.microsoft.globalsecureaccess
2026-05-21 22:38:10 : INFO  : microsoftglobalsecureaccessclient : name: Global Secure Access Client, appName: Global Secure Access Client.app
2026-05-21 22:38:11 : WARN  : microsoftglobalsecureaccessclient : No previous app found
2026-05-21 22:38:11 : WARN  : microsoftglobalsecureaccessclient : could not find Global Secure Access Client.app
2026-05-21 22:38:11 : INFO  : microsoftglobalsecureaccessclient : appversion:
2026-05-21 22:38:11 : INFO  : microsoftglobalsecureaccessclient : Latest version of Global Secure Access Client is 1.1.26030601
2026-05-21 22:38:11 : REQ   : microsoftglobalsecureaccessclient : Downloading https://aka.ms/GlobalSecureAccess-macOS to Global Secure Access Client.pkg
2026-05-21 22:38:11 : DEBUG : microsoftglobalsecureaccessclient : No Dialog connection, just download
2026-05-21 22:38:15 : INFO  : microsoftglobalsecureaccessclient : Downloaded Global Secure Access Client.pkg – Type is  xar archive compressed TOC – SHA is 317a5bb400646fd4fb2ea7636bb4388b181afeac – Size is 41196 kB
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : DEBUG mode 1, not checking for blocking processes
2026-05-21 22:38:15 : REQ   : microsoftglobalsecureaccessclient : Installing Global Secure Access Client
2026-05-21 22:38:15 : INFO  : microsoftglobalsecureaccessclient : Verifying: Global Secure Access Client.pkg
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : File list: -rw-r--r--@ 1 kenchan0130  staff    40M  5月 21 22:38 Global Secure Access Client.pkg
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : File type: Global Secure Access Client.pkg: xar archive compressed TOC: 4648, SHA-1 checksum
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : spctlOut is Global Secure Access Client.pkg: accepted
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : source=Notarized Developer ID
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2026-05-21 22:38:15 : INFO  : microsoftglobalsecureaccessclient : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2026-05-21 22:38:15 : DEBUG : microsoftglobalsecureaccessclient : DEBUG enabled, skipping installation
2026-05-21 22:38:15 : INFO  : microsoftglobalsecureaccessclient : Finishing...
2026-05-21 22:38:18 : INFO  : microsoftglobalsecureaccessclient : No version found using packageID com.microsoft.globalsecureaccess
2026-05-21 22:38:18 : INFO  : microsoftglobalsecureaccessclient : name: Global Secure Access Client, appName: Global Secure Access Client.app
2026-05-21 22:38:19 : WARN  : microsoftglobalsecureaccessclient : No previous app found
2026-05-21 22:38:19 : WARN  : microsoftglobalsecureaccessclient : could not find Global Secure Access Client.app
2026-05-21 22:38:19 : REQ   : microsoftglobalsecureaccessclient : Installed Global Secure Access Client, version 1.1.26030601
2026-05-21 22:38:19 : INFO  : microsoftglobalsecureaccessclient : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-05-21 22:38:19 : DEBUG : microsoftglobalsecureaccessclient : DEBUG mode 1, not reopening anything
2026-05-21 22:38:19 : REQ   : microsoftglobalsecureaccessclient : All done!
2026-05-21 22:38:19 : REQ   : microsoftglobalsecureaccessclient : ################## End Installomator, exit code 0
```
