### PR TITLE
Update camtasia2025.sh

### DIFF
--- a/fragments/labels/camtasia2025.sh
+++ b/fragments/labels/camtasia2025.sh
@@ -2,8 +2,11 @@ camtasia|\
 camtasia2025)
     name="Camtasia"
     type="dmg"
-    apiResult="$(curl -fsL "https://www.techsmith.com/api/v/1/products/getversioninfo/3265")"
-    downloadURL="https://download.techsmith.com$(getJSONValue "$apiResult" "PrimaryDownloadInformation.RelativePath")$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Name")"
-    appNewVersion="20$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Major").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Minor").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Maintenance")"
+    cdnData=$(curl -fsL "https://www.techsmith.com/api/v/1/products/getallversions/9" | jq '[.[] | select(.Major == 25)]')
+    appNewVersion=$(echo "${cdnData}" | jq '.[] | "20" + (.Major|tostring) + "." + (.Minor|tostring) + "." + (.Maintenance|tostring)' | tr -d '"')
+    versionID=$(echo "${cdnData}" | jq '.[].VersionID')
+    packageData=$(curl -fsl "https://www.techsmith.com/api/v/1/products/getversioninfo/${versionID}")
+    relativePath=$(echo "${packageData}" | jq '.PrimaryDownloadInformation.RelativePath' | tr -d '"')
+    downloadURL="https://download.techsmith.com${relativePath}camtasia.dmg"
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current camtasia2025 label is broken:
```
2025-10-07 13:23:35 : INFO  : camtasia2025 : Total items in argumentsArray: 0
2025-10-07 13:23:35 : INFO  : camtasia2025 : argumentsArray: 
2025-10-07 13:23:35 : REQ   : camtasia2025 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 13:23:35 : INFO  : camtasia2025 : ################## Version: 10.9beta
2025-10-07 13:23:35 : INFO  : camtasia2025 : ################## Date: 2025-10-07
2025-10-07 13:23:35 : INFO  : camtasia2025 : ################## camtasia2025
2025-10-07 13:23:35 : DEBUG : camtasia2025 : DEBUG mode 1 enabled.
2025-10-07 13:23:35 : INFO  : camtasia2025 : SwiftDialog is not installed, clear cmd file var

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.

no element found at line 2, column 0, byte 1:


^
 at /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level/XML/Parser.pm line 187.
2025-10-07 13:23:36 : INFO  : camtasia2025 : Reading arguments again: 
2025-10-07 13:23:36 : ERROR : camtasia2025 : need to provide 'downloadURL'
```

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-10-07 13:27:59 : INFO  : camtasia2025 : Total items in argumentsArray: 0
2025-10-07 13:27:59 : INFO  : camtasia2025 : argumentsArray: 
2025-10-07 13:27:59 : REQ   : camtasia2025 : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 13:27:59 : INFO  : camtasia2025 : ################## Version: 10.9beta
2025-10-07 13:27:59 : INFO  : camtasia2025 : ################## Date: 2025-10-07
2025-10-07 13:27:59 : INFO  : camtasia2025 : ################## camtasia2025
2025-10-07 13:27:59 : DEBUG : camtasia2025 : DEBUG mode 1 enabled.
2025-10-07 13:27:59 : INFO  : camtasia2025 : SwiftDialog is not installed, clear cmd file var
2025-10-07 13:28:00 : INFO  : camtasia2025 : Reading arguments again: 
2025-10-07 13:28:00 : DEBUG : camtasia2025 : name=Camtasia
2025-10-07 13:28:00 : DEBUG : camtasia2025 : appName=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : type=dmg
2025-10-07 13:28:00 : DEBUG : camtasia2025 : archiveName=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : downloadURL=https://download.techsmith.com/camtasiamac/releases/2523/camtasia.dmg
2025-10-07 13:28:00 : DEBUG : camtasia2025 : curlOptions=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : appNewVersion=2025.2.3
2025-10-07 13:28:00 : DEBUG : camtasia2025 : appCustomVersion function: Not defined
2025-10-07 13:28:00 : DEBUG : camtasia2025 : versionKey=CFBundleShortVersionString
2025-10-07 13:28:00 : DEBUG : camtasia2025 : packageID=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : pkgName=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : choiceChangesXML=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : expectedTeamID=7TQL462TU8
2025-10-07 13:28:00 : DEBUG : camtasia2025 : blockingProcesses=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : installerTool=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : CLIInstaller=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : CLIArguments=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : updateTool=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : updateToolArguments=
2025-10-07 13:28:00 : DEBUG : camtasia2025 : updateToolRunAsCurrentUser=
2025-10-07 13:28:00 : INFO  : camtasia2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 13:28:00 : INFO  : camtasia2025 : NOTIFY=success
2025-10-07 13:28:00 : INFO  : camtasia2025 : LOGGING=DEBUG
2025-10-07 13:28:00 : INFO  : camtasia2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 13:28:00 : INFO  : camtasia2025 : Label type: dmg
2025-10-07 13:28:00 : INFO  : camtasia2025 : archiveName: Camtasia.dmg
2025-10-07 13:28:00 : INFO  : camtasia2025 : no blocking processes defined, using Camtasia as default
2025-10-07 13:28:00 : DEBUG : camtasia2025 : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-10-07 13:28:00 : INFO  : camtasia2025 : name: Camtasia, appName: Camtasia.app
2025-10-07 13:28:01 : WARN  : camtasia2025 : No previous app found
2025-10-07 13:28:01 : WARN  : camtasia2025 : could not find Camtasia.app
2025-10-07 13:28:01 : INFO  : camtasia2025 : appversion: 
2025-10-07 13:28:01 : INFO  : camtasia2025 : Latest version of Camtasia is 2025.2.3
2025-10-07 13:28:01 : REQ   : camtasia2025 : Downloading https://download.techsmith.com/camtasiamac/releases/2523/camtasia.dmg to Camtasia.dmg
2025-10-07 13:28:01 : DEBUG : camtasia2025 : No Dialog connection, just download
2025-10-07 13:28:12 : INFO  : camtasia2025 : Downloaded Camtasia.dmg – Type is  zlib compressed data – SHA is e7c04ed7d13a1798ac01402c1ab4915fbfc520a8 – Size is 459108 kB
2025-10-07 13:28:12 : DEBUG : camtasia2025 : DEBUG mode 1, not checking for blocking processes
2025-10-07 13:28:12 : REQ   : camtasia2025 : Installing Camtasia
2025-10-07 13:28:12 : INFO  : camtasia2025 : Mounting /Users/kryptonit/Documents/github/Installomator/build/Camtasia.dmg
2025-10-07 13:28:15 : DEBUG : camtasia2025 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $9CFA0E85
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $067A4AE6
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified CRC32 $2D692F20
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
verified CRC32 $D02BF9BB
/dev/disk35         	Apple_partition_scheme
/dev/disk35s1       	Apple_partition_map
/dev/disk35s2       	Apple_HFS                      	/Volumes/Camtasia

