### PR TITLE
New Label - Globus Connect Personal

### DIFF
--- a/fragments/labels/globusconnectpersonal.sh
+++ b/fragments/labels/globusconnectpersonal.sh
@@ -1,0 +1,7 @@
+globusconnectpersonal)
+    name="Globus Connect Personal"
+    type="dmg"
+    downloadURL="https://downloads.globus.org/globus-connect-personal/mac/stable/globusconnectpersonal-latest.dmg"
+    appNewVersion="$(curl -fsL "https://downloads.globus.org/globus-connect-personal/mac/stable/personal-changelog.html" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    expectedTeamID="WYQ7U7YUC9"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

[Globus Connect Personal](https://www.globus.org/globus-connect-personal)

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
$ ./utils/assemble.sh globusconnectpersonal debug 1

2025-06-18 09:20:26 : INFO  : globusconnectpersonal : Total items in argumentsArray: 0
2025-06-18 09:20:26 : INFO  : globusconnectpersonal : argumentsArray: 
2025-06-18 09:20:26 : REQ   : globusconnectpersonal : ################## Start Installomator v. 10.9beta, date 2025-06-18
2025-06-18 09:20:26 : INFO  : globusconnectpersonal : ################## Version: 10.9beta
2025-06-18 09:20:26 : INFO  : globusconnectpersonal : ################## Date: 2025-06-18
2025-06-18 09:20:26 : INFO  : globusconnectpersonal : ################## globusconnectpersonal
2025-06-18 09:20:26 : DEBUG : globusconnectpersonal : DEBUG mode 1 enabled.
2025-06-18 09:20:26 : INFO  : globusconnectpersonal : SwiftDialog is not installed, clear cmd file var
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : Reading arguments again: 
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : name=Globus Connect Personal
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : appName=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : type=dmg
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : archiveName=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : downloadURL=https://downloads.globus.org/globus-connect-personal/mac/stable/globusconnectpersonal-latest.dmg
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : curlOptions=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : appNewVersion=3.2.7
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : appCustomVersion function: Not defined
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : versionKey=CFBundleShortVersionString
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : packageID=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : pkgName=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : choiceChangesXML=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : expectedTeamID=WYQ7U7YUC9
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : blockingProcesses=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : installerTool=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : CLIInstaller=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : CLIArguments=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : updateTool=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : updateToolArguments=
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : updateToolRunAsCurrentUser=
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : BLOCKING_PROCESS_ACTION=tell_user
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : NOTIFY=success
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : LOGGING=DEBUG
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : Label type: dmg
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : archiveName: Globus Connect Personal.dmg
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : no blocking processes defined, using Globus Connect Personal as default
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : Changing directory to /Users/bbp39934/Installomator/build
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : App(s) found: /Applications/Globus Connect Personal.app
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : found app at /Applications/Globus Connect Personal.app, version 3.2.7, on versionKey CFBundleShortVersionString
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : appversion: 3.2.7
2025-06-18 09:20:27 : INFO  : globusconnectpersonal : Latest version of Globus Connect Personal is 3.2.7
2025-06-18 09:20:27 : WARN  : globusconnectpersonal : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-06-18 09:20:27 : REQ   : globusconnectpersonal : Downloading https://downloads.globus.org/globus-connect-personal/mac/stable/globusconnectpersonal-latest.dmg to Globus Connect Personal.dmg
2025-06-18 09:20:27 : DEBUG : globusconnectpersonal : No Dialog connection, just download
2025-06-18 09:20:28 : INFO  : globusconnectpersonal : Downloaded Globus Connect Personal.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 3ee38968d42e1b4c8252467da6612a7fa5dc9935 – Size is 28896 kB
2025-06-18 09:20:28 : DEBUG : globusconnectpersonal : DEBUG mode 1, not checking for blocking processes
2025-06-18 09:20:28 : REQ   : globusconnectpersonal : Installing Globus Connect Personal
2025-06-18 09:20:28 : INFO  : globusconnectpersonal : Mounting /Users/bbp39934/Installomator/build/Globus Connect Personal.dmg
2025-06-18 09:20:30 : DEBUG : globusconnectpersonal : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $843C5294
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $50DDEE0B
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $4BB7A569
verified   CRC32 $BF4A7235
/dev/disk8          	Apple_partition_scheme
/dev/disk8s1        	Apple_partition_map
/dev/disk8s2        	Apple_HFS                      	/Volumes/Globus Connect Personal

2025-06-18 09:20:30 : INFO  : globusconnectpersonal : Mounted: /Volumes/Globus Connect Personal
2025-06-18 09:20:30 : INFO  : globusconnectpersonal : Verifying: /Volumes/Globus Connect Personal/Globus Connect Personal.app
2025-06-18 09:20:30 : DEBUG : globusconnectpersonal : App size:  86M	/Volumes/Globus Connect Personal/Globus Connect Personal.app
2025-06-18 09:20:34 : DEBUG : globusconnectpersonal : Debugging enabled, App Verification output was:
/Volumes/Globus Connect Personal/Globus Connect Personal.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The University of Chicago (WYQ7U7YUC9)

2025-06-18 09:20:34 : INFO  : globusconnectpersonal : Team ID matching: WYQ7U7YUC9 (expected: WYQ7U7YUC9 )
2025-06-18 09:20:34 : INFO  : globusconnectpersonal : Downloaded version of Globus Connect Personal is 3.2.7 on versionKey CFBundleShortVersionString, same as installed.
2025-06-18 09:20:34 : DEBUG : globusconnectpersonal : Unmounting /Volumes/Globus Connect Personal
2025-06-18 09:20:34 : DEBUG : globusconnectpersonal : Debugging enabled, Unmounting output was:
"disk8" ejected.
2025-06-18 09:20:34 : DEBUG : globusconnectpersonal : DEBUG mode 1, not reopening anything
2025-06-18 09:20:34 : REG   : globusconnectpersonal : No new version to install
2025-06-18 09:20:34 : REQ   : globusconnectpersonal : ################## End Installomator, exit code 0 
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
