### PR TITLE
Add a label for AppsAnywhere

### DIFF
--- a/fragments/labels/appsanywhere.sh
+++ b/fragments/labels/appsanywhere.sh
@@ -8,8 +8,8 @@ appsanywhere)
       | /usr/bin/head -n 1
     )"
     if [[ -z "$latestVersion" ]]; then
-        echo "ERROR: Could not determine latest AppsAnywhere macOS client version from $aaClientReleasePage"
-        exit 9
+        printlog "ERROR: Could not determine latest AppsAnywhere macOS client version from $aaClientReleasePage"
+        cleanupAndExit 99
     fi
     downloadURL="https://files.appsanywhere.com/clients/appsanywhere/mac/${latestVersion}/apps-anywhere-setup-InstitutionId-${latestVersion}.pkg"
     pkgName="apps-anywhere-setup-InstitutionId-${latestVersion}.pkg"
@@ -17,8 +17,6 @@ appsanywhere)
     appCustomVersion(){
         /usr/bin/defaults read "/Applications/AppsAnywhere/AppsAnywhere.app/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "0"
     }
-    appCustomVersionComparison="ver"
     appNewVersion="$latestVersion"
     updateTool="/Applications/AppsAnywhere/AppsAnywhere Updater.app/Contents/MacOS/AppsAnywhere Updater"
