### PR TITLE
New Label fontagent10

### DIFF
--- a/fragments/labels/fontagent10.sh
+++ b/fragments/labels/fontagent10.sh
@@ -1,0 +1,9 @@
+fontagent10)
+    name="FontAgent"
+    type="pkgInDmg"
+    packageID="com.insidersoftware.fontagent10.pkg"
+    downloadURL="https://store.insidersoftware.com/_downloads/FontAgent10.dmg"
+    appNewVersion="$(curl -fsL "https://updates.insidersoftware.com/software/fontagent10/release/notes.xml" | xpath 'string(//rss/channel/item[1]/enclosure/@sparkle:shortVersionString)')"
+    expectedTeamID="936VDEB3YQ"
+    blockingProcesses=( "FontAgent" "FontAgent Activator" )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered Yes before submitting the pull request.

Have you confirmed this pull request is not a duplicate?

yes

Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?

yes

Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?

yes

Additional context Add any other context about the label or fix here.

The sparkle feed is not fully up to date, but it's better than nothing. If anyone can find a better way to check the version of this software please do

Installomator log At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. DEBUG=1 can be enabled but do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Output:

2025-06-02 11:53:40 : INFO  : fontagent10 : Total items in argumentsArray: 0 2025-06-02 11:53:40 : INFO  : fontagent10 : argumentsArray:
2025-06-02 11:53:40 : REQ   : fontagent10 : ################## Start Installomator v. 10.9beta, date 2025-06-02
2025-06-02 11:53:40 : INFO  : fontagent10 : ################## Version: 10.9beta
2025-06-02 11:53:40 : INFO  : fontagent10 : ################## Date: 2025-06-02
2025-06-02 11:53:40 : INFO  : fontagent10 : ################## fontagent10
2025-06-02 11:53:40 : DEBUG : fontagent10 : DEBUG mode 1 enabled.
2025-06-02 11:53:40 : INFO  : fontagent10 : SwiftDialog is not installed, clear cmd file var
2025-06-02 11:53:40 : INFO  : fontagent10 : Reading arguments again:
2025-06-02 11:53:40 : DEBUG : fontagent10 : name=FontAgent
2025-06-02 11:53:40 : DEBUG : fontagent10 : appName=
2025-06-02 11:53:40 : DEBUG : fontagent10 : type=pkgInDmg
2025-06-02 11:53:40 : DEBUG : fontagent10 : archiveName=
2025-06-02 11:53:40 : DEBUG : fontagent10 : downloadURL=https://store.insidersoftware.com/_downloads/FontAgent10.dmg
2025-06-02 11:53:40 : DEBUG : fontagent10 : curlOptions=
2025-06-02 11:53:40 : DEBUG : fontagent10 : appNewVersion=10.2.3
2025-06-02 11:53:40 : DEBUG : fontagent10 : appCustomVersion function: Not defined
2025-06-02 11:53:40 : DEBUG : fontagent10 : versionKey=CFBundleShortVersionString
2025-06-02 11:53:40 : DEBUG : fontagent10 : packageID=com.insidersoftware.fontagent10.pkg
2025-06-02 11:53:40 : DEBUG : fontagent10 : pkgName=
2025-06-02 11:53:40 : DEBUG : fontagent10 : choiceChangesXML=
2025-06-02 11:53:40 : DEBUG : fontagent10 : expectedTeamID=936VDEB3YQ
2025-06-02 11:53:40 : DEBUG : fontagent10 : blockingProcesses=FontAgent FontAgent Activator
2025-06-02 11:53:40 : DEBUG : fontagent10 : installerTool=
2025-06-02 11:53:40 : DEBUG : fontagent10 : CLIInstaller=
2025-06-02 11:53:40 : DEBUG : fontagent10 : CLIArguments=
2025-06-02 11:53:40 : DEBUG : fontagent10 : updateTool=
2025-06-02 11:53:40 : DEBUG : fontagent10 : updateToolArguments=
2025-06-02 11:53:41 : DEBUG : fontagent10 : updateToolRunAsCurrentUser=
2025-06-02 11:53:41 : INFO  : fontagent10 : BLOCKING_PROCESS_ACTION=tell_user
2025-06-02 11:53:41 : INFO  : fontagent10 : NOTIFY=success
2025-06-02 11:53:41 : INFO  : fontagent10 : LOGGING=DEBUG
2025-06-02 11:53:41 : INFO  : fontagent10 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-02 11:53:41 : INFO  : fontagent10 : Label type: pkgInDmg
2025-06-02 11:53:41 : INFO  : fontagent10 : archiveName: FontAgent.dmg
2025-06-02 11:53:41 : DEBUG : fontagent10 : Changing directory to /Users/user/Documents/GitHub/Installomator/build
2025-06-02 11:53:41 : INFO  : fontagent10 : No version found using packageID com.insidersoftware.fontagent10.pkg
2025-06-02 11:53:41 : INFO  : fontagent10 : name: FontAgent, appName: FontAgent.app
2025-06-02 11:53:41 : WARN  : fontagent10 : No previous app found
2025-06-02 11:53:41 : WARN  : fontagent10 : could not find FontAgent.app
2025-06-02 11:53:41 : INFO  : fontagent10 : appversion:
2025-06-02 11:53:41 : INFO  : fontagent10 : Latest version of FontAgent is 10.2.3
2025-06-02 11:53:41 : INFO  : fontagent10 : FontAgent.dmg exists and DEBUG mode 1 enabled, skipping download
2025-06-02 11:53:41 : DEBUG : fontagent10 : DEBUG mode 1, not checking for blocking processes
2025-06-02 11:53:41 : REQ   : fontagent10 : Installing FontAgent
2025-06-02 11:53:41 : INFO  : fontagent10 : Mounting /Users/user/Documents/GitHub/Installomator/build/FontAgent.dmg
2025-06-02 11:53:41 : DEBUG : fontagent10 : Debugging enabled, dmgmount output was:
expected   CRC32 $44E99AB0
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/FontAgent 10.2.5

