### PR TITLE
Update asperaconnect.sh

### DIFF
--- a/fragments/labels/asperaconnect.sh
+++ b/fragments/labels/asperaconnect.sh
@@ -1,7 +1,7 @@
 asperaconnect)
     name="Aspera Connect"
     type="pkg"
-    downloadURL="https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/$(curl -fs 'https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm~Other%20software&product=ibm/Other+software/IBM+Aspera+Connect' --data-raw 'showStatus=false' | egrep -o "ibm-aspera-connect_[0-9.]+_macOS" | head -n1)_x86_64.pkg"
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*ibm-aspera-connect_([0-9]+(\.[0-9]+)*)_macOS.*\.pkg/\1/')
+    downloadURL="https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/$(curl -fs 'https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm~Other%20software&product=ibm/Other+software/IBM+Aspera+Connect' --data-raw 'showStatus=false' | egrep -o "ibm-aspera-connect_.*_macOS" | head -n1)_x86_64.pkg"
+    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*ibm-aspera-connect_([0-9]+(\.[0-9]+)*).*_macOS.*\.pkg/\1/')
     expectedTeamID="PETKK2G752"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The pkg file name format has changed, so the current label are unable to find the latest version of Aspera Connect and the download fails. These changes solves that problem.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-09-26 11:10:12 : INFO  : asperaconnect : Total items in argumentsArray: 0
