### PR TITLE
Update "App-install SS with swiftDialog and dockutil"

### DIFF
--- a/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -19,7 +19,7 @@ addToDock="0" # with dockutil after installation (0 if not)
 dockutilAppPath="/Applications/Cyberduck.app"
 
 # Other variables
-dialog_command_file="$(mktemp -d)/dialog.log"
+dialog_command_file="/var/tmp/dialog.log"
 dialogBinary="/usr/local/bin/dialog"
 dockutil="/usr/local/bin/dockutil"
 dialogPID=""


### PR DESCRIPTION
# Disclaimer
**Have you confirmed this pull request is not a duplicate?**
Yes

### **Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
N/A, improvement to an MDM subroutine directly

### **Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

# **Change details:**
Multiple improvements to prevent script errors and early exits that would leave the Dialog process running indefinitely

- update shebang to `#!/bin/zsh --no-rcs`

- Included a comment link to all current Installomator labels under the item string definition, to assist admins quickly deploying new installer scripts

- Added an early exit if no label has been set, preventing launching the Dialog process for doomed scripts

- Improved `installomatorVersion` string parsing:
``` bash
 installomatorVersion="$(${destFile} version | grep -Eo '[0-9]+\.[0-9]+' | head -1)"
```

- Set `Installomator.sh` script to run in a subshell. This is to prevent Installomator script exit commands originating from errors from exiting the `App normal SS` script early, preventing graceful close of Dialog process. Output is saved to a txt file under `/tmp` for the remainder of the `App normal SS` script processing:
``` bash 
(
    exec "${destFile}" "${item}" ${installomatorOptions} ${installomatorNotify}Add commentMore actions
) > /tmp/installomator_output.txt 2>&1
installomatorExitCode=$?
cmdOutput="$(cat /tmp/installomator_output.txt; echo "exit code $installomatorExitCode")"
rm -f /tmp/installomator_output.txt
```

- improved installomatorVersion and macOS Build version checks to accomodate for minor version numbers
``` bash
if [[ $(echo "$installomatorVersion < 10" | bc -l) -eq 1 ]] || [[ $(sw_vers -buildVersion | cut -c1-2) -lt 20 ]]; then
```

- added `dialogUpdate "quit:"` to `caffexit` to attempt graceful dialog closure if it has not already been done prior to script exit, followed by a force quit of the dialog PID `caffexit` in case it is still running after graceful exit command. Only the dialog PID generated by this script is closed, preventing any unrelated, simultaneous dialog processes from being closed:
``` bash
caffexit () {Add commentMore actions
    kill "$caffeinatepid"
    dialogUpdate "quit:"
    # Kill dialog if it's still running
    [[ -n "$dialogPID" ]] && kill -0 "$dialogPID" 2>/dev/null && kill "$dialogPID" 2>/dev/null || true
    exit $1
}
```

- modified LOGO argument parsing for the main installation command, to only include the LOGO argument if it is not empty, avoiding errors
``` bash
[[ -n "$LOGO" ]] && installomatorOptions="LOGO=$LOGO ${installomatorOptions}"
```

# **Installomator log**
Log deliberately does not include ICON value to demonstrate the new LOGO parsing commands
``` 
2025-06-24 14:50:03 [LOG-BEGIN] cyberduck, v10.1
cyberduck Cyberduck
ERROR: Cannot figure out icon . Reset icon.
2025-06-24 14:50:07.845 mdfind[45379:316141] [UserQueryParser] Loading keywords and predicates for locale "en_AU"
2025-06-24 14:50:08.797 mdfind[45379:316141] Couldn't determine the mapping between prefab keywords and predicates.
2025-06-24 14:50:08.908 defaults[45382:316160]
The domain/default pair of (/Contents/Info.plist, CFBundleIconFile) does not exist
ERROR in LOGO_PATH '', setting Mac App Store.
LOGO:
icon: /System/Applications/App Store.app/Contents/Resources/AppIcon.icns
dialogCMD: /usr/local/bin/dialog --title none --icon /System/Applications/App Store.app/Contents/Resources/AppIcon.icns --message Installing Cyberduck… --mini --progress 100 --position bottomright --moveable --commandfile /var/tmp/dialog.log
2025-06-24 14:50:08 : SwiftDialog started with PID 45387!
cyberduck succesfully installed.
2025-06-24 14:50:09 : REQ   : cyberduck : ################## Start Installomator v. 10.8, date 2025-03-28
2025-06-24 14:50:12 : WARN  : cyberduck : No previous app found
2025-06-24 14:50:12 : WARN  : cyberduck : could not find Cyberduck.app
2025-06-24 14:50:12 : REQ   : cyberduck : Downloading https://update.cyberduck.io//Cyberduck-9.1.6.43284.zip to Cyberduck.zip
2025-06-24 14:50:16 : REQ   : cyberduck : no more blocking processes, continue with update
2025-06-24 14:50:16 : REQ   : cyberduck : Installing Cyberduck
2025-06-24 14:50:19 : WARN  : cyberduck : Changing owner to testuser
2025-06-24 14:50:23 : REQ   : cyberduck : Installed Cyberduck, version 9.1.6
2025-06-24 14:50:23 : REQ   : cyberduck : All done!
2025-06-24 14:50:23 : REQ   : cyberduck : ################## End Installomator, exit code 0
Not adding to Dock.
[Tue 24 Jun 2025 14:50:23 AEST][LOG-END]
Dialog: quit:
```