### PR TITLE
sketchup_pro_2024

### DIFF
--- a/fragments/labels/sketchup2024.sh
+++ b/fragments/labels/sketchup2024.sh
@@ -1,0 +1,10 @@
+sketchup2024)
+    name="SketchUp 2024"
+    type="dmg"
+    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2024[^"]*.dmg')"
+    folderName="SketchUp 2024"
+    appName="${folderName}/SketchUp.app"
+    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    versionKey="CFBundleVersion"
+    expectedTeamID="J8PVMCY7KL"
+    ;;


### PR DESCRIPTION
output
```
Installomator/utils/assemble.sh sketchup2024 DEBUG=0
2025-10-09 14:25:35 : INFO  : sketchup2024 : setting variable from argument DEBUG=0
2025-10-09 14:25:35 : INFO  : sketchup2024 : Total items in argumentsArray: 1
2025-10-09 14:25:35 : INFO  : sketchup2024 : argumentsArray: DEBUG=0
2025-10-09 14:25:35 : REQ   : sketchup2024 : ################## Start Installomator v. 10.9beta, date 2025-10-09
2025-10-09 14:25:35 : INFO  : sketchup2024 : ################## Version: 10.9beta
2025-10-09 14:25:35 : INFO  : sketchup2024 : ################## Date: 2025-10-09
2025-10-09 14:25:35 : INFO  : sketchup2024 : ################## sketchup2024
2025-10-09 14:25:36 : INFO  : sketchup2024 : Reading arguments again: DEBUG=0
2025-10-09 14:25:36 : INFO  : sketchup2024 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-09 14:25:36 : INFO  : sketchup2024 : NOTIFY=success
2025-10-09 14:25:36 : INFO  : sketchup2024 : LOGGING=INFO
2025-10-09 14:25:36 : INFO  : sketchup2024 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-09 14:25:36 : INFO  : sketchup2024 : Label type: dmg
2025-10-09 14:25:36 : INFO  : sketchup2024 : archiveName: SketchUp 2024.dmg
2025-10-09 14:25:36 : INFO  : sketchup2024 : no blocking processes defined, using SketchUp 2024 as default
2025-10-09 14:25:36 : INFO  : sketchup2024 : name: SketchUp 2024, appName: SketchUp 2024/SketchUp.app
2025-10-09 14:25:36 : WARN  : sketchup2024 : No previous app found
2025-10-09 14:25:36 : WARN  : sketchup2024 : could not find SketchUp 2024/SketchUp.app
2025-10-09 14:25:36 : INFO  : sketchup2024 : appversion:
2025-10-09 14:25:36 : INFO  : sketchup2024 : Latest version of SketchUp 2024 is 24.0.598
2025-10-09 14:25:36 : REQ   : sketchup2024 : Downloading https://download.sketchup.com/SketchUp-2024-0-598-243.dmg to SketchUp 2024.dmg
2025-10-09 14:26:03 : INFO  : sketchup2024 : Downloaded SketchUp 2024.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 37fdec88720d971f94bbf444956557438b8356ed – Size is 1016320 kB
2025-10-09 14:26:03 : REQ   : sketchup2024 : no more blocking processes, continue with update
2025-10-09 14:26:03 : REQ   : sketchup2024 : Installing SketchUp 2024
2025-10-09 14:26:04 : INFO  : sketchup2024 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.jHPOzg3SWE/SketchUp 2024.dmg
2025-10-09 14:26:58 : INFO  : sketchup2024 : Mounted: /Volumes/SketchUp 2024
2025-10-09 14:26:58 : INFO  : sketchup2024 : Verifying: /Volumes/SketchUp 2024/SketchUp 2024/SketchUp.app
2025-10-09 14:28:27 : INFO  : sketchup2024 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2025-10-09 14:28:27 : INFO  : sketchup2024 : Installing SketchUp 2024 version 24.0.598 on versionKey CFBundleVersion.
2025-10-09 14:28:27 : INFO  : sketchup2024 : App has LSMinimumSystemVersion: 11.7
2025-10-09 14:28:27 : INFO  : sketchup2024 : Copy /Volumes/SketchUp 2024/SketchUp 2024/SketchUp.app to /Applications
2025-10-09 14:30:44 : WARN  : sketchup2024 : Changing owner to u0105821
2025-10-09 14:30:48 : INFO  : sketchup2024 : Finishing...
2025-10-09 14:30:51 : INFO  : sketchup2024 : App(s) found: /Applications/SketchUp 2024/SketchUp.app
2025-10-09 14:30:52 : INFO  : sketchup2024 : found app at /Applications/SketchUp 2024/SketchUp.app, version 24.0.598, on versionKey CFBundleVersion
2025-10-09 14:30:52 : REQ   : sketchup2024 : Installed SketchUp 2024, version 24.0.598
2025-10-09 14:30:52 : INFO  : sketchup2024 : notifying
2025-10-09 14:30:52 : INFO  : sketchup2024 : Installomator did not close any apps, so no need to reopen any apps.
2025-10-09 14:30:52 : REQ   : sketchup2024 : All done!
2025-10-09 14:30:52 : REQ   : sketchup2024 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

New label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
