### PR TITLE
Update label: Digiexam

### DIFF
--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -1,7 +1,7 @@
 digiexam)
-	name="Digiexam"
-	type="dmg"
+    name="Digiexam"
+    type="dmg"
     downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac_universal.dmg"
     appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://www.digiexam.com/release-notes | sed -ne '/<h2>Macbook<\/h2>/,$p' | grep -Eo 'Release \d{2,}.\d.\d{2,}' | head -1 | awk '{ print $NF }' )
-	expectedTeamID="73T9H7VE4P"
-	;;
+    expectedTeamID="73T9H7VE4P"
+    ;;

--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -1,7 +1,7 @@
 digiexam)
 	name="Digiexam"
 	type="dmg"
-	downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg"
-    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.digiexam.se/hc/en-us/articles/7119593625628-Client-updates | perl -ne 'print if /Version(?!.*Only(?!.*Mac))(?=.*Mac)?/' | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
+    downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac_universal.dmg"
+    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://www.digiexam.com/release-notes | sed -ne '/<h2>Macbook<\/h2>/,$p' | grep -Eo 'Release \d{2,}.\d.\d{2,}' | head -1 | awk '{ print $NF }' )
 	expectedTeamID="73T9H7VE4P"
 	;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Digiexam has moved the release notes and download url as a part of their latest major upgrade. This version corrects the url and appNewVersion. Since the v.15 will stop working this fall, I chose to update the existing label, instead of creating a new.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

2025-08-25 10:06:22 : INFO  : digiexam : setting variable from argument DEBUG=0
2025-08-25 10:06:22 : INFO  : digiexam : Total items in argumentsArray: 1
2025-08-25 10:06:22 : INFO  : digiexam : argumentsArray: DEBUG=0
2025-08-25 10:06:22 : REQ   : digiexam : ################## Start Installomator v. 10.9beta, date 2025-08-25
2025-08-25 10:06:22 : INFO  : digiexam : ################## Version: 10.9beta
2025-08-25 10:06:22 : INFO  : digiexam : ################## Date: 2025-08-25
2025-08-25 10:06:22 : INFO  : digiexam : ################## digiexam
2025-08-25 10:06:23 : INFO  : digiexam : Reading arguments again: DEBUG=0
2025-08-25 10:06:23 : INFO  : digiexam : BLOCKING_PROCESS_ACTION=tell_user
2025-08-25 10:06:23 : INFO  : digiexam : NOTIFY=success
2025-08-25 10:06:23 : INFO  : digiexam : LOGGING=INFO
2025-08-25 10:06:23 : INFO  : digiexam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-25 10:06:23 : INFO  : digiexam : Label type: dmg
2025-08-25 10:06:23 : INFO  : digiexam : archiveName: Digiexam.dmg
2025-08-25 10:06:23 : INFO  : digiexam : no blocking processes defined, using Digiexam as default
2025-08-25 10:06:23 : INFO  : digiexam : App(s) found: /Applications/Digiexam.app
2025-08-25 10:06:23 : INFO  : digiexam : found app at /Applications/Digiexam.app, version 15.0.21, on versionKey CFBundleShortVersionString
2025-08-25 10:06:23 : INFO  : digiexam : appversion: 15.0.21
2025-08-25 10:06:23 : INFO  : digiexam : Latest version of Digiexam is 25.2.82
2025-08-25 10:06:23 : REQ   : digiexam : Downloading https://www.digiexam.com/hubfs/client/Digiexam_Mac_universal.dmg to Digiexam.dmg
2025-08-25 10:06:24 : INFO  : digiexam : Downloaded Digiexam.dmg – Type is  zlib compressed data – SHA is 66d74c4cdb0a242ecd3f0127cef48606c66f8f52 – Size is 25904 kB
2025-08-25 10:06:24 : REQ   : digiexam : no more blocking processes, continue with update
2025-08-25 10:06:24 : REQ   : digiexam : Installing Digiexam
2025-08-25 10:06:24 : INFO  : digiexam : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lXCKZFfWre/Digiexam.dmg
2025-08-25 10:06:27 : INFO  : digiexam : Mounted: /Volumes/Digiexam 1
2025-08-25 10:06:27 : INFO  : digiexam : Verifying: /Volumes/Digiexam 1/Digiexam.app
2025-08-25 10:06:27 : INFO  : digiexam : Team ID matching: 73T9H7VE4P (expected: 73T9H7VE4P )
2025-08-25 10:06:27 : INFO  : digiexam : Downloaded version of Digiexam is 25.2.82 on versionKey CFBundleShortVersionString (replacing version 15.0.21).
2025-08-25 10:06:27 : INFO  : digiexam : App has LSMinimumSystemVersion: 10.13
2025-08-25 10:06:27 : WARN  : digiexam : Removing existing /Applications/Digiexam.app
2025-08-25 10:06:27 : INFO  : digiexam : Copy /Volumes/Digiexam 1/Digiexam.app to /Applications
2025-08-25 10:06:27 : WARN  : digiexam : Changing owner to olof.hennig
2025-08-25 10:06:27 : INFO  : digiexam : Finishing...
2025-08-25 10:06:30 : INFO  : digiexam : App(s) found: /Applications/Digiexam.app
2025-08-25 10:06:30 : INFO  : digiexam : found app at /Applications/Digiexam.app, version 25.2.82, on versionKey CFBundleShortVersionString
2025-08-25 10:06:31 : REQ   : digiexam : Installed Digiexam, version 25.2.82
2025-08-25 10:06:31 : INFO  : digiexam : notifying
2025-08-25 10:06:32 : INFO  : digiexam : Installomator did not close any apps, so no need to reopen any apps.
2025-08-25 10:06:32 : REQ   : digiexam : All done!
2025-08-25 10:06:32 : REQ   : digiexam : ################## End Installomator, exit code 0 