-    blockingProcesses=( "AppsAnywhere" "AppsAnywhere Updater" "Cloudpaging Player" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes.

**Additional context** Add any other context about the label or fix here.
This adds an AppsAnywhere generic label that can be used in conjunction with a config profile to provide a working AppsAnywhere application to the client computer.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
`2025-11-05 10:26:50 : INFO  : appsanywhere : Total items in argumentsArray: 0
2025-11-05 10:26:50 : INFO  : appsanywhere : argumentsArray: 
2025-11-05 10:26:50 : REQ   : appsanywhere : ################## Start Installomator v. 10.9beta, date 2025-11-05
2025-11-05 10:26:50 : INFO  : appsanywhere : ################## Version: 10.9beta
2025-11-05 10:26:50 : INFO  : appsanywhere : ################## Date: 2025-11-05
2025-11-05 10:26:50 : INFO  : appsanywhere : ################## appsanywhere
2025-11-05 10:26:50 : DEBUG : appsanywhere : DEBUG mode 1 enabled.
2025-11-05 10:26:51 : INFO  : appsanywhere : Reading arguments again: 
2025-11-05 10:26:51 : DEBUG : appsanywhere : name=AppsAnywhere Client (macOS)
2025-11-05 10:26:51 : DEBUG : appsanywhere : appName=
2025-11-05 10:26:51 : DEBUG : appsanywhere : type=pkg
2025-11-05 10:26:51 : DEBUG : appsanywhere : archiveName=
2025-11-05 10:26:51 : DEBUG : appsanywhere : downloadURL=https://files.appsanywhere.com/clients/appsanywhere/mac/2.2.1/apps-anywhere-setup-InstitutionId-2.2.1.pkg
2025-11-05 10:26:51 : DEBUG : appsanywhere : curlOptions=
2025-11-05 10:26:51 : DEBUG : appsanywhere : appNewVersion=2.2.1
2025-11-05 10:26:51 : DEBUG : appsanywhere : appCustomVersion function: Defined. 
2025-11-05 10:26:51 : DEBUG : appsanywhere : versionKey=CFBundleShortVersionString
2025-11-05 10:26:51 : DEBUG : appsanywhere : packageID=
2025-11-05 10:26:51 : DEBUG : appsanywhere : pkgName=apps-anywhere-setup-InstitutionId-2.2.1.pkg
2025-11-05 10:26:51 : DEBUG : appsanywhere : choiceChangesXML=
2025-11-05 10:26:51 : DEBUG : appsanywhere : expectedTeamID=9ZNX23CMVD
2025-11-05 10:26:51 : DEBUG : appsanywhere : blockingProcesses=AppsAnywhere AppsAnywhere Updater Cloudpaging Player
2025-11-05 10:26:51 : DEBUG : appsanywhere : installerTool=
2025-11-05 10:26:51 : DEBUG : appsanywhere : CLIInstaller=
2025-11-05 10:26:51 : DEBUG : appsanywhere : CLIArguments=
2025-11-05 10:26:51 : DEBUG : appsanywhere : updateTool=/Applications/AppsAnywhere/AppsAnywhere Updater.app/Contents/MacOS/AppsAnywhere Updater
2025-11-05 10:26:51 : DEBUG : appsanywhere : updateToolArguments=
2025-11-05 10:26:51 : DEBUG : appsanywhere : updateToolRunAsCurrentUser=
2025-11-05 10:26:51 : INFO  : appsanywhere : BLOCKING_PROCESS_ACTION=tell_user
2025-11-05 10:26:51 : INFO  : appsanywhere : NOTIFY=success
2025-11-05 10:26:51 : INFO  : appsanywhere : LOGGING=DEBUG
2025-11-05 10:26:51 : INFO  : appsanywhere : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-05 10:26:51 : INFO  : appsanywhere : Label type: pkg
2025-11-05 10:26:51 : INFO  : appsanywhere : archiveName: AppsAnywhere Client (macOS).pkg
2025-11-05 10:26:51 : DEBUG : appsanywhere : Changing directory to /Users/{my username}/Code/Installomator/build
2025-11-05 10:26:51 : INFO  : appsanywhere : Custom App Version detection is used, found 2.2.1
2025-11-05 10:26:51 : INFO  : appsanywhere : appversion: 2.2.1
2025-11-05 10:26:51 : INFO  : appsanywhere : Latest version of AppsAnywhere Client (macOS) is 2.2.1
2025-11-05 10:26:51 : WARN  : appsanywhere : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-11-05 10:26:51 : INFO  : appsanywhere : App needs to be updated and uses /Applications/AppsAnywhere/AppsAnywhere Updater.app/Contents/MacOS/AppsAnywhere Updater. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2025-11-05 10:26:51 : WARN  : appsanywhere : DEBUG mode 1 enabled, not running update tool
2025-11-05 10:26:51 : INFO  : appsanywhere : AppsAnywhere Client (macOS).pkg exists and DEBUG mode 1 enabled, skipping download
2025-11-05 10:26:51 : DEBUG : appsanywhere : DEBUG mode 1, not checking for blocking processes
2025-11-05 10:26:52 : REQ   : appsanywhere : Installing AppsAnywhere Client (macOS)
2025-11-05 10:26:52 : INFO  : appsanywhere : Verifying: AppsAnywhere Client (macOS).pkg
2025-11-05 10:26:52 : DEBUG : appsanywhere : File list: -rw-r--r--  1 {my username}  staff   3.3M Nov  5 10:26 AppsAnywhere Client (macOS).pkg
2025-11-05 10:26:52 : DEBUG : appsanywhere : File type: AppsAnywhere Client (macOS).pkg: xar archive compressed TOC: 4496, SHA-1 checksum
2025-11-05 10:26:52 : DEBUG : appsanywhere : spctlOut is AppsAnywhere Client (macOS).pkg: accepted
2025-11-05 10:26:52 : DEBUG : appsanywhere : source=Notarized Developer ID
2025-11-05 10:26:52 : DEBUG : appsanywhere : origin=Developer ID Installer: AppsAnywhere Limited (9ZNX23CMVD)
2025-11-05 10:26:52 : INFO  : appsanywhere : Team ID: 9ZNX23CMVD (expected: 9ZNX23CMVD )
2025-11-05 10:26:52 : DEBUG : appsanywhere : DEBUG enabled, skipping installation
2025-11-05 10:26:52 : INFO  : appsanywhere : Finishing...
2025-11-05 10:26:55 : INFO  : appsanywhere : Custom App Version detection is used, found 2.2.1
2025-11-05 10:26:55 : REQ   : appsanywhere : Installed AppsAnywhere Client (macOS), version 2.2.1
2025-11-05 10:26:55 : INFO  : appsanywhere : notifying
2025-11-05 10:26:55 : DEBUG : appsanywhere : DEBUG mode 1, not reopening anything
2025-11-05 10:26:55 : REQ   : appsanywhere : All done!
2025-11-05 10:26:55 : REQ   : appsanywhere : ################## End Installomator, exit code 0`
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
