### PR TITLE
Warp update

### DIFF
--- a/fragments/labels/warp.sh
+++ b/fragments/labels/warp.sh
@@ -2,7 +2,7 @@ warp)
     name="Warp"
     type="dmg"
     downloadURL="https://app.warp.dev/download"
-    appNewVersion=$(curl -fs "https://app.warp.dev/download?package=dmg" | grep -o 'v[0-9]\.[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}\.[0-9]\{2\}\.[0-9]\{2\}\.stable_[0-9]\{2\}')
+    appNewVersion=$(curl -fs https://releases.warp.dev/channel_versions.json | grep -A 3 '"stable"' | grep '"version"' | head -n 1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
     expectedTeamID="2BBY89MBSN"
     versionKey="WarpVersion"
     ;;

--- a/fragments/labels/warp.sh
+++ b/fragments/labels/warp.sh
@@ -2,6 +2,7 @@ warp)
     name="Warp"
     type="dmg"
     downloadURL="https://app.warp.dev/download"
-    appNewVersion=$(curl -s https://releases.warp.dev/channel_versions.json | grep -A 3 '"stable"' | grep '"version"' | head -n 1 | sed -E 's/.*"version": *"v([^"]+)".*/\1/')
+    appNewVersion=$(curl -fs "https://app.warp.dev/download?package=dmg" | grep -o 'v[0-9]\.[0-9]\{4\}\.[0-9]\{2\}\.[0-9]\{2\}\.[0-9]\{2\}\.[0-9]\{2\}\.stable_[0-9]\{2\}')
     expectedTeamID="2BBY89MBSN"
+    versionKey="WarpVersion"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

Warp includes a `WarpVersion` key in its Info.plist that reports values like `v0.2025.08.20.08.11.stable_03`, which is the version string Warp actually uses. The previous label relied on `CFBundleShortVersionString`, but that key reports a different value `0.2025.08.20.08.11.03` that doesn’t align with how Warp tracks releases. To fix this, I added `versionKey="WarpVersion"` and adjusted `appNewVersion` so the JSON output is normalized with the leading v, ensuring Installomator compares against the correct version string.

For background, the mismatch between `CFBundleShortVersionString` and what Warp was reporting the current version was, was discussed in [Warp issue #4852](https://github.com/warpdotdev/Warp/issues/4852), which led to the addition of the `WarpVersion` key. At the time I even sketched out a draft label using it, but I didn’t follow through with a PR then. When the Warp label was later added to Installomator, it used `CFBundleShortVersionString`, so this update now brings the label in line with the key Warp provides.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
sudo ./Installomator.sh warp
2025-08-27 09:14:52 : INFO  : warp : Total items in argumentsArray: 0
2025-08-27 09:14:52 : INFO  : warp : argumentsArray: 
2025-08-27 09:14:52 : REQ   : warp : ################## Start Installomator v. 10.9beta, date 2025-08-27
2025-08-27 09:14:52 : INFO  : warp : ################## Version: 10.9beta
2025-08-27 09:14:52 : INFO  : warp : ################## Date: 2025-08-27
2025-08-27 09:14:52 : INFO  : warp : ################## warp
2025-08-27 09:14:52 : DEBUG : warp : DEBUG mode 1 enabled.
2025-08-27 09:14:53 : INFO  : warp : Reading arguments again: 
2025-08-27 09:14:53 : DEBUG : warp : name=Warp
2025-08-27 09:14:53 : DEBUG : warp : appName=
2025-08-27 09:14:53 : DEBUG : warp : type=dmg
2025-08-27 09:14:53 : DEBUG : warp : archiveName=
2025-08-27 09:14:53 : DEBUG : warp : downloadURL=https://app.warp.dev/download
2025-08-27 09:14:53 : DEBUG : warp : curlOptions=
2025-08-27 09:14:53 : DEBUG : warp : appNewVersion=v0.2025.08.20.08.11.stable_03
2025-08-27 09:14:53 : DEBUG : warp : appCustomVersion function: Not defined
2025-08-27 09:14:53 : DEBUG : warp : versionKey=WarpVersion
2025-08-27 09:14:53 : DEBUG : warp : packageID=
2025-08-27 09:14:53 : DEBUG : warp : pkgName=
2025-08-27 09:14:53 : DEBUG : warp : choiceChangesXML=
2025-08-27 09:14:53 : DEBUG : warp : expectedTeamID=2BBY89MBSN
2025-08-27 09:14:53 : DEBUG : warp : blockingProcesses=
2025-08-27 09:14:53 : DEBUG : warp : installerTool=
2025-08-27 09:14:53 : DEBUG : warp : CLIInstaller=
2025-08-27 09:14:53 : DEBUG : warp : CLIArguments=
2025-08-27 09:14:53 : DEBUG : warp : updateTool=
2025-08-27 09:14:53 : DEBUG : warp : updateToolArguments=
2025-08-27 09:14:53 : DEBUG : warp : updateToolRunAsCurrentUser=
2025-08-27 09:14:53 : INFO  : warp : BLOCKING_PROCESS_ACTION=tell_user
2025-08-27 09:14:53 : INFO  : warp : NOTIFY=success
2025-08-27 09:14:53 : INFO  : warp : LOGGING=DEBUG
2025-08-27 09:14:53 : INFO  : warp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-27 09:14:53 : INFO  : warp : Label type: dmg
2025-08-27 09:14:53 : INFO  : warp : archiveName: Warp.dmg
2025-08-27 09:14:53 : INFO  : warp : no blocking processes defined, using Warp as default
2025-08-27 09:14:53 : DEBUG : warp : Changing directory to .
2025-08-27 09:14:53 : INFO  : warp : App(s) found: /Applications/Warp.app
2025-08-27 09:14:53 : INFO  : warp : found app at /Applications/Warp.app, version v0.2025.08.20.08.11.stable_03, on versionKey WarpVersion
2025-08-27 09:14:53 : INFO  : warp : appversion: v0.2025.08.20.08.11.stable_03
2025-08-27 09:14:53 : INFO  : warp : Latest version of Warp is v0.2025.08.20.08.11.stable_03
2025-08-27 09:14:53 : WARN  : warp : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-08-27 09:14:53 : INFO  : warp : Warp.dmg exists and DEBUG mode 1 enabled, skipping download
2025-08-27 09:14:53 : DEBUG : warp : DEBUG mode 1, not checking for blocking processes
2025-08-27 09:14:53 : REQ   : warp : Installing Warp
2025-08-27 09:14:53 : INFO  : warp : Mounting ./Warp.dmg
2025-08-27 09:14:53 : DEBUG : warp : Debugging enabled, dmgmount output was:
expected   CRC32 $3257F4B8
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Warp

2025-08-27 09:14:53 : INFO  : warp : Mounted: /Volumes/Warp
2025-08-27 09:14:53 : INFO  : warp : Verifying: /Volumes/Warp/Warp.app
2025-08-27 09:14:53 : DEBUG : warp : App size: 391M	/Volumes/Warp/Warp.app
2025-08-27 09:14:55 : DEBUG : warp : Debugging enabled, App Verification output was:
/Volumes/Warp/Warp.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Denver Technologies, Inc (2BBY89MBSN)

2025-08-27 09:14:55 : INFO  : warp : Team ID matching: 2BBY89MBSN (expected: 2BBY89MBSN )
2025-08-27 09:14:55 : INFO  : warp : Downloaded version of Warp is v0.2025.08.20.08.11.stable_03 on versionKey WarpVersion, same as installed.
2025-08-27 09:14:55 : DEBUG : warp : Unmounting /Volumes/Warp
2025-08-27 09:14:55 : DEBUG : warp : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-08-27 09:14:55 : DEBUG : warp : DEBUG mode 1, not reopening anything
2025-08-27 09:14:55 : REG   : warp : No new version to install
2025-08-27 09:14:55 : REQ   : warp : ################## End Installomator, exit code 0 
```
