### PR TITLE
Update adobedigitaleditions.sh

### DIFF
--- a/fragments/labels/adobedigitaleditions.sh
+++ b/fragments/labels/adobedigitaleditions.sh
@@ -1,7 +1,7 @@
 adobedigitaleditions)
     name="Adobe Digital Editions"
     type="pkgInDmg"
-    downloadURL=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep dmg | sed -n 's/.*href="\([^"]*\)".*/\1/p')
+    downloadURL=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep -oE 'https[^"]+\.dmg')
     appNewVersion=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep -o 'Adobe Digital Editions.*Installers' | awk -F' ' '{ print $4 }')
     expectedTeamID="JQ525L2MZD"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current adobedigitaleditions label is broken:
```
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : Total items in argumentsArray: 0
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : argumentsArray: 
2025-10-07 15:18:09 : REQ   : adobedigitaleditions : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : ################## Version: 10.9beta
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : ################## Date: 2025-10-07
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : ################## adobedigitaleditions
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : DEBUG mode 1 enabled.
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : SwiftDialog is not installed, clear cmd file var
2025-10-07 15:18:09 : INFO  : adobedigitaleditions : Reading arguments again: 
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : name=Adobe Digital Editions
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : appName=
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : type=pkgInDmg
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : archiveName=
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : downloadURL=https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.exe#_blank
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : curlOptions=
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : appNewVersion=4.5.12
2025-10-07 15:18:09 : DEBUG : adobedigitaleditions : appCustomVersion function: Not defined
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : versionKey=CFBundleShortVersionString
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : packageID=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : pkgName=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : choiceChangesXML=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : expectedTeamID=JQ525L2MZD
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : blockingProcesses=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : installerTool=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : CLIInstaller=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : CLIArguments=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : updateTool=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : updateToolArguments=
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : updateToolRunAsCurrentUser=
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : NOTIFY=success
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : LOGGING=DEBUG
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : Label type: pkgInDmg
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : archiveName: Adobe Digital Editions.dmg
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : no blocking processes defined, using Adobe Digital Editions as default
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : App(s) found: /Applications/Adobe Digital Editions.app
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : found app at /Applications/Adobe Digital Editions.app, version 4.5.12, on versionKey CFBundleShortVersionString
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : appversion: 4.5.12
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : Latest version of Adobe Digital Editions is 4.5.12
2025-10-07 15:18:10 : WARN  : adobedigitaleditions : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-10-07 15:18:10 : REQ   : adobedigitaleditions : Downloading https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.exe#_blank to Adobe Digital Editions.dmg
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : No Dialog connection, just download
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : Downloaded Adobe Digital Editions.dmg – Type is  PE32 executable (GUI) Intel 80386, for MS Windows, Nullsoft Installer self-extracting archive – SHA is 5d609b6c42643788e7e408262a9a93a6a64af022 – Size is 8816 kB
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : DEBUG mode 1, not checking for blocking processes
2025-10-07 15:18:10 : REQ   : adobedigitaleditions : Installing Adobe Digital Editions
2025-10-07 15:18:10 : INFO  : adobedigitaleditions : Mounting /Users/kryptonit/Documents/github/Installomator/build/Adobe Digital Editions.dmg
hdiutil: attach failed - image not recognised
2025-10-07 15:18:10 : DEBUG : adobedigitaleditions : DEBUG mode 1, not reopening anything
2025-10-07 15:18:10 : ERROR : adobedigitaleditions : ERROR: Error mounting /Users/kryptonit/Documents/github/Installomator/build/Adobe Digital Editions.dmg error:
Log

2025-10-07 15:18:10 : REQ   : adobedigitaleditions : ################## End Installomator, exit code 3 
```
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : Total items in argumentsArray: 0
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : argumentsArray: 
2025-10-07 15:30:08 : REQ   : adobedigitaleditions : ################## Start Installomator v. 10.9beta, date 2025-10-07
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : ################## Version: 10.9beta
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : ################## Date: 2025-10-07
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : ################## adobedigitaleditions
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : DEBUG mode 1 enabled.
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : SwiftDialog is not installed, clear cmd file var
2025-10-07 15:30:08 : INFO  : adobedigitaleditions : Reading arguments again: 
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : name=Adobe Digital Editions
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : appName=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : type=pkgInDmg
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : archiveName=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : downloadURL=https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.dmg
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : curlOptions=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : appNewVersion=4.5.12
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : appCustomVersion function: Not defined
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : versionKey=CFBundleShortVersionString
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : packageID=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : pkgName=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : choiceChangesXML=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : expectedTeamID=JQ525L2MZD
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : blockingProcesses=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : installerTool=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : CLIInstaller=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : CLIArguments=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : updateTool=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : updateToolArguments=
2025-10-07 15:30:08 : DEBUG : adobedigitaleditions : updateToolRunAsCurrentUser=
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : BLOCKING_PROCESS_ACTION=tell_user
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : NOTIFY=success
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : LOGGING=DEBUG
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : Label type: pkgInDmg
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : archiveName: Adobe Digital Editions.dmg
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : no blocking processes defined, using Adobe Digital Editions as default
2025-10-07 15:30:09 : DEBUG : adobedigitaleditions : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : name: Adobe Digital Editions, appName: Adobe Digital Editions.app
2025-10-07 15:30:09 : WARN  : adobedigitaleditions : No previous app found
2025-10-07 15:30:09 : WARN  : adobedigitaleditions : could not find Adobe Digital Editions.app
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : appversion: 
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : Latest version of Adobe Digital Editions is 4.5.12
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : Adobe Digital Editions.dmg exists and DEBUG mode 1 enabled, skipping download
2025-10-07 15:30:09 : DEBUG : adobedigitaleditions : DEBUG mode 1, not checking for blocking processes
2025-10-07 15:30:09 : REQ   : adobedigitaleditions : Installing Adobe Digital Editions
2025-10-07 15:30:09 : INFO  : adobedigitaleditions : Mounting /Users/kryptonit/Documents/github/Installomator/build/Adobe Digital Editions.dmg
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : Debugging enabled, dmgmount output was:
expected CRC32 $962948A8
/dev/disk38         	GUID_partition_scheme
/dev/disk38s1       	Apple_HFS                      	/Volumes/ADE 4.5

