### PR TITLE
Fix elgatocamerahub version checking - remove truncation and add appCustomVersion

### DIFF
--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -1,9 +1,14 @@
 elgatocamerahub)
     name="Elgato Camera Hub"
     type="pkg"
-    # packageID="com.elgato.CameraHub.Installer"
     downloadURL="https://gc-updates.elgato.com/mac/echm-update/final/download-website.php"
-    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3')
+    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g')
     expectedTeamID="Y93VXCB8Q5"
+    appCustomVersion() {
+        local infoPath="$1"
+        local version=$(defaults read "$infoPath" CFBundleShortVersionString 2>/dev/null)
+        local build=$(defaults read "$infoPath" CFBundleVersion 2>/dev/null)
+        echo "${version}.${build}"
+    }
     blockingProcesses=( "Camera Hub" )
     ;;

--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -2,7 +2,7 @@ elgatocamerahub)
     name="Elgato Camera Hub"
     type="pkg"
     downloadURL="https://gc-updates.elgato.com/mac/echm-update/final/download-website.php"
-    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g')
+    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*CameraHub_([0-9.]+)\.pkg/\1/g')
     expectedTeamID="Y93VXCB8Q5"
     appCustomVersion() {
         local infoPath="$1"

--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -1,15 +1,10 @@
 elgatocamerahub)
