### PR TITLE
Update deezer

### DIFF
--- a/fragments/labels/deezer.sh
+++ b/fragments/labels/deezer.sh
@@ -1,8 +1,7 @@
 deezer)
     name="Deezer"
     type="dmg"
-    # There is no arm/universal binary. Need rosetta2 to run it on apple silicon
-    downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64"
+    downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64&platformVersion=13"
     appNewVersion=$(curl -fsLI "$downloadURL" | grep -o "DeezerDesktop_[0-9]*\.[0-9]*\.[0-9]*" | cut -d'_' -f2)
     expectedTeamID="7QLUP2K45C"
     ;;

--- a/fragments/labels/deezer.sh
+++ b/fragments/labels/deezer.sh
@@ -1,7 +1,7 @@
 deezer)
     name="Deezer"
     type="dmg"
-    downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64&platformVersion=13"
+    downloadURL="https://www.deezer.com/desktop/download?platform=darwin&architecture=x64&platformVersion=9999"
     appNewVersion=$(curl -fsLI "$downloadURL" | grep -o "DeezerDesktop_[0-9]*\.[0-9]*\.[0-9]*" | cut -d'_' -f2)
     expectedTeamID="7QLUP2K45C"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Download url changed. Universal app.
The `&platformVersion `is a strange one. Anything below 11 will get the x86 deezer version 7.0.50; 11 and higher will download version 7.0.90, an universal build.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2423 

````
./assemble.sh deezer
2025-06-19 23:01:48 : INFO  : deezer : Total items in argumentsArray: 0
2025-06-19 23:01:48 : INFO  : deezer : argumentsArray: 
2025-06-19 23:01:48 : REQ   : deezer : ################## Start Installomator v. 10.9beta, date 2025-06-19
2025-06-19 23:01:48 : INFO  : deezer : ################## Version: 10.9beta
2025-06-19 23:01:48 : INFO  : deezer : ################## Date: 2025-06-19
2025-06-19 23:01:48 : INFO  : deezer : ################## deezer
2025-06-19 23:01:48 : DEBUG : deezer : DEBUG mode 1 enabled.
2025-06-19 23:01:49 : INFO  : deezer : Reading arguments again: 
2025-06-19 23:01:49 : DEBUG : deezer : name=Deezer
2025-06-19 23:01:49 : DEBUG : deezer : appName=
2025-06-19 23:01:49 : DEBUG : deezer : type=dmg
2025-06-19 23:01:49 : DEBUG : deezer : archiveName=
2025-06-19 23:01:49 : DEBUG : deezer : downloadURL=https://www.deezer.com/desktop/download?platform=darwin&architecture=x64&platformVersion=13
2025-06-19 23:01:49 : DEBUG : deezer : curlOptions=
2025-06-19 23:01:49 : DEBUG : deezer : appNewVersion=7.0.90
2025-06-19 23:01:49 : DEBUG : deezer : appCustomVersion function: Not defined
2025-06-19 23:01:49 : DEBUG : deezer : versionKey=CFBundleShortVersionString
2025-06-19 23:01:49 : DEBUG : deezer : packageID=
2025-06-19 23:01:49 : DEBUG : deezer : pkgName=
2025-06-19 23:01:49 : DEBUG : deezer : choiceChangesXML=
2025-06-19 23:01:49 : DEBUG : deezer : expectedTeamID=7QLUP2K45C
2025-06-19 23:01:49 : DEBUG : deezer : blockingProcesses=
2025-06-19 23:01:49 : DEBUG : deezer : installerTool=
2025-06-19 23:01:49 : DEBUG : deezer : CLIInstaller=
2025-06-19 23:01:49 : DEBUG : deezer : CLIArguments=
2025-06-19 23:01:49 : DEBUG : deezer : updateTool=
2025-06-19 23:01:49 : DEBUG : deezer : updateToolArguments=
2025-06-19 23:01:49 : DEBUG : deezer : updateToolRunAsCurrentUser=
2025-06-19 23:01:49 : INFO  : deezer : BLOCKING_PROCESS_ACTION=tell_user
2025-06-19 23:01:49 : INFO  : deezer : NOTIFY=success
2025-06-19 23:01:49 : INFO  : deezer : LOGGING=DEBUG
2025-06-19 23:01:49 : INFO  : deezer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-19 23:01:49 : INFO  : deezer : Label type: dmg
2025-06-19 23:01:49 : INFO  : deezer : archiveName: Deezer.dmg
2025-06-19 23:01:49 : INFO  : deezer : no blocking processes defined, using Deezer as default
2025-06-19 23:01:49 : DEBUG : deezer : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-06-19 23:01:49 : INFO  : deezer : name: Deezer, appName: Deezer.app
2025-06-19 23:01:49 : WARN  : deezer : No previous app found
2025-06-19 23:01:49 : WARN  : deezer : could not find Deezer.app
2025-06-19 23:01:49 : INFO  : deezer : appversion: 
2025-06-19 23:01:49 : INFO  : deezer : Latest version of Deezer is 7.0.90
2025-06-19 23:01:49 : REQ   : deezer : Downloading https://www.deezer.com/desktop/download?platform=darwin&architecture=x64&platformVersion=13 to Deezer.dmg
2025-06-19 23:01:49 : DEBUG : deezer : No Dialog connection, just download
2025-06-19 23:02:06 : INFO  : deezer : Downloaded Deezer.dmg – Type is  zlib compressed data – SHA is 60c36b5d6dc335c849e4b081a9c869ddd26e11b9 – Size is 196988 kB
2025-06-19 23:02:06 : DEBUG : deezer : DEBUG mode 1, not checking for blocking processes
2025-06-19 23:02:06 : REQ   : deezer : Installing Deezer
2025-06-19 23:02:06 : INFO  : deezer : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Deezer.dmg
2025-06-19 23:02:08 : DEBUG : deezer : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $DEFE41EA
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $3C075840
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $8A8DB12A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $9CD35C18
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $8A8DB12A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $E630A194
verified CRC32 $DDF0DD72
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Deezer 7.0.90-universal

