### PR TITLE
new app label - zen browser

### DIFF
--- a/fragments/labels/zen.sh
+++ b/fragments/labels/zen.sh
@@ -1,0 +1,11 @@
+zen|\
+zenbrowser)
+    # credit: Tully Jagoe
+    name="Zen"
+    type="dmg"
+    appNewVersion=$(versionFromGit zen-browser desktop)
+    versionKey="CFBundleShortVersionString"
+    downloadURL="https://github.com/zen-browser/desktop/releases/latest/download/zen.macos-universal.dmg"
+    archiveName="zen.macos-universal.dmg"
+    expectedTeamID="9V5K9TP787"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context**
https://zen-browser.app/
https://github.com/zen-browser/desktop

**Installomator log** 
``` bash
2025-09-22 15:23:12 : DEBUG : zen : DEBUG mode 1 enabled.
2025-09-22 15:23:13 : INFO  : zen : Reading arguments again: DEBUG=1
2025-09-22 15:23:13 : DEBUG : zen : argument: DEBUG=1
2025-09-22 15:23:13 : DEBUG : zen : name=Zen
2025-09-22 15:23:13 : DEBUG : zen : appName=
2025-09-22 15:23:13 : DEBUG : zen : type=dmg
2025-09-22 15:23:13 : DEBUG : zen : archiveName=zen.macos-universal.dmg
2025-09-22 15:23:13 : DEBUG : zen : downloadURL=https://github.com/zen-browser/desktop/releases/latest/download/zen.macos-universal.dmg
2025-09-22 15:23:13 : DEBUG : zen : curlOptions=
2025-09-22 15:23:13 : DEBUG : zen : appNewVersion=1.15.5
2025-09-22 15:23:13 : DEBUG : zen : appCustomVersion function: Not defined
2025-09-22 15:23:13 : DEBUG : zen : versionKey=CFBundleShortVersionString
2025-09-22 15:23:13 : DEBUG : zen : packageID=
2025-09-22 15:23:13 : DEBUG : zen : pkgName=
2025-09-22 15:23:13 : DEBUG : zen : choiceChangesXML=
2025-09-22 15:23:13 : DEBUG : zen : expectedTeamID=9V5K9TP787
2025-09-22 15:23:13 : DEBUG : zen : blockingProcesses=
2025-09-22 15:23:13 : DEBUG : zen : installerTool=
2025-09-22 15:23:13 : DEBUG : zen : CLIInstaller=
2025-09-22 15:23:13 : DEBUG : zen : CLIArguments=
2025-09-22 15:23:13 : DEBUG : zen : updateTool=
2025-09-22 15:23:13 : DEBUG : zen : updateToolArguments=
2025-09-22 15:23:13 : DEBUG : zen : updateToolRunAsCurrentUser=
2025-09-22 15:23:13 : INFO  : zen : BLOCKING_PROCESS_ACTION=tell_user
2025-09-22 15:23:13 : INFO  : zen : NOTIFY=success
2025-09-22 15:23:13 : INFO  : zen : LOGGING=DEBUG
2025-09-22 15:23:13 : INFO  : zen : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-22 15:23:13 : INFO  : zen : Label type: dmg
2025-09-22 15:23:13 : INFO  : zen : archiveName: zen.macos-universal.dmg
2025-09-22 15:23:13 : INFO  : zen : no blocking processes defined, using Zen as default
2025-09-22 15:23:13 : DEBUG : zen : Changing directory to <redacted>/Installomator/build
2025-09-22 15:23:13 : INFO  : zen : App(s) found: /Applications/Zen.app
2025-09-22 15:23:13 : INFO  : zen : found app at /Applications/Zen.app, version 1.15.5b, on versionKey CFBundleShortVersionString
2025-09-22 15:23:13 : INFO  : zen : appversion: 1.15.5b
2025-09-22 15:23:13 : INFO  : zen : Latest version of Zen is 1.15.5
2025-09-22 15:23:13 : INFO  : zen : zen.macos-universal.dmg exists and DEBUG mode 1 enabled, skipping download
2025-09-22 15:23:13 : DEBUG : zen : DEBUG mode 1, not checking for blocking processes
2025-09-22 15:23:13 : REQ   : zen : Installing Zen
2025-09-22 15:23:13 : INFO  : zen : Mounting <redacted>/Installomator/build/zen.macos-universal.dmg
2025-09-22 15:23:13 : DEBUG : zen : Debugging enabled, dmgmount output was:
expected   CRC32 $95E08B16
/dev/disk8              Apple_partition_scheme
/dev/disk8s1            Apple_partition_map
/dev/disk8s2            Apple_HFS                       /Volumes/Zen 1

2025-09-22 15:23:13 : INFO  : zen : Mounted: /Volumes/Zen 1
2025-09-22 15:23:13 : INFO  : zen : Verifying: /Volumes/Zen 1/Zen.app
2025-09-22 15:23:13 : DEBUG : zen : App size: 472M      /Volumes/Zen 1/Zen.app
2025-09-22 15:23:16 : DEBUG : zen : Debugging enabled, App Verification output was:
/Volumes/Zen 1/Zen.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mauro Baladés (9V5K9TP787)

2025-09-22 15:23:16 : INFO  : zen : Team ID matching: 9V5K9TP787 (expected: 9V5K9TP787 )
2025-09-22 15:23:16 : INFO  : zen : Downloaded version of Zen is 1.15.5b on versionKey CFBundleShortVersionString, same as installed.
2025-09-22 15:23:16 : DEBUG : zen : Unmounting /Volumes/Zen 1
2025-09-22 15:23:16 : DEBUG : zen : Debugging enabled, Unmounting output was:
"disk8" ejected.
2025-09-22 15:23:16 : DEBUG : zen : DEBUG mode 1, not reopening anything
2025-09-22 15:23:16 : REG   : zen : No new version to install
2025-09-22 15:23:16 : REQ   : zen : ################## End Installomator, exit code 0 
```