### PR TITLE
Update BalenaEtcher label

### DIFF
--- a/fragments/labels/balenaetcher.sh
+++ b/fragments/labels/balenaetcher.sh
@@ -1,13 +1,12 @@
 balenaetcher)
     name="balenaEtcher"
     type="dmg"
-    version=$(versionFromGit balena-io etcher)
-    arch=$(uname -m)
-    if [[ "$arch" == "arm64" ]]; then
-        downloadURL="https://github.com/balena-io/etcher/releases/download/v${version}/balenaEtcher-${version}-arm64.dmg"
-    else
-        downloadURL="https://github.com/balena-io/etcher/releases/download/v${version}/balenaEtcher-${version}-x64.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="balenaEtcher-[0-9.]*-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="balenaEtcher-[0-9.]*-x64.dmg"
     fi
-    appNewVersion="$version"
+    downloadURL="$(downloadURLFromGit balena-io etcher)"
+    appNewVersion="$(versionFromGit balena-io etcher)"
     expectedTeamID="66H43P8FRG"
     ;;

--- a/fragments/labels/balenaetcher.sh
+++ b/fragments/labels/balenaetcher.sh
@@ -1,7 +1,13 @@
 balenaetcher)
     name="balenaEtcher"
     type="dmg"
-    downloadURL=$(downloadURLFromGit balena-io etcher )
-    appNewVersion=$(versionFromGit balena-io etcher )
+    version=$(versionFromGit balena-io etcher)
+    arch=$(uname -m)
+    if [[ "$arch" == "arm64" ]]; then
+        downloadURL="https://github.com/balena-io/etcher/releases/download/v${version}/balenaEtcher-${version}-arm64.dmg"
+    else
+        downloadURL="https://github.com/balena-io/etcher/releases/download/v${version}/balenaEtcher-${version}-x64.dmg"
+    fi
+    appNewVersion="$version"
     expectedTeamID="66H43P8FRG"
     ;;


