### PR TITLE
Update Citrix Workspace Label

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -2,7 +2,7 @@ citrixworkspace)
     name="Citrix Workspace"
     type="pkg"
     parseURL=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/DownloadURL)' -)
-    downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod/$parseURL
+    downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod"$parseURL"
     appNewVersion=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/Version)' -)
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"


### PR DESCRIPTION
Resolving error where Citrix Workspace would not download due to an extra "/" in the downloadURL variable after the parseURL variable finds the download version

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

Upon attempting to use the citrixworkspace label, found that it was erroring with Error code 3. In further examination, found that the URL that was being parsed by the `parseURL` variable was adding an extra forward slash (/) between `Prod` and `Receiver`. I have resolved this by removing the extra forward slash in the `downloadURL` variable to account for this.

Original output:
```sh
parseURL=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/DownloadURL)' -)
echo $parseURL
/Receiver/Mac/CitrixWorkspaceAppUniversal25.11.0.36.pkg
downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod/$parseURL
echo $downloadURL
https://downloadplugins.citrix.com/ReceiverUpdates/Prod//Receiver/Mac/CitrixWorkspaceAppUniversal25.11.0.36.pkg
```

Updated Output
```sh
parseURL=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/DownloadURL)' -)
echo $parseURL
/Receiver/Mac/CitrixWorkspaceAppUniversal25.11.0.36.pkg
downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod"$parseURL"
echo $downloadURL
https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceAppUniversal25.11.0.36.pkg
```
This updated output allows the download to start, resulting in an exit code of 0

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```sh
sudo '/Users/lucasharrison/GitHub/Installomator/Installomator.sh' citrixworkspace DEBUG=0
Password:
2025-12-19 20:27:25 : INFO  : citrixworkspace : setting variable from argument DEBUG=0
2025-12-19 20:27:25 : INFO  : citrixworkspace : Total items in argumentsArray: 1
2025-12-19 20:27:25 : INFO  : citrixworkspace : argumentsArray: DEBUG=0
2025-12-19 20:27:25 : REQ   : citrixworkspace : ################## Start Installomator v. 10.9beta, date 2025-12-19
2025-12-19 20:27:25 : INFO  : citrixworkspace : ################## Version: 10.9beta
2025-12-19 20:27:25 : INFO  : citrixworkspace : ################## Date: 2025-12-19
2025-12-19 20:27:25 : INFO  : citrixworkspace : ################## citrixworkspace
2025-12-19 20:27:26 : INFO  : citrixworkspace : Reading arguments again: DEBUG=0
2025-12-19 20:27:26 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2025-12-19 20:27:26 : INFO  : citrixworkspace : NOTIFY=success
2025-12-19 20:27:26 : INFO  : citrixworkspace : LOGGING=INFO
2025-12-19 20:27:26 : INFO  : citrixworkspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-19 20:27:26 : INFO  : citrixworkspace : Label type: pkg
2025-12-19 20:27:26 : INFO  : citrixworkspace : archiveName: Citrix Workspace.pkg
2025-12-19 20:27:26 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2025-12-19 20:27:26 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2025-12-19 20:27:26 : WARN  : citrixworkspace : No previous app found
2025-12-19 20:27:26 : WARN  : citrixworkspace : could not find Citrix Workspace.app
2025-12-19 20:27:26 : INFO  : citrixworkspace : appversion: 
2025-12-19 20:27:26 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 25.11.0.36
2025-12-19 20:27:26 : REQ   : citrixworkspace : Downloading https://downloadplugins.citrix.com/ReceiverUpdates/Prod//Receiver/Mac/CitrixWorkspaceAppUniversal25.11.0.36.pkg to Citrix Workspace.pkg
2025-12-19 20:27:32 : INFO  : citrixworkspace : Downloaded Citrix Workspace.pkg – Type is  xar archive compressed TOC – SHA is ad21f419a3f1c8d0c0467b0934c64da5b4d75c9b – Size is 311536 kB
2025-12-19 20:27:33 : REQ   : citrixworkspace : no more blocking processes, continue with update
2025-12-19 20:27:33 : REQ   : citrixworkspace : Installing Citrix Workspace
2025-12-19 20:27:33 : INFO  : citrixworkspace : Verifying: Citrix Workspace.pkg
2025-12-19 20:27:33 : INFO  : citrixworkspace : Team ID: S272Y5R93J (expected: S272Y5R93J )
2025-12-19 20:27:33 : INFO  : citrixworkspace : Installing Citrix Workspace.pkg to /
2025-12-19 20:27:51 : INFO  : citrixworkspace : Finishing...
2025-12-19 20:27:54 : INFO  : citrixworkspace : App(s) found: /Applications/Citrix Workspace.app
2025-12-19 20:27:54 : INFO  : citrixworkspace : found app at /Applications/Citrix Workspace.app, version 25.11.0.36, on versionKey CitrixVersionString
2025-12-19 20:27:54 : REQ   : citrixworkspace : Installed Citrix Workspace, version 25.11.0.36
2025-12-19 20:27:54 : INFO  : citrixworkspace : notifying
2025-12-19 20:27:54 : INFO  : citrixworkspace : Installomator did not close any apps, so no need to reopen any apps.
2025-12-19 20:27:54 : REQ   : citrixworkspace : All done!
2025-12-19 20:27:54 : REQ   : citrixworkspace : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
