### PR TITLE
Camtasia URL Fixes

### DIFF
--- a/fragments/labels/camtasia2019.sh
+++ b/fragments/labels/camtasia2019.sh
@@ -1,7 +1,15 @@
 camtasia2019)
     name="Camtasia 2019"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Camtasia (Mac) 2019" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Camtasia (Mac) 2019" | sed -e 's/.*Camtasia (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2019.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2019.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][1]/title/text())' - | \
+        awk '{ print $2 }'
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][1]/enclosure[@xml:lang="en"]/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2020.sh
+++ b/fragments/labels/camtasia2020.sh
@@ -1,7 +1,15 @@
 camtasia2020)
     name="Camtasia 2020"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Camtasia (Mac) 2020" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Camtasia (Mac) 2020" | sed -e 's/.*Camtasia (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2020.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2020.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][1]/title/text())' - | \
+        awk '{ print $2 }'
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][1]/enclosure[@xml:lang="en"]/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2021.sh
+++ b/fragments/labels/camtasia2021.sh
@@ -1,7 +1,15 @@
 camtasia2021)
     name="Camtasia 2021"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Camtasia (Mac) 2021" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Camtasia (Mac) 2021" | sed -e 's/.*Camtasia (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2021.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2021.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/title/text())' - | \
+        awk '{ print $2 }'
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2022.sh
+++ b/fragments/labels/camtasia2022.sh
@@ -1,7 +1,14 @@
 camtasia2022)
     name="Camtasia 2022"
     type="dmg"
