### PR TITLE
Update jasp.sh

### DIFF
--- a/fragments/labels/jasp.sh
+++ b/fragments/labels/jasp.sh
@@ -7,6 +7,7 @@ jasp)
         archiveName="JASP-[0-9.]*-macOS-x86_64.dmg"
     fi
     downloadURL=$(downloadURLFromGit jasp-stats jasp-desktop )
+    appCustomVersion(){/usr/bin/defaults read "/Applications/JASP.app/Contents/Info.plist" "CFBundleVersion" | sed 's/..$//'}
     appNewVersion=$(versionFromGit jasp-stats jasp-desktop )
     expectedTeamID="AWJJ3YVK9B"
     ;;


### PR DESCRIPTION
Added AppCustomVersion to make the version pulled more accurate.  Default pulls something like `0.95` while posted versions go one degree further (ex: `0.95.4`).  Build on machine goes a bit further than that (ex: `0.95.4.0`) and is trimmed to match what the published release number is.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Modifying label from fragments folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Used XCode

**Additional context** Add any other context about the label or fix here.
Default pulls something like `0.95` while posted versions go one degree further (ex: `0.95.4`).  Build on machine goes a bit further than that (ex: `0.95.4.0`) and is trimmed to match what the published release number is.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Clean install:
```
[Redacted] Installomator-10.8 % sudo ./assemble.sh jasp DEBUG=0
Password:
2025-11-06 13:22:56 : INFO  : jasp : setting variable from argument DEBUG=0
2025-11-06 13:22:56 : INFO  : jasp : Total items in argumentsArray: 1
2025-11-06 13:22:56 : INFO  : jasp : argumentsArray: DEBUG=0
2025-11-06 13:22:57 : REQ   : jasp : ################## Start Installomator v. 10.8, date 2025-11-06
2025-11-06 13:22:57 : INFO  : jasp : ################## Version: 10.8
2025-11-06 13:22:57 : INFO  : jasp : ################## Date: 2025-11-06
2025-11-06 13:22:57 : INFO  : jasp : ################## jasp
2025-11-06 13:22:58 : INFO  : jasp : Reading arguments again: DEBUG=0
2025-11-06 13:22:58 : INFO  : jasp : BLOCKING_PROCESS_ACTION=tell_user
2025-11-06 13:22:58 : INFO  : jasp : NOTIFY=success
2025-11-06 13:22:58 : INFO  : jasp : LOGGING=INFO
2025-11-06 13:22:58 : INFO  : jasp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-06 13:22:58 : INFO  : jasp : Label type: dmg
2025-11-06 13:22:58 : INFO  : jasp : archiveName: JASP-[0-9.]*-macOS-arm64.dmg
2025-11-06 13:22:59 : INFO  : jasp : no blocking processes defined, using JASP as default
2025-11-06 13:22:59.042 defaults[24341:4313891] 
The domain/default pair of (/Applications/JASP.app/Contents/Info.plist, CFBundleVersion) does not exist
2025-11-06 13:22:59 : INFO  : jasp : Custom App Version detection is used, found 
2025-11-06 13:22:59 : INFO  : jasp : appversion: 
2025-11-06 13:22:59 : INFO  : jasp : Latest version of JASP is 0.95.4
2025-11-06 13:22:59 : REQ   : jasp : Downloading https://github.com/jasp-stats/jasp-desktop/releases/download/v0.95.4/JASP-0.95.4.0-MacOS-arm64.dmg to JASP-[0-9.]*-macOS-arm64.dmg
2025-11-06 13:23:12 : INFO  : jasp : Downloaded JASP-[0-9.]*-macOS-arm64.dmg – Type is  zlib compressed data – SHA is 82505a1f9bdebf699fbf0124201b5cd9a69d91a1 – Size is 1185324 kB
2025-11-06 13:23:13 : REQ   : jasp : no more blocking processes, continue with update
2025-11-06 13:23:13 : REQ   : jasp : Installing JASP
2025-11-06 13:23:13 : INFO  : jasp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mpHn8B7yrm/JASP-[0-9.]*-macOS-arm64.dmg
2025-11-06 13:23:20 : INFO  : jasp : Mounted: /Volumes/JASP-0.95.4.0-macOS-arm64
2025-11-06 13:23:20 : INFO  : jasp : Verifying: /Volumes/JASP-0.95.4.0-macOS-arm64/JASP.app
2025-11-06 13:23:41 : INFO  : jasp : Team ID matching: AWJJ3YVK9B (expected: AWJJ3YVK9B )
2025-11-06 13:23:42 : INFO  : jasp : Installing JASP version 0.95 on versionKey CFBundleShortVersionString.
2025-11-06 13:23:42 : INFO  : jasp : App has LSMinimumSystemVersion: 12.0
2025-11-06 13:23:42 : INFO  : jasp : Copy /Volumes/JASP-0.95.4.0-macOS-arm64/JASP.app to /Applications
2025-11-06 13:24:46 : WARN  : jasp : Changing owner to [redacted]
2025-11-06 13:24:52 : INFO  : jasp : Finishing...
2025-11-06 13:24:55 : INFO  : jasp : Custom App Version detection is used, found 0.95.4
2025-11-06 13:24:55 : REQ   : jasp : Installed JASP, version 0.95
2025-11-06 13:24:55 : INFO  : jasp : notifying
2025-11-06 13:24:56 : INFO  : jasp : Installomator did not close any apps, so no need to reopen any apps.
2025-11-06 13:24:56 : REQ   : jasp : All done!
2025-11-06 13:24:56 : REQ   : jasp : ################## End Installomator, exit code 0 

```

