### PR TITLE
sketchup_pro_2025_label

### DIFF
--- a/fragments/labels/sketchup2025.sh
+++ b/fragments/labels/sketchup2025.sh
@@ -1,0 +1,10 @@
+sketchup2025)
+    name="SketchUp 2025"
+    type="dmg"
+    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2025[^"]*.dmg')"
+    folderName="SketchUp 2025"
+    appName="${folderName}/SketchUp.app"
+    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    versionKey="CFBundleVersion"
+    expectedTeamID="J8PVMCY7KL"
+    ;;


### PR DESCRIPTION
Output
```Installomator/utils/assemble.sh sketchup2025 DEBUG=0
2025-10-09 14:03:45 : INFO  : sketchup2025 : setting variable from argument DEBUG=0
2025-10-09 14:03:45 : INFO  : sketchup2025 : Total items in argumentsArray: 1
2025-10-09 14:03:45 : INFO  : sketchup2025 : argumentsArray: DEBUG=0
2025-10-09 14:03:45 : REQ   : sketchup2025 : ################## Start Installomator v. 10.9beta, date 2025-10-09
2025-10-09 14:03:45 : INFO  : sketchup2025 : ################## Version: 10.9beta
2025-10-09 14:03:45 : INFO  : sketchup2025 : ################## Date: 2025-10-09
2025-10-09 14:03:45 : INFO  : sketchup2025 : ################## sketchup2025
2025-10-09 14:03:46 : INFO  : sketchup2025 : Reading arguments again: DEBUG=0
2025-10-09 14:03:46 : INFO  : sketchup2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-09 14:03:46 : INFO  : sketchup2025 : NOTIFY=success
2025-10-09 14:03:46 : INFO  : sketchup2025 : LOGGING=INFO
2025-10-09 14:03:46 : INFO  : sketchup2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-09 14:03:46 : INFO  : sketchup2025 : Label type: dmg
2025-10-09 14:03:46 : INFO  : sketchup2025 : archiveName: SketchUp 2025.dmg
2025-10-09 14:03:46 : INFO  : sketchup2025 : no blocking processes defined, using SketchUp 2025 as default
2025-10-09 14:03:46 : INFO  : sketchup2025 : name: SketchUp 2025, appName: SketchUp 2025/SketchUp.app
2025-10-09 14:03:46 : WARN  : sketchup2025 : No previous app found
2025-10-09 14:03:46 : WARN  : sketchup2025 : could not find SketchUp 2025/SketchUp.app
2025-10-09 14:03:46 : INFO  : sketchup2025 : appversion:
2025-10-09 14:03:46 : INFO  : sketchup2025 : Latest version of SketchUp 2025 is 25.0.659
2025-10-09 14:03:46 : REQ   : sketchup2025 : Downloading https://download.sketchup.com/SketchUp-2025-0-659-288.dmg to SketchUp 2025.dmg
2025-10-09 14:04:28 : INFO  : sketchup2025 : Downloaded SketchUp 2025.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 1615da994017fbb2b09bf839000f1d54085023b6 – Size is 1688468 kB
2025-10-09 14:04:28 : REQ   : sketchup2025 : no more blocking processes, continue with update
2025-10-09 14:04:28 : REQ   : sketchup2025 : Installing SketchUp 2025
2025-10-09 14:04:28 : INFO  : sketchup2025 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.dJczdgQhNl/SketchUp 2025.dmg
2025-10-09 14:05:47 : INFO  : sketchup2025 : Mounted: /Volumes/SketchUp 2025
2025-10-09 14:05:47 : INFO  : sketchup2025 : Verifying: /Volumes/SketchUp 2025/SketchUp 2025/SketchUp.app
2025-10-09 14:08:07 : INFO  : sketchup2025 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2025-10-09 14:08:07 : INFO  : sketchup2025 : Installing SketchUp 2025 version 25.0.659 on versionKey CFBundleVersion.
2025-10-09 14:08:07 : INFO  : sketchup2025 : App has LSMinimumSystemVersion: 11.7
2025-10-09 14:08:07 : INFO  : sketchup2025 : Copy /Volumes/SketchUp 2025/SketchUp 2025/SketchUp.app to /Applications
2025-10-09 14:11:03 : WARN  : sketchup2025 : Changing owner to u0105821
2025-10-09 14:11:08 : INFO  : sketchup2025 : Finishing...
2025-10-09 14:11:11 : INFO  : sketchup2025 : App(s) found: /Applications/SketchUp 2025/SketchUp.app
2025-10-09 14:11:11 : INFO  : sketchup2025 : found app at /Applications/SketchUp 2025/SketchUp.app, version 25.0.659, on versionKey CFBundleVersion
2025-10-09 14:11:11 : REQ   : sketchup2025 : Installed SketchUp 2025, version 25.0.659
2025-10-09 14:11:11 : INFO  : sketchup2025 : notifying
2025-10-09 14:11:12 : INFO  : sketchup2025 : Installomator did not close any apps, so no need to reopen any apps.
2025-10-09 14:11:12 : REQ   : sketchup2025 : All done!
2025-10-09 14:11:12 : REQ   : sketchup2025 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

New label n the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
