### PR TITLE
Update displaylinkmanager.sh

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -1,6 +1,6 @@
 displaylinkmanager)
     name="DisplayLink Manager"
-    type="pkgInZip"
+    type="pkg"
     #packageID="com.displaylink.displaylinkmanagerapp"
     downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 'class="download-link">Download' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
     appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 "Release:" | cut -d ' ' -f2)


### PR DESCRIPTION
Synaptics changed their download from a ZIP to a PKG. Changing the type from pkgInZip to pkg

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
`yes`
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
`yes`
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
`yes`
**Additional context** Add any other context about the label or fix here.
Changing type from `pkgInZip` to `pkg` due to a change in the file downloaded from the developer
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
This will most likely fix #2657 & #2573 since those are issues with the old type

Log
```
2025-12-22 08:57:21 : INFO  : displaylinkmanager : Total items in argumentsArray: 0
2025-12-22 08:57:21 : INFO  : displaylinkmanager : argumentsArray: 
2025-12-22 08:57:21 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.9beta, date 2025-12-19
2025-12-22 08:57:21 : INFO  : displaylinkmanager : ################## Version: 10.9beta
2025-12-22 08:57:21 : INFO  : displaylinkmanager : ################## Date: 2025-12-19
2025-12-22 08:57:21 : INFO  : displaylinkmanager : ################## displaylinkmanager
2025-12-22 08:57:24 : INFO  : displaylinkmanager : Reading arguments again: 
2025-12-22 08:57:25 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2025-12-22 08:57:25 : INFO  : displaylinkmanager : NOTIFY=success
2025-12-22 08:57:25 : INFO  : displaylinkmanager : LOGGING=INFO
2025-12-22 08:57:25 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-22 08:57:25 : INFO  : displaylinkmanager : Label type: pkg
2025-12-22 08:57:25 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.pkg
2025-12-22 08:57:25 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2025-12-22 08:57:25 : INFO  : displaylinkmanager : name: DisplayLink Manager, appName: DisplayLink Manager.app
2025-12-22 08:57:25 : WARN  : displaylinkmanager : No previous app found
2025-12-22 08:57:25 : WARN  : displaylinkmanager : could not find DisplayLink Manager.app
2025-12-22 08:57:25 : INFO  : displaylinkmanager : appversion: 
2025-12-22 08:57:25 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 15.0
2025-12-22 08:57:25 : REQ   : displaylinkmanager : Downloading https://www.synaptics.com/sites/default/files/exe_files/2025-12/DisplayLink%20Manager%20Graphics%20Connectivity15.0-EXE.pkg to DisplayLink Manager.pkg
2025-12-22 08:57:26 : INFO  : displaylinkmanager : Downloaded DisplayLink Manager.pkg – Type is  xar archive compressed TOC – SHA is 5747ba5e13fe0fb5c3eb05928ad7ccc842dee94f – Size is 9012 kB
2025-12-22 08:57:26 : REQ   : displaylinkmanager : no more blocking processes, continue with update
2025-12-22 08:57:26 : REQ   : displaylinkmanager : Installing DisplayLink Manager
2025-12-22 08:57:26 : INFO  : displaylinkmanager : Verifying: DisplayLink Manager.pkg
2025-12-22 08:57:27 : INFO  : displaylinkmanager : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2025-12-22 08:57:27 : INFO  : displaylinkmanager : Installing DisplayLink Manager.pkg to /
2025-12-22 08:57:35 : INFO  : displaylinkmanager : Finishing...
2025-12-22 08:57:38 : INFO  : displaylinkmanager : App(s) found: /Applications/DisplayLink Manager.app
2025-12-22 08:57:38 : INFO  : displaylinkmanager : found app at /Applications/DisplayLink Manager.app, version 15.0.0, on versionKey CFBundleShortVersionString
2025-12-22 08:57:38 : REQ   : displaylinkmanager : Installed DisplayLink Manager, version 15.0
2025-12-22 08:57:38 : INFO  : displaylinkmanager : notifying
2025-12-22 08:57:39 : INFO  : displaylinkmanager : Installomator did not close any apps, so no need to reopen any apps.
2025-12-22 08:57:39 : REQ   : displaylinkmanager : All done!
2025-12-22 08:57:39 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0 
```