### PR TITLE
new label for creative force triad

### DIFF
--- a/fragments/labels/creativeforcetriad.sh
+++ b/fragments/labels/creativeforcetriad.sh
@@ -1,0 +1,8 @@
+creativeforcetriad)
+    name="Triad"
+    baseURL="https://download.creativeforce.io/released-files.042024/prod/triad/mac"
+    appNewVersion="$(curl -s $baseURL/latest-mac.yml | awk '/version:/ { print $2 }')"
+    type="pkg"
+    downloadURL="$baseURL/Triad-$appNewVersion-mac.pkg"
+    expectedTeamID="Y5K3N5Y6PY"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-11-25 16:07:00 : INFO  : creativeforcetriad : Total items in argumentsArray: 0
2025-11-25 16:07:00 : INFO  : creativeforcetriad : argumentsArray: 
2025-11-25 16:07:00 : REQ   : creativeforcetriad : ################## Start Installomator v. 10.9beta, date 2025-11-25
2025-11-25 16:07:00 : INFO  : creativeforcetriad : ################## Version: 10.9beta
2025-11-25 16:07:01 : INFO  : creativeforcetriad : ################## Date: 2025-11-25
2025-11-25 16:07:01 : INFO  : creativeforcetriad : ################## creativeforcetriad
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : DEBUG mode 1 enabled.
2025-11-25 16:07:01 : INFO  : creativeforcetriad : SwiftDialog is not installed, clear cmd file var
2025-11-25 16:07:01 : INFO  : creativeforcetriad : Reading arguments again: 
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : name=Triad
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : appName=
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : type=pkg
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : archiveName=
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : downloadURL=https://download.creativeforce.io/released-files.042024/prod/triad/mac/Triad-4.4.0-mac.pkg
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : curlOptions=
2025-11-25 16:07:01 : DEBUG : creativeforcetriad : appNewVersion=4.4.0
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : appCustomVersion function: Not defined
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : versionKey=CFBundleShortVersionString
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : packageID=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : pkgName=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : choiceChangesXML=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : expectedTeamID=Y5K3N5Y6PY
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : blockingProcesses=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : installerTool=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : CLIInstaller=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : CLIArguments=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : updateTool=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : updateToolArguments=
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : updateToolRunAsCurrentUser=
2025-11-25 16:07:02 : INFO  : creativeforcetriad : BLOCKING_PROCESS_ACTION=tell_user
2025-11-25 16:07:02 : INFO  : creativeforcetriad : NOTIFY=success
2025-11-25 16:07:02 : INFO  : creativeforcetriad : LOGGING=DEBUG
2025-11-25 16:07:02 : INFO  : creativeforcetriad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-25 16:07:02 : INFO  : creativeforcetriad : Label type: pkg
2025-11-25 16:07:02 : INFO  : creativeforcetriad : archiveName: Triad.pkg
2025-11-25 16:07:02 : INFO  : creativeforcetriad : no blocking processes defined, using Triad as default
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : Changing directory to /Users/armin/Developer/GitHub/Installomator/Installomator/build
2025-11-25 16:07:02 : INFO  : creativeforcetriad : name: Triad, appName: Triad.app
2025-11-25 16:07:02 : WARN  : creativeforcetriad : No previous app found
2025-11-25 16:07:02 : WARN  : creativeforcetriad : could not find Triad.app
2025-11-25 16:07:02 : INFO  : creativeforcetriad : appversion: 
2025-11-25 16:07:02 : INFO  : creativeforcetriad : Latest version of Triad is 4.4.0
2025-11-25 16:07:02 : REQ   : creativeforcetriad : Downloading https://download.creativeforce.io/released-files.042024/prod/triad/mac/Triad-4.4.0-mac.pkg to Triad.pkg
2025-11-25 16:07:02 : DEBUG : creativeforcetriad : No Dialog connection, just download
2025-11-25 16:07:05 : INFO  : creativeforcetriad : Downloaded Triad.pkg – Type is  xar archive compressed TOC – SHA is f115e5fa7c150217522636b26d0b189b0e171142 – Size is 82836 kB
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : DEBUG mode 1, not checking for blocking processes
2025-11-25 16:07:05 : REQ   : creativeforcetriad : Installing Triad
2025-11-25 16:07:05 : INFO  : creativeforcetriad : Verifying: Triad.pkg
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : File list: -rw-r--r--  1 armin  staff    78M Nov 25 16:07 Triad.pkg
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : File type: Triad.pkg: xar archive compressed TOC: 4842, SHA-1 checksum
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : spctlOut is Triad.pkg: accepted
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : source=Notarized Developer ID
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : origin=Developer ID Installer: Creativeforce.io, Inc. (Y5K3N5Y6PY)
2025-11-25 16:07:05 : INFO  : creativeforcetriad : Team ID: Y5K3N5Y6PY (expected: Y5K3N5Y6PY )
2025-11-25 16:07:05 : DEBUG : creativeforcetriad : DEBUG enabled, skipping installation
2025-11-25 16:07:05 : INFO  : creativeforcetriad : Finishing...
2025-11-25 16:07:08 : INFO  : creativeforcetriad : name: Triad, appName: Triad.app
2025-11-25 16:07:08 : WARN  : creativeforcetriad : No previous app found
2025-11-25 16:07:08 : WARN  : creativeforcetriad : could not find Triad.app
2025-11-25 16:07:09 : REQ   : creativeforcetriad : Installed Triad, version 4.4.0
2025-11-25 16:07:09 : INFO  : creativeforcetriad : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-25 16:07:09 : DEBUG : creativeforcetriad : DEBUG mode 1, not reopening anything
2025-11-25 16:07:09 : REQ   : creativeforcetriad : All done!
2025-11-25 16:07:09 : REQ   : creativeforcetriad : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
