### PR TITLE
Create antigravity.sh

### DIFF
--- a/fragments/labels/antigravity.sh
+++ b/fragments/labels/antigravity.sh
@@ -1,18 +1,18 @@
 antigravity)
-name="Antigravity"
-type="dmg"
-indexFilePath=$(curl -fsL --compressed "https://antigravity.google/download" \
+    name="Antigravity"
+    type="dmg"
+    indexFilePath=$(curl -fsL --compressed "https://antigravity.google/download" \
         | grep -Eo 'main-[0-9A-Za-z]+\.js' | head -1)
-mainJS=$(curl -fsL --compressed "https://antigravity.google/${indexFilePath}")
-if [[ "$(arch)" == "arm64" ]]; then
-    downloadURL=$(echo "$mainJS" \
+    mainJS=$(curl -fsL --compressed "https://antigravity.google/${indexFilePath}")
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(echo "$mainJS" \
             | grep -Eo 'https://edgedl\.me\.gvt1\.com/edgedl/release2/[^"]+/antigravity/stable/[^"]+/darwin-arm/Antigravity\.dmg' \
             | head -1)
-else
-     downloadURL=$(echo "$mainJS" \
+    else
+        downloadURL=$(echo "$mainJS" \
             | grep -Eo 'https://edgedl\.me\.gvt1\.com/edgedl/release2/[^"]+/antigravity/stable/[^"]+/darwin-x64/Antigravity\.dmg' \
             | head -1)
-fi
-appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*/stable/([0-9.]+)-[0-9]+/darwin-.*#\1#p')
-expectedTeamID="EQHXZ8M8AV"
-;;
+    fi
+    appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*/stable/([0-9.]+)-[0-9]+/darwin-.*#\1#p')
+    expectedTeamID="EQHXZ8M8AV"
+    ;;

--- a/fragments/labels/antigravity.sh
+++ b/fragments/labels/antigravity.sh
@@ -4,7 +4,7 @@ antigravity)
     indexFilePath=$(curl -fsL --compressed "https://antigravity.google/download" \
         | grep -Eo 'main-[0-9A-Za-z]+\.js' | head -1)
     mainJS=$(curl -fsL --compressed "https://antigravity.google/${indexFilePath}")
-    if [[ "$(arch)" == "arm64" ]]; then
+    if [[ $(arch) == "arm64" ]]; then
         downloadURL=$(echo "$mainJS" \
             | grep -Eo 'https://edgedl\.me\.gvt1\.com/edgedl/release2/[^"]+/antigravity/stable/[^"]+/darwin-arm/Antigravity\.dmg' \
             | head -1)

--- a/fragments/labels/antigravity.sh
+++ b/fragments/labels/antigravity.sh
@@ -1,0 +1,18 @@
+antigravity)
+name="Antigravity"
+type="dmg"
+indexFilePath=$(curl -fsL --compressed "https://antigravity.google/download" \
+        | grep -Eo 'main-[0-9A-Za-z]+\.js' | head -1)
+mainJS=$(curl -fsL --compressed "https://antigravity.google/${indexFilePath}")
+if [[ "$(arch)" == "arm64" ]]; then
+    downloadURL=$(echo "$mainJS" \
+            | grep -Eo 'https://edgedl\.me\.gvt1\.com/edgedl/release2/[^"]+/antigravity/stable/[^"]+/darwin-arm/Antigravity\.dmg' \
+            | head -1)
+else
+     downloadURL=$(echo "$mainJS" \
+            | grep -Eo 'https://edgedl\.me\.gvt1\.com/edgedl/release2/[^"]+/antigravity/stable/[^"]+/darwin-x64/Antigravity\.dmg' \
+            | head -1)
+fi
+appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*/stable/([0-9.]+)-[0-9]+/darwin-.*#\1#p')
+expectedTeamID="EQHXZ8M8AV"
+;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

Google does not provide a static URL for download. After looking through other labels I found asperaconnect, which pulls a hashed JavaScript asset from the site and then extracts the real download information from that. Antigravity’s download page does return plain HTML, but the actual DMG URLs are embedded in a versioned JS bundle that changes each release. Using the same general idea as asperaconnect, I’m grabbing the current JS asset and using that to select the correct Intel or Apple Silicon DMG from the URLs it contains, instead of hardcoding a versioned download path.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Output:

```
./assemble.sh antigravity
2025-12-15 13:38:32 : INFO  : antigravity : Total items in argumentsArray: 0
2025-12-15 13:38:32 : INFO  : antigravity : argumentsArray: 
2025-12-15 13:38:32 : REQ   : antigravity : ################## Start Installomator v. 10.9beta, date 2025-12-15
2025-12-15 13:38:32 : INFO  : antigravity : ################## Version: 10.9beta
2025-12-15 13:38:32 : INFO  : antigravity : ################## Date: 2025-12-15
2025-12-15 13:38:32 : INFO  : antigravity : ################## antigravity
2025-12-15 13:38:32 : DEBUG : antigravity : DEBUG mode 1 enabled.
2025-12-15 13:38:34 : INFO  : antigravity : Reading arguments again: 
2025-12-15 13:38:34 : DEBUG : antigravity : name=Antigravity
2025-12-15 13:38:34 : DEBUG : antigravity : appName=
2025-12-15 13:38:34 : DEBUG : antigravity : type=dmg
2025-12-15 13:38:34 : DEBUG : antigravity : archiveName=
2025-12-15 13:38:34 : DEBUG : antigravity : downloadURL=https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.17-6639170008514560/darwin-arm/Antigravity.dmg
2025-12-15 13:38:34 : DEBUG : antigravity : curlOptions=
2025-12-15 13:38:34 : DEBUG : antigravity : appNewVersion=1.11.17
2025-12-15 13:38:34 : DEBUG : antigravity : appCustomVersion function: Not defined
2025-12-15 13:38:34 : DEBUG : antigravity : versionKey=CFBundleShortVersionString
2025-12-15 13:38:34 : DEBUG : antigravity : packageID=
2025-12-15 13:38:34 : DEBUG : antigravity : pkgName=
2025-12-15 13:38:34 : DEBUG : antigravity : choiceChangesXML=
2025-12-15 13:38:34 : DEBUG : antigravity : expectedTeamID=EQHXZ8M8AV
2025-12-15 13:38:34 : DEBUG : antigravity : blockingProcesses=
2025-12-15 13:38:34 : DEBUG : antigravity : installerTool=
2025-12-15 13:38:34 : DEBUG : antigravity : CLIInstaller=
2025-12-15 13:38:34 : DEBUG : antigravity : CLIArguments=
2025-12-15 13:38:34 : DEBUG : antigravity : updateTool=
2025-12-15 13:38:34 : DEBUG : antigravity : updateToolArguments=
2025-12-15 13:38:34 : DEBUG : antigravity : updateToolRunAsCurrentUser=
2025-12-15 13:38:34 : INFO  : antigravity : BLOCKING_PROCESS_ACTION=tell_user
2025-12-15 13:38:34 : INFO  : antigravity : NOTIFY=success
2025-12-15 13:38:34 : INFO  : antigravity : LOGGING=DEBUG
2025-12-15 13:38:34 : INFO  : antigravity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-15 13:38:34 : INFO  : antigravity : Label type: dmg
2025-12-15 13:38:34 : INFO  : antigravity : archiveName: Antigravity.dmg
2025-12-15 13:38:34 : INFO  : antigravity : no blocking processes defined, using Antigravity as default
2025-12-15 13:38:34 : DEBUG : antigravity : Changing directory to /Users/naschenbrenner/Documents/GitHub/Installomator/build
2025-12-15 13:38:34 : INFO  : antigravity : App(s) found: /Applications/Antigravity.app
2025-12-15 13:38:34 : INFO  : antigravity : found app at /Applications/Antigravity.app, version 1.11.17, on versionKey CFBundleShortVersionString
2025-12-15 13:38:34 : INFO  : antigravity : appversion: 1.11.17
2025-12-15 13:38:34 : INFO  : antigravity : Latest version of Antigravity is 1.11.17
2025-12-15 13:38:34 : WARN  : antigravity : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2025-12-15 13:38:34 : INFO  : antigravity : Antigravity.dmg exists and DEBUG mode 1 enabled, skipping download
2025-12-15 13:38:34 : DEBUG : antigravity : DEBUG mode 1, not checking for blocking processes
2025-12-15 13:38:34 : REQ   : antigravity : Installing Antigravity
2025-12-15 13:38:34 : INFO  : antigravity : Mounting /Users/naschenbrenner/Documents/GitHub/Installomator/build/Antigravity.dmg
2025-12-15 13:38:34 : DEBUG : antigravity : Debugging enabled, dmgmount output was:
expected   CRC32 $C59CD68E
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Antigravity 1

2025-12-15 13:38:34 : INFO  : antigravity : Mounted: /Volumes/Antigravity 1
2025-12-15 13:38:34 : INFO  : antigravity : Verifying: /Volumes/Antigravity 1/Antigravity.app
2025-12-15 13:38:35 : DEBUG : antigravity : App size: 703M	/Volumes/Antigravity 1/Antigravity.app
2025-12-15 13:39:01 : DEBUG : antigravity : Debugging enabled, App Verification output was:
/Volumes/Antigravity 1/Antigravity.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Google LLC (EQHXZ8M8AV)

2025-12-15 13:39:01 : INFO  : antigravity : Team ID matching: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2025-12-15 13:39:01 : INFO  : antigravity : Downloaded version of Antigravity is 1.11.17 on versionKey CFBundleShortVersionString, same as installed.
2025-12-15 13:39:01 : DEBUG : antigravity : Unmounting /Volumes/Antigravity 1
2025-12-15 13:39:01 : DEBUG : antigravity : Debugging enabled, Unmounting output was:
"disk6" ejected.
2025-12-15 13:39:01 : DEBUG : antigravity : DEBUG mode 1, not reopening anything
2025-12-15 13:39:01 : REG   : antigravity : No new version to install
2025-12-15 13:39:01 : REQ   : antigravity : ################## End Installomator, exit code 0 
```
