### PR TITLE
New label ricohtheta

### DIFF
--- a/fragments/labels/ricohtheta.sh
+++ b/fragments/labels/ricohtheta.sh
@@ -3,8 +3,6 @@ ricohtheta)
     type="dmg"
     versionKey="CFBundleShortVersionString"
     downloadURL="https://theta360.com/intl/support/download/pcapp/macosx"
-    # downloadURL="https://static.ricoh360.com/theta-resources/app/viewer/RICOH%20THETA.dmg"
     appNewVersion=$(curl -fsL "https://support.ricoh360.com/system-information?news-tags=support" | xmllint --html --xpath "string((//a[contains(normalize-space(), 'RICOH THETA PC App Version')])[1])" - 2>/dev/null | grep -Eom1 '[vV]?[0-9]+(\.[0-9]+)+' | sed 's/^[vV]//')
-    # appNewVersion=$(curl -fsL "https://support.ricoh360.com/system-information?news-tags=select-all" | xmllint --html --xpath "string((//a[contains(normalize-space(), 'RICOH THETA PC App Version Update Information')])[1])" - 2>/dev/null | grep -Eom1 '[vV]?[0-9]+(\.[0-9]+)+' | sed 's/^[vV]//')
     expectedTeamID="5KACUT3YX8"
     ;;


### PR DESCRIPTION
RICOH THETA PC App – Desktop utility for managing RICOH THETA 360° cameras: import/view and convert (stitch) photos and videos, plus camera settings.

2025-11-01 10:02:41 : INFO  : ricohtheta : setting variable from argument DEBUG=0
2025-11-01 10:02:41 : INFO  : ricohtheta : Total items in argumentsArray: 1
2025-11-01 10:02:41 : INFO  : ricohtheta : argumentsArray: DEBUG=0
2025-11-01 10:02:41 : REQ   : ricohtheta : ################## Start Installomator v. 10.8, date 2025-11-01
2025-11-01 10:02:41 : INFO  : ricohtheta : ################## Version: 10.8
2025-11-01 10:02:41 : INFO  : ricohtheta : ################## Date: 2025-11-01
2025-11-01 10:02:41 : INFO  : ricohtheta : ################## ricohtheta
2025-11-01 10:02:41 : INFO  : ricohtheta : Reading arguments again: DEBUG=0
2025-11-01 10:02:41 : INFO  : ricohtheta : BLOCKING_PROCESS_ACTION=tell_user
2025-11-01 10:02:41 : INFO  : ricohtheta : NOTIFY=success
2025-11-01 10:02:41 : INFO  : ricohtheta : LOGGING=INFO
2025-11-01 10:02:41 : INFO  : ricohtheta : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-01 10:02:41 : INFO  : ricohtheta : Label type: dmg
2025-11-01 10:02:41 : INFO  : ricohtheta : archiveName: RICOH THETA.dmg
2025-11-01 10:02:41 : INFO  : ricohtheta : no blocking processes defined, using RICOH THETA as default
2025-11-01 10:02:41 : INFO  : ricohtheta : name: RICOH THETA, appName: RICOH THETA.app
2025-11-01 10:02:41 : WARN  : ricohtheta : No previous app found
2025-11-01 10:02:41 : WARN  : ricohtheta : could not find RICOH THETA.app
2025-11-01 10:02:41 : INFO  : ricohtheta : appversion:
2025-11-01 10:02:41 : INFO  : ricohtheta : Latest version of RICOH THETA is 3.30.0
2025-11-01 10:02:41 : REQ   : ricohtheta : Downloading https://theta360.com/intl/support/download/pcapp/macosx to RICOH THETA.dmg
2025-11-01 10:02:53 : INFO  : ricohtheta : Downloaded RICOH THETA.dmg – Type is  zlib compressed data – SHA is 04158f072ee5fcfb6eb091f4b09f8e55fe6d3d7d – Size is 344340 kB
2025-11-01 10:02:53 : REQ   : ricohtheta : no more blocking processes, continue with update
2025-11-01 10:02:53 : REQ   : ricohtheta : Installing RICOH THETA
2025-11-01 10:02:53 : INFO  : ricohtheta : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.GULm5vm6HI/RICOH THETA.dmg
2025-11-01 10:02:56 : INFO  : ricohtheta : Mounted: /Volumes/RICOH THETA
2025-11-01 10:02:56 : INFO  : ricohtheta : Verifying: /Volumes/RICOH THETA/RICOH THETA.app
2025-11-01 10:03:01 : INFO  : ricohtheta : Team ID matching: 5KACUT3YX8 (expected: 5KACUT3YX8 )
2025-11-01 10:03:01 : INFO  : ricohtheta : Installing RICOH THETA version 3.30.0 on versionKey CFBundleShortVersionString.
2025-11-01 10:03:01 : INFO  : ricohtheta : App has LSMinimumSystemVersion: 10.11.0
2025-11-01 10:03:01 : INFO  : ricohtheta : Copy /Volumes/RICOH THETA/RICOH THETA.app to /Applications
2025-11-01 10:03:02 : WARN  : ricohtheta : Changing owner to savvas
2025-11-01 10:03:02 : INFO  : ricohtheta : Finishing...
2025-11-01 10:03:05 : INFO  : ricohtheta : App(s) found: /Applications/RICOH THETA.app
2025-11-01 10:03:05 : INFO  : ricohtheta : found app at /Applications/RICOH THETA.app, version 3.30.0, on versionKey CFBundleShortVersionString
2025-11-01 10:03:05 : REQ   : ricohtheta : Installed RICOH THETA, version 3.30.0
2025-11-01 10:03:06 : INFO  : ricohtheta : notifying
2025-11-01 10:03:17 : INFO  : ricohtheta : Installomator did not close any apps, so no need to reopen any apps.
2025-11-01 10:03:17 : REQ   : ricohtheta : All done!
2025-11-01 10:03:17 : REQ   : ricohtheta : ################## End Installomator, exit code 0

