### PR TITLE
Update airtamepkg.sh

### DIFF
--- a/fragments/labels/airtamepkg.sh
+++ b/fragments/labels/airtamepkg.sh
@@ -1,8 +1,6 @@
 airtamepkg)
     name="Airtame"
     type="pkg"
-    packageID="com.airtame.airtame-application"
-    appNewVersion="$(curl -fs https://airtame.com/download/ | grep -i platform=mac | head -1 | grep -o -i -E "https.*" | cut -d '"' -f1 | xargs curl -fsIL | grep -i ^location | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')"
-    downloadURL="https://airtame-app.b-cdn.net/app/latest/mac/Airtame-${appNewVersion}.pkg"
+    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac&pkg=true"
     expectedTeamID="4TPSP88HN2"
     ;;

--- a/fragments/labels/airtamepkg.sh
+++ b/fragments/labels/airtamepkg.sh
@@ -2,5 +2,6 @@ airtamepkg)
     name="Airtame"
     type="pkg"
     downloadURL="https://downloads-website.airtame.com/get.php?platform=mac&pkg=true"
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "location" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="4TPSP88HN2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
`downloadURL` changed.
The app installs in /Applications so I removed `packageID`
I had to remove `appNewVersion`; the new download url is keeping us in the dark.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh airtamepkg
2025-07-06 22:18:33 : INFO  : airtamepkg : Total items in argumentsArray: 0
2025-07-06 22:18:33 : INFO  : airtamepkg : argumentsArray:
2025-07-06 22:18:33 : REQ   : airtamepkg : ################## Start Installomator v. 10.9beta, date 2025-07-06
2025-07-06 22:18:33 : INFO  : airtamepkg : ################## Version: 10.9beta
2025-07-06 22:18:33 : INFO  : airtamepkg : ################## Date: 2025-07-06
2025-07-06 22:18:33 : INFO  : airtamepkg : ################## airtamepkg
2025-07-06 22:18:33 : DEBUG : airtamepkg : DEBUG mode 1 enabled.
2025-07-06 22:18:34 : INFO  : airtamepkg : Reading arguments again:
2025-07-06 22:18:34 : DEBUG : airtamepkg : name=Airtame
2025-07-06 22:18:34 : DEBUG : airtamepkg : appName=
2025-07-06 22:18:34 : DEBUG : airtamepkg : type=pkg
2025-07-06 22:18:34 : DEBUG : airtamepkg : archiveName=
2025-07-06 22:18:34 : DEBUG : airtamepkg : downloadURL=https://downloads-website.airtame.com/get.php?platform=mac&pkg=true
2025-07-06 22:18:34 : DEBUG : airtamepkg : curlOptions=
2025-07-06 22:18:34 : DEBUG : airtamepkg : appNewVersion=
2025-07-06 22:18:34 : DEBUG : airtamepkg : appCustomVersion function: Not defined
2025-07-06 22:18:34 : DEBUG : airtamepkg : versionKey=CFBundleShortVersionString
2025-07-06 22:18:34 : DEBUG : airtamepkg : packageID=
2025-07-06 22:18:34 : DEBUG : airtamepkg : pkgName=
2025-07-06 22:18:34 : DEBUG : airtamepkg : choiceChangesXML=
2025-07-06 22:18:34 : DEBUG : airtamepkg : expectedTeamID=4TPSP88HN2
2025-07-06 22:18:34 : DEBUG : airtamepkg : blockingProcesses=
2025-07-06 22:18:34 : DEBUG : airtamepkg : installerTool=
2025-07-06 22:18:34 : DEBUG : airtamepkg : CLIInstaller=
2025-07-06 22:18:34 : DEBUG : airtamepkg : CLIArguments=
2025-07-06 22:18:34 : DEBUG : airtamepkg : updateTool=
2025-07-06 22:18:34 : DEBUG : airtamepkg : updateToolArguments=
2025-07-06 22:18:34 : DEBUG : airtamepkg : updateToolRunAsCurrentUser=
2025-07-06 22:18:34 : INFO  : airtamepkg : BLOCKING_PROCESS_ACTION=tell_user
2025-07-06 22:18:34 : INFO  : airtamepkg : NOTIFY=success
2025-07-06 22:18:34 : INFO  : airtamepkg : LOGGING=DEBUG
2025-07-06 22:18:34 : INFO  : airtamepkg : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-06 22:18:34 : INFO  : airtamepkg : Label type: pkg
2025-07-06 22:18:34 : INFO  : airtamepkg : archiveName: Airtame.pkg
2025-07-06 22:18:34 : INFO  : airtamepkg : no blocking processes defined, using Airtame as default
2025-07-06 22:18:34 : DEBUG : airtamepkg : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-07-06 22:18:34 : INFO  : airtamepkg : name: Airtame, appName: Airtame.app
2025-07-06 22:18:34 : WARN  : airtamepkg : No previous app found
2025-07-06 22:18:34 : WARN  : airtamepkg : could not find Airtame.app
2025-07-06 22:18:34 : INFO  : airtamepkg : appversion:
2025-07-06 22:18:34 : INFO  : airtamepkg : Latest version not specified.
2025-07-06 22:18:34 : REQ   : airtamepkg : Downloading https://downloads-website.airtame.com/get.php?platform=mac&pkg=true to Airtame.pkg
2025-07-06 22:18:34 : DEBUG : airtamepkg : No Dialog connection, just download
2025-07-06 22:18:46 : INFO  : airtamepkg : Downloaded Airtame.pkg – Type is  xar archive compressed TOC – SHA is 3fc800586f860ec1d244c6fd8a06ed9ca44ff4eb – Size is 131588 kB
2025-07-06 22:18:46 : DEBUG : airtamepkg : DEBUG mode 1, not checking for blocking processes
2025-07-06 22:18:46 : REQ   : airtamepkg : Installing Airtame
2025-07-06 22:18:46 : INFO  : airtamepkg : Verifying: Airtame.pkg
2025-07-06 22:18:46 : DEBUG : airtamepkg : File list: -rw-r--r--@ 1 h.lans  admin   116M Jul  6 22:18 Airtame.pkg
2025-07-06 22:18:46 : DEBUG : airtamepkg : File type: Airtame.pkg: xar archive compressed TOC: 4625, SHA-1 checksum
2025-07-06 22:18:46 : DEBUG : airtamepkg : spctlOut is Airtame.pkg: accepted
2025-07-06 22:18:46 : DEBUG : airtamepkg : source=Notarized Developer ID
2025-07-06 22:18:46 : DEBUG : airtamepkg : origin=Developer ID Installer: AIRTAME APS (4TPSP88HN2)
2025-07-06 22:18:46 : INFO  : airtamepkg : Team ID: 4TPSP88HN2 (expected: 4TPSP88HN2 )
2025-07-06 22:18:46 : DEBUG : airtamepkg : DEBUG enabled, skipping installation
2025-07-06 22:18:46 : INFO  : airtamepkg : Finishing...
2025-07-06 22:18:49 : INFO  : airtamepkg : name: Airtame, appName: Airtame.app
2025-07-06 22:18:49 : WARN  : airtamepkg : No previous app found
2025-07-06 22:18:49 : WARN  : airtamepkg : could not find Airtame.app
2025-07-06 22:18:49 : REQ   : airtamepkg : Installed Airtame
2025-07-06 22:18:49 : INFO  : airtamepkg : notifying
2025-07-06 22:18:49 : DEBUG : airtamepkg : DEBUG mode 1, not reopening anything
2025-07-06 22:18:49 : REQ   : airtamepkg : All done!
2025-07-06 22:18:49 : REQ   : airtamepkg : ################## End Installomator, exit code 0
````