### PR TITLE
Update displaylinkmanager.sh

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -1,6 +1,6 @@
 displaylinkmanager)
     name="DisplayLink Manager"
-    type="pkg"
+    type="pkgInZip"
     #packageID="com.displaylink.displaylinkmanagerapp"
     downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 'class="download-link">Download' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
     appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 "Release:" | cut -d ' ' -f2)


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
As of May 29th, 2025, Synaptics made a change to their packaging and made the pkg file zipped. This broke the workflow of this label. After exploring the MacAdmins Slack, I found this thread: https://macadmins.slack.com/archives/C013HFTFQ13/p1748616603322459 which noted that changing the type to type=pkgInZip would fix the issue. I tested and confirmed this worked but found no one had sent in a Pull Request to update the label
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

[2025-06-14 23:46:55 : INFO  : displaylinkmanager : setting variable from argument DEBUG=0
2025-06-14 23:46:55 : INFO  : displaylinkmanager : Total items in argumentsArray: 1
2025-06-14 23:46:55 : INFO  : displaylinkmanager : argumentsArray: DEBUG=0
2025-06-14 23:46:55 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.9beta, date 2025-06-14
2025-06-14 23:46:55 : INFO  : displaylinkmanager : ################## Version: 10.9beta
2025-06-14 23:46:55 : INFO  : displaylinkmanager : ################## Date: 2025-06-14
2025-06-14 23:46:55 : INFO  : displaylinkmanager : ################## displaylinkmanager
2025-06-14 23:46:58 : INFO  : displaylinkmanager : Reading arguments again: DEBUG=0
2025-06-14 23:46:58 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2025-06-14 23:46:58 : INFO  : displaylinkmanager : NOTIFY=success
2025-06-14 23:46:58 : INFO  : displaylinkmanager : LOGGING=INFO
2025-06-14 23:46:58 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-14 23:46:58 : INFO  : displaylinkmanager : Label type: pkgInZip
2025-06-14 23:46:58 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.zip
2025-06-14 23:46:58 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2025-06-14 23:46:58 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2025-06-14 23:46:58 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 1.12.4, on versionKey CFBundleShortVersionString
2025-06-14 23:46:58 : INFO  : displaylinkmanager : appversion: 1.12.4
2025-06-14 23:46:58 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 1.12.4
2025-06-14 23:46:58 : INFO  : displaylinkmanager : There is no newer version available.
2025-06-14 23:46:58 : INFO  : displaylinkmanager : Installomator did not close any apps, so no need to reopen any apps.
2025-06-14 23:46:58 : REQ   : displaylinkmanager : No newer version.
2025-06-14 23:46:58 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0 ]

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
