### PR TITLE
Create DbVisualizer Label

### DIFF
--- a/fragments/labels/dbvisualizer.sh
+++ b/fragments/labels/dbvisualizer.sh
@@ -1,0 +1,12 @@
+dbvisualizer)
+    name="DbVisualizer"
+    type="dmg"
+    appNewVersion=$(curl -s https://www.dbvis.com/releasenotes/ | grep -o -E 'release--title" id="(.*)">' | sed 's/.*id="v\(.*\)">/\1/' | head -1)
+    altVersion=$(echo $appNewVersion | sed 's/\./_/g') # changes 25.1.2 to 25_1_2 for the download URL.
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://www.dbvis.com/product_download/dbvis-${appNewVersion}/media/dbvis_macos-aarch64_${altVersion}.dmg"
+    else
+        downloadURL="https://www.dbvis.com/product_download/dbvis-${appNewVersion}/media/dbvis_macos-x64_${altVersion}.dmg"
+    fi
+    expectedTeamID="U9TP5KYV49"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes.

**Additional context** Add any other context about the label or fix here.
App website: https://www.dbvis.com/

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
boylest@Installomator on  dbvisualizer ❯ ./assemble.sh dbvisualizer
2025-06-17 16:05:08 : INFO  : dbvisualizer : Total items in argumentsArray: 0
2025-06-17 16:05:08 : INFO  : dbvisualizer : argumentsArray:
2025-06-17 16:05:08 : REQ   : dbvisualizer : ################## Start Installomator v. 10.9beta, date 2025-06-17
2025-06-17 16:05:08 : INFO  : dbvisualizer : ################## Version: 10.9beta
2025-06-17 16:05:08 : INFO  : dbvisualizer : ################## Date: 2025-06-17
2025-06-17 16:05:08 : INFO  : dbvisualizer : ################## dbvisualizer
2025-06-17 16:05:08 : DEBUG : dbvisualizer : DEBUG mode 1 enabled.
2025-06-17 16:05:09 : INFO  : dbvisualizer : Reading arguments again:
2025-06-17 16:05:09 : DEBUG : dbvisualizer : name=DbVisualizer
2025-06-17 16:05:09 : DEBUG : dbvisualizer : appName=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : type=dmg
2025-06-17 16:05:09 : DEBUG : dbvisualizer : archiveName=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : downloadURL=https://www.dbvis.com/product_download/dbvis-25.1.4/media/dbvis_macos-x64_25_1_4.dmg
2025-06-17 16:05:09 : DEBUG : dbvisualizer : curlOptions=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : appNewVersion=25.1.4
2025-06-17 16:05:09 : DEBUG : dbvisualizer : appCustomVersion function: Not defined
2025-06-17 16:05:09 : DEBUG : dbvisualizer : versionKey=CFBundleShortVersionString
2025-06-17 16:05:09 : DEBUG : dbvisualizer : packageID=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : pkgName=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : choiceChangesXML=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : expectedTeamID=U9TP5KYV49
2025-06-17 16:05:09 : DEBUG : dbvisualizer : blockingProcesses=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : installerTool=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : CLIInstaller=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : CLIArguments=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : updateTool=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : updateToolArguments=
2025-06-17 16:05:09 : DEBUG : dbvisualizer : updateToolRunAsCurrentUser=
2025-06-17 16:05:09 : INFO  : dbvisualizer : BLOCKING_PROCESS_ACTION=tell_user
2025-06-17 16:05:10 : INFO  : dbvisualizer : NOTIFY=success
2025-06-17 16:05:10 : INFO  : dbvisualizer : LOGGING=DEBUG
2025-06-17 16:05:10 : INFO  : dbvisualizer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-17 16:05:10 : INFO  : dbvisualizer : Label type: dmg
2025-06-17 16:05:10 : INFO  : dbvisualizer : archiveName: DbVisualizer.dmg
2025-06-17 16:05:10 : INFO  : dbvisualizer : no blocking processes defined, using DbVisualizer as default
2025-06-17 16:05:10 : DEBUG : dbvisualizer : Changing directory to /Users/boylest/Library/CloudStorage/OneDrive-BIWorldwide/Documents/Scripts/Shell/installomator/Installomator/build
2025-06-17 16:05:10 : INFO  : dbvisualizer : App(s) found: /Applications/DbVisualizer.app
2025-06-17 16:05:10 : INFO  : dbvisualizer : found app at /Applications/DbVisualizer.app, version 25.1.4, on versionKey CFBundleShortVersionString
2025-06-17 16:05:10 : INFO  : dbvisualizer : appversion: 25.1.4
2025-06-17 16:05:10 : INFO  : dbvisualizer : Latest version of DbVisualizer is 25.1.4
2025-06-17 16:05:10 : WARN  : dbvisualizer : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-06-17 16:05:10 : REQ   : dbvisualizer : Downloading https://www.dbvis.com/product_download/dbvis-25.1.4/media/dbvis_macos-x64_25_1_4.dmg to DbVisualizer.dmg
2025-06-17 16:05:10 : DEBUG : dbvisualizer : No Dialog connection, just download
2025-06-17 16:05:52 : INFO  : dbvisualizer : Downloaded DbVisualizer.dmg – Type is  zlib compressed data – SHA is 1ea8d705206ec8d4d53d7e84021f8e6eab030926 – Size is 246060 kB
2025-06-17 16:05:52 : DEBUG : dbvisualizer : DEBUG mode 1, not checking for blocking processes
2025-06-17 16:05:52 : REQ   : dbvisualizer : Installing DbVisualizer
2025-06-17 16:05:53 : INFO  : dbvisualizer : Mounting /Users/boylest/Library/CloudStorage/OneDrive-BIWorldwide/Documents/Scripts/Shell/installomator/Installomator/build/DbVisualizer.dmg
2025-06-17 16:05:54 : DEBUG : dbvisualizer : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $08308DBF
verified   CRC32 $15685A78
/dev/disk2              Apple_partition_scheme
/dev/disk2s1            Apple_partition_map
/dev/disk2s2            Apple_HFS                       /Volumes/dbvis

2025-06-17 16:05:54 : INFO  : dbvisualizer : Mounted: /Volumes/dbvis
2025-06-17 16:05:54 : INFO  : dbvisualizer : Verifying: /Volumes/dbvis/DbVisualizer.app
2025-06-17 16:05:54 : DEBUG : dbvisualizer : App size: 340M     /Volumes/dbvis/DbVisualizer.app
2025-06-17 16:05:57 : DEBUG : dbvisualizer : Debugging enabled, App Verification output was:
/Volumes/dbvis/DbVisualizer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DbVis Software AB (U9TP5KYV49)

2025-06-17 16:05:57 : INFO  : dbvisualizer : Team ID matching: U9TP5KYV49 (expected: U9TP5KYV49 )
2025-06-17 16:05:57 : INFO  : dbvisualizer : Downloaded version of DbVisualizer is 25.1.4 on versionKey CFBundleShortVersionString, same as installed.
2025-06-17 16:05:57 : DEBUG : dbvisualizer : Unmounting /Volumes/dbvis
2025-06-17 16:05:57 : DEBUG : dbvisualizer : Debugging enabled, Unmounting output was:
"disk2" ejected.
2025-06-17 16:05:57 : DEBUG : dbvisualizer : DEBUG mode 1, not reopening anything
2025-06-17 16:05:57 : REG   : dbvisualizer : No new version to install
2025-06-17 16:05:57 : REQ   : dbvisualizer : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A