### PR TITLE
sketchup_pro_2026

### DIFF
--- a/fragments/labels/sketchup2026.sh
+++ b/fragments/labels/sketchup2026.sh
@@ -1,0 +1,10 @@
+sketchup2026)
+    name="SketchUp 2026"
+    type="dmg"
+    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2026[^"]*.dmg')"
+    folderName="SketchUp 2026"
+    appName="${folderName}/SketchUp.app"
+    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    versionKey="CFBundleVersion"
+    expectedTeamID="J8PVMCY7KL"
+    ;;


### PR DESCRIPTION
output
```
Installomator/utils/assemble.sh sketchup2026 DEBUG=0
2025-10-09 14:36:47 : INFO  : sketchup2026 : setting variable from argument DEBUG=0
2025-10-09 14:36:48 : INFO  : sketchup2026 : Total items in argumentsArray: 1
2025-10-09 14:36:48 : INFO  : sketchup2026 : argumentsArray: DEBUG=0
2025-10-09 14:36:48 : REQ   : sketchup2026 : ################## Start Installomator v. 10.9beta, date 2025-10-09
2025-10-09 14:36:48 : INFO  : sketchup2026 : ################## Version: 10.9beta
2025-10-09 14:36:48 : INFO  : sketchup2026 : ################## Date: 2025-10-09
2025-10-09 14:36:48 : INFO  : sketchup2026 : ################## sketchup2026
2025-10-09 14:36:48 : INFO  : sketchup2026 : Reading arguments again: DEBUG=0
2025-10-09 14:36:48 : INFO  : sketchup2026 : BLOCKING_PROCESS_ACTION=tell_user
2025-10-09 14:36:48 : INFO  : sketchup2026 : NOTIFY=success
2025-10-09 14:36:48 : INFO  : sketchup2026 : LOGGING=INFO
2025-10-09 14:36:48 : INFO  : sketchup2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-09 14:36:48 : INFO  : sketchup2026 : Label type: dmg
2025-10-09 14:36:48 : INFO  : sketchup2026 : archiveName: SketchUp 2026.dmg
2025-10-09 14:36:49 : INFO  : sketchup2026 : no blocking processes defined, using SketchUp 2026 as default
2025-10-09 14:36:49 : INFO  : sketchup2026 : name: SketchUp 2026, appName: SketchUp 2026/SketchUp.app
2025-10-09 14:36:49 : WARN  : sketchup2026 : No previous app found
2025-10-09 14:36:49 : WARN  : sketchup2026 : could not find SketchUp 2026/SketchUp.app
2025-10-09 14:36:49 : INFO  : sketchup2026 : appversion:
2025-10-09 14:36:49 : INFO  : sketchup2026 : Latest version of SketchUp 2026 is 26.0.428
2025-10-09 14:36:49 : REQ   : sketchup2026 : Downloading https://download.sketchup.com/SketchUp-2026-0-428-164.dmg to SketchUp 2026.dmg
2025-10-09 14:37:25 : INFO  : sketchup2026 : Downloaded SketchUp 2026.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is dce0bb8540034199a47397fe44eda944d39f6ebb – Size is 1474820 kB
2025-10-09 14:37:26 : REQ   : sketchup2026 : no more blocking processes, continue with update
2025-10-09 14:37:26 : REQ   : sketchup2026 : Installing SketchUp 2026
2025-10-09 14:37:26 : INFO  : sketchup2026 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Tau5gG6pTY/SketchUp 2026.dmg
2025-10-09 14:38:40 : INFO  : sketchup2026 : Mounted: /Volumes/SketchUp 2026
2025-10-09 14:38:40 : INFO  : sketchup2026 : Verifying: /Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app
2025-10-09 14:40:45 : INFO  : sketchup2026 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2025-10-09 14:40:46 : INFO  : sketchup2026 : Installing SketchUp 2026 version 26.0.428 on versionKey CFBundleVersion.
2025-10-09 14:40:46 : INFO  : sketchup2026 : App has LSMinimumSystemVersion: 13.0
2025-10-09 14:40:46 : INFO  : sketchup2026 : Copy /Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app to /Applications
2025-10-09 14:44:19 : WARN  : sketchup2026 : Changing owner to u0105821
2025-10-09 14:44:24 : INFO  : sketchup2026 : Finishing...
2025-10-09 14:44:27 : INFO  : sketchup2026 : App(s) found: /Applications/SketchUp 2026/SketchUp.app
2025-10-09 14:44:27 : INFO  : sketchup2026 : found app at /Applications/SketchUp 2026/SketchUp.app, version 26.0.428, on versionKey CFBundleVersion
2025-10-09 14:44:27 : REQ   : sketchup2026 : Installed SketchUp 2026, version 26.0.428
2025-10-09 14:44:27 : INFO  : sketchup2026 : notifying
2025-10-09 14:44:28 : INFO  : sketchup2026 : Installomator did not close any apps, so no need to reopen any apps.
2025-10-09 14:44:28 : REQ   : sketchup2026 : All done!
2025-10-09 14:44:28 : REQ   : sketchup2026 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

New label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
