### PR TITLE
Update topazvideo.sh to dmg installation

### DIFF
--- a/fragments/labels/topazvideo.sh
+++ b/fragments/labels/topazvideo.sh
@@ -1,9 +1,8 @@
 topazvideo|\
 topazvideoai)
     name="Topaz Video AI"
-    type="pkg"
+    type="dmg"
     appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'videoVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
     downloadURL="https://topazlabs.com/d/tvai/latest/mac/full"
-    archiveName="TopazVideoAI-${appNewVersion}.pkg"
     expectedTeamID="3G3JE37ZHF"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Topaz Video AI is provided as a dmg and not as a pkg. The pkg setting failed without error, in the sense that Topaz Video AI was not installed. After switching to dmg everything works fine.

**Log failed / pkg is set**
Script result: 2025-08-06 11:47:24 : REQ   :  : shifting arguments for Jamf
2025-08-06 11:47:24 : INFO  : topazvideoai : Total items in argumentsArray: 0
2025-08-06 11:47:24 : INFO  : topazvideoai : argumentsArray: 
2025-08-06 11:47:24 : REQ   : topazvideoai : ################## Start Installomator v. 10.8beta, date 2025-03-28
2025-08-06 11:47:24 : INFO  : topazvideoai : ################## Version: 10.8beta
2025-08-06 11:47:24 : INFO  : topazvideoai : ################## Date: 2025-03-28
2025-08-06 11:47:24 : INFO  : topazvideoai : ################## topazvideoai
2025-08-06 11:47:25 : INFO  : topazvideoai : Reading arguments again: 
2025-08-06 11:47:25 : INFO  : topazvideoai : BLOCKING_PROCESS_ACTION=tell_user
2025-08-06 11:47:25 : INFO  : topazvideoai : NOTIFY=success
2025-08-06 11:47:25 : INFO  : topazvideoai : LOGGING=INFO
2025-08-06 11:47:26 : INFO  : topazvideoai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-06 11:47:26 : INFO  : topazvideoai : Label type: pkg
2025-08-06 11:47:26 : INFO  : topazvideoai : archiveName: TopazVideoAI-7.1.0.pkg
2025-08-06 11:47:26 : INFO  : topazvideoai : no blocking processes defined, using Topaz Video AI as default
2025-08-06 11:47:26 : INFO  : topazvideoai : App(s) found: /Applications/Topaz Video AI.app
2025-08-06 11:47:26 : INFO  : topazvideoai : found app at /Applications/Topaz Video AI.app, version 6.2.2, on versionKey CFBundleShortVersionString
2025-08-06 11:47:26 : INFO  : topazvideoai : appversion: 6.2.2
2025-08-06 11:47:26 : INFO  : topazvideoai : Latest version of Topaz Video AI is 7.1.0
2025-08-06 11:47:26 : REQ   : topazvideoai : Downloading https://topazlabs.com/d/tvai/latest/mac/full to TopazVideoAI-7.1.0.pkg
2025-08-06 11:48:33 : INFO  : topazvideoai : Downloaded TopazVideoAI-7.1.0.pkg – Type is  bzip2 compressed data, block size = 100k – SHA is ebce6ee8ad9fe5195b2886cea31383ad78916681 – Size is 704636 kB
2025-08-06 11:48:33 : REQ   : topazvideoai : no more blocking processes, continue with update
2025-08-06 11:48:33 : REQ   : topazvideoai : Installing Topaz Video AI
2025-08-06 11:48:33 : INFO  : topazvideoai : Verifying: TopazVideoAI-7.1.0.pkg
2025-08-06 11:48:34 : INFO  : topazvideoai : Team ID: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2025-08-06 11:48:34 : INFO  : topazvideoai : Installing TopazVideoAI-7.1.0.pkg to /
2025-08-06 11:48:35 : INFO  : topazvideoai : Finishing...
2025-08-06 11:48:38 : INFO  : topazvideoai : App(s) found: /Applications/Topaz Video AI.app
2025-08-06 11:48:38 : INFO  : topazvideoai : found app at /Applications/Topaz Video AI.app, version 6.2.2, on versionKey CFBundleShortVersionString
2025-08-06 11:48:38 : REQ   : topazvideoai : Installed Topaz Video AI, version 7.1.0
2025-08-06 11:48:38 : INFO  : topazvideoai : notifying
2025-08-06 11:48:39 : INFO  : topazvideoai : Installomator did not close any apps, so no need to reopen any apps.
2025-08-06 11:48:39 : REQ   : topazvideoai : All done!
2025-08-06 11:48:39 : REQ   : topazvideoai : ################## End Installomator, exit code 0 

