### PR TITLE
Update processing4.sh

### DIFF
--- a/fragments/labels/processing4.sh
+++ b/fragments/labels/processing4.sh
@@ -1,9 +1,8 @@
 processing4)
     name="Processing"
-    type="zip"
-    archiveName="Processing-[0-9.]*-macOS-$( if [ "$( arch )" = "arm64" ]; then echo "aarch64" ; else echo "x64" ; fi ).zip"
+    type="dmg"
+    archiveName="Processing-[0-9.]*-macOS-$( if [ "$( arch )" = "arm64" ]; then echo "aarch64" ; else echo "x64" ; fi ).dmg"
     downloadURL=$(downloadURLFromGit processing processing4)
     appNewVersion=$(versionFromGit processing processing4)
-    expectedTeamID="8SBRM6J77J"
-    appCustomVersion(){ echo "$(defaults read /Applications/Processing.app/Contents/Info.plist CFBundleVersion )$( defaults read /Applications/Processing.app/Contents/Info.plist CFBundleShortVersionString )" }
+    expectedTeamID="6297K33652"
     ;;


### PR DESCRIPTION
Processing4 changed from zip to dmg. I've updated the type and archive name to reflect this. Updated the expectedTeamID.

Tested on both x64 and arm64

Also, the custom app version was generating 4.4.44.4.4 instead of 4.4.4. I removed the customVersion and installomator reports the correct version (4.4.4)

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
There is an open pull request from April #2309 that has the same Iteam Id update, but I didn't see one for the change from zip to dmg

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
Processing4 switched from zip to dmg, so the current label wasn't working. I also updated the Team ID. I noticed when running assemble.sh that it was reporting the version as 4.4.44.4.4 instead of 4.4.4, so I removed the custom version and let Installomator find the version, which it did correctly.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Adding to end

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2475 
Fixes processing4 part of #2209 

```
2025-08-11 13:00:12 : INFO  : processing4 : setting variable from argument LOGGING=INFO
2025-08-11 13:00:12 : INFO  : processing4 : setting variable from argument DEBUG=0
2025-08-11 13:00:12 : INFO  : processing4 : Total items in argumentsArray: 2
2025-08-11 13:00:12 : INFO  : processing4 : argumentsArray: LOGGING=INFO DEBUG=0
2025-08-11 13:00:12 : REQ   : processing4 : ################## Start Installomator v. 10.9beta, date 2025-08-11
2025-08-11 13:00:12 : INFO  : processing4 : ################## Version: 10.9beta
2025-08-11 13:00:12 : INFO  : processing4 : ################## Date: 2025-08-11
2025-08-11 13:00:12 : INFO  : processing4 : ################## processing4
2025-08-11 13:00:14 : INFO  : processing4 : Reading arguments again: LOGGING=INFO DEBUG=0
2025-08-11 13:00:14 : INFO  : processing4 : BLOCKING_PROCESS_ACTION=tell_user
2025-08-11 13:00:14 : INFO  : processing4 : NOTIFY=success
2025-08-11 13:00:14 : INFO  : processing4 : LOGGING=INFO
2025-08-11 13:00:14 : INFO  : processing4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-11 13:00:14 : INFO  : processing4 : Label type: dmg
2025-08-11 13:00:14 : INFO  : processing4 : archiveName: Processing-[0-9.]*-macOS-aarch64.dmg
2025-08-11 13:00:14 : INFO  : processing4 : no blocking processes defined, using Processing as default
2025-08-11 13:00:14 : INFO  : processing4 : name: Processing, appName: Processing.app
2025-08-11 13:00:14 : INFO  : processing4 : App(s) found: /Library/Application Support/Script Editor/Templates/Droplets/Recursive File Processing Droplet.app/Library/Application Support/Script Editor/Templates/Droplets/Recursive Image File Processing Droplet.app
2025-08-11 13:00:14 : WARN  : processing4 : could not determine location of Processing.app
2025-08-11 13:00:14 : INFO  : processing4 : appversion: 
2025-08-11 13:00:14 : INFO  : processing4 : Latest version of Processing is 13044.4.4
2025-08-11 13:00:14 : REQ   : processing4 : Downloading https://github.com/processing/processing4/releases/download/processing-1304-4.4.4/processing-4.4.4-macos-aarch64.dmg to Processing-[0-9.]*-macOS-aarch64.dmg
2025-08-11 13:00:19 : INFO  : processing4 : Downloaded Processing-[0-9.]*-macOS-aarch64.dmg – Type is  zlib compressed data – SHA is f621871a95170964fbbe041c9060769105fd8f1a – Size is 427272 kB
2025-08-11 13:00:19 : REQ   : processing4 : no more blocking processes, continue with update
2025-08-11 13:00:19 : REQ   : processing4 : Installing Processing
2025-08-11 13:00:19 : INFO  : processing4 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.E3eHQRokwT/Processing-[0-9.]*-macOS-aarch64.dmg
2025-08-11 13:00:21 : INFO  : processing4 : Mounted: /Volumes/Processing
2025-08-11 13:00:21 : INFO  : processing4 : Verifying: /Volumes/Processing/Processing.app
2025-08-11 13:00:24 : INFO  : processing4 : Team ID matching: 6297K33652 (expected: 6297K33652 )
2025-08-11 13:00:24 : INFO  : processing4 : Installing Processing version 4.4.4 on versionKey CFBundleShortVersionString.
2025-08-11 13:00:24 : INFO  : processing4 : App has LSMinimumSystemVersion: 10.13
2025-08-11 13:00:24 : INFO  : processing4 : Copy /Volumes/Processing/Processing.app to /Applications
2025-08-11 13:00:25 : WARN  : processing4 : Changing owner to xxxxxxx
2025-08-11 13:00:25 : INFO  : processing4 : Finishing...
2025-08-11 13:00:28 : INFO  : processing4 : App(s) found: /Applications/Processing.app
2025-08-11 13:00:28 : INFO  : processing4 : found app at /Applications/Processing.app, version 4.4.4, on versionKey CFBundleShortVersionString
2025-08-11 13:00:28 : REQ   : processing4 : Installed Processing, version 4.4.4
2025-08-11 13:00:28 : INFO  : processing4 : notifying
2025-08-11 13:00:28 : INFO  : processing4 : Installomator did not close any apps, so no need to reopen any apps.
2025-08-11 13:00:28 : REQ   : processing4 : All done!
2025-08-11 13:00:28 : REQ   : processing4 : ################## End Installomator, exit code 0 
```