### PR TITLE
Update camtasia2023.sh

### DIFF
--- a/fragments/labels/camtasia2023.sh
+++ b/fragments/labels/camtasia2023.sh
@@ -1,8 +1,8 @@
 camtasia2023)
     name="Camtasia 2023"
     type="dmg"
-    sparkleData=$(curl -fsL 'https://sparkle.cloud.techsmith.com/api/v1/AppcastManifest/?version=23.0.0&utm_source=product&utm_medium=cmac&utm_campaign=cm23&ipc_item_name=cmac&ipc_platform=macos')
-    appNewVersion=$( <<<"$sparkleData" xpath 'string(//item/sparkle:shortVersionString)' )
-    downloadURL=$( <<<"$sparkleData" xpath 'string(//item/enclosure/@url)' )
+    apiResult="$(curl -fsL "https://www.techsmith.com/api/v/1/products/getversioninfo/2080")"
+    downloadURL="https://download.techsmith.com$(getJSONValue "$apiResult" "PrimaryDownloadInformation.RelativePath")$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Name")"
+    appNewVersion="20$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Major").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Minor").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Maintenance")"
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current camtasia2023 label is broken:
```
2025-10-07 13:07:13 : INFO  : camtasia2023 : Total items in argumentsArray: 0
2025-10-07 13:07:13 : INFO  : camtasia2023 : argumentsArray: 
2025-10-07 13:07:13 : REQ   : camtasia2023 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 13:07:13 : INFO  : camtasia2023 : ################## Version: 10.9beta
2025-10-07 13:07:13 : INFO  : camtasia2023 : ################## Date: 2025-10-07
2025-10-07 13:07:13 : INFO  : camtasia2023 : ################## camtasia2023
2025-10-07 13:07:13 : DEBUG : camtasia2023 : DEBUG mode 1 enabled.
2025-10-07 13:07:13 : INFO  : camtasia2023 : SwiftDialog is not installed, clear cmd file var

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.
2025-10-07 13:07:14 : INFO  : camtasia2023 : Reading arguments again: 
2025-10-07 13:07:14 : ERROR : camtasia2023 : need to provide 'downloadURL'
```
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-10-07 13:11:55 : INFO  : camtasia2023 : Total items in argumentsArray: 0
2025-10-07 13:11:55 : INFO  : camtasia2023 : argumentsArray: 
2025-10-07 13:11:55 : REQ   : camtasia2023 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 13:11:55 : INFO  : camtasia2023 : ################## Version: 10.9beta
2025-10-07 13:11:55 : INFO  : camtasia2023 : ################## Date: 2025-10-07
2025-10-07 13:11:55 : INFO  : camtasia2023 : ################## camtasia2023
2025-10-07 13:11:55 : DEBUG : camtasia2023 : DEBUG mode 1 enabled.
2025-10-07 13:11:55 : INFO  : camtasia2023 : SwiftDialog is not installed, clear cmd file var
2025-10-07 13:11:56 : INFO  : camtasia2023 : Reading arguments again: 
2025-10-07 13:11:56 : DEBUG : camtasia2023 : name=Camtasia 2023
2025-10-07 13:11:56 : DEBUG : camtasia2023 : appName=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : type=dmg
2025-10-07 13:11:56 : DEBUG : camtasia2023 : archiveName=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : downloadURL=https://download.techsmith.com/camtasiamac/releases/23319/camtasia.dmg
2025-10-07 13:11:56 : DEBUG : camtasia2023 : curlOptions=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : appNewVersion=2023.3.19
2025-10-07 13:11:56 : DEBUG : camtasia2023 : appCustomVersion function: Not defined
2025-10-07 13:11:56 : DEBUG : camtasia2023 : versionKey=CFBundleShortVersionString
2025-10-07 13:11:56 : DEBUG : camtasia2023 : packageID=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : pkgName=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : choiceChangesXML=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : expectedTeamID=7TQL462TU8
2025-10-07 13:11:56 : DEBUG : camtasia2023 : blockingProcesses=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : installerTool=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : CLIInstaller=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : CLIArguments=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : updateTool=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : updateToolArguments=
2025-10-07 13:11:56 : DEBUG : camtasia2023 : updateToolRunAsCurrentUser=
2025-10-07 13:11:57 : INFO  : camtasia2023 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 13:11:57 : INFO  : camtasia2023 : NOTIFY=success
2025-10-07 13:11:57 : INFO  : camtasia2023 : LOGGING=DEBUG
2025-10-07 13:11:57 : INFO  : camtasia2023 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 13:11:57 : INFO  : camtasia2023 : Label type: dmg
2025-10-07 13:11:57 : INFO  : camtasia2023 : archiveName: Camtasia 2023.dmg
2025-10-07 13:11:57 : INFO  : camtasia2023 : no blocking processes defined, using Camtasia 2023 as default
2025-10-07 13:11:57 : DEBUG : camtasia2023 : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-10-07 13:11:57 : INFO  : camtasia2023 : name: Camtasia 2023, appName: Camtasia 2023.app
2025-10-07 13:11:57 : WARN  : camtasia2023 : No previous app found
2025-10-07 13:11:57 : WARN  : camtasia2023 : could not find Camtasia 2023.app
2025-10-07 13:11:57 : INFO  : camtasia2023 : appversion: 
2025-10-07 13:11:57 : INFO  : camtasia2023 : Latest version of Camtasia 2023 is 2023.3.19
2025-10-07 13:11:57 : REQ   : camtasia2023 : Downloading https://download.techsmith.com/camtasiamac/releases/23319/camtasia.dmg to Camtasia 2023.dmg
2025-10-07 13:11:57 : DEBUG : camtasia2023 : No Dialog connection, just download
2025-10-07 13:12:15 : INFO  : camtasia2023 : Downloaded Camtasia 2023.dmg – Type is  data – SHA is ce81abf66d49f9ee61484c30ae951edbcc9467be – Size is 442508 kB
2025-10-07 13:12:19 : DEBUG : camtasia2023 : DEBUG mode 1, not checking for blocking processes
2025-10-07 13:12:22 : REQ   : camtasia2023 : Installing Camtasia 2023
2025-10-07 13:12:25 : INFO  : camtasia2023 : Mounting /Users/kryptonit/Documents/github/Installomator/build/Camtasia 2023.dmg
2025-10-07 13:12:31 : DEBUG : camtasia2023 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $9CFA0E85
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $067A4AE6
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified CRC32 $5D356510
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
verified CRC32 $97EC7A64
/dev/disk35         	Apple_partition_scheme
/dev/disk35s1       	Apple_partition_map
/dev/disk35s2       	Apple_HFS                      	/Volumes/Camtasia

