### PR TITLE
add Dropbox Enterprise

### DIFF
--- a/fragments/labels/dropboxenterprise.sh
+++ b/fragments/labels/dropboxenterprise.sh
@@ -1,0 +1,15 @@
+dropboxenterprise)
+    name="Dropbox Enterprise"
+    appName="Dropbox.app"
+    type="pkg"
+    # Handling differens on Apple Silicon and Intel arch
+    if [[ $(arch) = "arm64" ]]; then
+        printlog "Architecture: arm64"
+        downloadURL="https://client.dropbox.com/desktop/desktop-dropbox/requestdownload?install_type=enterprise_install&platform=mac&arch=arm64"
+    else
+        printlog "Architecture: i386 (not arm64)"
+        downloadURL="https://client.dropbox.com/desktop/desktop-dropbox/requestdownload?install_type=enterprise_install&platform=mac&arch=x86_64"
+    fi
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -o "Dropbox.*.pkg"  | sed -E 's/.*%20([0-9.]*)\.([x86_64.]|[arm64.])*pkg/\1/g' | tr -d '[:cntrl:]' )
+    expectedTeamID="G7HH3F8CAK"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
This pkg installs  the Dropbox helpers during installation, allowing it for non-admin users without extra authentication. Standard Dropbox (app in dmg) needs to be authenticated on first run.

