### PR TITLE
anydesk-label-update

### DIFF
--- a/fragments/labels/anydesk.sh
+++ b/fragments/labels/anydesk.sh
@@ -2,6 +2,6 @@ anydesk)
     name="AnyDesk"
     type="dmg"
     downloadURL="https://download.anydesk.com/anydesk.dmg"
-    appNewVersion="$(curl -fs https://anydesk.com/en/downloads/mac-os | grep -i "d-block" | grep -E -o ">v[0-9.]* .*MB" | sed -E 's/.*v([0-9.]*) .*/\1/g')"
+    appNewVersion=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs "https://download.anydesk.com/changelog.txt" | grep -m1 "(macOS)" | sed -E 's/.*- ([0-9.]+) \(macOS\).*/\1/')
     expectedTeamID="KHRWM533LU"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh anydesk DEBUG=0
2025-12-31 11:04:55 : INFO  : anydesk : setting variable from argument DEBUG=0
2025-12-31 11:04:55 : INFO  : anydesk : Total items in argumentsArray: 1
2025-12-31 11:04:55 : INFO  : anydesk : argumentsArray: DEBUG=0
2025-12-31 11:04:55 : REQ   : anydesk : ################## Start Installomator v. 10.9beta, date 2025-12-31
2025-12-31 11:04:55 : INFO  : anydesk : ################## Version: 10.9beta
2025-12-31 11:04:55 : INFO  : anydesk : ################## Date: 2025-12-31
2025-12-31 11:04:55 : INFO  : anydesk : ################## anydesk
2025-12-31 11:04:56 : INFO  : anydesk : Reading arguments again: DEBUG=0
2025-12-31 11:04:57 : INFO  : anydesk : BLOCKING_PROCESS_ACTION=tell_user
2025-12-31 11:04:57 : INFO  : anydesk : NOTIFY=success
2025-12-31 11:04:57 : INFO  : anydesk : LOGGING=INFO
2025-12-31 11:04:57 : INFO  : anydesk : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2025-12-31 11:04:57 : INFO  : anydesk : Label type: dmg
2025-12-31 11:04:57 : INFO  : anydesk : archiveName: AnyDesk.dmg
2025-12-31 11:04:57 : INFO  : anydesk : no blocking processes defined, using AnyDesk as default
2025-12-31 11:04:57 : INFO  : anydesk : name: AnyDesk, appName: AnyDesk.app
2025-12-31 11:04:57 : WARN  : anydesk : No previous app found
2025-12-31 11:04:57 : WARN  : anydesk : could not find AnyDesk.app
2025-12-31 11:04:57 : INFO  : anydesk : appversion:
2025-12-31 11:04:57 : INFO  : anydesk : Latest version of AnyDesk is 9.6.1
2025-12-31 11:04:57 : REQ   : anydesk : Downloading https://download.anydesk.com/anydesk.dmg to AnyDesk.dmg
2025-12-31 11:05:00 : INFO  : anydesk : Downloaded AnyDesk.dmg – Type is  zlib compressed data – SHA is fa82b1ba273b739dbbd2ad71d63385e9dca25b0c – Size is 25980 kB
2025-12-31 11:05:00 : REQ   : anydesk : no more blocking processes, continue with update
2025-12-31 11:05:00 : REQ   : anydesk : Installing AnyDesk
2025-12-31 11:05:00 : INFO  : anydesk : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5eLAAFcqzj/AnyDesk.dmg
2025-12-31 11:05:04 : INFO  : anydesk : Mounted: /Volumes/AnyDesk
2025-12-31 11:05:04 : INFO  : anydesk : Verifying: /Volumes/AnyDesk/AnyDesk.app
2025-12-31 11:05:06 : INFO  : anydesk : Team ID matching: KHRWM533LU (expected: KHRWM533LU )
2025-12-31 11:05:06 : INFO  : anydesk : Installing AnyDesk version 9.6.1 on versionKey CFBundleShortVersionString.
2025-12-31 11:05:06 : INFO  : anydesk : App has LSMinimumSystemVersion: 10.13.0
2025-12-31 11:05:06 : INFO  : anydesk : Copy /Volumes/AnyDesk/AnyDesk.app to /Applications
2025-12-31 11:05:06 : WARN  : anydesk : Changing owner to u0105821
2025-12-31 11:05:06 : INFO  : anydesk : Finishing...
2025-12-31 11:05:09 : INFO  : anydesk : App(s) found: /Applications/AnyDesk.app
2025-12-31 11:05:09 : INFO  : anydesk : found app at /Applications/AnyDesk.app, version 9.6.1, on versionKey CFBundleShortVersionString
2025-12-31 11:05:09 : REQ   : anydesk : Installed AnyDesk, version 9.6.1
2025-12-31 11:05:09 : INFO  : anydesk : notifying
2025-12-31 11:05:10 : INFO  : anydesk : Installomator did not close any apps, so no need to reopen any apps.
2025-12-31 11:05:10 : REQ   : anydesk : All done!
2025-12-31 11:05:10 : REQ   : anydesk : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The updated Installomator label for AnyDesk introduces critical fixes for both version detection and security verification. The method for determining the latest version (appNewVersion) was overhauled to fetch a lightweight plaintext changelog (changelog.txt) using a specific User-Agent header, which is significantly more reliable and robust than the previous method of scraping the HTML structure of the main download page. Additionally, the `expectedTeamID` was updated from `KU6W3B6JMZ` to `KHRWM533LU`, a necessary change to ensure the installed application passes code signature validation against the vendor's current developer certificate.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
