### PR TITLE
Update nextcloud

### DIFF
--- a/fragments/labels/nextcloud.sh
+++ b/fragments/labels/nextcloud.sh
@@ -1,12 +1,8 @@
 nextcloud)
     name="nextcloud"
     type="pkg"
-    #packageID="com.nextcloud.desktopclient"
+    archiveName="Nextcloud-[0-9.]*-macOS-vfs.pkg"
     downloadURL=$(downloadURLFromGit nextcloud-releases desktop)
     appNewVersion=$(versionFromGit nextcloud-releases desktop)
-    # The version of the app is not equal to the version listed on GitHub.
-    # App version something like "3.1.3git (build 4850)" but web page lists as "3.1.3"
-    # Also it does not math packageID version "3.1.34850"
-    appCustomVersion(){defaults read /Applications/nextcloud.app/Contents/Info.plist CFBundleShortVersionString | sed -E 's/^([0-9.]*)git.*/\1/g'}
     expectedTeamID="NKUJUXUJ3B"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Added `archiveName`
Removed `appCustomVersion`
Removed commented lines

There are two Nextcloud apps for macOS: de classic one and the one with [Virtual files (vfs)](https://docs.nextcloud.com/server/latest/user_manual/en/desktop/macosvfs.html) enabled. The last pull request of the nextcloud label (#1155, July 28, 2023) was about the classic one, before the introduction of the vfs-client (in [version 3.13.3](https://github.com/nextcloud-releases/desktop/releases/tag/v3.13.3), August 2024) on macOS.

On GitHUb, this vfs-client is listed first, so since the introduction, this gets installed if you use the `nextcloud` label. I'd like to switch this label to `nextcloud-vfs`, but to be consistent with the current install base, let's keep the current nexcloud label for the vfs package. I'll create an `nextcloud-classic` label for the classic app.


**Installomator log**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh nextcloud
2025-10-23 14:34:46 : INFO  : nextcloud : Total items in argumentsArray: 0
2025-10-23 14:34:46 : INFO  : nextcloud : argumentsArray:
2025-10-23 14:34:46 : REQ   : nextcloud : ################## Start Installomator v. 10.9beta, date 2025-10-23
2025-10-23 14:34:46 : INFO  : nextcloud : ################## Version: 10.9beta
2025-10-23 14:34:46 : INFO  : nextcloud : ################## Date: 2025-10-23
2025-10-23 14:34:46 : INFO  : nextcloud : ################## nextcloud
2025-10-23 14:34:46 : DEBUG : nextcloud : DEBUG mode 1 enabled.
2025-10-23 14:34:50 : INFO  : nextcloud : Reading arguments again:
2025-10-23 14:34:50 : DEBUG : nextcloud : name=nextcloud
2025-10-23 14:34:50 : DEBUG : nextcloud : appName=
2025-10-23 14:34:50 : DEBUG : nextcloud : type=pkg
2025-10-23 14:34:50 : DEBUG : nextcloud : archiveName=Nextcloud-[0-9.]*-macOS-vfs.pkg
2025-10-23 14:34:50 : DEBUG : nextcloud : downloadURL=https://github.com/nextcloud-releases/desktop/releases/download/v4.0.0/Nextcloud-4.0.0-macOS-vfs.pkg
2025-10-23 14:34:50 : DEBUG : nextcloud : curlOptions=
2025-10-23 14:34:50 : DEBUG : nextcloud : appNewVersion=4.0.0
2025-10-23 14:34:50 : DEBUG : nextcloud : appCustomVersion function: Not defined
2025-10-23 14:34:50 : DEBUG : nextcloud : versionKey=CFBundleShortVersionString
2025-10-23 14:34:50 : DEBUG : nextcloud : packageID=
2025-10-23 14:34:50 : DEBUG : nextcloud : pkgName=
2025-10-23 14:34:50 : DEBUG : nextcloud : choiceChangesXML=
2025-10-23 14:34:50 : DEBUG : nextcloud : expectedTeamID=NKUJUXUJ3B
2025-10-23 14:34:50 : DEBUG : nextcloud : blockingProcesses=
2025-10-23 14:34:50 : DEBUG : nextcloud : installerTool=
2025-10-23 14:34:50 : DEBUG : nextcloud : CLIInstaller=
2025-10-23 14:34:50 : DEBUG : nextcloud : CLIArguments=
2025-10-23 14:34:50 : DEBUG : nextcloud : updateTool=
2025-10-23 14:34:50 : DEBUG : nextcloud : updateToolArguments=
2025-10-23 14:34:50 : DEBUG : nextcloud : updateToolRunAsCurrentUser=
2025-10-23 14:34:50 : INFO  : nextcloud : BLOCKING_PROCESS_ACTION=tell_user
2025-10-23 14:34:50 : INFO  : nextcloud : NOTIFY=success
2025-10-23 14:34:50 : INFO  : nextcloud : LOGGING=DEBUG
2025-10-23 14:34:50 : INFO  : nextcloud : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-23 14:34:50 : INFO  : nextcloud : Label type: pkg
2025-10-23 14:34:50 : INFO  : nextcloud : archiveName: Nextcloud-[0-9.]*-macOS-vfs.pkg
2025-10-23 14:34:50 : INFO  : nextcloud : no blocking processes defined, using nextcloud as default
2025-10-23 14:34:50 : DEBUG : nextcloud : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2025-10-23 14:34:50 : INFO  : nextcloud : App(s) found: /Applications/nextcloud.app
2025-10-23 14:34:50 : INFO  : nextcloud : found app at /Applications/nextcloud.app, version 4.0.0, on versionKey CFBundleShortVersionString
2025-10-23 14:34:50 : INFO  : nextcloud : appversion: 4.0.0
2025-10-23 14:34:50 : INFO  : nextcloud : Latest version of nextcloud is 4.0.0
2025-10-23 14:34:50 : WARN  : nextcloud : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-10-23 14:34:50 : REQ   : nextcloud : Downloading https://github.com/nextcloud-releases/desktop/releases/download/v4.0.0/Nextcloud-4.0.0-macOS-vfs.pkg to Nextcloud-[0-9.]*-macOS-vfs.pkg
2025-10-23 14:34:50 : DEBUG : nextcloud : No Dialog connection, just download
2025-10-23 14:35:25 : INFO  : nextcloud : Downloaded Nextcloud-[0-9.]*-macOS-vfs.pkg – Type is  xar archive compressed TOC – SHA is 969fdaa9c0ffd22f7c18c1ba1daf54a6168e3539 – Size is 377228 kB
2025-10-23 14:35:25 : DEBUG : nextcloud : DEBUG mode 1, not checking for blocking processes
2025-10-23 14:35:25 : REQ   : nextcloud : Installing nextcloud
2025-10-23 14:35:25 : INFO  : nextcloud : Verifying: Nextcloud-[0-9.]*-macOS-vfs.pkg
2025-10-23 14:35:25 : DEBUG : nextcloud : File list: -rw-r--r--@ 1 h.lans  admin   366M Oct 23 14:35 Nextcloud-[0-9.]*-macOS-vfs.pkg
2025-10-23 14:35:25 : DEBUG : nextcloud : File type: Nextcloud-[0-9.]*-macOS-vfs.pkg: xar archive compressed TOC: 5097, SHA-1 checksum
2025-10-23 14:35:25 : DEBUG : nextcloud : spctlOut is Nextcloud-[0-9.]*-macOS-vfs.pkg: accepted
2025-10-23 14:35:25 : DEBUG : nextcloud : source=Notarized Developer ID
2025-10-23 14:35:25 : DEBUG : nextcloud : origin=Developer ID Installer: Nextcloud GmbH (NKUJUXUJ3B)
2025-10-23 14:35:25 : INFO  : nextcloud : Team ID: NKUJUXUJ3B (expected: NKUJUXUJ3B )
2025-10-23 14:35:25 : DEBUG : nextcloud : DEBUG enabled, skipping installation
2025-10-23 14:35:25 : INFO  : nextcloud : Finishing...
2025-10-23 14:35:28 : INFO  : nextcloud : App(s) found: /Applications/nextcloud.app
2025-10-23 14:35:28 : INFO  : nextcloud : found app at /Applications/nextcloud.app, version 4.0.0, on versionKey CFBundleShortVersionString
2025-10-23 14:35:28 : REQ   : nextcloud : Installed nextcloud, version 4.0.0
2025-10-23 14:35:28 : INFO  : nextcloud : notifying
2025-10-23 14:35:28 : DEBUG : nextcloud : DEBUG mode 1, not reopening anything
2025-10-23 14:35:28 : REQ   : nextcloud : All done!
2025-10-23 14:35:28 : REQ   : nextcloud : ################## End Installomator, exit code 0
````
