### PR TITLE
Delete jamfconnect label

### DIFF
--- a/fragments/labels/jamfconnect.sh
+++ b/fragments/labels/jamfconnect.sh
@@ -1,8 +1,0 @@
-jamfconnect)
-    name="Jamf Connect"
-    type="pkgInDmg"
-    packageID="com.jamf.connect"
-    downloadURL="https://files.jamfconnect.com/JamfConnect.dmg"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep "x-amz-meta-version" | grep -o "[0-9.].*[0-9.].*[0-9]")
-    expectedTeamID="483DWKW443"
-    ;;


### PR DESCRIPTION
Jamf Connect.app is now deployed as part of the Jamf Self Service+.app.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Jamf Connect.app is now deployed through the Jamf Self Service+.app and can be fdound at this location:
/Applications/Self Service+.app/Contents/MacOS/Jamf Connect.app

That makes this label deprecated.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Log file not provided as we are removing a deprecated label.

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
