### PR TITLE
Update evernote.sh

### DIFF
--- a/fragments/labels/evernote.sh
+++ b/fragments/labels/evernote.sh
@@ -2,6 +2,6 @@ evernote)
     name="Evernote"
     type="dmg"
     downloadURL="https://mac.desktop.evernote.com/builds/Evernote-latest.dmg"
-    appNewVersion=$(curl -s https://evernote.com/release-notes | grep Latest | awk -F '<!-- -->' '{print $2}')
+    appNewVersion=$(curl -fs https://evernote.com/release-notes | sed -En 's/.*Version ([0-9.]+) - Latest.*/\1/p')
     expectedTeamID="Q79WDW8YH9"
     ;;

--- a/fragments/labels/evernote.sh
+++ b/fragments/labels/evernote.sh
@@ -1,7 +1,7 @@
 evernote)
     name="Evernote"
     type="dmg"
-    downloadURL="https://mac.desktop.evernote.com/builds/Evernote-latest.dmg"
-    appNewVersion=$(curl -fs https://evernote.com/release-notes | sed -En 's/.*Version ([0-9.]+) - Latest.*/\1/p')
+    downloadURL="$(curl -fs 'https://public.evernote.com/ddl-updater/updater/mac/public/latest-mac.yml' -H 'x-app-version: 11.00.0' -H 'x-os-release: 26.0.0' | awk -F'url:[[:space:]]*' '/url:[[:space:]]*.*\.dmg$/ { print $2 }')"
+    appNewVersion=$(curl -fs 'https://public.evernote.com/ddl-updater/updater/mac/public/latest-mac.yml' -H 'x-app-version: 11.00.0' -H 'x-os-release: 26.0.0' | awk -F': *' '/^version:/ { print $2 }')
     expectedTeamID="Q79WDW8YH9"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current appNewVersion variable for the evernote label doesn't work. This update fixes the appNewVersion variable.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2025-12-10 11:25:07 : INFO  : evernote : setting variable from argument DEBUG=0
2025-12-10 11:25:07 : INFO  : evernote : Total items in argumentsArray: 1
2025-12-10 11:25:07 : INFO  : evernote : argumentsArray: DEBUG=0
2025-12-10 11:25:07 : REQ   : evernote : ################## Start Installomator v. 10.9beta, date 2025-12-10
2025-12-10 11:25:07 : INFO  : evernote : ################## Version: 10.9beta
2025-12-10 11:25:07 : INFO  : evernote : ################## Date: 2025-12-10
2025-12-10 11:25:07 : INFO  : evernote : ################## evernote
2025-12-10 11:25:07 : INFO  : evernote : SwiftDialog is not installed, clear cmd file var
2025-12-10 11:25:08 : INFO  : evernote : Reading arguments again: DEBUG=0
2025-12-10 11:25:08 : INFO  : evernote : BLOCKING_PROCESS_ACTION=tell_user
2025-12-10 11:25:08 : INFO  : evernote : NOTIFY=success
2025-12-10 11:25:08 : INFO  : evernote : LOGGING=INFO
2025-12-10 11:25:08 : INFO  : evernote : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-10 11:25:08 : INFO  : evernote : Label type: dmg
2025-12-10 11:25:08 : INFO  : evernote : archiveName: Evernote.dmg
2025-12-10 11:25:09 : INFO  : evernote : no blocking processes defined, using Evernote as default
2025-12-10 11:25:09 : INFO  : evernote : name: Evernote, appName: Evernote.app
2025-12-10 11:25:09 : WARN  : evernote : No previous app found
2025-12-10 11:25:09 : WARN  : evernote : could not find Evernote.app
2025-12-10 11:25:09 : INFO  : evernote : appversion: 
2025-12-10 11:25:09 : INFO  : evernote : Latest version of Evernote is 10.166.2
2025-12-10 11:25:09 : REQ   : evernote : Downloading https://mac.desktop.evernote.com/builds/Evernote-latest.dmg to Evernote.dmg
2025-12-10 11:25:51 : INFO  : evernote : Downloaded Evernote.dmg – Type is  zlib compressed data – SHA is 4bc6cb0be09fc1187834ed16687b1d6697f779d5 – Size is 311840 kB
2025-12-10 11:25:52 : REQ   : evernote : no more blocking processes, continue with update
2025-12-10 11:25:52 : REQ   : evernote : Installing Evernote
2025-12-10 11:25:52 : INFO  : evernote : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hbUXUd1yjo/Evernote.dmg
2025-12-10 11:25:57 : INFO  : evernote : Mounted: /Volumes/Evernote 10.166.2-universal
2025-12-10 11:25:57 : INFO  : evernote : Verifying: /Volumes/Evernote 10.166.2-universal/Evernote.app
2025-12-10 11:26:01 : INFO  : evernote : Team ID matching: Q79WDW8YH9 (expected: Q79WDW8YH9 )
2025-12-10 11:26:01 : INFO  : evernote : Installing Evernote version 10.166.2 on versionKey CFBundleShortVersionString.
2025-12-10 11:26:01 : INFO  : evernote : App has LSMinimumSystemVersion: 11.0
2025-12-10 11:26:01 : INFO  : evernote : Copy /Volumes/Evernote 10.166.2-universal/Evernote.app to /Applications
2025-12-10 11:26:02 : WARN  : evernote : Changing owner to kryptonit
2025-12-10 11:26:02 : INFO  : evernote : Finishing...
2025-12-10 11:26:05 : INFO  : evernote : App(s) found: /Applications/Evernote.app
2025-12-10 11:26:05 : INFO  : evernote : found app at /Applications/Evernote.app, version 10.166.2, on versionKey CFBundleShortVersionString
2025-12-10 11:26:06 : REQ   : evernote : Installed Evernote, version 10.166.2
2025-12-10 11:26:06 : INFO  : evernote : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2025-12-10 11:26:06 : INFO  : evernote : Installomator did not close any apps, so no need to reopen any apps.
2025-12-10 11:26:06 : REQ   : evernote : All done!
2025-12-10 11:26:06 : REQ   : evernote : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A