### PR TITLE
add apsera (IBM Aspera)

### DIFF
--- a/fragments/labels/aspera.sh
+++ b/fragments/labels/aspera.sh
@@ -1,0 +1,8 @@
+aspera|\
+ibmaspera)
+    name="IBM Aspera"
+    type="pkg"
+    appNewVersion=$(curl -fsL https://downloads.ibmaspera.com/downloads/desktop/latest/stable/latest.json | jq -r '.entries.[] | select(.platform == "macos") | .version')
+    downloadURL=$(curl -fsL https://downloads.ibmaspera.com/downloads/desktop/latest/stable/latest.json | jq -r '.entries.[] | select(.platform == "macos") | .url')
+    expectedTeamID="PETKK2G752"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
`IBM Aspera` is a new product, destined to replace `IBM Aspera Connect`
They will co-exist for a while. Therefor a new label is needed

**Installomator log** 
New app install:
```
➜  Installomator git:(add_aspera) ✗ sudo ./utils/assemble.sh aspera DEBUG=0
2025-10-28 12:58:15 : INFO  : aspera : setting variable from argument DEBUG=0
2025-10-28 12:58:15 : INFO  : aspera : Total items in argumentsArray: 1
2025-10-28 12:58:15 : INFO  : aspera : argumentsArray: DEBUG=0
2025-10-28 12:58:15 : REQ   : aspera : ################## Start Installomator v. 10.9beta, date 2025-10-28
2025-10-28 12:58:15 : INFO  : aspera : ################## Version: 10.9beta
2025-10-28 12:58:15 : INFO  : aspera : ################## Date: 2025-10-28
2025-10-28 12:58:15 : INFO  : aspera : ################## aspera
2025-10-28 12:58:16 : INFO  : aspera : Reading arguments again: DEBUG=0
2025-10-28 12:58:16 : INFO  : aspera : BLOCKING_PROCESS_ACTION=tell_user
2025-10-28 12:58:16 : INFO  : aspera : NOTIFY=success
2025-10-28 12:58:16 : INFO  : aspera : LOGGING=INFO
2025-10-28 12:58:16 : INFO  : aspera : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-28 12:58:16 : INFO  : aspera : Label type: pkg
2025-10-28 12:58:16 : INFO  : aspera : archiveName: IBM Aspera.pkg
2025-10-28 12:58:16 : INFO  : aspera : no blocking processes defined, using IBM Aspera as default
2025-10-28 12:58:16 : INFO  : aspera : name: IBM Aspera, appName: IBM Aspera.app
2025-10-28 12:58:17 : INFO  : aspera : App(s) found: /Applications/IBM Aspera Connect.app/Applications/IBM Aspera Crypt.app/Applications/IBM Aspera Launcher.app
2025-10-28 12:58:17 : WARN  : aspera : could not determine location of IBM Aspera.app
2025-10-28 12:58:17 : INFO  : aspera : appversion: 
2025-10-28 12:58:17 : INFO  : aspera : Latest version of IBM Aspera is 1.0.14
2025-10-28 12:58:17 : REQ   : aspera : Downloading https://downloads.ibmaspera.com/downloads/desktop/macos/1.0.14/stable/universal/ibm-aspera-desktop-1.0.14.pkg to IBM Aspera.pkg
2025-10-28 12:58:21 : INFO  : aspera : Downloaded IBM Aspera.pkg – Type is  xar archive compressed TOC – SHA is d70dec9f12edc95a180ebae00ee8c28250ddf75b – Size is 82588 kB
2025-10-28 12:58:21 : REQ   : aspera : no more blocking processes, continue with update
2025-10-28 12:58:21 : REQ   : aspera : Installing IBM Aspera
2025-10-28 12:58:21 : INFO  : aspera : Verifying: IBM Aspera.pkg
2025-10-28 12:58:21 : INFO  : aspera : Team ID: PETKK2G752 (expected: PETKK2G752 )
2025-10-28 12:58:21 : INFO  : aspera : Installing IBM Aspera.pkg to /
2025-10-28 12:58:26 : INFO  : aspera : Finishing...
2025-10-28 12:58:29 : INFO  : aspera : App(s) found: /Applications/IBM Aspera.app
2025-10-28 12:58:29 : INFO  : aspera : found app at /Applications/IBM Aspera.app, version 1.0.14, on versionKey CFBundleShortVersionString
2025-10-28 12:58:29 : REQ   : aspera : Installed IBM Aspera, version 1.0.14
2025-10-28 12:58:29 : INFO  : aspera : notifying
2025-10-28 12:58:30 : INFO  : aspera : Installomator did not close any apps, so no need to reopen any apps.
2025-10-28 12:58:30 : REQ   : aspera : All done!
2025-10-28 12:58:30 : REQ   : aspera : ################## End Installomator, exit code 0 
```

With previous app installed:
```
➜  Installomator git:(add_aspera) ✗ sudo ./utils/assemble.sh aspera DEBUG=0
2025-10-28 12:58:34 : INFO  : aspera : setting variable from argument DEBUG=0
2025-10-28 12:58:34 : INFO  : aspera : Total items in argumentsArray: 1
2025-10-28 12:58:34 : INFO  : aspera : argumentsArray: DEBUG=0
2025-10-28 12:58:34 : REQ   : aspera : ################## Start Installomator v. 10.9beta, date 2025-10-28
2025-10-28 12:58:34 : INFO  : aspera : ################## Version: 10.9beta
2025-10-28 12:58:34 : INFO  : aspera : ################## Date: 2025-10-28
2025-10-28 12:58:34 : INFO  : aspera : ################## aspera
2025-10-28 12:58:34 : INFO  : aspera : Reading arguments again: DEBUG=0
2025-10-28 12:58:34 : INFO  : aspera : BLOCKING_PROCESS_ACTION=tell_user
2025-10-28 12:58:34 : INFO  : aspera : NOTIFY=success
2025-10-28 12:58:34 : INFO  : aspera : LOGGING=INFO
2025-10-28 12:58:34 : INFO  : aspera : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-28 12:58:34 : INFO  : aspera : Label type: pkg
2025-10-28 12:58:34 : INFO  : aspera : archiveName: IBM Aspera.pkg
2025-10-28 12:58:34 : INFO  : aspera : no blocking processes defined, using IBM Aspera as default
2025-10-28 12:58:34 : INFO  : aspera : App(s) found: /Applications/IBM Aspera.app
2025-10-28 12:58:34 : INFO  : aspera : found app at /Applications/IBM Aspera.app, version 1.0.14, on versionKey CFBundleShortVersionString
2025-10-28 12:58:34 : INFO  : aspera : appversion: 1.0.14
2025-10-28 12:58:34 : INFO  : aspera : Latest version of IBM Aspera is 1.0.14
2025-10-28 12:58:34 : INFO  : aspera : There is no newer version available.
2025-10-28 12:58:34 : INFO  : aspera : Installomator did not close any apps, so no need to reopen any apps.
2025-10-28 12:58:34 : REQ   : aspera : No newer version.
2025-10-28 12:58:34 : REQ   : aspera : ################## End Installomator, exit code 0 
```