### PR TITLE
opera-update-label

### DIFF
--- a/fragments/labels/opera.sh
+++ b/fragments/labels/opera.sh
@@ -1,8 +1,8 @@
 opera)
     name="Opera"
     type="dmg"
-    downloadURL="$(curl -fsIL $(curl -fsL $(curl -fsI "https://download.opera.com/download/get/?partner=www&opsys=MacOS" | grep -i "^location" | awk '{print $2}' | tr -d '\r') | grep -oE "https:\/\/download\.opera\.com\/[^\"]*" | sed 's/\&amp\;/\&/g') | grep -i "^location" | awk '{print $2}' | tr -d '\r')"
-    appNewVersion="$(printf "$downloadURL" | sed -E 's/https.*\/([0-9.]*)\/mac\/.*/\1/')"
-	versionKey="CFBundleVersion"
+    appNewVersion=$(curl -fs "https://get.geo.opera.com/pub/opera/desktop/" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+    downloadURL="https://get.geo.opera.com/pub/opera/desktop/${appNewVersion}/mac/Opera_${appNewVersion}_Setup.dmg"
+    versionKey="CFBundleVersion"
     expectedTeamID="A2P9LX4JPN"
     ;;


### PR DESCRIPTION
ouitput
```
sudo Installomator/utils/assemble.sh opera DEBUG=0
2025-12-11 08:48:40 : INFO  : opera : setting variable from argument DEBUG=0
2025-12-11 08:48:40 : INFO  : opera : Total items in argumentsArray: 1
2025-12-11 08:48:40 : INFO  : opera : argumentsArray: DEBUG=0
2025-12-11 08:48:40 : REQ   : opera : ################## Start Installomator v. 10.9beta, date 2025-12-11
2025-12-11 08:48:40 : INFO  : opera : ################## Version: 10.9beta
2025-12-11 08:48:40 : INFO  : opera : ################## Date: 2025-12-11
2025-12-11 08:48:40 : INFO  : opera : ################## opera
2025-12-11 08:48:41 : INFO  : opera : Reading arguments again: DEBUG=0
2025-12-11 08:48:41 : INFO  : opera : BLOCKING_PROCESS_ACTION=tell_user
2025-12-11 08:48:41 : INFO  : opera : NOTIFY=success
2025-12-11 08:48:41 : INFO  : opera : LOGGING=INFO
2025-12-11 08:48:41 : INFO  : opera : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-11 08:48:41 : INFO  : opera : Label type: dmg
2025-12-11 08:48:41 : INFO  : opera : archiveName: Opera.dmg
2025-12-11 08:48:41 : INFO  : opera : no blocking processes defined, using Opera as default
2025-12-11 08:48:41 : INFO  : opera : name: Opera, appName: Opera.app
2025-12-11 08:48:42 : WARN  : opera : No previous app found
2025-12-11 08:48:42 : WARN  : opera : could not find Opera.app
2025-12-11 08:48:42 : INFO  : opera : appversion:
2025-12-11 08:48:42 : INFO  : opera : Latest version of Opera is 125.0.5729.21
2025-12-11 08:48:42 : REQ   : opera : Downloading https://get.geo.opera.com/pub/opera/desktop/125.0.5729.21/mac/Opera_125.0.5729.21_Setup.dmg to Opera.dmg
2025-12-11 08:48:49 : INFO  : opera : Downloaded Opera.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is cc2f4c019abbc0172939e4aa0bce4e1003e990ad – Size is 246300 kB
2025-12-11 08:48:49 : REQ   : opera : no more blocking processes, continue with update
2025-12-11 08:48:49 : REQ   : opera : Installing Opera
2025-12-11 08:48:49 : INFO  : opera : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.QLLxCWqok7/Opera.dmg
2025-12-11 08:49:02 : INFO  : opera : Mounted: /Volumes/Opera
2025-12-11 08:49:02 : INFO  : opera : Verifying: /Volumes/Opera/Opera.app
2025-12-11 08:49:20 : INFO  : opera : Team ID matching: A2P9LX4JPN (expected: A2P9LX4JPN )
2025-12-11 08:49:20 : INFO  : opera : Installing Opera version 125.0.5729.21 on versionKey CFBundleVersion.
2025-12-11 08:49:20 : INFO  : opera : App has LSMinimumSystemVersion: 11.0
2025-12-11 08:49:20 : INFO  : opera : Copy /Volumes/Opera/Opera.app to /Applications
2025-12-11 08:49:33 : WARN  : opera : Changing owner to u0105821
2025-12-11 08:49:33 : INFO  : opera : Finishing...
2025-12-11 08:49:36 : INFO  : opera : App(s) found: /Applications/Opera.app
2025-12-11 08:49:36 : INFO  : opera : found app at /Applications/Opera.app, version 125.0.5729.21, on versionKey CFBundleVersion
2025-12-11 08:49:36 : REQ   : opera : Installed Opera, version 125.0.5729.21
2025-12-11 08:49:36 : INFO  : opera : notifying
2025-12-11 08:49:37 : INFO  : opera : Installomator did not close any apps, so no need to reopen any apps.
2025-12-11 08:49:37 : REQ   : opera : All done!
2025-12-11 08:49:37 : REQ   : opera : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update replaces a fragile triple-nested curl command chain that attempted to scrape Opera's website HTML and follow multiple redirects with a simple, direct approach that queries Opera's CDN directory listing. The old method failed because it relied on parsing HTML from Opera's download pages, which could change at any time, and the nested command substitutions were returning empty values that caused "blank argument" errors in curl. The new method directly fetches the list of available versions from https://get.geo.opera.com/pub/opera/desktop/, extracts all version numbers, sorts them to find the latest, and constructs the download URL using Opera's predictable CDN URL pattern.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
