### PR TITLE
Add protondrive

### DIFF
--- a/fragments/labels/protondrive.sh
+++ b/fragments/labels/protondrive.sh
@@ -1,0 +1,7 @@
+protondrive)
+    name="Proton Drive"
+    type="dmg"
+    appNewVersion=$(curl -fs "https://proton.me/download/drive/macos/appcast.xml" | sed -n 's/.*<sparkle:shortVersionString>\(.*\)<\/sparkle:shortVersionString>.*/\1/p')
+    downloadURL="https://proton.me/download/drive/macos/$appNewVersion/ProtonDrive-$appNewVersion.dmg"
+    expectedTeamID="2SB5Z68H26"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
New label for [Proton Drive](https://proton.me/drive)

**Installomator log**
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh protondrive
2025-11-05 22:16:07 : INFO  : protondrive : Total items in argumentsArray: 0
2025-11-05 22:16:07 : INFO  : protondrive : argumentsArray:
2025-11-05 22:16:07 : REQ   : protondrive : ################## Start Installomator v. 10.9beta, date 2025-11-05
2025-11-05 22:16:07 : INFO  : protondrive : ################## Version: 10.9beta
2025-11-05 22:16:07 : INFO  : protondrive : ################## Date: 2025-11-05
2025-11-05 22:16:07 : INFO  : protondrive : ################## protondrive
2025-11-05 22:16:07 : DEBUG : protondrive : DEBUG mode 1 enabled.
2025-11-05 22:16:08 : INFO  : protondrive : Reading arguments again:
2025-11-05 22:16:08 : DEBUG : protondrive : name=Proton Drive
2025-11-05 22:16:08 : DEBUG : protondrive : appName=
2025-11-05 22:16:08 : DEBUG : protondrive : type=dmg
2025-11-05 22:16:08 : DEBUG : protondrive : archiveName=
2025-11-05 22:16:08 : DEBUG : protondrive : downloadURL=https://proton.me/download/drive/macos/2.10.1/ProtonDrive-2.10.1.dmg
2025-11-05 22:16:08 : DEBUG : protondrive : curlOptions=
2025-11-05 22:16:08 : DEBUG : protondrive : appNewVersion=2.10.1
2025-11-05 22:16:08 : DEBUG : protondrive : appCustomVersion function: Not defined
2025-11-05 22:16:08 : DEBUG : protondrive : versionKey=CFBundleShortVersionString
2025-11-05 22:16:08 : DEBUG : protondrive : packageID=
2025-11-05 22:16:08 : DEBUG : protondrive : pkgName=
2025-11-05 22:16:08 : DEBUG : protondrive : choiceChangesXML=
2025-11-05 22:16:08 : DEBUG : protondrive : expectedTeamID=2SB5Z68H26
2025-11-05 22:16:08 : DEBUG : protondrive : blockingProcesses=
2025-11-05 22:16:08 : DEBUG : protondrive : installerTool=
2025-11-05 22:16:08 : DEBUG : protondrive : CLIInstaller=
2025-11-05 22:16:08 : DEBUG : protondrive : CLIArguments=
2025-11-05 22:16:08 : DEBUG : protondrive : updateTool=
2025-11-05 22:16:08 : DEBUG : protondrive : updateToolArguments=
2025-11-05 22:16:08 : DEBUG : protondrive : updateToolRunAsCurrentUser=
2025-11-05 22:16:08 : INFO  : protondrive : BLOCKING_PROCESS_ACTION=tell_user
2025-11-05 22:16:08 : INFO  : protondrive : NOTIFY=success
2025-11-05 22:16:08 : INFO  : protondrive : LOGGING=DEBUG
2025-11-05 22:16:08 : INFO  : protondrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-05 22:16:08 : INFO  : protondrive : Label type: dmg
2025-11-05 22:16:08 : INFO  : protondrive : archiveName: Proton Drive.dmg
2025-11-05 22:16:08 : INFO  : protondrive : no blocking processes defined, using Proton Drive as default
2025-11-05 22:16:08 : DEBUG : protondrive : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2025-11-05 22:16:08 : INFO  : protondrive : name: Proton Drive, appName: Proton Drive.app
2025-11-05 22:16:08 : WARN  : protondrive : No previous app found
2025-11-05 22:16:08 : WARN  : protondrive : could not find Proton Drive.app
2025-11-05 22:16:08 : INFO  : protondrive : appversion:
2025-11-05 22:16:08 : INFO  : protondrive : Latest version of Proton Drive is 2.10.1
2025-11-05 22:16:08 : REQ   : protondrive : Downloading https://proton.me/download/drive/macos/2.10.1/ProtonDrive-2.10.1.dmg to Proton Drive.dmg
2025-11-05 22:16:08 : DEBUG : protondrive : No Dialog connection, just download
2025-11-05 22:16:43 : INFO  : protondrive : Downloaded Proton Drive.dmg – Type is  data – SHA is c61fc97837d1704b980a53faa5cfea5f8323476f – Size is 295060 kB
2025-11-05 22:16:43 : DEBUG : protondrive : DEBUG mode 1, not checking for blocking processes
2025-11-05 22:16:43 : REQ   : protondrive : Installing Proton Drive
2025-11-05 22:16:43 : INFO  : protondrive : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/Proton Drive.dmg
2025-11-05 22:16:46 : DEBUG : protondrive : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $0F7142C4
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $C57438AA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $3F4EAC25
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $8543A641
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified CRC32 $3F4EAC25
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified CRC32 $19713F92
verified CRC32 $43DC1BA4
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Install Proton Drive

2025-11-05 22:16:46 : INFO  : protondrive : Mounted: /Volumes/Install Proton Drive
2025-11-05 22:16:46 : INFO  : protondrive : Verifying: /Volumes/Install Proton Drive/Proton Drive.app
2025-11-05 22:16:46 : DEBUG : protondrive : App size: 286M	/Volumes/Install Proton Drive/Proton Drive.app
2025-11-05 22:16:47 : DEBUG : protondrive : Debugging enabled, App Verification output was:
/Volumes/Install Proton Drive/Proton Drive.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Proton Technologies AG (2SB5Z68H26)

2025-11-05 22:16:47 : INFO  : protondrive : Team ID matching: 2SB5Z68H26 (expected: 2SB5Z68H26 )
2025-11-05 22:16:47 : INFO  : protondrive : Installing Proton Drive version 2.10.1 on versionKey CFBundleShortVersionString.
2025-11-05 22:16:47 : INFO  : protondrive : App has LSMinimumSystemVersion: 13.0
2025-11-05 22:16:47 : DEBUG : protondrive : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-11-05 22:16:47 : INFO  : protondrive : Finishing...
2025-11-05 22:16:50 : INFO  : protondrive : name: Proton Drive, appName: Proton Drive.app
2025-11-05 22:16:50 : WARN  : protondrive : No previous app found
2025-11-05 22:16:50 : WARN  : protondrive : could not find Proton Drive.app
2025-11-05 22:16:50 : REQ   : protondrive : Installed Proton Drive, version 2.10.1
2025-11-05 22:16:50 : INFO  : protondrive : notifying
2025-11-05 22:16:51 : DEBUG : protondrive : Unmounting /Volumes/Install Proton Drive
2025-11-05 22:16:51 : DEBUG : protondrive : Debugging enabled, Unmounting output was:
"disk4" ejected.
2025-11-05 22:16:51 : DEBUG : protondrive : DEBUG mode 1, not reopening anything
2025-11-05 22:16:51 : REQ   : protondrive : All done!
2025-11-05 22:16:51 : REQ   : protondrive : ################## End Installomator, exit code 0
````