### PR TITLE
Fix missing line breaks in two labels with alt names

### DIFF
--- a/fragments/labels/snapgene.sh
+++ b/fragments/labels/snapgene.sh
@@ -1,4 +1,5 @@
-snapgene|snapgeneviewer)
+snapgene|\
+snapgeneviewer)
     name="SnapGene"
     type="dmg"
     downloadURL="https://www.snapgene.com/local/targets/download.php?os=mac&majorRelease=latest&minorRelease=latest"

--- a/fragments/labels/vmwarehorizonclient.sh
+++ b/fragments/labels/vmwarehorizonclient.sh
@@ -1,4 +1,5 @@
-vmwarehorizonclient|omnissahorizonclient)
+vmwarehorizonclient|\
+omnissahorizonclient)
     name="Omnissa Horizon Client"
     type="pkgInDmg"
     jsonData=$(curl -fsL 'https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=omnissa_horizon_clients&version=8&dlgType=PRODUCT_BINARY')


### PR DESCRIPTION
Two labels, `vmwarehorizonclient` and `snapgene` have alt names but are missing the `|\` line break between names. This causes them  to not be added to labels.txt when assemble.sh runs.