### PR TITLE
Create captureone.sh

### DIFF
--- a/fragments/labels/captureone.sh
+++ b/fragments/labels/captureone.sh
@@ -1,0 +1,9 @@
+captureone|captureonepro)
+    name="Capture One"
+    type="dmg"
+    appName="Capture One.app"
+    blockingProcesses=("Capture One")
+    expectedTeamID="5WTDB5F65L"
+    downloadURL=$(curl -fsL "https://www.captureone.com/en/account/download/trial-confirmation?intent=trial-pro" | grep -Eo 'https://downloads\.captureone\.pro/d/mac/[A-Za-z0-9]+/CaptureOne\.Mac\.[0-9\.]+\.dmg' | head -1)
+    appNewVersion=$(echo "$downloadURL" | sed -n 's/.*CaptureOne\.Mac\.\([0-9.]*\)\.dmg.*/\1/p')
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2025-08-18 10:21:49 : INFO  : captureone : setting variable from argument LOGGING=INFO
2025-08-18 10:21:49 : INFO  : captureone : Total items in argumentsArray: 1
2025-08-18 10:21:49 : INFO  : captureone : argumentsArray: LOGGING=INFO
2025-08-18 10:21:49 : REQ   : captureone : ################## Start Installomator v. 10.9beta, date 2025-08-18
2025-08-18 10:21:49 : INFO  : captureone : ################## Version: 10.9beta
2025-08-18 10:21:49 : INFO  : captureone : ################## Date: 2025-08-18
2025-08-18 10:21:49 : INFO  : captureone : ################## captureone
2025-08-18 10:21:49 : DEBUG : captureone : DEBUG mode 1 enabled.
2025-08-18 10:21:50 : INFO  : captureone : Reading arguments again: LOGGING=INFO
2025-08-18 10:21:50 : DEBUG : captureone : argument: LOGGING=INFO
2025-08-18 10:21:50 : INFO  : captureone : BLOCKING_PROCESS_ACTION=tell_user
2025-08-18 10:21:50 : INFO  : captureone : NOTIFY=success
2025-08-18 10:21:50 : INFO  : captureone : LOGGING=INFO
2025-08-18 10:21:50 : INFO  : captureone : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-18 10:21:50 : INFO  : captureone : Label type: dmg
2025-08-18 10:21:50 : INFO  : captureone : archiveName: Capture One.dmg
2025-08-18 10:21:50 : INFO  : captureone : name: Capture One, appName: Capture One.app
2025-08-18 10:21:51 : WARN  : captureone : No previous app found
2025-08-18 10:21:51 : WARN  : captureone : could not find Capture One.app
2025-08-18 10:21:51 : INFO  : captureone : appversion: 
2025-08-18 10:21:51 : INFO  : captureone : Latest version of Capture One is 16.6.4.6
2025-08-18 10:21:51 : INFO  : captureone : Capture One.dmg exists and DEBUG mode 1 enabled, skipping download
2025-08-18 10:21:51 : REQ   : captureone : Installing Capture One
2025-08-18 10:21:51 : INFO  : captureone : Mounting ./Capture One.dmg
2025-08-18 10:21:51 : INFO  : captureone : Mounted: /Volumes/Capture One 1
2025-08-18 10:21:51 : INFO  : captureone : Verifying: /Volumes/Capture One 1/Capture One.app
2025-08-18 10:22:09 : INFO  : captureone : Team ID matching: 5WTDB5F65L (expected: 5WTDB5F65L )
2025-08-18 10:22:09 : INFO  : captureone : Installing Capture One version 16.6.4.6 on versionKey CFBundleShortVersionString.
2025-08-18 10:22:09 : INFO  : captureone : App has LSMinimumSystemVersion: 13.0
2025-08-18 10:22:09 : INFO  : captureone : Finishing...
2025-08-18 10:22:12 : INFO  : captureone : name: Capture One, appName: Capture One.app
2025-08-18 10:22:12 : WARN  : captureone : No previous app found
2025-08-18 10:22:12 : WARN  : captureone : could not find Capture One.app
2025-08-18 10:22:12 : REQ   : captureone : Installed Capture One, version 16.6.4.6
2025-08-18 10:22:12 : INFO  : captureone : notifying
2025-08-18 10:22:12 : REQ   : captureone : All done!
2025-08-18 10:22:12 : REQ   : captureone : ################## End Installomator, exit code 0 
```
