### PR TITLE
Update citrixworkspace.sh

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -1,20 +1,8 @@
 citrixworkspace)
-    #credit: Erik Stam (@erikstam) and #Philipp on MacAdmins Slack
     name="Citrix Workspace"
     type="pkgInDmg"
-    curlOptions=( --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36")
-    parseURL() {
-        urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html#ctx-dl-eula-external'
-        htmlDocument=$(curl -s -L $urlToParse $curlOptions)
-        xmllint --html --xpath "string(//a[contains(@rel, 'downloads.citrix.com')]/@rel)" 2> /dev/null <(print $htmlDocument)
-    }
-    downloadURL="https:$(parseURL)"
-    newVersionString() {
-        urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
-        htmlDocument=$(curl -fs $urlToParse $curlOptions)
-        xmllint --html --xpath 'string(//p[contains(., "Version")])' 2> /dev/null <(print $htmlDocument)
-    }
-    appNewVersion=$(newVersionString | cut -d ' ' -f2 | cut -d '(' -f1)
+    downloadURL="https://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg"
+    appNewVersion=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/Version)' -)
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current download URL that the ```citrixworkspace``` label uses requires sign in (a change must have been made recently). These changes to the label fixes this problem.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-09-22 14:03:44 : INFO  : citrixworkspace : Total items in argumentsArray: 0
2025-09-22 14:03:44 : INFO  : citrixworkspace : argumentsArray: 
2025-09-22 14:03:44 : REQ   : citrixworkspace : ################## Start Installomator v. 10.9beta, date 2025-09-22
2025-09-22 14:03:44 : INFO  : citrixworkspace : ################## Version: 10.9beta
2025-09-22 14:03:44 : INFO  : citrixworkspace : ################## Date: 2025-09-22
2025-09-22 14:03:44 : INFO  : citrixworkspace : ################## citrixworkspace
2025-09-22 14:03:44 : DEBUG : citrixworkspace : DEBUG mode 1 enabled.
2025-09-22 14:03:44 : INFO  : citrixworkspace : SwiftDialog is not installed, clear cmd file var
2025-09-22 14:03:45 : INFO  : citrixworkspace : Reading arguments again: 
2025-09-22 14:03:45 : DEBUG : citrixworkspace : name=Citrix Workspace
2025-09-22 14:03:45 : DEBUG : citrixworkspace : appName=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : type=pkgInDmg
2025-09-22 14:03:45 : DEBUG : citrixworkspace : archiveName=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : downloadURL=https://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg
2025-09-22 14:03:45 : DEBUG : citrixworkspace : curlOptions=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : appNewVersion=25.08.0.48
2025-09-22 14:03:45 : DEBUG : citrixworkspace : appCustomVersion function: Not defined
2025-09-22 14:03:45 : DEBUG : citrixworkspace : versionKey=CitrixVersionString
2025-09-22 14:03:45 : DEBUG : citrixworkspace : packageID=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : pkgName=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : choiceChangesXML=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : expectedTeamID=S272Y5R93J
2025-09-22 14:03:45 : DEBUG : citrixworkspace : blockingProcesses=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : installerTool=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : CLIInstaller=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : CLIArguments=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : updateTool=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : updateToolArguments=
2025-09-22 14:03:45 : DEBUG : citrixworkspace : updateToolRunAsCurrentUser=
2025-09-22 14:03:45 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2025-09-22 14:03:45 : INFO  : citrixworkspace : NOTIFY=success
2025-09-22 14:03:45 : INFO  : citrixworkspace : LOGGING=DEBUG
2025-09-22 14:03:45 : INFO  : citrixworkspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-22 14:03:45 : INFO  : citrixworkspace : Label type: pkgInDmg
2025-09-22 14:03:45 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2025-09-22 14:03:45 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2025-09-22 14:03:45 : DEBUG : citrixworkspace : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-09-22 14:03:45 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2025-09-22 14:03:46 : INFO  : citrixworkspace : App(s) found: /Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app
2025-09-22 14:03:46 : INFO  : citrixworkspace : found app at /Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app, version 25.08.0.48, on versionKey CitrixVersionString
2025-09-22 14:03:46 : INFO  : citrixworkspace : appversion: 25.08.0.48
2025-09-22 14:03:46 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 25.08.0.48
2025-09-22 14:03:46 : WARN  : citrixworkspace : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-09-22 14:03:46 : REQ   : citrixworkspace : Downloading https://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg to Citrix Workspace.dmg
2025-09-22 14:03:46 : DEBUG : citrixworkspace : No Dialog connection, just download
2025-09-22 14:03:57 : INFO  : citrixworkspace : Downloaded Citrix Workspace.dmg – Type is  zlib compressed data – SHA is 472c37a77ac277793d99ec993ea27bbcb1101440 – Size is 607532 kB
2025-09-22 14:03:57 : DEBUG : citrixworkspace : DEBUG mode 1, not checking for blocking processes
2025-09-22 14:03:57 : REQ   : citrixworkspace : Installing Citrix Workspace
2025-09-22 14:03:57 : INFO  : citrixworkspace : Mounting /Users/kryptonit/Documents/github/Installomator/build/Citrix Workspace.dmg
2025-09-22 14:03:58 : DEBUG : citrixworkspace : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $9B47749E
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $0883DF9A
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified CRC32 $20429BAF
verified CRC32 $712B31F6
/dev/disk7          	Apple_partition_scheme
/dev/disk7s1        	Apple_partition_map
/dev/disk7s2        	Apple_HFS                      	/Volumes/Citrix Workspace

