### PR TITLE
wechat-label-update

### DIFF
--- a/fragments/labels/wechat.sh
+++ b/fragments/labels/wechat.sh
@@ -1,7 +1,7 @@
 wechat)
     name="WeChat"
     type="dmg"
-    downloadURL="https://dldir1.qq.com/weixin/mac/WeChatMac.dmg"
-    appNewVersion=$(curl -fsL 'https://dldir1.qq.com/weixin/mac/mac-release.xml' | xpath 'string(//rss/channel/item[1]/title)' 2>/dev/null)
+    appNewVersion=$(curl -fsL 'https://dldir1.qq.com/weixin/mac/mac-release.xml' | grep -o '<sparkle:shortVersionString>[^<]*' | head -1 | cut -d'>' -f2)
+    downloadURL=$(curl -fsL 'https://dldir1.qq.com/weixin/mac/mac-release.xml' | grep '<enclosure' | head -1 | grep -o 'url="[^"]*"' | cut -d'"' -f2)
     expectedTeamID="5A4RE8SF68"
     ;;


### PR DESCRIPTION
output
```
# sudo Installomator/utils/assemble.sh wechat DEBUG=0
2025-10-16 15:16:02 : INFO  : wechat : setting variable from argument DEBUG=0
2025-10-16 15:16:02 : INFO  : wechat : Total items in argumentsArray: 1
2025-10-16 15:16:02 : INFO  : wechat : argumentsArray: DEBUG=0
2025-10-16 15:16:02 : REQ   : wechat : ################## Start Installomator v. 10.9beta, date 2025-10-16
2025-10-16 15:16:02 : INFO  : wechat : ################## Version: 10.9beta
2025-10-16 15:16:02 : INFO  : wechat : ################## Date: 2025-10-16
2025-10-16 15:16:02 : INFO  : wechat : ################## wechat
2025-10-16 15:16:04 : INFO  : wechat : Reading arguments again: DEBUG=0
2025-10-16 15:16:04 : INFO  : wechat : BLOCKING_PROCESS_ACTION=tell_user
2025-10-16 15:16:04 : INFO  : wechat : NOTIFY=success
2025-10-16 15:16:04 : INFO  : wechat : LOGGING=INFO
2025-10-16 15:16:04 : INFO  : wechat : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-16 15:16:04 : INFO  : wechat : Label type: dmg
2025-10-16 15:16:04 : INFO  : wechat : archiveName: WeChat.dmg
2025-10-16 15:16:04 : INFO  : wechat : no blocking processes defined, using WeChat as default
2025-10-16 15:16:04 : INFO  : wechat : name: WeChat, appName: WeChat.app
2025-10-16 15:16:04 : WARN  : wechat : No previous app found
2025-10-16 15:16:04 : WARN  : wechat : could not find WeChat.app
2025-10-16 15:16:04 : INFO  : wechat : appversion:
2025-10-16 15:16:04 : INFO  : wechat : Latest version of WeChat is 4.1.0.34
2025-10-16 15:16:04 : REQ   : wechat : Downloading https://dldir1v6.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.0.34_29721.dmg?t=1756904509 to WeChat.dmg
2025-10-16 15:16:50 : INFO  : wechat : Downloaded WeChat.dmg – Type is  XZ compressed data, checksum NONE – SHA is fbd62bce81bb224efa1dccc6492700f361ead1b1 – Size is 426000 kB
2025-10-16 15:16:50 : REQ   : wechat : no more blocking processes, continue with update
2025-10-16 15:16:50 : REQ   : wechat : Installing WeChat
2025-10-16 15:16:50 : INFO  : wechat : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8af7f0KanU/WeChat.dmg
2025-10-16 15:17:05 : INFO  : wechat : Mounted: /Volumes/微信 WeChat
2025-10-16 15:17:05 : INFO  : wechat : Verifying: /Volumes/微信 WeChat/WeChat.app
2025-10-16 15:17:26 : INFO  : wechat : Team ID matching: 5A4RE8SF68 (expected: 5A4RE8SF68 )
2025-10-16 15:17:26 : INFO  : wechat : Installing WeChat version 4.1.0 on versionKey CFBundleShortVersionString.
2025-10-16 15:17:26 : INFO  : wechat : App has LSMinimumSystemVersion: 11.0
2025-10-16 15:17:26 : INFO  : wechat : Copy /Volumes/微信 WeChat/WeChat.app to /Applications
2025-10-16 15:17:42 : WARN  : wechat : Changing owner to u0105821
2025-10-16 15:17:42 : INFO  : wechat : Finishing...
2025-10-16 15:17:45 : INFO  : wechat : App(s) found: /Applications/WeChat.app
2025-10-16 15:17:45 : INFO  : wechat : found app at /Applications/WeChat.app, version 4.1.0, on versionKey CFBundleShortVersionString
2025-10-16 15:17:45 : REQ   : wechat : Installed WeChat, version 4.1.0
2025-10-16 15:17:45 : INFO  : wechat : notifying
2025-10-16 15:17:46 : INFO  : wechat : Installomator did not close any apps, so no need to reopen any apps.
2025-10-16 15:17:46 : REQ   : wechat : All done!
2025-10-16 15:17:46 : REQ   : wechat : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

The improved WeChat label fixes a critical issue where the hardcoded download URL was only retrieving an outdated version (3.8.10.17) instead of the latest release. The new implementation dynamically parses the official release XML feed to extract both the current version number and the correct download URL, ensuring users always get the most recent version. 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
