### PR TITLE
Add Cinema 4D 2026

### DIFF
--- a/fragments/labels/cinema4d2026.sh
+++ b/fragments/labels/cinema4d2026.sh
@@ -1,0 +1,15 @@
+cinema4d2026)
+    name="Cinema 4D"
+    type="dmg"
+    appCustomVersion(){
+      defaults read "/Applications/Maxon Cinema 4D 2026/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "2026+\.[0-9]+\.[0-9]+"
+    }
+    productDownloadsPage=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*downloads/cinema-4d-2026[^"]*' | head -1)
+    downloadURL=$(curl -fsL $productDownloadsPage | grep -oE 'https://[^"]*\.dmg' | head -1)
+    appNewVersion=$(grep -Eo "/2026.([[0-9]+).([[0-9]+)/" <<< $downloadURL | sed 's|/||g')
+    targetDir="/Applications/Maxon Cinema 4D 2026"
+    installerTool="Maxon Cinema 4D Installer.app"
+    CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=(--mode unattended --unattendedmodeui none)
+    expectedTeamID="4ZY22YGXQG"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes 

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Cinema 4D 2026 creates a new installation path, in the same way as previous versions.
Therefore I believe it's necessary to have separate labels for every major C4D version

**Installomator log** 
First clean install:
```
2025-09-11 16:48:20 : INFO  : cinema4d2026 : setting variable from argument DEBUG=0
2025-09-11 16:48:20 : INFO  : cinema4d2026 : Total items in argumentsArray: 1
2025-09-11 16:48:20 : INFO  : cinema4d2026 : argumentsArray: DEBUG=0
2025-09-11 16:48:20 : REQ   : cinema4d2026 : ################## Start Installomator v. 10.9beta, date 2025-09-11
2025-09-11 16:48:20 : INFO  : cinema4d2026 : ################## Version: 10.9beta
2025-09-11 16:48:20 : INFO  : cinema4d2026 : ################## Date: 2025-09-11
2025-09-11 16:48:20 : INFO  : cinema4d2026 : ################## cinema4d2026
2025-09-11 16:48:21 : INFO  : cinema4d2026 : Reading arguments again: DEBUG=0
2025-09-11 16:48:21 : INFO  : cinema4d2026 : BLOCKING_PROCESS_ACTION=tell_user
2025-09-11 16:48:21 : INFO  : cinema4d2026 : NOTIFY=success
2025-09-11 16:48:21 : INFO  : cinema4d2026 : LOGGING=INFO
2025-09-11 16:48:21 : INFO  : cinema4d2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-11 16:48:21 : INFO  : cinema4d2026 : Label type: dmg
2025-09-11 16:48:21 : INFO  : cinema4d2026 : archiveName: Cinema 4D.dmg
2025-09-11 16:48:21 : INFO  : cinema4d2026 : no blocking processes defined, using Cinema 4D as default
2025-09-11 16:48:21 : INFO  : cinema4d2026 : Custom App Version detection is used, found 2026.0.0
2025-09-11 16:48:21 : INFO  : cinema4d2026 : appversion: 2026.0.0
2025-09-11 16:48:21 : INFO  : cinema4d2026 : Latest version of Cinema 4D is 2026.0.0
2025-09-11 16:48:21 : REQ   : cinema4d2026 : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2026.0.0/Cinema4D_2026_2026.0_Mac.dmg to Cinema 4D.dmg
2025-09-11 16:48:36 : INFO  : cinema4d2026 : Downloaded Cinema 4D.dmg – Type is  zlib compressed data – SHA is 59f798314a2ac60df42c19637460d67b4b4950a5 – Size is 1377936 kB
2025-09-11 16:48:37 : REQ   : cinema4d2026 : no more blocking processes, continue with update
2025-09-11 16:48:37 : REQ   : cinema4d2026 : Installing Cinema 4D
2025-09-11 16:48:37 : REQ   : cinema4d2026 : installerTool used: Maxon Cinema 4D Installer.app
2025-09-11 16:48:37 : INFO  : cinema4d2026 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Hd7DaYG000/Cinema 4D.dmg
2025-09-11 16:48:40 : INFO  : cinema4d2026 : Mounted: /Volumes/Maxon Cinema 4D
2025-09-11 16:48:40 : INFO  : cinema4d2026 : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2025-09-11 16:48:41 : INFO  : cinema4d2026 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2025-09-11 16:48:41 : INFO  : cinema4d2026 : Downloaded version of Cinema 4D is 2026.0.0 on versionKey CFBundleShortVersionString, same as installed.
2025-09-11 16:48:42 : INFO  : cinema4d2026 : Installomator did not close any apps, so no need to reopen any apps.
2025-09-11 16:48:42 : REQ   : cinema4d2026 : ################## End Installomator, exit code 0 
```

Second run, with app installed:
```
2025-09-11 16:50:37 : INFO  : cinema4d2026 : setting variable from argument DEBUG=0
2025-09-11 16:50:37 : INFO  : cinema4d2026 : Total items in argumentsArray: 1
2025-09-11 16:50:37 : INFO  : cinema4d2026 : argumentsArray: DEBUG=0
2025-09-11 16:50:37 : REQ   : cinema4d2026 : ################## Start Installomator v. 10.9beta, date 2025-09-11
2025-09-11 16:50:37 : INFO  : cinema4d2026 : ################## Version: 10.9beta
2025-09-11 16:50:37 : INFO  : cinema4d2026 : ################## Date: 2025-09-11
2025-09-11 16:50:37 : INFO  : cinema4d2026 : ################## cinema4d2026
2025-09-11 16:50:38 : INFO  : cinema4d2026 : Reading arguments again: DEBUG=0
2025-09-11 16:50:38 : INFO  : cinema4d2026 : BLOCKING_PROCESS_ACTION=tell_user
2025-09-11 16:50:38 : INFO  : cinema4d2026 : NOTIFY=success
2025-09-11 16:50:38 : INFO  : cinema4d2026 : LOGGING=INFO
2025-09-11 16:50:38 : INFO  : cinema4d2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-11 16:50:38 : INFO  : cinema4d2026 : Label type: dmg
2025-09-11 16:50:38 : INFO  : cinema4d2026 : archiveName: Cinema 4D.dmg
2025-09-11 16:50:38 : INFO  : cinema4d2026 : no blocking processes defined, using Cinema 4D as default
2025-09-11 16:50:38 : INFO  : cinema4d2026 : Custom App Version detection is used, found 2026.0.0
2025-09-11 16:50:38 : INFO  : cinema4d2026 : appversion: 2026.0.0
2025-09-11 16:50:38 : INFO  : cinema4d2026 : Latest version of Cinema 4D is 2026.0.0
2025-09-11 16:50:38 : INFO  : cinema4d2026 : There is no newer version available.
2025-09-11 16:50:38 : INFO  : cinema4d2026 : Installomator did not close any apps, so no need to reopen any apps.
2025-09-11 16:50:38 : REQ   : cinema4d2026 : No newer version.
2025-09-11 16:50:38 : REQ   : cinema4d2026 : ################## End Installomator, exit code 0 
```