**Installomator log** 
Installation with out app installed, followed by a check to see that it doesn't try to install over and over again.
```
Installomator git:(add_dropboxenterprise) ✗ sudo ./assemble.sh dropboxenterprise DEBUG=0
2025-09-04 14:56:04 : INFO  : dropboxenterprise : setting variable from argument DEBUG=0
2025-09-04 14:56:04 : INFO  : dropboxenterprise : Total items in argumentsArray: 1
2025-09-04 14:56:04 : INFO  : dropboxenterprise : argumentsArray: DEBUG=0
2025-09-04 14:56:04 : REQ   : dropboxenterprise : ################## Start Installomator v. 10.9beta, date 2025-09-04
2025-09-04 14:56:04 : INFO  : dropboxenterprise : ################## Version: 10.9beta
2025-09-04 14:56:04 : INFO  : dropboxenterprise : ################## Date: 2025-09-04
2025-09-04 14:56:04 : INFO  : dropboxenterprise : ################## dropboxenterprise
2025-09-04 14:56:04 : INFO  : dropboxenterprise : Architecture: arm64
2025-09-04 14:56:06 : INFO  : dropboxenterprise : Reading arguments again: DEBUG=0
2025-09-04 14:56:06 : INFO  : dropboxenterprise : BLOCKING_PROCESS_ACTION=tell_user
2025-09-04 14:56:06 : INFO  : dropboxenterprise : NOTIFY=success
2025-09-04 14:56:06 : INFO  : dropboxenterprise : LOGGING=INFO
2025-09-04 14:56:06 : INFO  : dropboxenterprise : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-04 14:56:06 : INFO  : dropboxenterprise : Label type: pkg
2025-09-04 14:56:06 : INFO  : dropboxenterprise : archiveName: Dropbox Enterprise.pkg
2025-09-04 14:56:06 : INFO  : dropboxenterprise : no blocking processes defined, using Dropbox Enterprise as default
2025-09-04 14:56:06 : INFO  : dropboxenterprise : name: Dropbox Enterprise, appName: Dropbox.app
2025-09-04 14:56:06 : WARN  : dropboxenterprise : No previous app found
2025-09-04 14:56:06 : WARN  : dropboxenterprise : could not find Dropbox.app
2025-09-04 14:56:06 : INFO  : dropboxenterprise : appversion: 
2025-09-04 14:56:06 : INFO  : dropboxenterprise : Latest version of Dropbox Enterprise is 231.4.5770
2025-09-04 14:56:06 : REQ   : dropboxenterprise : Downloading https://client.dropbox.com/desktop/desktop-dropbox/requestdownload?install_type=enterprise_install&platform=mac&arch=arm64 to Dropbox Enterprise.pkg
2025-09-04 14:58:13 : INFO  : dropboxenterprise : Downloaded Dropbox Enterprise.pkg – Type is  xar archive compressed TOC – SHA is ca48cb1baf03a8e2eec2fa7d015cb2aa916f34e9 – Size is 311596 kB
2025-09-04 14:58:13 : REQ   : dropboxenterprise : no more blocking processes, continue with update
2025-09-04 14:58:13 : REQ   : dropboxenterprise : Installing Dropbox Enterprise
2025-09-04 14:58:13 : INFO  : dropboxenterprise : Verifying: Dropbox Enterprise.pkg
2025-09-04 14:58:13 : INFO  : dropboxenterprise : Team ID: G7HH3F8CAK (expected: G7HH3F8CAK )
2025-09-04 14:58:13 : INFO  : dropboxenterprise : Installing Dropbox Enterprise.pkg to /
2025-09-04 14:58:19 : INFO  : dropboxenterprise : Finishing...
2025-09-04 14:58:22 : INFO  : dropboxenterprise : App(s) found: /Applications/Dropbox.app
2025-09-04 14:58:22 : INFO  : dropboxenterprise : found app at /Applications/Dropbox.app, version 231.4.5770, on versionKey CFBundleShortVersionString
2025-09-04 14:58:22 : REQ   : dropboxenterprise : Installed Dropbox Enterprise, version 231.4.5770
2025-09-04 14:58:22 : INFO  : dropboxenterprise : notifying
2025-09-04 14:58:23 : INFO  : dropboxenterprise : Installomator did not close any apps, so no need to reopen any apps.
2025-09-04 14:58:23 : REQ   : dropboxenterprise : All done!
2025-09-04 14:58:23 : REQ   : dropboxenterprise : ################## End Installomator, exit code 0 

➜  Installomator git:(add_dropboxenterprise) ✗ sudo ./assemble.sh dropboxenterprise DEBUG=0
2025-09-04 14:59:42 : INFO  : dropboxenterprise : setting variable from argument DEBUG=0
2025-09-04 14:59:42 : INFO  : dropboxenterprise : Total items in argumentsArray: 1
2025-09-04 14:59:42 : INFO  : dropboxenterprise : argumentsArray: DEBUG=0
2025-09-04 14:59:42 : REQ   : dropboxenterprise : ################## Start Installomator v. 10.9beta, date 2025-09-04
2025-09-04 14:59:42 : INFO  : dropboxenterprise : ################## Version: 10.9beta
2025-09-04 14:59:42 : INFO  : dropboxenterprise : ################## Date: 2025-09-04
2025-09-04 14:59:42 : INFO  : dropboxenterprise : ################## dropboxenterprise
2025-09-04 14:59:43 : INFO  : dropboxenterprise : Architecture: arm64
2025-09-04 14:59:44 : INFO  : dropboxenterprise : Reading arguments again: DEBUG=0
2025-09-04 14:59:44 : INFO  : dropboxenterprise : BLOCKING_PROCESS_ACTION=tell_user
2025-09-04 14:59:44 : INFO  : dropboxenterprise : NOTIFY=success
2025-09-04 14:59:44 : INFO  : dropboxenterprise : LOGGING=INFO
2025-09-04 14:59:44 : INFO  : dropboxenterprise : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-04 14:59:44 : INFO  : dropboxenterprise : Label type: pkg
2025-09-04 14:59:44 : INFO  : dropboxenterprise : archiveName: Dropbox Enterprise.pkg
2025-09-04 14:59:44 : INFO  : dropboxenterprise : no blocking processes defined, using Dropbox Enterprise as default
2025-09-04 14:59:44 : INFO  : dropboxenterprise : App(s) found: /Applications/Dropbox.app
2025-09-04 14:59:44 : INFO  : dropboxenterprise : found app at /Applications/Dropbox.app, version 231.4.5770, on versionKey CFBundleShortVersionString
2025-09-04 14:59:44 : INFO  : dropboxenterprise : appversion: 231.4.5770
2025-09-04 14:59:44 : INFO  : dropboxenterprise : Latest version of Dropbox Enterprise is 231.4.5770
2025-09-04 14:59:44 : INFO  : dropboxenterprise : There is no newer version available.
2025-09-04 14:59:44 : INFO  : dropboxenterprise : Installomator did not close any apps, so no need to reopen any apps.
2025-09-04 14:59:44 : REQ   : dropboxenterprise : No newer version.
2025-09-04 14:59:44 : REQ   : dropboxenterprise : ################## End Installomator, exit code 0 
```