### PR TITLE
Update camtasia2024.sh

### DIFF
--- a/fragments/labels/camtasia2024.sh
+++ b/fragments/labels/camtasia2024.sh
@@ -1,8 +1,8 @@
 camtasia2024)
     name="Camtasia 2024"
     type="dmg"
-    sparkleData=$(curl -fsL 'https://sparkle.cloud.techsmith.com/api/v1/AppcastManifest/?version=24.0.0&utm_source=product&utm_medium=cmac&utm_campaign=cm24&ipc_item_name=cmac&ipc_platform=macos')
-    appNewVersion=$( <<<"$sparkleData" xpath 'string(//item[last()]/sparkle:shortVersionString)' )
-    downloadURL=$( <<<"$sparkleData" xpath 'string(//item[last()]/enclosure/@url)' )
+    apiResult="$(curl -fsL "https://www.techsmith.com/api/v/1/products/getversioninfo/2200")"
+    downloadURL="https://download.techsmith.com/$(getJSONValue "$apiResult" "PrimaryDownloadInformation.RelativePath")$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Name")"
+    appNewVersion="20$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Major").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Minor").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Maintenance")"
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current camtasia2024 label is broken:

```
2025-10-07 12:34:40 : INFO  : camtasia2024 : Total items in argumentsArray: 0
2025-10-07 12:34:40 : INFO  : camtasia2024 : argumentsArray: 
2025-10-07 12:34:40 : REQ   : camtasia2024 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 12:34:40 : INFO  : camtasia2024 : ################## Version: 10.9beta
2025-10-07 12:34:40 : INFO  : camtasia2024 : ################## Date: 2025-10-07
2025-10-07 12:34:40 : INFO  : camtasia2024 : ################## camtasia2024
2025-10-07 12:34:40 : DEBUG : camtasia2024 : DEBUG mode 1 enabled.
2025-10-07 12:34:40 : INFO  : camtasia2024 : SwiftDialog is not installed, clear cmd file var

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.
2025-10-07 12:34:41 : INFO  : camtasia2024 : Reading arguments again: 
2025-10-07 12:34:41 : ERROR : camtasia2024 : need to provide 'downloadURL'
```

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-10-07 13:02:56 : INFO  : camtasia2024 : Total items in argumentsArray: 0
2025-10-07 13:02:56 : INFO  : camtasia2024 : argumentsArray: 
2025-10-07 13:02:56 : REQ   : camtasia2024 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 13:02:56 : INFO  : camtasia2024 : ################## Version: 10.9beta
2025-10-07 13:02:56 : INFO  : camtasia2024 : ################## Date: 2025-10-07
2025-10-07 13:02:56 : INFO  : camtasia2024 : ################## camtasia2024
2025-10-07 13:02:56 : DEBUG : camtasia2024 : DEBUG mode 1 enabled.
2025-10-07 13:02:56 : INFO  : camtasia2024 : SwiftDialog is not installed, clear cmd file var
2025-10-07 13:02:57 : INFO  : camtasia2024 : Reading arguments again: 
2025-10-07 13:02:57 : DEBUG : camtasia2024 : name=Camtasia 2024
2025-10-07 13:02:57 : DEBUG : camtasia2024 : appName=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : type=dmg
2025-10-07 13:02:57 : DEBUG : camtasia2024 : archiveName=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : downloadURL=https://download.techsmith.com/camtasiamac/releases/2418/camtasia.dmg
2025-10-07 13:02:57 : DEBUG : camtasia2024 : curlOptions=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : appNewVersion=2024.1.8
2025-10-07 13:02:57 : DEBUG : camtasia2024 : appCustomVersion function: Not defined
2025-10-07 13:02:57 : DEBUG : camtasia2024 : versionKey=CFBundleShortVersionString
2025-10-07 13:02:57 : DEBUG : camtasia2024 : packageID=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : pkgName=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : choiceChangesXML=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : expectedTeamID=7TQL462TU8
2025-10-07 13:02:57 : DEBUG : camtasia2024 : blockingProcesses=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : installerTool=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : CLIInstaller=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : CLIArguments=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : updateTool=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : updateToolArguments=
2025-10-07 13:02:57 : DEBUG : camtasia2024 : updateToolRunAsCurrentUser=
2025-10-07 13:02:57 : INFO  : camtasia2024 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 13:02:57 : INFO  : camtasia2024 : NOTIFY=success
2025-10-07 13:02:57 : INFO  : camtasia2024 : LOGGING=DEBUG
2025-10-07 13:02:57 : INFO  : camtasia2024 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 13:02:57 : INFO  : camtasia2024 : Label type: dmg
2025-10-07 13:02:57 : INFO  : camtasia2024 : archiveName: Camtasia 2024.dmg
2025-10-07 13:02:57 : INFO  : camtasia2024 : no blocking processes defined, using Camtasia 2024 as default
2025-10-07 13:02:57 : DEBUG : camtasia2024 : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-10-07 13:02:57 : INFO  : camtasia2024 : name: Camtasia 2024, appName: Camtasia 2024.app
2025-10-07 13:02:57 : WARN  : camtasia2024 : No previous app found
2025-10-07 13:02:57 : WARN  : camtasia2024 : could not find Camtasia 2024.app
2025-10-07 13:02:57 : INFO  : camtasia2024 : appversion: 
2025-10-07 13:02:57 : INFO  : camtasia2024 : Latest version of Camtasia 2024 is 2024.1.8
2025-10-07 13:02:58 : INFO  : camtasia2024 : Camtasia 2024.dmg exists and DEBUG mode 1 enabled, skipping download
2025-10-07 13:02:58 : DEBUG : camtasia2024 : DEBUG mode 1, not checking for blocking processes
2025-10-07 13:02:58 : REQ   : camtasia2024 : Installing Camtasia 2024
2025-10-07 13:02:58 : INFO  : camtasia2024 : Mounting /Users/kryptonit/Documents/github/Installomator/build/Camtasia 2024.dmg
2025-10-07 13:02:58 : DEBUG : camtasia2024 : Debugging enabled, dmgmount output was:
expected CRC32 $83A01010
/dev/disk35         	Apple_partition_scheme
/dev/disk35s1       	Apple_partition_map
/dev/disk35s2       	Apple_HFS                      	/Volumes/Camtasia

