### PR TITLE
Update logitechoptionsplus.sh

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -2,13 +2,13 @@ logitechoptionsplus)
     name="Logi Options+"
     appName="logioptionsplus.app"
     archiveName="logioptionsplus_installer.zip"
-    installerTool="logioptionsplus_installer.app"
+    installerTool="Logi Options+ Installer.app"
     type="zip"
     downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
     # Latest version of Logi Options+ requires macOS 12+
     # If older macOS is specified in the url for appNewVersion, it will never correspond to the installed version
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-12.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
-    CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
+    CLIInstaller="${installerTool}/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"
     ;;


### PR DESCRIPTION
There was a name change for the installerTool

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
There was a name change for the installerTool app file/folder

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=0
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : Total items in argumentsArray: 1
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : argumentsArray: DEBUG=0
2025-08-18 07:46:41 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.8, date 2025-03-28
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : ################## Version: 10.8
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : ################## Date: 2025-03-28
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2025-08-18 07:46:41 : INFO  : logitechoptionsplus : Reading arguments again: DEBUG=0
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : NOTIFY=silent
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : LOGGING=INFO
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : Label type: zip
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : archiveName: logioptionsplus_installer.zip
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : App(s) found: /Applications/logioptionsplus.app
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : found app at /Applications/logioptionsplus.app, version 1.93.755984, on versionKey CFBundleShortVersionString
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : appversion: 1.93.755984
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 1.93.755983
2025-08-18 07:46:42 : REQ   : logitechoptionsplus : Downloading https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip to logioptionsplus_installer.zip
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : Downloaded logioptionsplus_installer.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=store – SHA is 0e6dc53ce4effeb4b90de0c76a65ef75024a7a12 – Size is 19192 kB
2025-08-18 07:46:42 : REQ   : logitechoptionsplus : no more blocking processes, continue with update
2025-08-18 07:46:42 : REQ   : logitechoptionsplus : Installing Logi Options+
2025-08-18 07:46:42 : REQ   : logitechoptionsplus : installerTool used: Logi Options+ Installer.app
2025-08-18 07:46:42 : INFO  : logitechoptionsplus : Unzipping logioptionsplus_installer.zip
2025-08-18 07:46:43 : INFO  : logitechoptionsplus : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lvChpNaNYD/Logi Options+ Installer.app
2025-08-18 07:46:43 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2025-08-18 07:46:43.806 defaults[60469:1826690]
The domain/default pair of (/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lvChpNaNYD/Logi Options+ Installer.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2025-08-18 07:46:43 : INFO  : logitechoptionsplus : Downloaded version of Logi Options+ is  on versionKey CFBundleShortVersionString (replacing version 1.93.755984).
2025-08-18 07:46:43 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 13.0
2025-08-18 07:46:43 : INFO  : logitechoptionsplus : CLIInstaller exists, running installer command /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lvChpNaNYD/Logi Options+ Installer.app/Contents/MacOS/logioptionsplus_installer --quiet
2025-08-18 07:46:45 : INFO  : logitechoptionsplus : Succesfully ran /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lvChpNaNYD/Logi Options+ Installer.app/Contents/MacOS/logioptionsplus_installer --quiet
2025-08-18 07:46:45 : INFO  : logitechoptionsplus : Finishing...
2025-08-18 07:46:48 : INFO  : logitechoptionsplus : name: Logi Options+, appName: Logi Options+ Installer.app
2025-08-18 07:46:48 : INFO  : logitechoptionsplus : App(s) found: /Users/timdejong/Downloads/Logi Options+ Installer.app
2025-08-18 07:46:48 : WARN  : logitechoptionsplus : could not determine location of Logi Options+ Installer.app
2025-08-18 07:46:48 : REQ   : logitechoptionsplus : Installed Logi Options+
2025-08-18 07:46:48 : INFO  : logitechoptionsplus : Installomator did not close any apps, so no need to reopen any apps.
2025-08-18 07:46:48 : REQ   : logitechoptionsplus : All done!
2025-08-18 07:46:48 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes #2513