### PR TITLE
Update Android Studio

### DIFF
--- a/fragments/labels/androidstudio.sh
+++ b/fragments/labels/androidstudio.sh
@@ -12,23 +12,11 @@ androidstudio)
     blockingProcesses=( androidstudio )
 
     appCustomVersion() {
-        # Android Studio only contains the Major.minor in the Info.plist
-        # We're going to use a hidden file to store the full Major.minor.minor.minor version number
         customVersionFile="/Users/Shared/.AndroidStudioInstalledVersion"
-
-        # Check it the hidden custom version file exists. If so, use that version number.
         if [ -f "${customVersionFile}" ]; then
             result=$(cat "${customVersionFile}")
         fi
-
-        # Write the appNewVersion value to the custom version file.
-        # This assumes any run of this label executed successfully and the installed version was updated to the
-        #   latest version because Installomator doesn't provide that kind of feedback to the label fragment code.
-        #   This is a hack, but it solves the problem of the software being re-installed on every run because the
-        #   installed version doesn't accurately report it's full version.
         echo $appNewVersion > "${customVersionFile}"
-
-        # Write out whichever installed version number we found into appCustomVersion
         echo $result
     }
     ;;


### PR DESCRIPTION
Add fix to prevent Installomator from re-installing Android Studio over and over again. The issue is that Android Studio only contains the Major.minor version in the Info.plist.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
This is a fix to prevent Installomator from re-installing Android Studio over and over again. The issue is that Android Studio only contains the Major.minor version in the Info.plist.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
username@hostname: Installomator % sudo ./build/Installomator.sh androidstudio DEBUG=1
2025-10-24 15:02:01 : INFO  : androidstudio : setting variable from argument DEBUG=1
2025-10-24 15:02:01 : INFO  : androidstudio : Total items in argumentsArray: 1
2025-10-24 15:02:01 : INFO  : androidstudio : argumentsArray: DEBUG=1
2025-10-24 15:02:01 : REQ   : androidstudio : ################## Start Installomator v. 10.9beta, date 2025-10-24
2025-10-24 15:02:01 : INFO  : androidstudio : ################## Version: 10.9beta
2025-10-24 15:02:01 : INFO  : androidstudio : ################## Date: 2025-10-24
2025-10-24 15:02:01 : INFO  : androidstudio : ################## androidstudio
2025-10-24 15:02:02 : DEBUG : androidstudio : DEBUG mode 1 enabled.
2025-10-24 15:02:02 : INFO  : androidstudio : Reading arguments again: DEBUG=1
2025-10-24 15:02:02 : DEBUG : androidstudio : argument: DEBUG=1
2025-10-24 15:02:02 : DEBUG : androidstudio : name=Android Studio
2025-10-24 15:02:02 : DEBUG : androidstudio : appName=
2025-10-24 15:02:02 : DEBUG : androidstudio : type=dmg
2025-10-24 15:02:02 : DEBUG : androidstudio : archiveName=
2025-10-24 15:02:02 : DEBUG : androidstudio : downloadURL=https://redirector.gvt1.com/edgedl/android/studio/install/2025.1.4.8/android-studio-2025.1.4.8-mac_arm.dmg
2025-10-24 15:02:03 : DEBUG : androidstudio : curlOptions=
2025-10-24 15:02:03 : DEBUG : androidstudio : appNewVersion=2025.1.4.8
2025-10-24 15:02:03 : DEBUG : androidstudio : appCustomVersion function: Defined. 
2025-10-24 15:02:03 : DEBUG : androidstudio : versionKey=CFBundleShortVersionString
2025-10-24 15:02:03 : DEBUG : androidstudio : packageID=
2025-10-24 15:02:03 : DEBUG : androidstudio : pkgName=
2025-10-24 15:02:03 : DEBUG : androidstudio : choiceChangesXML=
2025-10-24 15:02:03 : DEBUG : androidstudio : expectedTeamID=EQHXZ8M8AV
2025-10-24 15:02:03 : DEBUG : androidstudio : blockingProcesses=androidstudio
2025-10-24 15:02:03 : DEBUG : androidstudio : installerTool=
2025-10-24 15:02:03 : DEBUG : androidstudio : CLIInstaller=
2025-10-24 15:02:03 : DEBUG : androidstudio : CLIArguments=
2025-10-24 15:02:03 : DEBUG : androidstudio : updateTool=
2025-10-24 15:02:03 : DEBUG : androidstudio : updateToolArguments=
2025-10-24 15:02:03 : DEBUG : androidstudio : updateToolRunAsCurrentUser=
2025-10-24 15:02:03 : INFO  : androidstudio : BLOCKING_PROCESS_ACTION=tell_user
2025-10-24 15:02:03 : INFO  : androidstudio : NOTIFY=success
2025-10-24 15:02:03 : INFO  : androidstudio : LOGGING=DEBUG
2025-10-24 15:02:03 : INFO  : androidstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-24 15:02:03 : INFO  : androidstudio : Label type: dmg
2025-10-24 15:02:03 : INFO  : androidstudio : archiveName: Android Studio.dmg
2025-10-24 15:02:03 : DEBUG : androidstudio : Changing directory to ./build
2025-10-24 15:02:03 : INFO  : androidstudio : Custom App Version detection is used, found 2025.1.4.8
2025-10-24 15:02:03 : INFO  : androidstudio : appversion: 2025.1.4.8
2025-10-24 15:02:03 : INFO  : androidstudio : Latest version of Android Studio is 2025.1.4.8
2025-10-24 15:02:03 : WARN  : androidstudio : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-10-24 15:02:03 : INFO  : androidstudio : Android Studio.dmg exists and DEBUG mode 1 enabled, skipping download
2025-10-24 15:02:03 : DEBUG : androidstudio : DEBUG mode 1, not checking for blocking processes
2025-10-24 15:02:03 : REQ   : androidstudio : Installing Android Studio
2025-10-24 15:02:03 : INFO  : androidstudio : Mounting ./build/Android Studio.dmg
hdiutil: attach failed - No such file or directory
2025-10-24 15:02:03 : DEBUG : androidstudio : DEBUG mode 1, not reopening anything
2025-10-24 15:02:03 : ERROR : androidstudio : ERROR: Error mounting ./build/Android Studio.dmg error:
Log

2025-10-24 15:02:03 : REQ   : androidstudio : ################## End Installomator, exit code 3 
```