### PR TITLE
Update airtame.sh

### DIFF
--- a/fragments/labels/airtame.sh
+++ b/fragments/labels/airtame.sh
@@ -1,7 +1,6 @@
 airtame)
     name="Airtame"
     type="dmg"
-    downloadURL="$(curl -fs https://airtame.com/download/ | grep -i platform=mac | head -1 | grep -o -i -E "https.*" | cut -d '"' -f1)"
-    appNewVersion="$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')"
+    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac"
     expectedTeamID="4TPSP88HN2"
     ;;

--- a/fragments/labels/airtame.sh
+++ b/fragments/labels/airtame.sh
@@ -1,6 +1,7 @@
 airtame)
     name="Airtame"
-    type="dmg"
-    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac"
+    type="pkg"
+    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac&pkg=true"
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "location" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="4TPSP88HN2"
     ;;

--- a/fragments/labels/airtame.sh
+++ b/fragments/labels/airtame.sh
@@ -1,7 +1,7 @@
 airtame)
     name="Airtame"
-    type="pkg"
-    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac&pkg=true"
+    type="dmg"
+    downloadURL="https://downloads-website.airtame.com/get.php?platform=mac"
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "location" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
     expectedTeamID="4TPSP88HN2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
`downloadURL` changed.
I had to remove `appNewVersion`; the new download url is keeping us in the dark.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2463 

````
./assemble.sh airtame
2025-07-06 22:38:57 : INFO  : airtame : Total items in argumentsArray: 0
2025-07-06 22:38:57 : INFO  : airtame : argumentsArray:
2025-07-06 22:38:57 : REQ   : airtame : ################## Start Installomator v. 10.9beta, date 2025-07-06
2025-07-06 22:38:57 : INFO  : airtame : ################## Version: 10.9beta
2025-07-06 22:38:57 : INFO  : airtame : ################## Date: 2025-07-06
2025-07-06 22:38:57 : INFO  : airtame : ################## airtame
2025-07-06 22:38:57 : DEBUG : airtame : DEBUG mode 1 enabled.
2025-07-06 22:38:58 : INFO  : airtame : Reading arguments again:
2025-07-06 22:38:58 : DEBUG : airtame : name=Airtame
2025-07-06 22:38:58 : DEBUG : airtame : appName=
2025-07-06 22:38:58 : DEBUG : airtame : type=dmg
2025-07-06 22:38:58 : DEBUG : airtame : archiveName=
2025-07-06 22:38:58 : DEBUG : airtame : downloadURL=https://downloads-website.airtame.com/get.php?platform=mac
2025-07-06 22:38:58 : DEBUG : airtame : curlOptions=
2025-07-06 22:38:58 : DEBUG : airtame : appNewVersion=
2025-07-06 22:38:58 : DEBUG : airtame : appCustomVersion function: Not defined
2025-07-06 22:38:58 : DEBUG : airtame : versionKey=CFBundleShortVersionString
2025-07-06 22:38:58 : DEBUG : airtame : packageID=
2025-07-06 22:38:58 : DEBUG : airtame : pkgName=
2025-07-06 22:38:58 : DEBUG : airtame : choiceChangesXML=
2025-07-06 22:38:58 : DEBUG : airtame : expectedTeamID=4TPSP88HN2
2025-07-06 22:38:58 : DEBUG : airtame : blockingProcesses=
2025-07-06 22:38:58 : DEBUG : airtame : installerTool=
2025-07-06 22:38:58 : DEBUG : airtame : CLIInstaller=
2025-07-06 22:38:58 : DEBUG : airtame : CLIArguments=
2025-07-06 22:38:58 : DEBUG : airtame : updateTool=
2025-07-06 22:38:58 : DEBUG : airtame : updateToolArguments=
2025-07-06 22:38:58 : DEBUG : airtame : updateToolRunAsCurrentUser=
2025-07-06 22:38:58 : INFO  : airtame : BLOCKING_PROCESS_ACTION=tell_user
2025-07-06 22:38:58 : INFO  : airtame : NOTIFY=success
2025-07-06 22:38:58 : INFO  : airtame : LOGGING=DEBUG
2025-07-06 22:38:58 : INFO  : airtame : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-06 22:38:58 : INFO  : airtame : Label type: dmg
2025-07-06 22:38:58 : INFO  : airtame : archiveName: Airtame.dmg
2025-07-06 22:38:58 : INFO  : airtame : no blocking processes defined, using Airtame as default
2025-07-06 22:38:58 : DEBUG : airtame : Changing directory to /Users/h.lans/Documents/GitHub/Installomator/build
2025-07-06 22:38:58 : INFO  : airtame : name: Airtame, appName: Airtame.app
2025-07-06 22:38:58 : WARN  : airtame : No previous app found
2025-07-06 22:38:58 : WARN  : airtame : could not find Airtame.app
2025-07-06 22:38:58 : INFO  : airtame : appversion:
2025-07-06 22:38:58 : INFO  : airtame : Latest version not specified.
2025-07-06 22:38:58 : REQ   : airtame : Downloading https://downloads-website.airtame.com/get.php?platform=mac to Airtame.dmg
2025-07-06 22:38:58 : DEBUG : airtame : No Dialog connection, just download
2025-07-06 22:39:09 : INFO  : airtame : Downloaded Airtame.dmg – Type is  zlib compressed data – SHA is cfa26adc44c23ceb37504721b0016d08cc813ba6 – Size is 131596 kB
2025-07-06 22:39:09 : DEBUG : airtame : DEBUG mode 1, not checking for blocking processes
2025-07-06 22:39:09 : REQ   : airtame : Installing Airtame
2025-07-06 22:39:09 : INFO  : airtame : Mounting /Users/h.lans/Documents/GitHub/Installomator/build/Airtame.dmg
2025-07-06 22:39:14 : DEBUG : airtame : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $0E1587F0
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $A0848190
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $5D8799FA
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $7C147529
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $5D8799FA
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $CABB07C9
verified CRC32 $D353CFAA
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Airtame 4.13.1