If already installed:
```
[REDACTED] Installomator-10.8 % sudo ./assemble.sh jasp DEBUG=0
Password:
2025-11-06 12:17:53 : INFO  : jasp : setting variable from argument DEBUG=0
2025-11-06 12:17:53 : INFO  : jasp : Total items in argumentsArray: 1
2025-11-06 12:17:53 : INFO  : jasp : argumentsArray: DEBUG=0
2025-11-06 12:17:53 : REQ   : jasp : ################## Start Installomator v. 10.8, date 2025-11-06
2025-11-06 12:17:53 : INFO  : jasp : ################## Version: 10.8
2025-11-06 12:17:53 : INFO  : jasp : ################## Date: 2025-11-06
2025-11-06 12:17:53 : INFO  : jasp : ################## jasp
2025-11-06 12:17:55 : INFO  : jasp : Reading arguments again: DEBUG=0
2025-11-06 12:17:55 : INFO  : jasp : BLOCKING_PROCESS_ACTION=tell_user
2025-11-06 12:17:55 : INFO  : jasp : NOTIFY=success
2025-11-06 12:17:55 : INFO  : jasp : LOGGING=INFO
2025-11-06 12:17:55 : INFO  : jasp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-06 12:17:55 : INFO  : jasp : Label type: dmg
2025-11-06 12:17:55 : INFO  : jasp : archiveName: JASP-[0-9.]*-macOS-arm64.dmg
2025-11-06 12:17:55 : INFO  : jasp : no blocking processes defined, using JASP as default
2025-11-06 12:17:55 : INFO  : jasp : Custom App Version detection is used, found 0.95.4
2025-11-06 12:17:55 : INFO  : jasp : appversion: 0.95.4
2025-11-06 12:17:55 : INFO  : jasp : Latest version of JASP is 0.95.4
2025-11-06 12:17:55 : INFO  : jasp : There is no newer version available.
2025-11-06 12:17:55 : INFO  : jasp : Installomator did not close any apps, so no need to reopen any apps.
2025-11-06 12:17:55 : REQ   : jasp : No newer version.
2025-11-06 12:17:55 : REQ   : jasp : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