2025-10-07 15:30:10 : INFO  : adobedigitaleditions : Mounted: /Volumes/ADE 4.5
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : Found pkg(s):
/Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2025-10-07 15:30:10 : INFO  : adobedigitaleditions : found pkg: /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2025-10-07 15:30:10 : INFO  : adobedigitaleditions : Verifying: /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : File list: -rw-r--r--@ 1 kryptonit  staff    27M Jul 10  2023 /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : File type: /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg: xar archive compressed TOC: 6816, SHA-1 checksum
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : spctlOut is /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg: accepted
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : source=Notarized Developer ID
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : origin=Developer ID Installer: Adobe Inc. (JQ525L2MZD)
2025-10-07 15:30:10 : INFO  : adobedigitaleditions : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2025-10-07 15:30:10 : DEBUG : adobedigitaleditions : DEBUG enabled, skipping installation
2025-10-07 15:30:10 : INFO  : adobedigitaleditions : Finishing...
2025-10-07 15:30:13 : INFO  : adobedigitaleditions : name: Adobe Digital Editions, appName: Adobe Digital Editions.app
2025-10-07 15:30:14 : WARN  : adobedigitaleditions : No previous app found
2025-10-07 15:30:14 : WARN  : adobedigitaleditions : could not find Adobe Digital Editions.app
2025-10-07 15:30:14 : REQ   : adobedigitaleditions : Installed Adobe Digital Editions, version 4.5.12
2025-10-07 15:30:14 : INFO  : adobedigitaleditions : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-07 15:30:14 : DEBUG : adobedigitaleditions : Unmounting /Volumes/ADE 4.5
2025-10-07 15:30:14 : DEBUG : adobedigitaleditions : Debugging enabled, Unmounting output was:
"disk38" ejected.
2025-10-07 15:30:14 : DEBUG : adobedigitaleditions : DEBUG mode 1, not reopening anything
2025-10-07 15:30:14 : REQ   : adobedigitaleditions : All done!
2025-10-07 15:30:14 : REQ   : adobedigitaleditions : ################## End Installomator, exit code 0 
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
#2525 