### PR TITLE
Update download URL and version for Airflow

### DIFF
--- a/fragments/labels/airflow.sh
+++ b/fragments/labels/airflow.sh
@@ -1,6 +1,12 @@
 airflow)
     name="Air"
     type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="Air-arm64.dmg"
+
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="Air-x64.dmg"
+    fi
     downloadURL="$(downloadURLFromGit AirLabsTeam airflow-releases)"
     appNewVersion="$(versionFromGit AirLabsTeam airflow-releases)"
     expectedTeamID="8RBYE8TY7T"


### PR DESCRIPTION
Hey all!

I want to flag that the releases link you have for Air Flow is outdated. This PR should fix that. We're over at https://github.com/AirLabsTeam/airflow-releases ever since we released version 4.0.0 onwards. You can verify this is the correct link via our official marketing page: http://air.inc/air-flow.

Let me know if you have any questions!

---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
