### PR TITLE
Create touchdesigner.sh

### DIFF
--- a/fragments/labels/touchdesigner.sh
+++ b/fragments/labels/touchdesigner.sh
@@ -1,0 +1,13 @@
+touchdesigner)
+    name="TouchDesigner"
+    type="dmg"
+    appNewVersion=$(curl -s -A "Mozilla/5.0" https://derivative.ca/download | grep -oE '[0-9]{4}\.[0-9]{5}' | head -n1)
+    if [[ $(arch) == i386 ]]; then
+        downloadURL="https://download.derivative.ca/TouchDesigner.$appNewVersion.intel.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL="https://download.derivative.ca/TouchDesigner.$appNewVersion.arm64.dmg"
+    fi
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="Z7MPGSMXH2"
+    ;;
+

--- a/fragments/labels/touchdesigner.sh
+++ b/fragments/labels/touchdesigner.sh
@@ -10,4 +10,3 @@ touchdesigner)
     versionKey="CFBundleShortVersionString"
     expectedTeamID="Z7MPGSMXH2"
     ;;
-


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** creating

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2025-12-15 11:45:33 : INFO  : touchdesigner : Total items in argumentsArray: 0
2025-12-15 11:45:33 : INFO  : touchdesigner : argumentsArray: 
2025-12-15 11:45:33 : REQ   : touchdesigner : ################## Start Installomator v. 10.9beta, date 2025-12-15
2025-12-15 11:45:33 : INFO  : touchdesigner : ################## Version: 10.9beta
2025-12-15 11:45:33 : INFO  : touchdesigner : ################## Date: 2025-12-15
2025-12-15 11:45:33 : INFO  : touchdesigner : ################## touchdesigner
2025-12-15 11:45:33 : DEBUG : touchdesigner : DEBUG mode 1 enabled.
2025-12-15 11:45:34 : INFO  : touchdesigner : Reading arguments again: 
2025-12-15 11:45:34 : DEBUG : touchdesigner : name=TouchDesigner
2025-12-15 11:45:34 : DEBUG : touchdesigner : appName=
2025-12-15 11:45:34 : DEBUG : touchdesigner : type=dmg
2025-12-15 11:45:34 : DEBUG : touchdesigner : archiveName=
2025-12-15 11:45:34 : DEBUG : touchdesigner : downloadURL=https://download.derivative.ca/TouchDesigner.2025.32050.arm64.dmg
2025-12-15 11:45:34 : DEBUG : touchdesigner : curlOptions=
2025-12-15 11:45:34 : DEBUG : touchdesigner : appNewVersion=2025.32050
2025-12-15 11:45:34 : DEBUG : touchdesigner : appCustomVersion function: Not defined
2025-12-15 11:45:34 : DEBUG : touchdesigner : versionKey=CFBundleShortVersionString
2025-12-15 11:45:34 : DEBUG : touchdesigner : packageID=
2025-12-15 11:45:34 : DEBUG : touchdesigner : pkgName=
2025-12-15 11:45:34 : DEBUG : touchdesigner : choiceChangesXML=
2025-12-15 11:45:34 : DEBUG : touchdesigner : expectedTeamID=Z7MPGSMXH2
2025-12-15 11:45:34 : DEBUG : touchdesigner : blockingProcesses=
2025-12-15 11:45:34 : DEBUG : touchdesigner : installerTool=
2025-12-15 11:45:34 : DEBUG : touchdesigner : CLIInstaller=
2025-12-15 11:45:34 : DEBUG : touchdesigner : CLIArguments=
2025-12-15 11:45:34 : DEBUG : touchdesigner : updateTool=
2025-12-15 11:45:34 : DEBUG : touchdesigner : updateToolArguments=
2025-12-15 11:45:34 : DEBUG : touchdesigner : updateToolRunAsCurrentUser=
2025-12-15 11:45:34 : INFO  : touchdesigner : BLOCKING_PROCESS_ACTION=tell_user
2025-12-15 11:45:34 : INFO  : touchdesigner : NOTIFY=success
2025-12-15 11:45:34 : INFO  : touchdesigner : LOGGING=DEBUG
2025-12-15 11:45:34 : INFO  : touchdesigner : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-15 11:45:34 : INFO  : touchdesigner : Label type: dmg
2025-12-15 11:45:34 : INFO  : touchdesigner : archiveName: TouchDesigner.dmg
2025-12-15 11:45:34 : INFO  : touchdesigner : no blocking processes defined, using TouchDesigner as default
2025-12-15 11:45:34 : DEBUG : touchdesigner : Changing directory to /Users/coreyg/Documents/GitHub/Installomator/build
2025-12-15 11:45:34 : INFO  : touchdesigner : name: TouchDesigner, appName: TouchDesigner.app
2025-12-15 11:45:35 : WARN  : touchdesigner : No previous app found
2025-12-15 11:45:35 : WARN  : touchdesigner : could not find TouchDesigner.app
2025-12-15 11:45:35 : INFO  : touchdesigner : appversion: 
2025-12-15 11:45:35 : INFO  : touchdesigner : Latest version of TouchDesigner is 2025.32050
2025-12-15 11:45:35 : REQ   : touchdesigner : Downloading https://download.derivative.ca/TouchDesigner.2025.32050.arm64.dmg to TouchDesigner.dmg
2025-12-15 11:45:35 : DEBUG : touchdesigner : No Dialog connection, just download
2025-12-15 11:45:42 : INFO  : touchdesigner : Downloaded TouchDesigner.dmg – Type is  zlib compressed data – SHA is 32a94b28eee059a8fa0c5c0aacfc6def4036da49 – Size is 674020 kB
2025-12-15 11:45:42 : DEBUG : touchdesigner : DEBUG mode 1, not checking for blocking processes
2025-12-15 11:45:42 : REQ   : touchdesigner : Installing TouchDesigner
2025-12-15 11:45:42 : INFO  : touchdesigner : Mounting /Users/coreyg/Documents/GitHub/Installomator/build/TouchDesigner.dmg
2025-12-15 11:45:47 : DEBUG : touchdesigner : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C87B9AB7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8F8C0516
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $01103B84
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $50B17671
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $01103B84
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CE2E7346
verified   CRC32 $8011E219
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/TouchDesigner 2025.32050 1

