### PR TITLE
Update boxdrive.sh

### DIFF
--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -1,6 +1,7 @@
 boxdrive)
     name="Box"
     type="pkg"
+    packageID="com.box.desktop.installer.desktop"
     downloadURL="https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg"
     expectedTeamID="M683GB7CPW"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Adds the PackageID for boxdrive, fixes version control in App Auto-Patch

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```2025-12-01 16:46:09 : INFO  : boxdrive : Total items in argumentsArray: 0
2025-12-01 16:46:09 : INFO  : boxdrive : argumentsArray:
2025-12-01 16:46:09 : REQ   : boxdrive : ################## Start Installomator v. 10.9beta-a3, date 2025-12-04
2025-12-01 16:46:09 : INFO  : boxdrive : ################## Version: 10.9beta-a3
2025-12-01 16:46:10 : INFO  : boxdrive : ################## Date: 2025-12-04
2025-12-01 16:46:10 : INFO  : boxdrive : ################## boxdrive
2025-12-01 16:46:10 : INFO  : boxdrive : Reading arguments again:
2025-12-01 16:46:10 : INFO  : boxdrive : BLOCKING_PROCESS_ACTION=tell_user_then_kill
2025-12-01 16:46:10 : INFO  : boxdrive : NOTIFY=silent
2025-12-01 16:46:10 : INFO  : boxdrive : LOGGING=INFO
2025-12-01 16:46:10 : INFO  : boxdrive : LOGO=/Library/Management/AcneStudiosBranding/ASIcon.icns
2025-12-01 16:46:10 : INFO  : boxdrive : Label type: pkg
2025-12-01 16:46:10 : INFO  : boxdrive : archiveName: Box.pkg
2025-12-01 16:46:10 : INFO  : boxdrive : no blocking processes defined, using Box as default
2025-12-01 16:46:10 : INFO  : boxdrive : found packageID com.box.desktop.installer.desktop installed, version 2.48.243
2025-12-01 16:46:10 : INFO  : boxdrive : appversion: 2.48.243
2025-12-01 16:46:10 : INFO  : boxdrive : Latest version not specified.
2025-12-01 16:46:10 : REQ   : boxdrive : Downloading https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg to Box.pkg
2025-12-01 16:46:12 : INFO  : boxdrive : Downloaded Box.pkg – Type is  xar archive compressed TOC – SHA is be5e7b3f5a77eff5d389159a6ae6b71f7d9ec46c – Size is 60048 kB
2025-12-01 16:46:12 : INFO  : boxdrive : found blocking process Box
2025-12-01 16:46:21 : INFO  : boxdrive : telling app Box to quit
2025-12-01 16:46:21 : INFO  : boxdrive : waiting 30 seconds for processes to quit
2025-12-01 16:46:51 : REQ   : boxdrive : no more blocking processes, continue with update
2025-12-01 16:46:51 : REQ   : boxdrive : Installing Box
2025-12-01 16:46:51 : INFO  : boxdrive : Verifying: Box.pkg
2025-12-01 16:46:51 : INFO  : boxdrive : Team ID: M683GB7CPW (expected: M683GB7CPW )
2025-12-01 16:46:51 : INFO  : boxdrive : Checking package version.
2025-12-01 16:46:52 : INFO  : boxdrive : Downloaded package com.box.desktop.installer.desktop version 2.48.243
2025-12-01 16:46:52 : INFO  : boxdrive : Downloaded version of Box is the same as installed.
2025-12-01 16:46:52 : INFO  : boxdrive : Telling app Box.app to open
2025-12-01 16:46:52 : INFO  : boxdrive : Reopened Box.app as max.sundell
2025-12-01 16:46:52 : REQ   : boxdrive : No new version to install
2025-12-01 16:46:52 : REQ   : boxdrive : ################## End Installomator, exit code 0
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Semi-fixes #2294 at least when running Installomator via App Auto-Patch
