### PR TITLE
Update duckduckgo

### DIFF
--- a/fragments/labels/duckduckgo.sh
+++ b/fragments/labels/duckduckgo.sh
@@ -1,10 +1,6 @@
 duckduckgo)
     name="DuckDuckGo"
     type="dmg"
-    #downloadURL="https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo.dmg"
-    downloadURL=$(curl -fs https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast.xml | xpath '(//rss/channel/item/enclosure/@url)[last()]' 2>/dev/null | cut -d '"' -f2)
-    #downloadURL=$(curl -fs https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast.xml | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f2)
-    appNewVersion=$(curl -fs https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast.xml | xpath '(//rss/channel/item/enclosure/@sparkle:version)[last()]' 2>/dev/null | cut -d '"' -f2)
-    #appNewVersion=$(curl -fs https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast.xml | xpath '(//rss/channel/item/sparkle:shortVersionString)[1]' 2>/dev/null | cut -d ">" -f2 | cut -d "<" -f1)
+    downloadURL="https://staticcdn.duckduckgo.com/macos-desktop-browser/funnel_browser/duckduckgo.dmg"
     expectedTeamID="HKE973VLUW"
     ;;

--- a/fragments/labels/duckduckgo.sh
+++ b/fragments/labels/duckduckgo.sh
@@ -1,6 +1,7 @@
 duckduckgo)
     name="DuckDuckGo"
     type="dmg"
-    downloadURL="https://staticcdn.duckduckgo.com/macos-desktop-browser/funnel_browser/duckduckgo.dmg"
+    appNewVersion=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath  '(//rss/channel/item/sparkle:shortVersionString/text())' | head -1)
+    downloadURL=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/enclosure/@url' 2>/dev/null | cut -d '"' -f 2  | head -1)
     expectedTeamID="HKE973VLUW"
     ;;

--- a/fragments/labels/duckduckgo.sh
+++ b/fragments/labels/duckduckgo.sh
@@ -1,7 +1,7 @@
 duckduckgo)
     name="DuckDuckGo"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath  '(//rss/channel/item/sparkle:shortVersionString/text())' | head -1)
-    downloadURL=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/enclosure/@url' 2>/dev/null | cut -d '"' -f 2  | head -1)
+    appNewVersion=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/sparkle:shortVersionString/text())' | head -1)
+    downloadURL=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 | head -1)
     expectedTeamID="HKE973VLUW"
     ;;

--- a/fragments/labels/duckduckgo.sh
+++ b/fragments/labels/duckduckgo.sh
@@ -1,7 +1,8 @@
 duckduckgo)
     name="DuckDuckGo"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/sparkle:shortVersionString/text())' | head -1)
-    downloadURL=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml" | xpath '(//rss/channel/item/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 | head -1)
+    ddgXML=$(curl -fsL "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml")
+    appNewVersion=$(echo "$ddgXML" | xpath '(//rss/channel/item/sparkle:shortVersionString/text())' | head -1)
+    downloadURL=$(echo "$ddgXML" | xpath '(//rss/channel/item/enclosure/@url' 2>/dev/null | cut -d '"' -f 2 | head -1)
     expectedTeamID="HKE973VLUW"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
