### PR TITLE
Add Logitech G HUB

### DIFF
--- a/fragments/labels/logitechghub.sh
+++ b/fragments/labels/logitechghub.sh
@@ -1,0 +1,15 @@
+logitechghub|\
+logighub)
+    name="Logi G-HUB"
+    appName="lghub.app"
+    archiveName="lghub_installer.zip"
+    installerTool="lghub_installer.app"
+    type="zip"
+    versionKey="CFBundleVersion"
+    onlineHTMLinfo=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.logi.com/api/v2/help_center/en-us/articles.json\?label_names\=webcontent\=productdownload,webproduct\=b972df0c-7db0-11e9-b911-fb4b2d0df96c,webos\=mac-macos-x-15.0 | jq -r '.articles.[0].body')
+    downloadURL=$(echo ${onlineHTMLinfo} | xmllint --html --xpath 'string(//div/div/ul/div/a/@href)' -)
+    appNewVersion=$(echo ${onlineHTMLinfo} | xmllint --html --xpath 'string(//li[b/span= "Software Version: "])' - | tail -1 | awk '{print$3}' -)
+    CLIInstaller="lghub_installer.app/Contents/MacOS/lghub_installer"
+    CLIArguments=(--silent)
+    expectedTeamID="QED4VVPZWA"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 

**Installomator log** 
No previous app:
```
➜  Installomator git:(add_logitechghub) ✗ sudo ./assemble.sh logitechghub DEBUG=0
2025-11-10 13:51:05 : INFO  : logitechghub : setting variable from argument DEBUG=0
2025-11-10 13:51:05 : INFO  : logitechghub : Total items in argumentsArray: 1
2025-11-10 13:51:05 : INFO  : logitechghub : argumentsArray: DEBUG=0
2025-11-10 13:51:05 : REQ   : logitechghub : ################## Start Installomator v. 10.9beta, date 2025-11-10
2025-11-10 13:51:05 : INFO  : logitechghub : ################## Version: 10.9beta
2025-11-10 13:51:05 : INFO  : logitechghub : ################## Date: 2025-11-10
2025-11-10 13:51:05 : INFO  : logitechghub : ################## logitechghub
2025-11-10 13:51:06 : INFO  : logitechghub : Reading arguments again: DEBUG=0
2025-11-10 13:51:06 : INFO  : logitechghub : BLOCKING_PROCESS_ACTION=tell_user
2025-11-10 13:51:06 : INFO  : logitechghub : NOTIFY=success
2025-11-10 13:51:06 : INFO  : logitechghub : LOGGING=INFO
2025-11-10 13:51:06 : INFO  : logitechghub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-10 13:51:06 : INFO  : logitechghub : Label type: zip
2025-11-10 13:51:06 : INFO  : logitechghub : archiveName: lghub_installer.zip
2025-11-10 13:51:06 : INFO  : logitechghub : no blocking processes defined, using Logi G-HUB as default
2025-11-10 13:51:06 : INFO  : logitechghub : name: Logi G-HUB, appName: lghub.app
2025-11-10 13:51:06 : WARN  : logitechghub : No previous app found
2025-11-10 13:51:06 : WARN  : logitechghub : could not find lghub.app
2025-11-10 13:51:06 : INFO  : logitechghub : appversion: 
2025-11-10 13:51:06 : INFO  : logitechghub : Latest version of Logi G-HUB is 2025.8.789376
2025-11-10 13:51:06 : REQ   : logitechghub : Downloading https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.zip to lghub_installer.zip
2025-11-10 13:51:06 : INFO  : logitechghub : Downloaded lghub_installer.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=store – SHA is 4fed591f0f586faf3718e6cea35fc736df549c36 – Size is 10804 kB
2025-11-10 13:51:06 : REQ   : logitechghub : no more blocking processes, continue with update
2025-11-10 13:51:06 : REQ   : logitechghub : Installing Logi G-HUB
2025-11-10 13:51:06 : REQ   : logitechghub : installerTool used: lghub_installer.app
2025-11-10 13:51:06 : INFO  : logitechghub : Unzipping lghub_installer.zip
2025-11-10 13:51:07 : INFO  : logitechghub : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swUO8ccAl7/lghub_installer.app
2025-11-10 13:51:07 : INFO  : logitechghub : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2025-11-10 13:51:07 : INFO  : logitechghub : Installing Logi G-HUB version 2025.8.789376 on versionKey CFBundleVersion.
2025-11-10 13:51:07 : INFO  : logitechghub : App has LSMinimumSystemVersion: 12.0
2025-11-10 13:51:07 : INFO  : logitechghub : CLIInstaller exists, running installer command /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swUO8ccAl7/lghub_installer.app/Contents/MacOS/lghub_installer --silent
2025-11-10 13:51:30 : INFO  : logitechghub : Succesfully ran /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.swUO8ccAl7/lghub_installer.app/Contents/MacOS/lghub_installer --silent
2025-11-10 13:51:30 : INFO  : logitechghub : Finishing...
2025-11-10 13:51:33 : INFO  : logitechghub : name: Logi G-HUB, appName: lghub_installer.app
2025-11-10 13:51:33 : WARN  : logitechghub : No previous app found
2025-11-10 13:51:33 : WARN  : logitechghub : could not find lghub_installer.app
2025-11-10 13:51:33 : REQ   : logitechghub : Installed Logi G-HUB, version 2025.8.789376
2025-11-10 13:51:33 : INFO  : logitechghub : notifying
2025-11-10 13:51:34 : INFO  : logitechghub : Installomator did not close any apps, so no need to reopen any apps.
2025-11-10 13:51:34 : REQ   : logitechghub : All done!
2025-11-10 13:51:34 : REQ   : logitechghub : ################## End Installomator, exit code 0 
```

