### PR TITLE
Clean up wireshark label for 4.6.0

### DIFF
--- a/fragments/labels/wireshark.sh
+++ b/fragments/labels/wireshark.sh
@@ -1,12 +1,9 @@
 wireshark)
     name="Wireshark"
     type="dmg"
-    if [[ $(arch) == i386 ]]; then
-      sparkleFeedURL="https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/x86-64/en-US/stable.xml"
-    elif [[ $(arch) == arm64 ]]; then
-      sparkleFeedURL="https://www.wireshark.org/update/0/Wireshark/4.0.0/macOS/arm64/en-US/stable.xml"
-    fi
-    sparkleFeed=$(curl -fs "$sparkleFeedURL")
+    # Wireshark is a universal binary as of 4.6.0
+    # while the feed URL contains 'x86-64', the download works on both Intel and Apple silicon
+    sparkleFeed=$(curl -fs "https://www.wireshark.org/update/0/Wireshark/4.6.0/macOS/x86-64/en-US/stable.xml")
     appNewVersion=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@sparkle:version)[1]' 2>/dev/null | cut -d '"' -f 2)
     downloadURL=$(echo "$sparkleFeed" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f 2)
     expectedTeamID="7Z6EMTD2C6"


### PR DESCRIPTION
This is just a clean up of the wireshark label now that the app is universal. The existing label works for now to download the universal 4.6.0 on both Intel and Apple silicon.