2025-06-19 23:02:08 : INFO  : deezer : Mounted: /Volumes/Deezer 7.0.90-universal
2025-06-19 23:02:08 : INFO  : deezer : Verifying: /Volumes/Deezer 7.0.90-universal/Deezer.app
2025-06-19 23:02:08 : DEBUG : deezer : App size: 441M	/Volumes/Deezer 7.0.90-universal/Deezer.app
2025-06-19 23:02:10 : DEBUG : deezer : Debugging enabled, App Verification output was:
/Volumes/Deezer 7.0.90-universal/Deezer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DEEZER SA (7QLUP2K45C)

2025-06-19 23:02:10 : INFO  : deezer : Team ID matching: 7QLUP2K45C (expected: 7QLUP2K45C )
2025-06-19 23:02:10 : INFO  : deezer : Installing Deezer version 7.0.90 on versionKey CFBundleShortVersionString.
2025-06-19 23:02:10 : INFO  : deezer : App has LSMinimumSystemVersion: 11.0
2025-06-19 23:02:10 : DEBUG : deezer : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-06-19 23:02:10 : INFO  : deezer : Finishing...
2025-06-19 23:02:13 : INFO  : deezer : name: Deezer, appName: Deezer.app
2025-06-19 23:02:13 : WARN  : deezer : No previous app found
2025-06-19 23:02:13 : WARN  : deezer : could not find Deezer.app
2025-06-19 23:02:13 : REQ   : deezer : Installed Deezer, version 7.0.90
2025-06-19 23:02:13 : INFO  : deezer : notifying
2025-06-19 23:02:13 : DEBUG : deezer : Unmounting /Volumes/Deezer 7.0.90-universal
2025-06-19 23:02:14 : DEBUG : deezer : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-06-19 23:02:14 : DEBUG : deezer : DEBUG mode 1, not reopening anything
2025-06-19 23:02:14 : REQ   : deezer : All done!
2025-06-19 23:02:14 : REQ   : deezer : ################## End Installomator, exit code 0 
````