2025-12-15 11:45:47 : INFO  : touchdesigner : Mounted: /Volumes/TouchDesigner 2025.32050 1
2025-12-15 11:45:47 : INFO  : touchdesigner : Verifying: /Volumes/TouchDesigner 2025.32050 1/TouchDesigner.app
2025-12-15 11:45:47 : DEBUG : touchdesigner : App size: 1.5G	/Volumes/TouchDesigner 2025.32050 1/TouchDesigner.app
2025-12-15 11:45:57 : DEBUG : touchdesigner : Debugging enabled, App Verification output was:
/Volumes/TouchDesigner 2025.32050 1/TouchDesigner.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Derivative (Z7MPGSMXH2)

2025-12-15 11:45:57 : INFO  : touchdesigner : Team ID matching: Z7MPGSMXH2 (expected: Z7MPGSMXH2 )
2025-12-15 11:45:57 : INFO  : touchdesigner : Installing TouchDesigner version 2025.32050 on versionKey CFBundleShortVersionString.
2025-12-15 11:45:57 : INFO  : touchdesigner : App has LSMinimumSystemVersion: 13.0
2025-12-15 11:45:57 : DEBUG : touchdesigner : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2025-12-15 11:45:57 : INFO  : touchdesigner : Finishing...
2025-12-15 11:46:00 : INFO  : touchdesigner : name: TouchDesigner, appName: TouchDesigner.app
2025-12-15 11:46:00 : WARN  : touchdesigner : No previous app found
2025-12-15 11:46:00 : WARN  : touchdesigner : could not find TouchDesigner.app
2025-12-15 11:46:00 : REQ   : touchdesigner : Installed TouchDesigner, version 2025.32050
2025-12-15 11:46:00 : INFO  : touchdesigner : notifying
2025-12-15 11:46:00 : DEBUG : touchdesigner : Unmounting /Volumes/TouchDesigner 2025.32050 1
2025-12-15 11:46:01 : DEBUG : touchdesigner : Debugging enabled, Unmounting output was:
"disk7" ejected.
2025-12-15 11:46:01 : DEBUG : touchdesigner : DEBUG mode 1, not reopening anything
2025-12-15 11:46:01 : REQ   : touchdesigner : All done!
2025-12-15 11:46:01 : REQ   : touchdesigner : ################## End Installomator, exit code 0 



```