-    downloadURL=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links" | grep -A 3 "Camtasia (Mac) 2022" | sed 's/.*href="//' | sed 's/".*//' | grep .dmg)
-    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://support.techsmith.com/hc/en-us/articles/360004908652-Desktop-Product-Download-Links"  | grep "Camtasia (Mac) 2022" | sed -e 's/.*Camtasia (Mac) //' -e 's/<\/td>.*//')
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2022.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2022.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/*[local-name()="shortVersionString"]/text())' -
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2023.sh
+++ b/fragments/labels/camtasia2023.sh
@@ -1,8 +1,14 @@
 camtasia2023)
     name="Camtasia 2023"
     type="dmg"
-    apiResult="$(curl -fsL "https://www.techsmith.com/api/v/1/products/getversioninfo/2080")"
-    downloadURL="https://download.techsmith.com$(getJSONValue "$apiResult" "PrimaryDownloadInformation.RelativePath")$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Name")"
-    appNewVersion="20$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Major").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Minor").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Maintenance")"
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2023.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2023.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/*[local-name()="shortVersionString"]/text())' -
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2024.sh
+++ b/fragments/labels/camtasia2024.sh
@@ -1,8 +1,14 @@
 camtasia2024)
-    name="Camtasia 2024"
+    name="Camtasia"
     type="dmg"
-    apiResult="$(curl -fsL "https://www.techsmith.com/api/v/1/products/getversioninfo/2200")"
-    downloadURL="https://download.techsmith.com$(getJSONValue "$apiResult" "PrimaryDownloadInformation.RelativePath")$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Name")"
-    appNewVersion="20$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Major").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Minor").$(getJSONValue "$apiResult" "PrimaryDownloadInformation.Maintenance")"
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2024.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2024.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/*[local-name()="shortVersionString"]/text())' -
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;

--- a/fragments/labels/camtasia2025.sh
+++ b/fragments/labels/camtasia2025.sh
@@ -1,12 +1,14 @@
-camtasia|\
 camtasia2025)
     name="Camtasia"
     type="dmg"
-    cdnData=$(curl -fsL "https://www.techsmith.com/api/v/1/products/getallversions/9" | jq '[.[] | select(.Major == 25)]')
-    appNewVersion=$(echo "${cdnData}" | jq '.[] | "20" + (.Major|tostring) + "." + (.Minor|tostring) + "." + (.Maintenance|tostring)' | tr -d '"')
-    versionID=$(echo "${cdnData}" | jq '.[].VersionID')
-    packageData=$(curl -fsl "https://www.techsmith.com/api/v/1/products/getversioninfo/${versionID}")
-    relativePath=$(echo "${packageData}" | jq '.PrimaryDownloadInformation.RelativePath' | tr -d '"')
-    downloadURL="https://download.techsmith.com${relativePath}camtasia.dmg"
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2025.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2025.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/*[local-name()="shortVersionString"]/text())' -
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
     expectedTeamID="7TQL462TU8"
     ;;


### PR DESCRIPTION
Fixes feed URLs and download URL detections.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This fixes the following:

- The feed URL and parsing to get the downloadURL and appNewVersion
- All versions of the Camtasia label (2019-2025) now work properly again.
- Aligns and is consistent with discussion for sister-product Snagit in #2438 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

2025-11-10 14:50:34 : INFO  : camtasia2025 : Total items in argumentsArray: 0
2025-11-10 14:50:34 : INFO  : camtasia2025 : argumentsArray: 
2025-11-10 14:50:34 : REQ   : camtasia2025 : ################## Start Installomator v. 10.9beta, date 2025-11-10
2025-11-10 14:50:34 : INFO  : camtasia2025 : ################## Version: 10.9beta
2025-11-10 14:50:34 : INFO  : camtasia2025 : ################## Date: 2025-11-10
2025-11-10 14:50:34 : INFO  : camtasia2025 : ################## camtasia2025
2025-11-10 14:50:34 : DEBUG : camtasia2025 : DEBUG mode 1 enabled.
2025-11-10 14:50:35 : INFO  : camtasia2025 : Reading arguments again: 
2025-11-10 14:50:35 : DEBUG : camtasia2025 : name=Camtasia
2025-11-10 14:50:35 : DEBUG : camtasia2025 : appName=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : type=dmg
2025-11-10 14:50:35 : DEBUG : camtasia2025 : archiveName=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : downloadURL=https://download.techsmith.com/camtasiamac/releases/2525/camtasia.dmg
2025-11-10 14:50:35 : DEBUG : camtasia2025 : curlOptions=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : appNewVersion=2025.2.5
2025-11-10 14:50:35 : DEBUG : camtasia2025 : appCustomVersion function: Not defined
2025-11-10 14:50:35 : DEBUG : camtasia2025 : versionKey=CFBundleShortVersionString
2025-11-10 14:50:35 : DEBUG : camtasia2025 : packageID=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : pkgName=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : choiceChangesXML=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : expectedTeamID=7TQL462TU8
2025-11-10 14:50:35 : DEBUG : camtasia2025 : blockingProcesses=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : installerTool=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : CLIInstaller=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : CLIArguments=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : updateTool=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : updateToolArguments=
2025-11-10 14:50:35 : DEBUG : camtasia2025 : updateToolRunAsCurrentUser=
2025-11-10 14:50:35 : INFO  : camtasia2025 : BLOCKING_PROCESS_ACTION=tell_user
2025-11-10 14:50:35 : INFO  : camtasia2025 : NOTIFY=success
2025-11-10 14:50:35 : INFO  : camtasia2025 : LOGGING=DEBUG
2025-11-10 14:50:35 : INFO  : camtasia2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-10 14:50:35 : INFO  : camtasia2025 : Label type: dmg
2025-11-10 14:50:35 : INFO  : camtasia2025 : archiveName: Camtasia.dmg
2025-11-10 14:50:35 : INFO  : camtasia2025 : no blocking processes defined, using Camtasia as default
2025-11-10 14:50:35 : DEBUG : camtasia2025 : Changing directory to /Users/bkerns/PUGitHub/Main-Installomator/Main-Installomator/build
2025-11-10 14:50:35 : INFO  : camtasia2025 : name: Camtasia, appName: Camtasia.app
2025-11-10 14:50:35 : WARN  : camtasia2025 : No previous app found
2025-11-10 14:50:35 : WARN  : camtasia2025 : could not find Camtasia.app
2025-11-10 14:50:35 : INFO  : camtasia2025 : appversion: 
2025-11-10 14:50:35 : INFO  : camtasia2025 : Latest version of Camtasia is 2025.2.5
2025-11-10 14:50:35 : REQ   : camtasia2025 : Downloading https://download.techsmith.com/camtasiamac/releases/2525/camtasia.dmg to Camtasia.dmg
2025-11-10 14:50:35 : DEBUG : camtasia2025 : No Dialog connection, just download
2025-11-10 14:51:01 : INFO  : camtasia2025 : Downloaded Camtasia.dmg – Type is  zlib compressed data – SHA is b82237742c2b8c999a9355d3f99347fbbeeffd3b – Size is 458808 kB
2025-11-10 14:51:01 : DEBUG : camtasia2025 : DEBUG mode 1, not checking for blocking processes
2025-11-10 14:51:01 : REQ   : camtasia2025 : Installing Camtasia
2025-11-10 14:51:01 : INFO  : camtasia2025 : Mounting /Users/bkerns/PUGitHub/Main-Installomator/Main-Installomator/build/Camtasia.dmg
2025-11-10 14:51:03 : DEBUG : camtasia2025 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $9CFA0E85
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $067A4AE6
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $C7387883
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $6195FF18
/dev/disk18         	Apple_partition_scheme
/dev/disk18s1       	Apple_partition_map
/dev/disk18s2       	Apple_HFS                      	/Volumes/Camtasia

2025-11-10 14:51:03 : INFO  : camtasia2025 : Mounted: /Volumes/Camtasia
2025-11-10 14:51:03 : INFO  : camtasia2025 : Verifying: /Volumes/Camtasia/Camtasia.app
2025-11-10 14:51:03 : DEBUG : camtasia2025 : App size: 843M	/Volumes/Camtasia/Camtasia.app
2025-11-10 14:51:09 : DEBUG : camtasia2025 : Debugging enabled, App Verification output was:
/Volumes/Camtasia/Camtasia.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TechSmith Corporation (7TQL462TU8)

2025-11-10 14:51:09 : INFO  : camtasia2025 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2025-11-10 14:51:09 : INFO  : camtasia2025 : Installing Camtasia version 2025.2.5 on versionKey CFBundleShortVersionString.
2025-11-10 14:51:09 : INFO  : camtasia2025 : App has LSMinimumSystemVersion: 13.0
2025-11-10 14:51:09 : DEBUG : camtasia2025 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-11-10 14:51:09 : INFO  : camtasia2025 : Finishing...
2025-11-10 14:51:12 : INFO  : camtasia2025 : name: Camtasia, appName: Camtasia.app
2025-11-10 14:51:12 : WARN  : camtasia2025 : No previous app found
2025-11-10 14:51:12 : WARN  : camtasia2025 : could not find Camtasia.app
2025-11-10 14:51:12 : REQ   : camtasia2025 : Installed Camtasia, version 2025.2.5
2025-11-10 14:51:12 : INFO  : camtasia2025 : notifying
2025-11-10 14:51:13 : DEBUG : camtasia2025 : Unmounting /Volumes/Camtasia
2025-11-10 14:51:13 : DEBUG : camtasia2025 : Debugging enabled, Unmounting output was:
"disk18" ejected.
2025-11-10 14:51:13 : DEBUG : camtasia2025 : DEBUG mode 1, not reopening anything
2025-11-10 14:51:13 : REQ   : camtasia2025 : All done!
2025-11-10 14:51:13 : REQ   : camtasia2025 : ################## End Installomator, exit code 0 
