### PR TITLE
New label hpclick

### DIFF
--- a/fragments/labels/hpclick.sh
+++ b/fragments/labels/hpclick.sh
@@ -43,7 +43,7 @@ hpclick)
             downloadURL=$(echo "$api_response" | grep -o '"fileUrl":"[^"]*"' | head -1 | sed 's/"fileUrl":"//;s/"//')
 
             # Extract version field value
-            appNewVersion=$(echo "$api_response" | grep -o '"version":"[^"]*"' | head -1 | sed 's/"version":"//;s/"//')
+        	appNewVersion=$(echo "$api_response" | grep -o '"version":"[^"]*"' | head -1 | sed 's/"version":"//;s/"//')
 
             if [[ -n "$downloadURL" ]] && [[ -n "$appNewVersion" ]]; then
                 printlog "Found HP Click version: $appNewVersion"
@@ -61,5 +61,5 @@ hpclick)
     fi
 
     expectedTeamID="6HB5Y2QTA3"
-    blockingProcesses=( "HP Click" )
+	blockingProcesses=( "HP Click" )
     ;;

--- a/fragments/labels/hpclick.sh
+++ b/fragments/labels/hpclick.sh
@@ -1,0 +1,65 @@
+hpclick)
+    # HP Click - Printing software for HP DesignJet large format printers
+    # https://support.hp.com/us-en/drivers/hp-click-printing-software/15550865
+    # HP Product ID: 15550865
+    # Bundle ID: com.hp.hpclick
+    # Compatibility: macOS 10.4 - 10.15 (may have issues with newer macOS versions)
+
+    name="HP Click"
+    type="dmg"
+
+    # Fetch download URL from HP API if not provided
+    if [[ -z "$downloadURL" ]]; then
+        printlog "Fetching download URL from HP API..."
+
+        # HP API endpoint for driver details
+        api_url="https://support.hp.com/wcc-services/swd-v2/driverDetails?authState=anonymous&template=SWDSeriesDownload"
+
+        # API payload (reverse engineered from Safari Web Inspector)
+        # These values are specific to HP Click for macOS
+        api_payload='{
+            "productLineCode": "GE",
+            "lc": "en",
+            "cc": "us",
+            "osTMSId": "18015185915131310124113888731054140111953115",
+            "osName": "Mac OS",
+            "productNumberOid": 21355055,
+            "productSeriesOid": 15550865,
+            "platformId": "275027708611380099388405694207665"
+        }'
+
+        # Call HP API
+        api_response=$(curl -fsS -X POST "$api_url" \
+            -H "Accept: application/json, text/plain, */*" \
+            -H "Content-Type: application/json" \
+            -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+            -H "Origin: https://support.hp.com" \
+            -H "Referer: https://support.hp.com/us-en/drivers/hp-click-printing-software/15550865" \
+            -d "$api_payload" 2>&1)
+
+        if [[ $? -eq 0 ]] && [[ -n "$api_response" ]]; then
+            # Extract download URL from JSON response using pure shell commands
+            # Extract fileUrl field value
+            downloadURL=$(echo "$api_response" | grep -o '"fileUrl":"[^"]*"' | head -1 | sed 's/"fileUrl":"//;s/"//')
+
+            # Extract version field value
+            appNewVersion=$(echo "$api_response" | grep -o '"version":"[^"]*"' | head -1 | sed 's/"version":"//;s/"//')
+
+            if [[ -n "$downloadURL" ]] && [[ -n "$appNewVersion" ]]; then
+                printlog "Found HP Click version: $appNewVersion"
+                printlog "Download URL: $downloadURL"
+            else
+                printlog "ERROR: Failed to parse HP API response"
+                printlog "Response preview: ${api_response:0:200}"
+                cleanupAndExit 99 "ERROR: Could not extract download URL from HP API"
+            fi
+        else
+            printlog "ERROR: Failed to fetch download URL from HP API"
+            printlog "You can manually specify the URL with: DOWNLOAD_URL=\"https://...\""
+            cleanupAndExit 99 "ERROR: HP API request failed"
+        fi
+    fi
+
+    expectedTeamID="6HB5Y2QTA3"
+    blockingProcesses=( "HP Click" )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
New label for HP Click https://support.hp.com/us-en/drivers/hp-click-printing-software/15550865 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