2025-07-06 22:39:14 : INFO  : airtame : Mounted: /Volumes/Airtame 4.13.1
2025-07-06 22:39:14 : INFO  : airtame : Verifying: /Volumes/Airtame 4.13.1/Airtame.app
2025-07-06 22:39:14 : DEBUG : airtame : App size: 268M	/Volumes/Airtame 4.13.1/Airtame.app
2025-07-06 22:39:16 : DEBUG : airtame : Debugging enabled, App Verification output was:
/Volumes/Airtame 4.13.1/Airtame.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: AIRTAME APS (4TPSP88HN2)

2025-07-06 22:39:16 : INFO  : airtame : Team ID matching: 4TPSP88HN2 (expected: 4TPSP88HN2 )
2025-07-06 22:39:16 : INFO  : airtame : Installing Airtame version 4.13.1 on versionKey CFBundleShortVersionString.
2025-07-06 22:39:16 : INFO  : airtame : App has LSMinimumSystemVersion: 10.15
2025-07-06 22:39:16 : DEBUG : airtame : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-07-06 22:39:16 : INFO  : airtame : Finishing...
2025-07-06 22:39:19 : INFO  : airtame : name: Airtame, appName: Airtame.app
2025-07-06 22:39:19 : WARN  : airtame : No previous app found
2025-07-06 22:39:19 : WARN  : airtame : could not find Airtame.app
2025-07-06 22:39:19 : REQ   : airtame : Installed Airtame, version 4.13.1
2025-07-06 22:39:19 : INFO  : airtame : notifying
2025-07-06 22:39:19 : DEBUG : airtame : Unmounting /Volumes/Airtame 4.13.1
2025-07-06 22:39:19 : DEBUG : airtame : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-07-06 22:39:19 : DEBUG : airtame : DEBUG mode 1, not reopening anything
2025-07-06 22:39:19 : REQ   : airtame : All done!
2025-07-06 22:39:19 : REQ   : airtame : ################## End Installomator, exit code 0
````