### PR TITLE
Fix fujifilmwebcam

### DIFF
--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -1,7 +1,7 @@
 fujifilmwebcam)
-     name="FUJIFILM X Webcam 2"
-     type="pkg"
-     downloadURL=$(curl -fsL "https://www.fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
-     appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g')
-     expectedTeamID="34LRP8AV2M"
-     ;;
+    name="FUJIFILM X Webcam 2"
+    type="pkg"
+    downloadURL=$(curl -fsL "https://www.fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
+    appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g')
+    expectedTeamID="34LRP8AV2M"
+    ;;

--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -1,7 +1,7 @@
 fujifilmwebcam)
      name="FUJIFILM X Webcam 2"
      type="pkg"
-     downloadURL=$(curl -fs "https://fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
+     downloadURL=$(curl -fs "https://www.fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
      appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g')
      expectedTeamID="34LRP8AV2M"
      ;;

--- a/fragments/labels/fujifilmwebcam.sh
+++ b/fragments/labels/fujifilmwebcam.sh
@@ -1,7 +1,7 @@
 fujifilmwebcam)
      name="FUJIFILM X Webcam 2"
      type="pkg"
-     downloadURL=$(curl -fs "https://www.fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
+     downloadURL=$(curl -fsL "https://www.fujifilm-x.com/en-us/support/download/software/x-webcam/" | grep "https.*pkg" | sed -E 's/.*(https:\/\/dl.fujifilm-x\.com\/support\/software\/.*\.pkg[^\<]).*/\1/g' | sed -e 's/^"//' -e 's/"$//')
      appNewVersion=$( echo “${downloadURL}” | sed -E 's/.*XWebcamIns([0-9]*).*/\1/g' | sed -E 's/([0-9])([0-9]).*/\1\.\2/g')
      expectedTeamID="34LRP8AV2M"
      ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
sh
```
$ build/Installomator.sh fujifilmwebcam DEBUG=1
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : setting variable from argument DEBUG=1
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : Total items in argumentsArray: 1
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : argumentsArray: DEBUG=1
2025-11-07 17:01:46 : REQ   : fujifilmwebcam : ################## Start Installomator v. 10.9beta, date 2025-11-07
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : ################## Version: 10.9beta
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : ################## Date: 2025-11-07
2025-11-07 17:01:46 : INFO  : fujifilmwebcam : ################## fujifilmwebcam
2025-11-07 17:01:46 : DEBUG : fujifilmwebcam : DEBUG mode 1 enabled.
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : Reading arguments again: DEBUG=1
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : argument: DEBUG=1
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : name=FUJIFILM X Webcam 2
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : appName=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : type=pkg
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : archiveName=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : downloadURL=https://dl.fujifilm-x.com/support/software/x-webcam-mac210-z0lr203j/XWebcamIns210.pkg
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : curlOptions=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : appNewVersion=2.1
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : appCustomVersion function: Not defined
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : versionKey=CFBundleShortVersionString
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : packageID=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : pkgName=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : choiceChangesXML=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : expectedTeamID=34LRP8AV2M
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : blockingProcesses=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : installerTool=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : CLIInstaller=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : CLIArguments=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : updateTool=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : updateToolArguments=
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : updateToolRunAsCurrentUser=
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : BLOCKING_PROCESS_ACTION=tell_user
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : NOTIFY=success
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : LOGGING=DEBUG
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : Label type: pkg
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : archiveName: FUJIFILM X Webcam 2.pkg
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : no blocking processes defined, using FUJIFILM X Webcam 2 as default
2025-11-07 17:01:49 : DEBUG : fujifilmwebcam : Changing directory to build
2025-11-07 17:01:49 : INFO  : fujifilmwebcam : name: FUJIFILM X Webcam 2, appName: FUJIFILM X Webcam 2.app
2025-11-07 17:01:50 : WARN  : fujifilmwebcam : No previous app found
2025-11-07 17:01:50 : WARN  : fujifilmwebcam : could not find FUJIFILM X Webcam 2.app
2025-11-07 17:01:50 : INFO  : fujifilmwebcam : appversion: 
2025-11-07 17:01:50 : INFO  : fujifilmwebcam : Latest version of FUJIFILM X Webcam 2 is 2.1
2025-11-07 17:01:50 : REQ   : fujifilmwebcam : Downloading https://dl.fujifilm-x.com/support/software/x-webcam-mac210-z0lr203j/XWebcamIns210.pkg to FUJIFILM X Webcam 2.pkg
2025-11-07 17:01:50 : DEBUG : fujifilmwebcam : No Dialog connection, just download
2025-11-07 17:01:52 : INFO  : fujifilmwebcam : Downloaded FUJIFILM X Webcam 2.pkg – Type is  xar archive compressed TOC – SHA is df3c9bd83b457de2f6a08af581985252da358bf2 – Size is 1648 kB
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : DEBUG mode 1, not checking for blocking processes
2025-11-07 17:01:52 : REQ   : fujifilmwebcam : Installing FUJIFILM X Webcam 2
2025-11-07 17:01:52 : INFO  : fujifilmwebcam : Verifying: FUJIFILM X Webcam 2.pkg
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : File list: -rw-r--r--  1 sean.christians  staff   1.6M Nov  7 17:01 FUJIFILM X Webcam 2.pkg
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : File type: FUJIFILM X Webcam 2.pkg: xar archive compressed TOC: 4885, SHA-1 checksum
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : spctlOut is FUJIFILM X Webcam 2.pkg: accepted
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : source=Notarized Developer ID
2025-11-07 17:01:52 : DEBUG : fujifilmwebcam : origin=Developer ID Installer: FUJIFILM Corporation (34LRP8AV2M)
2025-11-07 17:01:53 : INFO  : fujifilmwebcam : Team ID: 34LRP8AV2M (expected: 34LRP8AV2M )
2025-11-07 17:01:53 : DEBUG : fujifilmwebcam : DEBUG enabled, skipping installation
2025-11-07 17:01:53 : INFO  : fujifilmwebcam : Finishing...
2025-11-07 17:01:56 : INFO  : fujifilmwebcam : name: FUJIFILM X Webcam 2, appName: FUJIFILM X Webcam 2.app
2025-11-07 17:01:56 : WARN  : fujifilmwebcam : No previous app found
2025-11-07 17:01:56 : WARN  : fujifilmwebcam : could not find FUJIFILM X Webcam 2.app
2025-11-07 17:01:56 : REQ   : fujifilmwebcam : Installed FUJIFILM X Webcam 2, version 2.1
2025-11-07 17:01:56 : INFO  : fujifilmwebcam : notifying
2025-11-07 17:01:56 : DEBUG : fujifilmwebcam : DEBUG mode 1, not reopening anything
2025-11-07 17:01:56 : REQ   : fujifilmwebcam : All done!
2025-11-07 17:01:56 : REQ   : fujifilmwebcam : ################## End Installomator, exit code 0 

```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