2025-09-26 11:10:12 : INFO  : asperaconnect : argumentsArray: 
2025-09-26 11:10:12 : REQ   : asperaconnect : ################## Start Installomator v. 10.9beta, date 2025-09-26
2025-09-26 11:10:12 : INFO  : asperaconnect : ################## Version: 10.9beta
2025-09-26 11:10:12 : INFO  : asperaconnect : ################## Date: 2025-09-26
2025-09-26 11:10:12 : INFO  : asperaconnect : ################## asperaconnect
2025-09-26 11:10:12 : DEBUG : asperaconnect : DEBUG mode 1 enabled.
2025-09-26 11:10:12 : INFO  : asperaconnect : SwiftDialog is not installed, clear cmd file var
2025-09-26 11:10:17 : INFO  : asperaconnect : Reading arguments again: 
2025-09-26 11:10:17 : DEBUG : asperaconnect : name=Aspera Connect
2025-09-26 11:10:17 : DEBUG : asperaconnect : appName=
2025-09-26 11:10:17 : DEBUG : asperaconnect : type=pkg
2025-09-26 11:10:17 : DEBUG : asperaconnect : archiveName=
2025-09-26 11:10:17 : DEBUG : asperaconnect : downloadURL=https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.17.893-HEAD_macOS_x86_64.pkg
2025-09-26 11:10:17 : DEBUG : asperaconnect : curlOptions=
2025-09-26 11:10:17 : DEBUG : asperaconnect : appNewVersion=4.2.17.893
2025-09-26 11:10:17 : DEBUG : asperaconnect : appCustomVersion function: Not defined
2025-09-26 11:10:17 : DEBUG : asperaconnect : versionKey=CFBundleShortVersionString
2025-09-26 11:10:17 : DEBUG : asperaconnect : packageID=
2025-09-26 11:10:17 : DEBUG : asperaconnect : pkgName=
2025-09-26 11:10:17 : DEBUG : asperaconnect : choiceChangesXML=
2025-09-26 11:10:17 : DEBUG : asperaconnect : expectedTeamID=PETKK2G752
2025-09-26 11:10:17 : DEBUG : asperaconnect : blockingProcesses=
2025-09-26 11:10:17 : DEBUG : asperaconnect : installerTool=
2025-09-26 11:10:17 : DEBUG : asperaconnect : CLIInstaller=
2025-09-26 11:10:17 : DEBUG : asperaconnect : CLIArguments=
2025-09-26 11:10:17 : DEBUG : asperaconnect : updateTool=
2025-09-26 11:10:17 : DEBUG : asperaconnect : updateToolArguments=
2025-09-26 11:10:17 : DEBUG : asperaconnect : updateToolRunAsCurrentUser=
2025-09-26 11:10:17 : INFO  : asperaconnect : BLOCKING_PROCESS_ACTION=tell_user
2025-09-26 11:10:17 : INFO  : asperaconnect : NOTIFY=success
2025-09-26 11:10:17 : INFO  : asperaconnect : LOGGING=DEBUG
2025-09-26 11:10:17 : INFO  : asperaconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-26 11:10:17 : INFO  : asperaconnect : Label type: pkg
2025-09-26 11:10:17 : INFO  : asperaconnect : archiveName: Aspera Connect.pkg
2025-09-26 11:10:17 : INFO  : asperaconnect : no blocking processes defined, using Aspera Connect as default
2025-09-26 11:10:17 : DEBUG : asperaconnect : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-09-26 11:10:17 : INFO  : asperaconnect : name: Aspera Connect, appName: Aspera Connect.app
2025-09-26 11:10:18 : WARN  : asperaconnect : No previous app found
2025-09-26 11:10:18 : WARN  : asperaconnect : could not find Aspera Connect.app
2025-09-26 11:10:18 : INFO  : asperaconnect : appversion: 
2025-09-26 11:10:18 : INFO  : asperaconnect : Latest version of Aspera Connect is 4.2.17.893
2025-09-26 11:10:18 : REQ   : asperaconnect : Downloading https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.17.893-HEAD_macOS_x86_64.pkg to Aspera Connect.pkg
2025-09-26 11:10:18 : DEBUG : asperaconnect : No Dialog connection, just download
2025-09-26 11:10:22 : INFO  : asperaconnect : Downloaded Aspera Connect.pkg – Type is  xar archive compressed TOC – SHA is c8c9ef60d5203356f0e2e96734d24b3947c9b313 – Size is 98440 kB
2025-09-26 11:10:22 : DEBUG : asperaconnect : DEBUG mode 1, not checking for blocking processes
2025-09-26 11:10:22 : REQ   : asperaconnect : Installing Aspera Connect
2025-09-26 11:10:22 : INFO  : asperaconnect : Verifying: Aspera Connect.pkg
2025-09-26 11:10:22 : DEBUG : asperaconnect : File list: -rw-r--r--  1 root  staff    81M Sep 26 11:10 Aspera Connect.pkg
2025-09-26 11:10:22 : DEBUG : asperaconnect : File type: Aspera Connect.pkg: xar archive compressed TOC: 5621, SHA-1 checksum
2025-09-26 11:10:22 : DEBUG : asperaconnect : spctlOut is Aspera Connect.pkg: accepted
2025-09-26 11:10:22 : DEBUG : asperaconnect : source=Notarized Developer ID
2025-09-26 11:10:22 : DEBUG : asperaconnect : origin=Developer ID Installer: International  Business Machines Corp (PETKK2G752)
2025-09-26 11:10:22 : INFO  : asperaconnect : Team ID: PETKK2G752 (expected: PETKK2G752 )
2025-09-26 11:10:22 : DEBUG : asperaconnect : DEBUG enabled, skipping installation
2025-09-26 11:10:22 : INFO  : asperaconnect : Finishing...
2025-09-26 11:10:25 : INFO  : asperaconnect : name: Aspera Connect, appName: Aspera Connect.app
2025-09-26 11:10:26 : WARN  : asperaconnect : No previous app found
2025-09-26 11:10:26 : WARN  : asperaconnect : could not find Aspera Connect.app
2025-09-26 11:10:26 : REQ   : asperaconnect : Installed Aspera Connect, version 4.2.17.893
2025-09-26 11:10:26 : INFO  : asperaconnect : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-09-26 11:10:26 : DEBUG : asperaconnect : DEBUG mode 1, not reopening anything
2025-09-26 11:10:26 : REQ   : asperaconnect : All done!
2025-09-26 11:10:26 : REQ   : asperaconnect : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
No issue has been created about this so far.