### PR TITLE
Correct appNewVersion for rodecentral

### DIFF
--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -3,6 +3,6 @@ rodecentral)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
-    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | grep -o "release-notes-data='.*'>" | sed -E 's/release-notes-data='\''|'\''>//g' | jq -r '.[].version' | sed 's/[V|v]ersion //g' | sort --version-sort | tail -1)
+    appNewVersion=$(curl -fLs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | grep -o "release-notes-data='.*'>" | sed -E 's/release-notes-data='\''|'\''>//g' | jq -r '.[].version' | sed 's/[V|v]ersion //g' | sort --version-sort | tail -1)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -3,6 +3,6 @@ rodecentral)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
-    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | tr '"' '\n' | sed 's/\&quot\;/\n/g' | grep -i -o "Version .*" | cut -w -f2 | tail -n +2 | head -1)
+    appNewVersion=$(curl -fs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | grep -o "release-notes-data='.*'>" | sed -E 's/release-notes-data='\''|'\''>//g' | jq -r '.[].version' | sed 's/[V|v]ersion //g' | sort --version-sort | tail -1)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -3,6 +3,6 @@ rodecentral)
     type="pkgInZip"
     #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
-    appNewVersion=$(curl -fLs https://rode.com/en/release-notes/rode-central | xmllint --html --format - 2>/dev/null | grep -o "release-notes-data='.*'>" | sed -E 's/release-notes-data='\''|'\''>//g' | jq -r '.[].version' | sed 's/[V|v]ersion //g' | sort --version-sort | tail -1)
+    appNewVersion=$(curl -fLs https://rode.com/en/release-notes/rode-central | grep -oE "Version [0-9].[0-9].[0-9.]*" | awk '{print$2}' | sort --version-sort | tail -1)
     expectedTeamID="Z9T72PWTJA"
     ;;

--- a/fragments/labels/rodecentral.sh
+++ b/fragments/labels/rodecentral.sh
@@ -1,7 +1,6 @@
 rodecentral)
     name="RODE Central"
     type="pkgInZip"
-    #packageID="com.rodecentral.installer"
     downloadURL="https://update.rode.com/central/RODE_Central_MACOS.zip"
     appNewVersion=$(curl -fLs https://rode.com/en/release-notes/rode-central | grep -oE "Version [0-9].[0-9].[0-9.]*" | awk '{print$2}' | sort --version-sort | tail -1)
     expectedTeamID="Z9T72PWTJA"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
I've changed the way to get the latest version, to parse the json in the html answer. Hopefully this will be a little more future proof.

**Installomator log** 
```
2025-08-28 14:53:42 : INFO  : rodecentral : setting variable from argument DEBUG=0
2025-08-28 14:53:42 : INFO  : rodecentral : Total items in argumentsArray: 1
2025-08-28 14:53:42 : INFO  : rodecentral : argumentsArray: DEBUG=0
2025-08-28 14:53:42 : REQ   : rodecentral : ################## Start Installomator v. 10.9beta, date 2025-08-28
2025-08-28 14:53:42 : INFO  : rodecentral : ################## Version: 10.9beta
2025-08-28 14:53:42 : INFO  : rodecentral : ################## Date: 2025-08-28
2025-08-28 14:53:42 : INFO  : rodecentral : ################## rodecentral
2025-08-28 14:53:45 : INFO  : rodecentral : Reading arguments again: DEBUG=0
2025-08-28 14:53:45 : INFO  : rodecentral : BLOCKING_PROCESS_ACTION=tell_user
2025-08-28 14:53:45 : INFO  : rodecentral : NOTIFY=success
2025-08-28 14:53:45 : INFO  : rodecentral : LOGGING=INFO
2025-08-28 14:53:45 : INFO  : rodecentral : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-08-28 14:53:45 : INFO  : rodecentral : Label type: pkgInZip
2025-08-28 14:53:45 : INFO  : rodecentral : archiveName: RODE Central.zip
2025-08-28 14:53:45 : INFO  : rodecentral : no blocking processes defined, using RODE Central as default
2025-08-28 14:53:45 : INFO  : rodecentral : App(s) found: /Applications/RODE Central.app
2025-08-28 14:53:45 : INFO  : rodecentral : found app at /Applications/RODE Central.app, version 2.0.101, on versionKey CFBundleShortVersionString
2025-08-28 14:53:45 : INFO  : rodecentral : appversion: 2.0.101
2025-08-28 14:53:45 : INFO  : rodecentral : Latest version of RODE Central is 2.0.101
2025-08-28 14:53:45 : INFO  : rodecentral : There is no newer version available.
2025-08-28 14:53:45 : INFO  : rodecentral : Installomator did not close any apps, so no need to reopen any apps.
2025-08-28 14:53:45 : REQ   : rodecentral : No newer version.
2025-08-28 14:53:45 : REQ   : rodecentral : ################## End Installomator, exit code 0 
```

Fixes #2540 
