### PR TITLE
new label for creative force kelvin

### DIFF
--- a/fragments/labels/creativeforcekelvin.sh
+++ b/fragments/labels/creativeforcekelvin.sh
@@ -1,0 +1,12 @@
+creativeforcekelvin)
+    name="Kelvin"
+    baseURL="https://download.creativeforce.io/released-files.042024/prod/kelvin/mac"
+    appNewVersion="$(curl -s $baseURL/latest-mac.yml | awk '/version:/ { print $2 }')"
+    type="pkg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="$baseURL/Kelvin-$appNewVersion-mac-arm64.pkg"
+    else
+        downloadURL="$baseURL/Kelvin-$appNewVersion-mac.pkg"
+    fi
+    expectedTeamID="Y5K3N5Y6PY"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**


```
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : Total items in argumentsArray: 0
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : argumentsArray: 
2025-11-25 15:44:20 : REQ   : creativeforcekelvin : ################## Start Installomator v. 10.9beta, date 2025-11-25
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : ################## Version: 10.9beta
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : ################## Date: 2025-11-25
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : ################## creativeforcekelvin
2025-11-25 15:44:20 : DEBUG : creativeforcekelvin : DEBUG mode 1 enabled.
2025-11-25 15:44:20 : INFO  : creativeforcekelvin : SwiftDialog is not installed, clear cmd file var
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : Reading arguments again: 
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : name=Kelvin
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : appName=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : type=pkg
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : archiveName=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : downloadURL=https://download.creativeforce.io/released-files.042024/prod/kelvin/mac/Kelvin-5.36.0-mac-arm64.pkg
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : curlOptions=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : appNewVersion=5.36.0
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : appCustomVersion function: Not defined
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : versionKey=CFBundleShortVersionString
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : packageID=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : pkgName=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : choiceChangesXML=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : expectedTeamID=Y5K3N5Y6PY
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : blockingProcesses=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : installerTool=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : CLIInstaller=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : CLIArguments=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : updateTool=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : updateToolArguments=
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : updateToolRunAsCurrentUser=
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : BLOCKING_PROCESS_ACTION=tell_user
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : NOTIFY=success
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : LOGGING=DEBUG
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : Label type: pkg
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : archiveName: Kelvin.pkg
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : no blocking processes defined, using Kelvin as default
2025-11-25 15:44:21 : DEBUG : creativeforcekelvin : Changing directory to /Users/armin/Developer/GitHub/Installomator/Installomator/build
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : name: Kelvin, appName: Kelvin.app
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : App(s) found: /Users/armin/Downloads/Kelvin.app
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : found app at /Users/armin/Downloads/Kelvin.app, version 5.36.0, on versionKey CFBundleShortVersionString
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : appversion: 5.36.0
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : Latest version of Kelvin is 5.36.0
2025-11-25 15:44:21 : WARN  : creativeforcekelvin : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-11-25 15:44:21 : INFO  : creativeforcekelvin : Kelvin.pkg exists and DEBUG mode 1 enabled, skipping download
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : DEBUG mode 1, not checking for blocking processes
2025-11-25 15:44:22 : REQ   : creativeforcekelvin : Installing Kelvin
2025-11-25 15:44:22 : INFO  : creativeforcekelvin : Verifying: Kelvin.pkg
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : File list: -rw-r--r--  1 armin  staff   454M Nov 25 15:43 Kelvin.pkg
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : File type: Kelvin.pkg: xar archive compressed TOC: 4933, SHA-1 checksum
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : spctlOut is Kelvin.pkg: accepted
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : source=Notarized Developer ID
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : origin=Developer ID Installer: Creativeforce.io, Inc. (Y5K3N5Y6PY)
2025-11-25 15:44:22 : INFO  : creativeforcekelvin : Team ID: Y5K3N5Y6PY (expected: Y5K3N5Y6PY )
2025-11-25 15:44:22 : DEBUG : creativeforcekelvin : DEBUG enabled, skipping installation
2025-11-25 15:44:22 : INFO  : creativeforcekelvin : Finishing...
2025-11-25 15:44:25 : INFO  : creativeforcekelvin : name: Kelvin, appName: Kelvin.app
2025-11-25 15:44:25 : INFO  : creativeforcekelvin : App(s) found: /Users/armin/Downloads/Kelvin.app
2025-11-25 15:44:25 : INFO  : creativeforcekelvin : found app at /Users/armin/Downloads/Kelvin.app, version 5.36.0, on versionKey CFBundleShortVersionString
2025-11-25 15:44:25 : REQ   : creativeforcekelvin : Installed Kelvin, version 5.36.0
2025-11-25 15:44:25 : INFO  : creativeforcekelvin : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-25 15:44:25 : DEBUG : creativeforcekelvin : DEBUG mode 1, not reopening anything
2025-11-25 15:44:25 : REQ   : creativeforcekelvin : All done!
2025-11-25 15:44:25 : REQ   : creativeforcekelvin : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
