### PR TITLE
New label: LTspice

### DIFF
--- a/fragments/labels/ltspice.sh
+++ b/fragments/labels/ltspice.sh
@@ -1,0 +1,8 @@
+ltspice)
+    name="LTspice"
+    type="pkg"
+    packageID="com.analog.LTspice"
+    downloadURL="https://ltspice.analog.com/software/LTspice.pkg"
+    appNewVersion=$(curl -fs "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html" -H "Accept: text/html" -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Safari/605.1.15" -H "Accept-Encoding: gzip, deflate" --compressed | grep -oE '[0-9]+\.[0-9.]+' | sed -n '4p')
+    expectedTeamID="6ZM4J3A422"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Technically a dupe of #1933 but this one works

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-11-24 15:56:05 : INFO  : ltspice : setting variable from argument DEBUG=1
2025-11-24 15:56:05 : INFO  : ltspice : Total items in argumentsArray: 1
2025-11-24 15:56:05 : INFO  : ltspice : argumentsArray: DEBUG=1
2025-11-24 15:56:05 : REQ   : ltspice : ################## Start Installomator v. 10.9beta, date 2025-11-24
2025-11-24 15:56:05 : INFO  : ltspice : ################## Version: 10.9beta
2025-11-24 15:56:05 : INFO  : ltspice : ################## Date: 2025-11-24
2025-11-24 15:56:05 : INFO  : ltspice : ################## ltspice
2025-11-24 15:56:05 : DEBUG : ltspice : DEBUG mode 1 enabled.
2025-11-24 15:56:05 : INFO  : ltspice : Reading arguments again: DEBUG=1
2025-11-24 15:56:05 : DEBUG : ltspice : argument: DEBUG=1
2025-11-24 15:56:05 : DEBUG : ltspice : name=LTspice
2025-11-24 15:56:05 : DEBUG : ltspice : appName=
2025-11-24 15:56:05 : DEBUG : ltspice : type=pkg
2025-11-24 15:56:05 : DEBUG : ltspice : archiveName=
2025-11-24 15:56:05 : DEBUG : ltspice : downloadURL=https://ltspice.analog.com/software/LTspice.pkg
2025-11-24 15:56:05 : DEBUG : ltspice : curlOptions=
2025-11-24 15:56:05 : DEBUG : ltspice : appNewVersion=17.2.4
2025-11-24 15:56:05 : DEBUG : ltspice : appCustomVersion function: Not defined
2025-11-24 15:56:05 : DEBUG : ltspice : versionKey=CFBundleShortVersionString
2025-11-24 15:56:05 : DEBUG : ltspice : packageID=com.analog.LTspice
2025-11-24 15:56:05 : DEBUG : ltspice : pkgName=
2025-11-24 15:56:06 : DEBUG : ltspice : choiceChangesXML=
2025-11-24 15:56:06 : DEBUG : ltspice : expectedTeamID=6ZM4J3A422
2025-11-24 15:56:06 : DEBUG : ltspice : blockingProcesses=
2025-11-24 15:56:06 : DEBUG : ltspice : installerTool=
2025-11-24 15:56:06 : DEBUG : ltspice : CLIInstaller=
2025-11-24 15:56:06 : DEBUG : ltspice : CLIArguments=
2025-11-24 15:56:06 : DEBUG : ltspice : updateTool=
2025-11-24 15:56:06 : DEBUG : ltspice : updateToolArguments=
2025-11-24 15:56:06 : DEBUG : ltspice : updateToolRunAsCurrentUser=
2025-11-24 15:56:06 : INFO  : ltspice : BLOCKING_PROCESS_ACTION=tell_user
2025-11-24 15:56:06 : INFO  : ltspice : NOTIFY=success
2025-11-24 15:56:06 : INFO  : ltspice : LOGGING=DEBUG
2025-11-24 15:56:06 : INFO  : ltspice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-24 15:56:06 : INFO  : ltspice : Label type: pkg
2025-11-24 15:56:06 : INFO  : ltspice : archiveName: LTspice.pkg
2025-11-24 15:56:06 : INFO  : ltspice : no blocking processes defined, using LTspice as default
2025-11-24 15:56:06 : DEBUG : ltspice : Changing directory to /Users/aahgr/Documents/Installomator/build
2025-11-24 15:56:06 : INFO  : ltspice : found packageID com.analog.LTspice installed, version 17.2.4
2025-11-24 15:56:06 : INFO  : ltspice : appversion: 17.2.4
2025-11-24 15:56:06 : INFO  : ltspice : Latest version of LTspice is 17.2.4
2025-11-24 15:56:06 : WARN  : ltspice : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-11-24 15:56:06 : INFO  : ltspice : LTspice.pkg exists and DEBUG mode 1 enabled, skipping download
2025-11-24 15:56:06 : DEBUG : ltspice : DEBUG mode 1, not checking for blocking processes
2025-11-24 15:56:06 : REQ   : ltspice : Installing LTspice
2025-11-24 15:56:06 : INFO  : ltspice : Verifying: LTspice.pkg
2025-11-24 15:56:06 : DEBUG : ltspice : File list: -rw-r--r--  1 root  staff    96M Nov 24 15:54 LTspice.pkg
2025-11-24 15:56:06 : DEBUG : ltspice : File type: LTspice.pkg: xar archive compressed TOC: 5556, SHA-1 checksum
2025-11-24 15:56:06 : DEBUG : ltspice : spctlOut is LTspice.pkg: accepted
2025-11-24 15:56:06 : DEBUG : ltspice : source=Notarized Developer ID
2025-11-24 15:56:06 : DEBUG : ltspice : origin=Developer ID Installer: German Ergueta (6ZM4J3A422)
2025-11-24 15:56:06 : INFO  : ltspice : Team ID: 6ZM4J3A422 (expected: 6ZM4J3A422 )
2025-11-24 15:56:06 : INFO  : ltspice : Checking package version.
2025-11-24 15:56:07 : INFO  : ltspice : Downloaded package com.analog.LTspice version 17.2.4
2025-11-24 15:56:07 : INFO  : ltspice : Downloaded version of LTspice is the same as installed.
2025-11-24 15:56:07 : DEBUG : ltspice : DEBUG mode 1, not reopening anything
2025-11-24 15:56:07 : REQ   : ltspice : No new version to install
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