-       name="Elgato Camera Hub"
-       type="pkg"
-       elgatoJSON=$(curl -fsSL "https://gc-updates.elgato.com/mac/echm-update/final/app-version-check.json")
-       appNewVersion=$(echo "$elgatoJSON" | grep -o '"Version":"[^"]*"' | head -1 | cut -d'"' -f4)
-       downloadURL=$(echo "$elgatoJSON" | grep -o '"fileURL":"[^"]*"' | head -1 | cut -d'"' -f4)
-       appCustomVersion() {
-           local infoPath="$1"
-           local version=$(defaults read "$infoPath" CFBundleShortVersionString 2>/dev/null)
-           local build=$(defaults read "$infoPath" CFBundleVersion 2>/dev/null)
-           echo "${version}.${build}"
-       }
-       expectedTeamID="Y93VXCB8Q5"
-       blockingProcesses=( "Camera Hub" )
-       ;;
+    name="Elgato Camera Hub"
+    type="pkg"
+    elgatoJSON=$(curl -fsSL "https://gc-updates.elgato.com/mac/echm-update/final/app-version-check.json")
+    appNewVersion=$(getJSONValue "$elgatoJSON" "Automatic.Version")
+    downloadURL=$(getJSONValue "$elgatoJSON" "Automatic.fileURL")
+    appCustomVersion() { version=$(defaults read "/Applications/Camera Hub.app/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null); build=$(defaults read "/Applications/Camera Hub.app/Contents/Info.plist" CFBundleVersion 2>/dev/null); echo "${version}.${build}"; }
+    expectedTeamID="Y93VXCB8Q5"
+    blockingProcesses=( "Camera Hub" )
+    ;;

--- a/fragments/labels/elgatocamerahub.sh
+++ b/fragments/labels/elgatocamerahub.sh
@@ -1,14 +1,15 @@
 elgatocamerahub)
-    name="Elgato Camera Hub"
-    type="pkg"
-    downloadURL="https://gc-updates.elgato.com/mac/echm-update/final/download-website.php"
-    appNewVersion=$(curl -fsI "https://gc-updates.elgato.com/mac/echm-update/final/download-website.php" | grep -i ^location | sed -E 's/.*CameraHub_([0-9.]+)\.pkg/\1/g')
-    expectedTeamID="Y93VXCB8Q5"
-    appCustomVersion() {
-        local infoPath="$1"
-        local version=$(defaults read "$infoPath" CFBundleShortVersionString 2>/dev/null)
-        local build=$(defaults read "$infoPath" CFBundleVersion 2>/dev/null)
-        echo "${version}.${build}"
-    }
-    blockingProcesses=( "Camera Hub" )
-    ;;
+       name="Elgato Camera Hub"
+       type="pkg"
+       elgatoJSON=$(curl -fsSL "https://gc-updates.elgato.com/mac/echm-update/final/app-version-check.json")
+       appNewVersion=$(echo "$elgatoJSON" | grep -o '"Version":"[^"]*"' | head -1 | cut -d'"' -f4)
+       downloadURL=$(echo "$elgatoJSON" | grep -o '"fileURL":"[^"]*"' | head -1 | cut -d'"' -f4)
+       appCustomVersion() {
+           local infoPath="$1"
+           local version=$(defaults read "$infoPath" CFBundleShortVersionString 2>/dev/null)
+           local build=$(defaults read "$infoPath" CFBundleVersion 2>/dev/null)
+           echo "${version}.${build}"
+       }
+       expectedTeamID="Y93VXCB8Q5"
+       blockingProcesses=( "Camera Hub" )
+       ;;


### PR DESCRIPTION
Removed truncating sed from appNewVersion and added appCustomVersion() to properly compare version.build format for both installed and available versions. Fixes update loop issue.

**Have you confirmed this pull request is not a duplicate?**
Yes - Searched existing PRs and issues for "elgatocamerahub" and "camera hub" with no existing PR found for this issue.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes - This PR only modifies `fragments/labels/elgatocamerahub.sh`

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes - Followed editorconfig standards for shell scripts

---

## Issue
The `elgatocamerahub` label causes constant update attempts even when the latest version is already installed.

## Root Cause
Two problems were found:

1. **appNewVersion extracts incorrectly**: The current label uses `sed 's/\.[^.]*//3'` which truncates the version from `2.2.1.6945` to `2.2.1`, losing the build number.

2. **Installed version only checks short version**: By default, Installomator checks `CFBundleShortVersionString` which returns `2.2.1`, while the build number `6945` is stored separately in `CFBundleVersion`.

This results in comparing `2.2.1` (installed) vs `2.2.1` (available), causing Installomator to think they're identical when builds are actually different.

## Solution
Two changes were made:

1. **Fixed appNewVersion extraction**: Changed from:
```bash
   sed -E 's/.*Camera_Hub_([0-9.]*).pkg/\1/g' | sed 's/\.[^.]*//3'
```
   To:
```bash
   sed -E 's/.*CameraHub_([0-9.]+)\.pkg/\1/g'
```
   This correctly extracts the full version `2.2.1.6945` from the download URL and fixes the filename pattern (CameraHub vs Camera_Hub).

2. **Added appCustomVersion() function**: 
```bash
   appCustomVersion() {
       local infoPath="$1"
       local version=$(defaults read "$infoPath" CFBundleShortVersionString 2>/dev/null)
       local build=$(defaults read "$infoPath" CFBundleVersion 2>/dev/null)
       echo "${version}.${build}"
   }
```
   This combines the installed app's version (`2.2.1`) and build (`6945`) into the same format (`2.2.1.6945`) for accurate comparison.

Both changes are necessary to ensure the installed and available versions use the same `VERSION.BUILD` format.

## Testing
Tested on macOS 26.1 Tahoe with Installomator v10.9beta.

Note: Camera Hub was not installed on the test system, so installed version detection shows `.` in the log. However, the critical appNewVersion extraction is working correctly as demonstrated below.

## Future-Proof
This fix handles future version upgrades correctly. When Camera Hub 3.0 releases (potentially with reset build numbers):
- Current: `2.2.1.6945`
- Future: `3.0.0.100`
- Comparison: `2.2.1.6945` vs `3.0.0.100` → Correctly detects major version upgrade

## Additional context
Camera Hub uses a two-part versioning scheme:
- Marketing version (CFBundleShortVersionString): e.g., `2.2.1`
- Build number (CFBundleVersion): e.g., `6945`

Multiple builds are released within the same marketing version. The current label was unable to detect these build-level updates due to version truncation and not checking the build number from the installed app.

**Fixes:** No existing issue number (newly discovered bug)

---

```
## Installomator log

**Test run with DEBUG=1 on macOS 26.1 Tahoe:**
2025-12-02 15:37:37 : INFO  : elgatocamerahub : setting variable from argument DEBUG=1
2025-12-02 15:37:37 : INFO  : elgatocamerahub : Total items in argumentsArray: 1
2025-12-02 15:37:37 : INFO  : elgatocamerahub : argumentsArray: DEBUG=1
2025-12-02 15:37:37 : REQ   : elgatocamerahub : ################## Start Installomator v. 10.9beta, date 2025-12-02
2025-12-02 15:37:37 : INFO  : elgatocamerahub : ################## Version: 10.9beta
2025-12-02 15:37:37 : INFO  : elgatocamerahub : ################## Date: 2025-12-02
2025-12-02 15:37:37 : INFO  : elgatocamerahub : ################## elgatocamerahub
2025-12-02 15:37:37 : DEBUG : elgatocamerahub : DEBUG mode 1 enabled.
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Reading arguments again: DEBUG=1
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : argument: DEBUG=1
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : name=Elgato Camera Hub
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : appName=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : type=pkg
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : archiveName=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : downloadURL=https://gc-updates.elgato.com/mac/echm-update/final/download-website.php
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : curlOptions=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : appNewVersion=2.2.1.6945
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : appCustomVersion function: Defined. 
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : versionKey=CFBundleShortVersionString
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : packageID=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : pkgName=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : choiceChangesXML=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : expectedTeamID=Y93VXCB8Q5
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : blockingProcesses=Camera Hub
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : installerTool=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : CLIInstaller=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : CLIArguments=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : updateTool=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : updateToolArguments=
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : updateToolRunAsCurrentUser=
2025-12-02 15:37:38 : INFO  : elgatocamerahub : BLOCKING_PROCESS_ACTION=tell_user
2025-12-02 15:37:38 : INFO  : elgatocamerahub : NOTIFY=success
2025-12-02 15:37:38 : INFO  : elgatocamerahub : LOGGING=DEBUG
2025-12-02 15:37:38 : INFO  : elgatocamerahub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Label type: pkg
2025-12-02 15:37:38 : INFO  : elgatocamerahub : archiveName: Elgato Camera Hub.pkg
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : Changing directory to ~/Documents/GitHub/Installomator/build
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Custom App Version detection is used, found .
2025-12-02 15:37:38 : INFO  : elgatocamerahub : appversion: .
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Latest version of Elgato Camera Hub is 2.2.1.6945
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Elgato Camera Hub.pkg exists and DEBUG mode 1 enabled, skipping download
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : DEBUG mode 1, not checking for blocking processes
2025-12-02 15:37:38 : REQ   : elgatocamerahub : Installing Elgato Camera Hub
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Verifying: Elgato Camera Hub.pkg
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : File list: -rw-r--r--  1 root  staff   350M Dec  2 15:34 Elgato Camera Hub.pkg
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : File type: Elgato Camera Hub.pkg: xar archive compressed TOC: 6730, SHA-1 checksum
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : spctlOut is Elgato Camera Hub.pkg: accepted
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : source=Notarized Developer ID
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : origin=Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Team ID: Y93VXCB8Q5 (expected: Y93VXCB8Q5 )
2025-12-02 15:37:38 : DEBUG : elgatocamerahub : DEBUG enabled, skipping installation
2025-12-02 15:37:38 : INFO  : elgatocamerahub : Finishing...
2025-12-02 15:37:41 : INFO  : elgatocamerahub : Custom App Version detection is used, found .
2025-12-02 15:37:41 : REQ   : elgatocamerahub : Installed Elgato Camera Hub, version 2.2.1.6945
2025-12-02 15:37:41 : INFO  : elgatocamerahub : notifying
2025-12-02 15:37:41 : DEBUG : elgatocamerahub : DEBUG mode 1, not reopening anything
2025-12-02 15:37:41 : REQ   : elgatocamerahub : All done!
2025-12-02 15:37:41 : REQ   : elgatocamerahub : ################## End Installomator, exit code 0 
```

