### PR TITLE
Create DanteVirtualSoundcard.sh

### DIFF
--- a/fragments/labels/DanteVirtualSoundcard.sh
+++ b/fragments/labels/DanteVirtualSoundcard.sh
@@ -1,0 +1,8 @@
+dantevirtualsoundcard)
+    name="Dante Virtual Soundcard"
+    type="pkgInDmg"
+    appNewVersion=$(curl -sL https://my.audinate.com/support/downloads/download-latest-dante-software | grep -oE 'Dante Virtual Soundcard v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ for macOS' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    downloadURL="https://my.audinate.com/system/files/release/DVS-${appNewVersion}_macos.dmg"
+    versionKey="CFBundleVersion"
+    expectedTeamID="P4WCR6Y822"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** creating a label

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2025-06-16 13:40:09 : REQ   : dantevirtualsoundcard : ################## Start Installomator v. 10.6beta, date 2024-04-23
2025-06-16 13:40:09 : INFO  : dantevirtualsoundcard : ################## Version: 10.6beta
2025-06-16 13:40:09 : INFO  : dantevirtualsoundcard : ################## Date: 2024-04-23
2025-06-16 13:40:09 : INFO  : dantevirtualsoundcard : ################## dantevirtualsoundcard
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : setting variable from argument DEBUG=0
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : BLOCKING_PROCESS_ACTION=tell_user
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : NOTIFY=success
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : LOGGING=INFO
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : Label type: pkgInDmg
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : archiveName: Dante Virtual Soundcard.dmg
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : no blocking processes defined, using Dante Virtual Soundcard as default
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : name: Dante Virtual Soundcard, appName: Dante Virtual Soundcard.app
2025-06-16 13:40:11.266 mdfind[43551:30324111] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-06-16 13:40:11.266 mdfind[43551:30324111] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-06-16 13:40:11.424 mdfind[43551:30324111] Couldn't determine the mapping between prefab keywords and predicates.
2025-06-16 13:40:11 : WARN  : dantevirtualsoundcard : No previous app found
2025-06-16 13:40:11 : WARN  : dantevirtualsoundcard : could not find Dante Virtual Soundcard.app
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : appversion: 
2025-06-16 13:40:11 : INFO  : dantevirtualsoundcard : Latest version of Dante Virtual Soundcard is 4.5.1.1
2025-06-16 13:40:11 : REQ   : dantevirtualsoundcard : Downloading https://my.audinate.com/system/files/release/DVS-4.5.1.1_macos.dmg to Dante Virtual Soundcard.dmg
2025-06-16 13:40:13 : REQ   : dantevirtualsoundcard : no more blocking processes, continue with update
2025-06-16 13:40:13 : REQ   : dantevirtualsoundcard : Installing Dante Virtual Soundcard
2025-06-16 13:40:13 : INFO  : dantevirtualsoundcard : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.nK57Hll1iB/Dante Virtual Soundcard.dmg
2025-06-16 13:40:18 : INFO  : dantevirtualsoundcard : Mounted: /Volumes/Dante Virtual Soundcard 1
2025-06-16 13:40:18 : INFO  : dantevirtualsoundcard : found pkg: /Volumes/Dante Virtual Soundcard 1/DanteVirtualSoundcard.pkg
2025-06-16 13:40:18 : INFO  : dantevirtualsoundcard : Verifying: /Volumes/Dante Virtual Soundcard 1/DanteVirtualSoundcard.pkg
2025-06-16 13:40:18 : INFO  : dantevirtualsoundcard : Team ID: P4WCR6Y822 (expected: P4WCR6Y822 )
2025-06-16 13:40:18 : INFO  : dantevirtualsoundcard : Installing /Volumes/Dante Virtual Soundcard 1/DanteVirtualSoundcard.pkg to /
2025-06-16 13:40:33 : INFO  : dantevirtualsoundcard : Finishing...
2025-06-16 13:40:36 : INFO  : dantevirtualsoundcard : App(s) found: /Applications/Dante Virtual Soundcard.app
2025-06-16 13:40:36 : INFO  : dantevirtualsoundcard : found app at /Applications/Dante Virtual Soundcard.app, version 4.5.1.1, on versionKey CFBundleVersion
2025-06-16 13:40:36 : REQ   : dantevirtualsoundcard : Installed Dante Virtual Soundcard, version 4.5.1.1
2025-06-16 13:40:36 : INFO  : dantevirtualsoundcard : notifying
2025-06-16 13:40:36 : INFO  : dantevirtualsoundcard : Installomator did not close any apps, so no need to reopen any apps.
2025-06-16 13:40:36 : REQ   : dantevirtualsoundcard : All done!
2025-06-16 13:40:36 : REQ   : dantevirtualsoundcard : ################## End Installomator, exit code 0 
```