### PR DESCRIPTION
This label update adds architecture check for balenaEtcher otherwise it downloads the latest AppleSilicon version even on an Intel machine

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes 

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Installomator Log 
```
2025-08-07 11:34:17 : INFO  : balenaetcher : setting variable from argument DEBUG=1
2025-08-07 11:34:17 : INFO  : balenaetcher : Total items in argumentsArray: 1
2025-08-07 11:34:17 : INFO  : balenaetcher : argumentsArray: DEBUG=1
2025-08-07 11:34:17 : REQ   : balenaetcher : ################## Start Installomator v. 10.9beta, date 2025-08-07
2025-08-07 11:34:17 : INFO  : balenaetcher : ################## Version: 10.9beta
2025-08-07 11:34:17 : INFO  : balenaetcher : ################## Date: 2025-08-07
2025-08-07 11:34:17 : INFO  : balenaetcher : ################## balenaetcher
2025-08-07 11:34:17 : DEBUG : balenaetcher : DEBUG mode 1 enabled.
2025-08-07 11:34:18 : INFO  : balenaetcher : Reading arguments again: DEBUG=1
2025-08-07 11:34:18 : DEBUG : balenaetcher : argument: DEBUG=1
2025-08-07 11:34:18 : DEBUG : balenaetcher : name=balenaEtcher
2025-08-07 11:34:18 : DEBUG : balenaetcher : appName=
2025-08-07 11:34:18 : DEBUG : balenaetcher : type=dmg
2025-08-07 11:34:18 : DEBUG : balenaetcher : archiveName=
2025-08-07 11:34:18 : DEBUG : balenaetcher : downloadURL=https://github.com/balena-io/etcher/releases/download/v2.1.4/balenaEtcher-2.1.4-arm64.dmg
2025-08-07 11:34:18 : DEBUG : balenaetcher : curlOptions=
2025-08-07 11:34:18 : DEBUG : balenaetcher : appNewVersion=2.1.4
2025-08-07 11:34:18 : DEBUG : balenaetcher : appCustomVersion function: Not defined
2025-08-07 11:34:18 : DEBUG : balenaetcher : versionKey=CFBundleShortVersionString
2025-08-07 11:34:18 : DEBUG : balenaetcher : packageID=
2025-08-07 11:34:18 : DEBUG : balenaetcher : pkgName=
2025-08-07 11:34:18 : DEBUG : balenaetcher : choiceChangesXML=
2025-08-07 11:34:18 : DEBUG : balenaetcher : expectedTeamID=66H43P8FRG
2025-08-07 11:34:18 : DEBUG : balenaetcher : blockingProcesses=
2025-08-07 11:34:18 : DEBUG : balenaetcher : installerTool=
2025-08-07 11:34:18 : DEBUG : balenaetcher : CLIInstaller=
2025-08-07 11:34:18 : DEBUG : balenaetcher : CLIArguments=
2025-08-07 11:34:18 : DEBUG : balenaetcher : updateTool=
2025-08-07 11:34:18 : DEBUG : balenaetcher : updateToolArguments=
2025-08-07 11:34:18 : DEBUG : balenaetcher : updateToolRunAsCurrentUser=
2025-08-07 11:34:18 : INFO  : balenaetcher : BLOCKING_PROCESS_ACTION=tell_user
2025-08-07 11:34:18 : INFO  : balenaetcher : NOTIFY=success
2025-08-07 11:34:18 : INFO  : balenaetcher : LOGGING=DEBUG
2025-08-07 11:34:18 : INFO  : balenaetcher : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-07 11:34:18 : INFO  : balenaetcher : Label type: dmg
2025-08-07 11:34:18 : INFO  : balenaetcher : archiveName: balenaEtcher.dmg
2025-08-07 11:34:18 : INFO  : balenaetcher : no blocking processes defined, using balenaEtcher as default
2025-08-07 11:34:18 : DEBUG : balenaetcher : Changing directory to /Users/gustavo.sanchez/Documents/Installomator-Contributions/Installomator/build
2025-08-07 11:34:18 : INFO  : balenaetcher : App(s) found: /Applications/balenaEtcher.app
2025-08-07 11:34:18 : INFO  : balenaetcher : found app at /Applications/balenaEtcher.app, version 2.1.4, on versionKey CFBundleShortVersionString
2025-08-07 11:34:18 : INFO  : balenaetcher : appversion: 2.1.4
2025-08-07 11:34:18 : INFO  : balenaetcher : Latest version of balenaEtcher is 2.1.4
2025-08-07 11:34:18 : WARN  : balenaetcher : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-08-07 11:34:18 : REQ   : balenaetcher : Downloading https://github.com/balena-io/etcher/releases/download/v2.1.4/balenaEtcher-2.1.4-arm64.dmg to balenaEtcher.dmg
2025-08-07 11:34:18 : DEBUG : balenaetcher : No Dialog connection, just download
2025-08-07 11:34:24 : INFO  : balenaetcher : Downloaded balenaEtcher.dmg – Type is  zlib compressed data – SHA is f11fb9137c9f67646e442f354c8ff91443f13ccb – Size is 164060 kB
2025-08-07 11:34:24 : DEBUG : balenaetcher : DEBUG mode 1, not checking for blocking processes
2025-08-07 11:34:24 : REQ   : balenaetcher : Installing balenaEtcher
2025-08-07 11:34:24 : INFO  : balenaetcher : Mounting /Users/gustavo.sanchez/Documents/Installomator-Contributions/Installomator/build/balenaEtcher.dmg
2025-08-07 11:34:28 : DEBUG : balenaetcher : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $1AFCC6A2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $4FE5F551
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $2F17EEDC
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $B8D71898
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $2F17EEDC
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $7CDBDAA8
verified CRC32 $8C616A5C
/dev/disk10             GUID_partition_scheme
/dev/disk10s1           Apple_HFS                       /Volumes/balenaEtcher 2

2025-08-07 11:34:28 : INFO  : balenaetcher : Mounted: /Volumes/balenaEtcher 2
2025-08-07 11:34:28 : INFO  : balenaetcher : Verifying: /Volumes/balenaEtcher 2/balenaEtcher.app
2025-08-07 11:34:28 : DEBUG : balenaetcher : App size: 376M     /Volumes/balenaEtcher 2/balenaEtcher.app
2025-08-07 11:34:29 : DEBUG : balenaetcher : Debugging enabled, App Verification output was:
/Volumes/balenaEtcher 2/balenaEtcher.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Balena Ltd (66H43P8FRG)

2025-08-07 11:34:29 : INFO  : balenaetcher : Team ID matching: 66H43P8FRG (expected: 66H43P8FRG )
2025-08-07 11:34:29 : INFO  : balenaetcher : Downloaded version of balenaEtcher is 2.1.4 on versionKey CFBundleShortVersionString, same as installed.
2025-08-07 11:34:29 : DEBUG : balenaetcher : Unmounting /Volumes/balenaEtcher 2
2025-08-07 11:34:30 : DEBUG : balenaetcher : Debugging enabled, Unmounting output was:
"disk10" ejected.
2025-08-07 11:34:30 : DEBUG : balenaetcher : DEBUG mode 1, not reopening anything
2025-08-07 11:34:30 : REG   : balenaetcher : No new version to install
2025-08-07 11:34:30 : REQ   : balenaetcher : ################## End Installomator, exit code 0 
```
