### PR TITLE
updated googleadseditor

### DIFF
--- a/fragments/labels/googleadseditor.sh
+++ b/fragments/labels/googleadseditor.sh
@@ -2,7 +2,7 @@ googleadseditor)
     name="Google Ads Editor"
     type="dmg"
     downloadURL="https://dl.google.com/adwords_editor/google_ads_editor.dmg"
-    appNewVersion="$(curl -s "https://support.google.com/google-ads/editor/topic/13728" | grep -E -o "Google Ads Editor version.{1,4}" | head -1 | tail -c 4)"
+    appNewVersion="$(curl -s "https://support.google.com/google-ads/editor/topic/13728" | grep -Eo 'Google Ads Editor version [0-9]+(\.[0-9]+)*' | head -1 | grep -Eo '[0-9]+(\.[0-9]+)*')"
     appCustomVersion(){cat /Applications/Google\ Ads\ Editor.app/Contents/Versions/*/Google\ Ads\ Editor.app/Contents/locale/content/welcome1/welcome1-en-US.htm | grep -o -E " about version.{0,4}" | tail -c 4}
     expectedTeamID="EQHXZ8M8AV"
     ;;


### PR DESCRIPTION
The appNewVersion was only reporting 2.1 instead of 2.10 updated so it now correctly pulls the correct version

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** old NewAppVersion was only reporting 2.1 instead of 2.10 as the grep command was only lookg for 4 characters, updated to support 2.10 and above

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

2025-08-06 13:01:53 : INFO  : googleadseditor : setting variable from argument DEBUG=1
2025-08-06 13:01:53 : INFO  : googleadseditor : Total items in argumentsArray: 1
2025-08-06 13:01:53 : INFO  : googleadseditor : argumentsArray: DEBUG=1
2025-08-06 13:01:53 : REQ   : googleadseditor : ################## Start Installomator v. 10.9beta, date 2025-08-06
2025-08-06 13:01:53 : INFO  : googleadseditor : ################## Version: 10.9beta
2025-08-06 13:01:53 : INFO  : googleadseditor : ################## Date: 2025-08-06
2025-08-06 13:01:53 : INFO  : googleadseditor : ################## googleadseditor
2025-08-06 13:01:53 : DEBUG : googleadseditor : DEBUG mode 1 enabled.
2025-08-06 13:01:53 : INFO  : googleadseditor : SwiftDialog is not installed, clear cmd file var
2025-08-06 13:01:54 : INFO  : googleadseditor : Reading arguments again: DEBUG=1
2025-08-06 13:01:54 : DEBUG : googleadseditor : argument: DEBUG=1
2025-08-06 13:01:54 : DEBUG : googleadseditor : name=Google Ads Editor
2025-08-06 13:01:54 : DEBUG : googleadseditor : appName=
2025-08-06 13:01:54 : DEBUG : googleadseditor : type=dmg
2025-08-06 13:01:54 : DEBUG : googleadseditor : archiveName=
2025-08-06 13:01:54 : DEBUG : googleadseditor : downloadURL=https://dl.google.com/adwords_editor/google_ads_editor.dmg
2025-08-06 13:01:54 : DEBUG : googleadseditor : curlOptions=
2025-08-06 13:01:54 : DEBUG : googleadseditor : appNewVersion=2.10
2025-08-06 13:01:54 : DEBUG : googleadseditor : appCustomVersion function: Defined. 
2025-08-06 13:01:54 : DEBUG : googleadseditor : versionKey=CFBundleShortVersionString
2025-08-06 13:01:54 : DEBUG : googleadseditor : packageID=
2025-08-06 13:01:54 : DEBUG : googleadseditor : pkgName=
2025-08-06 13:01:54 : DEBUG : googleadseditor : choiceChangesXML=
2025-08-06 13:01:54 : DEBUG : googleadseditor : expectedTeamID=EQHXZ8M8AV
2025-08-06 13:01:54 : DEBUG : googleadseditor : blockingProcesses=
2025-08-06 13:01:54 : DEBUG : googleadseditor : installerTool=
2025-08-06 13:01:54 : DEBUG : googleadseditor : CLIInstaller=
2025-08-06 13:01:54 : DEBUG : googleadseditor : CLIArguments=
2025-08-06 13:01:54 : DEBUG : googleadseditor : updateTool=
2025-08-06 13:01:54 : DEBUG : googleadseditor : updateToolArguments=
2025-08-06 13:01:54 : DEBUG : googleadseditor : updateToolRunAsCurrentUser=
2025-08-06 13:01:54 : INFO  : googleadseditor : BLOCKING_PROCESS_ACTION=tell_user
2025-08-06 13:01:54 : INFO  : googleadseditor : NOTIFY=success
2025-08-06 13:01:54 : INFO  : googleadseditor : LOGGING=DEBUG
2025-08-06 13:01:54 : INFO  : googleadseditor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-06 13:01:55 : INFO  : googleadseditor : Label type: dmg
2025-08-06 13:01:55 : INFO  : googleadseditor : archiveName: Google Ads Editor.dmg
2025-08-06 13:01:55 : INFO  : googleadseditor : no blocking processes defined, using Google Ads Editor as default
2025-08-06 13:01:55 : DEBUG : googleadseditor : Changing directory to /Users/jhawkins/Library/CloudStorage/OneDrive-GravityGlobal/Documents/GitHub/Installomator/build
2025-08-06 13:01:55 : INFO  : googleadseditor : Custom App Version detection is used, found 2.1
2025-08-06 13:01:55 : INFO  : googleadseditor : appversion: 2.1
2025-08-06 13:01:55 : INFO  : googleadseditor : Latest version of Google Ads Editor is 2.10
2025-08-06 13:01:55 : REQ   : googleadseditor : Downloading https://dl.google.com/adwords_editor/google_ads_editor.dmg to Google Ads Editor.dmg
2025-08-06 13:01:55 : DEBUG : googleadseditor : No Dialog connection, just download
2025-08-06 13:02:01 : INFO  : googleadseditor : Downloaded Google Ads Editor.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 283cedf4856ce7ee9e6b73b47fa2a80276b2c731 – Size is 322812 kB
2025-08-06 13:02:01 : DEBUG : googleadseditor : DEBUG mode 1, not checking for blocking processes
2025-08-06 13:02:01 : REQ   : googleadseditor : Installing Google Ads Editor
2025-08-06 13:02:01 : INFO  : googleadseditor : Mounting /Users/jhawkins/Library/CloudStorage/OneDrive-GravityGlobal/Documents/GitHub/Installomator/build/Google Ads Editor.dmg
2025-08-06 13:02:04 : DEBUG : googleadseditor : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $22296C83
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $D52F0979
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $EA94CD6A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $40A38CC8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $EA94CD6A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $39A2248E
verified CRC32 $FF3364A7
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/Google Ads Editor 1

2025-08-06 13:02:04 : INFO  : googleadseditor : Mounted: /Volumes/Google Ads Editor 1
2025-08-06 13:02:04 : INFO  : googleadseditor : Verifying: /Volumes/Google Ads Editor 1/Google Ads Editor.app
2025-08-06 13:02:04 : DEBUG : googleadseditor : App size: 911M  /Volumes/Google Ads Editor 1/Google Ads Editor.app
2025-08-06 13:02:06 : DEBUG : googleadseditor : Debugging enabled, App Verification output was:
/Volumes/Google Ads Editor 1/Google Ads Editor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Google LLC (EQHXZ8M8AV)

2025-08-06 13:02:06 : INFO  : googleadseditor : Team ID matching: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2025-08-06 13:02:06 : INFO  : googleadseditor : Downloaded version of Google Ads Editor is 14.10 on versionKey CFBundleShortVersionString (replacing version 2.1).
2025-08-06 13:02:06 : INFO  : googleadseditor : App has LSMinimumSystemVersion: 12.0
2025-08-06 13:02:06 : DEBUG : googleadseditor : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-08-06 13:02:06 : INFO  : googleadseditor : Finishing...
2025-08-06 13:02:09 : INFO  : googleadseditor : Custom App Version detection is used, found 2.1
2025-08-06 13:02:09 : REQ   : googleadseditor : Installed Google Ads Editor, version 14.10
2025-08-06 13:02:09 : INFO  : googleadseditor : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-08-06 13:02:09 : DEBUG : googleadseditor : Unmounting /Volumes/Google Ads Editor 1
2025-08-06 13:02:09 : DEBUG : googleadseditor : Debugging enabled, Unmounting output was:
"disk5" ejected.
2025-08-06 13:02:09 : DEBUG : googleadseditor : DEBUG mode 1, not reopening anything
2025-08-06 13:02:09 : REQ   : googleadseditor : All done!
2025-08-06 13:02:09 : REQ   : googleadseditor : ################## End Installomator, exit code 0

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