2025-10-07 13:02:58 : INFO  : camtasia2024 : Mounted: /Volumes/Camtasia
2025-10-07 13:02:58 : INFO  : camtasia2024 : Verifying: /Volumes/Camtasia/Camtasia 2024.app
2025-10-07 13:02:58 : DEBUG : camtasia2024 : App size: 813M	/Volumes/Camtasia/Camtasia 2024.app
2025-10-07 13:03:06 : DEBUG : camtasia2024 : Debugging enabled, App Verification output was:
/Volumes/Camtasia/Camtasia 2024.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2025-10-07 13:03:06 : INFO  : camtasia2024 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2025-10-07 13:03:06 : INFO  : camtasia2024 : Installing Camtasia 2024 version 2024.1.8 on versionKey CFBundleShortVersionString.
2025-10-07 13:03:06 : INFO  : camtasia2024 : App has LSMinimumSystemVersion: 13.0
2025-10-07 13:03:06 : DEBUG : camtasia2024 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-07 13:03:06 : INFO  : camtasia2024 : Finishing...
2025-10-07 13:03:09 : INFO  : camtasia2024 : name: Camtasia 2024, appName: Camtasia 2024.app
2025-10-07 13:03:10 : WARN  : camtasia2024 : No previous app found
2025-10-07 13:03:10 : WARN  : camtasia2024 : could not find Camtasia 2024.app
2025-10-07 13:03:10 : REQ   : camtasia2024 : Installed Camtasia 2024, version 2024.1.8
2025-10-07 13:03:10 : INFO  : camtasia2024 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-07 13:03:10 : DEBUG : camtasia2024 : Unmounting /Volumes/Camtasia
2025-10-07 13:03:10 : DEBUG : camtasia2024 : Debugging enabled, Unmounting output was:
"disk35" ejected.
2025-10-07 13:03:10 : DEBUG : camtasia2024 : DEBUG mode 1, not reopening anything
2025-10-07 13:03:10 : REQ   : camtasia2024 : All done!
2025-10-07 13:03:10 : REQ   : camtasia2024 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A