### PR TITLE
Update tableaupublic.sh

### DIFF
--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -1,8 +1,12 @@
 tableaupublic)
     name="Tableau Public"
     type="pkgInDmg"
-    packageID="com.tableausoftware.tableaudesktop"
-    downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
+    packageID="com.tableausoftware.tableaupublic"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac-arm64 | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
+    fi
     appNewVersion=$( echo $downloadURL | sed -E 's/.*TableauPublic-([-0-9]*)\.dmg/\1/g' | tr "-" "." )
     expectedTeamID="QJ4XPRK37C"
     ;;


### PR DESCRIPTION
Changed the packageID and added architecture check

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
No, I used Github's web editor

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-05-27 13:30:49 [LOG-BEGIN]
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:7: no such file or directory: /usr/local/bin/dialog
displaynotification:7: no such file or directory: /usr/local/bin/dialog
succesfully installed.
2025-05-27 13:30:49 : REQ : valuesfromarguments : ################## Start Installomator v. 10.8, date 2025-03-28
2025-05-27 13:30:50 : WARN : valuesfromarguments : No previous app found
2025-05-27 13:30:50 : WARN : valuesfromarguments : could not find TableauPublic.app
2025-05-27 13:30:50 : REQ : valuesfromarguments : Downloading https://downloads.tableau.com/public/TableauPublic-2025-1-2.dmg to TableauPublic.dmg
2025-05-27 13:31:36 : REQ : valuesfromarguments : no more blocking processes, continue with update
2025-05-27 13:31:36 : REQ : valuesfromarguments : Installing TableauPublic
2025-05-27 13:33:37 : WARN : valuesfromarguments : No previous app found
2025-05-27 13:33:37 : WARN : valuesfromarguments : could not find TableauPublic.app
2025-05-27 13:33:38 : REQ : valuesfromarguments : Installed TableauPublic, version 2025.1.2
2025-05-27 13:33:38 : REQ : valuesfromarguments : All done!
2025-05-27 13:33:38 : REQ : valuesfromarguments : ################## End Installomator, exit code 0
[Tue May 27 13:33:38 +03 2025][LOG-END]

```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
