### PR TITLE
More stable reading of downloadURL and appNewVersion for asperaconnect

### DIFF
--- a/fragments/labels/asperaconnect.sh
+++ b/fragments/labels/asperaconnect.sh
@@ -1,7 +1,10 @@
 asperaconnect)
     name="Aspera Connect"
     type="pkg"
-    downloadURL="https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/$(curl -fs 'https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm~Other%20software&product=ibm/Other+software/IBM+Aspera+Connect' --data-raw 'showStatus=false' | egrep -o "ibm-aspera-connect_[0-9.]+_macOS" | head -n1)_x86_64.pkg"
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*ibm-aspera-connect_([0-9]+(\.[0-9]+)*)_macOS.*\.pkg/\1/')
+    indexFilePath=$(curl -fsL https://ibmaspera.com/help/downloads/desktop | grep 'script type="module"' | grep -o "/.*.js")
+    downloadBaseUrl="https:$(curl -fsL https://ibmaspera.com${indexFilePath} | grep versions.js | grep -o "var i=\"//.*downloads/connect" | sed -E 's/var i="//g')"
+    appInfo=$(curl -fs ${downloadBaseUrl}/latest/versions.js | grep -o "{.*}")
+    appNewVersion=$(echo ${appInfo} | jq -r '.entries.[] | select(.title == "Aspera Connect for macOS") | .version' | awk -F "." '{print$1"."$2"."$3}')
+    downloadURL="${downloadBaseUrl}/latest/$(echo ${appInfo} | jq -r '.entries.[] | select(.title == "Aspera Connect for macOS").links.[] | select(.rel == "enclosure-one-click").href')"
     expectedTeamID="PETKK2G752"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes. 

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
It's a duplicate for #2577 but I consider this method to be more future safe, since it's pulling the cloudfront url from the ibmsaspera download page. It also reads the download url and latest version from the actual json instead of parsing the rendered web page.

**Installomator log**
No app installed:
```➜  Installomator git:(fix_apseraconnect_appNewVersion) ✗ sudo ./assemble.sh asperaconnect DEBUG=0
2025-10-28 12:52:44 : INFO  : asperaconnect : setting variable from argument DEBUG=0
2025-10-28 12:52:44 : INFO  : asperaconnect : Total items in argumentsArray: 1
2025-10-28 12:52:44 : INFO  : asperaconnect : argumentsArray: DEBUG=0
2025-10-28 12:52:44 : REQ   : asperaconnect : ################## Start Installomator v. 10.9beta, date 2025-10-28
2025-10-28 12:52:44 : INFO  : asperaconnect : ################## Version: 10.9beta
2025-10-28 12:52:44 : INFO  : asperaconnect : ################## Date: 2025-10-28
2025-10-28 12:52:44 : INFO  : asperaconnect : ################## asperaconnect
2025-10-28 12:52:46 : INFO  : asperaconnect : Reading arguments again: DEBUG=0
2025-10-28 12:52:46 : INFO  : asperaconnect : BLOCKING_PROCESS_ACTION=tell_user
2025-10-28 12:52:46 : INFO  : asperaconnect : NOTIFY=success
2025-10-28 12:52:46 : INFO  : asperaconnect : LOGGING=INFO
2025-10-28 12:52:46 : INFO  : asperaconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-28 12:52:46 : INFO  : asperaconnect : Label type: pkg
2025-10-28 12:52:46 : INFO  : asperaconnect : archiveName: Aspera Connect.pkg
2025-10-28 12:52:46 : INFO  : asperaconnect : no blocking processes defined, using Aspera Connect as default
2025-10-28 12:52:46 : INFO  : asperaconnect : name: Aspera Connect, appName: Aspera Connect.app
2025-10-28 12:52:47 : WARN  : asperaconnect : No previous app found
2025-10-28 12:52:47 : WARN  : asperaconnect : could not find Aspera Connect.app
2025-10-28 12:52:47 : INFO  : asperaconnect : appversion: 
2025-10-28 12:52:47 : INFO  : asperaconnect : Latest version of Aspera Connect is 4.2.18
2025-10-28 12:52:47 : REQ   : asperaconnect : Downloading https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_4.2.18.918-HEAD_macOS_x86_64.pkg to Aspera Connect.pkg
2025-10-28 12:52:48 : INFO  : asperaconnect : Downloaded Aspera Connect.pkg – Type is  xar archive compressed TOC – SHA is b9de2f40acad4515adaa1ca380e3dbe2575af60e – Size is 82800 kB
2025-10-28 12:52:48 : REQ   : asperaconnect : no more blocking processes, continue with update
2025-10-28 12:52:48 : REQ   : asperaconnect : Installing Aspera Connect
2025-10-28 12:52:48 : INFO  : asperaconnect : Verifying: Aspera Connect.pkg
2025-10-28 12:52:48 : INFO  : asperaconnect : Team ID: PETKK2G752 (expected: PETKK2G752 )
2025-10-28 12:52:48 : INFO  : asperaconnect : Installing Aspera Connect.pkg to /
2025-10-28 12:53:13 : INFO  : asperaconnect : Finishing...
2025-10-28 12:53:16 : INFO  : asperaconnect : name: Aspera Connect, appName: Aspera Connect.app
2025-10-28 12:53:16 : INFO  : asperaconnect : App(s) found: /Applications/IBM Aspera Connect.app
2025-10-28 12:53:16 : INFO  : asperaconnect : found app at /Applications/IBM Aspera Connect.app, version 4.2.18, on versionKey CFBundleShortVersionString
2025-10-28 12:53:16 : REQ   : asperaconnect : Installed Aspera Connect, version 4.2.18
2025-10-28 12:53:16 : INFO  : asperaconnect : notifying
2025-10-28 12:53:17 : INFO  : asperaconnect : Installomator did not close any apps, so no need to reopen any apps.
2025-10-28 12:53:17 : REQ   : asperaconnect : All done!
2025-10-28 12:53:17 : REQ   : asperaconnect : ################## End Installomator, exit code 0 
```

