### PR TITLE
Fix appNewVersion format in shottr.sh

### DIFF
--- a/fragments/labels/shottr.sh
+++ b/fragments/labels/shottr.sh
@@ -3,5 +3,7 @@ shottr)
     type="dmg"
     downloadURL="https://shottr.cc$(curl -fs "https://shottr.cc/newversion.html" | grep -o '\/dl\/Shottr-[0-9.]*\.dmg' | head -1 | xargs)"
     appNewVersion=$(echo $downloadURL | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 | xargs)
+    [[ "$appNewVersion" =~ ^[0-9]+\.[0-9]+$ ]] && appNewVersion="${appNewVersion}.0"
     expectedTeamID="2Y683PRQWN"
     ;;
+    

--- a/fragments/labels/shottr.sh
+++ b/fragments/labels/shottr.sh
@@ -6,4 +6,3 @@ shottr)
     [[ "$appNewVersion" =~ ^[0-9]+\.[0-9]+$ ]] && appNewVersion="${appNewVersion}.0"
     expectedTeamID="2Y683PRQWN"
     ;;
-    


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Ensure appNewVersion has a third digit if needed.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2025-12-02 09:39:43 : INFO  : shottr : Total items in argumentsArray: 0
2025-12-02 09:39:43 : INFO  : shottr : argumentsArray:
2025-12-02 09:39:43 : REQ   : shottr : ################## Start Installomator v. 10.8, date 2025-03-28
2025-12-02 09:39:43 : INFO  : shottr : ################## Version: 10.8
2025-12-02 09:39:43 : INFO  : shottr : ################## Date: 2025-03-28
2025-12-02 09:39:43 : INFO  : shottr : ################## shottr
2025-12-02 09:39:44 : INFO  : shottr : Reading arguments again:
2025-12-02 09:39:44 : INFO  : shottr : BLOCKING_PROCESS_ACTION=tell_user
2025-12-02 09:39:44 : INFO  : shottr : NOTIFY=success
2025-12-02 09:39:44 : INFO  : shottr : LOGGING=INFO
2025-12-02 09:39:44 : INFO  : shottr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-02 09:39:44 : INFO  : shottr : Label type: dmg
2025-12-02 09:39:44 : INFO  : shottr : archiveName: Shottr.dmg
2025-12-02 09:39:44 : INFO  : shottr : no blocking processes defined, using Shottr as default
2025-12-02 09:39:44 : INFO  : shottr : App(s) found: /Applications/Shottr.app
2025-12-02 09:39:44 : INFO  : shottr : found app at /Applications/Shottr.app, version 1.9.0, on versionKey CFBundleShortVersionString
2025-12-02 09:39:44 : INFO  : shottr : appversion: 1.9.0
2025-12-02 09:39:44 : INFO  : shottr : Latest version of Shottr is 1.9.0
2025-12-02 09:39:44 : INFO  : shottr : There is no newer version available.
2025-12-02 09:39:44 : INFO  : shottr : Installomator did not close any apps, so no need to reopen any apps.
2025-12-02 09:39:44 : REQ   : shottr : No newer version.
2025-12-02 09:39:44 : REQ   : shottr : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2667 