### PR TITLE
vuescanintel-new-label

### DIFF
--- a/fragments/labels/vuescanintel.sh
+++ b/fragments/labels/vuescanintel.sh
@@ -5,5 +5,4 @@ vuescanintel)
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
     downloadURL="https://www.hamrick.com/files/vuex64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
     expectedTeamID="5D5BXT9KP5"
-    blockingProcesses=("VueScan")
     ;;

--- a/fragments/labels/vuescanintel.sh
+++ b/fragments/labels/vuescanintel.sh
@@ -1,0 +1,9 @@
+vuescanintel)
+    # VueScan is a 64-bit app, Intel version for scanner compatibility
+    name="VueScan"
+    type="dmg"
+    appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    downloadURL="https://www.hamrick.com/files/vuex64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
+    expectedTeamID="5D5BXT9KP5"
+    blockingProcesses=("VueScan")
+    ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh vuescanintel DEBUG=0
2025-12-19 08:15:57 : INFO  : vuescanintel : setting variable from argument DEBUG=0
2025-12-19 08:15:58 : INFO  : vuescanintel : Total items in argumentsArray: 1
2025-12-19 08:15:58 : INFO  : vuescanintel : argumentsArray: DEBUG=0
2025-12-19 08:15:58 : REQ   : vuescanintel : ################## Start Installomator v. 10.9beta, date 2025-12-19
2025-12-19 08:15:58 : INFO  : vuescanintel : ################## Version: 10.9beta
2025-12-19 08:15:58 : INFO  : vuescanintel : ################## Date: 2025-12-19
2025-12-19 08:15:58 : INFO  : vuescanintel : ################## vuescanintel
2025-12-19 08:15:59 : INFO  : vuescanintel : Reading arguments again: DEBUG=0
2025-12-19 08:15:59 : INFO  : vuescanintel : BLOCKING_PROCESS_ACTION=tell_user
2025-12-19 08:15:59 : INFO  : vuescanintel : NOTIFY=success
2025-12-19 08:15:59 : INFO  : vuescanintel : LOGGING=INFO
2025-12-19 08:15:59 : INFO  : vuescanintel : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-19 08:15:59 : INFO  : vuescanintel : Label type: dmg
2025-12-19 08:15:59 : INFO  : vuescanintel : archiveName: VueScan.dmg
2025-12-19 08:15:59 : INFO  : vuescanintel : name: VueScan, appName: VueScan.app
2025-12-19 08:16:00 : WARN  : vuescanintel : No previous app found
2025-12-19 08:16:00 : WARN  : vuescanintel : could not find VueScan.app
2025-12-19 08:16:00 : INFO  : vuescanintel : appversion:
2025-12-19 08:16:00 : INFO  : vuescanintel : Latest version of VueScan is 9.8.50
2025-12-19 08:16:00 : REQ   : vuescanintel : Downloading https://www.hamrick.com/files/vuex6498.dmg to VueScan.dmg
2025-12-19 08:16:03 : INFO  : vuescanintel : Downloaded VueScan.dmg – Type is  zlib compressed data – SHA is e4cfd67cafbf580b0d950b08af0268d246e54e90 – Size is 37932 kB
2025-12-19 08:16:03 : REQ   : vuescanintel : no more blocking processes, continue with update
2025-12-19 08:16:03 : REQ   : vuescanintel : Installing VueScan
2025-12-19 08:16:03 : INFO  : vuescanintel : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.y0DydC44UW/VueScan.dmg
2025-12-19 08:16:07 : INFO  : vuescanintel : Mounted: /Volumes/VueScan
2025-12-19 08:16:07 : INFO  : vuescanintel : Verifying: /Volumes/VueScan/VueScan.app
2025-12-19 08:16:08 : INFO  : vuescanintel : Team ID matching: 5D5BXT9KP5 (expected: 5D5BXT9KP5 )
2025-12-19 08:16:08 : INFO  : vuescanintel : Installing VueScan version 9.8.50 on versionKey CFBundleShortVersionString.
2025-12-19 08:16:08 : INFO  : vuescanintel : Copy /Volumes/VueScan/VueScan.app to /Applications
2025-12-19 08:16:09 : WARN  : vuescanintel : Changing owner to u0105821
2025-12-19 08:16:09 : INFO  : vuescanintel : Finishing...
2025-12-19 08:16:12 : INFO  : vuescanintel : App(s) found: /Applications/VueScan.app
2025-12-19 08:16:12 : INFO  : vuescanintel : found app at /Applications/VueScan.app, version 9.8.50, on versionKey CFBundleShortVersionString
2025-12-19 08:16:12 : REQ   : vuescanintel : Installed VueScan, version 9.8.50
2025-12-19 08:16:12 : INFO  : vuescanintel : notifying
2025-12-19 08:16:14 : INFO  : vuescanintel : Installomator did not close any apps, so no need to reopen any apps.
2025-12-19 08:16:14 : REQ   : vuescanintel : All done!
2025-12-19 08:16:14 : REQ   : vuescanintel : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

A pull request creating or modifying a label in the fragments/labels folder.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

FYI, here is a new label for VueScan for Intel architecture. VueScan is a scanning application for macOS that provides advanced scanning features and supports a wide range of scanner models, including older scanners that may no longer have official driver support. You would want to use the Intel version on Apple Silicon Macs when using certain scanners that have drivers or kernel extensions that only work with Intel binaries and aren't compatible with Apple Silicon native code, even when running through Rosetta 2 translation.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
