### PR TITLE
Update Macports (adding Sequoia support)

### DIFF
--- a/fragments/labels/macports.sh
+++ b/fragments/labels/macports.sh
@@ -3,9 +3,9 @@ macports)
     type="pkg"
     #buildVersion=$(uname -r | cut -d '.' -f 1)
     case $(uname -r | cut -d '.' -f 1) in
-	24)
-	    archiveName="Sequoia.pkg"
-	    ;;
+	    24)
+	        archiveName="Sequoia.pkg"
+	        ;;
         23)
             archiveName="Sonoma.pkg"
             ;;

--- a/fragments/labels/macports.sh
+++ b/fragments/labels/macports.sh
@@ -27,7 +27,7 @@ macports)
     esac
     downloadURL=$(downloadURLFromGit macports macports-base)
     appNewVersion=$(versionFromGit macports macports-base)
-    appCustomVersion(){ if [ -x /opt/local/bin/port ]; then /opt/local/bin/port version | awk '{print $2}'; else "0"; fi }
+    appCustomVersion(){ if [ -x /opt/local/bin/port ]; then /opt/local/bin/port version | awk '{print $2}'; fi }
     updateTool="/opt/local/bin/port"
     updateToolArguments="selfupdate"
     expectedTeamID="QTA3A3B7F3"

--- a/fragments/labels/macports.sh
+++ b/fragments/labels/macports.sh
@@ -3,6 +3,9 @@ macports)
     type="pkg"
     #buildVersion=$(uname -r | cut -d '.' -f 1)
     case $(uname -r | cut -d '.' -f 1) in
+	24)
+	    archiveName="Sequoia.pkg"
+	    ;;
         23)
             archiveName="Sonoma.pkg"
             ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.
Also includes a fix for getCustomVersion to remove an else statement that caused an error log when running but doesn't actually affect the installation process.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-08-12 14:12:04 : INFO  : macports : setting variable from argument DEBUG=1
2025-08-12 14:12:04 : INFO  : macports : setting variable from argument LOGGING=INFO
2025-08-12 14:12:04 : INFO  : macports : Total items in argumentsArray: 2
2025-08-12 14:12:04 : INFO  : macports : argumentsArray: DEBUG=1 LOGGING=INFO
2025-08-12 14:12:04 : REQ   : macports : ################## Start Installomator v. 10.9beta, date 2025-08-12
2025-08-12 14:12:04 : INFO  : macports : ################## Version: 10.9beta
2025-08-12 14:12:04 : INFO  : macports : ################## Date: 2025-08-12
2025-08-12 14:12:04 : INFO  : macports : ################## macports
2025-08-12 14:12:04 : DEBUG : macports : DEBUG mode 1 enabled.
2025-08-12 14:12:06 : INFO  : macports : Reading arguments again: DEBUG=1 LOGGING=INFO
2025-08-12 14:12:06 : DEBUG : macports : argument: DEBUG=1
2025-08-12 14:12:06 : DEBUG : macports : argument: LOGGING=INFO
2025-08-12 14:12:06 : INFO  : macports : BLOCKING_PROCESS_ACTION=tell_user
2025-08-12 14:12:06 : INFO  : macports : NOTIFY=success
2025-08-12 14:12:06 : INFO  : macports : LOGGING=INFO
2025-08-12 14:12:06 : INFO  : macports : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-12 14:12:06 : INFO  : macports : Label type: pkg
2025-08-12 14:12:06 : INFO  : macports : archiveName: Sequoia.pkg
2025-08-12 14:12:06 : INFO  : macports : no blocking processes defined, using MacPorts as default
2025-08-12 14:12:06 : INFO  : macports : Custom App Version detection is used, found 
2025-08-12 14:12:06 : INFO  : macports : appversion: 
2025-08-12 14:12:06 : INFO  : macports : Latest version of MacPorts is 2.11.4
2025-08-12 14:12:06 : INFO  : macports : Sequoia.pkg exists and DEBUG mode 1 enabled, skipping download
2025-08-12 14:12:06 : REQ   : macports : Installing MacPorts
2025-08-12 14:12:06 : INFO  : macports : Verifying: Sequoia.pkg
2025-08-12 14:12:06 : INFO  : macports : Team ID: QTA3A3B7F3 (expected: QTA3A3B7F3 )
2025-08-12 14:12:06 : INFO  : macports : Finishing...
2025-08-12 14:12:09 : INFO  : macports : Custom App Version detection is used, found 
2025-08-12 14:12:09 : REQ   : macports : Installed MacPorts, version 2.11.4
2025-08-12 14:12:09 : INFO  : macports : notifying
2025-08-12 14:12:09 : REQ   : macports : All done!
2025-08-12 14:12:10 : REQ   : macports : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
