### PR TITLE
apache-netBeans-label-fix

### DIFF
--- a/fragments/labels/apachenetbeans.sh
+++ b/fragments/labels/apachenetbeans.sh
@@ -1,7 +1,12 @@
 apachenetbeans)
     name="Apache NetBeans"
     type="pkg"
-    appNewVersion=$( curl -fs "https://netbeans.apache.org/front/main/download/index.html" | grep -o 'Apache NetBeans [0-9]\+' | sed 's/Apache NetBeans //' | head -n 1 )
-    downloadURL="https://dlcdn.apache.org/netbeans/netbeans-installers/"${appNewVersion}"/Apache-NetBeans-"${appNewVersion}".pkg"
-    expectedTeamID="2GLGAFWEQD"
+    if [[ $(arch) = "arm64" ]]; then
+        archiveName="Apache-NetBeans-[0-9]*-arm64.pkg"
+    else
+        archiveName="Apache-NetBeans-[0-9]*-x86_64.pkg"
+    fi
+    downloadURL="$(downloadURLFromGit Friends-of-Apache-NetBeans netbeans-installers)"
+    appNewVersion="$(versionFromGit Friends-of-Apache-NetBeans netbeans-installers)"
+    expectedTeamID="3KH8VFSK7Q"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh apachenetbeans DEBUG=0
2025-10-20 13:51:51 : INFO  : apachenetbeans : setting variable from argument DEBUG=0
2025-10-20 13:51:51 : INFO  : apachenetbeans : Total items in argumentsArray: 1
2025-10-20 13:51:51 : INFO  : apachenetbeans : argumentsArray: DEBUG=0
2025-10-20 13:51:51 : REQ   : apachenetbeans : ################## Start Installomator v. 10.9beta, date 2025-10-20
2025-10-20 13:51:51 : INFO  : apachenetbeans : ################## Version: 10.9beta
2025-10-20 13:51:51 : INFO  : apachenetbeans : ################## Date: 2025-10-20
2025-10-20 13:51:51 : INFO  : apachenetbeans : ################## apachenetbeans
2025-10-20 13:51:53 : INFO  : apachenetbeans : Reading arguments again: DEBUG=0
2025-10-20 13:51:53 : INFO  : apachenetbeans : BLOCKING_PROCESS_ACTION=tell_user
2025-10-20 13:51:53 : INFO  : apachenetbeans : NOTIFY=success
2025-10-20 13:51:53 : INFO  : apachenetbeans : LOGGING=INFO
2025-10-20 13:51:53 : INFO  : apachenetbeans : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-20 13:51:53 : INFO  : apachenetbeans : Label type: pkg
2025-10-20 13:51:53 : INFO  : apachenetbeans : archiveName: Apache-NetBeans-[0-9]*-arm64.pkg
2025-10-20 13:51:53 : INFO  : apachenetbeans : no blocking processes defined, using Apache NetBeans as default
2025-10-20 13:51:53 : INFO  : apachenetbeans : name: Apache NetBeans, appName: Apache NetBeans.app
2025-10-20 13:51:53 : WARN  : apachenetbeans : No previous app found
2025-10-20 13:51:53 : WARN  : apachenetbeans : could not find Apache NetBeans.app
2025-10-20 13:51:53 : INFO  : apachenetbeans : appversion:
2025-10-20 13:51:53 : INFO  : apachenetbeans : Latest version of Apache NetBeans is 271
2025-10-20 13:51:53 : REQ   : apachenetbeans : Downloading https://github.com/Friends-of-Apache-NetBeans/netbeans-installers/releases/download/v27-build1/Apache-NetBeans-27-arm64.pkg to Apache-NetBeans-[0-9]*-arm64.pkg
2025-10-20 13:52:12 : INFO  : apachenetbeans : Downloaded Apache-NetBeans-[0-9]*-arm64.pkg – Type is  xar archive compressed TOC – SHA is 6fa71c0fd213cc1da56a48e47cfaa0051583623d – Size is 721300 kB
2025-10-20 13:52:13 : REQ   : apachenetbeans : no more blocking processes, continue with update
2025-10-20 13:52:13 : REQ   : apachenetbeans : Installing Apache NetBeans
2025-10-20 13:52:13 : INFO  : apachenetbeans : Verifying: Apache-NetBeans-[0-9]*-arm64.pkg
2025-10-20 13:52:13 : INFO  : apachenetbeans : Team ID: 3KH8VFSK7Q (expected: 3KH8VFSK7Q )
2025-10-20 13:52:13 : INFO  : apachenetbeans : Installing Apache-NetBeans-[0-9]*-arm64.pkg to /
2025-10-20 13:52:27 : INFO  : apachenetbeans : Finishing...
2025-10-20 13:52:30 : INFO  : apachenetbeans : App(s) found: /Applications/Apache NetBeans.app
2025-10-20 13:52:30 : INFO  : apachenetbeans : found app at /Applications/Apache NetBeans.app, version 27, on versionKey CFBundleShortVersionString
2025-10-20 13:52:30 : REQ   : apachenetbeans : Installed Apache NetBeans, version 271
2025-10-20 13:52:30 : INFO  : apachenetbeans : notifying
2025-10-20 13:52:30 : INFO  : apachenetbeans : Installomator did not close any apps, so no need to reopen any apps.
2025-10-20 13:52:30 : REQ   : apachenetbeans : All done!
2025-10-20 13:52:30 : REQ   : apachenetbeans : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The old label failed because Apache doesn't host pre-built PKG installers on their CDN anymore. The packages are now maintained and distributed by the Friends of Apache NetBeans organization through GitHub releases, requiring a complete rewrite of the download logic.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
