### PR TITLE
Create minecraftedu.sh

### DIFF
--- a/fragments/labels/minecraftedu.sh
+++ b/fragments/labels/minecraftedu.sh
@@ -1,0 +1,7 @@
+minecraftedu)
+    name="minecraft-edu"
+    type="dmg"
+    downloadURL="https://aka.ms/meeclientmacos"
+    appNewVersion="curl -fsI ${downloadURL} | tr -d '\r' | grep -i ^location | cut -d "/" -f6 | cut -d "_" -f3 | cut -d "." -f1-4"
+    expectedTeamID="UBF8T346G9"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


Output:
```
./assemble.sh minecraftedu
2025-09-30 14:32:43 : INFO  : minecraftedu : Total items in argumentsArray: 0
2025-09-30 14:32:43 : INFO  : minecraftedu : argumentsArray:
2025-09-30 14:32:43 : REQ   : minecraftedu : ################## Start Installomator v. 10.9beta, date 2025-09-30
2025-09-30 14:32:43 : INFO  : minecraftedu : ################## Version: 10.9beta
2025-09-30 14:32:43 : INFO  : minecraftedu : ################## Date: 2025-09-30
2025-09-30 14:32:43 : INFO  : minecraftedu : ################## minecraftedu
2025-09-30 14:32:43 : DEBUG : minecraftedu : DEBUG mode 1 enabled.
2025-09-30 14:32:43 : INFO  : minecraftedu : Reading arguments again:
2025-09-30 14:32:43 : DEBUG : minecraftedu : name=minecraft-edu
2025-09-30 14:32:43 : DEBUG : minecraftedu : appName=
2025-09-30 14:32:43 : DEBUG : minecraftedu : type=dmg
2025-09-30 14:32:43 : DEBUG : minecraftedu : archiveName=
2025-09-30 14:32:43 : DEBUG : minecraftedu : downloadURL=https://aka.ms/meeclientmacos
2025-09-30 14:32:43 : DEBUG : minecraftedu : curlOptions=
' | grep -i ^location | cut -d / -f6 | cut -d _ -f3 | cut -d . -f1-4 https://aka.ms/meeclientmacos | tr -d '
2025-09-30 14:32:43 : DEBUG : minecraftedu : appCustomVersion function: Not defined
2025-09-30 14:32:43 : DEBUG : minecraftedu : versionKey=CFBundleShortVersionString
2025-09-30 14:32:43 : DEBUG : minecraftedu : packageID=
2025-09-30 14:32:43 : DEBUG : minecraftedu : pkgName=
2025-09-30 14:32:43 : DEBUG : minecraftedu : choiceChangesXML=
2025-09-30 14:32:43 : DEBUG : minecraftedu : expectedTeamID=UBF8T346G9
2025-09-30 14:32:43 : DEBUG : minecraftedu : blockingProcesses=
2025-09-30 14:32:43 : DEBUG : minecraftedu : installerTool=
2025-09-30 14:32:43 : DEBUG : minecraftedu : CLIInstaller=
2025-09-30 14:32:43 : DEBUG : minecraftedu : CLIArguments=
2025-09-30 14:32:43 : DEBUG : minecraftedu : updateTool=
2025-09-30 14:32:43 : DEBUG : minecraftedu : updateToolArguments=
2025-09-30 14:32:43 : DEBUG : minecraftedu : updateToolRunAsCurrentUser=
2025-09-30 14:32:43 : INFO  : minecraftedu : BLOCKING_PROCESS_ACTION=tell_user
2025-09-30 14:32:43 : INFO  : minecraftedu : NOTIFY=success
2025-09-30 14:32:43 : INFO  : minecraftedu : LOGGING=DEBUG
2025-09-30 14:32:43 : INFO  : minecraftedu : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-09-30 14:32:43 : INFO  : minecraftedu : Label type: dmg
2025-09-30 14:32:43 : INFO  : minecraftedu : archiveName: minecraft-edu.dmg
2025-09-30 14:32:43 : INFO  : minecraftedu : no blocking processes defined, using minecraft-edu as default
2025-09-30 14:32:43 : DEBUG : minecraftedu : Changing directory to /Users/naschenbrenner/Documents/GitHub/Installomator/build
2025-09-30 14:32:43 : INFO  : minecraftedu : App(s) found: /Applications/minecraft-edu.app
2025-09-30 14:32:43 : INFO  : minecraftedu : found app at /Applications/minecraft-edu.app, version 1.21.92, on versionKey CFBundleShortVersionString
2025-09-30 14:32:43 : INFO  : minecraftedu : appversion: 1.21.92
' | grep -i ^location | cut -d / -f6 | cut -d _ -f3 | cut -d . -f1-4raft-edu is curl -fsI https://aka.ms/meeclientmacos | tr -d '
2025-09-30 14:32:43 : REQ   : minecraftedu : Downloading https://aka.ms/meeclientmacos to minecraft-edu.dmg
2025-09-30 14:32:43 : DEBUG : minecraftedu : No Dialog connection, just download
2025-09-30 14:32:54 : INFO  : minecraftedu : Downloaded minecraft-edu.dmg – Type is  zlib compressed data – SHA is 5c852789d5a811f3830d4e09a71c34f8ae97aa71 – Size is 651356 kB
2025-09-30 14:32:54 : DEBUG : minecraftedu : DEBUG mode 1, not checking for blocking processes
2025-09-30 14:32:54 : REQ   : minecraftedu : Installing minecraft-edu
2025-09-30 14:32:54 : INFO  : minecraftedu : Mounting /Users/naschenbrenner/Documents/GitHub/Installomator/build/minecraft-edu.dmg
2025-09-30 14:32:57 : DEBUG : minecraftedu : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F773D8BF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $555C5893
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $C17B5D50
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $3AB8AB19
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $C17B5D50
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $A904F8F6
verified   CRC32 $80F5FB82
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	EFI
/dev/disk7s2        	Apple_HFS                      	/Volumes/Minecraft Education 1

2025-09-30 14:32:57 : INFO  : minecraftedu : Mounted: /Volumes/Minecraft Education 1
2025-09-30 14:32:57 : INFO  : minecraftedu : Verifying: /Volumes/Minecraft Education 1/minecraft-edu.app
2025-09-30 14:32:57 : DEBUG : minecraftedu : App size: 1.4G	/Volumes/Minecraft Education 1/minecraft-edu.app
2025-09-30 14:33:06 : DEBUG : minecraftedu : Debugging enabled, App Verification output was:
/Volumes/Minecraft Education 1/minecraft-edu.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Microsoft Corporation (UBF8T346G9)

2025-09-30 14:33:06 : INFO  : minecraftedu : Team ID matching: UBF8T346G9 (expected: UBF8T346G9 )
2025-09-30 14:33:06 : INFO  : minecraftedu : Downloaded version of minecraft-edu is 1.21.92 on versionKey CFBundleShortVersionString, same as installed.
2025-09-30 14:33:06 : DEBUG : minecraftedu : Unmounting /Volumes/Minecraft Education 1
2025-09-30 14:33:17 : DEBUG : minecraftedu : Debugging enabled, Unmounting output was:
"disk7" ejected.
2025-09-30 14:33:17 : DEBUG : minecraftedu : DEBUG mode 1, not reopening anything
2025-09-30 14:33:17 : REG   : minecraftedu : No new version to install
2025-09-30 14:33:17 : REQ   : minecraftedu : ################## End Installomator, exit code 0
```
