### PR TITLE
Fix bitwarden Label

### DIFF
--- a/fragments/labels/bitwarden.sh
+++ b/fragments/labels/bitwarden.sh
@@ -3,5 +3,6 @@ bitwarden)
     type="dmg"
     appNewVersion=$(curl -s "https://github.com/bitwarden/clients/releases?q\=desktop" | xmllint --html --xpath 'substring-after(string(//h2[starts-with(text(),"Desktop v")]), " v")' - 2>/dev/null)
     downloadURL="https://github.com/bitwarden/clients/releases/download/desktop-v${appNewVersion}/Bitwarden-${appNewVersion}-universal.dmg"
+    expectedVolumeName="Bitwarden ${appNewVersion}-universal"
     expectedTeamID="LTZ2PFU5D6"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
No

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Added the variable `expectedVolumeName="Bitwarden ${appNewVersion}-universal"` to tell the correct Volume Name.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-11-17 09:06:23 : INFO  : bitwarden : setting variable from argument LOGGING=INFO
2025-11-17 09:06:23 : INFO  : bitwarden : Total items in argumentsArray: 1
2025-11-17 09:06:23 : INFO  : bitwarden : argumentsArray: LOGGING=INFO
2025-11-17 09:06:23 : REQ   : bitwarden : ################## Start Installomator v. 10.9beta, date 2025-11-17
2025-11-17 09:06:23 : INFO  : bitwarden : ################## Version: 10.9beta
2025-11-17 09:06:23 : INFO  : bitwarden : ################## Date: 2025-11-17
2025-11-17 09:06:23 : INFO  : bitwarden : ################## bitwarden
2025-11-17 09:06:24 : DEBUG : bitwarden : DEBUG mode 1 enabled.
2025-11-17 09:06:24 : INFO  : bitwarden : Reading arguments again: LOGGING=INFO
2025-11-17 09:06:24 : DEBUG : bitwarden : argument: LOGGING=INFO
2025-11-17 09:06:24 : INFO  : bitwarden : BLOCKING_PROCESS_ACTION=tell_user
2025-11-17 09:06:24 : INFO  : bitwarden : NOTIFY=success
2025-11-17 09:06:24 : INFO  : bitwarden : LOGGING=INFO
2025-11-17 09:06:24 : INFO  : bitwarden : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-17 09:06:24 : INFO  : bitwarden : Label type: dmg
2025-11-17 09:06:24 : INFO  : bitwarden : archiveName: Bitwarden.dmg
2025-11-17 09:06:24 : INFO  : bitwarden : no blocking processes defined, using Bitwarden as default
2025-11-17 09:06:24 : INFO  : bitwarden : App(s) found: /Applications/Bitwarden.app
2025-11-17 09:06:24 : INFO  : bitwarden : found app at /Applications/Bitwarden.app, version 2025.11.0, on versionKey CFBundleShortVersionString
2025-11-17 09:06:24 : INFO  : bitwarden : appversion: 2025.11.0
2025-11-17 09:06:24 : INFO  : bitwarden : Latest version of Bitwarden is 2025.11.0
2025-11-17 09:06:24 : WARN  : bitwarden : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-11-17 09:06:24 : INFO  : bitwarden : Bitwarden.dmg exists and DEBUG mode 1 enabled, skipping download
2025-11-17 09:06:24 : REQ   : bitwarden : Installing Bitwarden
2025-11-17 09:06:24 : INFO  : bitwarden : Mounting ./Bitwarden.dmg
2025-11-17 09:06:25 : INFO  : bitwarden : Mounted: /Volumes/Bitwarden 2025.11.0-universal 1
2025-11-17 09:06:25 : INFO  : bitwarden : Verifying: /Volumes/Bitwarden 2025.11.0-universal 1/Bitwarden.app
2025-11-17 09:06:28 : INFO  : bitwarden : Team ID matching: LTZ2PFU5D6 (expected: LTZ2PFU5D6 )
2025-11-17 09:06:28 : INFO  : bitwarden : Downloaded version of Bitwarden is 2025.11.0 on versionKey CFBundleShortVersionString, same as installed.
2025-11-17 09:06:28 : REQ   : bitwarden : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
