### PR TITLE
create Jamf Connect Login label

### DIFF
--- a/fragments/labels/jamfconnectlogin.sh
+++ b/fragments/labels/jamfconnectlogin.sh
@@ -1,0 +1,9 @@
+jamfconnectlogin)
+    name="Jamf Connect Login"
+    type="pkgInDmg"
+    pkgName="JamfConnectLogin.pkg"
+    packageID="com.jamf.connect.login"
+    downloadURL="https://files.jamfconnect.com/JamfConnect.dmg"
+    appNewVersion=$(curl -fsIL "${downloadURL}" | grep "x-amz-meta-version" | grep -o "[0-9.].*[0-9.].*[0-9]")
+    expectedTeamID="483DWKW443"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Jamf now provides the Jamf Connect login window framework as a separate install. This label adds that framework installer to installomator.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
sudo ./build/Installomator.sh jamfconnectlogin DEBUG=0
Password:
2025-10-22 10:13:19 : INFO  : jamfconnectlogin : setting variable from argument DEBUG=0
2025-10-22 10:13:19 : INFO  : jamfconnectlogin : Total items in argumentsArray: 1
2025-10-22 10:13:19 : INFO  : jamfconnectlogin : argumentsArray: DEBUG=0
2025-10-22 10:13:20 : REQ   : jamfconnectlogin : ################## Start Installomator v. 10.9beta, date 2025-10-22
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : ################## Version: 10.9beta
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : ################## Date: 2025-10-22
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : ################## jamfconnectlogin
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : Reading arguments again: DEBUG=0
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : BLOCKING_PROCESS_ACTION=tell_user
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : NOTIFY=success
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : LOGGING=INFO
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : Label type: pkgInDmg
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : archiveName: Jamf Connect Login.dmg
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : no blocking processes defined, using Jamf Connect Login as default
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : found packageID com.jamf.connect.login installed, version 3.3.0
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : appversion: 3.3.0
2025-10-22 10:13:20 : INFO  : jamfconnectlogin : Latest version of Jamf Connect Login is 3.4.0
2025-10-22 10:13:20 : REQ   : jamfconnectlogin : Downloading https://files.jamfconnect.com/JamfConnect.dmg to Jamf Connect Login.dmg
2025-10-22 10:13:21 : INFO  : jamfconnectlogin : Downloaded Jamf Connect Login.dmg – Type is  zlib compressed data – SHA is 83fd457a410bbe01dbb90e2d1a8de0cc090eba1d – Size is 22184 kB
2025-10-22 10:13:21 : REQ   : jamfconnectlogin : no more blocking processes, continue with update
2025-10-22 10:13:21 : REQ   : jamfconnectlogin : Installing Jamf Connect Login
2025-10-22 10:13:21 : INFO  : jamfconnectlogin : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8qaRxgOflQ/Jamf Connect Login.dmg
2025-10-22 10:13:25 : INFO  : jamfconnectlogin : Mounted: /Volumes/JamfConnectLogin 1
2025-10-22 10:13:25 : INFO  : jamfconnectlogin : found pkg: /Volumes/JamfConnectLogin 1/JamfConnectLogin.pkg
2025-10-22 10:13:25 : INFO  : jamfconnectlogin : Verifying: /Volumes/JamfConnectLogin 1/JamfConnectLogin.pkg
2025-10-22 10:13:26 : INFO  : jamfconnectlogin : Team ID: 483DWKW443 (expected: 483DWKW443 )
2025-10-22 10:13:26 : INFO  : jamfconnectlogin : Checking package version.
2025-10-22 10:13:26 : INFO  : jamfconnectlogin : Downloaded package com.jamf.connect.login version 3.4.0
2025-10-22 10:13:26 : INFO  : jamfconnectlogin : Installing /Volumes/JamfConnectLogin 1/JamfConnectLogin.pkg to /
2025-10-22 10:13:30 : INFO  : jamfconnectlogin : Finishing...
2025-10-22 10:13:33 : INFO  : jamfconnectlogin : found packageID com.jamf.connect.login installed, version 3.4.0
2025-10-22 10:13:33 : REQ   : jamfconnectlogin : Installed Jamf Connect Login, version 3.4.0
2025-10-22 10:13:33 : INFO  : jamfconnectlogin : notifying
2025-10-22 10:13:33 : INFO  : jamfconnectlogin : Installomator did not close any apps, so no need to reopen any apps.
2025-10-22 10:13:33 : REQ   : jamfconnectlogin : All done!
2025-10-22 10:13:33 : REQ   : jamfconnectlogin : ################## End Installomator, exit code 0 
```