2025-06-02 11:53:41 : INFO  : fontagent10 : Mounted: /Volumes/FontAgent 10.2.5 2025-06-02 11:53:41 : DEBUG : fontagent10 : Found pkg(s): /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg 2025-06-02 11:53:41 : INFO  : fontagent10 : found pkg: /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg 2025-06-02 11:53:41 : INFO  : fontagent10 : Verifying: /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg
2025-06-02 11:53:41 : DEBUG : fontagent10 : File list: -rw-r--r--@ 1 user  staff   124M Nov  6  2024 /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg
2025-06-02 11:53:41 : DEBUG : fontagent10 : File type: /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg: xar archive compressed TOC: 4710, SHA-1 checksum
2025-06-02 11:53:41 : DEBUG : fontagent10 : spctlOut is /Volumes/FontAgent 10.2.5/Double-click to install FontAgent.pkg: accepted
2025-06-02 11:53:41 : DEBUG : fontagent10 : source=Notarized Developer ID
2025-06-02 11:53:41 : DEBUG : fontagent10 : origin=Developer ID Installer: Insider Software Inc. (936VDEB3YQ)
2025-06-02 11:53:41 : INFO  : fontagent10 : Team ID: 936VDEB3YQ (expected: 936VDEB3YQ )
2025-06-02 11:53:41 : DEBUG : fontagent10 : DEBUG enabled, skipping installation
2025-06-02 11:53:41 : INFO  : fontagent10 : Finishing...
2025-06-02 11:53:44 : INFO  : fontagent10 : No version found using packageID com.insidersoftware.fontagent10.pkg
2025-06-02 11:53:44 : INFO  : fontagent10 : name: FontAgent, appName: FontAgent.app
2025-06-02 11:53:44 : WARN  : fontagent10 : No previous app found
2025-06-02 11:53:44 : WARN  : fontagent10 : could not find FontAgent.app
2025-06-02 11:53:44 : REQ   : fontagent10 : Installed FontAgent, version 10.2.3
2025-06-02 11:53:44 : INFO  : fontagent10 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-06-02 11:53:44 : DEBUG : fontagent10 : Unmounting /Volumes/FontAgent 10.2.5
2025-06-02 11:53:45 : DEBUG : fontagent10 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-06-02 11:53:45 : DEBUG : fontagent10 : DEBUG mode 1, not reopening anything
2025-06-02 11:53:45 : REQ   : fontagent10 : All done!
2025-06-02 11:53:45 : REQ   : fontagent10 : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
