### PR TITLE
New label for Camtasia 2026

### DIFF
--- a/fragments/labels/camtasia2026.sh
+++ b/fragments/labels/camtasia2026.sh
@@ -1,0 +1,14 @@
+camtasia2026)
+    name="Camtasia"
+    type="dmg"
+    sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2026.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2026.0.0&lang=enu&os=mac')
+    appNewVersion=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/*[local-name()="shortVersionString"]/text())' -
+    )
+    downloadURL=$(
+        echo "$sparkleData" | \
+        xmllint -xpath 'string(//*[local-name()="item"][last()]/enclosure/@url)' -
+    )
+    expectedTeamID="7TQL462TU8"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

`2025-12-17 11:19:51 : INFO  : camtasia2026 : Total items in argumentsArray: 3
2025-12-17 11:19:51 : INFO  : camtasia2026 : argumentsArray: NOTIFY=silent DEBUG=0 downloadURL=https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg
2025-12-17 11:19:52 : REQ   : camtasia2026 : ################## Start Installomator v. 10.9beta, date 2025-12-01
2025-12-17 11:19:53 : INFO  : camtasia2026 : ################## Version: 10.9beta
2025-12-17 11:19:53 : INFO  : camtasia2026 : ################## Date: 2025-12-01
2025-12-17 11:19:53 : INFO  : camtasia2026 : ################## camtasia2026
2025-12-17 11:19:54 : INFO  : camtasia2026 : Reading arguments again: NOTIFY=silent DEBUG=0 downloadURL=https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg
2025-12-17 11:19:54 : INFO  : camtasia2026 : BLOCKING_PROCESS_ACTION=tell_user
2025-12-17 11:19:54 : INFO  : camtasia2026 : NOTIFY=silent
2025-12-17 11:19:55 : INFO  : camtasia2026 : LOGGING=INFO
2025-12-17 11:19:55 : INFO  : camtasia2026 : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2025-12-17 11:19:55 : INFO  : camtasia2026 : Label type: dmg
2025-12-17 11:19:55 : INFO  : camtasia2026 : archiveName: Camtasia.dmg
2025-12-17 11:19:55 : INFO  : camtasia2026 : no blocking processes defined, using Camtasia as default
2025-12-17 11:19:55 : INFO  : camtasia2026 : name: Camtasia, appName: Camtasia.app
2025-12-17 11:19:56 : WARN  : camtasia2026 : No previous app found
2025-12-17 11:19:56 : WARN  : camtasia2026 : could not find Camtasia.app
2025-12-17 11:19:56 : INFO  : camtasia2026 : appversion: 
2025-12-17 11:19:56 : INFO  : camtasia2026 : Latest version not specified.
2025-12-17 11:19:56 : REQ   : camtasia2026 : Downloading https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg to Camtasia.dmg
2025-12-17 11:20:04 : INFO  : camtasia2026 : Downloaded Camtasia.dmg – Type is  zlib compressed data – SHA is 6d5e3899bf6e3ff0238785276b20ff92188acca0 – Size is 426312 kB
2025-12-17 11:20:04 : REQ   : camtasia2026 : no more blocking processes, continue with update
2025-12-17 11:20:04 : REQ   : camtasia2026 : Installing Camtasia
2025-12-17 11:20:04 : INFO  : camtasia2026 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.waYtqBGRbH/Camtasia.dmg
2025-12-17 11:20:06 : INFO  : camtasia2026 : Mounted: /Volumes/Camtasia
2025-12-17 11:20:06 : INFO  : camtasia2026 : Verifying: /Volumes/Camtasia/Camtasia.app
2025-12-17 11:20:14 : INFO  : camtasia2026 : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2025-12-17 11:20:14 : INFO  : camtasia2026 : Installing Camtasia version 2026.0.3 on versionKey CFBundleShortVersionString.
2025-12-17 11:20:14 : INFO  : camtasia2026 : App has LSMinimumSystemVersion: 14.0
2025-12-17 11:20:14 : INFO  : camtasia2026 : Copy /Volumes/Camtasia/Camtasia.app to /Applications
2025-12-17 11:20:25 : WARN  : camtasia2026 : Changing owner to mfredette
2025-12-17 11:20:26 : INFO  : camtasia2026 : Finishing...
2025-12-17 11:20:29 : INFO  : camtasia2026 : App(s) found: /Applications/Camtasia.app
2025-12-17 11:20:29 : INFO  : camtasia2026 : found app at /Applications/Camtasia.app, version 2026.0.3, on versionKey CFBundleShortVersionString
2025-12-17 11:20:29 : REQ   : camtasia2026 : Installed Camtasia, version 2026.0.3
2025-12-17 11:20:30 : INFO  : camtasia2026 : Installomator did not close any apps, so no need to reopen any apps.
2025-12-17 11:20:30 : REQ   : camtasia2026 : All done!
2025-12-17 11:20:30 : REQ   : camtasia2026 : ################## End Installomator, exit code 0 `

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
