### PR TITLE
Create vocevistavideopro.sh

### DIFF
--- a/fragments/labels/vocevistavideopro.sh
+++ b/fragments/labels/vocevistavideopro.sh
@@ -1,0 +1,8 @@
+vocevistavideopro)
+    name="VoceVista Video Pro"
+    type="dmg"
+    appNewVersion=$(curl --compressed -fsL "https://www.vocevista.com/en/download-mac/" | grep -o ".\{0,0\}Version.\{0,20\}" | sed 's/\Version //'| cut -d "<" -f1)
+    trimVersion=$(curl --compressed -fsL "https://www.vocevista.com/en/download-mac/" | grep -o ".\{0,0\}Version.\{0,20\}" | sed 's/\Version //'| cut -d "." -f 1-3)
+    downloadURL="https://download.sygyt.com/$trimVersion/VoceVistaVideoPro_macOS_$appNewVersion.dmg"
+    expectedTeamID="MZ25LZ65AM"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes, I am new to this however so if there's a way to confirm I liked to know. Installed the plugin for VS-Code and worked from a branch created from main.

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-11-13 08:50:43 : INFO  : vocevistavideopro : setting variable from argument DEBUG=0
2025-11-13 08:50:43 : INFO  : vocevistavideopro : Total items in argumentsArray: 1
2025-11-13 08:50:43 : INFO  : vocevistavideopro : argumentsArray: DEBUG=0
2025-11-13 08:50:43 : REQ   : vocevistavideopro : ################## Start Installomator v. 10.9beta, date 2025-11-13
2025-11-13 08:50:43 : INFO  : vocevistavideopro : ################## Version: 10.9beta
2025-11-13 08:50:43 : INFO  : vocevistavideopro : ################## Date: 2025-11-13
2025-11-13 08:50:43 : INFO  : vocevistavideopro : ################## vocevistavideopro
2025-11-13 08:50:43 : INFO  : vocevistavideopro : SwiftDialog is not installed, clear cmd file var
2025-11-13 08:50:44 : INFO  : vocevistavideopro : Reading arguments again: DEBUG=0
2025-11-13 08:50:44 : INFO  : vocevistavideopro : BLOCKING_PROCESS_ACTION=tell_user
2025-11-13 08:50:44 : INFO  : vocevistavideopro : NOTIFY=success
2025-11-13 08:50:44 : INFO  : vocevistavideopro : LOGGING=INFO
2025-11-13 08:50:44 : INFO  : vocevistavideopro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-13 08:50:44 : INFO  : vocevistavideopro : Label type: dmg
2025-11-13 08:50:44 : INFO  : vocevistavideopro : archiveName: VoceVista Video Pro.dmg
2025-11-13 08:50:44 : INFO  : vocevistavideopro : no blocking processes defined, using VoceVista Video Pro as default
2025-11-13 08:50:44 : INFO  : vocevistavideopro : name: VoceVista Video Pro, appName: VoceVista Video Pro.app
2025-11-13 08:50:44 : WARN  : vocevistavideopro : No previous app found
2025-11-13 08:50:44 : WARN  : vocevistavideopro : could not find VoceVista Video Pro.app
2025-11-13 08:50:44 : INFO  : vocevistavideopro : appversion: 
2025-11-13 08:50:44 : INFO  : vocevistavideopro : Latest version of VoceVista Video Pro is 5.10.0.8802
2025-11-13 08:50:44 : REQ   : vocevistavideopro : Downloading https://download.sygyt.com/5.10.0/VoceVistaVideoPro_macOS_5.10.0.8802.dmg to VoceVista Video Pro.dmg
2025-11-13 08:50:54 : INFO  : vocevistavideopro : Downloaded VoceVista Video Pro.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 46ae6f2fc6e1d3ec23bb95a70887411200178533 – Size is 99084 kB
2025-11-13 08:50:55 : REQ   : vocevistavideopro : no more blocking processes, continue with update
2025-11-13 08:50:55 : REQ   : vocevistavideopro : Installing VoceVista Video Pro
2025-11-13 08:50:55 : INFO  : vocevistavideopro : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.DQudSKedf1/VoceVista Video Pro.dmg
2025-11-13 08:51:01 : INFO  : vocevistavideopro : Mounted: /Volumes/Install VoceVista Video Pro
2025-11-13 08:51:01 : INFO  : vocevistavideopro : Verifying: /Volumes/Install VoceVista Video Pro/VoceVista Video Pro.app
2025-11-13 08:51:09 : INFO  : vocevistavideopro : Team ID matching: MZ25LZ65AM (expected: MZ25LZ65AM )
2025-11-13 08:51:09 : INFO  : vocevistavideopro : Installing VoceVista Video Pro version 5.10.0 on versionKey CFBundleShortVersionString.
2025-11-13 08:51:09 : INFO  : vocevistavideopro : App has LSMinimumSystemVersion: 12
2025-11-13 08:51:09 : INFO  : vocevistavideopro : Copy /Volumes/Install VoceVista Video Pro/VoceVista Video Pro.app to /Applications
2025-11-13 08:51:14 : WARN  : vocevistavideopro : Changing owner to andreaslundberg
2025-11-13 08:51:14 : INFO  : vocevistavideopro : Finishing...
2025-11-13 08:51:17 : INFO  : vocevistavideopro : App(s) found: /Applications/VoceVista Video Pro.app
2025-11-13 08:51:17 : INFO  : vocevistavideopro : found app at /Applications/VoceVista Video Pro.app, version 5.10.0, on versionKey CFBundleShortVersionString
2025-11-13 08:51:17 : REQ   : vocevistavideopro : Installed VoceVista Video Pro, version 5.10.0
2025-11-13 08:51:17 : INFO  : vocevistavideopro : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-13 08:51:17 : INFO  : vocevistavideopro : Installomator did not close any apps, so no need to reopen any apps.
2025-11-13 08:51:17 : REQ   : vocevistavideopro : All done!
2025-11-13 08:51:17 : REQ   : vocevistavideopro : ################## End Installomator, exit code 0 
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