savvas@mac utils % sudo ./assemble.sh -l /Mosyle/Resources/InstallomatorLabels ricohtheta DEBUG=0 2025-11-01 10:03:25 : INFO  : ricohtheta : setting variable from argument DEBUG=0 2025-11-01 10:03:25 : INFO  : ricohtheta : Total items in argumentsArray: 1 2025-11-01 10:03:25 : INFO  : ricohtheta : argumentsArray: DEBUG=0
2025-11-01 10:03:25 : REQ   : ricohtheta : ################## Start Installomator v. 10.8, date 2025-11-01
2025-11-01 10:03:25 : INFO  : ricohtheta : ################## Version: 10.8
2025-11-01 10:03:25 : INFO  : ricohtheta : ################## Date: 2025-11-01
2025-11-01 10:03:25 : INFO  : ricohtheta : ################## ricohtheta
2025-11-01 10:03:25 : INFO  : ricohtheta : Reading arguments again: DEBUG=0
2025-11-01 10:03:26 : INFO  : ricohtheta : BLOCKING_PROCESS_ACTION=tell_user
2025-11-01 10:03:26 : INFO  : ricohtheta : NOTIFY=success
2025-11-01 10:03:26 : INFO  : ricohtheta : LOGGING=INFO
2025-11-01 10:03:26 : INFO  : ricohtheta : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-01 10:03:26 : INFO  : ricohtheta : Label type: dmg
2025-11-01 10:03:26 : INFO  : ricohtheta : archiveName: RICOH THETA.dmg
2025-11-01 10:03:26 : INFO  : ricohtheta : no blocking processes defined, using RICOH THETA as default
2025-11-01 10:03:26 : INFO  : ricohtheta : App(s) found: /Applications/RICOH THETA.app
2025-11-01 10:03:26 : INFO  : ricohtheta : found app at /Applications/RICOH THETA.app, version 3.30.0, on versionKey CFBundleShortVersionString
2025-11-01 10:03:26 : INFO  : ricohtheta : appversion: 3.30.0
2025-11-01 10:03:26 : INFO  : ricohtheta : Latest version of RICOH THETA is 3.30.0
2025-11-01 10:03:26 : INFO  : ricohtheta : There is no newer version available.
2025-11-01 10:03:26 : INFO  : ricohtheta : Installomator did not close any apps, so no need to reopen any apps.
2025-11-01 10:03:26 : REQ   : ricohtheta : No newer version.
2025-11-01 10:03:26 : REQ   : ricohtheta : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
