### PR TITLE
SwiftDialog Background Mode

### DIFF
--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -19,6 +19,9 @@ icon=${6:-"/System/Applications/App Store.app/Contents/Resources/AppIcon.icns"}
 # Parameter 7: Overlayicon as Path or URL in swiftDialog (like a company logo) (if not configured, custom Dialog icon will be used, or Jamf Self Service icon)
 overlayicon=${7}
 
+# Parameter 8: Display mode. 0 (default) for Foreground Mode, where the dialog window appears on top of other windows, this can be disruptive while the user is typing. 1 for Background Mode, where the dialog window appears behind other windows.
+mode=${8:-"0"}
+
 
 # MARK: Constants
 
@@ -79,8 +82,9 @@ echo "message: $message"
 echo "icon: $icon"
 echo "overlayicon: $overlayicon"
 
-# display first screen
-dialogCMD=("$dialogBinary"
+# Background or Foreground Mode
+if [[ $mode = 1 ]]; then
+    dialogCMD=(open -g -a "$dialogBinary" --args
            --title none
            --icon "$icon"
            --overlayicon "$overlayicon"
@@ -90,7 +94,20 @@ dialogCMD=("$dialogBinary"
            --position bottomright
            --moveable
            --commandfile "$dialog_command_file"
-)
+	)
+else 
+	dialogCMD=("$dialogBinary"
+           --title none
+           --icon "$icon"
+           --overlayicon "$overlayicon"
+           --message "$message"
+           --mini
+           --progress 100
+           --position bottomright
+           --moveable
+           --commandfile "$dialog_command_file"
+	)
+fi
 
 echo "dialogCMD: ${dialogCMD[@]}"
 


### PR DESCRIPTION
Adding the option for "Background" mode, so that Swift Dialog is less disruptive when appearing.

Best used when updating apps in the background quietly, while keeping users informed.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
no
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
no
**Additional context** Add any other context about the label or fix here.
Creates a less disruptive experience for end users. This is a switch that, when enabled, uses the following runtime context for swift dialog, rather than just calling the binary directly:
```open -g -a /usr/local/bin/dialog --args```

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

n/a


Run with Foreground Mode (default/current behavior)
```
{private}@{private} ~ % sudo jamf policy -event firefoxBeta
Enter PIN for 'Certificate For PIV Authentication ({private})': 
Checking for policies triggered by "firefoxBeta" for user "{private}"...
Executing Policy Installomator | Firefox | Install Beta
Running script -0_Install swiftDialog direct...
Script exit code: 0
Script result: /Library/Application Support/Dialog: directory
icon not defined.
INSTALL=
Dialog check for installation
Dialog version installed: 2.5.6
Dialog version 2.5.6 already found. Perfect!

Running script 00_Prepare_SwiftDialog.sh Modified...
Script exit code: 0
Script result: 2025-06-26 11:17:12 : Installomator starting up SwiftDialog
overlayicon used from Dialog.png
dialog_command_file: /var/tmp/dialog.log
message: Installing Firefox
icon: https://use2.ics.services.jamfcloud.com/icon/hash_{private}
overlayicon: /Library/Application Support/Dialog/Dialog.png
dialogCMD: /usr/local/bin/dialog --title none --icon https://use2.ics.services.jamfcloud.com/icon/hash_{private} --overlayicon /Library/Application Support/Dialog/Dialog.png --message Installing Firefox --mini --progress 100 --position bottomright --moveable --commandfile /var/tmp/dialog.log
2025-06-26 11:17:12 : SwiftDialog started!

Running script Installomator...
Script exit code: 0
Script result: 2025-06-26 11:17:12 : REQ   :  : shifting arguments for Jamf
2025-06-26 11:17:12 : INFO  : firefoxpkg : setting variable from argument DEBUG=0
2025-06-26 11:17:12 : INFO  : firefoxpkg : setting variable from argument NOTIFY=ALL
2025-06-26 11:17:12 : INFO  : firefoxpkg : setting variable from argument DIALOG_CMD_FILE=/var/tmp/dialog.log
2025-06-26 11:17:12 : INFO  : firefoxpkg : setting variable from argument INSTALL=force
2025-06-26 11:17:12 : INFO  : firefoxpkg : Total items in argumentsArray: 4
2025-06-26 11:17:12 : INFO  : firefoxpkg : argumentsArray: DEBUG=0 NOTIFY=ALL DIALOG_CMD_FILE=/var/tmp/dialog.log INSTALL=force
2025-06-26 11:17:12 : REQ   : firefoxpkg : ################## Start Installomator v. 10.9beta, date 2025-06-20
2025-06-26 11:17:12 : INFO  : firefoxpkg : ################## Version: 10.9beta
2025-06-26 11:17:12 : INFO  : firefoxpkg : ################## Date: 2025-06-20
2025-06-26 11:17:12 : INFO  : firefoxpkg : ################## firefoxpkg
2025-06-26 11:17:13 : INFO  : firefoxpkg : Reading arguments again: DEBUG=0 NOTIFY=ALL DIALOG_CMD_FILE=/var/tmp/dialog.log INSTALL=force
2025-06-26 11:17:13 : INFO  : firefoxpkg : BLOCKING_PROCESS_ACTION=tell_user
2025-06-26 11:17:13 : INFO  : firefoxpkg : NOTIFY=ALL
2025-06-26 11:17:13 : INFO  : firefoxpkg : LOGGING=INFO
2025-06-26 11:17:13 : INFO  : firefoxpkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-26 11:17:13 : INFO  : firefoxpkg : Label type: pkg
2025-06-26 11:17:13 : INFO  : firefoxpkg : archiveName: Firefox.pkg
2025-06-26 11:17:13 : INFO  : firefoxpkg : App(s) found: /Applications/Firefox.app
2025-06-26 11:17:13 : INFO  : firefoxpkg : found app at /Applications/Firefox.app, version 140.0.1, on versionKey CFBundleShortVersionString
2025-06-26 11:17:13 : INFO  : firefoxpkg : appversion: 140.0.1
2025-06-26 11:17:13 : INFO  : firefoxpkg : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2025-06-26 11:17:13 : INFO  : firefoxpkg : Latest version of Firefox is 140.0.1
2025-06-26 11:17:13 : INFO  : firefoxpkg : There is no newer version available.
2025-06-26 11:17:13 : REQ   : firefoxpkg : Downloading https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang=en-US to Firefox.pkg
2025-06-26 11:17:20 : INFO  : firefoxpkg : Downloaded Firefox.pkg – Type is  xar archive compressed TOC – SHA is 6a9c5ec2f3b9f042292e38f149f21724e8c3cae6 – Size is 181100 kB
2025-06-26 11:17:20 : REQ   : firefoxpkg : no more blocking processes, continue with update
2025-06-26 11:17:20 : REQ   : firefoxpkg : Installing Firefox
2025-06-26 11:17:20 : INFO  : firefoxpkg : Verifying: Firefox.pkg
2025-06-26 11:17:20 : INFO  : firefoxpkg : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2025-06-26 11:17:20 : INFO  : firefoxpkg : Installing Firefox.pkg to /
2025-06-26 11:17:24 : INFO  : firefoxpkg : Finishing...
2025-06-26 11:17:27 : INFO  : firefoxpkg : App(s) found: /Applications/Firefox.app
2025-06-26 11:17:27 : INFO  : firefoxpkg : found app at /Applications/Firefox.app, version 140.0.1, on versionKey CFBundleShortVersionString
2025-06-26 11:17:27 : REQ   : firefoxpkg : Installed Firefox, version 140.0.1
2025-06-26 11:17:27 : INFO  : firefoxpkg : Installomator did not close any apps, so no need to reopen any apps.
2025-06-26 11:17:27 : REQ   : firefoxpkg : All done!
2025-06-26 11:17:27 : REQ   : firefoxpkg : ################## End Installomator, exit code 0 


Running script zz_Quit_SwiftDialog...
Script exit code: 0
Script result: 2025-06-26 11:17:27 : Installomator finishing off SwiftDialog
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
2025-06-26 11:17:27 : No Installomator installation happened. No Jamf recon
2025-06-26 11:17:27 : Ending SwiftDialog
Dialog: progress: complete
Dialog: progresstext: Done
Dialog: quit:
No matching processes were found
2025-06-26 11:17:28 : SwiftDialog stopped!

Submitting log to https://nwave.jamfcloud.com/
```
Run with Background Mode
```
{private}@{private} ~ % sudo jamf policy -event firefoxBeta
Enter PIN for 'Certificate For PIV Authentication ({private})': 
Checking for policies triggered by "firefoxBeta" for user "{private}"...
Executing Policy Installomator | Firefox | Install Beta
Running script -0_Install swiftDialog direct...
Script exit code: 0
Script result: /Library/Application Support/Dialog: directory
icon not defined.
INSTALL=
Dialog check for installation
Dialog version installed: 2.5.6
Dialog version 2.5.6 already found. Perfect!

Running script 00_Prepare_SwiftDialog.sh Modified...
Script exit code: 0
Script result: 2025-06-26 11:18:00 : Installomator starting up SwiftDialog
overlayicon used from Dialog.png
dialog_command_file: /var/tmp/dialog.log
message: Installing Firefox
icon: https://use2.ics.services.jamfcloud.com/icon/hash_{private}
overlayicon: /Library/Application Support/Dialog/Dialog.png
dialogCMD: open -g -a /usr/local/bin/dialog --args --title none --icon https://use2.ics.services.jamfcloud.com/icon/hash_{private} --overlayicon /Library/Application Support/Dialog/Dialog.png --message Installing Firefox --mini --progress 100 --position bottomright --moveable --commandfile /var/tmp/dialog.log
2025-06-26 11:18:00 : SwiftDialog started!

Running script Installomator...
Script exit code: 0
Script result: 2025-06-26 11:18:00 : REQ   :  : shifting arguments for Jamf
2025-06-26 11:18:00 : INFO  : firefoxpkg : setting variable from argument DEBUG=0
2025-06-26 11:18:00 : INFO  : firefoxpkg : setting variable from argument NOTIFY=ALL
2025-06-26 11:18:00 : INFO  : firefoxpkg : setting variable from argument DIALOG_CMD_FILE=/var/tmp/dialog.log
2025-06-26 11:18:00 : INFO  : firefoxpkg : setting variable from argument INSTALL=force
2025-06-26 11:18:00 : INFO  : firefoxpkg : Total items in argumentsArray: 4
2025-06-26 11:18:00 : INFO  : firefoxpkg : argumentsArray: DEBUG=0 NOTIFY=ALL DIALOG_CMD_FILE=/var/tmp/dialog.log INSTALL=force
2025-06-26 11:18:00 : REQ   : firefoxpkg : ################## Start Installomator v. 10.9beta, date 2025-06-20
2025-06-26 11:18:00 : INFO  : firefoxpkg : ################## Version: 10.9beta
2025-06-26 11:18:00 : INFO  : firefoxpkg : ################## Date: 2025-06-20
2025-06-26 11:18:00 : INFO  : firefoxpkg : ################## firefoxpkg
2025-06-26 11:18:01 : INFO  : firefoxpkg : Reading arguments again: DEBUG=0 NOTIFY=ALL DIALOG_CMD_FILE=/var/tmp/dialog.log INSTALL=force
2025-06-26 11:18:01 : INFO  : firefoxpkg : BLOCKING_PROCESS_ACTION=tell_user
2025-06-26 11:18:01 : INFO  : firefoxpkg : NOTIFY=ALL
2025-06-26 11:18:01 : INFO  : firefoxpkg : LOGGING=INFO
2025-06-26 11:18:01 : INFO  : firefoxpkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-06-26 11:18:01 : INFO  : firefoxpkg : Label type: pkg
2025-06-26 11:18:01 : INFO  : firefoxpkg : archiveName: Firefox.pkg
2025-06-26 11:18:01 : INFO  : firefoxpkg : App(s) found: /Applications/Firefox.app
2025-06-26 11:18:01 : INFO  : firefoxpkg : found app at /Applications/Firefox.app, version 140.0.1, on versionKey CFBundleShortVersionString
2025-06-26 11:18:01 : INFO  : firefoxpkg : appversion: 140.0.1
2025-06-26 11:18:01 : INFO  : firefoxpkg : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2025-06-26 11:18:01 : INFO  : firefoxpkg : Latest version of Firefox is 140.0.1
2025-06-26 11:18:01 : INFO  : firefoxpkg : There is no newer version available.
2025-06-26 11:18:01 : REQ   : firefoxpkg : Downloading https://download.mozilla.org/?product=firefox-pkg-latest-ssl&os=osx&lang=en-US to Firefox.pkg
2025-06-26 11:18:07 : INFO  : firefoxpkg : Downloaded Firefox.pkg – Type is  xar archive compressed TOC – SHA is 6a9c5ec2f3b9f042292e38f149f21724e8c3cae6 – Size is 180828 kB
2025-06-26 11:18:07 : REQ   : firefoxpkg : no more blocking processes, continue with update
2025-06-26 11:18:07 : REQ   : firefoxpkg : Installing Firefox
2025-06-26 11:18:07 : INFO  : firefoxpkg : Verifying: Firefox.pkg
2025-06-26 11:18:07 : INFO  : firefoxpkg : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2025-06-26 11:18:07 : INFO  : firefoxpkg : Installing Firefox.pkg to /
2025-06-26 11:18:11 : INFO  : firefoxpkg : Finishing...
2025-06-26 11:18:14 : INFO  : firefoxpkg : App(s) found: /Applications/Firefox.app
2025-06-26 11:18:14 : INFO  : firefoxpkg : found app at /Applications/Firefox.app, version 140.0.1, on versionKey CFBundleShortVersionString
2025-06-26 11:18:14 : REQ   : firefoxpkg : Installed Firefox, version 140.0.1
2025-06-26 11:18:14 : INFO  : firefoxpkg : Installomator did not close any apps, so no need to reopen any apps.
2025-06-26 11:18:14 : REQ   : firefoxpkg : All done!
2025-06-26 11:18:14 : REQ   : firefoxpkg : ################## End Installomator, exit code 0 


Running script zz_Quit_SwiftDialog...
Script exit code: 0
Script result: 2025-06-26 11:18:14 : Installomator finishing off SwiftDialog
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
progresstext: Latest version already installed...
2025-06-26 11:18:14 : No Installomator installation happened. No Jamf recon
2025-06-26 11:18:14 : Ending SwiftDialog
Dialog: progress: complete
Dialog: progresstext: Done
Dialog: quit:
No matching processes were found
2025-06-26 11:18:15 : SwiftDialog stopped!

Submitting log to https://nwave.jamfcloud.com/
```