Latest app installed:
```➜  Installomator git:(fix_apseraconnect_appNewVersion) ✗ sudo ./assemble.sh asperaconnect DEBUG=0
2025-10-28 12:53:19 : INFO  : asperaconnect : setting variable from argument DEBUG=0
2025-10-28 12:53:19 : INFO  : asperaconnect : Total items in argumentsArray: 1
2025-10-28 12:53:19 : INFO  : asperaconnect : argumentsArray: DEBUG=0
2025-10-28 12:53:19 : REQ   : asperaconnect : ################## Start Installomator v. 10.9beta, date 2025-10-28
2025-10-28 12:53:19 : INFO  : asperaconnect : ################## Version: 10.9beta
2025-10-28 12:53:20 : INFO  : asperaconnect : ################## Date: 2025-10-28
2025-10-28 12:53:20 : INFO  : asperaconnect : ################## asperaconnect
2025-10-28 12:53:22 : INFO  : asperaconnect : Reading arguments again: DEBUG=0
2025-10-28 12:53:23 : INFO  : asperaconnect : BLOCKING_PROCESS_ACTION=tell_user
2025-10-28 12:53:23 : INFO  : asperaconnect : NOTIFY=success
2025-10-28 12:53:23 : INFO  : asperaconnect : LOGGING=INFO
2025-10-28 12:53:23 : INFO  : asperaconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-28 12:53:23 : INFO  : asperaconnect : Label type: pkg
2025-10-28 12:53:23 : INFO  : asperaconnect : archiveName: Aspera Connect.pkg
2025-10-28 12:53:23 : INFO  : asperaconnect : no blocking processes defined, using Aspera Connect as default
2025-10-28 12:53:23 : INFO  : asperaconnect : name: Aspera Connect, appName: Aspera Connect.app
2025-10-28 12:53:23 : INFO  : asperaconnect : App(s) found: /Applications/IBM Aspera Connect.app
2025-10-28 12:53:23 : INFO  : asperaconnect : found app at /Applications/IBM Aspera Connect.app, version 4.2.18, on versionKey CFBundleShortVersionString
2025-10-28 12:53:23 : INFO  : asperaconnect : appversion: 4.2.18
2025-10-28 12:53:23 : INFO  : asperaconnect : Latest version of Aspera Connect is 4.2.18
2025-10-28 12:53:23 : INFO  : asperaconnect : There is no newer version available.
2025-10-28 12:53:23 : INFO  : asperaconnect : Installomator did not close any apps, so no need to reopen any apps.
2025-10-28 12:53:23 : REQ   : asperaconnect : No newer version.
2025-10-28 12:53:23 : REQ   : asperaconnect : ################## End Installomator, exit code 0 
```