2025-10-07 13:12:34 : INFO  : camtasia2023 : Mounted: /Volumes/Camtasia
2025-10-07 13:12:38 : INFO  : camtasia2023 : Verifying: /Volumes/Camtasia/Camtasia 2023.app
2025-10-07 13:12:41 : DEBUG : camtasia2023 : App size: 743M	/Volumes/Camtasia/Camtasia 2023.app
2025-10-07 13:12:50 : DEBUG : camtasia2023 : Debugging enabled, App Verification output was:
/Volumes/Camtasia/Camtasia 2023.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2025-10-07 13:12:53 : INFO  : camtasia2023 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2025-10-07 13:12:57 : INFO  : camtasia2023 : Installing Camtasia 2023 version 2023.3.19 on versionKey CFBundleShortVersionString.
2025-10-07 13:13:00 : INFO  : camtasia2023 : App has LSMinimumSystemVersion: 11.0
2025-10-07 13:13:03 : DEBUG : camtasia2023 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-07 13:13:07 : INFO  : camtasia2023 : Finishing...
2025-10-07 13:13:13 : INFO  : camtasia2023 : name: Camtasia 2023, appName: Camtasia 2023.app
2025-10-07 13:13:17 : WARN  : camtasia2023 : No previous app found
2025-10-07 13:13:20 : WARN  : camtasia2023 : could not find Camtasia 2023.app
2025-10-07 13:13:23 : REQ   : camtasia2023 : Installed Camtasia 2023, version 2023.3.19
2025-10-07 13:13:27 : INFO  : camtasia2023 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-07 13:13:30 : DEBUG : camtasia2023 : Unmounting /Volumes/Camtasia
2025-10-07 13:13:34 : DEBUG : camtasia2023 : Debugging enabled, Unmounting output was:
"disk35" ejected.
2025-10-07 13:13:37 : DEBUG : camtasia2023 : DEBUG mode 1, not reopening anything
2025-10-07 13:13:48 : REQ   : camtasia2023 : All done!
2025-10-07 13:13:59 : REQ   : camtasia2023 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A