### PR TITLE
Update duet.sh

### DIFF
--- a/fragments/labels/duet.sh
+++ b/fragments/labels/duet.sh
@@ -1,8 +1,8 @@
 duet)
     name="Duet"
-    type="zip"
+    type="dmg"
     downloadURL="https://updates.duetdisplay.com/AppleSilicon"
-    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i ^location | cut -d "/" -f6 | sed 's/duet-//' | sed 's/.zip//' | sed 's/-/./g')"
+    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i ^location | cut -d "/" -f6 | sed 's/duet-dd-//' | sed 's/.dmg//' | sed 's/-/./g')"
     expectedTeamID="J6L96W8A86"
     blockingProcesses=( "duet" "duet Networking" )
     ;;

--- a/fragments/labels/duet.sh
+++ b/fragments/labels/duet.sh
@@ -1,8 +1,9 @@
 duet)
-    name="Duet"
+    name="duet"
     type="dmg"
-    downloadURL="https://updates.duetdisplay.com/AppleSilicon"
-    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i ^location | cut -d "/" -f6 | sed 's/duet-dd-//' | sed 's/.dmg//' | sed 's/-/./g')"
+    sparkleData=$(curl -fsL 'https://updater.duetdownload.com/dd/sparkle.xml?lang=en-US&appName=Duet')
+    appNewVersion=$( <<<"$sparkleData" xpath '//*[local-name()="enclosure"]/@*[local-name()="version"]' | sed 's/.*="//;s/"//' | sort -V | tail -n 1 )
+    downloadURL=$( <<<"$sparkleData" xpath 'string(//*[local-name()="enclosure"][@*[local-name()="version"] = "'"$appNewVersion"'"]/@url)' )
     expectedTeamID="J6L96W8A86"
     blockingProcesses=( "duet" "duet Networking" )
     ;;


