### PR TITLE
Update microsoftteams-rollingout.sh

### DIFF
--- a/fragments/labels/microsoftteams-rollingout.sh
+++ b/fragments/labels/microsoftteams-rollingout.sh
@@ -3,7 +3,7 @@ microsoftteams-rollingout)
     type="pkg"
     packageID="com.microsoft.teams2"
     # Fetch the latest version number from the Microsoft documentation page
-    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning | awk '/<h4 id="mac-version-history">Mac version history<\/h4>/,/<\/table>/' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+    appNewVersion=$(curl -s https://learn.microsoft.com/en-us/officeupdates/teams-app-versioning | awk '/<h4 id="mac">Mac<\/h4>/,/<\/table>/' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
     downloadURL="https://statics.teams.cdn.office.net/production-osx/${appNewVersion}/MicrosoftTeams.pkg"
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( Teams MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams WebView Helper" "Microsoft Teams Launcher" "Microsoft Teams (work preview)" "Microsoft Teams classic Helper" "com.microsoft.teams2.respawn")


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
No

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Microsoft is just awesome! Changing `<h4 id="mac-version-history">Mac version history</h4>` to /`<h4 id="mac">Mac</h4>`made the world a whole another place!

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-10-02 11:03:42 : REQ   : microsoftteams-rollingout : ################## Start Installomator v. 10.9beta, date 2025-10-02
2025-10-02 11:03:42 : INFO  : microsoftteams-rollingout : ################## Version: 10.9beta
2025-10-02 11:03:42 : INFO  : microsoftteams-rollingout : ################## Date: 2025-10-02
2025-10-02 11:03:42 : INFO  : microsoftteams-rollingout : ################## microsoftteams-rollingout
2025-10-02 11:03:42 : DEBUG : microsoftteams-rollingout : DEBUG mode 1 enabled.
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Reading arguments again: 
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : name=Microsoft Teams
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : appName=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : type=pkg
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : archiveName=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : downloadURL=https://statics.teams.cdn.office.net/production-osx/25255.702.3963.1832/MicrosoftTeams.pkg
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : curlOptions=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : appNewVersion=25255.702.3963.1832
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : appCustomVersion function: Not defined
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : versionKey=CFBundleShortVersionString
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : packageID=com.microsoft.teams2
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : pkgName=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : choiceChangesXML=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : expectedTeamID=UBF8T346G9
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : blockingProcesses=Teams MSTeams Microsoft Teams Microsoft Teams WebView Microsoft Teams WebView Helper Microsoft Teams Launcher Microsoft Teams (work preview) Microsoft Teams classic Helper com.microsoft.teams2.respawn
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : installerTool=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : CLIInstaller=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : CLIArguments=
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : updateToolArguments=--install --apps TEAMS21
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : updateToolRunAsCurrentUser=
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : BLOCKING_PROCESS_ACTION=tell_user
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : NOTIFY=success
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : LOGGING=DEBUG
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Label type: pkg
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : archiveName: Microsoft Teams.pkg
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : Changing directory to .
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : found packageID com.microsoft.teams2 installed, version 25255.702.3963.1832
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : appversion: 25255.702.3963.1832
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Latest version of Microsoft Teams is 25255.702.3963.1832
2025-10-02 11:03:43 : WARN  : microsoftteams-rollingout : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : App needs to be updated and uses /Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2025-10-02 11:03:43 : WARN  : microsoftteams-rollingout : DEBUG mode 1 enabled, not running update tool
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Microsoft Teams.pkg exists and DEBUG mode 1 enabled, skipping download
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : DEBUG mode 1, not checking for blocking processes
2025-10-02 11:03:43 : REQ   : microsoftteams-rollingout : Installing Microsoft Teams
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Verifying: Microsoft Teams.pkg
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : File list: -rw-r--r--@ 1 root  staff   356M Oct  2 10:58 Microsoft Teams.pkg
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : File type: Microsoft Teams.pkg: xar archive compressed TOC: 5377, SHA-1 checksum
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : spctlOut is Microsoft Teams.pkg: accepted
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : source=Notarized Developer ID
2025-10-02 11:03:43 : DEBUG : microsoftteams-rollingout : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2025-10-02 11:03:43 : INFO  : microsoftteams-rollingout : Checking package version.
2025-10-02 11:03:44 : INFO  : microsoftteams-rollingout : Downloaded package com.microsoft.teams2 version 25255.702.3963.1832
2025-10-02 11:03:44 : INFO  : microsoftteams-rollingout : Downloaded version of Microsoft Teams is the same as installed.
2025-10-02 11:03:44 : DEBUG : microsoftteams-rollingout : DEBUG mode 1, not reopening anything
2025-10-02 11:03:44 : REQ   : microsoftteams-rollingout : No new version to install
2025-10-02 11:03:44 : REQ   : microsoftteams-rollingout : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
