### PR TITLE
Update tableaureader.sh

### DIFF
--- a/fragments/labels/tableaureader.sh
+++ b/fragments/labels/tableaureader.sh
@@ -1,17 +1,12 @@
 tableaureader)
     name="Tableau Reader"
-    type="pkg"
-    tableauUpdateFeed=$(curl -fsL "https://downloads.tableau.com/TableauAutoUpdate.xml")
-    latestVersion=$(echo "${tableauUpdateFeed}" | xmllint --xpath '//*[local-name()="version"]/@latestVersion' - | tr ' ' '\n' | awk -F'"' '{print $2}' | sort -nr | head -n1)
-    nameVersion=$(echo "${tableauUpdateFeed}" | xmllint --xpath "//*[local-name()='version'][@latestVersion='$latestVersion']/@name" - 2>/dev/null | awk -F'"' '{print $2}')
-    name="${name} ${nameVersion}"
-    appNewVersion=$(echo "${tableauUpdateFeed}" | xmllint --xpath "//*[local-name()='version'][@latestVersion='$latestVersion']/@releaseNotesVersion" - | awk -F'"' '{print $2}')
+    type="pkgInDmg"
     if [[ $(arch) == "arm64" ]]; then
-        readerMac=$(echo "${tableauUpdateFeed}" | xmllint --xpath "//*[local-name()='version'][@latestVersion='$latestVersion']//*[local-name()='installer'][@type='readerMacArm64']/@name" - | awk -F'"' '{print $2}')
+        downloadURL="https://www.tableau.com/downloads/reader/mac-arm64"
     elif [[ $(arch) == "i386" ]]; then
-        readerMac=$(echo "${tableauUpdateFeed}"  | xmllint --xpath "//*[local-name()='version'][@latestVersion='$latestVersion']//*[local-name()='installer'][@type='readerMac']/@name" - | awk -F'"' '{print $2}')
+        downloadURL="https://www.tableau.com/downloads/reader/mac"
     fi
-    downloadURL="https://downloads.tableau.com/esdalt/$appNewVersion/$readerMac"
+    appNewVersion=${$(curl -fsIL "$downloadURL" | sed -nE 's/.*Reader-([0-9-]*).*/\1/p')//-/.}
+    appNewVersion=$( echo "$appNewVersion" | sed -r 's/\.$//' )
     expectedTeamID="QJ4XPRK37C"
     ;;
-


### PR DESCRIPTION
Fix download URLs and appNewVersion

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Tableau changed how they package Tableau Reader and how they structure their downloads.  Updating the label to fix that.

```
./assemble.sh: line 16: zparseopts: command not found
./assemble.sh: line 18: (I)(-h|--help): syntax error in expression (error token is "(-h|--help)")
./assemble.sh: line 23: (I)(-s|--script): syntax error in expression (error token is "(-s|--script)")
./assemble.sh: line 25: (I)(-p|--pkg): syntax error in expression (error token is "(-p|--pkg)")
./assemble.sh: line 27: (I)(-n|--notarize): syntax error in expression (error token is "(-n|--notarize)")
./assemble.sh: line 30: (I)(-r|--run): syntax error in expression (error token is "(-r|--run)")
2025-07-11 11:03:04 : INFO  : tableaureader : setting variable from argument DEBUG=0
2025-07-11 11:03:04 : INFO  : tableaureader : Total items in argumentsArray: 1
2025-07-11 11:03:04 : INFO  : tableaureader : argumentsArray: DEBUG=0
2025-07-11 11:03:04 : REQ   : tableaureader : ################## Start Installomator v. 10.8, date 2025-07-11
2025-07-11 11:03:04 : INFO  : tableaureader : ################## Version: 10.8
2025-07-11 11:03:04 : INFO  : tableaureader : ################## Date: 2025-07-11
2025-07-11 11:03:04 : INFO  : tableaureader : ################## tableaureader
2025-07-11 11:03:05 : INFO  : tableaureader : Reading arguments again: DEBUG=0
2025-07-11 11:03:05 : INFO  : tableaureader : BLOCKING_PROCESS_ACTION=tell_user
2025-07-11 11:03:05 : INFO  : tableaureader : NOTIFY=success
2025-07-11 11:03:05 : INFO  : tableaureader : LOGGING=INFO
2025-07-11 11:03:05 : INFO  : tableaureader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-11 11:03:05 : INFO  : tableaureader : Label type: pkgInDmg
2025-07-11 11:03:05 : INFO  : tableaureader : archiveName: Tableau Reader.dmg
2025-07-11 11:03:05 : INFO  : tableaureader : no blocking processes defined, using Tableau Reader as default
2025-07-11 11:03:05 : INFO  : tableaureader : name: Tableau Reader, appName: Tableau Reader.app
2025-07-11 11:03:05 : WARN  : tableaureader : No previous app found
2025-07-11 11:03:05 : WARN  : tableaureader : could not find Tableau Reader.app
2025-07-11 11:03:05 : INFO  : tableaureader : appversion: 
2025-07-11 11:03:05 : INFO  : tableaureader : Latest version of Tableau Reader is 2025.2.0
2025-07-11 11:03:05 : REQ   : tableaureader : Downloading https://www.tableau.com/downloads/reader/mac-arm64 to Tableau Reader.dmg
2025-07-11 11:03:18 : INFO  : tableaureader : Downloaded Tableau Reader.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 92a4fe44daeebd21184f80b0989aff3f2f552d21 – Size is 721864 kB
2025-07-11 11:03:18 : REQ   : tableaureader : no more blocking processes, continue with update
2025-07-11 11:03:18 : REQ   : tableaureader : Installing Tableau Reader
2025-07-11 11:03:18 : INFO  : tableaureader : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.qI3K1tcFqY/Tableau Reader.dmg
2025-07-11 11:03:42 : INFO  : tableaureader : Mounted: /Volumes/Tableau Reader
2025-07-11 11:03:42 : INFO  : tableaureader : found pkg: /Volumes/Tableau Reader/Tableau Reader.pkg
2025-07-11 11:03:42 : INFO  : tableaureader : Verifying: /Volumes/Tableau Reader/Tableau Reader.pkg
2025-07-11 11:03:43 : INFO  : tableaureader : Team ID: QJ4XPRK37C (expected: QJ4XPRK37C )
2025-07-11 11:03:43 : INFO  : tableaureader : Installing /Volumes/Tableau Reader/Tableau Reader.pkg to /
2025-07-11 11:04:19 : INFO  : tableaureader : Finishing...
2025-07-11 11:04:22 : INFO  : tableaureader : name: Tableau Reader, appName: Tableau Reader.app
2025-07-11 11:04:22 : INFO  : tableaureader : App(s) found: /Applications/Tableau Reader (Apple silicon) 2025.2.app
2025-07-11 11:04:22 : INFO  : tableaureader : found app at /Applications/Tableau Reader (Apple silicon) 2025.2.app, version 2025.2.0, on versionKey CFBundleShortVersionString
2025-07-11 11:04:22 : REQ   : tableaureader : Installed Tableau Reader, version 2025.2.0
2025-07-11 11:04:22 : INFO  : tableaureader : notifying
2025-07-11 11:04:22 : INFO  : tableaureader : Installomator did not close any apps, so no need to reopen any apps.
2025-07-11 11:04:22 : REQ   : tableaureader : All done!
2025-07-11 11:04:22 : REQ   : tableaureader : ################## End Installomator, exit code 0 
```

