### PR TITLE
add macfuse appCustomVersion

### DIFF
--- a/fragments/labels/macfuse.sh
+++ b/fragments/labels/macfuse.sh
@@ -4,5 +4,10 @@ macfuse)
     pkgName="Install macFUSE.pkg"
     downloadURL=$(downloadURLFromGit osxfuse osxfuse)
     appNewVersion=$(versionFromGit osxfuse osxfuse)
+    appCustomVersion(){
+        if [ -f "/Library/Filesystems/macfuse.fs/Contents/Info.plist" ]; then
+            defaults read /Library/Filesystems/macfuse.fs/Contents/Info.plist CFBundleShortVersionString
+        fi
+    }
     expectedTeamID="3T5GSNBU6W"
     ;;

--- a/fragments/labels/macfuse.sh
+++ b/fragments/labels/macfuse.sh
@@ -4,10 +4,6 @@ macfuse)
     pkgName="Install macFUSE.pkg"
     downloadURL=$(downloadURLFromGit osxfuse osxfuse)
     appNewVersion=$(versionFromGit osxfuse osxfuse)
-    appCustomVersion(){
-        if [ -f "/Library/Filesystems/macfuse.fs/Contents/Info.plist" ]; then
-            defaults read /Library/Filesystems/macfuse.fs/Contents/Info.plist CFBundleShortVersionString
-        fi
-    }
+    appCustomVersion(){ if [ -f "/Library/Filesystems/macfuse.fs/Contents/Info.plist" ]; then defaults read /Library/Filesystems/macfuse.fs/Contents/Info.plist CFBundleShortVersionString; fi}
     expectedTeamID="3T5GSNBU6W"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
This PR adds version checking towards to prevent unnecessary installs

**Installomator log** 
Without pkg installed:
```
➜  Installomator git:(main) sudo ./assemble.sh macfuse DEBUG=0
2025-10-07 08:56:32 : INFO  : macfuse : setting variable from argument DEBUG=0
2025-10-07 08:56:32 : INFO  : macfuse : Total items in argumentsArray: 1
2025-10-07 08:56:32 : INFO  : macfuse : argumentsArray: DEBUG=0
2025-10-07 08:56:32 : REQ   : macfuse : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 08:56:32 : INFO  : macfuse : ################## Version: 10.9beta
2025-10-07 08:56:32 : INFO  : macfuse : ################## Date: 2025-10-07
2025-10-07 08:56:32 : INFO  : macfuse : ################## macfuse
2025-10-07 08:56:34 : INFO  : macfuse : Reading arguments again: DEBUG=0
2025-10-07 08:56:35 : INFO  : macfuse : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 08:56:35 : INFO  : macfuse : NOTIFY=success
2025-10-07 08:56:35 : INFO  : macfuse : LOGGING=INFO
2025-10-07 08:56:35 : INFO  : macfuse : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 08:56:35 : INFO  : macfuse : Label type: pkgInDmg
2025-10-07 08:56:35 : INFO  : macfuse : archiveName: FUSE for macOS.dmg
2025-10-07 08:56:35 : INFO  : macfuse : no blocking processes defined, using FUSE for macOS as default
2025-10-07 08:56:35 : INFO  : macfuse : Custom App Version detection is used, found 
2025-10-07 08:56:35 : INFO  : macfuse : appversion: 
2025-10-07 08:56:35 : INFO  : macfuse : Latest version of FUSE for macOS is 5.0.7
2025-10-07 08:56:35 : REQ   : macfuse : Downloading https://github.com/macfuse/macfuse/releases/download/macfuse-5.0.7/macfuse-5.0.7.dmg to FUSE for macOS.dmg
2025-10-07 08:56:36 : INFO  : macfuse : Downloaded FUSE for macOS.dmg – Type is  zlib compressed data – SHA is 6d23ba3b3b6b424a3400ad883f450f3e8b9fe560 – Size is 10312 kB
2025-10-07 08:56:36 : REQ   : macfuse : no more blocking processes, continue with update
2025-10-07 08:56:36 : REQ   : macfuse : Installing FUSE for macOS
2025-10-07 08:56:36 : INFO  : macfuse : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.IUWwnaPDzS/FUSE for macOS.dmg
2025-10-07 08:56:36 : INFO  : macfuse : Mounted: /Volumes/macFUSE
2025-10-07 08:56:36 : INFO  : macfuse : found pkg: /Volumes/macFUSE/Install macFUSE.pkg
2025-10-07 08:56:36 : INFO  : macfuse : Verifying: /Volumes/macFUSE/Install macFUSE.pkg
2025-10-07 08:56:37 : INFO  : macfuse : Team ID: 3T5GSNBU6W (expected: 3T5GSNBU6W )
2025-10-07 08:56:37 : INFO  : macfuse : Installing /Volumes/macFUSE/Install macFUSE.pkg to /
2025-10-07 08:56:42 : INFO  : macfuse : Finishing...
2025-10-07 08:56:45 : INFO  : macfuse : Custom App Version detection is used, found 5.0.7
2025-10-07 08:56:45 : REQ   : macfuse : Installed FUSE for macOS, version 5.0.7
2025-10-07 08:56:45 : INFO  : macfuse : notifying
2025-10-07 08:56:46 : INFO  : macfuse : Installomator did not close any apps, so no need to reopen any apps.
2025-10-07 08:56:46 : REQ   : macfuse : All done!
2025-10-07 08:56:46 : REQ   : macfuse : ################## End Installomator, exit code 0 
```

With pkg installed:
```
➜  Installomator git:(add_macfuse_appCustomVersion) sudo ./assemble.sh macfuse DEBUG=0
2025-10-07 08:56:52 : INFO  : macfuse : setting variable from argument DEBUG=0
2025-10-07 08:56:52 : INFO  : macfuse : Total items in argumentsArray: 1
2025-10-07 08:56:52 : INFO  : macfuse : argumentsArray: DEBUG=0
2025-10-07 08:56:52 : REQ   : macfuse : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 08:56:52 : INFO  : macfuse : ################## Version: 10.9beta
2025-10-07 08:56:52 : INFO  : macfuse : ################## Date: 2025-10-07
2025-10-07 08:56:52 : INFO  : macfuse : ################## macfuse
2025-10-07 08:56:53 : INFO  : macfuse : Reading arguments again: DEBUG=0
2025-10-07 08:56:53 : INFO  : macfuse : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 08:56:53 : INFO  : macfuse : NOTIFY=success
2025-10-07 08:56:53 : INFO  : macfuse : LOGGING=INFO
2025-10-07 08:56:53 : INFO  : macfuse : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 08:56:53 : INFO  : macfuse : Label type: pkgInDmg
2025-10-07 08:56:53 : INFO  : macfuse : archiveName: FUSE for macOS.dmg
2025-10-07 08:56:53 : INFO  : macfuse : no blocking processes defined, using FUSE for macOS as default
2025-10-07 08:56:53 : INFO  : macfuse : Custom App Version detection is used, found 5.0.7
2025-10-07 08:56:53 : INFO  : macfuse : appversion: 5.0.7
2025-10-07 08:56:53 : INFO  : macfuse : Latest version of FUSE for macOS is 5.0.7
2025-10-07 08:56:53 : INFO  : macfuse : There is no newer version available.
2025-10-07 08:56:54 : INFO  : macfuse : Installomator did not close any apps, so no need to reopen any apps.
2025-10-07 08:56:54 : REQ   : macfuse : No newer version.
2025-10-07 08:56:54 : REQ   : macfuse : ################## End Installomator, exit code 0 
```