### PR TITLE
Foxit PDF Editor Added to Labels

### DIFF
--- a/fragments/labels/foxitpdfeditor.sh
+++ b/fragments/labels/foxitpdfeditor.sh
@@ -1,0 +1,12 @@
+foxitpdfeditor)
+    name="Foxit PDF Editor"
+    type="pkg"
+    #packageID="com.foxit.pkg.pdfeditor"
+    downloadURL="https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac"
+    appNewVersion=$(curl -fsL "https://www.foxit.com/pdf-editor/version-history.html" \
+        | grep -oE 'Subscription Release\s+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
+        | head -n1 \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+    expectedTeamID="8GN47HTP75"
+    blockingProcesses=( "Foxit PDF Editor" )
+    ;;


### PR DESCRIPTION
Output:
```
./assemble.sh foxitpdfeditor DEBUG=0
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : setting variable from argument DEBUG=0
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : Total items in argumentsArray: 1
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : argumentsArray: DEBUG=0
2025-08-15 09:15:29 : REQ   : foxitpdfeditor : ################## Start Installomator v. 10.9beta, date 2025-08-15
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : ################## Version: 10.9beta
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : ################## Date: 2025-08-15
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : ################## foxitpdfeditor
2025-08-15 09:15:29 : INFO  : foxitpdfeditor : SwiftDialog is not installed, clear cmd file var
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : Reading arguments again: DEBUG=0
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : BLOCKING_PROCESS_ACTION=tell_user
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : NOTIFY=success
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : LOGGING=INFO
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : Label type: pkg
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : archiveName: Foxit PDF Editor.pkg
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : App(s) found: /Applications/Foxit PDF Editor.app
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : found app at /Applications/Foxit PDF Editor.app, version 2025.1.0.66692, on versionKey CFBundleShortVersionString
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : appversion: 2025.1.0.66692
2025-08-15 09:15:30 : INFO  : foxitpdfeditor : Latest version of Foxit PDF Editor is 2025.2.0.33046
2025-08-15 09:15:30 : REQ   : foxitpdfeditor : Downloading https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac to Foxit PDF Editor.pkg
2025-08-15 09:24:57 : INFO  : foxitpdfeditor : Downloaded Foxit PDF Editor.pkg – Type is  xar archive compressed TOC – SHA is 0bebba8a03761281de0b6773d527f10a92779297 – Size is 1524172 kB
2025-08-15 09:24:58 : INFO  : foxitpdfeditor : found blocking process Foxit PDF Editor
2025-08-15 09:25:12 : INFO  : foxitpdfeditor : telling app Foxit PDF Editor to quit
31:35: execution error: Foxit PDF Editor got an error: User canceled. (-128)
2025-08-15 09:25:12 : INFO  : foxitpdfeditor : waiting 30 seconds for processes to quit
2025-08-15 09:25:42 : REQ   : foxitpdfeditor : no more blocking processes, continue with update
2025-08-15 09:25:42 : REQ   : foxitpdfeditor : Installing Foxit PDF Editor
2025-08-15 09:25:42 : INFO  : foxitpdfeditor : Verifying: Foxit PDF Editor.pkg
2025-08-15 09:25:42 : INFO  : foxitpdfeditor : Team ID: 8GN47HTP75 (expected: 8GN47HTP75 )
2025-08-15 09:25:42 : INFO  : foxitpdfeditor : Installing Foxit PDF Editor.pkg to /
2025-08-15 09:26:38 : INFO  : foxitpdfeditor : Finishing...
2025-08-15 09:26:41 : INFO  : foxitpdfeditor : App(s) found: /Applications/Foxit PDF Editor.app
2025-08-15 09:26:41 : INFO  : foxitpdfeditor : found app at /Applications/Foxit PDF Editor.app, version 2025.2.0.68868, on versionKey CFBundleShortVersionString
2025-08-15 09:26:41 : REQ   : foxitpdfeditor : Installed Foxit PDF Editor, version 2025.2.0.33046
2025-08-15 09:26:41 : INFO  : foxitpdfeditor : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-08-15 09:26:41 : INFO  : foxitpdfeditor : Telling app Foxit PDF Editor.app to open
2025-08-15 09:26:42 : INFO  : foxitpdfeditor : Reopened Foxit PDF Editor.app as muu
2025-08-15 09:26:42 : INFO  : foxitpdfeditor : root
2025-08-15 09:26:42 : REQ   : foxitpdfeditor : All done!
2025-08-15 09:26:42 : REQ   : foxitpdfeditor : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 
Yes - there was an unrelated foxit pdf editor PR which was closed without being merged.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** 
Yes, creating a label in the labels folder.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes, used the editorconfig file with Xcode

**Additional context** Add any other context about the label or fix here.
n/a

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
