### PR TITLE
fix downloadURL for remotedesktopmanagerfree

### DIFF
--- a/fragments/labels/remotedesktopmanagerfree.sh
+++ b/fragments/labels/remotedesktopmanagerfree.sh
@@ -1,7 +1,7 @@
 remotedesktopmanagerfree)
     name="Remote Desktop Manager"
     type="dmg"
-    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/home/thankyou/rdmmacbin/ | grep -oe "http.*\.dmg" | head -1)
+    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/download/thank-you/\?platform\=RDMMacbin\&edition\=free\&os\=macos | grep "const productInfo" | grep -oe "{.*}" | jq -r '."RDMMacbin.Url"')
     appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
     expectedTeamID="N592S9ASDB"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
Fixes #2348 

**Installomator log** 
No app installed:
```
➜  Installomator git:(fix_ remotedesktopmanagerfree) ✗ sudo ./assemble.sh remotedesktopmanagerfree DEBUG=0                                                                                                                                                                                          
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : setting variable from argument DEBUG=0
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : Total items in argumentsArray: 1
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : argumentsArray: DEBUG=0
2025-09-25 10:11:29 : REQ   : remotedesktopmanagerfree : ################## Start Installomator v. 10.9beta, date 2025-09-25
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : ################## Version: 10.9beta
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : ################## Date: 2025-09-25
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : ################## remotedesktopmanagerfree
2025-09-25 10:11:29 : INFO  : remotedesktopmanagerfree : Reading arguments again: DEBUG=0
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : BLOCKING_PROCESS_ACTION=tell_user
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : NOTIFY=success
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : LOGGING=INFO
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : Label type: dmg
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : archiveName: Remote Desktop Manager.dmg
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : no blocking processes defined, using Remote Desktop Manager as default
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : name: Remote Desktop Manager, appName: Remote Desktop Manager.app
2025-09-25 10:11:30 : WARN  : remotedesktopmanagerfree : No previous app found
2025-09-25 10:11:30 : WARN  : remotedesktopmanagerfree : could not find Remote Desktop Manager.app
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : appversion: 
2025-09-25 10:11:30 : INFO  : remotedesktopmanagerfree : Latest version of Remote Desktop Manager is 2025.2.12.6
2025-09-25 10:11:30 : REQ   : remotedesktopmanagerfree : Downloading https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2025.2.12.6.dmg to Remote Desktop Manager.dmg
2025-09-25 10:11:34 : INFO  : remotedesktopmanagerfree : Downloaded Remote Desktop Manager.dmg – Type is  zlib compressed data – SHA is 88d808d914196efcc1ac42d16eb7526619170ce6 – Size is 340876 kB
2025-09-25 10:11:34 : REQ   : remotedesktopmanagerfree : no more blocking processes, continue with update
2025-09-25 10:11:34 : REQ   : remotedesktopmanagerfree : Installing Remote Desktop Manager
2025-09-25 10:11:34 : INFO  : remotedesktopmanagerfree : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7NSxNQyVYx/Remote Desktop Manager.dmg
2025-09-25 10:11:38 : INFO  : remotedesktopmanagerfree : Mounted: /Volumes/Remote Desktop Manager.app Installer 1
2025-09-25 10:11:38 : INFO  : remotedesktopmanagerfree : Verifying: /Volumes/Remote Desktop Manager.app Installer 1/Remote Desktop Manager.app
2025-09-25 10:11:42 : INFO  : remotedesktopmanagerfree : Team ID matching: N592S9ASDB (expected: N592S9ASDB )
2025-09-25 10:11:42 : INFO  : remotedesktopmanagerfree : Installing Remote Desktop Manager version 2025.2.12.6 on versionKey CFBundleShortVersionString.
2025-09-25 10:11:42 : INFO  : remotedesktopmanagerfree : App has LSMinimumSystemVersion: 12.0
2025-09-25 10:11:42 : INFO  : remotedesktopmanagerfree : Copy /Volumes/Remote Desktop Manager.app Installer 1/Remote Desktop Manager.app to /Applications
2025-09-25 10:11:43 : WARN  : remotedesktopmanagerfree : Changing owner to p-m.lejon
2025-09-25 10:11:43 : INFO  : remotedesktopmanagerfree : Finishing...
2025-09-25 10:11:46 : INFO  : remotedesktopmanagerfree : App(s) found: /Applications/Remote Desktop Manager.app
2025-09-25 10:11:46 : INFO  : remotedesktopmanagerfree : found app at /Applications/Remote Desktop Manager.app, version 2025.2.12.6, on versionKey CFBundleShortVersionString
2025-09-25 10:11:46 : REQ   : remotedesktopmanagerfree : Installed Remote Desktop Manager, version 2025.2.12.6
2025-09-25 10:11:46 : INFO  : remotedesktopmanagerfree : notifying
2025-09-25 10:11:47 : INFO  : remotedesktopmanagerfree : Installomator did not close any apps, so no need to reopen any apps.
2025-09-25 10:11:47 : REQ   : remotedesktopmanagerfree : All done!
2025-09-25 10:11:47 : REQ   : remotedesktopmanagerfree : ################## End Installomator, exit code 0 
```

Latest app installed:
```
➜  Installomator git:(fix_ remotedesktopmanagerfree) ✗ sudo ./assemble.sh remotedesktopmanagerfree DEBUG=0
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : setting variable from argument DEBUG=0
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : Total items in argumentsArray: 1
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : argumentsArray: DEBUG=0
2025-09-25 10:16:11 : REQ   : remotedesktopmanagerfree : ################## Start Installomator v. 10.9beta, date 2025-09-25
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : ################## Version: 10.9beta
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : ################## Date: 2025-09-25
2025-09-25 10:16:11 : INFO  : remotedesktopmanagerfree : ################## remotedesktopmanagerfree
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : Reading arguments again: DEBUG=0
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : BLOCKING_PROCESS_ACTION=tell_user
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : NOTIFY=success
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : LOGGING=INFO
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : Label type: dmg
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : archiveName: Remote Desktop Manager.dmg
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : no blocking processes defined, using Remote Desktop Manager as default
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : App(s) found: /Applications/Remote Desktop Manager.app
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : found app at /Applications/Remote Desktop Manager.app, version 2025.2.12.6, on versionKey CFBundleShortVersionString
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : appversion: 2025.2.12.6
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : Latest version of Remote Desktop Manager is 2025.2.12.6
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : There is no newer version available.
2025-09-25 10:16:12 : INFO  : remotedesktopmanagerfree : Installomator did not close any apps, so no need to reopen any apps.
2025-09-25 10:16:12 : REQ   : remotedesktopmanagerfree : No newer version.
2025-09-25 10:16:12 : REQ   : remotedesktopmanagerfree : ################## End Installomator, exit code 0 
```