### PR TITLE
Riverside Studio label

### DIFF
--- a/fragments/labels/riversidestudio.sh
+++ b/fragments/labels/riversidestudio.sh
@@ -1,0 +1,7 @@
+riversidestudio)
+    name="Riverside Studio"
+    type="dmg"
+    appNewVersion="$(curl -fs "https://assets.riverside.fm/mac-desktop-app/current-release/appcast.xml" | xpath '(//rss/channel/item/sparkle:shortVersionString)[1]' 2>/dev/null | sed -n 's:.*>\(.*\)<.*:\1:p')"
+    downloadURL="$(curl -fs "https://assets.riverside.fm/mac-desktop-app/current-release/appcast.xml" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f2)"
+    expectedTeamID="LH94UTHM4U"
+    ;;


### PR DESCRIPTION
Record podcasts, videos and your screen with our Mac app.

Installomator/utils/assemble.sh riversidestudio
2025-06-18 22:49:07 : INFO  : riversidestudio : Total items in argumentsArray: 0 2025-06-18 22:49:07 : INFO  : riversidestudio : argumentsArray:
2025-06-18 22:49:07 : REQ   : riversidestudio : ################## Start Installomator v. 10.9beta, date 2025-06-18
2025-06-18 22:49:07 : INFO  : riversidestudio : ################## Version: 10.9beta
2025-06-18 22:49:07 : INFO  : riversidestudio : ################## Date: 2025-06-18
2025-06-18 22:49:07 : INFO  : riversidestudio : ################## riversidestudio
2025-06-18 22:49:07 : DEBUG : riversidestudio : DEBUG mode 1 enabled.
2025-06-18 22:49:07 : INFO  : riversidestudio : Reading arguments again:
2025-06-18 22:49:07 : DEBUG : riversidestudio : name=Riverside Studio
2025-06-18 22:49:07 : DEBUG : riversidestudio : appName=
2025-06-18 22:49:07 : DEBUG : riversidestudio : type=dmg
2025-06-18 22:49:07 : DEBUG : riversidestudio : archiveName=
2025-06-18 22:49:07 : DEBUG : riversidestudio : downloadURL=https://assets.riverside.fm/mac-desktop-app/current-release/RiversideStudio.dmg
2025-06-18 22:49:07 : DEBUG : riversidestudio : curlOptions=
2025-06-18 22:49:07 : DEBUG : riversidestudio : appNewVersion=1.10.3
2025-06-18 22:49:07 : DEBUG : riversidestudio : appCustomVersion function: Not defined
2025-06-18 22:49:07 : DEBUG : riversidestudio : versionKey=CFBundleShortVersionString
2025-06-18 22:49:07 : DEBUG : riversidestudio : packageID=
2025-06-18 22:49:08 : DEBUG : riversidestudio : pkgName=
2025-06-18 22:49:08 : DEBUG : riversidestudio : choiceChangesXML=
2025-06-18 22:49:08 : DEBUG : riversidestudio : expectedTeamID=LH94UTHM4U
2025-06-18 22:49:08 : DEBUG : riversidestudio : blockingProcesses=
2025-06-18 22:49:08 : DEBUG : riversidestudio : installerTool=
2025-06-18 22:49:08 : DEBUG : riversidestudio : CLIInstaller=
2025-06-18 22:49:08 : DEBUG : riversidestudio : CLIArguments=
2025-06-18 22:49:08 : DEBUG : riversidestudio : updateTool=
2025-06-18 22:49:08 : DEBUG : riversidestudio : updateToolArguments=
2025-06-18 22:49:08 : DEBUG : riversidestudio : updateToolRunAsCurrentUser=
2025-06-18 22:49:08 : INFO  : riversidestudio : BLOCKING_PROCESS_ACTION=tell_user
2025-06-18 22:49:08 : INFO  : riversidestudio : NOTIFY=success
2025-06-18 22:49:08 : INFO  : riversidestudio : LOGGING=DEBUG
2025-06-18 22:49:08 : INFO  : riversidestudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-18 22:49:08 : INFO  : riversidestudio : Label type: dmg
2025-06-18 22:49:08 : INFO  : riversidestudio : archiveName: Riverside Studio.dmg
2025-06-18 22:49:08 : INFO  : riversidestudio : no blocking processes defined, using Riverside Studio as default
2025-06-18 22:49:08 : DEBUG : riversidestudio : Changing directory to /Users/xx/Documents/GitHub/Installomator/build
2025-06-18 22:49:08 : INFO  : riversidestudio : name: Riverside Studio, appName: Riverside Studio.app
2025-06-18 22:49:08 : INFO  : riversidestudio : App(s) found: /Library/Application Support/JAMF/Composer/Sources/Riverside Studio 1.9.3/ROOT/Applications/Riverside Studio.app
2025-06-18 22:49:08 : WARN  : riversidestudio : could not determine location of Riverside Studio.app
2025-06-18 22:49:08 : INFO  : riversidestudio : appversion:
2025-06-18 22:49:08 : INFO  : riversidestudio : Latest version of Riverside Studio is 1.10.3
2025-06-18 22:49:08 : REQ   : riversidestudio : Downloading https://assets.riverside.fm/mac-desktop-app/current-release/RiversideStudio.dmg to Riverside Studio.dmg
2025-06-18 22:49:08 : DEBUG : riversidestudio : No Dialog connection, just download
2025-06-18 22:49:11 : INFO  : riversidestudio : Downloaded Riverside Studio.dmg – Type is  zlib compressed data – SHA is caea942fd3b6c7b7bdec3a5c3363ef43de30877c – Size is 99288 kB
2025-06-18 22:49:11 : DEBUG : riversidestudio : DEBUG mode 1, not checking for blocking processes
2025-06-18 22:49:11 : REQ   : riversidestudio : Installing Riverside Studio
2025-06-18 22:49:11 : INFO  : riversidestudio : Mounting /Users/xx/Documents/GitHub/Installomator/build/Riverside Studio.dmg
2025-06-18 22:49:15 : DEBUG : riversidestudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F69D5821
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D6204729
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $166294F3
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $42F4334D
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $166294F3
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $7B27A32D
verified   CRC32 $59850912
/dev/disk45         	GUID_partition_scheme
/dev/disk45s1       	Apple_HFS                      	/Volumes/Riverside Studio