2025-10-07 13:28:15 : INFO  : camtasia2025 : Mounted: /Volumes/Camtasia
2025-10-07 13:28:15 : INFO  : camtasia2025 : Verifying: /Volumes/Camtasia/Camtasia.app
2025-10-07 13:28:15 : DEBUG : camtasia2025 : App size: 843M	/Volumes/Camtasia/Camtasia.app
2025-10-07 13:28:21 : DEBUG : camtasia2025 : Debugging enabled, App Verification output was:
/Volumes/Camtasia/Camtasia.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2025-10-07 13:28:21 : INFO  : camtasia2025 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2025-10-07 13:28:21 : INFO  : camtasia2025 : Installing Camtasia version 2025.2.3 on versionKey CFBundleShortVersionString.
2025-10-07 13:28:21 : INFO  : camtasia2025 : App has LSMinimumSystemVersion: 13.0
2025-10-07 13:28:21 : DEBUG : camtasia2025 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-07 13:28:21 : INFO  : camtasia2025 : Finishing...
2025-10-07 13:28:24 : INFO  : camtasia2025 : name: Camtasia, appName: Camtasia.app
2025-10-07 13:28:25 : WARN  : camtasia2025 : No previous app found
2025-10-07 13:28:25 : WARN  : camtasia2025 : could not find Camtasia.app
2025-10-07 13:28:25 : REQ   : camtasia2025 : Installed Camtasia, version 2025.2.3
2025-10-07 13:28:25 : INFO  : camtasia2025 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-07 13:28:25 : DEBUG : camtasia2025 : Unmounting /Volumes/Camtasia
2025-10-07 13:28:25 : DEBUG : camtasia2025 : Debugging enabled, Unmounting output was:
"disk35" ejected.
2025-10-07 13:28:25 : DEBUG : camtasia2025 : DEBUG mode 1, not reopening anything
2025-10-07 13:28:25 : REQ   : camtasia2025 : All done!
2025-10-07 13:28:25 : REQ   : camtasia2025 : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A