### PR TITLE
Add Label Nextcloud Talk

### DIFF
--- a/fragments/labels/nextcloudtalk.sh
+++ b/fragments/labels/nextcloudtalk.sh
@@ -1,0 +1,7 @@
+nextcloudtalk)
+    name="Nextcloud Talk"
+    type="dmg"
+    downloadURL="https://github.com/nextcloud-releases/talk-desktop/releases/latest/download/Nextcloud.Talk-macos-universal.dmg"
+    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i ^location | grep -oE '/v[0-9]+\.[0-9]+\.[0-9]+/' | cut -d '/' -f2 | sed 's/^v//')"
+    expectedTeamID="NKUJUXUJ3B"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Nextcloud Talk is a Chat & Video Conferencing Tool from Nextcloud
https://nextcloud.com/talk/

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
sudo Installomator/utils/assemble.sh nextcloudtalk DEBUG=0
2025-07-30 11:35:47 : INFO  : nextcloudtalk : setting variable from argument DEBUG=0 2025-07-30 11:35:47 : INFO  : nextcloudtalk : Total items in argumentsArray: 1 2025-07-30 11:35:47 : INFO  : nextcloudtalk : argumentsArray: DEBUG=0
2025-07-30 11:35:47 : REQ   : nextcloudtalk : ################## Start Installomator v. 10.9beta, date 2025-07-30
2025-07-30 11:35:47 : INFO  : nextcloudtalk : ################## Version: 10.9beta
2025-07-30 11:35:47 : INFO  : nextcloudtalk : ################## Date: 2025-07-30
2025-07-30 11:35:47 : INFO  : nextcloudtalk : ################## nextcloudtalk
2025-07-30 11:35:47 : INFO  : nextcloudtalk : SwiftDialog is not installed, clear cmd file var
2025-07-30 11:35:48 : INFO  : nextcloudtalk : Reading arguments again: DEBUG=0
2025-07-30 11:35:48 : INFO  : nextcloudtalk : BLOCKING_PROCESS_ACTION=tell_user
2025-07-30 11:35:48 : INFO  : nextcloudtalk : NOTIFY=success
2025-07-30 11:35:48 : INFO  : nextcloudtalk : LOGGING=INFO
2025-07-30 11:35:48 : INFO  : nextcloudtalk : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-07-30 11:35:48 : INFO  : nextcloudtalk : Label type: dmg
2025-07-30 11:35:48 : INFO  : nextcloudtalk : archiveName: Nextcloud Talk.dmg
2025-07-30 11:35:48 : INFO  : nextcloudtalk : no blocking processes defined, using Nextcloud Talk as default
2025-07-30 11:35:48 : INFO  : nextcloudtalk : App(s) found: /Applications/Nextcloud Talk.app
2025-07-30 11:35:48 : INFO  : nextcloudtalk : found app at /Applications/Nextcloud Talk.app, version 1.2.3, on versionKey CFBundleShortVersionString
2025-07-30 11:35:48 : INFO  : nextcloudtalk : appversion: 1.2.3
2025-07-30 11:35:48 : INFO  : nextcloudtalk : Latest version of Nextcloud Talk is 1.2.5
2025-07-30 11:35:48 : REQ   : nextcloudtalk : Downloading https://github.com/nextcloud-releases/talk-desktop/releases/latest/download/Nextcloud.Talk-macos-universal.dmg to Nextcloud Talk.dmg
2025-07-30 11:36:01 : INFO  : nextcloudtalk : Downloaded Nextcloud Talk.dmg – Type is  zlib compressed data – SHA is 2110507230731e15ed713ecd04480f87b28c0199 – Size is 263164 kB
2025-07-30 11:36:01 : INFO  : nextcloudtalk : found blocking process Nextcloud Talk
2025-07-30 11:36:04 : INFO  : nextcloudtalk : telling app Nextcloud Talk to quit
2025-07-30 11:36:04 : INFO  : nextcloudtalk : waiting 30 seconds for processes to quit
2025-07-30 11:36:34 : REQ   : nextcloudtalk : no more blocking processes, continue with update
2025-07-30 11:36:34 : REQ   : nextcloudtalk : Installing Nextcloud Talk
2025-07-30 11:36:34 : INFO  : nextcloudtalk : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6xNCtqVc0A/Nextcloud Talk.dmg
2025-07-30 11:36:37 : INFO  : nextcloudtalk : Mounted: /Volumes/NextcloudTalk
2025-07-30 11:36:37 : INFO  : nextcloudtalk : Verifying: /Volumes/NextcloudTalk/Nextcloud Talk.app
2025-07-30 11:36:42 : INFO  : nextcloudtalk : Team ID matching: NKUJUXUJ3B (expected: NKUJUXUJ3B )
2025-07-30 11:36:42 : INFO  : nextcloudtalk : Downloaded version of Nextcloud Talk is 1.2.5 on versionKey CFBundleShortVersionString (replacing version 1.2.3).
2025-07-30 11:36:42 : INFO  : nextcloudtalk : App has LSMinimumSystemVersion: 11.0
2025-07-30 11:36:42 : WARN  : nextcloudtalk : Removing existing /Applications/Nextcloud Talk.app
2025-07-30 11:36:43 : INFO  : nextcloudtalk : Copy /Volumes/NextcloudTalk/Nextcloud Talk.app to /Applications
2025-07-30 11:36:44 : WARN  : nextcloudtalk : Changing owner to frose
2025-07-30 11:36:44 : INFO  : nextcloudtalk : Finishing...
2025-07-30 11:36:47 : INFO  : nextcloudtalk : App(s) found: /Applications/Nextcloud Talk.app
2025-07-30 11:36:47 : INFO  : nextcloudtalk : found app at /Applications/Nextcloud Talk.app, version 1.2.5, on versionKey CFBundleShortVersionString
2025-07-30 11:36:47 : REQ   : nextcloudtalk : Installed Nextcloud Talk, version 1.2.5
2025-07-30 11:36:47 : INFO  : nextcloudtalk : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-07-30 11:36:47 : INFO  : nextcloudtalk : Telling app Nextcloud Talk.app to open
2025-07-30 11:36:48 : INFO  : nextcloudtalk : Reopened Nextcloud Talk.app as user
2025-07-30 11:36:48 : REQ   : nextcloudtalk : All done!
2025-07-30 11:36:48 : REQ   : nextcloudtalk : ################## End Installomator, exit code 0
```