### PR TITLE
new label for creative force luma

### DIFF
--- a/fragments/labels/creativeforceluma.sh
+++ b/fragments/labels/creativeforceluma.sh
@@ -1,0 +1,12 @@
+creativeforceluma)
+    name="Luma"
+    baseURL="https://download.creativeforce.io/released-files.042024/prod/luma/mac"
+    appNewVersion="$(curl -s $baseURL/latest-mac.yml | awk '/version:/ { print $2 }')"
+    type="pkg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="$baseURL/Luma-$appNewVersion-mac-arm64.pkg"
+    else
+        downloadURL="$baseURL/Luma-$appNewVersion-mac.pkg"
+    fi
+    expectedTeamID="Y5K3N5Y6PY"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-11-25 16:11:35 : INFO  : creativeforceluma : Total items in argumentsArray: 0
2025-11-25 16:11:35 : INFO  : creativeforceluma : argumentsArray: 
2025-11-25 16:11:35 : REQ   : creativeforceluma : ################## Start Installomator v. 10.9beta, date 2025-11-25
2025-11-25 16:11:35 : INFO  : creativeforceluma : ################## Version: 10.9beta
2025-11-25 16:11:35 : INFO  : creativeforceluma : ################## Date: 2025-11-25
2025-11-25 16:11:35 : INFO  : creativeforceluma : ################## creativeforceluma
2025-11-25 16:11:35 : DEBUG : creativeforceluma : DEBUG mode 1 enabled.
2025-11-25 16:11:36 : INFO  : creativeforceluma : SwiftDialog is not installed, clear cmd file var
2025-11-25 16:11:36 : INFO  : creativeforceluma : Reading arguments again: 
2025-11-25 16:11:36 : DEBUG : creativeforceluma : name=Luma
2025-11-25 16:11:36 : DEBUG : creativeforceluma : appName=
2025-11-25 16:11:36 : DEBUG : creativeforceluma : type=pkg
2025-11-25 16:11:36 : DEBUG : creativeforceluma : archiveName=
2025-11-25 16:11:36 : DEBUG : creativeforceluma : downloadURL=https://download.creativeforce.io/released-files.042024/prod/luma/mac/Luma-1.13.0-mac-arm64.pkg
2025-11-25 16:11:36 : DEBUG : creativeforceluma : curlOptions=
2025-11-25 16:11:36 : DEBUG : creativeforceluma : appNewVersion=1.13.0
2025-11-25 16:11:36 : DEBUG : creativeforceluma : appCustomVersion function: Not defined
2025-11-25 16:11:36 : DEBUG : creativeforceluma : versionKey=CFBundleShortVersionString
2025-11-25 16:11:36 : DEBUG : creativeforceluma : packageID=
2025-11-25 16:11:36 : DEBUG : creativeforceluma : pkgName=
2025-11-25 16:11:36 : DEBUG : creativeforceluma : choiceChangesXML=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : expectedTeamID=Y5K3N5Y6PY
2025-11-25 16:11:37 : DEBUG : creativeforceluma : blockingProcesses=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : installerTool=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : CLIInstaller=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : CLIArguments=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : updateTool=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : updateToolArguments=
2025-11-25 16:11:37 : DEBUG : creativeforceluma : updateToolRunAsCurrentUser=
2025-11-25 16:11:37 : INFO  : creativeforceluma : BLOCKING_PROCESS_ACTION=tell_user
2025-11-25 16:11:37 : INFO  : creativeforceluma : NOTIFY=success
2025-11-25 16:11:37 : INFO  : creativeforceluma : LOGGING=DEBUG
2025-11-25 16:11:37 : INFO  : creativeforceluma : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-11-25 16:11:37 : INFO  : creativeforceluma : Label type: pkg
2025-11-25 16:11:37 : INFO  : creativeforceluma : archiveName: Luma.pkg
2025-11-25 16:11:37 : INFO  : creativeforceluma : no blocking processes defined, using Luma as default
2025-11-25 16:11:37 : DEBUG : creativeforceluma : Changing directory to /Users/armin/Developer/GitHub/Installomator/Installomator/build
2025-11-25 16:11:37 : INFO  : creativeforceluma : name: Luma, appName: Luma.app
2025-11-25 16:11:37 : WARN  : creativeforceluma : No previous app found
2025-11-25 16:11:37 : WARN  : creativeforceluma : could not find Luma.app
2025-11-25 16:11:37 : INFO  : creativeforceluma : appversion: 
2025-11-25 16:11:37 : INFO  : creativeforceluma : Latest version of Luma is 1.13.0
2025-11-25 16:11:37 : REQ   : creativeforceluma : Downloading https://download.creativeforce.io/released-files.042024/prod/luma/mac/Luma-1.13.0-mac-arm64.pkg to Luma.pkg
2025-11-25 16:11:37 : DEBUG : creativeforceluma : No Dialog connection, just download
2025-11-25 16:11:46 : INFO  : creativeforceluma : Downloaded Luma.pkg – Type is  xar archive compressed TOC – SHA is 61a8f8b8d973093de7b52ad98a32ec18e73e174c – Size is 245776 kB
2025-11-25 16:11:46 : DEBUG : creativeforceluma : DEBUG mode 1, not checking for blocking processes
2025-11-25 16:11:46 : REQ   : creativeforceluma : Installing Luma
2025-11-25 16:11:46 : INFO  : creativeforceluma : Verifying: Luma.pkg
2025-11-25 16:11:46 : DEBUG : creativeforceluma : File list: -rw-r--r--  1 armin  staff   231M Nov 25 16:11 Luma.pkg
2025-11-25 16:11:46 : DEBUG : creativeforceluma : File type: Luma.pkg: xar archive compressed TOC: 4739, SHA-1 checksum
2025-11-25 16:11:46 : DEBUG : creativeforceluma : spctlOut is Luma.pkg: accepted
2025-11-25 16:11:46 : DEBUG : creativeforceluma : source=Notarized Developer ID
2025-11-25 16:11:46 : DEBUG : creativeforceluma : origin=Developer ID Installer: Creativeforce.io, Inc. (Y5K3N5Y6PY)
2025-11-25 16:11:46 : INFO  : creativeforceluma : Team ID: Y5K3N5Y6PY (expected: Y5K3N5Y6PY )
2025-11-25 16:11:46 : DEBUG : creativeforceluma : DEBUG enabled, skipping installation
2025-11-25 16:11:46 : INFO  : creativeforceluma : Finishing...
2025-11-25 16:11:49 : INFO  : creativeforceluma : name: Luma, appName: Luma.app
2025-11-25 16:11:49 : WARN  : creativeforceluma : No previous app found
2025-11-25 16:11:49 : WARN  : creativeforceluma : could not find Luma.app
2025-11-25 16:11:49 : REQ   : creativeforceluma : Installed Luma, version 1.13.0
2025-11-25 16:11:49 : INFO  : creativeforceluma : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-11-25 16:11:49 : DEBUG : creativeforceluma : DEBUG mode 1, not reopening anything
2025-11-25 16:11:50 : REQ   : creativeforceluma : All done!
2025-11-25 16:11:50 : REQ   : creativeforceluma : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