### PR DESCRIPTION
Vendor-supplied download is now dmg instead of zip, and the filename changed. Adjusted recipe to match.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
user@COMPUTER utils % sudo ../build/Installomator.sh duet DEBUG=1                                                                         
Password:
2025-06-12 09:07:01 : INFO  : duet : setting variable from argument DEBUG=1
2025-06-12 09:07:01 : INFO  : duet : Total items in argumentsArray: 1
2025-06-12 09:07:01 : INFO  : duet : argumentsArray: DEBUG=1
2025-06-12 09:07:01 : REQ   : duet : ################## Start Installomator v. 10.9beta, date 2025-06-12
2025-06-12 09:07:01 : INFO  : duet : ################## Version: 10.9beta
2025-06-12 09:07:01 : INFO  : duet : ################## Date: 2025-06-12
2025-06-12 09:07:01 : INFO  : duet : ################## duet
2025-06-12 09:07:01 : DEBUG : duet : DEBUG mode 1 enabled.
2025-06-12 09:07:02 : INFO  : duet : Reading arguments again: DEBUG=1
2025-06-12 09:07:02 : DEBUG : duet : argument: DEBUG=1
2025-06-12 09:07:02 : DEBUG : duet : name=Duet
2025-06-12 09:07:02 : DEBUG : duet : appName=
2025-06-12 09:07:02 : DEBUG : duet : type=dmg
2025-06-12 09:07:02 : DEBUG : duet : archiveName=
2025-06-12 09:07:02 : DEBUG : duet : downloadURL=https://updates.duetdisplay.com/AppleSilicon
2025-06-12 09:07:02 : DEBUG : duet : curlOptions=
2025-06-12 09:07:02 : DEBUG : duet : appNewVersion=3.20.3.0
2025-06-12 09:07:02 : DEBUG : duet : appCustomVersion function: Not defined
2025-06-12 09:07:02 : DEBUG : duet : versionKey=CFBundleShortVersionString
2025-06-12 09:07:02 : DEBUG : duet : packageID=
2025-06-12 09:07:02 : DEBUG : duet : pkgName=
2025-06-12 09:07:02 : DEBUG : duet : choiceChangesXML=
2025-06-12 09:07:02 : DEBUG : duet : expectedTeamID=J6L96W8A86
2025-06-12 09:07:02 : DEBUG : duet : blockingProcesses=duet duet Networking
2025-06-12 09:07:02 : DEBUG : duet : installerTool=
2025-06-12 09:07:02 : DEBUG : duet : CLIInstaller=
2025-06-12 09:07:02 : DEBUG : duet : CLIArguments=
2025-06-12 09:07:02 : DEBUG : duet : updateTool=
2025-06-12 09:07:02 : DEBUG : duet : updateToolArguments=
2025-06-12 09:07:02 : DEBUG : duet : updateToolRunAsCurrentUser=
2025-06-12 09:07:02 : INFO  : duet : BLOCKING_PROCESS_ACTION=tell_user
2025-06-12 09:07:02 : INFO  : duet : NOTIFY=success
2025-06-12 09:07:02 : INFO  : duet : LOGGING=DEBUG
2025-06-12 09:07:02 : INFO  : duet : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-12 09:07:02 : INFO  : duet : Label type: dmg
2025-06-12 09:07:02 : INFO  : duet : archiveName: Duet.dmg
2025-06-12 09:07:02 : DEBUG : duet : Changing directory to ../build
2025-06-12 09:07:02 : INFO  : duet : App(s) found: /Applications/Duet.app
2025-06-12 09:07:02 : INFO  : duet : found app at /Applications/Duet.app, version 3.20.3.0, on versionKey CFBundleShortVersionString
2025-06-12 09:07:02 : INFO  : duet : appversion: 3.20.3.0
2025-06-12 09:07:02 : INFO  : duet : Latest version of Duet is 3.20.3.0
2025-06-12 09:07:02 : REQ   : duet : Downloading https://updates.duetdisplay.com/AppleSilicon to Duet.dmg
2025-06-12 09:07:02 : DEBUG : duet : No Dialog connection, just download
2025-06-12 09:07:05 : INFO  : duet : Downloaded Duet.dmg – Type is  zlib compressed data – SHA is c22bdfa4df3d86fda0d9f2dc405b03068b301e08 – Size is 53752 kB
2025-06-12 09:07:05 : DEBUG : duet : DEBUG mode 1, not checking for blocking processes
2025-06-12 09:07:05 : REQ   : duet : Installing Duet
2025-06-12 09:07:05 : INFO  : duet : Mounting ../build/Duet.dmg
2025-06-12 09:07:09 : DEBUG : duet : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $B6B665DF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $61AE7911
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $C530355F
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $33FECC8F
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $C530355F
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $34D9BF2C
verified   CRC32 $42107591
/dev/disk28             GUID_partition_scheme
/dev/disk28s1           Apple_HFS                       /Volumes/Duet Display

2025-06-12 09:07:09 : INFO  : duet : Mounted: /Volumes/Duet Display
2025-06-12 09:07:09 : INFO  : duet : Verifying: /Volumes/Duet Display/Duet.app
2025-06-12 09:07:09 : DEBUG : duet : App size:  99M     /Volumes/Duet Display/Duet.app
2025-06-12 09:07:10 : DEBUG : duet : Debugging enabled, App Verification output was:
/Volumes/Duet Display/Duet.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Duet, Inc. (J6L96W8A86)

2025-06-12 09:07:10 : INFO  : duet : Team ID matching: J6L96W8A86 (expected: J6L96W8A86 )
2025-06-12 09:07:10 : INFO  : duet : Downloaded version of Duet is 3.20.3.0 on versionKey CFBundleShortVersionString, same as installed.
2025-06-12 09:07:10 : DEBUG : duet : Unmounting /Volumes/Duet Display
2025-06-12 09:07:10 : DEBUG : duet : Debugging enabled, Unmounting output was:
"disk28" ejected.
2025-06-12 09:07:10 : DEBUG : duet : DEBUG mode 1, not reopening anything
2025-06-12 09:07:10 : REG   : duet : No new version to install
2025-06-12 09:07:10 : REQ   : duet : ################## End Installomator, exit code 0 
```