```
% utils/assemble.sh wireshark
2025-10-10 16:03:03 : INFO  : wireshark : Total items in argumentsArray: 0
2025-10-10 16:03:03 : INFO  : wireshark : argumentsArray:
2025-10-10 16:03:03 : REQ   : wireshark : ################## Start Installomator v. 10.9beta, date 2025-10-10
2025-10-10 16:03:03 : INFO  : wireshark : ################## Version: 10.9beta
2025-10-10 16:03:03 : INFO  : wireshark : ################## Date: 2025-10-10
2025-10-10 16:03:03 : INFO  : wireshark : ################## wireshark
2025-10-10 16:03:03 : DEBUG : wireshark : DEBUG mode 1 enabled.
2025-10-10 16:03:04 : INFO  : wireshark : Reading arguments again:
2025-10-10 16:03:04 : DEBUG : wireshark : name=Wireshark
2025-10-10 16:03:04 : DEBUG : wireshark : appName=
2025-10-10 16:03:04 : DEBUG : wireshark : type=dmg
2025-10-10 16:03:04 : DEBUG : wireshark : archiveName=
2025-10-10 16:03:04 : DEBUG : wireshark : downloadURL=https://2.na.dl.wireshark.org/osx/all-versions/Wireshark%204.6.0.dmg
2025-10-10 16:03:04 : DEBUG : wireshark : curlOptions=
2025-10-10 16:03:04 : DEBUG : wireshark : appNewVersion=4.6.0
2025-10-10 16:03:04 : DEBUG : wireshark : appCustomVersion function: Not defined
2025-10-10 16:03:04 : DEBUG : wireshark : versionKey=CFBundleShortVersionString
2025-10-10 16:03:04 : DEBUG : wireshark : packageID=
2025-10-10 16:03:04 : DEBUG : wireshark : pkgName=
2025-10-10 16:03:04 : DEBUG : wireshark : choiceChangesXML=
2025-10-10 16:03:04 : DEBUG : wireshark : expectedTeamID=7Z6EMTD2C6
2025-10-10 16:03:04 : DEBUG : wireshark : blockingProcesses=
2025-10-10 16:03:04 : DEBUG : wireshark : installerTool=
2025-10-10 16:03:04 : DEBUG : wireshark : CLIInstaller=
2025-10-10 16:03:04 : DEBUG : wireshark : CLIArguments=
2025-10-10 16:03:04 : DEBUG : wireshark : updateTool=
2025-10-10 16:03:04 : DEBUG : wireshark : updateToolArguments=
2025-10-10 16:03:04 : DEBUG : wireshark : updateToolRunAsCurrentUser=
2025-10-10 16:03:04 : INFO  : wireshark : BLOCKING_PROCESS_ACTION=tell_user
2025-10-10 16:03:04 : INFO  : wireshark : NOTIFY=success
2025-10-10 16:03:04 : INFO  : wireshark : LOGGING=DEBUG
2025-10-10 16:03:04 : INFO  : wireshark : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-10 16:03:04 : INFO  : wireshark : Label type: dmg
2025-10-10 16:03:04 : INFO  : wireshark : archiveName: Wireshark.dmg
2025-10-10 16:03:04 : INFO  : wireshark : no blocking processes defined, using Wireshark as default
2025-10-10 16:03:04 : DEBUG : wireshark : Changing directory to /Users/hessf/Git/Installomator/build
2025-10-10 16:03:04 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2025-10-10 16:03:04 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 4.4.10, on versionKey CFBundleShortVersionString
2025-10-10 16:03:04 : INFO  : wireshark : appversion: 4.4.10
2025-10-10 16:03:04 : INFO  : wireshark : Latest version of Wireshark is 4.6.0
2025-10-10 16:03:04 : INFO  : wireshark : Wireshark.dmg exists and DEBUG mode 1 enabled, skipping download
2025-10-10 16:03:04 : DEBUG : wireshark : DEBUG mode 1, not checking for blocking processes
2025-10-10 16:03:04 : REQ   : wireshark : Installing Wireshark
2025-10-10 16:03:04 : INFO  : wireshark : Mounting /Users/hessf/Git/Installomator/build/Wireshark.dmg
2025-10-10 16:03:05 : DEBUG : wireshark : Debugging enabled, dmgmount output was:
expected   CRC32 $B9DCF3DF
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Wireshark 4.6.0

2025-10-10 16:03:05 : INFO  : wireshark : Mounted: /Volumes/Wireshark 4.6.0
2025-10-10 16:03:05 : INFO  : wireshark : Verifying: /Volumes/Wireshark 4.6.0/Wireshark.app
2025-10-10 16:03:05 : DEBUG : wireshark : App size: 453M	/Volumes/Wireshark 4.6.0/Wireshark.app
2025-10-10 16:03:08 : DEBUG : wireshark : Debugging enabled, App Verification output was:
/Volumes/Wireshark 4.6.0/Wireshark.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Wireshark Foundation (7Z6EMTD2C6)

2025-10-10 16:03:08 : INFO  : wireshark : Team ID matching: 7Z6EMTD2C6 (expected: 7Z6EMTD2C6 )
2025-10-10 16:03:08 : INFO  : wireshark : Downloaded version of Wireshark is 4.6.0 on versionKey CFBundleShortVersionString (replacing version 4.4.10).
2025-10-10 16:03:08 : INFO  : wireshark : App has LSMinimumSystemVersion: 12.0
2025-10-10 16:03:08 : DEBUG : wireshark : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-10 16:03:08 : INFO  : wireshark : Finishing...
2025-10-10 16:03:11 : INFO  : wireshark : App(s) found: /Applications/Wireshark.app
2025-10-10 16:03:11 : INFO  : wireshark : found app at /Applications/Wireshark.app, version 4.4.10, on versionKey CFBundleShortVersionString
2025-10-10 16:03:11 : REQ   : wireshark : Installed Wireshark, version 4.6.0
2025-10-10 16:03:11 : INFO  : wireshark : notifying
2025-10-10 16:03:11 : DEBUG : wireshark : Unmounting /Volumes/Wireshark 4.6.0
2025-10-10 16:03:11 : DEBUG : wireshark : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-10-10 16:03:11 : DEBUG : wireshark : DEBUG mode 1, not reopening anything
2025-10-10 16:03:11 : REQ   : wireshark : All done!
2025-10-10 16:03:11 : REQ   : wireshark : ################## End Installomator, exit code 0```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
