### PR TITLE
New Label - Filmlab

### DIFF
--- a/fragments/labels/filmlab.sh
+++ b/fragments/labels/filmlab.sh
@@ -1,0 +1,7 @@
+filmlab)
+    name="FilmLab"
+    type="dmg"
+    appNewVersion="$(curl -fsL "https://downloads.filmlabapp.com/desktop/latest-mac.yml" | grep -E 'version' | awk '{print $2}')"
+    downloadURL="https://downloads.filmlabapp.com/desktop/FilmLab-$appNewVersion-universal.dmg"
+    expectedTeamID="UAGC35XKV5"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

Software that converts digital captures of film negatives into color or black-and-white images. 
https://www.filmlabapp.com

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
bbp39934@OVPR-MAC-742400 Installomator $ ./utils/assemble.sh filmlab DEBUG=1   
2025-10-02 09:37:49 : INFO  : filmlab : setting variable from argument DEBUG=1
2025-10-02 09:37:49 : INFO  : filmlab : Total items in argumentsArray: 1
2025-10-02 09:37:49 : INFO  : filmlab : argumentsArray: DEBUG=1
2025-10-02 09:37:49 : REQ   : filmlab : ################## Start Installomator v. 10.9beta, date 2025-10-02
2025-10-02 09:37:49 : INFO  : filmlab : ################## Version: 10.9beta
2025-10-02 09:37:49 : INFO  : filmlab : ################## Date: 2025-10-02
2025-10-02 09:37:49 : INFO  : filmlab : ################## filmlab
2025-10-02 09:37:49 : DEBUG : filmlab : DEBUG mode 1 enabled.
2025-10-02 09:37:49 : INFO  : filmlab : SwiftDialog is not installed, clear cmd file var
2025-10-02 09:37:50 : INFO  : filmlab : Reading arguments again: DEBUG=1
2025-10-02 09:37:50 : DEBUG : filmlab : argument: DEBUG=1
2025-10-02 09:37:50 : DEBUG : filmlab : name=FilmLab
2025-10-02 09:37:50 : DEBUG : filmlab : appName=
2025-10-02 09:37:50 : DEBUG : filmlab : type=dmg
2025-10-02 09:37:50 : DEBUG : filmlab : archiveName=
2025-10-02 09:37:50 : DEBUG : filmlab : downloadURL=https://downloads.filmlabapp.com/desktop/FilmLab-3.2.1-universal.dmg
2025-10-02 09:37:50 : DEBUG : filmlab : curlOptions=
2025-10-02 09:37:50 : DEBUG : filmlab : appNewVersion=3.2.1
2025-10-02 09:37:50 : DEBUG : filmlab : appCustomVersion function: Not defined
2025-10-02 09:37:50 : DEBUG : filmlab : versionKey=CFBundleShortVersionString
2025-10-02 09:37:50 : DEBUG : filmlab : packageID=
2025-10-02 09:37:50 : DEBUG : filmlab : pkgName=
2025-10-02 09:37:50 : DEBUG : filmlab : choiceChangesXML=
2025-10-02 09:37:50 : DEBUG : filmlab : expectedTeamID=UAGC35XKV5
2025-10-02 09:37:50 : DEBUG : filmlab : blockingProcesses=
2025-10-02 09:37:50 : DEBUG : filmlab : installerTool=
2025-10-02 09:37:50 : DEBUG : filmlab : CLIInstaller=
2025-10-02 09:37:50 : DEBUG : filmlab : CLIArguments=
2025-10-02 09:37:50 : DEBUG : filmlab : updateTool=
2025-10-02 09:37:50 : DEBUG : filmlab : updateToolArguments=
2025-10-02 09:37:50 : DEBUG : filmlab : updateToolRunAsCurrentUser=
2025-10-02 09:37:50 : INFO  : filmlab : BLOCKING_PROCESS_ACTION=tell_user
2025-10-02 09:37:50 : INFO  : filmlab : NOTIFY=success
2025-10-02 09:37:50 : INFO  : filmlab : LOGGING=DEBUG
2025-10-02 09:37:50 : INFO  : filmlab : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-02 09:37:50 : INFO  : filmlab : Label type: dmg
2025-10-02 09:37:50 : INFO  : filmlab : archiveName: FilmLab.dmg
2025-10-02 09:37:50 : INFO  : filmlab : no blocking processes defined, using FilmLab as default
2025-10-02 09:37:50 : DEBUG : filmlab : Changing directory to /Users/bbp39934/Downloads/Installomator/build
2025-10-02 09:37:50 : INFO  : filmlab : name: FilmLab, appName: FilmLab.app
2025-10-02 09:37:50 : WARN  : filmlab : No previous app found
2025-10-02 09:37:50 : WARN  : filmlab : could not find FilmLab.app
2025-10-02 09:37:50 : INFO  : filmlab : appversion: 
2025-10-02 09:37:50 : INFO  : filmlab : Latest version of FilmLab is 3.2.1
2025-10-02 09:37:50 : REQ   : filmlab : Downloading https://downloads.filmlabapp.com/desktop/FilmLab-3.2.1-universal.dmg to FilmLab.dmg
2025-10-02 09:37:50 : DEBUG : filmlab : No Dialog connection, just download
2025-10-02 09:38:04 : INFO  : filmlab : Downloaded FilmLab.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 950279e8a22485e91cfda5ed6608efd152ef604f – Size is 197628 kB
2025-10-02 09:38:04 : DEBUG : filmlab : DEBUG mode 1, not checking for blocking processes
2025-10-02 09:38:04 : REQ   : filmlab : Installing FilmLab
2025-10-02 09:38:04 : INFO  : filmlab : Mounting /Users/bbp39934/Downloads/Installomator/build/FilmLab.dmg
2025-10-02 09:38:05 : DEBUG : filmlab : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $B20C65B9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $16C3E2C7
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $0DB9BC2E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $A697EAA2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $0DB9BC2E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $A9BCDEE6
verified   CRC32 $7714ED0E
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/FilmLab 3.2.1-universal 1

