### PR TITLE
Update protonvpn.sh to use new ProtonVPM XML version file URL

### DIFF
--- a/fragments/labels/protonvpn.sh
+++ b/fragments/labels/protonvpn.sh
@@ -1,7 +1,7 @@
 protonvpn)
     name="ProtonVPN"
     type="dmg"
-    downloadURL=$(curl -s "https://protonvpn.com/download/macos-update3.xml" | xmllint --xpath 'string(//enclosure/@url)' -)
+    downloadURL=$(curl -s "https://protonvpn.com/download/macos-update4.xml" | xmllint --xpath 'string(//enclosure/@url)' -)
     appNewVersion=$(echo $downloadURL | sed -e 's/^.*\/Proton.*_v\([0-9.]*\)\.dmg/\1/g')
     expectedTeamID="J6S6Q257EK"
     ;;


### PR DESCRIPTION
Update ProtonVPN XML version file location to new location

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** The old XML file only has ProtonVPN versions up to 4.5.0, the new one has 5.1.0 as expected.
Old XML file currently used: https://protonvpn.com/download/macos-update3.xml
New XML file: https://protonvpn.com/download/macos-update4.xml

**Installomator log**
```
2025-07-19 10:42:30 : INFO  : protonvpn : setting variable from argument DEBUG=1
2025-07-19 10:42:30 : INFO  : protonvpn : Total items in argumentsArray: 1
2025-07-19 10:42:30 : INFO  : protonvpn : argumentsArray: DEBUG=1
2025-07-19 10:42:30 : REQ   : protonvpn : ################## Start Installomator v. 10.9beta, date 2025-07-16
2025-07-19 10:42:30 : INFO  : protonvpn : ################## Version: 10.9beta
2025-07-19 10:42:30 : INFO  : protonvpn : ################## Date: 2025-07-16
2025-07-19 10:42:30 : INFO  : protonvpn : ################## protonvpn
2025-07-19 10:42:30 : DEBUG : protonvpn : DEBUG mode 1 enabled.
2025-07-19 10:42:30 : INFO  : protonvpn : SwiftDialog is not installed, clear cmd file var
2025-07-19 10:42:31 : INFO  : protonvpn : Reading arguments again: DEBUG=1
2025-07-19 10:42:31 : DEBUG : protonvpn : argument: DEBUG=1
2025-07-19 10:42:31 : DEBUG : protonvpn : name=ProtonVPN
2025-07-19 10:42:31 : DEBUG : protonvpn : appName=
2025-07-19 10:42:31 : DEBUG : protonvpn : type=dmg
2025-07-19 10:42:31 : DEBUG : protonvpn : archiveName=
2025-07-19 10:42:31 : DEBUG : protonvpn : downloadURL=https://vpn.protondownload.com/download/ProtonVPN_mac_v4.5.0.dmg
2025-07-19 10:42:31 : DEBUG : protonvpn : curlOptions=
2025-07-19 10:42:31 : DEBUG : protonvpn : appNewVersion=4.5.0
2025-07-19 10:42:31 : DEBUG : protonvpn : appCustomVersion function: Not defined
2025-07-19 10:42:31 : DEBUG : protonvpn : versionKey=CFBundleShortVersionString
2025-07-19 10:42:31 : DEBUG : protonvpn : packageID=
2025-07-19 10:42:31 : DEBUG : protonvpn : pkgName=
2025-07-19 10:42:31 : DEBUG : protonvpn : choiceChangesXML=
2025-07-19 10:42:31 : DEBUG : protonvpn : expectedTeamID=J6S6Q257EK
2025-07-19 10:42:31 : DEBUG : protonvpn : blockingProcesses=
2025-07-19 10:42:31 : DEBUG : protonvpn : installerTool=
2025-07-19 10:42:31 : DEBUG : protonvpn : CLIInstaller=
2025-07-19 10:42:31 : DEBUG : protonvpn : CLIArguments=
2025-07-19 10:42:31 : DEBUG : protonvpn : updateTool=
2025-07-19 10:42:31 : DEBUG : protonvpn : updateToolArguments=
2025-07-19 10:42:31 : DEBUG : protonvpn : updateToolRunAsCurrentUser=
2025-07-19 10:42:31 : INFO  : protonvpn : BLOCKING_PROCESS_ACTION=tell_user
2025-07-19 10:42:31 : INFO  : protonvpn : NOTIFY=success
2025-07-19 10:42:31 : INFO  : protonvpn : LOGGING=DEBUG
2025-07-19 10:42:31 : INFO  : protonvpn : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-19 10:42:31 : INFO  : protonvpn : Label type: dmg
2025-07-19 10:42:31 : INFO  : protonvpn : archiveName: ProtonVPN.dmg
2025-07-19 10:42:31 : INFO  : protonvpn : no blocking processes defined, using ProtonVPN as default
2025-07-19 10:42:31 : DEBUG : protonvpn : Changing directory to .
2025-07-19 10:42:31 : INFO  : protonvpn : App(s) found: /Applications/ProtonVPN.app
2025-07-19 10:42:31 : INFO  : protonvpn : found app at /Applications/ProtonVPN.app, version 5.1.0, on versionKey CFBundleShortVersionString
2025-07-19 10:42:31 : INFO  : protonvpn : appversion: 5.1.0
2025-07-19 10:42:31 : INFO  : protonvpn : Latest version of ProtonVPN is 4.5.0
2025-07-19 10:42:31 : REQ   : protonvpn : Downloading https://vpn.protondownload.com/download/ProtonVPN_mac_v4.5.0.dmg to ProtonVPN.dmg
2025-07-19 10:42:31 : DEBUG : protonvpn : No Dialog connection, just download
2025-07-19 10:42:33 : INFO  : protonvpn : Downloaded ProtonVPN.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 6aec1378e3b967b74968094a01cf934d0e7f9627 – Size is 81996 kB
2025-07-19 10:42:33 : DEBUG : protonvpn : DEBUG mode 1, not checking for blocking processes
2025-07-19 10:42:33 : REQ   : protonvpn : Installing ProtonVPN
2025-07-19 10:42:33 : INFO  : protonvpn : Mounting ./ProtonVPN.dmg
2025-07-19 10:42:38 : DEBUG : protonvpn : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7FB70247
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D84A2D35
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $534683B8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $B0465F24
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $534683B8
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9333B38C
verified   CRC32 $7B66B28F
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/ProtonVPN

2025-07-19 10:42:38 : INFO  : protonvpn : Mounted: /Volumes/ProtonVPN
2025-07-19 10:42:38 : INFO  : protonvpn : Verifying: /Volumes/ProtonVPN/ProtonVPN.app
2025-07-19 10:42:38 : DEBUG : protonvpn : App size: 137M	/Volumes/ProtonVPN/ProtonVPN.app
2025-07-19 10:42:45 : DEBUG : protonvpn : Debugging enabled, App Verification output was:
/Volumes/ProtonVPN/ProtonVPN.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: ProtonVPN AG (J6S6Q257EK)

2025-07-19 10:42:45 : INFO  : protonvpn : Team ID matching: J6S6Q257EK (expected: J6S6Q257EK )
2025-07-19 10:42:45 : INFO  : protonvpn : Downloaded version of ProtonVPN is 4.5.0 on versionKey CFBundleShortVersionString (replacing version 5.1.0).
2025-07-19 10:42:45 : INFO  : protonvpn : App has LSMinimumSystemVersion: 11.0
2025-07-19 10:42:45 : DEBUG : protonvpn : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-07-19 10:42:45 : INFO  : protonvpn : Finishing...
2025-07-19 10:42:48 : INFO  : protonvpn : App(s) found: /Applications/ProtonVPN.app
2025-07-19 10:42:48 : INFO  : protonvpn : found app at /Applications/ProtonVPN.app, version 5.1.0, on versionKey CFBundleShortVersionString
2025-07-19 10:42:48 : REQ   : protonvpn : Installed ProtonVPN, version 4.5.0
2025-07-19 10:42:48 : INFO  : protonvpn : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-07-19 10:42:48 : DEBUG : protonvpn : Unmounting /Volumes/ProtonVPN
2025-07-19 10:42:48 : DEBUG : protonvpn : Debugging enabled, Unmounting output was:
"disk5" ejected.
2025-07-19 10:42:48 : DEBUG : protonvpn : DEBUG mode 1, not reopening anything
2025-07-19 10:42:48 : REQ   : protonvpn : All done!
2025-07-19 10:42:48 : REQ   : protonvpn : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number.
This fixes: https://github.com/Installomator/Installomator/issues/2490
