### PR TITLE
Update pitch

### DIFF
--- a/fragments/labels/pitch.sh
+++ b/fragments/labels/pitch.sh
@@ -2,5 +2,6 @@ pitch)
     name="Pitch"
     type="dmg"
     downloadURL="https://desktop.pitch.com/mac/Pitch.dmg"
+    curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
     expectedTeamID="KUCN8NUU6Z"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Added the default `curlOptions`

**Installomator log**
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2621 


````
./assemble.sh pitch
2025-11-01 23:54:33 : INFO  : pitch : Total items in argumentsArray: 0
2025-11-01 23:54:33 : INFO  : pitch : argumentsArray: 
2025-11-01 23:54:33 : REQ   : pitch : ################## Start Installomator v. 10.9beta, date 2025-11-01
2025-11-01 23:54:33 : INFO  : pitch : ################## Version: 10.9beta
2025-11-01 23:54:33 : INFO  : pitch : ################## Date: 2025-11-01
2025-11-01 23:54:33 : INFO  : pitch : ################## pitch
2025-11-01 23:54:33 : DEBUG : pitch : DEBUG mode 1 enabled.
2025-11-01 23:54:34 : INFO  : pitch : Reading arguments again: 
2025-11-01 23:54:34 : DEBUG : pitch : name=Pitch
2025-11-01 23:54:34 : DEBUG : pitch : appName=
2025-11-01 23:54:34 : DEBUG : pitch : type=dmg
2025-11-01 23:54:34 : DEBUG : pitch : archiveName=
2025-11-01 23:54:34 : DEBUG : pitch : downloadURL=https://desktop.pitch.com/mac/Pitch.dmg
2025-11-01 23:54:34 : DEBUG : pitch : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15
2025-11-01 23:54:34 : DEBUG : pitch : appNewVersion=
2025-11-01 23:54:34 : DEBUG : pitch : appCustomVersion function: Not defined
2025-11-01 23:54:34 : DEBUG : pitch : versionKey=CFBundleShortVersionString
2025-11-01 23:54:34 : DEBUG : pitch : packageID=
2025-11-01 23:54:34 : DEBUG : pitch : pkgName=
2025-11-01 23:54:34 : DEBUG : pitch : choiceChangesXML=
2025-11-01 23:54:34 : DEBUG : pitch : expectedTeamID=KUCN8NUU6Z
2025-11-01 23:54:34 : DEBUG : pitch : blockingProcesses=
2025-11-01 23:54:34 : DEBUG : pitch : installerTool=
2025-11-01 23:54:34 : DEBUG : pitch : CLIInstaller=
2025-11-01 23:54:34 : DEBUG : pitch : CLIArguments=
2025-11-01 23:54:34 : DEBUG : pitch : updateTool=
2025-11-01 23:54:34 : DEBUG : pitch : updateToolArguments=
2025-11-01 23:54:34 : DEBUG : pitch : updateToolRunAsCurrentUser=
2025-11-01 23:54:34 : INFO  : pitch : BLOCKING_PROCESS_ACTION=tell_user
2025-11-01 23:54:34 : INFO  : pitch : NOTIFY=success
2025-11-01 23:54:34 : INFO  : pitch : LOGGING=DEBUG
2025-11-01 23:54:34 : INFO  : pitch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-01 23:54:34 : INFO  : pitch : Label type: dmg
2025-11-01 23:54:34 : INFO  : pitch : archiveName: Pitch.dmg
2025-11-01 23:54:34 : INFO  : pitch : no blocking processes defined, using Pitch as default
2025-11-01 23:54:34 : DEBUG : pitch : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2025-11-01 23:54:34 : INFO  : pitch : name: Pitch, appName: Pitch.app
2025-11-01 23:54:34 : WARN  : pitch : No previous app found
2025-11-01 23:54:34 : WARN  : pitch : could not find Pitch.app
2025-11-01 23:54:34 : INFO  : pitch : appversion: 
2025-11-01 23:54:34 : INFO  : pitch : Latest version not specified.
2025-11-01 23:54:34 : REQ   : pitch : Downloading https://desktop.pitch.com/mac/Pitch.dmg to Pitch.dmg
2025-11-01 23:54:34 : DEBUG : pitch : No Dialog connection, just download
2025-11-01 23:55:02 : INFO  : pitch : Downloaded Pitch.dmg – Type is  zlib compressed data – SHA is de6b433b496e9aa9037c14f7fe98a639e30ebfe3 – Size is 295884 kB
2025-11-01 23:55:02 : DEBUG : pitch : DEBUG mode 1, not checking for blocking processes
2025-11-01 23:55:02 : REQ   : pitch : Installing Pitch
2025-11-01 23:55:02 : INFO  : pitch : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/Pitch.dmg
2025-11-01 23:55:05 : DEBUG : pitch : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $C9730A3E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $63FDB1F1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $028094CE
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $4B403BE1
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $028094CE
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $7A0FB04F
verified CRC32 $8C96AECC
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Pitch

2025-11-01 23:55:05 : INFO  : pitch : Mounted: /Volumes/Pitch
2025-11-01 23:55:05 : INFO  : pitch : Verifying: /Volumes/Pitch/Pitch.app
2025-11-01 23:55:05 : DEBUG : pitch : App size: 592M	/Volumes/Pitch/Pitch.app
2025-11-01 23:55:08 : DEBUG : pitch : Debugging enabled, App Verification output was:
/Volumes/Pitch/Pitch.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Pitch Software GmbH (KUCN8NUU6Z)

2025-11-01 23:55:08 : INFO  : pitch : Team ID matching: KUCN8NUU6Z (expected: KUCN8NUU6Z )
2025-11-01 23:55:08 : INFO  : pitch : Installing Pitch version 2.98.0-stable.4 on versionKey CFBundleShortVersionString.
2025-11-01 23:55:08 : INFO  : pitch : App has LSMinimumSystemVersion: 12.0
2025-11-01 23:55:08 : DEBUG : pitch : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-11-01 23:55:08 : INFO  : pitch : Finishing...
2025-11-01 23:55:11 : INFO  : pitch : name: Pitch, appName: Pitch.app
2025-11-01 23:55:11 : WARN  : pitch : No previous app found
2025-11-01 23:55:11 : WARN  : pitch : could not find Pitch.app
2025-11-01 23:55:11 : REQ   : pitch : Installed Pitch, version 2.98.0-stable.4
2025-11-01 23:55:11 : INFO  : pitch : notifying
2025-11-01 23:55:11 : DEBUG : pitch : Unmounting /Volumes/Pitch
2025-11-01 23:55:11 : DEBUG : pitch : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-11-01 23:55:11 : DEBUG : pitch : DEBUG mode 1, not reopening anything
2025-11-01 23:55:11 : REQ   : pitch : All done!
2025-11-01 23:55:11 : REQ   : pitch : ################## End Installomator, exit code 0
````