### PR TITLE
Update spotify.sh

### DIFF
--- a/fragments/labels/spotify.sh
+++ b/fragments/labels/spotify.sh
@@ -6,6 +6,5 @@ spotify)
     elif [[ $(arch) == i386 ]]; then
         downloadURL="https://download.scdn.co/Spotify.dmg"
     fi
-    appNewVersion=$(curl -fs https://www.spotify.com/us/opensource/ | sed 's/","/\n/g' | grep "clientVersion" | sed -e 's/clientVersion":"\(.*\)"}.*bz2/\1/' | head -1 | awk -F "." '{print$1"."$2"."$3"."$4}')
     expectedTeamID="2FNC3A47ZF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Removes appNewVersion, since it does not return the same version as the app downloaded via downloadURL. This messes up version comparison. Was unable to find an reliable source for the latest version unfortunately.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-12-01 17:02:56 : INFO  : spotify : Total items in argumentsArray: 0
2025-12-01 17:02:56 : INFO  : spotify : argumentsArray:
2025-12-01 17:02:56 : REQ   : spotify : ################## Start Installomator v. 10.9beta-a3, date 2025-12-04
2025-12-01 17:02:56 : INFO  : spotify : ################## Version: 10.9beta-a3
2025-12-01 17:02:56 : INFO  : spotify : ################## Date: 2025-12-04
2025-12-01 17:02:56 : INFO  : spotify : ################## spotify
2025-12-01 17:02:56 : INFO  : spotify : Reading arguments again:
2025-12-01 17:02:56 : INFO  : spotify : BLOCKING_PROCESS_ACTION=tell_user_then_kill
2025-12-01 17:02:57 : INFO  : spotify : NOTIFY=silent
2025-12-01 17:02:57 : INFO  : spotify : LOGGING=INFO
2025-12-01 17:02:57 : INFO  : spotify : LOGO=/Library/Management/AcneStudiosBranding/ASIcon.icns
2025-12-01 17:02:57 : INFO  : spotify : Label type: dmg
2025-12-01 17:02:57 : INFO  : spotify : archiveName: Spotify.dmg
2025-12-01 17:02:57 : INFO  : spotify : no blocking processes defined, using Spotify as default
2025-12-01 17:02:57 : INFO  : spotify : App(s) found: /Applications/Spotify.app
2025-12-01 17:02:57 : INFO  : spotify : found app at /Applications/Spotify.app, version 1.2.77.358, on versionKey CFBundleShortVersionString
2025-12-01 17:02:57 : INFO  : spotify : appversion: 1.2.77.358
2025-12-01 17:02:57 : INFO  : spotify : Latest version not specified.
2025-12-01 17:02:57 : REQ   : spotify : Downloading https://download.scdn.co/SpotifyARM64.dmg to Spotify.dmg
2025-12-01 17:02:59 : INFO  : spotify : Downloaded Spotify.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is dd2358c25141c4133965bb2354e816fd094e6864 – Size is 148460 kB
2025-12-01 17:02:59 : REQ   : spotify : no more blocking processes, continue with update
2025-12-01 17:02:59 : REQ   : spotify : Installing Spotify
2025-12-01 17:02:59 : INFO  : spotify : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Ej9igAf3sC/Spotify.dmg
2025-12-01 17:03:06 : INFO  : spotify : Mounted: /Volumes/Spotify
2025-12-01 17:03:06 : INFO  : spotify : Verifying: /Volumes/Spotify/Spotify.app
2025-12-01 17:03:16 : INFO  : spotify : Team ID matching: 2FNC3A47ZF (expected: 2FNC3A47ZF )
2025-12-01 17:03:16 : INFO  : spotify : Downloaded version of Spotify is 1.2.77.358 on versionKey CFBundleShortVersionString, same as installed.
2025-12-01 17:03:16 : INFO  : spotify : Installomator did not close any apps, so no need to reopen any apps.
2025-12-01 17:03:16 : REQ   : spotify : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
