### PR TITLE
Fix adobecreativeclouddesktop downloadURL

### DIFF
--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -8,9 +8,9 @@ adobecreativeclouddesktop)
         exit 75
     fi
     if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL=$(curl -fs "https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*macarm64.*dmg' | head -1 | cut -d '"' -f1)
+        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*macarm64.*dmg' | head -1 | cut -d '"' -f1)
     else
-        downloadURL=$(curl -fs "https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*osx10.*dmg' | head -1 | cut -d '"' -f1)
+        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*osx10.*dmg' | head -1 | cut -d '"' -f1)
     fi
     #appNewVersion=$(curl -fs "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html" | grep "mandatory" | head -1 | grep -o "Version *.* released" | cut -d " " -f2)
     appNewVersion=$(echo $downloadURL | grep -o '[^x]*$' | cut -d '.' -f 1 | sed 's/_/\./g')


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
This fixes the Creative Cloud label as discussed here: https://github.com/Installomator/Installomator/issues/2346

**Installomator log**

```
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : setting variable from argument NOTIFY=success
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : setting variable from argument DEBUG=0
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : Total items in argumentsArray: 2
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : argumentsArray: NOTIFY=success DEBUG=0
2025-06-17 12:40:39 : REQ   : adobecreativeclouddesktop : ################## Start Installomator v. 10.8.3, date 2025-06-17
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : ################## Version: 10.8.3
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : ################## Date: 2025-06-17
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : ################## adobecreativeclouddesktop
2025-06-17 12:40:39 : INFO  : adobecreativeclouddesktop : SwiftDialog is not installed, clear cmd file var
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : Reading arguments again: NOTIFY=success DEBUG=0
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : BLOCKING_PROCESS_ACTION=tell_user
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : NOTIFY=success
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : LOGGING=INFO
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : Label type: dmg
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : archiveName: Adobe Creative Cloud.dmg
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : name: Adobe Creative Cloud, appName: Creative Cloud.app
2025-06-17 12:40:40 : WARN  : adobecreativeclouddesktop : No previous app found
2025-06-17 12:40:40 : WARN  : adobecreativeclouddesktop : could not find Creative Cloud.app
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : appversion: 
2025-06-17 12:40:40 : INFO  : adobecreativeclouddesktop : Latest version of Adobe Creative Cloud is 6.6.0.611
2025-06-17 12:40:41 : REQ   : adobecreativeclouddesktop : Downloading https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.6.0/611/macarm64/ACCCx6_6_0_611.dmg to Adobe Creative Cloud.dmg
2025-06-17 12:40:49 : INFO  : adobecreativeclouddesktop : Downloaded Adobe Creative Cloud.dmg – Type is  zlib compressed data – SHA is 832526fda459c3a3338ac75abfdc5fd5295519df – Size is 295776 kB
2025-06-17 12:40:49 : REQ   : adobecreativeclouddesktop : no more blocking processes, continue with update
2025-06-17 12:40:49 : REQ   : adobecreativeclouddesktop : Installing Adobe Creative Cloud
2025-06-17 12:40:49 : REQ   : adobecreativeclouddesktop : installerTool used: Install.app
2025-06-17 12:40:49 : INFO  : adobecreativeclouddesktop : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.LQ7bpdQY3W/Adobe Creative Cloud.dmg
2025-06-17 12:40:50 : INFO  : adobecreativeclouddesktop : Mounted: /Volumes/Creative Cloud
2025-06-17 12:40:50 : INFO  : adobecreativeclouddesktop : Verifying: /Volumes/Creative Cloud/Install.app
2025-06-17 12:40:51 : INFO  : adobecreativeclouddesktop : Team ID matching: JQ525L2MZD (expected: JQ525L2MZD )
2025-06-17 12:40:51 : INFO  : adobecreativeclouddesktop : Installing Adobe Creative Cloud version 2.14.0.39 on versionKey CFBundleShortVersionString.
2025-06-17 12:40:51 : INFO  : adobecreativeclouddesktop : App has LSMinimumSystemVersion: 10.13
2025-06-17 12:40:51 : INFO  : adobecreativeclouddesktop : CLIInstaller exists, running installer command /Volumes/Creative Cloud/Install.app/Contents/MacOS/Install --mode=silent
2025-06-17 12:41:04 : INFO  : adobecreativeclouddesktop : Succesfully ran /Volumes/Creative Cloud/Install.app/Contents/MacOS/Install --mode=silent
2025-06-17 12:41:04 : INFO  : adobecreativeclouddesktop : Finishing...
2025-06-17 12:41:07 : INFO  : adobecreativeclouddesktop : name: Adobe Creative Cloud, appName: Install.app
2025-06-17 12:41:07 : WARN  : adobecreativeclouddesktop : No previous app found
2025-06-17 12:41:07 : WARN  : adobecreativeclouddesktop : could not find Install.app
2025-06-17 12:41:07 : REQ   : adobecreativeclouddesktop : Installed Adobe Creative Cloud, version 2.14.0.39
2025-06-17 12:41:07 : INFO  : adobecreativeclouddesktop : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-06-17 12:41:08 : INFO  : adobecreativeclouddesktop : Installomator did not close any apps, so no need to reopen any apps.
2025-06-17 12:41:08 : REQ   : adobecreativeclouddesktop : All done!
2025-06-17 12:41:08 : REQ   : adobecreativeclouddesktop : ################## End Installomator, exit code 0 
Done
```
