### PR TITLE
obs-label-update

### DIFF
--- a/fragments/labels/obs.sh
+++ b/fragments/labels/obs.sh
@@ -1,15 +1,13 @@
 obs)
     name="OBS"
+    appName="OBS.app"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        SUFeedURL="https://obsproject.com/osx_update/updates_arm64_v2.xml"
+        archiveName="OBS-Studio-[0-9.]*-macOS-Apple.dmg"
     elif [[ $(arch) == "i386" ]]; then
-        SUFeedURL="https://obsproject.com/osx_update/updates_x86_64_v2.xml"
+        archiveName="OBS-Studio-[0-9.]*-macOS-Intel.dmg"
     fi
-    appNewVersion=$(curl -fs "$SUFeedURL" | xpath '(//rss/channel/item[sparkle:channel="stable"]/sparkle:shortVersionString/text())[1]' 2>/dev/null)
-    downloadURL=$(curl -fs "$SUFeedURL" | xpath 'string(//rss/channel/item[sparkle:channel="stable"]/enclosure/@url[1])' 2>/dev/null)
-    archiveName=$(basename "$downloadURL")   
-    versionKey="CFBundleShortVersionString"
-    blockingProcesses=( "OBS Studio" )
+    downloadURL=$(downloadURLFromGit obsproject obs-studio )
+    appNewVersion=$(versionFromGit obsproject obs-studio )
     expectedTeamID="2MMRE5MTB8"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh obs DEBUG=0
2025-12-08 08:41:36 : INFO  : obs : setting variable from argument DEBUG=0
2025-12-08 08:41:36 : INFO  : obs : Total items in argumentsArray: 1
2025-12-08 08:41:36 : INFO  : obs : argumentsArray: DEBUG=0
2025-12-08 08:41:36 : REQ   : obs : ################## Start Installomator v. 10.9beta, date 2025-12-08
2025-12-08 08:41:36 : INFO  : obs : ################## Version: 10.9beta
2025-12-08 08:41:36 : INFO  : obs : ################## Date: 2025-12-08
2025-12-08 08:41:36 : INFO  : obs : ################## obs
2025-12-08 08:41:37 : INFO  : obs : Reading arguments again: DEBUG=0
2025-12-08 08:41:37 : INFO  : obs : BLOCKING_PROCESS_ACTION=tell_user
2025-12-08 08:41:37 : INFO  : obs : NOTIFY=success
2025-12-08 08:41:37 : INFO  : obs : LOGGING=INFO
2025-12-08 08:41:37 : INFO  : obs : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-08 08:41:37 : INFO  : obs : Label type: dmg
2025-12-08 08:41:37 : INFO  : obs : archiveName: OBS-Studio-[0-9.]*-macOS-Apple.dmg
2025-12-08 08:41:37 : INFO  : obs : no blocking processes defined, using OBS as default
2025-12-08 08:41:37 : INFO  : obs : name: OBS, appName: OBS.app
2025-12-08 08:41:37 : WARN  : obs : No previous app found
2025-12-08 08:41:37 : WARN  : obs : could not find OBS.app
2025-12-08 08:41:38 : INFO  : obs : appversion:
2025-12-08 08:41:38 : INFO  : obs : Latest version of OBS is 32.0.3
2025-12-08 08:41:38 : REQ   : obs : Downloading https://github.com/obsproject/obs-studio/releases/download/32.0.3/OBS-Studio-32.0.3-macOS-Apple.dmg to OBS-Studio-[0-9.]*-macOS-Apple.dmg
2025-12-08 08:41:43 : INFO  : obs : Downloaded OBS-Studio-[0-9.]*-macOS-Apple.dmg – Type is  lzfse encoded, lzvn compressed – SHA is c292d3fed1699fc598f9e7018012f13f7069ad13 – Size is 197580 kB
2025-12-08 08:41:43 : REQ   : obs : no more blocking processes, continue with update
2025-12-08 08:41:43 : REQ   : obs : Installing OBS
2025-12-08 08:41:43 : INFO  : obs : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8JDE5QjL5i/OBS-Studio-[0-9.]*-macOS-Apple.dmg
2025-12-08 08:41:46 : INFO  : obs : Mounted: /Volumes/OBS Studio 32.0.3 (Apple) 1
2025-12-08 08:41:46 : INFO  : obs : Verifying: /Volumes/OBS Studio 32.0.3 (Apple) 1/OBS.app
2025-12-08 08:41:49 : INFO  : obs : Team ID matching: 2MMRE5MTB8 (expected: 2MMRE5MTB8 )
2025-12-08 08:41:49 : INFO  : obs : Installing OBS version 32.0.3 on versionKey CFBundleShortVersionString.
2025-12-08 08:41:49 : INFO  : obs : App has LSMinimumSystemVersion: 12.0
2025-12-08 08:41:49 : INFO  : obs : Copy /Volumes/OBS Studio 32.0.3 (Apple) 1/OBS.app to /Applications
2025-12-08 08:41:52 : WARN  : obs : Changing owner to u0105821
2025-12-08 08:41:53 : INFO  : obs : Finishing...
2025-12-08 08:41:56 : INFO  : obs : App(s) found: /Applications/OBS.app
2025-12-08 08:41:56 : INFO  : obs : found app at /Applications/OBS.app, version 32.0.3, on versionKey CFBundleShortVersionString
2025-12-08 08:41:56 : REQ   : obs : Installed OBS, version 32.0.3
2025-12-08 08:41:56 : INFO  : obs : notifying
2025-12-08 08:41:56 : INFO  : obs : Installomator did not close any apps, so no need to reopen any apps.
2025-12-08 08:41:56 : REQ   : obs : All done!
2025-12-08 08:41:56 : REQ   : obs : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

This update fixes the OBS label to work with the new DMG naming convention introduced by the OBS project starting with version 32.0.3. The archive name patterns have been updated to reflect the new capitalization (OBS-Studio instead of obs-studio, macOS instead of macos) and new architecture identifiers (Apple instead of arm64, Intel instead of x86_64). Additionally, an explicit appName="OBS.app" has been added to prevent the script from incorrectly matching Obsidian.app when searching for existing installations.