### PR TITLE
Update libreoffice

### DIFF
--- a/fragments/labels/libreoffice.sh
+++ b/fragments/labels/libreoffice.sh
@@ -1,13 +1,13 @@
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appMajorVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
     if [[ $(arch) == "arm64" ]]; then
-    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/"$appMajorVersion"/mac/aarch64/LibreOffice_"$appMajorVersion"_MacOS_aarch64.dmg"
+    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then
-    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/"$appMajorVersion"/mac/x86_64/LibreOffice_"$appMajorVersion"_MacOS_x86-64.dmg"
+    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/x86_64/LibreOffice_${appNewVersion}_MacOS_x86-64.dmg"
     fi
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep -m 1 ".tar.xz" | sed "s|.*libreoffice-\(.*\).tar.xz?.*|\\1|")"
+    appCustomVersion(){ defaults read "/Applications/LibreOffice.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-3 }
     expectedTeamID="7P5S3ZLCN7"
     blockingProcesses=( soffice )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The `CFBundleShortVersionString` (and `CFBundleVersion`) is 25.8.2.2 while the version mentioned online is 25.8.2.
`/Applications/LibreOffice.app/Contents/MacOS/soffice --version` shows `25.8.2.2`
To prevent Installomator from downloading LibreOffice every time the label is run, I limited `CFBundleShortVersionString` to the first 3 digits for a `appCustomVersion`. This was also done in the `audacity` label in #1075

**Installomator log**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2607 

````
./assemble.sh libreoffice
2025-10-29 19:59:44 : INFO  : libreoffice : Total items in argumentsArray: 0
2025-10-29 19:59:44 : INFO  : libreoffice : argumentsArray:
2025-10-29 19:59:44 : REQ   : libreoffice : ################## Start Installomator v. 10.9beta, date 2025-10-29
2025-10-29 19:59:44 : INFO  : libreoffice : ################## Version: 10.9beta
2025-10-29 19:59:44 : INFO  : libreoffice : ################## Date: 2025-10-29
2025-10-29 19:59:44 : INFO  : libreoffice : ################## libreoffice
2025-10-29 19:59:44 : DEBUG : libreoffice : DEBUG mode 1 enabled.
2025-10-29 19:59:44 : INFO  : libreoffice : Reading arguments again:
2025-10-29 19:59:44 : DEBUG : libreoffice : name=LibreOffice
2025-10-29 19:59:44 : DEBUG : libreoffice : appName=
2025-10-29 19:59:44 : DEBUG : libreoffice : type=dmg
2025-10-29 19:59:44 : DEBUG : libreoffice : archiveName=
2025-10-29 19:59:44 : DEBUG : libreoffice : downloadURL=https://download.documentfoundation.org/libreoffice/stable/25.8.2/mac/aarch64/LibreOffice_25.8.2_MacOS_aarch64.dmg
2025-10-29 19:59:44 : DEBUG : libreoffice : curlOptions=
2025-10-29 19:59:44 : DEBUG : libreoffice : appNewVersion=25.8.2
2025-10-29 19:59:44 : DEBUG : libreoffice : appCustomVersion function: Defined.
2025-10-29 19:59:44 : DEBUG : libreoffice : versionKey=CFBundleShortVersionString
2025-10-29 19:59:44 : DEBUG : libreoffice : packageID=
2025-10-29 19:59:44 : DEBUG : libreoffice : pkgName=
2025-10-29 19:59:44 : DEBUG : libreoffice : choiceChangesXML=
2025-10-29 19:59:44 : DEBUG : libreoffice : expectedTeamID=7P5S3ZLCN7
2025-10-29 19:59:44 : DEBUG : libreoffice : blockingProcesses=soffice
2025-10-29 19:59:44 : DEBUG : libreoffice : installerTool=
2025-10-29 19:59:44 : DEBUG : libreoffice : CLIInstaller=
2025-10-29 19:59:44 : DEBUG : libreoffice : CLIArguments=
2025-10-29 19:59:44 : DEBUG : libreoffice : updateTool=
2025-10-29 19:59:44 : DEBUG : libreoffice : updateToolArguments=
2025-10-29 19:59:44 : DEBUG : libreoffice : updateToolRunAsCurrentUser=
2025-10-29 19:59:44 : INFO  : libreoffice : BLOCKING_PROCESS_ACTION=tell_user
2025-10-29 19:59:44 : INFO  : libreoffice : NOTIFY=success
2025-10-29 19:59:44 : INFO  : libreoffice : LOGGING=DEBUG
2025-10-29 19:59:44 : INFO  : libreoffice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-29 19:59:44 : INFO  : libreoffice : Label type: dmg
2025-10-29 19:59:44 : INFO  : libreoffice : archiveName: LibreOffice.dmg
2025-10-29 19:59:45 : DEBUG : libreoffice : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2025-10-29 19:59:45.013 defaults[83800:1174340]
The domain/default pair of (/Applications/LibreOffice.app/Contents/Info.plist, CFBundleVersion) does not exist
2025-10-29 19:59:45 : INFO  : libreoffice : Custom App Version detection is used, found
2025-10-29 19:59:45 : INFO  : libreoffice : appversion:
2025-10-29 19:59:45 : INFO  : libreoffice : Latest version of LibreOffice is 25.8.2
2025-10-29 19:59:45 : REQ   : libreoffice : Downloading https://download.documentfoundation.org/libreoffice/stable/25.8.2/mac/aarch64/LibreOffice_25.8.2_MacOS_aarch64.dmg to LibreOffice.dmg
2025-10-29 19:59:45 : DEBUG : libreoffice : No Dialog connection, just download
2025-10-29 20:00:21 : INFO  : libreoffice : Downloaded LibreOffice.dmg – Type is  lzfse encoded, lzvn compressed – SHA is f2b238c00b12cc0ef01a60cbea417e4f07d53487 – Size is 295104 kB
2025-10-29 20:00:21 : DEBUG : libreoffice : DEBUG mode 1, not checking for blocking processes
2025-10-29 20:00:21 : REQ   : libreoffice : Installing LibreOffice
2025-10-29 20:00:21 : INFO  : libreoffice : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/LibreOffice.dmg
2025-10-29 20:00:24 : DEBUG : libreoffice : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $F7A82429
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $FB678650
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $94ED9F32
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $40EE3D97
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $94ED9F32
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $B5CC88D8
verified CRC32 $E8A7FE02
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/LibreOffice

2025-10-29 20:00:24 : INFO  : libreoffice : Mounted: /Volumes/LibreOffice
2025-10-29 20:00:24 : INFO  : libreoffice : Verifying: /Volumes/LibreOffice/LibreOffice.app
2025-10-29 20:00:24 : DEBUG : libreoffice : App size: 813M	/Volumes/LibreOffice/LibreOffice.app
2025-10-29 20:00:30 : DEBUG : libreoffice : Debugging enabled, App Verification output was:
/Volumes/LibreOffice/LibreOffice.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Document Foundation (7P5S3ZLCN7)

2025-10-29 20:00:30 : INFO  : libreoffice : Team ID matching: 7P5S3ZLCN7 (expected: 7P5S3ZLCN7 )
2025-10-29 20:00:30 : INFO  : libreoffice : Installing LibreOffice version 25.8.2.2 on versionKey CFBundleShortVersionString.
2025-10-29 20:00:30 : INFO  : libreoffice : App has LSMinimumSystemVersion: 11.0.0
2025-10-29 20:00:30 : DEBUG : libreoffice : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-10-29 20:00:30 : INFO  : libreoffice : Finishing...
2025-10-29 20:00:33.653 defaults[83931:1175223]
The domain/default pair of (/Applications/LibreOffice.app/Contents/Info.plist, CFBundleVersion) does not exist
2025-10-29 20:00:33 : INFO  : libreoffice : Custom App Version detection is used, found
2025-10-29 20:00:33 : REQ   : libreoffice : Installed LibreOffice, version 25.8.2.2
2025-10-29 20:00:33 : INFO  : libreoffice : notifying
2025-10-29 20:00:33 : DEBUG : libreoffice : Unmounting /Volumes/LibreOffice
2025-10-29 20:00:33 : DEBUG : libreoffice : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-10-29 20:00:33 : DEBUG : libreoffice : DEBUG mode 1, not reopening anything
2025-10-29 20:00:33 : REQ   : libreoffice : All done!
2025-10-29 20:00:33 : REQ   : libreoffice : ################## End Installomator, exit code 0
````
