### PR TITLE
New Label: Insta360 Studio

### DIFF
--- a/fragments/labels/insta360studio.sh
+++ b/fragments/labels/insta360studio.sh
@@ -4,8 +4,8 @@ insta360)
     name="Insta360 Studio"
     type="pkg"
     pkgName=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*\(Insta360Studio_.*\.pkg\).*/\1/p')
-    appNewVersion=$(echo "${archiveName}" | sed -n 's/.*Insta360Studio_\([0-9.]*\)_release_insta360.*/\1/p')
+    appNewVersion=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*Insta360Studio_\([0-9.]*\)_release_insta360.*/\1/p')
     versionKey="CFBundleShortVersionString"
-    downloadURL=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*\(https:\/\/.*\.pkg\).*/\1/p') ; echo "${downloadURL}"
+    downloadURL=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*\(https:\/\/.*\.pkg\).*/\1/p')
     expectedTeamID="UBX9CH9GDX"
     ;;

--- a/fragments/labels/insta360studio.sh
+++ b/fragments/labels/insta360studio.sh
@@ -1,0 +1,11 @@
+insta360studio|\
+insta360)
+    # credit: Tully Jagoe
+    name="Insta360 Studio"
+    type="pkg"
+    pkgName=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*\(Insta360Studio_.*\.pkg\).*/\1/p')
+    appNewVersion=$(echo "${archiveName}" | sed -n 's/.*Insta360Studio_\([0-9.]*\)_release_insta360.*/\1/p')
+    versionKey="CFBundleShortVersionString"
+    downloadURL=$(curl -fs -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15" "https://www.insta360.com/download/hot-download" | sed -n 's/.*\(https:\/\/.*\.pkg\).*/\1/p') ; echo "${downloadURL}"
+    expectedTeamID="UBX9CH9GDX"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Installomator log** 
``` bash
2025-06-16 16:51:10 : INFO  : insta360studio : setting variable from argument DEBUG=1
2025-06-16 16:51:10 : INFO  : insta360studio : Total items in argumentsArray: 1
2025-06-16 16:51:10 : INFO  : insta360studio : argumentsArray: DEBUG=1
2025-06-16 16:51:10 : REQ   : insta360studio : ################## Start Installomator v. 10.9beta, date 2025-06-16
2025-06-16 16:51:10 : INFO  : insta360studio : ################## Version: 10.9beta
2025-06-16 16:51:10 : INFO  : insta360studio : ################## Date: 2025-06-16
2025-06-16 16:51:10 : INFO  : insta360studio : ################## insta360studio
2025-06-16 16:51:10 : DEBUG : insta360studio : DEBUG mode 1 enabled.
2025-06-16 16:52:12 : INFO  : insta360studio : Reading arguments again: DEBUG=1
2025-06-16 16:52:12 : DEBUG : insta360studio : argument: DEBUG=1
2025-06-16 16:52:12 : DEBUG : insta360studio : name=Insta360 Studio
2025-06-16 16:52:12 : DEBUG : insta360studio : appName=
2025-06-16 16:52:12 : DEBUG : insta360studio : type=pkg
2025-06-16 16:52:12 : DEBUG : insta360studio : archiveName=
2025-06-16 16:52:12 : DEBUG : insta360studio : downloadURL=https://file.insta360.com/static/43d4f953e0ed5b30d3bdd31062fc339f/Insta360Studio_5.6.2_release_insta360(RC_build79)_20250612_124903_signed_1749703849040.pkg
2025-06-16 16:52:12 : DEBUG : insta360studio : curlOptions=
2025-06-16 16:52:12 : DEBUG : insta360studio : appNewVersion=5.6.2
2025-06-16 16:52:12 : DEBUG : insta360studio : appCustomVersion function: Not defined
2025-06-16 16:52:12 : DEBUG : insta360studio : versionKey=CFBundleShortVersionString
2025-06-16 16:52:12 : DEBUG : insta360studio : packageID=
2025-06-16 16:52:12 : DEBUG : insta360studio : pkgName=Insta360Studio_5.6.2_release_insta360(RC_build79)_20250612_124903_signed_1749703849040.pkg
2025-06-16 16:52:12 : DEBUG : insta360studio : choiceChangesXML=
2025-06-16 16:52:12 : DEBUG : insta360studio : expectedTeamID=UBX9CH9GDX
2025-06-16 16:52:12 : DEBUG : insta360studio : blockingProcesses=
2025-06-16 16:52:12 : DEBUG : insta360studio : installerTool=
2025-06-16 16:52:12 : DEBUG : insta360studio : CLIInstaller=
2025-06-16 16:52:12 : DEBUG : insta360studio : CLIArguments=
2025-06-16 16:52:12 : DEBUG : insta360studio : updateTool=
2025-06-16 16:52:12 : DEBUG : insta360studio : updateToolArguments=
2025-06-16 16:52:12 : DEBUG : insta360studio : updateToolRunAsCurrentUser=
2025-06-16 16:52:12 : INFO  : insta360studio : BLOCKING_PROCESS_ACTION=tell_user
2025-06-16 16:52:12 : INFO  : insta360studio : NOTIFY=success
2025-06-16 16:52:12 : INFO  : insta360studio : LOGGING=DEBUG
2025-06-16 16:52:12 : INFO  : insta360studio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-16 16:52:12 : INFO  : insta360studio : Label type: pkg
2025-06-16 16:52:12 : INFO  : insta360studio : archiveName: Insta360 Studio.pkg
2025-06-16 16:52:12 : INFO  : insta360studio : no blocking processes defined, using Insta360 Studio as default
2025-06-16 16:52:12 : DEBUG : insta360studio : Changing directory to /redacted_personal_information/Installomator/build
2025-06-16 16:52:13 : INFO  : insta360studio : name: Insta360 Studio, appName: Insta360 Studio.app
2025-06-16 16:52:13 : WARN  : insta360studio : No previous app found
2025-06-16 16:52:13 : WARN  : insta360studio : could not find Insta360 Studio.app
2025-06-16 16:52:13 : INFO  : insta360studio : appversion:
2025-06-16 16:52:13 : INFO  : insta360studio : Latest version of Insta360 Studio is 5.6.2
2025-06-16 16:52:13 : INFO  : insta360studio : Insta360 Studio.pkg exists and DEBUG mode 1 enabled, skipping download
2025-06-16 16:52:13 : DEBUG : insta360studio : DEBUG mode 1, not checking for blocking processes
2025-06-16 16:52:13 : REQ   : insta360studio : Installing Insta360 Studio
2025-06-16 16:52:13 : INFO  : insta360studio : Verifying: Insta360 Studio.pkg
2025-06-16 16:52:13 : DEBUG : insta360studio : File list: -rw-r--r--  1 root  staff   1.0G 16 Jun 16:31 Insta360 Studio.pkg
2025-06-16 16:52:13 : DEBUG : insta360studio : File type: Insta360 Studio.pkg: xar archive compressed TOC: 8291, SHA-1 checksum
2025-06-16 16:52:13 : DEBUG : insta360studio : spctlOut is Insta360 Studio.pkg: accepted
2025-06-16 16:52:13 : DEBUG : insta360studio : source=Notarized Developer ID
2025-06-16 16:52:13 : DEBUG : insta360studio : override=security disabled
2025-06-16 16:52:13 : DEBUG : insta360studio : origin=Developer ID Installer: Shenzhen Arashi Vision Co., Ltd. (UBX9CH9GDX)
2025-06-16 16:52:13 : INFO  : insta360studio : Team ID: UBX9CH9GDX (expected: UBX9CH9GDX )
2025-06-16 16:52:13 : DEBUG : insta360studio : DEBUG enabled, skipping installation
2025-06-16 16:52:13 : INFO  : insta360studio : Finishing...
2025-06-16 16:52:16 : INFO  : insta360studio : name: Insta360 Studio, appName: Insta360 Studio.app
2025-06-16 16:52:16 : WARN  : insta360studio : No previous app found
2025-06-16 16:52:16 : WARN  : insta360studio : could not find Insta360 Studio.app
2025-06-16 16:52:16 : REQ   : insta360studio : Installed Insta360 Studio, version 5.6.2
2025-06-16 16:52:16 : INFO  : insta360studio : notifying
2025-06-16 16:52:17 : DEBUG : insta360studio : DEBUG mode 1, not reopening anything
2025-06-16 16:52:17 : REQ   : insta360studio : All done!
2025-06-16 16:52:17 : REQ   : insta360studio : ################## End Installomator, exit code 0
```
