### PR TITLE
tropy-new-label

### DIFF
--- a/fragments/labels/tropy.sh
+++ b/fragments/labels/tropy.sh
@@ -1,0 +1,12 @@
+tropy)
+    name="Tropy"
+    type="dmg"
+    if [[ $(arch) == arm64 ]]; then
+        archiveName="tropy-[0-9.]*-arm64.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        archiveName="tropy-[0-9.]*.dmg"
+    fi
+    appNewVersion="$(versionFromGit tropy tropy)"
+    downloadURL="$(downloadURLFromGit tropy tropy)"
+    expectedTeamID="8LAYR367YV"
+    ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh tropy DEBUG=0
2025-09-25 09:48:35 : INFO  : tropy : setting variable from argument DEBUG=0
2025-09-25 09:48:35 : INFO  : tropy : Total items in argumentsArray: 1
2025-09-25 09:48:35 : INFO  : tropy : argumentsArray: DEBUG=0
2025-09-25 09:48:35 : REQ   : tropy : ################## Start Installomator v. 10.9beta, date 2025-09-25
2025-09-25 09:48:35 : INFO  : tropy : ################## Version: 10.9beta
2025-09-25 09:48:35 : INFO  : tropy : ################## Date: 2025-09-25
2025-09-25 09:48:35 : INFO  : tropy : ################## tropy
2025-09-25 09:48:36 : INFO  : tropy : Reading arguments again: DEBUG=0
2025-09-25 09:48:37 : INFO  : tropy : BLOCKING_PROCESS_ACTION=tell_user
2025-09-25 09:48:37 : INFO  : tropy : NOTIFY=success
2025-09-25 09:48:37 : INFO  : tropy : LOGGING=INFO
2025-09-25 09:48:37 : INFO  : tropy : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-25 09:48:37 : INFO  : tropy : Label type: dmg
2025-09-25 09:48:37 : INFO  : tropy : archiveName: tropy-[0-9.]*-arm64.dmg
2025-09-25 09:48:37 : INFO  : tropy : no blocking processes defined, using Tropy as default
2025-09-25 09:48:37 : INFO  : tropy : name: Tropy, appName: Tropy.app
2025-09-25 09:48:37 : WARN  : tropy : No previous app found
2025-09-25 09:48:37 : WARN  : tropy : could not find Tropy.app
2025-09-25 09:48:37 : INFO  : tropy : appversion:
2025-09-25 09:48:37 : INFO  : tropy : Latest version of Tropy is 1.16.2
2025-09-25 09:48:37 : REQ   : tropy : Downloading https://github.com/tropy/tropy/releases/download/v1.16.2/tropy-1.16.2-arm64.dmg to tropy-[0-9.]*-arm64.dmg
2025-09-25 09:48:40 : INFO  : tropy : Downloaded tropy-[0-9.]*-arm64.dmg – Type is  zlib compressed data – SHA is 7d2af740eed23283dd83de8b3a4e159930895e0b – Size is 115260 kB
2025-09-25 09:48:40 : REQ   : tropy : no more blocking processes, continue with update
2025-09-25 09:48:40 : REQ   : tropy : Installing Tropy
2025-09-25 09:48:40 : INFO  : tropy : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.6fOmo2cAIF/tropy-[0-9.]*-arm64.dmg
2025-09-25 09:48:43 : INFO  : tropy : Mounted: /Volumes/Tropy
2025-09-25 09:48:43 : INFO  : tropy : Verifying: /Volumes/Tropy/Tropy.app
2025-09-25 09:48:44 : INFO  : tropy : Team ID matching: 8LAYR367YV (expected: 8LAYR367YV )
2025-09-25 09:48:44 : INFO  : tropy : Installing Tropy version 1.16.2 on versionKey CFBundleShortVersionString.
2025-09-25 09:48:44 : INFO  : tropy : App has LSMinimumSystemVersion: 10.13.0
2025-09-25 09:48:44 : INFO  : tropy : Copy /Volumes/Tropy/Tropy.app to /Applications
2025-09-25 09:48:45 : WARN  : tropy : Changing owner to u0105821
2025-09-25 09:48:46 : INFO  : tropy : Finishing...
2025-09-25 09:48:49 : INFO  : tropy : App(s) found: /Applications/Tropy.app
2025-09-25 09:48:49 : INFO  : tropy : found app at /Applications/Tropy.app, version 1.16.2, on versionKey CFBundleShortVersionString
2025-09-25 09:48:49 : REQ   : tropy : Installed Tropy, version 1.16.2
2025-09-25 09:48:49 : INFO  : tropy : notifying
2025-09-25 09:48:49 : INFO  : tropy : Installomator did not close any apps, so no need to reopen any apps.
2025-09-25 09:48:49 : REQ   : tropy : All done!
2025-09-25 09:48:49 : REQ   : tropy : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

creating a label

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
