### PR TITLE
Improve Cinema 4D 2025 appNewVersion and downloadURL

### DIFF
--- a/fragments/labels/cinema4d2025.sh
+++ b/fragments/labels/cinema4d2025.sh
@@ -6,9 +6,8 @@ cinema4d2025)
     }
     productDownloadsPage=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*downloads/cinema-4d-2025[^"]*' | head -1)
     downloadURL=$(curl -fsL $productDownloadsPage | grep -oE 'https://[^"]*\.dmg' | head -1)
-    appNewVersion=$(sed -E 's/.*_([0-9.]*)_Mac\.dmg/\1/g' <<< $downloadURL)
+    appNewVersion=$(grep -Eo "/2025.([[0-9]+).([[0-9]+)/" <<< $downloadURL | sed 's|/||g')
     targetDir="/Applications/Maxon Cinema 4D 2025"
-    downloadURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/${appNewVersion}/Cinema4D_2025_${appNewVersion}_Mac.dmg"
     installerTool="Maxon Cinema 4D Installer.app"
     CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
     CLIArguments=(--mode unattended --unattendedmodeui none)

--- a/fragments/labels/cinema4d2025.sh
+++ b/fragments/labels/cinema4d2025.sh
@@ -1,13 +1,11 @@
 cinema4d2025)
     name="Cinema 4D"
     type="dmg"
