### PR TITLE
Update unityhub.sh

### DIFF
--- a/fragments/labels/unityhub.sh
+++ b/fragments/labels/unityhub.sh
@@ -1,8 +1,13 @@
 unityhub)
     name="Unity Hub"
     type="dmg"
-    downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-x64.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL="https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg"
+    fi
     appNewVersion=$(curl -s https://unity.com/unity-hub/release-notes | grep -oE '>[0-9]+\.[0-9]+\.[0-9]+<' | head -1 | tr -d '<>')
+    versionKey="CFBundleVersion"
     expectedTeamID="9QW8UQUTAA"
     ;;
 


### PR DESCRIPTION
added versionKey check, updated URLs for x64 and ARM

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** it's an update

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** modifying

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here. added versionKey check, fix outdated URL and added a decision tree for x64 and ARM options

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")



```
2025-06-17 14:58:12 : REQ   : unityhub : ################## Start Installomator v. 10.6beta, date 2024-04-23
2025-06-17 14:58:12 : INFO  : unityhub : ################## Version: 10.6beta
2025-06-17 14:58:12 : INFO  : unityhub : ################## Date: 2024-04-23
2025-06-17 14:58:12 : INFO  : unityhub : ################## unityhub
2025-06-17 14:58:23 : INFO  : unityhub : setting variable from argument DEBUG=1
2025-06-17 14:58:23 : INFO  : unityhub : BLOCKING_PROCESS_ACTION=tell_user
2025-06-17 14:58:23 : INFO  : unityhub : NOTIFY=success
2025-06-17 14:58:23 : INFO  : unityhub : LOGGING=INFO
2025-06-17 14:58:23 : INFO  : unityhub : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2025-06-17 14:58:23 : INFO  : unityhub : Label type: dmg
2025-06-17 14:58:23 : INFO  : unityhub : archiveName: Unity Hub.dmg
2025-06-17 14:58:23 : INFO  : unityhub : no blocking processes defined, using Unity Hub as default
2025-06-17 14:58:23 : INFO  : unityhub : name: Unity Hub, appName: Unity Hub.app
2025-06-17 14:58:23.290 mdfind[37330:33182796] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-06-17 14:58:23.290 mdfind[37330:33182796] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-06-17 14:58:23.422 mdfind[37330:33182796] Couldn't determine the mapping between prefab keywords and predicates.
2025-06-17 14:58:23 : WARN  : unityhub : No previous app found
2025-06-17 14:58:23 : WARN  : unityhub : could not find Unity Hub.app
2025-06-17 14:58:23 : INFO  : unityhub : appversion: 
2025-06-17 14:58:23 : INFO  : unityhub : Latest version of Unity Hub is 3.12.1
2025-06-17 14:58:23 : REQ   : unityhub : Downloading https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg to Unity Hub.dmg
2025-06-17 14:58:27 : REQ   : unityhub : Installing Unity Hub
2025-06-17 14:58:27 : INFO  : unityhub : Mounting /Users/coreyg/Server/Unity Hub.dmg
2025-06-17 14:58:35 : INFO  : unityhub : Mounted: /Volumes/Unity Hub 3.12.1-arm64 1
2025-06-17 14:58:35 : INFO  : unityhub : Verifying: /Volumes/Unity Hub 3.12.1-arm64 1/Unity Hub.app
2025-06-17 14:58:45 : INFO  : unityhub : Team ID matching: 9QW8UQUTAA (expected: 9QW8UQUTAA )
2025-06-17 14:58:45 : INFO  : unityhub : Installing Unity Hub version 3.12.1 on versionKey CFBundleVersion.
2025-06-17 14:58:45 : INFO  : unityhub : App has LSMinimumSystemVersion: 10.13
2025-06-17 14:58:45 : INFO  : unityhub : Finishing...
2025-06-17 14:58:48 : INFO  : unityhub : name: Unity Hub, appName: Unity Hub.app
2025-06-17 14:58:48.398 mdfind[37460:33183739] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-06-17 14:58:48.398 mdfind[37460:33183739] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-06-17 14:58:48.459 mdfind[37460:33183739] Couldn't determine the mapping between prefab keywords and predicates.
2025-06-17 14:58:48 : WARN  : unityhub : No previous app found
2025-06-17 14:58:48 : WARN  : unityhub : could not find Unity Hub.app
2025-06-17 14:58:48 : REQ   : unityhub : Installed Unity Hub, version 3.12.1
2025-06-17 14:58:48 : INFO  : unityhub : notifying
2025-06-17 14:58:48 : REQ   : unityhub : All done!
2025-06-17 14:58:48 : REQ   : unityhub : ################## End Installomator, exit code 0 
```