With latest app installed:
```
➜  Installomator git:(add_logitechghub) ✗ sudo ./assemble.sh logitechghub DEBUG=0
2025-11-10 13:59:04 : INFO  : logitechghub : setting variable from argument DEBUG=0
2025-11-10 13:59:04 : INFO  : logitechghub : Total items in argumentsArray: 1
2025-11-10 13:59:04 : INFO  : logitechghub : argumentsArray: DEBUG=0
2025-11-10 13:59:04 : REQ   : logitechghub : ################## Start Installomator v. 10.9beta, date 2025-11-10
2025-11-10 13:59:04 : INFO  : logitechghub : ################## Version: 10.9beta
2025-11-10 13:59:04 : INFO  : logitechghub : ################## Date: 2025-11-10
2025-11-10 13:59:04 : INFO  : logitechghub : ################## logitechghub
2025-11-10 13:59:05 : INFO  : logitechghub : Reading arguments again: DEBUG=0
2025-11-10 13:59:05 : INFO  : logitechghub : BLOCKING_PROCESS_ACTION=tell_user
2025-11-10 13:59:05 : INFO  : logitechghub : NOTIFY=success
2025-11-10 13:59:05 : INFO  : logitechghub : LOGGING=INFO
2025-11-10 13:59:05 : INFO  : logitechghub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-10 13:59:05 : INFO  : logitechghub : Label type: zip
2025-11-10 13:59:05 : INFO  : logitechghub : archiveName: lghub_installer.zip
2025-11-10 13:59:05 : INFO  : logitechghub : no blocking processes defined, using Logi G-HUB as default
2025-11-10 13:59:05 : INFO  : logitechghub : App(s) found: /Applications/lghub.app
2025-11-10 13:59:05 : INFO  : logitechghub : found app at /Applications/lghub.app, version 2025.8.789376, on versionKey CFBundleVersion
2025-11-10 13:59:05 : INFO  : logitechghub : appversion: 2025.8.789376
2025-11-10 13:59:05 : INFO  : logitechghub : Latest version of Logi G-HUB is 2025.8.789376
2025-11-10 13:59:05 : INFO  : logitechghub : There is no newer version available.
2025-11-10 13:59:05 : INFO  : logitechghub : Installomator did not close any apps, so no need to reopen any apps.
2025-11-10 13:59:05 : REQ   : logitechghub : No newer version.
2025-11-10 13:59:05 : REQ   : logitechghub : ################## End Installomator, exit code 0 
```