### PR TITLE
Update slack.sh

### DIFF
--- a/fragments/labels/slack.sh
+++ b/fragments/labels/slack.sh
@@ -1,7 +1,7 @@
 slack)
     name="Slack"
-    type="dmg"
-    downloadURL="https://slack.com/ssb/download-osx-universal"
+    type="pkg"
+    downloadURL="https://slack.com/api/desktop.latestRelease?redirect=1&variant=pkg&arch=universal"
     appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | cut -d "/" -f7 )
     expectedTeamID="BQR82RBBHL"
     ;;


### PR DESCRIPTION
Slack now offers a PKG download instead of the DMG. We should switch to the PKG

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.

Have you confirmed this pull request is not a duplicate? yes

Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself? yes

Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)? yes
---
```bash
2025-07-24 10:24:40 : INFO  : slack : Total items in argumentsArray: 0
2025-07-24 10:24:40 : INFO  : slack : argumentsArray: 
2025-07-24 10:24:40 : REQ   : slack : ################## Start Installomator v. 10.8, date 2025-03-28
2025-07-24 10:24:40 : INFO  : slack : ################## Version: 10.8
2025-07-24 10:24:40 : INFO  : slack : ################## Date: 2025-03-28
2025-07-24 10:24:40 : INFO  : slack : ################## slack
2025-07-24 10:24:41 : INFO  : slack : Reading arguments again: 
2025-07-24 10:24:41 : INFO  : slack : BLOCKING_PROCESS_ACTION=tell_user
2025-07-24 10:24:41 : INFO  : slack : NOTIFY=success
2025-07-24 10:24:41 : INFO  : slack : LOGGING=INFO
2025-07-24 10:24:41 : INFO  : slack : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-24 10:24:41 : INFO  : slack : Label type: pkg
2025-07-24 10:24:41 : INFO  : slack : archiveName: Slack.pkg
2025-07-24 10:24:41 : INFO  : slack : no blocking processes defined, using Slack as default
2025-07-24 10:24:41 : INFO  : slack : App(s) found: /Applications/Slack.app
2025-07-24 10:24:41 : INFO  : slack : found app at /Applications/Slack.app, version 4.44.65, on versionKey CFBundleShortVersionString
2025-07-24 10:24:41 : INFO  : slack : appversion: 4.44.65
2025-07-24 10:24:41 : INFO  : slack : Latest version of Slack is 4.45.64
2025-07-24 10:24:41 : REQ   : slack : Downloading https://slack.com/api/desktop.latestRelease?redirect=1&variant=pkg&arch=universal to Slack.pkg
2025-07-24 10:24:44 : INFO  : slack : Downloaded Slack.pkg – Type is  xar archive compressed TOC – SHA is 16eeb793f4d2bb9aeea5574f847a857bfa5853ab – Size is 214460 kB
2025-07-24 10:24:44 : INFO  : slack : found blocking process Slack
2025-07-24 10:24:47 : INFO  : slack : telling app Slack to quit
2025-07-24 10:24:47 : INFO  : slack : waiting 30 seconds for processes to quit
2025-07-24 10:25:18 : REQ   : slack : no more blocking processes, continue with update
2025-07-24 10:25:18 : REQ   : slack : Installing Slack
2025-07-24 10:25:18 : INFO  : slack : Verifying: Slack.pkg
2025-07-24 10:25:18 : INFO  : slack : Team ID: BQR82RBBHL (expected: BQR82RBBHL )
2025-07-24 10:25:18 : INFO  : slack : Installing Slack.pkg to /
2025-07-24 10:25:26 : INFO  : slack : Finishing...
2025-07-24 10:25:29 : INFO  : slack : App(s) found: /Applications/Slack.app
2025-07-24 10:25:29 : INFO  : slack : found app at /Applications/Slack.app, version 4.45.64, on versionKey CFBundleShortVersionString
2025-07-24 10:25:29 : REQ   : slack : Installed Slack, version 4.45.64
2025-07-24 10:25:29 : INFO  : slack : notifying
2025-07-24 10:25:29 : INFO  : slack : Telling app Slack.app to open
/Users/mmatter/.zshenv:2: command not found: rbenv
2025-07-24 10:25:30 : INFO  : slack : Reopened Slack.app as mmatter
2025-07-24 10:25:30 : REQ   : slack : All done!
2025-07-24 10:25:30 : REQ   : slack : ################## End Installomator, exit code 0 
```