### PR TITLE
Fix label: scenebuilder - Download URL incorrect

### DIFF
--- a/fragments/labels/scenebuilder.sh
+++ b/fragments/labels/scenebuilder.sh
@@ -2,9 +2,9 @@ scenebuilder)
     name="SceneBuilder"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -sfL "https://gluonhq.com/products/scene-builder/" | xmllint --html --format - 2>/dev/null | grep -o "https://.*SceneBuilder.*aarch64.dmg")
+        downloadURL=$(curl -sfL "https://gluonhq.com/products/scene-builder/" | xmllint --html --format - 2>/dev/null | grep -v 'RC' | grep -o "https://.*SceneBuilder.*aarch64.dmg")
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL=$(curl -sfL "https://gluonhq.com/products/scene-builder/" | xmllint --html --format - 2>/dev/null | grep -o "https://.*SceneBuilder.*amd64.dmg")
+        downloadURL=$(curl -sfL "https://gluonhq.com/products/scene-builder/" | xmllint --html --format - 2>/dev/null | grep -v 'RC' | grep -o "https://.*SceneBuilder.*amd64.dmg")
     fi
     appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)-.*/\1/g' )
     expectedTeamID="S7ZR395D8U"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The existing download URL was pulling and extra "release candidate" line that was breaking the download. Modified to exclude the "RC" line.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Output:

```
2025-09-30 12:46:00 : INFO  : scenebuilder : setting variable from argument DEBUG=0
2025-09-30 12:46:00 : INFO  : scenebuilder : Total items in argumentsArray: 1
2025-09-30 12:46:00 : INFO  : scenebuilder : argumentsArray: DEBUG=0
2025-09-30 12:46:00 : REQ   : scenebuilder : ################## Start Installomator v. 10.9beta, date 2025-09-30
2025-09-30 12:46:00 : INFO  : scenebuilder : ################## Version: 10.9beta
2025-09-30 12:46:00 : INFO  : scenebuilder : ################## Date: 2025-09-30
2025-09-30 12:46:00 : INFO  : scenebuilder : ################## scenebuilder
2025-09-30 12:46:01 : INFO  : scenebuilder : Reading arguments again: DEBUG=0
2025-09-30 12:46:01 : INFO  : scenebuilder : BLOCKING_PROCESS_ACTION=tell_user
2025-09-30 12:46:01 : INFO  : scenebuilder : NOTIFY=success
2025-09-30 12:46:01 : INFO  : scenebuilder : LOGGING=INFO
2025-09-30 12:46:01 : INFO  : scenebuilder : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-30 12:46:01 : INFO  : scenebuilder : Label type: dmg
2025-09-30 12:46:01 : INFO  : scenebuilder : archiveName: SceneBuilder.dmg
2025-09-30 12:46:01 : INFO  : scenebuilder : no blocking processes defined, using SceneBuilder as default
2025-09-30 12:46:01 : INFO  : scenebuilder : name: SceneBuilder, appName: SceneBuilder.app
2025-09-30 12:46:01 : WARN  : scenebuilder : No previous app found
2025-09-30 12:46:01 : WARN  : scenebuilder : could not find SceneBuilder.app
2025-09-30 12:46:01 : INFO  : scenebuilder : appversion:
2025-09-30 12:46:01 : INFO  : scenebuilder : Latest version of SceneBuilder is 25.0.0
2025-09-30 12:46:01 : REQ   : scenebuilder : Downloading https://download2.gluonhq.com/scenebuilder/25.0.0/install/mac/SceneBuilder-25.0.0-aarch64.dmg to SceneBuilder.dmg
2025-09-30 12:46:28 : INFO  : scenebuilder : Downloaded SceneBuilder.dmg – Type is  zlib compressed data – SHA is 90929e5ef847e3d07f951174473f497682047700 – Size is 99308 kB
2025-09-30 12:46:28 : REQ   : scenebuilder : no more blocking processes, continue with update
2025-09-30 12:46:28 : REQ   : scenebuilder : Installing SceneBuilder
2025-09-30 12:46:28 : INFO  : scenebuilder : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lv8etvKniM/SceneBuilder.dmg
2025-09-30 12:46:32 : INFO  : scenebuilder : Mounted: /Volumes/SceneBuilder
2025-09-30 12:46:32 : INFO  : scenebuilder : Verifying: /Volumes/SceneBuilder/SceneBuilder.app
2025-09-30 12:46:33 : INFO  : scenebuilder : Team ID matching: S7ZR395D8U (expected: S7ZR395D8U )
2025-09-30 12:46:33 : INFO  : scenebuilder : Installing SceneBuilder version 25.0.0 on versionKey CFBundleShortVersionString.
2025-09-30 12:46:33 : INFO  : scenebuilder : App has LSMinimumSystemVersion: 10.11
2025-09-30 12:46:33 : INFO  : scenebuilder : Copy /Volumes/SceneBuilder/SceneBuilder.app to /Applications
2025-09-30 12:46:33 : WARN  : scenebuilder : Changing owner to bkerns
2025-09-30 12:46:33 : INFO  : scenebuilder : Finishing...
2025-09-30 12:46:36 : INFO  : scenebuilder : App(s) found: /Applications/SceneBuilder.app
2025-09-30 12:46:36 : INFO  : scenebuilder : found app at /Applications/SceneBuilder.app, version 25.0.0, on versionKey CFBundleShortVersionString
2025-09-30 12:46:36 : REQ   : scenebuilder : Installed SceneBuilder, version 25.0.0
2025-09-30 12:46:36 : INFO  : scenebuilder : notifying
2025-09-30 12:46:47 : INFO  : scenebuilder : Installomator did not close any apps, so no need to reopen any apps.
2025-09-30 12:46:47 : REQ   : scenebuilder : All done!
2025-09-30 12:46:47 : REQ   : scenebuilder : ################## End Installomator, exit code 0
```
