### PR TITLE
fix garminexpress appNewVersion

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -3,7 +3,6 @@ garminexpress)
     blockingProcesses=( "Garmin Express" "Garmin Express Service" )
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
-    garminfaqURL=$(curl -sf https://support.garmin.com/capi/content/en-US/\?productID\=168768\&tab\=software\&topicTag\=region_softwareproduct\&productTagName\=topic_express0\&ct\=content\&mr\=5\&locale\=en-US\&si\=0\&tags\=topic_express0%2Cregion_softwareproduct%2C%2C | tr "{" "\n" | grep "Garmin Express" | tr "," "\n" | grep "contentURL" | awk -F "\"" '{print$4}')
-    appNewVersion="$(curl -sfL $garminfaqURL | tr '><' "\n" | grep "Garmin Express for Mac" | head -1 | awk 'sub(/.*Mac: */,""){f=1} f{if ( sub(/ *as of.*/,"") ) f=0; print}').0"
+    appNewVersion="$(curl -fsL https://support.garmin.com/en-US/\?faq\=4QVp7mKSIA1LDk5fc1OHX8 | grep latest | grep -o "{.*}" | jq -r '.faq.content' | xmllint --html - 2>/dev/null | grep -o "for Mac: .* as" | grep -o "[0-9].*[0-9]").0"
     expectedTeamID="72ES32VZUA"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** 
New url for app faq

**Installomator log** 
Only checked against already installed app (since only change is for appNewVersion):

```➜  Installomator git:(fix_garminexpress_appNewVersion) ✗ sudo ./assemble.sh garminexpress DEBUG=0
2025-10-30 10:51:50 : INFO  : garminexpress : setting variable from argument DEBUG=0
2025-10-30 10:51:50 : INFO  : garminexpress : Total items in argumentsArray: 1
2025-10-30 10:51:50 : INFO  : garminexpress : argumentsArray: DEBUG=0
2025-10-30 10:51:50 : REQ   : garminexpress : ################## Start Installomator v. 10.9beta, date 2025-10-30
2025-10-30 10:51:50 : INFO  : garminexpress : ################## Version: 10.9beta
2025-10-30 10:51:50 : INFO  : garminexpress : ################## Date: 2025-10-30
2025-10-30 10:51:50 : INFO  : garminexpress : ################## garminexpress
2025-10-30 10:51:50 : INFO  : garminexpress : Reading arguments again: DEBUG=0
2025-10-30 10:51:50 : INFO  : garminexpress : BLOCKING_PROCESS_ACTION=tell_user
2025-10-30 10:51:50 : INFO  : garminexpress : NOTIFY=success
2025-10-30 10:51:50 : INFO  : garminexpress : LOGGING=INFO
2025-10-30 10:51:50 : INFO  : garminexpress : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-10-30 10:51:50 : INFO  : garminexpress : Label type: pkgInDmg
2025-10-30 10:51:50 : INFO  : garminexpress : archiveName: Garmin Express.dmg
2025-10-30 10:51:50 : INFO  : garminexpress : App(s) found: /Applications/Garmin Express.app
2025-10-30 10:51:50 : INFO  : garminexpress : found app at /Applications/Garmin Express.app, version 7.27.0.0, on versionKey CFBundleShortVersionString
2025-10-30 10:51:50 : INFO  : garminexpress : appversion: 7.27.0.0
2025-10-30 10:51:50 : INFO  : garminexpress : Latest version of Garmin Express is 7.27.0.0
2025-10-30 10:51:50 : INFO  : garminexpress : There is no newer version available.
2025-10-30 10:51:50 : INFO  : garminexpress : Installomator did not close any apps, so no need to reopen any apps.
2025-10-30 10:51:50 : REQ   : garminexpress : No newer version.
2025-10-30 10:51:50 : REQ   : garminexpress : ################## End Installomator, exit code 0 
```