### PR TITLE
vuescan-universal-new-label

### DIFF
--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -1,0 +1,9 @@
+vuescanuni)
+    # VueScan Universal (Apple Silicon + Intel)
+    name="VueScan"
+    type="dmg"
+    appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
+    expectedTeamID="5D5BXT9KP5"
+    blockingProcesses=("VueScan")
+    ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -5,5 +5,4 @@ vuescanuni)
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
     downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
     expectedTeamID="5D5BXT9KP5"
-    blockingProcesses=("VueScan")
     ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -2,6 +2,6 @@ vuescanuni)
     name="VueScan"
     type="dmg"
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    downloadURL="https://www.hamrick.com/files/vuea64-${appNewVersion}.dmg"
+    downloadURL="https://files.hamrick.com/vuea64-${appNewVersion}.dmg"
     expectedTeamID="5D5BXT9KP5"
     ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -2,6 +2,6 @@ vuescanuni)
     name="VueScan"
     type="dmg"
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    downloadURL="https://files.hamrick.com/vuea64-${appNewVersion}.dmg"
+    downloadURL="https://www.hamrick.com/download.html?v=a64&dl=1"
     expectedTeamID="5D5BXT9KP5"
     ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -1,8 +1,7 @@
 vuescanuni)
-    # VueScan Universal (Apple Silicon + Intel)
     name="VueScan"
     type="dmg"
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
+    downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | tr -d '.').dmg"
     expectedTeamID="5D5BXT9KP5"
     ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -2,6 +2,6 @@ vuescanuni)
     name="VueScan"
     type="dmg"
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    downloadURL="https://www.hamrick.com/download.html?v=a64&dl=1"
+    downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | cut -d'.' -f1,2 | tr -d '.').dmg"
     expectedTeamID="5D5BXT9KP5"
     ;;

--- a/fragments/labels/vuescanuni.sh
+++ b/fragments/labels/vuescanuni.sh
@@ -2,6 +2,6 @@ vuescanuni)
     name="VueScan"
     type="dmg"
     appNewVersion=$(curl -sfL https://www.hamrick.com/vuescan/vuescan.htm | grep -Eo 'VueScan [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-    downloadURL="https://www.hamrick.com/files/vuea64$(echo "$appNewVersion" | tr -d '.').dmg"
+    downloadURL="https://www.hamrick.com/files/vuea64-${appNewVersion}.dmg"
     expectedTeamID="5D5BXT9KP5"
     ;;


### PR DESCRIPTION
ourput
```
sudo Installomator/utils/assemble.sh vuescanuni DEBUG=0
2025-12-19 08:25:36 : REQ   : vuescanuni : ################## Start Installomator v. 10.6beta, date 2025-12-19
2025-12-19 08:25:36 : INFO  : vuescanuni : ################## Version: 10.6beta
2025-12-19 08:25:37 : INFO  : vuescanuni : ################## Date: 2025-12-19
2025-12-19 08:25:37 : INFO  : vuescanuni : ################## vuescanuni
2025-12-19 08:25:37 : DEBUG : vuescanuni : DEBUG mode 1 enabled.
2025-12-19 08:25:37 : INFO  : vuescanuni : setting variable from argument DEBUG=0
2025-12-19 08:25:37 : DEBUG : vuescanuni : name=VueScan
2025-12-19 08:25:37 : DEBUG : vuescanuni : appName=
2025-12-19 08:25:37 : DEBUG : vuescanuni : type=dmg
2025-12-19 08:25:37 : DEBUG : vuescanuni : archiveName=
2025-12-19 08:25:37 : DEBUG : vuescanuni : downloadURL=https://www.hamrick.com/files/vuea6498.dmg
2025-12-19 08:25:37 : DEBUG : vuescanuni : curlOptions=
2025-12-19 08:25:37 : DEBUG : vuescanuni : appNewVersion=9.8.50
2025-12-19 08:25:38 : DEBUG : vuescanuni : appCustomVersion function: Not defined
2025-12-19 08:25:38 : DEBUG : vuescanuni : versionKey=CFBundleShortVersionString
2025-12-19 08:25:38 : DEBUG : vuescanuni : packageID=
2025-12-19 08:25:38 : DEBUG : vuescanuni : pkgName=
2025-12-19 08:25:38 : DEBUG : vuescanuni : choiceChangesXML=
2025-12-19 08:25:38 : DEBUG : vuescanuni : expectedTeamID=5D5BXT9KP5
2025-12-19 08:25:38 : DEBUG : vuescanuni : blockingProcesses=VueScan
2025-12-19 08:25:38 : DEBUG : vuescanuni : installerTool=
2025-12-19 08:25:38 : DEBUG : vuescanuni : CLIInstaller=
2025-12-19 08:25:38 : DEBUG : vuescanuni : CLIArguments=
2025-12-19 08:25:38 : DEBUG : vuescanuni : updateTool=
2025-12-19 08:25:38 : DEBUG : vuescanuni : updateToolArguments=
2025-12-19 08:25:38 : DEBUG : vuescanuni : updateToolRunAsCurrentUser=
2025-12-19 08:25:38 : INFO  : vuescanuni : BLOCKING_PROCESS_ACTION=tell_user
2025-12-19 08:25:38 : INFO  : vuescanuni : NOTIFY=success
2025-12-19 08:25:38 : INFO  : vuescanuni : LOGGING=DEBUG
2025-12-19 08:25:38 : INFO  : vuescanuni : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-19 08:25:38 : INFO  : vuescanuni : Label type: dmg
2025-12-19 08:25:38 : INFO  : vuescanuni : archiveName: VueScan.dmg
2025-12-19 08:25:38 : DEBUG : vuescanuni : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2SbzE9kNMv
2025-12-19 08:25:38 : INFO  : vuescanuni : App(s) found: /Applications/VueScan.app
2025-12-19 08:25:38 : INFO  : vuescanuni : found app at /Applications/VueScan.app, version 9.8.50, on versionKey CFBundleShortVersionString
2025-12-19 08:25:38 : INFO  : vuescanuni : appversion: 9.8.50
2025-12-19 08:25:38 : INFO  : vuescanuni : Latest version of VueScan is 9.8.50
2025-12-19 08:25:38 : INFO  : vuescanuni : There is no newer version available.
2025-12-19 08:25:38 : DEBUG : vuescanuni : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2SbzE9kNMv
2025-12-19 08:25:38 : DEBUG : vuescanuni : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2SbzE9kNMv
2025-12-19 08:25:38 : INFO  : vuescanuni : Installomator did not close any apps, so no need to reopen any apps.
2025-12-19 08:25:38 : REQ   : vuescanuni : No newer version.
2025-12-19 08:25:38 : REQ   : vuescanuni : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes,  creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

FYI, here is a new label for VueScan for Universal architectures (aka Intel, Apple Silicon processors). VueScan is a scanning application for macOS that provides advanced scanning features and supports a wide range of scanner models, including older scanners that may no longer have official driver support. 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
