### PR TITLE
Create chatgptatlas.sh

### DIFF
--- a/fragments/labels/chatgptatlas.sh
+++ b/fragments/labels/chatgptatlas.sh
@@ -1,0 +1,7 @@
+chatgptatlas)
+    name="ChatGPT Atlas"
+    type="dmg"
+    downloadURL="https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas.dmg"
+    appNewVersion="curl -fs https://persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml | xpath -e 'string((/rss/channel/item/*[local-name()="shortVersionString"])[1])' 2>/dev/null"
+    expectedTeamID="2DC432GLL2"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
sudo ./Installomator.sh chatgptatlas
2025-10-23 08:32:24 : INFO  : chatgptatlas : Total items in argumentsArray: 0
2025-10-23 08:32:24 : INFO  : chatgptatlas : argumentsArray: 
2025-10-23 08:32:24 : REQ   : chatgptatlas : ################## Start Installomator v. 10.9beta, date 2025-10-23
2025-10-23 08:32:24 : INFO  : chatgptatlas : ################## Version: 10.9beta
2025-10-23 08:32:24 : INFO  : chatgptatlas : ################## Date: 2025-10-23
2025-10-23 08:32:24 : INFO  : chatgptatlas : ################## chatgptatlas
2025-10-23 08:32:24 : DEBUG : chatgptatlas : DEBUG mode 1 enabled.
2025-10-23 08:32:25 : INFO  : chatgptatlas : Reading arguments again: 
2025-10-23 08:32:25 : DEBUG : chatgptatlas : name=ChatGPT Atlas
2025-10-23 08:32:25 : DEBUG : chatgptatlas : appName=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : type=dmg
2025-10-23 08:32:25 : DEBUG : chatgptatlas : archiveName=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : downloadURL=https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas.dmg
2025-10-23 08:32:25 : DEBUG : chatgptatlas : curlOptions=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : appNewVersion=curl -fs https://persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml | xpath -e 'string((/rss/channel/item/*[local-name()=shortVersionString])[1])' 2>/dev/null
2025-10-23 08:32:25 : DEBUG : chatgptatlas : appCustomVersion function: Not defined
2025-10-23 08:32:25 : DEBUG : chatgptatlas : versionKey=CFBundleShortVersionString
2025-10-23 08:32:25 : DEBUG : chatgptatlas : packageID=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : pkgName=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : choiceChangesXML=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : expectedTeamID=2DC432GLL2
2025-10-23 08:32:25 : DEBUG : chatgptatlas : blockingProcesses=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : installerTool=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : CLIInstaller=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : CLIArguments=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : updateTool=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : updateToolArguments=
2025-10-23 08:32:25 : DEBUG : chatgptatlas : updateToolRunAsCurrentUser=
2025-10-23 08:32:25 : INFO  : chatgptatlas : BLOCKING_PROCESS_ACTION=tell_user
2025-10-23 08:32:25 : INFO  : chatgptatlas : NOTIFY=success
2025-10-23 08:32:25 : INFO  : chatgptatlas : LOGGING=DEBUG
2025-10-23 08:32:25 : INFO  : chatgptatlas : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-23 08:32:25 : INFO  : chatgptatlas : Label type: dmg
2025-10-23 08:32:25 : INFO  : chatgptatlas : archiveName: ChatGPT Atlas.dmg
2025-10-23 08:32:25 : INFO  : chatgptatlas : no blocking processes defined, using ChatGPT Atlas as default
2025-10-23 08:32:25 : DEBUG : chatgptatlas : Changing directory to .
2025-10-23 08:32:25 : INFO  : chatgptatlas : App(s) found: /Applications/ChatGPT Atlas.app
2025-10-23 08:32:25 : INFO  : chatgptatlas : found app at /Applications/ChatGPT Atlas.app, version 1.2025.288.13, on versionKey CFBundleShortVersionString
2025-10-23 08:32:25 : INFO  : chatgptatlas : appversion: 1.2025.288.13
2025-10-23 08:32:25 : INFO  : chatgptatlas : Latest version of ChatGPT Atlas is curl -fs https://persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml | xpath -e 'string((/rss/channel/item/*[local-name()=shortVersionString])[1])' 2>/dev/null
2025-10-23 08:32:25 : INFO  : chatgptatlas : ChatGPT Atlas.dmg exists and DEBUG mode 1 enabled, skipping download
2025-10-23 08:32:25 : DEBUG : chatgptatlas : DEBUG mode 1, not checking for blocking processes
2025-10-23 08:32:25 : REQ   : chatgptatlas : Installing ChatGPT Atlas
2025-10-23 08:32:25 : INFO  : chatgptatlas : Mounting ./ChatGPT Atlas.dmg
2025-10-23 08:32:25 : DEBUG : chatgptatlas : Debugging enabled, dmgmount output was:
expected   CRC32 $75E5C942
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/ChatGPT Atlas Installer

2025-10-23 08:32:25 : INFO  : chatgptatlas : Mounted: /Volumes/ChatGPT Atlas Installer
2025-10-23 08:32:25 : INFO  : chatgptatlas : Verifying: /Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app
2025-10-23 08:32:25 : DEBUG : chatgptatlas : App size: 476M	/Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app
2025-10-23 08:32:27 : DEBUG : chatgptatlas : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI, L.L.C. (2DC432GLL2)

2025-10-23 08:32:27 : INFO  : chatgptatlas : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2025-10-23 08:32:27 : INFO  : chatgptatlas : Downloaded version of ChatGPT Atlas is 1.2025.288.14 on versionKey CFBundleShortVersionString (replacing version 1.2025.288.13).
2025-10-23 08:32:27 : INFO  : chatgptatlas : App has LSMinimumSystemVersion: 14.2
2025-10-23 08:32:27 : DEBUG : chatgptatlas : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-23 08:32:27 : INFO  : chatgptatlas : Finishing...
2025-10-23 08:32:30 : INFO  : chatgptatlas : App(s) found: /Applications/ChatGPT Atlas.app
2025-10-23 08:32:30 : INFO  : chatgptatlas : found app at /Applications/ChatGPT Atlas.app, version 1.2025.288.13, on versionKey CFBundleShortVersionString
2025-10-23 08:32:30 : REQ   : chatgptatlas : Installed ChatGPT Atlas, version 1.2025.288.14
2025-10-23 08:32:30 : INFO  : chatgptatlas : notifying
2025-10-23 08:32:30 : DEBUG : chatgptatlas : Unmounting /Volumes/ChatGPT Atlas Installer
2025-10-23 08:32:30 : DEBUG : chatgptatlas : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-10-23 08:32:30 : DEBUG : chatgptatlas : DEBUG mode 1, not reopening anything
2025-10-23 08:32:30 : REQ   : chatgptatlas : All done!
2025-10-23 08:32:30 : REQ   : chatgptatlas : ################## End Installomator, exit code 0 
```
