### PR TITLE
Create PanooRemote (new label panoo)

### DIFF
--- a/fragments/labels/panoo.sh
+++ b/fragments/labels/panoo.sh
@@ -1,0 +1,11 @@
+panoo)
+    name="PanooRemote"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(curl -fs "https://download.panoo.com" | grep -oE 'https://[^"]+arm64\.dmg' | sort -V | tail -n1)
+    else
+        downloadURL=$(curl -fs "https://download.panoo.com" | grep -oE 'https://[^"]+\.dmg' | grep -v "arm64" | sort -V | tail -n1)
+    fi
+    appNewVersion=$(curl -fs "https://download.panoo.com" | grep 'id="latest_darwin_arm64_label"' | sed 's/.*>\(.*\)<\/p>/\1/' | sort -V | tail -n1)
+    expectedTeamID="BL2X4T29U9"
+    ;;


### PR DESCRIPTION
```
sudo /Users/duf0002a/workdir/GitHub/Installomator/utils/assemble.sh panoo DEBUG=0
```

```
2025-10-08 16:09:10 : REQ   : panoo : ################## Start Installomator v. 10.6beta, date 2025-10-08
2025-10-08 16:09:10 : INFO  : panoo : ################## Version: 10.6beta
2025-10-08 16:09:10 : INFO  : panoo : ################## Date: 2025-10-08
2025-10-08 16:09:10 : INFO  : panoo : ################## panoo
2025-10-08 16:09:10 : DEBUG : panoo : DEBUG mode 1 enabled.
2025-10-08 16:09:11 : INFO  : panoo : setting variable from argument DEBUG=0
2025-10-08 16:09:11 : DEBUG : panoo : name=PanooRemote
2025-10-08 16:09:11 : DEBUG : panoo : appName=
2025-10-08 16:09:11 : DEBUG : panoo : type=dmg
2025-10-08 16:09:11 : DEBUG : panoo : archiveName=
2025-10-08 16:09:11 : DEBUG : panoo : downloadURL=https://download.panoo.com/download/remote/PanooRemote-14.0.79-arm64.dmg
2025-10-08 16:09:11 : DEBUG : panoo : curlOptions=
2025-10-08 16:09:11 : DEBUG : panoo : appNewVersion=14.0.73
2025-10-08 16:09:11 : DEBUG : panoo : appCustomVersion function: Not defined
2025-10-08 16:09:11 : DEBUG : panoo : versionKey=CFBundleShortVersionString
2025-10-08 16:09:11 : DEBUG : panoo : packageID=
2025-10-08 16:09:11 : DEBUG : panoo : pkgName=
2025-10-08 16:09:11 : DEBUG : panoo : choiceChangesXML=
2025-10-08 16:09:11 : DEBUG : panoo : expectedTeamID=BL2X4T29U9
2025-10-08 16:09:11 : DEBUG : panoo : blockingProcesses=
2025-10-08 16:09:11 : DEBUG : panoo : installerTool=
2025-10-08 16:09:11 : DEBUG : panoo : CLIInstaller=
2025-10-08 16:09:11 : DEBUG : panoo : CLIArguments=
2025-10-08 16:09:11 : DEBUG : panoo : updateTool=
2025-10-08 16:09:11 : DEBUG : panoo : updateToolArguments=
2025-10-08 16:09:11 : DEBUG : panoo : updateToolRunAsCurrentUser=
2025-10-08 16:09:11 : INFO  : panoo : BLOCKING_PROCESS_ACTION=tell_user
2025-10-08 16:09:11 : INFO  : panoo : NOTIFY=success
2025-10-08 16:09:11 : INFO  : panoo : LOGGING=DEBUG
2025-10-08 16:09:11 : INFO  : panoo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-08 16:09:11 : INFO  : panoo : Label type: dmg
2025-10-08 16:09:11 : INFO  : panoo : archiveName: PanooRemote.dmg
2025-10-08 16:09:11 : INFO  : panoo : no blocking processes defined, using PanooRemote as default
2025-10-08 16:09:11 : DEBUG : panoo : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dW4AWjH8yV
2025-10-08 16:09:11 : INFO  : panoo : name: PanooRemote, appName: PanooRemote.app
2025-10-08 16:09:11.791 mdfind[97738:2264277] [UserQueryParser] Loading keywords and predicates for locale "de_DE"
2025-10-08 16:09:11.792 mdfind[97738:2264277] [UserQueryParser] Loading keywords and predicates for locale "de"
2025-10-08 16:09:11.836 mdfind[97738:2264277] Couldn't determine the mapping between prefab keywords and predicates.
2025-10-08 16:09:11 : WARN  : panoo : No previous app found
2025-10-08 16:09:11 : WARN  : panoo : could not find PanooRemote.app
2025-10-08 16:09:11 : INFO  : panoo : appversion: 
2025-10-08 16:09:11 : INFO  : panoo : Latest version of PanooRemote is 14.0.73
2025-10-08 16:09:11 : REQ   : panoo : Downloading https://download.panoo.com/download/remote/PanooRemote-14.0.79-arm64.dmg to PanooRemote.dmg
2025-10-08 16:09:11 : DEBUG : panoo : No Dialog connection, just download
2025-10-08 16:09:21 : DEBUG : panoo : File list: -rw-r--r--  1 root  wheel   101M  8 Okt. 16:09 PanooRemote.dmg
2025-10-08 16:09:21 : DEBUG : panoo : File type: PanooRemote.dmg: zlib compressed data
2025-10-08 16:09:21 : DEBUG : panoo : curl output was:
* Host download.panoo.com:443 was resolved.
* IPv6: (none)
* IPv4: 212.227.141.218
*   Trying 212.227.141.218:443...
* Connected to download.panoo.com (212.227.141.218) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [323 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [25 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2590 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [52 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [52 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: CN=download.panoo.com
*  start date: Sep 19 13:50:17 2025 GMT
*  expire date: Dec 18 13:50:16 2025 GMT
*  subjectAltName: host "download.panoo.com" matched cert's "download.panoo.com"
*  issuer: C=US; O=Let's Encrypt; CN=R13
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /download/remote/PanooRemote-14.0.79-arm64.dmg HTTP/1.1
> Host: download.panoo.com
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Date: Wed, 08 Oct 2025 14:09:12 GMT
< Server: Apache/2.4.29 (Ubuntu)
< Last-Modified: Mon, 02 Jun 2025 16:06:53 GMT
< ETag: "65667c6-63698f3d06240"
< Accept-Ranges: bytes
< Content-Length: 106325958
< Access-Control-Allow-Origin: *
< Content-Type: application/x-apple-diskimage
< 
{ [16384 bytes data]
* Connection #0 to host download.panoo.com left intact

2025-10-08 16:09:21 : REQ   : panoo : no more blocking processes, continue with update
2025-10-08 16:09:21 : REQ   : panoo : Installing PanooRemote
2025-10-08 16:09:21 : INFO  : panoo : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dW4AWjH8yV/PanooRemote.dmg
2025-10-08 16:09:25 : DEBUG : panoo : Debugging enabled, dmgmount output was:
Prüfsumme für Protective Master Boot Record (MBR : 0) berechnen …
Protective Master Boot Record (MBR :: Die überprüfte CRC32-Prüfsumme ist $0F9788F2
Prüfsumme für GPT Header (Primary GPT Header : 1) berechnen …
GPT Header (Primary GPT Header : 1): Die überprüfte CRC32-Prüfsumme ist $3225E02A
Prüfsumme für GPT Partition Data (Primary GPT Table : 2) berechnen …
GPT Partition Data (Primary GPT Tabl: Die überprüfte CRC32-Prüfsumme ist $C3C21553
Prüfsumme für  (Apple_Free : 3) berechnen …
(Apple_Free : 3): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für disk image (Apple_APFS : 4) berechnen …
disk image (Apple_APFS : 4): Die überprüfte CRC32-Prüfsumme ist $DB0DC26F
Prüfsumme für  (Apple_Free : 5) berechnen …
(Apple_Free : 5): Die überprüfte CRC32-Prüfsumme ist $00000000
Prüfsumme für GPT Partition Data (Backup GPT Table : 6) berechnen …
GPT Partition Data (Backup GPT Table: Die überprüfte CRC32-Prüfsumme ist $C3C21553
Prüfsumme für GPT Header (Backup GPT Header : 7) berechnen …
GPT Header (Backup GPT Header : 7): Die überprüfte CRC32-Prüfsumme ist $22149E6B
Die überprüfte CRC32-Prüfsumme ist $7F60C7B9
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/PanooRemote 14.0.79-arm64

2025-10-08 16:09:25 : INFO  : panoo : Mounted: /Volumes/PanooRemote 14.0.79-arm64
2025-10-08 16:09:25 : INFO  : panoo : Verifying: /Volumes/PanooRemote 14.0.79-arm64/PanooRemote.app
2025-10-08 16:09:25 : DEBUG : panoo : App size: 248M	/Volumes/PanooRemote 14.0.79-arm64/PanooRemote.app
2025-10-08 16:09:26 : DEBUG : panoo : Debugging enabled, App Verification output was:
/Volumes/PanooRemote 14.0.79-arm64/PanooRemote.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: 4=1 Gesellschaft zur Entwicklung von Multimedia-Software GmbH (BL2X4T29U9)

2025-10-08 16:09:26 : INFO  : panoo : Team ID matching: BL2X4T29U9 (expected: BL2X4T29U9 )
2025-10-08 16:09:26 : INFO  : panoo : Installing PanooRemote version 14.0.79 on versionKey CFBundleShortVersionString.
2025-10-08 16:09:27 : INFO  : panoo : App has LSMinimumSystemVersion: 10.15
2025-10-08 16:09:27 : INFO  : panoo : Copy /Volumes/PanooRemote 14.0.79-arm64/PanooRemote.app to /Applications
2025-10-08 16:09:27 : DEBUG : panoo : Debugging enabled, App copy output was:
Copying /Volumes/PanooRemote 14.0.79-arm64/PanooRemote.app

2025-10-08 16:09:27 : WARN  : panoo : Changing owner to duf0002a
2025-10-08 16:09:27 : INFO  : panoo : Finishing...
2025-10-08 16:09:30 : INFO  : panoo : App(s) found: /Applications/PanooRemote.app
2025-10-08 16:09:30 : INFO  : panoo : found app at /Applications/PanooRemote.app, version 14.0.79, on versionKey CFBundleShortVersionString
2025-10-08 16:09:30 : REQ   : panoo : Installed PanooRemote, version 14.0.79
2025-10-08 16:09:30 : INFO  : panoo : notifying
2025-10-08 16:09:31 : DEBUG : panoo : Unmounting /Volumes/PanooRemote 14.0.79-arm64
2025-10-08 16:09:31 : DEBUG : panoo : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-10-08 16:09:31 : DEBUG : panoo : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dW4AWjH8yV
2025-10-08 16:09:31 : DEBUG : panoo : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dW4AWjH8yV/PanooRemote.dmg
2025-10-08 16:09:31 : DEBUG : panoo : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dW4AWjH8yV
2025-10-08 16:09:31 : INFO  : panoo : Installomator did not close any apps, so no need to reopen any apps.
2025-10-08 16:09:31 : REQ   : panoo : All done!
2025-10-08 16:09:31 : REQ   : panoo : ################## End Installomator, exit code 0 
```