### PR TITLE
Create eclipseideforjavadevelopers.sh

### DIFF
--- a/fragments/labels/eclipseideforjavadevelopers.sh
+++ b/fragments/labels/eclipseideforjavadevelopers.sh
@@ -1,0 +1,12 @@
+eclipseideforjavadevelopers)
+    name="Eclipse"
+    type="dmg"
+    alphaChar=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o 'eclipse-java-[0-9]\{4\}-[0-9]\{2\}-[A-Za-z0-9]\+-macosx-cocoa-x86_64\.dmg' | awk -F'-' '{print $5}')
+    yearMonth=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o "eclipse-java-[0-9]\{4\}-[0-9]\{2\}-$alphaChar-macosx-cocoa-x86_64.dmg" | sed -E 's/.*eclipse-java-([0-9]{4}-[0-9]{2})-R.*/\1/')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-aarch64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-x86_64.dmg"
+    fi
+    expectedTeamID="JCDTMS22B4"
+    ;;

--- a/fragments/labels/eclipseideforjavadevelopers.sh
+++ b/fragments/labels/eclipseideforjavadevelopers.sh
@@ -1,12 +1,11 @@
 eclipseideforjavadevelopers)
     name="Eclipse"
     type="dmg"
-    alphaChar=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o 'eclipse-java-[0-9]\{4\}-[0-9]\{2\}-[A-Za-z0-9]\+-macosx-cocoa-x86_64\.dmg' | awk -F'-' '{print $5}')
-    yearMonth=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o "eclipse-java-[0-9]\{4\}-[0-9]\{2\}-$alphaChar-macosx-cocoa-x86_64.dmg" | sed -E 's/.*eclipse-java-([0-9]{4}-[0-9]{2})-R.*/\1/')
+    appNewVersion=$(curl -fs "https://www.eclipse.org/downloads/packages/" | grep -o 'Eclipse IDE [0-9]\{4\}-[0-9]\{2\} [A-Z0-9]*' | head -1 | awk '{print $3"-"$4}')
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-aarch64.dmg"
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/${appNewVersion%-*}/${appNewVersion##*-}/eclipse-java-$appNewVersion-macosx-cocoa-aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/$yearMonth/$alphaChar/eclipse-java-$yearMonth-$alphaChar-macosx-cocoa-x86_64.dmg"
+        downloadURL="https://download.eclipse.org/technology/epp/downloads/release/${appNewVersion%-*}/${appNewVersion##*-}/eclipse-java-$appNewVersion-macosx-cocoa-x86_64.dmg"
     fi
     expectedTeamID="JCDTMS22B4"
     ;;


### PR DESCRIPTION
output...
```
sudo Installomator/utils/assemble.sh eclipseideforjavadevelopers DEBUG=0
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : setting variable from argument DEBUG=0
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : Total items in argumentsArray: 1
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : argumentsArray: DEBUG=0
2025-12-10 12:52:43 : REQ   : eclipseideforjavadevelopers : ################## Start Installomator v. 10.9beta, date 2025-12-10
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : ################## Version: 10.9beta
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : ################## Date: 2025-12-10
2025-12-10 12:52:43 : INFO  : eclipseideforjavadevelopers : ################## eclipseideforjavadevelopers
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : Reading arguments again: DEBUG=0
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : BLOCKING_PROCESS_ACTION=tell_user
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : NOTIFY=success
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : LOGGING=INFO
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : Label type: dmg
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : archiveName: Eclipse.dmg
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : no blocking processes defined, using Eclipse as default
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : name: Eclipse, appName: Eclipse.app
2025-12-10 12:52:45 : WARN  : eclipseideforjavadevelopers : No previous app found
2025-12-10 12:52:45 : WARN  : eclipseideforjavadevelopers : could not find Eclipse.app
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : appversion:
2025-12-10 12:52:45 : INFO  : eclipseideforjavadevelopers : Latest version not specified.
2025-12-10 12:52:45 : REQ   : eclipseideforjavadevelopers : Downloading https://download.eclipse.org/technology/epp/downloads/release/2025-12/R/eclipse-java-2025-12-R-macosx-cocoa-aarch64.dmg to Eclipse.dmg
2025-12-10 12:59:50 : INFO  : eclipseideforjavadevelopers : Downloaded Eclipse.dmg – Type is  zlib compressed data – SHA is 6aa28afcf30299c5550e58df1e1f0994d0b94746 – Size is 360504 kB
2025-12-10 12:59:50 : REQ   : eclipseideforjavadevelopers : no more blocking processes, continue with update
2025-12-10 12:59:50 : REQ   : eclipseideforjavadevelopers : Installing Eclipse
2025-12-10 12:59:50 : INFO  : eclipseideforjavadevelopers : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iyrBYIcnsl/Eclipse.dmg
2025-12-10 12:59:55 : INFO  : eclipseideforjavadevelopers : Mounted: /Volumes/Eclipse
2025-12-10 12:59:55 : INFO  : eclipseideforjavadevelopers : Verifying: /Volumes/Eclipse/Eclipse.app
2025-12-10 12:59:58 : INFO  : eclipseideforjavadevelopers : Team ID matching: JCDTMS22B4 (expected: JCDTMS22B4 )
2025-12-10 12:59:58 : INFO  : eclipseideforjavadevelopers : Installing Eclipse version 4.38.0 on versionKey CFBundleShortVersionString.
2025-12-10 12:59:58 : INFO  : eclipseideforjavadevelopers : Copy /Volumes/Eclipse/Eclipse.app to /Applications
2025-12-10 13:00:01 : WARN  : eclipseideforjavadevelopers : Changing owner to u0105821
2025-12-10 13:00:01 : INFO  : eclipseideforjavadevelopers : Finishing...
2025-12-10 13:00:04 : INFO  : eclipseideforjavadevelopers : App(s) found: /Applications/Eclipse.app
2025-12-10 13:00:05 : INFO  : eclipseideforjavadevelopers : found app at /Applications/Eclipse.app, version 4.38.0, on versionKey CFBundleShortVersionString
2025-12-10 13:00:05 : REQ   : eclipseideforjavadevelopers : Installed Eclipse, version 4.38.0
2025-12-10 13:00:05 : INFO  : eclipseideforjavadevelopers : notifying
2025-12-10 13:00:05 : INFO  : eclipseideforjavadevelopers : Installomator did not close any apps, so no need to reopen any apps.
2025-12-10 13:00:05 : REQ   : eclipseideforjavadevelopers : All done!
2025-12-10 13:00:05 : REQ   : eclipseideforjavadevelopers : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
