### PR TITLE
boxdrive-label-update

### DIFF
--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -1,6 +1,8 @@
 boxdrive)
     name="Box"
     type="pkg"
-    downloadURL="https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg"
+    packageID="com.box.desktop.installer.desktop"
+    appNewVersion=$(curl -fsL "https://formulae.brew.sh/api/cask/box-drive.json" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 | cut -d',' -f1)
+    downloadURL="https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-${appNewVersion}.pkg"
     expectedTeamID="M683GB7CPW"
     ;;


### PR DESCRIPTION
Output...
```
sudo Installomator/utils/assemble.sh boxdrive DEBUG=0
2025-12-18 08:28:24 : INFO  : boxdrive : setting variable from argument DEBUG=0
2025-12-18 08:28:24 : INFO  : boxdrive : Total items in argumentsArray: 1
2025-12-18 08:28:25 : INFO  : boxdrive : argumentsArray: DEBUG=0
2025-12-18 08:28:25 : REQ   : boxdrive : ################## Start Installomator v. 10.9beta, date 2025-12-18
2025-12-18 08:28:25 : INFO  : boxdrive : ################## Version: 10.9beta
2025-12-18 08:28:25 : INFO  : boxdrive : ################## Date: 2025-12-18
2025-12-18 08:28:25 : INFO  : boxdrive : ################## boxdrive
2025-12-18 08:28:25 : INFO  : boxdrive : Reading arguments again: DEBUG=0
2025-12-18 08:28:25 : INFO  : boxdrive : BLOCKING_PROCESS_ACTION=tell_user
2025-12-18 08:28:25 : INFO  : boxdrive : NOTIFY=success
2025-12-18 08:28:25 : INFO  : boxdrive : LOGGING=INFO
2025-12-18 08:28:25 : INFO  : boxdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-18 08:28:26 : INFO  : boxdrive : Label type: pkg
2025-12-18 08:28:26 : INFO  : boxdrive : archiveName: Box.pkg
2025-12-18 08:28:26 : INFO  : boxdrive : no blocking processes defined, using Box as default
2025-12-18 08:28:26 : INFO  : boxdrive : found packageID com.box.desktop.installer.desktop installed, version 2.43.205
2025-12-18 08:28:26 : INFO  : boxdrive : appversion: 2.43.205
2025-12-18 08:28:26 : INFO  : boxdrive : Latest version of Box is 2.43.205
2025-12-18 08:28:26 : INFO  : boxdrive : There is no newer version available.
2025-12-18 08:28:26 : INFO  : boxdrive : Installomator did not close any apps, so no need to reopen any apps.
2025-12-18 08:28:26 : REQ   : boxdrive : No newer version.
2025-12-18 08:28:26 : REQ   : boxdrive : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.

Yes, I've confirmed this is not a duplicate of [PR #2669](https://github.com/Installomator/Installomator/pull/2669/files). While that PR adds the `packageID`, it doesn't address the underlying issue with Box Drive's download URL.

**The Problem:**
The static URL https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg doesn't always point to the latest version. Currently, this URL serves version 2.48.243, but the latest version available is 2.43.205 (according to Box's distribution channels and Homebrew).

**This PR's Solution:**
This PR implements dynamic version detection and URL construction:

`appNewVersion` fetches the current version from Homebrew's API (2.43.205)
`downloadURL` constructs the versioned URL: BoxDrive-${appNewVersion}.pkg

This ensures the installer downloaded always matches the detected latest version, preventing version mismatches and ensuring users get the correct, most up-to-date installer.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