**Log succeed / dmg is set**
Script result: 2025-08-06 12:37:43 : REQ   :  : shifting arguments for Jamf
2025-08-06 12:37:43 : INFO  : topazvideoai : Total items in argumentsArray: 0
2025-08-06 12:37:43 : INFO  : topazvideoai : argumentsArray: 
2025-08-06 12:37:43 : REQ   : topazvideoai : ################## Start Installomator v. 10.8beta, date 2025-03-28
2025-08-06 12:37:43 : INFO  : topazvideoai : ################## Version: 10.8beta
2025-08-06 12:37:43 : INFO  : topazvideoai : ################## Date: 2025-03-28
2025-08-06 12:37:43 : INFO  : topazvideoai : ################## topazvideoai
2025-08-06 12:37:44 : INFO  : topazvideoai : Reading arguments again: 
2025-08-06 12:37:45 : INFO  : topazvideoai : BLOCKING_PROCESS_ACTION=tell_user
2025-08-06 12:37:45 : INFO  : topazvideoai : NOTIFY=success
2025-08-06 12:37:45 : INFO  : topazvideoai : LOGGING=INFO
2025-08-06 12:37:45 : INFO  : topazvideoai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-06 12:37:45 : INFO  : topazvideoai : Label type: dmg
2025-08-06 12:37:45 : INFO  : topazvideoai : archiveName: Topaz Video AI.dmg
2025-08-06 12:37:45 : INFO  : topazvideoai : no blocking processes defined, using Topaz Video AI as default
2025-08-06 12:37:45 : INFO  : topazvideoai : App(s) found: /Applications/Topaz Video AI.app
2025-08-06 12:37:45 : INFO  : topazvideoai : found app at /Applications/Topaz Video AI.app, version 6.2.2, on versionKey CFBundleShortVersionString
2025-08-06 12:37:45 : INFO  : topazvideoai : appversion: 6.2.2
2025-08-06 12:37:45 : INFO  : topazvideoai : Latest version of Topaz Video AI is 7.1.0
2025-08-06 12:37:45 : REQ   : topazvideoai : Downloading https://topazlabs.com/d/tvai/latest/mac/full to Topaz Video AI.dmg
2025-08-06 12:38:45 : INFO  : topazvideoai : Downloaded Topaz Video AI.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is ebce6ee8ad9fe5195b2886cea31383ad78916681 – Size is 705452 kB
2025-08-06 12:38:45 : REQ   : topazvideoai : no more blocking processes, continue with update
2025-08-06 12:38:45 : REQ   : topazvideoai : Installing Topaz Video AI
2025-08-06 12:38:45 : INFO  : topazvideoai : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5isl3cjrby/Topaz Video AI.dmg
2025-08-06 12:39:18 : INFO  : topazvideoai : Mounted: /Volumes/Topaz Video AI 7.1.0
2025-08-06 12:39:18 : INFO  : topazvideoai : Verifying: /Volumes/Topaz Video AI 7.1.0/Topaz Video AI.app
2025-08-06 12:40:07 : INFO  : topazvideoai : Team ID matching: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2025-08-06 12:40:07 : INFO  : topazvideoai : Downloaded version of Topaz Video AI is 7.1.0 on versionKey CFBundleShortVersionString (replacing version 6.2.2).
2025-08-06 12:40:07 : INFO  : topazvideoai : App has LSMinimumSystemVersion: 10.14
2025-08-06 12:40:07 : WARN  : topazvideoai : Removing existing /Applications/Topaz Video AI.app
2025-08-06 12:40:08 : INFO  : topazvideoai : Copy /Volumes/Topaz Video AI 7.1.0/Topaz Video AI.app to /Applications
2025-08-06 12:40:46 : WARN  : topazvideoai : Changing owner to xxx.yyy
2025-08-06 12:40:46 : INFO  : topazvideoai : Finishing...
2025-08-06 12:40:49 : INFO  : topazvideoai : App(s) found: /Applications/Topaz Video AI.app
2025-08-06 12:40:49 : INFO  : topazvideoai : found app at /Applications/Topaz Video AI.app, version 7.1.0, on versionKey CFBundleShortVersionString
2025-08-06 12:40:49 : REQ   : topazvideoai : Installed Topaz Video AI, version 7.1.0
2025-08-06 12:40:49 : INFO  : topazvideoai : notifying
2025-08-06 12:40:50 : INFO  : topazvideoai : Installomator did not close any apps, so no need to reopen any apps.
2025-08-06 12:40:50 : REQ   : topazvideoai : All done!
2025-08-06 12:40:50 : REQ   : topazvideoai : ################## End Installomator, exit code 0 