### PR TITLE
Fix dockutil check before adding to Dock

### DIFF
--- a/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
+++ b/MDM/MDMs with local installed Installomator/App-install SS with swiftDialog and dockutil/App normal SS.sh
@@ -257,7 +257,7 @@ cmdOutput="$(${destFile} ${item} LOGO=$LOGO ${installomatorOptions} ${installoma
 checkCmdOutput "${cmdOutput}"
 
 # Mark: dockutil stuff
-if [[ $addToDock -eq 1 ]]; then
+if [[ $addToDock -eq 1 && -d $dockutilAppPath ]]; then
     dialogUpdate "progresstext: Adding to Dock"
     if [[ ! -x $dockutil ]]; then
         echo "Cannot find dockutil at $dockutil, trying installation"


### PR DESCRIPTION
dockutil runs now only if the app is really installed.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
NO

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
NO - Used the GitHub Web Editor.

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
