### PR TITLE
polleverywhere label update

### DIFF
--- a/fragments/labels/polleverywhere.sh
+++ b/fragments/labels/polleverywhere.sh
@@ -1,7 +1,8 @@
 polleverywhere)
     name="Poll Everywhere"
     type="dmg"
-    downloadURL="https://www.polleverywhere.com/app.dmg"
-    appNewVersion=""
+    appNewVersion=$(curl -fsL https://www.polleverywhere.com/app/releases/mac | grep h3 --max-count 1 | awk '{ gsub(/<\/?h3>/, ""); print }')
+    downloadURL="https://polleverywhere-app.s3.amazonaws.com/mac-stable/$appNewVersion/pollev.dmg"
     expectedTeamID="W48F3X5M8W"
+    versionKey="CFBundleVersion"
     ;;


### PR DESCRIPTION
Added logic to determine the appNewVersion. Changed the downloadURL to use the retrieved version. Updated versionKey to be CFBundleVersion since Poll Everywhere's info.plist doesn't use the short version.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Output:
```

2025-10-13 15:08:50 : INFO  : polleverywhere : setting variable from argument DEBUG=0
2025-10-13 15:08:50 : INFO  : polleverywhere : Total items in argumentsArray: 1
2025-10-13 15:08:50 : INFO  : polleverywhere : argumentsArray: DEBUG=0
2025-10-13 15:08:50 : REQ   : polleverywhere : ################## Start Installomator v. 10.9beta, date 2025-10-13
2025-10-13 15:08:50 : INFO  : polleverywhere : ################## Version: 10.9beta
2025-10-13 15:08:50 : INFO  : polleverywhere : ################## Date: 2025-10-13
2025-10-13 15:08:50 : INFO  : polleverywhere : ################## polleverywhere
2025-10-13 15:08:51 : INFO  : polleverywhere : Reading arguments again: DEBUG=0
2025-10-13 15:08:51 : INFO  : polleverywhere : BLOCKING_PROCESS_ACTION=tell_user
2025-10-13 15:08:51 : INFO  : polleverywhere : NOTIFY=success
2025-10-13 15:08:51 : INFO  : polleverywhere : LOGGING=INFO
2025-10-13 15:08:51 : INFO  : polleverywhere : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-13 15:08:51 : INFO  : polleverywhere : Label type: dmg
2025-10-13 15:08:51 : INFO  : polleverywhere : archiveName: Poll Everywhere.dmg
2025-10-13 15:08:51 : INFO  : polleverywhere : no blocking processes defined, using Poll Everywhere as default
2025-10-13 15:08:51 : INFO  : polleverywhere : App(s) found: /Applications/Poll Everywhere.app
2025-10-13 15:08:52 : INFO  : polleverywhere : found app at /Applications/Poll Everywhere.app, version 3.0.1, on versionKey CFBundleVersion
2025-10-13 15:08:52 : INFO  : polleverywhere : appversion: 3.0.1
2025-10-13 15:08:52 : INFO  : polleverywhere : Latest version of Poll Everywhere is 4.0.0
2025-10-13 15:08:52 : REQ   : polleverywhere : Downloading https://polleverywhere-app.s3.amazonaws.com/mac-stable/4.0.0/pollev.dmg to Poll Everywhere.dmg
2025-10-13 15:08:53 : INFO  : polleverywhere : Downloaded Poll Everywhere.dmg – Type is  zlib compressed data – SHA is 12e4156f1a616677d188c9dcd401035be36b22cd – Size is 3052 kB
2025-10-13 15:08:53 : REQ   : polleverywhere : no more blocking processes, continue with update
2025-10-13 15:08:53 : REQ   : polleverywhere : Installing Poll Everywhere
2025-10-13 15:08:53 : INFO  : polleverywhere : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.3vDt8DNQ4p/Poll Everywhere.dmg
2025-10-13 15:08:58 : INFO  : polleverywhere : Mounted: /Volumes/Poll Everywhere 1
2025-10-13 15:08:58 : INFO  : polleverywhere : Verifying: /Volumes/Poll Everywhere 1/Poll Everywhere.app
2025-10-13 15:08:59 : INFO  : polleverywhere : Team ID matching: W48F3X5M8W (expected: W48F3X5M8W )
2025-10-13 15:08:59 : INFO  : polleverywhere : Downloaded version of Poll Everywhere is 4.0.0 on versionKey CFBundleVersion (replacing version 3.0.1).
2025-10-13 15:08:59 : INFO  : polleverywhere : App has LSMinimumSystemVersion: 14.6
2025-10-13 15:08:59 : WARN  : polleverywhere : Removing existing /Applications/Poll Everywhere.app
2025-10-13 15:08:59 : INFO  : polleverywhere : Copy /Volumes/Poll Everywhere 1/Poll Everywhere.app to /Applications
2025-10-13 15:09:00 : WARN  : polleverywhere : Changing owner to u0861439
2025-10-13 15:09:00 : INFO  : polleverywhere : Finishing...
2025-10-13 15:09:03 : INFO  : polleverywhere : App(s) found: /Applications/Poll Everywhere.app
2025-10-13 15:09:03 : INFO  : polleverywhere : found app at /Applications/Poll Everywhere.app, version 4.0.0, on versionKey CFBundleVersion
2025-10-13 15:09:03 : REQ   : polleverywhere : Installed Poll Everywhere, version 4.0.0
2025-10-13 15:09:03 : INFO  : polleverywhere : notifying
2025-10-13 15:09:04 : INFO  : polleverywhere : Installomator did not close any apps, so no need to reopen any apps.
2025-10-13 15:09:04 : REQ   : polleverywhere : All done!
2025-10-13 15:09:04 : REQ   : polleverywhere : ################## End Installomator, exit code 0
```