2025-06-18 22:49:15 : INFO  : riversidestudio : Mounted: /Volumes/Riverside Studio 2025-06-18 22:49:15 : INFO  : riversidestudio : Verifying: /Volumes/Riverside Studio/Riverside Studio.app 2025-06-18 22:49:15 : DEBUG : riversidestudio : App size: 219M	/Volumes/Riverside Studio/Riverside Studio.app 2025-06-18 22:49:17 : DEBUG : riversidestudio : Debugging enabled, App Verification output was: /Volumes/Riverside Studio/Riverside Studio.app: accepted source=Notarized Developer ID
origin=Developer ID Application: RIVERSIDEFM, INC (LH94UTHM4U)

2025-06-18 22:49:17 : INFO  : riversidestudio : Team ID matching: LH94UTHM4U (expected: LH94UTHM4U ) 2025-06-18 22:49:17 : INFO  : riversidestudio : Installing Riverside Studio version 1.10.3 on versionKey CFBundleShortVersionString. 2025-06-18 22:49:17 : INFO  : riversidestudio : App has LSMinimumSystemVersion: 13.0 2025-06-18 22:49:17 : DEBUG : riversidestudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2025-06-18 22:49:17 : INFO  : riversidestudio : Finishing... 2025-06-18 22:49:20 : INFO  : riversidestudio : name: Riverside Studio, appName: Riverside Studio.app 2025-06-18 22:49:20 : INFO  : riversidestudio : App(s) found: /Library/Application Support/JAMF/Composer/Sources/Riverside Studio 1.9.3/ROOT/Applications/Riverside Studio.app 2025-06-18 22:49:20 : WARN  : riversidestudio : could not determine location of Riverside Studio.app
2025-06-18 22:49:20 : REQ   : riversidestudio : Installed Riverside Studio, version 1.10.3
2025-06-18 22:49:20 : INFO  : riversidestudio : notifying
2025-06-18 22:49:21 : DEBUG : riversidestudio : Unmounting /Volumes/Riverside Studio
2025-06-18 22:49:21 : DEBUG : riversidestudio : Debugging enabled, Unmounting output was:
"disk45" ejected.
2025-06-18 22:49:21 : DEBUG : riversidestudio : DEBUG mode 1, not reopening anything
2025-06-18 22:49:21 : REQ   : riversidestudio : All done!
2025-06-18 22:49:21 : REQ   : riversidestudio : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
