### PR TITLE
Create affinityapp.sh

### DIFF
--- a/fragments/labels/affinityapp.sh
+++ b/fragments/labels/affinityapp.sh
@@ -3,6 +3,5 @@ affinityapp)
     type="dmg"
     appName="Affinity.app"
     downloadURL="https://downloads.affinity.studio/Affinity.dmg"
-    appNewVersion=""
     expectedTeamID="5HD2ARTBFS"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Could not determine the value for appnewversion.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-11-05 15:26:18 : INFO  : affinityapp : setting variable from argument LOGGING=INFO
2025-11-05 15:26:18 : INFO  : affinityapp : Total items in argumentsArray: 1
2025-11-05 15:26:18 : INFO  : affinityapp : argumentsArray: LOGGING=INFO
2025-11-05 15:26:18 : REQ   : affinityapp : ################## Start Installomator v. 10.9beta, date 2025-11-05
2025-11-05 15:26:18 : INFO  : affinityapp : ################## Version: 10.9beta
2025-11-05 15:26:18 : INFO  : affinityapp : ################## Date: 2025-11-05
2025-11-05 15:26:18 : INFO  : affinityapp : ################## affinityapp
2025-11-05 15:26:18 : DEBUG : affinityapp : DEBUG mode 1 enabled.
2025-11-05 15:26:18 : INFO  : affinityapp : Reading arguments again: LOGGING=INFO
2025-11-05 15:26:18 : DEBUG : affinityapp : argument: LOGGING=INFO
2025-11-05 15:26:18 : INFO  : affinityapp : BLOCKING_PROCESS_ACTION=tell_user
2025-11-05 15:26:18 : INFO  : affinityapp : NOTIFY=success
2025-11-05 15:26:18 : INFO  : affinityapp : LOGGING=INFO
2025-11-05 15:26:18 : INFO  : affinityapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-05 15:26:18 : INFO  : affinityapp : Label type: dmg
2025-11-05 15:26:18 : INFO  : affinityapp : archiveName: Affinity.dmg
2025-11-05 15:26:18 : INFO  : affinityapp : no blocking processes defined, using Affinity as default
2025-11-05 15:26:18 : INFO  : affinityapp : App(s) found: /Applications/Affinity.app
2025-11-05 15:26:19 : INFO  : affinityapp : found app at /Applications/Affinity.app, version 3.0.0, on versionKey CFBundleShortVersionString
2025-11-05 15:26:19 : INFO  : affinityapp : appversion: 3.0.0
2025-11-05 15:26:19 : INFO  : affinityapp : Latest version not specified.
2025-11-05 15:26:19 : INFO  : affinityapp : Affinity.dmg exists and DEBUG mode 1 enabled, skipping download
2025-11-05 15:26:19 : REQ   : affinityapp : Installing Affinity
2025-11-05 15:26:19 : INFO  : affinityapp : Mounting ./Affinity.dmg
2025-11-05 15:26:19 : INFO  : affinityapp : Mounted: /Volumes/Affinity
2025-11-05 15:26:19 : INFO  : affinityapp : Verifying: /Volumes/Affinity/Affinity.app
2025-11-05 15:26:36 : INFO  : affinityapp : Team ID matching: 5HD2ARTBFS (expected: 5HD2ARTBFS )
2025-11-05 15:26:36 : INFO  : affinityapp : Downloaded version of Affinity is 3.0.0 on versionKey CFBundleShortVersionString, same as installed.
2025-11-05 15:26:36 : REQ   : affinityapp : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
