### PR TITLE
appNewVersion query added to the label wrikeformac

### DIFF
--- a/fragments/labels/wrikeformac.sh
+++ b/fragments/labels/wrikeformac.sh
@@ -2,7 +2,9 @@ wrikeformac)
 #Il faut chercher une solution pour DL la version ARM
     name="Wrike for Mac"
     type="dmg"
-    appNewVersion="4.0.6"
+    wrikeDetails="$(curl -fsL 'https://www.wrike.com/api/v4/internal/integration_info?type=WrikeDesktopMac')"
+    appNewVersion="$(getJSONValue "$wrikeDetails" 'data[0].version')"
+    #appNewVersion="4.0.6"      # macOS 15 reports old version as being damaged after initually running it
     if [[ $(arch) == i386 ]]; then
         #downloadURL="https://dl.wrike.com/download/WrikeDesktopApp.latest.dmg"      # valide pour arch i386
         downloadURL="https://dl.wrike.com/download/WrikeDesktopApp.v${appNewVersion}.dmg"      # pour la coherence avec silicon, on hardcode le numéro de vesrion


### PR DESCRIPTION

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes, I think so.  I installed EditorConfig for VS Code prior to making the change to the wrikeformac.sh.  I apologize for not knowing this better, but it's my first time ever trying to contribute to GitHub.  I'm a big fan of Installomator, so I want to figure this out so I can update labels as I run into issues.  

**Additional context** Add any other context about the label or fix here.
Previously version 4.0.6 was just hardcoded for the Wrike label.  That version would install on macOS 15, open once, but then would fail to open thereafter saying the application was damaged.  The changed lines will now query a JSON on Wrike's website for the latest version, and then download that version.  

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
GB2347621:GitHub ledvinar$ sudo ./Installomator/utils/assemble.sh wrikeformac DEBUG=0 
2025-07-03 17:23:51 : INFO  : wrikeformac : setting variable from argument DEBUG=0 2025-07-03 17:23:51 : INFO  : wrikeformac : Total items in argumentsArray: 1 2025-07-03 17:23:51 : INFO  : wrikeformac : argumentsArray: DEBUG=0
2025-07-03 17:23:51 : REQ   : wrikeformac : ################## Start Installomator v. 10.9beta, date 2025-07-03
2025-07-03 17:23:51 : INFO  : wrikeformac : ################## Version: 10.9beta
2025-07-03 17:23:51 : INFO  : wrikeformac : ################## Date: 2025-07-03
2025-07-03 17:23:51 : INFO  : wrikeformac : ################## wrikeformac
2025-07-03 17:23:51 : INFO  : wrikeformac : SwiftDialog is not installed, clear cmd file var
2025-07-03 17:23:51 : INFO  : wrikeformac : Reading arguments again: DEBUG=0
2025-07-03 17:23:52 : INFO  : wrikeformac : BLOCKING_PROCESS_ACTION=tell_user
2025-07-03 17:23:52 : INFO  : wrikeformac : NOTIFY=success
2025-07-03 17:23:52 : INFO  : wrikeformac : LOGGING=INFO
2025-07-03 17:23:52 : INFO  : wrikeformac : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-03 17:23:52 : INFO  : wrikeformac : Label type: dmg
2025-07-03 17:23:52 : INFO  : wrikeformac : archiveName: Wrike for Mac.dmg
2025-07-03 17:23:52 : INFO  : wrikeformac : no blocking processes defined, using Wrike for Mac as default
2025-07-03 17:23:52 : INFO  : wrikeformac : name: Wrike for Mac, appName: Wrike for Mac.app
2025-07-03 17:23:52 : WARN  : wrikeformac : No previous app found
2025-07-03 17:23:52 : WARN  : wrikeformac : could not find Wrike for Mac.app
2025-07-03 17:23:52 : INFO  : wrikeformac : appversion:
2025-07-03 17:23:52 : INFO  : wrikeformac : Latest version of Wrike for Mac is 4.5.2
2025-07-03 17:23:52 : REQ   : wrikeformac : Downloading https://dl.wrike.com/download/WrikeDesktopApp_ARM.v4.5.2.dmg to Wrike for Mac.dmg
2025-07-03 17:23:53 : INFO  : wrikeformac : Downloaded Wrike for Mac.dmg – Type is  zlib compressed data – SHA is f1bd3f5b3a326b8f49f7b04c58bbdff310a90545 – Size is 114220 kB
2025-07-03 17:23:53 : REQ   : wrikeformac : no more blocking processes, continue with update
2025-07-03 17:23:53 : REQ   : wrikeformac : Installing Wrike for Mac
2025-07-03 17:23:53 : INFO  : wrikeformac : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.u3tq7v9C9w/Wrike for Mac.dmg
2025-07-03 17:23:57 : INFO  : wrikeformac : Mounted: /Volumes/Wrike for Mac Installer
2025-07-03 17:23:57 : INFO  : wrikeformac : Verifying: /Volumes/Wrike for Mac Installer/Wrike for Mac.app
2025-07-03 17:23:58 : INFO  : wrikeformac : Team ID matching: BD3YL53XT4 (expected: BD3YL53XT4 )
2025-07-03 17:23:58 : INFO  : wrikeformac : Installing Wrike for Mac version 4.5.2 on versionKey CFBundleShortVersionString.
2025-07-03 17:23:58 : INFO  : wrikeformac : App has LSMinimumSystemVersion: 11.0
2025-07-03 17:23:58 : INFO  : wrikeformac : Copy /Volumes/Wrike for Mac Installer/Wrike for Mac.app to /Applications
2025-07-03 17:23:59 : WARN  : wrikeformac : Changing owner to ledvinar
2025-07-03 17:23:59 : INFO  : wrikeformac : Finishing...
2025-07-03 17:24:02 : INFO  : wrikeformac : App(s) found: /Applications/Wrike for Mac.app
2025-07-03 17:24:02 : INFO  : wrikeformac : found app at /Applications/Wrike for Mac.app, version 4.5.2, on versionKey CFBundleShortVersionString
2025-07-03 17:24:02 : REQ   : wrikeformac : Installed Wrike for Mac, version 4.5.2
2025-07-03 17:24:02 : INFO  : wrikeformac : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-07-03 17:24:02 : INFO  : wrikeformac : Installomator did not close any apps, so no need to reopen any apps.
2025-07-03 17:24:02 : REQ   : wrikeformac : All done!
2025-07-03 17:24:02 : REQ   : wrikeformac : ################## End Installomator, exit code 0
```