### PR TITLE
xcreds-label-update

### DIFF
--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -4,7 +4,6 @@ xcreds)
     packageID="com.twocanoes.pkg.secureremoteaccess"
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg"
     appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build.*/\1/p')
-    # XCreds postinstall kills loginwindow and restarts the app, ignore blocking processes since the app manages its own restart
-    BLOCKING_PROCESS_ACTION=ignore
     expectedTeamID="UXP6YEHSPW"
+    blockingProcesses=( NONE )
     ;;

--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -1,14 +1,10 @@
 xcreds)
     name="XCreds"
-    # Downloading from twocanoes homepage
     type="pkg"
-    #packageID="com.twocanoes.pkg.secureremoteaccess"
+    packageID="com.twocanoes.pkg.secureremoteaccess"
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg"
     appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build.*/\1/p')
-    # GitHub download
-    # type="pkg"
-    # downloadURL="$(downloadURLFromGit twocanoes xcreds)"
-    # appNewVersion="$(versionFromGit twocanoes xcreds)" # GitHub tag contain “_” and not “.” so our function fails to get the right version
-    # appNewVersion=$(echo "$downloadURL" | sed -E 's/.*XCreds_.*-([0-9.]*)\.pkg/\1/')
+    # XCreds postinstall kills loginwindow and restarts the app, ignore blocking processes since the app manages its own restart
+    BLOCKING_PROCESS_ACTION=ignore
     expectedTeamID="UXP6YEHSPW"
     ;;

--- a/fragments/labels/xcreds.sh
+++ b/fragments/labels/xcreds.sh
@@ -5,5 +5,4 @@ xcreds)
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg"
     appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/xcreds/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build.*/\1/p')
     expectedTeamID="UXP6YEHSPW"
-    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
output
'''
sudo Installomator/utils/assemble.sh xcreds DEBUG=0 2025-12-18 14:38:38 : INFO  : xcreds : setting variable from argument DEBUG=0 2025-12-18 14:38:38 : INFO  : xcreds : Total items in argumentsArray: 1 2025-12-18 14:38:38 : INFO  : xcreds : argumentsArray: DEBUG=0
2025-12-18 14:38:38 : REQ   : xcreds : ################## Start Installomator v. 10.9beta, date 2025-12-18
2025-12-18 14:38:38 : INFO  : xcreds : ################## Version: 10.9beta
2025-12-18 14:38:38 : INFO  : xcreds : ################## Date: 2025-12-18
2025-12-18 14:38:38 : INFO  : xcreds : ################## xcreds
2025-12-18 14:38:39 : INFO  : xcreds : Reading arguments again: DEBUG=0
2025-12-18 14:38:39 : INFO  : xcreds : BLOCKING_PROCESS_ACTION=ignore
2025-12-18 14:38:39 : INFO  : xcreds : NOTIFY=success
2025-12-18 14:38:39 : INFO  : xcreds : LOGGING=INFO
2025-12-18 14:38:39 : INFO  : xcreds : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-18 14:38:39 : INFO  : xcreds : Label type: pkg
2025-12-18 14:38:39 : INFO  : xcreds : archiveName: XCreds.pkg
2025-12-18 14:38:39 : INFO  : xcreds : no blocking processes defined, using XCreds as default
2025-12-18 14:38:39 : INFO  : xcreds : found packageID com.twocanoes.pkg.secureremoteaccess installed, version 5.1.7264
2025-12-18 14:38:39 : INFO  : xcreds : appversion: 5.1.7264
2025-12-18 14:38:39 : INFO  : xcreds : Latest version of XCreds is 5.8
2025-12-18 14:38:39 : REQ   : xcreds : Downloading https://twocanoes-software-updates.s3.amazonaws.com/XCreds.pkg to XCreds.pkg
2025-12-18 14:38:40 : INFO  : xcreds : Downloaded XCreds.pkg – Type is  xar archive compressed TOC – SHA is d5c10e3cfccd707581491aa12c1d76aed1e985f8 – Size is 6280 kB
2025-12-18 14:38:41 : INFO  : xcreds : ignoring blocking processes
2025-12-18 14:38:41 : REQ   : xcreds : Installing XCreds
2025-12-18 14:38:41 : INFO  : xcreds : Verifying: XCreds.pkg
2025-12-18 14:38:41 : INFO  : xcreds : Team ID: UXP6YEHSPW (expected: UXP6YEHSPW )
2025-12-18 14:38:41 : INFO  : xcreds : Checking package version.
2025-12-18 14:38:41 : INFO  : xcreds : Downloaded package com.twocanoes.pkg.secureremoteaccess version 5.8.9058
2025-12-18 14:38:41 : INFO  : xcreds : Installing XCreds.pkg to /
2025-12-18 14:38:48 : INFO  : xcreds : Finishing...
2025-12-18 14:38:51 : INFO  : xcreds : found packageID com.twocanoes.pkg.secureremoteaccess installed, version 5.8.9058
2025-12-18 14:38:51 : REQ   : xcreds : Installed XCreds, version 5.8.9058
2025-12-18 14:38:51 : INFO  : xcreds : notifying
2025-12-18 14:38:52 : INFO  : xcreds : Installomator did not close any apps, so no need to reopen any apps.
2025-12-18 14:38:52 : REQ   : xcreds : All done!
2025-12-18 14:38:52 : REQ   : xcreds : ################## End Installomator, exit code 0
'''

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes, creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The new label uses `BLOCKING_PROCESS_ACTION=ignore` to skip Installomator's blocking process checks, preventing the exit code 11 error from the old label. The original label repeatedly tried to quit XCreds and failed because XCreds' postinstall script kills loginwindow, immediately restarting the app before Installomator could verify it quit. Since XCreds' own pre/postinstall scripts already handle killing and restarting the app, the new label simply lets XCreds manage its own lifecycle instead of fighting against it, allowing installation to complete successfully.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
