### PR TITLE
Update shotcut.sh

### DIFF
--- a/fragments/labels/shotcut.sh
+++ b/fragments/labels/shotcut.sh
@@ -3,7 +3,7 @@ shotcut)
     type="dmg"
     appNewVersion=$(curl -fsL https://www.shotcut.org/download/releasenotes | grep 'release-' | head -n 1 | cut -d '"' -f 2 | cut -d '-' -f 2)
     appCustomVersion() { echo "$(/usr/bin/defaults read "/Applications/shotcut.app/Contents/Info.plist" "CFBundleVersion" | sed -r 's/[.]//g')" }
-    archiveName="shotcut-macos-$appNewVersion.dmg"
+    archiveName="shotcut-macos-${appNewVersion:0:2}.${appNewVersion:2:2}.${appNewVersion:4:2}.dmg"
     downloadURL=$(downloadURLFromGit mltframework shotcut)
     expectedTeamID="Y6RX44QG2G"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Current label tries to install "shotcut-macos-xxxxxx.dmg" but the actual name is "shotcut-macos-xx.xx.xx.dmg" so I added that.


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**


```
2025-11-11 09:54:56 : INFO  : shotcut : setting variable from argument DEBUG=0
2025-11-11 09:54:56 : INFO  : shotcut : Total items in argumentsArray: 1
2025-11-11 09:54:56 : INFO  : shotcut : argumentsArray: DEBUG=0
2025-11-11 09:54:56 : REQ   : shotcut : ################## Start Installomator v. 10.9beta, date 2025-11-11
2025-11-11 09:54:56 : INFO  : shotcut : ################## Version: 10.9beta
2025-11-11 09:54:56 : INFO  : shotcut : ################## Date: 2025-11-11
2025-11-11 09:54:56 : INFO  : shotcut : ################## shotcut
2025-11-11 09:54:56 : INFO  : shotcut : SwiftDialog is not installed, clear cmd file var
2025-11-11 09:54:57 : INFO  : shotcut : Reading arguments again: DEBUG=0
2025-11-11 09:54:57 : INFO  : shotcut : BLOCKING_PROCESS_ACTION=tell_user
2025-11-11 09:54:57 : INFO  : shotcut : NOTIFY=success
2025-11-11 09:54:57 : INFO  : shotcut : LOGGING=INFO
2025-11-11 09:54:57 : INFO  : shotcut : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-11 09:54:57 : INFO  : shotcut : Label type: dmg
2025-11-11 09:54:57 : INFO  : shotcut : archiveName: shotcut-macos-25.10.31.dmg
2025-11-11 09:54:57 : INFO  : shotcut : no blocking processes defined, using shotcut as default
2025-11-11 09:54:57.595 defaults[34100:1915613] 
The domain/default pair of (/Applications/shotcut.app/Contents/Info.plist, CFBundleVersion) does not exist
2025-11-11 09:54:57 : INFO  : shotcut : Custom App Version detection is used, found 
2025-11-11 09:54:57 : INFO  : shotcut : appversion: 
2025-11-11 09:54:57 : INFO  : shotcut : Latest version of shotcut is 251031
2025-11-11 09:54:57 : REQ   : shotcut : Downloading https://github.com/mltframework/shotcut/releases/download/v25.10.31/shotcut-macos-25.10.31.dmg to shotcut-macos-25.10.31.dmg
2025-11-11 09:55:03 : INFO  : shotcut : Downloaded shotcut-macos-25.10.31.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 88c26961e53a2ef886ca3551461011bca9af9359 – Size is 350028 kB
2025-11-11 09:55:03 : REQ   : shotcut : no more blocking processes, continue with update
2025-11-11 09:55:03 : REQ   : shotcut : Installing shotcut
2025-11-11 09:55:03 : INFO  : shotcut : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PP1tQXnMGF/shotcut-macos-25.10.31.dmg
2025-11-11 09:55:17 : INFO  : shotcut : Mounted: /Volumes/Shotcut
2025-11-11 09:55:17 : INFO  : shotcut : Verifying: /Volumes/Shotcut/shotcut.app
2025-11-11 09:55:40 : INFO  : shotcut : Team ID matching: Y6RX44QG2G (expected: Y6RX44QG2G )
2025-11-11 09:55:40 : INFO  : shotcut : Installing shotcut version 25.10 on versionKey CFBundleShortVersionString.
2025-11-11 09:55:40 : INFO  : shotcut : App has LSMinimumSystemVersion: 12.0.0
2025-11-11 09:55:40 : INFO  : shotcut : Copy /Volumes/Shotcut/shotcut.app to /Applications
2025-11-11 09:56:08 : WARN  : shotcut : Changing owner to andreaslundberg
2025-11-11 09:56:09 : INFO  : shotcut : Finishing...
2025-11-11 09:56:12 : INFO  : shotcut : Custom App Version detection is used, found 251031
2025-11-11 09:56:12 : REQ   : shotcut : Installed shotcut, version 25.10
2025-11-11 09:56:12 : INFO  : shotcut : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-11 09:56:12 : INFO  : shotcut : Installomator did not close any apps, so no need to reopen any apps.
2025-11-11 09:56:12 : REQ   : shotcut : All done!
2025-11-11 09:56:12 : REQ   : shotcut : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
