### PR TITLE
Use 13.0 as minimum system requirement on logitechoptionsplus

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -7,7 +7,7 @@ logitechoptionsplus)
     downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
     # Latest version of Logi Options+ requires macOS 12+
     # If older macOS is specified in the url for appNewVersion, it will never correspond to the installed version
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-12.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-13.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
Current label uses a filter for macOS 12.0 to search for the latest release. Since recently the latest release has a minimum system version of 13.0.

**Installomator log** 
First current label and appNewVersion:
```
2025-08-28 12:52:57 : INFO  : logitechoptionsplus : Total items in argumentsArray: 0
2025-08-28 12:52:57 : INFO  : logitechoptionsplus : argumentsArray: 
2025-08-28 12:52:57 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.9beta, date 2025-08-28
2025-08-28 12:52:57 : INFO  : logitechoptionsplus : ################## Version: 10.9beta
2025-08-28 12:52:57 : INFO  : logitechoptionsplus : ################## Date: 2025-08-28
2025-08-28 12:52:57 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2025-08-28 12:52:57 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled.
2025-08-28 12:52:58 : INFO  : logitechoptionsplus : Reading arguments again: 
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : name=Logi Options+
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : appName=logioptionsplus.app
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : type=zip
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : archiveName=logioptionsplus_installer.zip
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : curlOptions=
2025-08-28 12:52:58 : DEBUG : logitechoptionsplus : appNewVersion=1.93.755983
```

This is for the updated label:
```
2025-08-28 13:16:08 : INFO  : logitechoptionsplus : Total items in argumentsArray: 0
2025-08-28 13:16:08 : INFO  : logitechoptionsplus : argumentsArray: 
2025-08-28 13:16:08 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.9beta, date 2025-08-28
2025-08-28 13:16:08 : INFO  : logitechoptionsplus : ################## Version: 10.9beta
2025-08-28 13:16:08 : INFO  : logitechoptionsplus : ################## Date: 2025-08-28
2025-08-28 13:16:08 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2025-08-28 13:16:08 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled.
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Reading arguments again: 
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : name=Logi Options+
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : appName=logioptionsplus.app
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : type=zip
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : archiveName=logioptionsplus_installer.zip
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : curlOptions=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : appNewVersion=1.94.762104
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : appCustomVersion function: Not defined
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : versionKey=CFBundleShortVersionString
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : packageID=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : pkgName=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : choiceChangesXML=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : expectedTeamID=QED4VVPZWA
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : blockingProcesses=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : installerTool=logioptionsplus_installer.app
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : CLIInstaller=logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : CLIArguments=--quiet
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : updateTool=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : updateToolArguments=
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : updateToolRunAsCurrentUser=
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : NOTIFY=success
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : LOGGING=DEBUG
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Label type: zip
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : archiveName: logioptionsplus_installer.zip
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : Changing directory to /somepath/Installomator/build
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : App(s) found: /Applications/logioptionsplus.app
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : found app at /Applications/logioptionsplus.app, version 1.94.762104, on versionKey CFBundleShortVersionString
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : appversion: 1.94.762104
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 1.94.762104
2025-08-28 13:16:09 : WARN  : logitechoptionsplus : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : logioptionsplus_installer.zip exists and DEBUG mode 1 enabled, skipping download
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : DEBUG mode 1, not checking for blocking processes
2025-08-28 13:16:09 : REQ   : logitechoptionsplus : Installing Logi Options+
2025-08-28 13:16:09 : REQ   : logitechoptionsplus : installerTool used: logioptionsplus_installer.app
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Unzipping logioptionsplus_installer.zip
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Verifying: /somepath/Installomator/build/logioptionsplus_installer.app
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : App size:  43M      /somepath/Installomator/build/logioptionsplus_installer.app
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : Debugging enabled, App Verification output was:
/somepath/Installomator/build/logioptionsplus_installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2025-08-28 13:16:09.782 defaults[60870:838909] 
The domain/default pair of (/somepath/Installomator/build/logioptionsplus_installer.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Downloaded version of Logi Options+ is  on versionKey CFBundleShortVersionString (replacing version 1.94.762104).
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 13.0
2025-08-28 13:16:09 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-08-28 13:16:09 : INFO  : logitechoptionsplus : Finishing...
2025-08-28 13:16:12 : INFO  : logitechoptionsplus : name: Logi Options+, appName: logioptionsplus_installer.app
2025-08-28 13:16:13 : WARN  : logitechoptionsplus : No previous app found
2025-08-28 13:16:13 : WARN  : logitechoptionsplus : could not find logioptionsplus_installer.app
2025-08-28 13:16:13 : REQ   : logitechoptionsplus : Installed Logi Options+
2025-08-28 13:16:13 : INFO  : logitechoptionsplus : notifying
2025-08-28 13:16:13 : DEBUG : logitechoptionsplus : DEBUG mode 1, not reopening anything
2025-08-28 13:16:13 : REQ   : logitechoptionsplus : All done!
2025-08-28 13:16:13 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0 
```