-    appCustomVersion(){
-      defaults read "/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "2025+\.[0-9]+\.[0-9]+"
-    }
     productDownloadsPage=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*downloads/cinema-4d-2025[^"]*' | head -1)
     downloadURL=$(curl -fsL $productDownloadsPage | grep -oE 'https://[^"]*\.dmg' | head -1)
     appNewVersion=$(grep -Eo "/2025.([[0-9]+).([[0-9]+)/" <<< $downloadURL | sed 's|/||g')
     targetDir="/Applications/Maxon Cinema 4D 2025"
+    appCustomVersion(){defaults read "${targetDir}/Cinema 4D.app/Contents/Info.plist" CFBundleGetInfoString | grep -Eo "2025+\.[0-9]+\.[0-9]+"}
     installerTool="Maxon Cinema 4D Installer.app"
     CLIInstaller="Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh"
     CLIArguments=(--mode unattended --unattendedmodeui none)


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
When creating a new C4D 2026 label I realized that the code for appNewVersion and downloadURL could be improved.
Especially the appNewVersion will break if dmg isn't named with the full short version (eg. 2025.4, instead of 2025.4.0).

**Installomator log** 
Clean install:
```
2025-09-12 09:08:26 : INFO  : cinema4d2025 : setting variable from argument DEBUG=0
2025-09-12 09:08:26 : INFO  : cinema4d2025 : Total items in argumentsArray: 1
2025-09-12 09:08:26 : INFO  : cinema4d2025 : argumentsArray: DEBUG=0
2025-09-12 09:08:26 : REQ   : cinema4d2025 : ################## Start Installomator v. 10.9beta, date 2025-09-12
2025-09-12 09:08:26 : INFO  : cinema4d2025 : ################## Version: 10.9beta
2025-09-12 09:08:26 : INFO  : cinema4d2025 : ################## Date: 2025-09-12
2025-09-12 09:08:26 : INFO  : cinema4d2025 : ################## cinema4d2025
2025-09-12 09:08:27 : INFO  : cinema4d2025 : Reading arguments again: DEBUG=0
2025-09-12 09:08:27 : INFO  : cinema4d2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-09-12 09:08:27 : INFO  : cinema4d2025 : NOTIFY=success
2025-09-12 09:08:27 : INFO  : cinema4d2025 : LOGGING=INFO
2025-09-12 09:08:27 : INFO  : cinema4d2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-12 09:08:27 : INFO  : cinema4d2025 : Label type: dmg
2025-09-12 09:08:27 : INFO  : cinema4d2025 : archiveName: Cinema 4D.dmg
2025-09-12 09:08:27 : INFO  : cinema4d2025 : no blocking processes defined, using Cinema 4D as default
2025-09-12 09:08:27.556 defaults[93437:45732382] 
The domain/default pair of (/Applications/Maxon Cinema 4D 2025/Cinema 4D.app/Contents/Info.plist, CFBundleGetInfoString) does not exist
2025-09-12 09:08:27 : INFO  : cinema4d2025 : Custom App Version detection is used, found 
2025-09-12 09:08:27 : INFO  : cinema4d2025 : appversion: 
2025-09-12 09:08:27 : INFO  : cinema4d2025 : Latest version of Cinema 4D is 2025.3.3
2025-09-12 09:08:27 : REQ   : cinema4d2025 : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/cinema4d/releases/2025.3.3/Cinema4D_2025_2025.3.3_Mac.dmg to Cinema 4D.dmg
2025-09-12 09:08:42 : INFO  : cinema4d2025 : Downloaded Cinema 4D.dmg – Type is  zlib compressed data – SHA is 7064eb7e68ceea73699bbc406fbc8f2d2d2ed801 – Size is 1376260 kB
2025-09-12 09:08:42 : REQ   : cinema4d2025 : no more blocking processes, continue with update
2025-09-12 09:08:42 : REQ   : cinema4d2025 : Installing Cinema 4D
2025-09-12 09:08:42 : REQ   : cinema4d2025 : installerTool used: Maxon Cinema 4D Installer.app
2025-09-12 09:08:42 : INFO  : cinema4d2025 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Ymv7Z1RsY8/Cinema 4D.dmg
2025-09-12 09:08:45 : INFO  : cinema4d2025 : Mounted: /Volumes/Maxon Cinema 4D
2025-09-12 09:08:45 : INFO  : cinema4d2025 : Verifying: /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app
2025-09-12 09:08:47 : INFO  : cinema4d2025 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2025-09-12 09:08:47 : INFO  : cinema4d2025 : Installing Cinema 4D version 2025.3.3 on versionKey CFBundleShortVersionString.
2025-09-12 09:08:47 : INFO  : cinema4d2025 : CLIInstaller exists, running installer command /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --unattendedmodeui none
2025-09-12 09:09:36 : INFO  : cinema4d2025 : Succesfully ran /Volumes/Maxon Cinema 4D/Maxon Cinema 4D Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --unattendedmodeui none
2025-09-12 09:09:36 : INFO  : cinema4d2025 : Finishing...
2025-09-12 09:09:39 : INFO  : cinema4d2025 : Custom App Version detection is used, found 2025.3.3
2025-09-12 09:09:39 : REQ   : cinema4d2025 : Installed Cinema 4D, version 2025.3.3
2025-09-12 09:09:39 : INFO  : cinema4d2025 : notifying
2025-09-12 09:09:41 : INFO  : cinema4d2025 : Installomator did not close any apps, so no need to reopen any apps.
2025-09-12 09:09:41 : REQ   : cinema4d2025 : All done!
2025-09-12 09:09:41 : REQ   : cinema4d2025 : ################## End Installomator, exit code 0  
```

With app installed:
```
2025-09-12 09:14:06 : INFO  : cinema4d2025 : setting variable from argument DEBUG=0
2025-09-12 09:14:06 : INFO  : cinema4d2025 : Total items in argumentsArray: 1
2025-09-12 09:14:06 : INFO  : cinema4d2025 : argumentsArray: DEBUG=0
2025-09-12 09:14:06 : REQ   : cinema4d2025 : ################## Start Installomator v. 10.9beta, date 2025-09-12
2025-09-12 09:14:06 : INFO  : cinema4d2025 : ################## Version: 10.9beta
2025-09-12 09:14:06 : INFO  : cinema4d2025 : ################## Date: 2025-09-12
2025-09-12 09:14:06 : INFO  : cinema4d2025 : ################## cinema4d2025
2025-09-12 09:14:07 : INFO  : cinema4d2025 : Reading arguments again: DEBUG=0
2025-09-12 09:14:08 : INFO  : cinema4d2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-09-12 09:14:08 : INFO  : cinema4d2025 : NOTIFY=success
2025-09-12 09:14:08 : INFO  : cinema4d2025 : LOGGING=INFO
2025-09-12 09:14:08 : INFO  : cinema4d2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-12 09:14:08 : INFO  : cinema4d2025 : Label type: dmg
2025-09-12 09:14:08 : INFO  : cinema4d2025 : archiveName: Cinema 4D.dmg
2025-09-12 09:14:08 : INFO  : cinema4d2025 : no blocking processes defined, using Cinema 4D as default
2025-09-12 09:14:08 : INFO  : cinema4d2025 : Custom App Version detection is used, found 2025.3.3
2025-09-12 09:14:08 : INFO  : cinema4d2025 : appversion: 2025.3.3
2025-09-12 09:14:08 : INFO  : cinema4d2025 : Latest version of Cinema 4D is 2025.3.3
2025-09-12 09:14:08 : INFO  : cinema4d2025 : There is no newer version available.
2025-09-12 09:14:08 : INFO  : cinema4d2025 : Installomator did not close any apps, so no need to reopen any apps.
2025-09-12 09:14:08 : REQ   : cinema4d2025 : No newer version.
2025-09-12 09:14:08 : REQ   : cinema4d2025 : ################## End Installomator, exit code 0 
```