### PR TITLE
New Label - Garmin BaseCamp

### DIFF
--- a/fragments/labels/garminbasecamp.sh
+++ b/fragments/labels/garminbasecamp.sh
@@ -1,0 +1,8 @@
+garminbasecamp)
+    name="Garmin BaseCamp"
+    type="pkgInDmg"
+    downloadURL=$(curl -fs "https://www8.garmin.com/support/download_details.jsp?id=4449" | grep -Eo 'BaseCampforMac_[0-9]+\.dmg' | sort -V | tail -1 | sed 's#^#https://download.garmin.com/software/#')
+    appNewVersion=$(curl -fs "https://www8.garmin.com/support/download_details.jsp?id=4449" | grep "BaseCamp for Mac software version" | head -n 2 | tail -n 1 | sed -E 's/.* ([0-9\.]*) .*/\1/g')
+    expectedTeamID="72ES32VZUA"
+    appName="BaseCamp.app"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

[Garmin BaseCamp](https://www.garmin.com/en-US/software/basecamp/)

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo utils/assemble.sh garminbasecamp DEBUG=1
2025-10-11 09:12:39 : INFO  : garminbasecamp : setting variable from argument DEBUG=1
2025-10-11 09:12:39 : INFO  : garminbasecamp : Total items in argumentsArray: 1
2025-10-11 09:12:39 : INFO  : garminbasecamp : argumentsArray: DEBUG=1
2025-10-11 09:12:39 : REQ   : garminbasecamp : ################## Start Installomator v. 10.9beta, date 2025-10-11
2025-10-11 09:12:39 : INFO  : garminbasecamp : ################## Version: 10.9beta
2025-10-11 09:12:39 : INFO  : garminbasecamp : ################## Date: 2025-10-11
2025-10-11 09:12:39 : INFO  : garminbasecamp : ################## garminbasecamp
2025-10-11 09:12:39 : DEBUG : garminbasecamp : DEBUG mode 1 enabled.
2025-10-11 09:12:39 : INFO  : garminbasecamp : SwiftDialog is not installed, clear cmd file var
2025-10-11 09:12:42 : INFO  : garminbasecamp : Reading arguments again: DEBUG=1
2025-10-11 09:12:42 : DEBUG : garminbasecamp : argument: DEBUG=1
2025-10-11 09:12:42 : DEBUG : garminbasecamp : name=Garmin BaseCamp
2025-10-11 09:12:42 : DEBUG : garminbasecamp : appName=BaseCamp.app
2025-10-11 09:12:42 : DEBUG : garminbasecamp : type=pkgInDmg
2025-10-11 09:12:42 : DEBUG : garminbasecamp : archiveName=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : downloadURL=https://download.garmin.com/software/BaseCampforMac_4813.dmg
2025-10-11 09:12:42 : DEBUG : garminbasecamp : curlOptions=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : appNewVersion=4.8.13
2025-10-11 09:12:42 : DEBUG : garminbasecamp : appCustomVersion function: Not defined
2025-10-11 09:12:42 : DEBUG : garminbasecamp : versionKey=CFBundleShortVersionString
2025-10-11 09:12:42 : DEBUG : garminbasecamp : packageID=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : pkgName=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : choiceChangesXML=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : expectedTeamID=72ES32VZUA
2025-10-11 09:12:42 : DEBUG : garminbasecamp : blockingProcesses=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : installerTool=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : CLIInstaller=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : CLIArguments=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : updateTool=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : updateToolArguments=
2025-10-11 09:12:42 : DEBUG : garminbasecamp : updateToolRunAsCurrentUser=
2025-10-11 09:12:42 : INFO  : garminbasecamp : BLOCKING_PROCESS_ACTION=tell_user
2025-10-11 09:12:42 : INFO  : garminbasecamp : NOTIFY=success
2025-10-11 09:12:42 : INFO  : garminbasecamp : LOGGING=DEBUG
2025-10-11 09:12:42 : INFO  : garminbasecamp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-11 09:12:42 : INFO  : garminbasecamp : Label type: pkgInDmg
2025-10-11 09:12:42 : INFO  : garminbasecamp : archiveName: Garmin BaseCamp.dmg
2025-10-11 09:12:42 : INFO  : garminbasecamp : no blocking processes defined, using Garmin BaseCamp as default
2025-10-11 09:12:42 : DEBUG : garminbasecamp : Changing directory to /Users/bbp39934/Downloads/Installomator/build
2025-10-11 09:12:42 : INFO  : garminbasecamp : name: Garmin BaseCamp, appName: BaseCamp.app
2025-10-11 09:12:42 : WARN  : garminbasecamp : No previous app found
2025-10-11 09:12:42 : WARN  : garminbasecamp : could not find BaseCamp.app
2025-10-11 09:12:42 : INFO  : garminbasecamp : appversion: 
2025-10-11 09:12:42 : INFO  : garminbasecamp : Latest version of Garmin BaseCamp is 4.8.13
2025-10-11 09:12:42 : REQ   : garminbasecamp : Downloading https://download.garmin.com/software/BaseCampforMac_4813.dmg to Garmin BaseCamp.dmg
2025-10-11 09:12:42 : DEBUG : garminbasecamp : No Dialog connection, just download
2025-10-11 09:12:44 : INFO  : garminbasecamp : Downloaded Garmin BaseCamp.dmg – Type is  zlib compressed data – SHA is 593fead8ccc111b90b551ebeacb9585851a9533c – Size is 98668 kB
2025-10-11 09:12:44 : DEBUG : garminbasecamp : DEBUG mode 1, not checking for blocking processes
2025-10-11 09:12:44 : REQ   : garminbasecamp : Installing Garmin BaseCamp
2025-10-11 09:12:44 : INFO  : garminbasecamp : Mounting /Users/bbp39934/Downloads/Installomator/build/Garmin BaseCamp.dmg
2025-10-11 09:12:45 : DEBUG : garminbasecamp : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $85381A2D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7DD82BD0
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $A0417BD4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $D7A16B9E
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $A0417BD4
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $F22D0777
verified   CRC32 $E52EF871
/dev/disk10         	GUID_partition_scheme
/dev/disk10s1       	Apple_HFS                      	/Volumes/Garmin BaseCamp

2025-10-11 09:12:45 : INFO  : garminbasecamp : Mounted: /Volumes/Garmin BaseCamp
2025-10-11 09:12:45 : DEBUG : garminbasecamp : Found pkg(s):
/Volumes/Garmin BaseCamp/Install BaseCamp.pkg
2025-10-11 09:12:45 : INFO  : garminbasecamp : found pkg: /Volumes/Garmin BaseCamp/Install BaseCamp.pkg
2025-10-11 09:12:45 : INFO  : garminbasecamp : Verifying: /Volumes/Garmin BaseCamp/Install BaseCamp.pkg
2025-10-11 09:12:45 : DEBUG : garminbasecamp : File list: -rw-r--r--@ 1 test  staff    82M Mar 30  2023 /Volumes/Garmin BaseCamp/Install BaseCamp.pkg
2025-10-11 09:12:45 : DEBUG : garminbasecamp : File type: /Volumes/Garmin BaseCamp/Install BaseCamp.pkg: xar archive compressed TOC: 9037, SHA-1 checksum
2025-10-11 09:12:45 : DEBUG : garminbasecamp : spctlOut is /Volumes/Garmin BaseCamp/Install BaseCamp.pkg: accepted
2025-10-11 09:12:45 : DEBUG : garminbasecamp : source=Notarized Developer ID
2025-10-11 09:12:45 : DEBUG : garminbasecamp : origin=Developer ID Installer: Garmin International (72ES32VZUA)
2025-10-11 09:12:45 : INFO  : garminbasecamp : Team ID: 72ES32VZUA (expected: 72ES32VZUA )
2025-10-11 09:12:45 : DEBUG : garminbasecamp : DEBUG enabled, skipping installation
2025-10-11 09:12:45 : INFO  : garminbasecamp : Finishing...
2025-10-11 09:12:48 : INFO  : garminbasecamp : name: Garmin BaseCamp, appName: BaseCamp.app
2025-10-11 09:12:48 : WARN  : garminbasecamp : No previous app found
2025-10-11 09:12:48 : WARN  : garminbasecamp : could not find BaseCamp.app
2025-10-11 09:12:48 : REQ   : garminbasecamp : Installed Garmin BaseCamp, version 4.8.13
2025-10-11 09:12:48 : INFO  : garminbasecamp : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-10-11 09:12:48 : DEBUG : garminbasecamp : Unmounting /Volumes/Garmin BaseCamp
2025-10-11 09:12:48 : DEBUG : garminbasecamp : Debugging enabled, Unmounting output was:
"disk10" ejected.
2025-10-11 09:12:48 : DEBUG : garminbasecamp : DEBUG mode 1, not reopening anything
2025-10-11 09:12:48 : REQ   : garminbasecamp : All done!
2025-10-11 09:12:48 : REQ   : garminbasecamp : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")