### PR TITLE
fixed: adobecreativecloud download url

### DIFF
--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -8,9 +8,9 @@ adobecreativeclouddesktop)
         exit 75
     fi
     if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*macarm64.*dmg' | head -1 | cut -d '"' -f1)
+        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html" | grep -o 'https.*macarm64.*dmg' | head -1 | cut -d '"' -f1)
     else
-        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/kb/creative-cloud-desktop-app-download.html" | grep -o 'https.*osx10.*dmg' | head -1 | cut -d '"' -f1)
+        downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html" | grep -o 'https.*osx10.*dmg' | head -1 | cut -d '"' -f1)
     fi
     #appNewVersion=$(curl -fs "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html" | grep "mandatory" | head -1 | grep -o "Version *.* released" | cut -d " " -f2)
     appNewVersion=$(echo $downloadURL | grep -o '[^x]*$' | cut -d '.' -f 1 | sed 's/_/\./g')


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

The old URL is now redirecting to https://helpx.adobe.com/in/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-from-web.html instead of the direct links URL.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
Script result: 2025-09-23 15:00:21 : REQ   :  : shifting arguments for Jamf
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument NOTIFY_DIALOG=1
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument NOTIFY=success
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument BLOCKING_PROCESS_ACTION="prompt_user"
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument PROMPT_TIMEOUT=300
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument REOPEN=yes
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : setting variable from argument DIALOG_CMD_FILE=/var/tmp/dialog_adobecc.log
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : Total items in argumentsArray: 7
2025-09-23 15:00:21 : INFO  : adobecreativeclouddesktop : argumentsArray: NOTIFY_DIALOG=1 NOTIFY=success BLOCKING_PROCESS_ACTION="prompt_user" PROMPT_TIMEOUT=300 REOPEN=yes DIALOG_CMD_FILE=/var/tmp/dialog_adobecc.log
2025-09-23 15:00:21 : REQ   : adobecreativeclouddesktop : ################## Start Installomator v. 10.9beta, date 2025-04-11
2025-09-23 15:00:22 : INFO  : adobecreativeclouddesktop : ################## Version: 10.9beta
2025-09-23 15:00:22 : INFO  : adobecreativeclouddesktop : ################## Date: 2025-04-11
2025-09-23 15:00:22 : INFO  : adobecreativeclouddesktop : ################## adobecreativeclouddesktop
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : Reading arguments again: NOTIFY_DIALOG=1 NOTIFY=success BLOCKING_PROCESS_ACTION="prompt_user" PROMPT_TIMEOUT=300 REOPEN=yes DIALOG_CMD_FILE=/var/tmp/dialog_adobecc.log
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : BLOCKING_PROCESS_ACTION=prompt_user
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : NOTIFY=success
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : LOGGING=INFO
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : 
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : Label type: dmg
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : archiveName: Adobe Creative Cloud.dmg
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : name: Adobe Creative Cloud, appName: Creative Cloud.app
2025-09-23 15:00:27.617 mdfind[8239:1508637] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-09-23 15:00:27.618 mdfind[8239:1508637] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-09-23 15:00:27.788 mdfind[8239:1508637] Couldn't determine the mapping between prefab keywords and predicates.
2025-09-23 15:00:27 : WARN  : adobecreativeclouddesktop : No previous app found
2025-09-23 15:00:27 : WARN  : adobecreativeclouddesktop : could not find Creative Cloud.app
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : appversion: 
2025-09-23 15:00:27 : INFO  : adobecreativeclouddesktop : Latest version of Adobe Creative Cloud is 6.7.0.278
2025-09-23 15:00:27 : REQ   : adobecreativeclouddesktop : Downloading https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.7.0/278/macarm64/ACCCx6_7_0_278.dmg to Adobe Creative Cloud.dmg
2025-09-23 15:01:15 : INFO  : adobecreativeclouddesktop : Downloaded Adobe Creative Cloud.dmg – Type is  zlib compressed data – SHA is e871fe435e95fb8ef0bcb53b3cd23f094db242bf – Size is 294960 kB
2025-09-23 15:01:15 : REQ   : adobecreativeclouddesktop : no more blocking processes, continue with update
2025-09-23 15:01:15 : REQ   : adobecreativeclouddesktop : Installing Adobe Creative Cloud
2025-09-23 15:01:15 : REQ   : adobecreativeclouddesktop : installerTool used: Install.app
2025-09-23 15:01:15 : INFO  : adobecreativeclouddesktop : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MS1JcRGzOW/Adobe Creative Cloud.dmg
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : Mounted: /Volumes/Creative Cloud
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : Verifying: /Volumes/Creative Cloud/Install.app
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : Team ID matching: JQ525L2MZD (expected: JQ525L2MZD )
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : Installing Adobe Creative Cloud version 2.14.0.43 on versionKey CFBundleShortVersionString.
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : App has LSMinimumSystemVersion: 10.13
2025-09-23 15:01:16 : INFO  : adobecreativeclouddesktop : CLIInstaller exists, running installer command /Volumes/Creative Cloud/Install.app/Contents/MacOS/Install --mode=silent
2025-09-23 15:01:28 : INFO  : adobecreativeclouddesktop : Succesfully ran /Volumes/Creative Cloud/Install.app/Contents/MacOS/Install --mode=silent
2025-09-23 15:01:28 : INFO  : adobecreativeclouddesktop : Finishing...
2025-09-23 15:01:31 : INFO  : adobecreativeclouddesktop : name: Adobe Creative Cloud, appName: Install.app
2025-09-23 15:01:31.948 mdfind[8703:1512123] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2025-09-23 15:01:31.948 mdfind[8703:1512123] [UserQueryParser] Loading keywords and predicates for locale "en"
2025-09-23 15:01:32.029 mdfind[8703:1512123] Couldn't determine the mapping between prefab keywords and predicates.
2025-09-23 15:01:32 : WARN  : adobecreativeclouddesktop : No previous app found
2025-09-23 15:01:32 : WARN  : adobecreativeclouddesktop : could not find Install.app
2025-09-23 15:01:32 : REQ   : adobecreativeclouddesktop : Installed Adobe Creative Cloud, version 2.14.0.43
2025-09-23 15:01:32 : INFO  : adobecreativeclouddesktop : notifying
2025-09-23 15:01:33 : INFO  : adobecreativeclouddesktop : Installomator did not close any apps, so no need to reopen any apps.
2025-09-23 15:01:33 : REQ   : adobecreativeclouddesktop : All done!
2025-09-23 15:01:33 : REQ   : adobecreativeclouddesktop : ################## End Installomator, exit code 0
```