### PR TITLE
fix: Rework $teamID to properly account for parentheses

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -628,7 +628,7 @@ installFromPKG() {
     spctlStatus=$(echo $?)
     printlog "spctlOut is $spctlOut" DEBUG
 
-    teamID=$(echo $spctlOut | awk -F '(' '/origin=/ {print $2 }' | tr -d '()' )
+    teamID=$(echo $spctlOut | awk -F '[()]' '/origin=/ {print $(NF-1)}' )
     # Apple signed software has no teamID, grab entire origin instead
     if [[ -z $teamID ]]; then
         teamID=$(echo $spctlOut | awk -F '=' '/origin=/ {print $NF }')

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -471,7 +471,7 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
     printlog "App size: $(du -sh "$appPath")" DEBUG
     appVerify=$(spctl -a -vv "$appPath" 2>&1 )
     appVerifyStatus=$(echo $?)
-    teamID=$(echo $appVerify | awk '/origin=/ {print $NF }' | tr -d '()' )
+    teamID=$(echo $appVerify |  awk -F '[()]' '/origin=/ {print $(NF-1)}' )
     deduplicatelogs "$appVerify"
 
     if [[ $appVerifyStatus -ne 0 ]] ; then
@@ -639,11 +639,6 @@ installFromPKG() {
     if [[ $spctlStatus -ne 0 ]] ; then
     #if ! spctlout=$(spctl -a -vv -t install "$archiveName" 2>&1 ); then
         cleanupAndExit 4 "Error verifying $archiveName error:\n$logoutput" ERROR
-    fi
-
-    # Apple signed software has no teamID, grab entire origin instead
-    if [[ -z $teamID ]]; then
-        teamID=$(echo $spctlout | awk -F '=' '/origin=/ {print $NF }')
     fi
 
     printlog "Team ID: $teamID (expected: $expectedTeamID )"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Updating a fragment itself

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** 
I attempted to use the fix noted in slack [here](https://macadmins.slack.com/archives/C013HFTFQ13/p1755831168069829?thread_ts=1755830478.104869&cid=C013HFTFQ13), but it also failed to work, so I instead changed the awk field separator from `(` only to `[()]`. This splits on both ( and ), and then the $(NF-1) will the second-to-last field, which is the content of the last parentheses pair to handle any potential cases where company names contain either one or more pairs of parentheses. 
In the log below, the data is `Monospace Unternehmergesellschaft (haftungsbeschränkt) (9466VHH352)` and it splits to `"Monospace Unternehmergesellschaft ", "haftungsbeschränkt", " ", "9466VHH352", ""`, so taking the second to last result is the one we want

**Installomator log** 

```sh
❯ ./assemble.sh lightkey DEBUG=1
2025-08-22 09:22:39 : INFO  : lightkey : setting variable from argument DEBUG=1
2025-08-22 09:22:39 : INFO  : lightkey : Total items in argumentsArray: 1
2025-08-22 09:22:39 : INFO  : lightkey : argumentsArray: DEBUG=1
2025-08-22 09:22:39 : REQ   : lightkey : ################## Start Installomator v. 10.9beta, date 2025-08-22
2025-08-22 09:22:39 : INFO  : lightkey : ################## Version: 10.9beta
2025-08-22 09:22:39 : INFO  : lightkey : ################## Date: 2025-08-22
2025-08-22 09:22:39 : INFO  : lightkey : ################## lightkey
2025-08-22 09:22:39 : DEBUG : lightkey : DEBUG mode 1 enabled.
2025-08-22 09:22:40 : INFO  : lightkey : Reading arguments again: DEBUG=1
2025-08-22 09:22:40 : DEBUG : lightkey : argument: DEBUG=1
2025-08-22 09:22:40 : DEBUG : lightkey : name=Lightkey
2025-08-22 09:22:40 : DEBUG : lightkey : appName=
2025-08-22 09:22:40 : DEBUG : lightkey : type=pkgInZip
2025-08-22 09:22:40 : DEBUG : lightkey : archiveName=
2025-08-22 09:22:40 : DEBUG : lightkey : downloadURL=https://lightkeyapp.com/en/download
2025-08-22 09:22:40 : DEBUG : lightkey : curlOptions=
2025-08-22 09:22:40 : DEBUG : lightkey : appNewVersion=5.6.1
2025-08-22 09:22:40 : DEBUG : lightkey : appCustomVersion function: Not defined
2025-08-22 09:22:40 : DEBUG : lightkey : versionKey=CFBundleShortVersionString
2025-08-22 09:22:40 : DEBUG : lightkey : packageID=
2025-08-22 09:22:40 : DEBUG : lightkey : pkgName=
2025-08-22 09:22:40 : DEBUG : lightkey : choiceChangesXML=
2025-08-22 09:22:40 : DEBUG : lightkey : expectedTeamID=9466VHH352
2025-08-22 09:22:40 : DEBUG : lightkey : blockingProcesses=Lightkey Lightkey Graphics and Media Lightkey Networking Lightkey Web Content
2025-08-22 09:22:40 : DEBUG : lightkey : installerTool=
2025-08-22 09:22:40 : DEBUG : lightkey : CLIInstaller=
2025-08-22 09:22:40 : DEBUG : lightkey : CLIArguments=
2025-08-22 09:22:40 : DEBUG : lightkey : updateTool=
2025-08-22 09:22:40 : DEBUG : lightkey : updateToolArguments=
2025-08-22 09:22:40 : DEBUG : lightkey : updateToolRunAsCurrentUser=
2025-08-22 09:22:40 : INFO  : lightkey : BLOCKING_PROCESS_ACTION=tell_user
2025-08-22 09:22:40 : INFO  : lightkey : NOTIFY=success
2025-08-22 09:22:40 : INFO  : lightkey : LOGGING=DEBUG
2025-08-22 09:22:40 : INFO  : lightkey : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-22 09:22:40 : INFO  : lightkey : Label type: pkgInZip
2025-08-22 09:22:40 : INFO  : lightkey : archiveName: Lightkey.zip
2025-08-22 09:22:40 : DEBUG : lightkey : Changing directory to /Users/shadow/Projects/Installomator/build
2025-08-22 09:22:40 : INFO  : lightkey : App(s) found: /Applications/Lightkey.app
2025-08-22 09:22:40 : INFO  : lightkey : found app at /Applications/Lightkey.app, version 5.5.1, on versionKey CFBundleShortVersionString
2025-08-22 09:22:40 : INFO  : lightkey : appversion: 5.5.1
2025-08-22 09:22:40 : INFO  : lightkey : Latest version of Lightkey is 5.6.1
2025-08-22 09:22:40 : INFO  : lightkey : Lightkey.zip exists and DEBUG mode 1 enabled, skipping download
2025-08-22 09:22:40 : DEBUG : lightkey : DEBUG mode 1, not checking for blocking processes
2025-08-22 09:22:40 : REQ   : lightkey : Installing Lightkey
2025-08-22 09:22:40 : INFO  : lightkey : Unzipping Lightkey.zip
2025-08-22 09:22:41 : DEBUG : lightkey : Found pkg(s):
/Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg
2025-08-22 09:22:41 : INFO  : lightkey : found pkg: /Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg
2025-08-22 09:22:41 : INFO  : lightkey : Verifying: /Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg
2025-08-22 09:22:42 : DEBUG : lightkey : File list: -rw-r--r--@ 1 shadow  staff   247M Aug 11 02:08 /Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg
2025-08-22 09:22:42 : DEBUG : lightkey : File type: /Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg: xar archive compressed TOC: 6435, SHA-1 checksum
2025-08-22 09:22:42 : DEBUG : lightkey : spctlOut is /Users/shadow/Projects/Installomator/build/LightkeyInstaller.pkg: accepted
2025-08-22 09:22:42 : DEBUG : lightkey : source=Notarized Developer ID
2025-08-22 09:22:42 : DEBUG : lightkey : origin=Developer ID Installer: Monospace Unternehmergesellschaft (haftungsbeschränkt) (9466VHH352)
2025-08-22 09:22:42 : INFO  : lightkey : Team ID: 9466VHH352 (expected: 9466VHH352 )
2025-08-22 09:22:42 : DEBUG : lightkey : DEBUG enabled, skipping installation
2025-08-22 09:22:42 : INFO  : lightkey : Finishing...
2025-08-22 09:22:45 : INFO  : lightkey : App(s) found: /Applications/Lightkey.app
2025-08-22 09:22:45 : INFO  : lightkey : found app at /Applications/Lightkey.app, version 5.5.1, on versionKey CFBundleShortVersionString
2025-08-22 09:22:45 : REQ   : lightkey : Installed Lightkey, version 5.6.1
2025-08-22 09:22:45 : INFO  : lightkey : notifying
2025-08-22 09:22:46 : DEBUG : lightkey : DEBUG mode 1, not reopening anything
2025-08-22 09:22:46 : REQ   : lightkey : All done!
2025-08-22 09:22:46 : REQ   : lightkey : ################## End Installomator, exit code 0
```


Fixes #2529