I had to drop `appNewVersion`. The appcast url is not longer up to date. There is a [github](https://github.com/duckduckgo/apple-browsers), but we can't use the GitHub version function since it's a combined page for iOS and macOS releases.


**Installomator log**
Fixes #2347 

````
./assemble.sh duckduckgo
2025-05-30 22:57:03 : INFO  : duckduckgo : Total items in argumentsArray: 0
2025-05-30 22:57:03 : INFO  : duckduckgo : argumentsArray: 
2025-05-30 22:57:03 : REQ   : duckduckgo : ################## Start Installomator v. 10.9beta, date 2025-05-30
2025-05-30 22:57:03 : INFO  : duckduckgo : ################## Version: 10.9beta
2025-05-30 22:57:03 : INFO  : duckduckgo : ################## Date: 2025-05-30
2025-05-30 22:57:03 : INFO  : duckduckgo : ################## duckduckgo
2025-05-30 22:57:03 : DEBUG : duckduckgo : DEBUG mode 1 enabled.
2025-05-30 22:57:03 : INFO  : duckduckgo : Reading arguments again: 
2025-05-30 22:57:03 : DEBUG : duckduckgo : name=DuckDuckGo
2025-05-30 22:57:03 : DEBUG : duckduckgo : appName=
2025-05-30 22:57:03 : DEBUG : duckduckgo : type=dmg
2025-05-30 22:57:03 : DEBUG : duckduckgo : archiveName=
2025-05-30 22:57:03 : DEBUG : duckduckgo : downloadURL=https://staticcdn.duckduckgo.com/macos-desktop-browser/funnel_browser/duckduckgo.dmg
2025-05-30 22:57:03 : DEBUG : duckduckgo : curlOptions=
2025-05-30 22:57:03 : DEBUG : duckduckgo : appNewVersion=
2025-05-30 22:57:03 : DEBUG : duckduckgo : appCustomVersion function: Not defined
2025-05-30 22:57:03 : DEBUG : duckduckgo : versionKey=CFBundleShortVersionString
2025-05-30 22:57:04 : DEBUG : duckduckgo : packageID=
2025-05-30 22:57:04 : DEBUG : duckduckgo : pkgName=
2025-05-30 22:57:04 : DEBUG : duckduckgo : choiceChangesXML=
2025-05-30 22:57:04 : DEBUG : duckduckgo : expectedTeamID=HKE973VLUW
2025-05-30 22:57:04 : DEBUG : duckduckgo : blockingProcesses=
2025-05-30 22:57:04 : DEBUG : duckduckgo : installerTool=
2025-05-30 22:57:04 : DEBUG : duckduckgo : CLIInstaller=
2025-05-30 22:57:04 : DEBUG : duckduckgo : CLIArguments=
2025-05-30 22:57:04 : DEBUG : duckduckgo : updateTool=
2025-05-30 22:57:04 : DEBUG : duckduckgo : updateToolArguments=
2025-05-30 22:57:04 : DEBUG : duckduckgo : updateToolRunAsCurrentUser=
2025-05-30 22:57:04 : INFO  : duckduckgo : BLOCKING_PROCESS_ACTION=tell_user
2025-05-30 22:57:04 : INFO  : duckduckgo : NOTIFY=success
2025-05-30 22:57:04 : INFO  : duckduckgo : LOGGING=DEBUG
2025-05-30 22:57:04 : INFO  : duckduckgo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-05-30 22:57:04 : INFO  : duckduckgo : Label type: dmg
2025-05-30 22:57:04 : INFO  : duckduckgo : archiveName: DuckDuckGo.dmg
2025-05-30 22:57:04 : INFO  : duckduckgo : no blocking processes defined, using DuckDuckGo as default
2025-05-30 22:57:04 : DEBUG : duckduckgo : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-05-30 22:57:04 : INFO  : duckduckgo : App(s) found: /Applications/DuckDuckGo.app
2025-05-30 22:57:04 : INFO  : duckduckgo : found app at /Applications/DuckDuckGo.app, version 1.140.0, on versionKey CFBundleShortVersionString
2025-05-30 22:57:04 : INFO  : duckduckgo : appversion: 1.140.0
2025-05-30 22:57:04 : INFO  : duckduckgo : Latest version not specified.
2025-05-30 22:57:04 : REQ   : duckduckgo : Downloading https://staticcdn.duckduckgo.com/macos-desktop-browser/funnel_browser/duckduckgo.dmg to DuckDuckGo.dmg
2025-05-30 22:57:04 : DEBUG : duckduckgo : No Dialog connection, just download
2025-05-30 22:57:25 : INFO  : duckduckgo : Downloaded DuckDuckGo.dmg – Type is  zlib compressed data – SHA is 4710dd9c362b7a975f773325f94dabaaa3b71039 – Size is 131196 kB
2025-05-30 22:57:25 : DEBUG : duckduckgo : DEBUG mode 1, not checking for blocking processes
2025-05-30 22:57:25 : REQ   : duckduckgo : Installing DuckDuckGo
2025-05-30 22:57:25 : INFO  : duckduckgo : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/DuckDuckGo.dmg
2025-05-30 22:57:29 : DEBUG : duckduckgo : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $A9E2CED9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $7BA42EED
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $62347C8D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $96D9F5C6
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $62347C8D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $AA1685EB
verified CRC32 $8CC53CFD
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/DuckDuckGo

2025-05-30 22:57:29 : INFO  : duckduckgo : Mounted: /Volumes/DuckDuckGo
2025-05-30 22:57:29 : INFO  : duckduckgo : Verifying: /Volumes/DuckDuckGo/DuckDuckGo.app
2025-05-30 22:57:29 : DEBUG : duckduckgo : App size: 333M	/Volumes/DuckDuckGo/DuckDuckGo.app
2025-05-30 22:57:31 : DEBUG : duckduckgo : Debugging enabled, App Verification output was:
/Volumes/DuckDuckGo/DuckDuckGo.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Duck Duck Go, Inc. (HKE973VLUW)

2025-05-30 22:57:31 : INFO  : duckduckgo : Team ID matching: HKE973VLUW (expected: HKE973VLUW )
2025-05-30 22:57:31 : INFO  : duckduckgo : Downloaded version of DuckDuckGo is 1.140.0 on versionKey CFBundleShortVersionString, same as installed.
2025-05-30 22:57:31 : DEBUG : duckduckgo : Unmounting /Volumes/DuckDuckGo
2025-05-30 22:57:31 : DEBUG : duckduckgo : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-05-30 22:57:31 : DEBUG : duckduckgo : DEBUG mode 1, not reopening anything
2025-05-30 22:57:31 : REG   : duckduckgo : No new version to install
2025-05-30 22:57:31 : REQ   : duckduckgo : ################## End Installomator, exit code 0
````