### PR TITLE
new label for creative force hue

### DIFF
--- a/fragments/labels/creativeforcehue.sh
+++ b/fragments/labels/creativeforcehue.sh
@@ -1,0 +1,12 @@
+creativeforcehue)
+    name="Hue"
+    baseURL="https://download.creativeforce.io/released-files.042024/prod/hue-uxp/mac"
+    appNewVersion="$(curl -s $baseURL/latest-mac.yml | awk '/version:/ { print $2 }')"
+    type="pkg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="$baseURL/Hue-$appNewVersion-mac-arm64.pkg"
+    else
+        downloadURL="$baseURL/Hue-$appNewVersion-mac.pkg"
+    fi
+    expectedTeamID="Y5K3N5Y6PY"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**


```
2025-11-25 15:52:29 : INFO  : creativeforcehue : Total items in argumentsArray: 0
2025-11-25 15:52:29 : INFO  : creativeforcehue : argumentsArray: 
2025-11-25 15:52:29 : REQ   : creativeforcehue : ################## Start Installomator v. 10.9beta, date 2025-11-25
2025-11-25 15:52:29 : INFO  : creativeforcehue : ################## Version: 10.9beta
2025-11-25 15:52:29 : INFO  : creativeforcehue : ################## Date: 2025-11-25
2025-11-25 15:52:29 : INFO  : creativeforcehue : ################## creativeforcehue
2025-11-25 15:52:29 : DEBUG : creativeforcehue : DEBUG mode 1 enabled.
2025-11-25 15:52:29 : INFO  : creativeforcehue : SwiftDialog is not installed, clear cmd file var
2025-11-25 15:52:30 : INFO  : creativeforcehue : Reading arguments again: 
2025-11-25 15:52:30 : DEBUG : creativeforcehue : name=Hue
2025-11-25 15:52:30 : DEBUG : creativeforcehue : appName=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : type=pkg
2025-11-25 15:52:30 : DEBUG : creativeforcehue : archiveName=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : downloadURL=https://download.creativeforce.io/released-files.042024/prod/hue-uxp/mac/Hue-5.28.0-mac-arm64.pkg
2025-11-25 15:52:30 : DEBUG : creativeforcehue : curlOptions=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : appNewVersion=5.28.0
2025-11-25 15:52:30 : DEBUG : creativeforcehue : appCustomVersion function: Not defined
2025-11-25 15:52:30 : DEBUG : creativeforcehue : versionKey=CFBundleShortVersionString
2025-11-25 15:52:30 : DEBUG : creativeforcehue : packageID=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : pkgName=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : choiceChangesXML=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : expectedTeamID=Y5K3N5Y6PY
2025-11-25 15:52:30 : DEBUG : creativeforcehue : blockingProcesses=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : installerTool=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : CLIInstaller=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : CLIArguments=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : updateTool=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : updateToolArguments=
2025-11-25 15:52:30 : DEBUG : creativeforcehue : updateToolRunAsCurrentUser=
2025-11-25 15:52:30 : INFO  : creativeforcehue : BLOCKING_PROCESS_ACTION=tell_user
2025-11-25 15:52:30 : INFO  : creativeforcehue : NOTIFY=success
2025-11-25 15:52:30 : INFO  : creativeforcehue : LOGGING=DEBUG
2025-11-25 15:52:30 : INFO  : creativeforcehue : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-25 15:52:30 : INFO  : creativeforcehue : Label type: pkg
2025-11-25 15:52:30 : INFO  : creativeforcehue : archiveName: Hue.pkg
2025-11-25 15:52:30 : INFO  : creativeforcehue : no blocking processes defined, using Hue as default
2025-11-25 15:52:30 : DEBUG : creativeforcehue : Changing directory to /Users/armin/Developer/GitHub/Installomator/Installomator/build
2025-11-25 15:52:30 : INFO  : creativeforcehue : name: Hue, appName: Hue.app
2025-11-25 15:52:31 : WARN  : creativeforcehue : No previous app found
2025-11-25 15:52:31 : WARN  : creativeforcehue : could not find Hue.app
2025-11-25 15:52:31 : INFO  : creativeforcehue : appversion: 
2025-11-25 15:52:31 : INFO  : creativeforcehue : Latest version of Hue is 5.28.0
2025-11-25 15:52:31 : REQ   : creativeforcehue : Downloading https://download.creativeforce.io/released-files.042024/prod/hue-uxp/mac/Hue-5.28.0-mac-arm64.pkg to Hue.pkg
2025-11-25 15:52:31 : DEBUG : creativeforcehue : No Dialog connection, just download
2025-11-25 15:52:37 : INFO  : creativeforcehue : Downloaded Hue.pkg – Type is  xar archive compressed TOC – SHA is dc9dd2afe7cce313e193989a31d66c95358c831a – Size is 246184 kB
2025-11-25 15:52:37 : DEBUG : creativeforcehue : DEBUG mode 1, not checking for blocking processes
2025-11-25 15:52:37 : REQ   : creativeforcehue : Installing Hue
2025-11-25 15:52:37 : INFO  : creativeforcehue : Verifying: Hue.pkg
2025-11-25 15:52:37 : DEBUG : creativeforcehue : File list: -rw-r--r--  1 armin  staff   231M Nov 25 15:52 Hue.pkg
2025-11-25 15:52:37 : DEBUG : creativeforcehue : File type: Hue.pkg: xar archive compressed TOC: 4941, SHA-1 checksum
2025-11-25 15:52:37 : DEBUG : creativeforcehue : spctlOut is Hue.pkg: accepted
2025-11-25 15:52:37 : DEBUG : creativeforcehue : source=Notarized Developer ID
2025-11-25 15:52:37 : DEBUG : creativeforcehue : origin=Developer ID Installer: Creativeforce.io, Inc. (Y5K3N5Y6PY)
2025-11-25 15:52:37 : INFO  : creativeforcehue : Team ID: Y5K3N5Y6PY (expected: Y5K3N5Y6PY )
2025-11-25 15:52:37 : DEBUG : creativeforcehue : DEBUG enabled, skipping installation
2025-11-25 15:52:37 : INFO  : creativeforcehue : Finishing...
2025-11-25 15:52:40 : INFO  : creativeforcehue : name: Hue, appName: Hue.app
2025-11-25 15:52:40 : WARN  : creativeforcehue : No previous app found
2025-11-25 15:52:40 : WARN  : creativeforcehue : could not find Hue.app
2025-11-25 15:52:40 : REQ   : creativeforcehue : Installed Hue, version 5.28.0
2025-11-25 15:52:40 : INFO  : creativeforcehue : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-25 15:52:40 : DEBUG : creativeforcehue : DEBUG mode 1, not reopening anything
2025-11-25 15:52:40 : REQ   : creativeforcehue : All done!
2025-11-25 15:52:41 : REQ   : creativeforcehue : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