OUTPUT (I installed an old version to test updates)
```
andrew@capstan-m1-mba installomator_hpclick % sudo /usr/local/Installomator/Installomator.sh hpclick
2025-12-11 15:39:20 : INFO  : hpclick : Total items in argumentsArray: 0
2025-12-11 15:39:20 : INFO  : hpclick : argumentsArray: 
2025-12-11 15:39:20 : REQ   : hpclick : ################## Start Installomator v. 10.8, date 2025-03-28
2025-12-11 15:39:20 : INFO  : hpclick : ################## Version: 10.8
2025-12-11 15:39:20 : INFO  : hpclick : ################## Date: 2025-03-28
2025-12-11 15:39:20 : INFO  : hpclick : ################## hpclick
2025-12-11 15:39:21 : INFO  : hpclick : Fetching download URL from HP API...
2025-12-11 15:39:21 : INFO  : hpclick : Found HP Click version: 4.5.21
2025-12-11 15:39:21 : INFO  : hpclick : Download URL: https://ftp.hp.com/pub/softlib/software13/printers/hpdesignjetclick/HPClick-4.5.21.dmg
2025-12-11 15:39:21 : INFO  : hpclick : Reading arguments again: 
2025-12-11 15:39:21 : INFO  : hpclick : BLOCKING_PROCESS_ACTION=tell_user
2025-12-11 15:39:21 : INFO  : hpclick : NOTIFY=success
2025-12-11 15:39:21 : INFO  : hpclick : LOGGING=INFO
2025-12-11 15:39:21 : INFO  : hpclick : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-11 15:39:21 : INFO  : hpclick : Label type: dmg
2025-12-11 15:39:21 : INFO  : hpclick : archiveName: HP Click.dmg
2025-12-11 15:39:21 : INFO  : hpclick : App(s) found: /Applications/HP Click.app
2025-12-11 15:39:21 : INFO  : hpclick : found app at /Applications/HP Click.app, version 3.1.348, on versionKey CFBundleShortVersionString
2025-12-11 15:39:21 : INFO  : hpclick : appversion: 3.1.348
2025-12-11 15:39:21 : INFO  : hpclick : Latest version of HP Click is 4.5.21
2025-12-11 15:39:21 : REQ   : hpclick : Downloading https://ftp.hp.com/pub/softlib/software13/printers/hpdesignjetclick/HPClick-4.5.21.dmg to HP Click.dmg
2025-12-11 15:39:27 : INFO  : hpclick : Downloaded HP Click.dmg – Type is  zlib compressed data – SHA is 06cf9ca9cb92b9645301da60aba54e94d6e71ca1 – Size is 328060 kB
2025-12-11 15:39:27 : REQ   : hpclick : no more blocking processes, continue with update
2025-12-11 15:39:27 : REQ   : hpclick : Installing HP Click
2025-12-11 15:39:27 : INFO  : hpclick : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.BsI4Lr6Nx0/HP Click.dmg
2025-12-11 15:39:33 : INFO  : hpclick : Mounted: /Volumes/HP Click
2025-12-11 15:39:33 : INFO  : hpclick : Verifying: /Volumes/HP Click/HP Click.app
2025-12-11 15:39:36 : INFO  : hpclick : Team ID matching: 6HB5Y2QTA3 (expected: 6HB5Y2QTA3 )
2025-12-11 15:39:36 : INFO  : hpclick : Downloaded version of HP Click is 4.5.21 on versionKey CFBundleShortVersionString (replacing version 3.1.348).
2025-12-11 15:39:36 : INFO  : hpclick : App has LSMinimumSystemVersion: 10.10.0
2025-12-11 15:39:36 : WARN  : hpclick : Removing existing /Applications/HP Click.app
2025-12-11 15:39:36 : INFO  : hpclick : Copy /Volumes/HP Click/HP Click.app to /Applications
2025-12-11 15:39:37 : WARN  : hpclick : Changing owner to andrew
2025-12-11 15:39:37 : INFO  : hpclick : Finishing...
2025-12-11 15:39:40 : INFO  : hpclick : App(s) found: /Applications/HP Click.app
2025-12-11 15:39:41 : INFO  : hpclick : found app at /Applications/HP Click.app, version 4.5.21, on versionKey CFBundleShortVersionString
2025-12-11 15:39:41 : REQ   : hpclick : Installed HP Click, version 4.5.21
2025-12-11 15:39:41 : INFO  : hpclick : notifying
2025-12-11 15:39:41 : INFO  : hpclick : Installomator did not close any apps, so no need to reopen any apps.
2025-12-11 15:39:41 : REQ   : hpclick : All done!
2025-12-11 15:39:41 : REQ   : hpclick : ################## End Installomator, exit code 0 
```