### PR TITLE
Update 8x8.sh

### DIFF
--- a/fragments/labels/8x8.sh
+++ b/fragments/labels/8x8.sh
@@ -1,9 +1,15 @@
 8x8)
-    # credit: #D-A-James from MacAdmins Slack and Isaac Ordonez, Mann consulting (@mannconsulting)
     name="8x8 Work"
     type="dmg"
-    downloadURL=$(curl -fs -L https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}')
-    # As for appNewVersion, it needs to be checked for newer version than 7.2.4
-    appNewVersion=$(curl -fs -L https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}' | sed -E 's/.*-v([0-9\.]*)[-\.]*.*/\1/' )
+    downloadURL=$( \
+      arch=$(uname -m); \
+      curl -fsSL "https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d" | \
+      if [[ "$arch" == "arm64" ]]; then \
+        grep -oE 'https://work-desktop-assets\.8x8\.com[^"]*arm64[^"]*\.dmg' | head -n1; \
+      else \
+        grep -oE 'https://work-desktop-assets\.8x8\.com[^"]*\.dmg' | grep -v 'arm64' | head -n1; \
+      fi \
+    )
+    appNewVersion=""
     expectedTeamID="FC967L3QRG"
     ;;


### PR DESCRIPTION
The downloadURL variable is fully updated to dynamically detect and fetch the correct 8x8 Work DMG based on architecture (Intel or ARM), reflecting changes in the support portal's page structure.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
