### PR TITLE
Add OBS iOS Camera

### DIFF
--- a/fragments/labels/obsioscamera.sh
+++ b/fragments/labels/obsioscamera.sh
@@ -1,0 +1,14 @@
+obsioscamera)
+    name="iOS Camera for OBS Studio"
+    type="pkg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="$(curl -fsL https://obs.camera/docs/getting-started/ios-camera-plugin-usb/ | tr '>' '\n' | grep -oE 'https://github.com/.*arm64.pkg' | sort | tail -1)"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="$(curl -fsL https://obs.camera/docs/getting-started/ios-camera-plugin-usb/ | tr '>' '\n' | grep -oE 'https://github.com/.*x86_64.pkg' | sort | tail -1)"
+    fi
+    appNewVersion=$(echo $downloadURL | grep -oe "-[0-99].[0-99].[0-99]-" | sed 's|-||g')
+    appCustomVersion(){
+      defaults read "/Library/Application Support/obs-studio/plugins/obs-ios-camera-source.plugin/Contents/Info.plist" CFBundleVersion
+    }
+    expectedTeamID="DQA7HX6GV3"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**

**Installomator log** 
Clean install:
```
2025-08-14 12:48:25 : INFO  : obsioscamera : setting variable from argument DEBUG=0
2025-08-14 12:48:25 : INFO  : obsioscamera : Total items in argumentsArray: 1
2025-08-14 12:48:25 : INFO  : obsioscamera : argumentsArray: DEBUG=0
2025-08-14 12:48:25 : REQ   : obsioscamera : ################## Start Installomator v. 10.9beta, date 2025-08-14
2025-08-14 12:48:25 : INFO  : obsioscamera : ################## Version: 10.9beta
2025-08-14 12:48:25 : INFO  : obsioscamera : ################## Date: 2025-08-14
2025-08-14 12:48:25 : INFO  : obsioscamera : ################## obsioscamera
2025-08-14 12:48:26 : INFO  : obsioscamera : Reading arguments again: DEBUG=0
2025-08-14 12:48:26 : INFO  : obsioscamera : BLOCKING_PROCESS_ACTION=tell_user
2025-08-14 12:48:26 : INFO  : obsioscamera : NOTIFY=success
2025-08-14 12:48:26 : INFO  : obsioscamera : LOGGING=INFO
2025-08-14 12:48:26 : INFO  : obsioscamera : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-14 12:48:26 : INFO  : obsioscamera : Label type: pkg
2025-08-14 12:48:26 : INFO  : obsioscamera : archiveName: iOS Camera for OBS Studio.pkg
2025-08-14 12:48:26 : INFO  : obsioscamera : no blocking processes defined, using iOS Camera for OBS Studio as default
2025-08-14 12:48:26.785 defaults[54158:650240] 
The domain/default pair of (/Library/Application Support/obs-studio/plugins/obs-ios-camera-source.plugin/Contents/Info.plist, CFBundleVersion) does not exist
2025-08-14 12:48:26 : INFO  : obsioscamera : Custom App Version detection is used, found 
2025-08-14 12:48:26 : INFO  : obsioscamera : appversion: 
2025-08-14 12:48:26 : INFO  : obsioscamera : Latest version of iOS Camera for OBS Studio is 2.9.6
2025-08-14 12:48:26 : REQ   : obsioscamera : Downloading https://github.com/wtsnz/obs-ios-camera-source/releases/download/v2.9.6/obs-ios-camera-source-2.9.6-macos-arm64.pkg to iOS Camera for OBS Studio.pkg
2025-08-14 12:48:27 : INFO  : obsioscamera : Downloaded iOS Camera for OBS Studio.pkg – Type is  xar archive compressed TOC – SHA is ca17a225e7e2cf25c561b00d283ae9d383f83158 – Size is 1332 kB
2025-08-14 12:48:27 : REQ   : obsioscamera : no more blocking processes, continue with update
2025-08-14 12:48:27 : REQ   : obsioscamera : Installing iOS Camera for OBS Studio
2025-08-14 12:48:27 : INFO  : obsioscamera : Verifying: iOS Camera for OBS Studio.pkg
2025-08-14 12:48:27 : INFO  : obsioscamera : Team ID: DQA7HX6GV3 (expected: DQA7HX6GV3 )
2025-08-14 12:48:27 : INFO  : obsioscamera : Installing iOS Camera for OBS Studio.pkg to /
2025-08-14 12:48:30 : INFO  : obsioscamera : Finishing...
2025-08-14 12:48:33 : INFO  : obsioscamera : Custom App Version detection is used, found 2.9.6
2025-08-14 12:48:33 : REQ   : obsioscamera : Installed iOS Camera for OBS Studio, version 2.9.6
2025-08-14 12:48:33 : INFO  : obsioscamera : notifying
2025-08-14 12:48:33 : INFO  : obsioscamera : Installomator did not close any apps, so no need to reopen any apps.
2025-08-14 12:48:33 : REQ   : obsioscamera : All done!
2025-08-14 12:48:33 : REQ   : obsioscamera : ################## End Installomator, exit code 0 
```

Second run, to verify version checking:
```
2025-08-14 12:49:05 : INFO  : obsioscamera : setting variable from argument DEBUG=0
2025-08-14 12:49:05 : INFO  : obsioscamera : Total items in argumentsArray: 1
2025-08-14 12:49:05 : INFO  : obsioscamera : argumentsArray: DEBUG=0
2025-08-14 12:49:05 : REQ   : obsioscamera : ################## Start Installomator v. 10.9beta, date 2025-08-14
2025-08-14 12:49:05 : INFO  : obsioscamera : ################## Version: 10.9beta
2025-08-14 12:49:05 : INFO  : obsioscamera : ################## Date: 2025-08-14
2025-08-14 12:49:05 : INFO  : obsioscamera : ################## obsioscamera
2025-08-14 12:49:06 : INFO  : obsioscamera : Reading arguments again: DEBUG=0
2025-08-14 12:49:06 : INFO  : obsioscamera : BLOCKING_PROCESS_ACTION=tell_user
2025-08-14 12:49:06 : INFO  : obsioscamera : NOTIFY=success
2025-08-14 12:49:06 : INFO  : obsioscamera : LOGGING=INFO
2025-08-14 12:49:06 : INFO  : obsioscamera : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-14 12:49:06 : INFO  : obsioscamera : Label type: pkg
2025-08-14 12:49:06 : INFO  : obsioscamera : archiveName: iOS Camera for OBS Studio.pkg
2025-08-14 12:49:06 : INFO  : obsioscamera : no blocking processes defined, using iOS Camera for OBS Studio as default
2025-08-14 12:49:06 : INFO  : obsioscamera : Custom App Version detection is used, found 2.9.6
2025-08-14 12:49:06 : INFO  : obsioscamera : appversion: 2.9.6
2025-08-14 12:49:06 : INFO  : obsioscamera : Latest version of iOS Camera for OBS Studio is 2.9.6
2025-08-14 12:49:06 : INFO  : obsioscamera : There is no newer version available.
2025-08-14 12:49:06 : INFO  : obsioscamera : Installomator did not close any apps, so no need to reopen any apps.
2025-08-14 12:49:06 : REQ   : obsioscamera : No newer version.
2025-08-14 12:49:06 : REQ   : obsioscamera : ################## End Installomator, exit code 0 
```