2025-09-22 14:03:59 : INFO  : citrixworkspace : Mounted: /Volumes/Citrix Workspace
2025-09-22 14:03:59 : DEBUG : citrixworkspace : Found pkg(s):
/Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-09-22 14:03:59 : INFO  : citrixworkspace : found pkg: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-09-22 14:03:59 : INFO  : citrixworkspace : Verifying: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-09-22 14:03:59 : DEBUG : citrixworkspace : File list: -rw-r--r--@ 1 kryptonit  wheel   566M Sep 15 12:13 /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2025-09-22 14:03:59 : DEBUG : citrixworkspace : File type: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: xar archive compressed TOC: 7525, SHA-1 checksum
2025-09-22 14:03:59 : DEBUG : citrixworkspace : spctlOut is /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: accepted
2025-09-22 14:03:59 : DEBUG : citrixworkspace : source=Notarized Developer ID
2025-09-22 14:03:59 : DEBUG : citrixworkspace : origin=Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)
2025-09-22 14:03:59 : INFO  : citrixworkspace : Team ID: S272Y5R93J (expected: S272Y5R93J )
2025-09-22 14:03:59 : DEBUG : citrixworkspace : DEBUG enabled, skipping installation
2025-09-22 14:03:59 : INFO  : citrixworkspace : Finishing...
2025-09-22 14:04:02 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2025-09-22 14:04:03 : INFO  : citrixworkspace : App(s) found: /Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app
2025-09-22 14:04:03 : INFO  : citrixworkspace : found app at /Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app, version 25.08.0.48, on versionKey CitrixVersionString
2025-09-22 14:04:03 : REQ   : citrixworkspace : Installed Citrix Workspace, version 25.08.0.48
2025-09-22 14:04:03 : INFO  : citrixworkspace : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-09-22 14:04:03 : DEBUG : citrixworkspace : Unmounting /Volumes/Citrix Workspace
2025-09-22 14:04:03 : DEBUG : citrixworkspace : Debugging enabled, Unmounting output was:
"disk7" ejected.
2025-09-22 14:04:03 : DEBUG : citrixworkspace : DEBUG mode 1, not reopening anything
2025-09-22 14:04:03 : REQ   : citrixworkspace : All done!
2025-09-22 14:04:03 : REQ   : citrixworkspace : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
