### PR TITLE
granola-new-label

### DIFF
--- a/fragments/labels/granola.sh
+++ b/fragments/labels/granola.sh
@@ -1,0 +1,10 @@
+granola)
+    name="Granola"
+    type="dmg"
+    # Uses Homebrew Cask API (does not require Homebrew installation)
+    # Most reliable as it's community-maintained and always up-to-date
+    granolaJSON=$(curl -fsL "https://formulae.brew.sh/api/cask/granola.json")
+    appNewVersion=$(getJSONValue "$granolaJSON" "version")
+    downloadURL=$(getJSONValue "$granolaJSON" "url")
+    expectedTeamID="QZ7DHHLN25"
+    ;;


### PR DESCRIPTION
output
```
# sudo Installomator/utils/assemble.sh granola DEBUG=0
2025-12-10 13:39:14 : INFO  : granola : setting variable from argument DEBUG=0
2025-12-10 13:39:14 : INFO  : granola : Total items in argumentsArray: 1
2025-12-10 13:39:14 : INFO  : granola : argumentsArray: DEBUG=0
2025-12-10 13:39:14 : REQ   : granola : ################## Start Installomator v. 10.9beta, date 2025-12-10
2025-12-10 13:39:14 : INFO  : granola : ################## Version: 10.9beta
2025-12-10 13:39:14 : INFO  : granola : ################## Date: 2025-12-10
2025-12-10 13:39:14 : INFO  : granola : ################## granola
2025-12-10 13:39:15 : INFO  : granola : Reading arguments again: DEBUG=0
2025-12-10 13:39:15 : INFO  : granola : BLOCKING_PROCESS_ACTION=tell_user
2025-12-10 13:39:15 : INFO  : granola : NOTIFY=success
2025-12-10 13:39:15 : INFO  : granola : LOGGING=INFO
2025-12-10 13:39:15 : INFO  : granola : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-10 13:39:15 : INFO  : granola : Label type: dmg
2025-12-10 13:39:15 : INFO  : granola : archiveName: Granola.dmg
2025-12-10 13:39:15 : INFO  : granola : no blocking processes defined, using Granola as default
2025-12-10 13:39:15 : INFO  : granola : name: Granola, appName: Granola.app
2025-12-10 13:39:15 : WARN  : granola : No previous app found
2025-12-10 13:39:15 : WARN  : granola : could not find Granola.app
2025-12-10 13:39:15 : INFO  : granola : appversion:
2025-12-10 13:39:15 : INFO  : granola : Latest version of Granola is 6.399.0
2025-12-10 13:39:16 : REQ   : granola : Downloading https://dr2v7l5emb758.cloudfront.net/6.399.0/Granola-6.399.0-mac-universal.dmg to Granola.dmg
2025-12-10 13:39:22 : INFO  : granola : Downloaded Granola.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is f341d95e34ed11c55d85ce6f03933ddf470843ed – Size is 246424 kB
2025-12-10 13:39:22 : REQ   : granola : no more blocking processes, continue with update
2025-12-10 13:39:22 : REQ   : granola : Installing Granola
2025-12-10 13:39:22 : INFO  : granola : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OG8VxAVMSI/Granola.dmg
2025-12-10 13:39:36 : INFO  : granola : Mounted: /Volumes/Granola 1
2025-12-10 13:39:36 : INFO  : granola : Verifying: /Volumes/Granola 1/Granola.app
2025-12-10 13:39:53 : INFO  : granola : Team ID matching: QZ7DHHLN25 (expected: QZ7DHHLN25 )
2025-12-10 13:39:53 : INFO  : granola : Installing Granola version 6.399.0 on versionKey CFBundleShortVersionString.
2025-12-10 13:39:53 : INFO  : granola : App has LSMinimumSystemVersion: 11.0
2025-12-10 13:39:53 : INFO  : granola : Copy /Volumes/Granola 1/Granola.app to /Applications
2025-12-10 13:40:06 : WARN  : granola : Changing owner to u0105821
2025-12-10 13:40:06 : INFO  : granola : Finishing...
2025-12-10 13:40:09 : INFO  : granola : App(s) found: /Applications/Granola.app
2025-12-10 13:40:09 : INFO  : granola : found app at /Applications/Granola.app, version 6.399.0, on versionKey CFBundleShortVersionString
2025-12-10 13:40:10 : REQ   : granola : Installed Granola, version 6.399.0
2025-12-10 13:40:10 : INFO  : granola : notifying
2025-12-10 13:40:10 : INFO  : granola : Installomator did not close any apps, so no need to reopen any apps.
2025-12-10 13:40:10 : REQ   : granola : All done!
2025-12-10 13:40:10 : REQ   : granola : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