2025-10-02 09:38:05 : INFO  : filmlab : Mounted: /Volumes/FilmLab 3.2.1-universal 1
2025-10-02 09:38:05 : INFO  : filmlab : Verifying: /Volumes/FilmLab 3.2.1-universal 1/FilmLab.app
2025-10-02 09:38:05 : DEBUG : filmlab : App size: 499M	/Volumes/FilmLab 3.2.1-universal 1/FilmLab.app
2025-10-02 09:38:08 : DEBUG : filmlab : Debugging enabled, App Verification output was:
/Volumes/FilmLab 3.2.1-universal 1/FilmLab.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Develop and Fix, Inc. (UAGC35XKV5)

2025-10-02 09:38:08 : INFO  : filmlab : Team ID matching: UAGC35XKV5 (expected: UAGC35XKV5 )
2025-10-02 09:38:08 : INFO  : filmlab : Installing FilmLab version 3.2.1 on versionKey CFBundleShortVersionString.
2025-10-02 09:38:08 : INFO  : filmlab : App has LSMinimumSystemVersion: 10.11.0
2025-10-02 09:38:08 : DEBUG : filmlab : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-02 09:38:08 : INFO  : filmlab : Finishing...
2025-10-02 09:38:11 : INFO  : filmlab : name: FilmLab, appName: FilmLab.app
2025-10-02 09:38:11 : WARN  : filmlab : No previous app found
2025-10-02 09:38:11 : WARN  : filmlab : could not find FilmLab.app
2025-10-02 09:38:11 : REQ   : filmlab : Installed FilmLab, version 3.2.1
2025-10-02 09:38:11 : INFO  : filmlab : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-02 09:38:11 : DEBUG : filmlab : Unmounting /Volumes/FilmLab 3.2.1-universal 1
2025-10-02 09:38:11 : DEBUG : filmlab : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-10-02 09:38:12 : DEBUG : filmlab : DEBUG mode 1, not reopening anything
2025-10-02 09:38:12 : REQ   : filmlab : All done!
2025-10-02 09:38:12 : REQ   : filmlab : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
