### PR TITLE
Update microsoftteams-rollingout.sh

### DIFF
--- a/fragments/labels/microsoftteams-rollingout.sh
+++ b/fragments/labels/microsoftteams-rollingout.sh
@@ -3,7 +3,7 @@ microsoftteams-rollingout)
     type="pkg"
     packageID="com.microsoft.teams2"
     # Fetch the latest version number from the Microsoft documentation page
-    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning | awk '/<h4 id="mac-version-history">Mac version history<\/h4>/,/<\/table>/' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning | awk '/<h4 id="mac">Mac<\/h4>/,/<\/table>/' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
     downloadURL="https://statics.teams.cdn.office.net/production-osx/${appNewVersion}/MicrosoftTeams.pkg"
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams WebView Helper" "Microsoft Teams Launcher" "Microsoft Teams (work preview)" "Microsoft Teams classic Helper" "com.microsoft.teams2.respawn")


### PR DESCRIPTION
Changed the awk search query because of a change on the webpage.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
This fixed #2534. The headers of the webpage were changed so the appnewversion came out blank. This fixes that.

To see the change:
current page: https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning
web archive time machine: https://web.archive.org/web/20250715122034/https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : setting variable from argument DEBUG=2
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : Total items in argumentsArray: 1
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : argumentsArray: DEBUG=2
2025-08-25 15:50:12 : REQ   : microsoftteams-rollingout : ################## Start Installomator v. 10.8, date 2025-03-28
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : ################## Version: 10.8
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : ################## Date: 2025-03-28
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : ################## microsoftteams-rollingout
2025-08-25 15:50:12 : DEBUG : microsoftteams-rollingout : DEBUG mode 2 enabled.
2025-08-25 15:50:12 : INFO  : microsoftteams-rollingout : Reading arguments again: DEBUG=2
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : argument: DEBUG=2
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : name=Microsoft Teams
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : appName=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : type=pkg
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : archiveName=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : downloadURL=https://statics.teams.cdn.office.net/production-osx/25212.2404.3875.1360/MicrosoftTeams.pkg
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : curlOptions=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : appNewVersion=25212.2404.3875.1360
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : appCustomVersion function: Not defined
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : versionKey=CFBundleShortVersionString
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : packageID=com.microsoft.teams2
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : pkgName=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : choiceChangesXML=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : expectedTeamID=UBF8T346G9
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : blockingProcesses=Teams MSTeams Microsoft Teams Microsoft Teams WebView Microsoft Teams WebView Helper Microsoft Teams Launcher Microsoft Teams (work preview) Microsoft Teams classic Helper com.microsoft.teams2.respawn
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : installerTool=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : CLIInstaller=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : CLIArguments=
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : updateToolArguments=--install --apps TEAMS21
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : updateToolRunAsCurrentUser=
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : BLOCKING_PROCESS_ACTION=tell_user
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : NOTIFY=silent
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : LOGGING=DEBUG
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : Label type: pkg
2025-08-25 15:50:13 : INFO  : microsoftteams-rollingout : archiveName: Microsoft Teams.pkg
2025-08-25 15:50:13 : DEBUG : microsoftteams-rollingout : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lBLwXb93Ii
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : found packageID com.microsoft.teams2 installed, version 25227.301.3887.7726
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : appversion: 25227.301.3887.7726
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : Latest version of Microsoft Teams is 25212.2404.3875.1360
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : App needs to be updated and uses /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : Function called: runUpdateTool
2025-08-25 15:50:14 : INFO  : microsoftteams-rollingout : running /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate --install --apps TEAMS21
2025-08-25 15:50:25 : DEBUG : microsoftteams-rollingout : Debugging enabled, update tool output was:

Update Assistant: Idle


2025-08-25 15:50:25 : INFO  : microsoftteams-rollingout : Finishing...
2025-08-25 15:50:28 : INFO  : microsoftteams-rollingout : found packageID com.microsoft.teams2 installed, version 25227.301.3887.7726
2025-08-25 15:50:28 : REQ   : microsoftteams-rollingout : Installed Microsoft Teams, version 25212.2404.3875.1360
2025-08-25 15:50:28 : DEBUG : microsoftteams-rollingout : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lBLwXb93Ii
2025-08-25 15:50:28 : DEBUG : microsoftteams-rollingout : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lBLwXb93Ii
2025-08-25 15:50:28 : INFO  : microsoftteams-rollingout : Installomator did not close any apps, so no need to reopen any apps.
2025-08-25 15:50:28 : REQ   : microsoftteams-rollingout : updateTool has run
2025-08-25 15:50:28 : REQ   : microsoftteams-rollingout : ################## End Installomator, exit code 0
```


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
#2534 

