### PR TITLE
Create rokokostudiopreview.sh

### DIFF
--- a/fragments/labels/rokokostudiopreview.sh
+++ b/fragments/labels/rokokostudiopreview.sh
@@ -1,0 +1,10 @@
+rokokostudiopreview)
+    name="Rokoko Studio Preview"
+    appName="Rokoko Studio Preview.app"
+    type="dmg"
+    downloadURL=$(curl -s https://www.rokoko.com/products/studio/studio-preview | grep -oE 'https[^"]+Rokoko\+Studio\+Preview-[0-9]+\.[0-9]+\.[0-9]+-arm64\.dmg' | sort -V | tail -n1)
+    appNewVersion=$(echo $downloadURL | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    versionKey="CFBundleVersion"
+    expectedTeamID="5K4RZM8SUS"
+    ;;
+


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** creating

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : setting variable from argument DEBUG=1
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : Total items in argumentsArray: 1
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : argumentsArray: DEBUG=1
2025-07-29 12:27:03 : REQ   : rokokostudiopreview : ################## Start Installomator v. 10.9beta, date 2025-07-16
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : ################## Version: 10.9beta
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : ################## Date: 2025-07-16
2025-07-29 12:27:03 : INFO  : rokokostudiopreview : ################## rokokostudiopreview
2025-07-29 12:27:03 : DEBUG : rokokostudiopreview : DEBUG mode 1 enabled.
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : Reading arguments again: DEBUG=1
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : argument: DEBUG=1
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : name=Rokoko Studio Preview
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : appName=Rokoko Studio Preview.app
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : type=dmg
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : archiveName=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : downloadURL=https://project-phoenix-vqsz5pvjg8viaxqq.s3.us-east-1.amazonaws.com/Rokoko+Studio+Preview-1.0.1-arm64.dmg
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : curlOptions=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : appNewVersion=1.0.1
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : appCustomVersion function: Not defined
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : versionKey=CFBundleVersion
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : packageID=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : pkgName=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : choiceChangesXML=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : expectedTeamID=5K4RZM8SUS
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : blockingProcesses=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : installerTool=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : CLIInstaller=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : CLIArguments=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : updateTool=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : updateToolArguments=
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : updateToolRunAsCurrentUser=
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : BLOCKING_PROCESS_ACTION=tell_user
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : NOTIFY=success
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : LOGGING=DEBUG
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : Label type: dmg
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : archiveName: Rokoko Studio Preview.dmg
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : no blocking processes defined, using Rokoko Studio Preview as default
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : Changing directory to /Users/coreyg/Documents/GitHub/Installomator
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : App(s) found: /Applications/Rokoko Studio Preview.app
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : found app at /Applications/Rokoko Studio Preview.app, version 1.0.1, on versionKey CFBundleVersion
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : appversion: 1.0.1
2025-07-29 12:27:04 : INFO  : rokokostudiopreview : Latest version of Rokoko Studio Preview is 1.0.1
2025-07-29 12:27:04 : WARN  : rokokostudiopreview : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-07-29 12:27:04 : REQ   : rokokostudiopreview : Downloading https://project-phoenix-vqsz5pvjg8viaxqq.s3.us-east-1.amazonaws.com/Rokoko+Studio+Preview-1.0.1-arm64.dmg to Rokoko Studio Preview.dmg
2025-07-29 12:27:04 : DEBUG : rokokostudiopreview : No Dialog connection, just download
2025-07-29 12:27:07 : INFO  : rokokostudiopreview : Downloaded Rokoko Studio Preview.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 3b755afe04203d8482c8596e6b5039d6ead11dcc – Size is 188452 kB
2025-07-29 12:27:07 : DEBUG : rokokostudiopreview : DEBUG mode 1, not checking for blocking processes
2025-07-29 12:27:07 : REQ   : rokokostudiopreview : Installing Rokoko Studio Preview
2025-07-29 12:27:07 : INFO  : rokokostudiopreview : Mounting /Users/coreyg/Documents/GitHub/Installomator/Rokoko Studio Preview.dmg
2025-07-29 12:27:08 : DEBUG : rokokostudiopreview : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C76C9B37
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D7D4908D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $959D41F5
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $1F1CE8C1
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $959D41F5
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $0EDC3683
verified   CRC32 $C92CC78A
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Rokoko Studio Preview 1

2025-07-29 12:27:08 : INFO  : rokokostudiopreview : Mounted: /Volumes/Rokoko Studio Preview 1
2025-07-29 12:27:08 : INFO  : rokokostudiopreview : Verifying: /Volumes/Rokoko Studio Preview 1/Rokoko Studio Preview.app
2025-07-29 12:27:08 : DEBUG : rokokostudiopreview : App size: 439M	/Volumes/Rokoko Studio Preview 1/Rokoko Studio Preview.app
2025-07-29 12:27:09 : DEBUG : rokokostudiopreview : Debugging enabled, App Verification output was:
/Volumes/Rokoko Studio Preview 1/Rokoko Studio Preview.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Rokoko Electronics ApS (5K4RZM8SUS)

2025-07-29 12:27:09 : INFO  : rokokostudiopreview : Team ID matching: 5K4RZM8SUS (expected: 5K4RZM8SUS )
2025-07-29 12:27:09 : INFO  : rokokostudiopreview : Downloaded version of Rokoko Studio Preview is 1.0.1 on versionKey CFBundleVersion, same as installed.
2025-07-29 12:27:09 : DEBUG : rokokostudiopreview : Unmounting /Volumes/Rokoko Studio Preview 1
2025-07-29 12:27:10 : DEBUG : rokokostudiopreview : Debugging enabled, Unmounting output was:
"disk5" ejected.
2025-07-29 12:27:10 : DEBUG : rokokostudiopreview : DEBUG mode 1, not reopening anything
2025-07-29 12:27:10 : REG   : rokokostudiopreview : No new version to install
2025-07-29 12:27:10 : REQ   : rokokostudiopreview : ################## End Installomator, exit code 0 


```
