### PR TITLE
Update basecamp3

### DIFF
--- a/fragments/labels/basecamp3.sh
+++ b/fragments/labels/basecamp3.sh
@@ -2,9 +2,9 @@ basecamp3)
     name="Basecamp 3"
     type="dmg"
     if [[ $(/usr/bin/arch) == "arm64" ]]; then
-        downloadURL="https://bc3-desktop.s3.amazonaws.com/mac_arm64/basecamp3_arm64.dmg"
+        downloadURL="https://basecamp.com/desktop/mac_arm64/basecamp3_arm64.dmg"
     else
-        downloadURL="https://bc3-desktop.s3.amazonaws.com/mac/basecamp3.dmg"
+        downloadURL="https://basecamp.com/desktop/mac/basecamp3.dmg"
     fi
     expectedTeamID="2WNYUYRS7G"
     appName="Basecamp.app"

--- a/fragments/labels/basecamp3.sh
+++ b/fragments/labels/basecamp3.sh
@@ -1,10 +1,12 @@
 basecamp3)
     name="Basecamp 3"
-    type="dmg"
+    type="zip"
     if [[ $(/usr/bin/arch) == "arm64" ]]; then
-        downloadURL="https://basecamp.com/desktop/mac_arm64/basecamp3_arm64.dmg"
+        downloadURL=$(getJSONValue "$(curl -fsL https://basecamp.com/desktop/mac_arm64/updates.json)" "url")
+        appNewVersion=$(getJSONValue "$(curl -fsL https://basecamp.com/desktop/mac_arm64/updates.json)" "version")
     else
-        downloadURL="https://basecamp.com/desktop/mac/basecamp3.dmg"
+        downloadURL=$(getJSONValue "$(curl -fsL https://basecamp.com/desktop/mac/updates.json)" "url")
+        appNewVersion=$(getJSONValue "$(curl -fsL https://basecamp.com/desktop/mac/updates.json)" "version")
     fi
     expectedTeamID="2WNYUYRS7G"
     appName="Basecamp.app"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
 
**Additional context** Add any other context about the label or fix here.
@fdigiovanni [mentioned](https://github.com/Installomator/Installomator/pull/2239#issuecomment-3649599885) in already merged #2239 new download links.

**Installomator log** 

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh basecamp3
2026-01-03 22:47:55 : INFO  : basecamp3 : Total items in argumentsArray: 0
2026-01-03 22:47:55 : INFO  : basecamp3 : argumentsArray:
2026-01-03 22:47:55 : REQ   : basecamp3 : ################## Start Installomator v. 10.9beta, date 2026-01-03
2026-01-03 22:47:55 : INFO  : basecamp3 : ################## Version: 10.9beta
2026-01-03 22:47:55 : INFO  : basecamp3 : ################## Date: 2026-01-03
2026-01-03 22:47:55 : INFO  : basecamp3 : ################## basecamp3
2026-01-03 22:47:55 : DEBUG : basecamp3 : DEBUG mode 1 enabled.
2026-01-03 22:47:55 : INFO  : basecamp3 : Reading arguments again:
2026-01-03 22:47:55 : DEBUG : basecamp3 : name=Basecamp 3
2026-01-03 22:47:55 : DEBUG : basecamp3 : appName=Basecamp.app
2026-01-03 22:47:55 : DEBUG : basecamp3 : type=dmg
2026-01-03 22:47:55 : DEBUG : basecamp3 : archiveName=
2026-01-03 22:47:55 : DEBUG : basecamp3 : downloadURL=https://basecamp.com/desktop/mac_arm64/basecamp3_arm64.dmg
2026-01-03 22:47:55 : DEBUG : basecamp3 : curlOptions=
2026-01-03 22:47:55 : DEBUG : basecamp3 : appNewVersion=
2026-01-03 22:47:55 : DEBUG : basecamp3 : appCustomVersion function: Not defined
2026-01-03 22:47:55 : DEBUG : basecamp3 : versionKey=CFBundleShortVersionString
2026-01-03 22:47:55 : DEBUG : basecamp3 : packageID=
2026-01-03 22:47:55 : DEBUG : basecamp3 : pkgName=
2026-01-03 22:47:55 : DEBUG : basecamp3 : choiceChangesXML=
2026-01-03 22:47:55 : DEBUG : basecamp3 : expectedTeamID=2WNYUYRS7G
2026-01-03 22:47:55 : DEBUG : basecamp3 : blockingProcesses=
2026-01-03 22:47:55 : DEBUG : basecamp3 : installerTool=
2026-01-03 22:47:55 : DEBUG : basecamp3 : CLIInstaller=
2026-01-03 22:47:55 : DEBUG : basecamp3 : CLIArguments=
2026-01-03 22:47:55 : DEBUG : basecamp3 : updateTool=
2026-01-03 22:47:55 : DEBUG : basecamp3 : updateToolArguments=
2026-01-03 22:47:55 : DEBUG : basecamp3 : updateToolRunAsCurrentUser=
2026-01-03 22:47:55 : INFO  : basecamp3 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-03 22:47:55 : INFO  : basecamp3 : NOTIFY=success
2026-01-03 22:47:55 : INFO  : basecamp3 : LOGGING=DEBUG
2026-01-03 22:47:55 : INFO  : basecamp3 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-03 22:47:55 : INFO  : basecamp3 : Label type: dmg
2026-01-03 22:47:55 : INFO  : basecamp3 : archiveName: Basecamp 3.dmg
2026-01-03 22:47:55 : INFO  : basecamp3 : no blocking processes defined, using Basecamp 3 as default
2026-01-03 22:47:55 : DEBUG : basecamp3 : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2026-01-03 22:47:56 : INFO  : basecamp3 : name: Basecamp 3, appName: Basecamp.app
2026-01-03 22:47:56 : WARN  : basecamp3 : No previous app found
2026-01-03 22:47:56 : WARN  : basecamp3 : could not find Basecamp.app
2026-01-03 22:47:56 : INFO  : basecamp3 : appversion:
2026-01-03 22:47:56 : INFO  : basecamp3 : Latest version not specified.
2026-01-03 22:47:56 : REQ   : basecamp3 : Downloading https://basecamp.com/desktop/mac_arm64/basecamp3_arm64.dmg to Basecamp 3.dmg
2026-01-03 22:47:56 : DEBUG : basecamp3 : No Dialog connection, just download
2026-01-03 22:48:05 : INFO  : basecamp3 : Downloaded Basecamp 3.dmg – Type is  zlib compressed data – SHA is 3667632e5f2f612f7fef0a9bf069065781bc15a4 – Size is 114900 kB
2026-01-03 22:48:05 : DEBUG : basecamp3 : DEBUG mode 1, not checking for blocking processes
2026-01-03 22:48:05 : REQ   : basecamp3 : Installing Basecamp 3
2026-01-03 22:48:05 : INFO  : basecamp3 : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/Basecamp 3.dmg
2026-01-03 22:48:09 : DEBUG : basecamp3 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $F23ABF42
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $27939F57
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $14668EBA
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $9C7E3BE0
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $14668EBA
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $6BA8315A
verified CRC32 $6D890A4B
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Basecamp

2026-01-03 22:48:09 : INFO  : basecamp3 : Mounted: /Volumes/Basecamp
2026-01-03 22:48:09 : INFO  : basecamp3 : Verifying: /Volumes/Basecamp/Basecamp.app
2026-01-03 22:48:09 : DEBUG : basecamp3 : App size: 244M	/Volumes/Basecamp/Basecamp.app
2026-01-03 22:48:10 : DEBUG : basecamp3 : Debugging enabled, App Verification output was:
/Volumes/Basecamp/Basecamp.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Basecamp, LLC (2WNYUYRS7G)

2026-01-03 22:48:10 : INFO  : basecamp3 : Team ID matching: 2WNYUYRS7G (expected: 2WNYUYRS7G )
2026-01-03 22:48:10 : INFO  : basecamp3 : Installing Basecamp 3 version 2.5.2 on versionKey CFBundleShortVersionString.
2026-01-03 22:48:10 : INFO  : basecamp3 : App has LSMinimumSystemVersion: 11.0
2026-01-03 22:48:10 : DEBUG : basecamp3 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-01-03 22:48:10 : INFO  : basecamp3 : Finishing...
2026-01-03 22:48:13 : INFO  : basecamp3 : name: Basecamp 3, appName: Basecamp.app
2026-01-03 22:48:13 : WARN  : basecamp3 : No previous app found
2026-01-03 22:48:13 : WARN  : basecamp3 : could not find Basecamp.app
2026-01-03 22:48:13 : REQ   : basecamp3 : Installed Basecamp 3, version 2.5.2
2026-01-03 22:48:13 : INFO  : basecamp3 : notifying
2026-01-03 22:48:13 : DEBUG : basecamp3 : Unmounting /Volumes/Basecamp
2026-01-03 22:48:13 : DEBUG : basecamp3 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-01-03 22:48:13 : DEBUG : basecamp3 : DEBUG mode 1, not reopening anything
2026-01-03 22:48:13 : REQ   : basecamp3 : All done!
2026-01-03 22:48:13 : REQ   : basecamp3 : ################## End Installomator, exit code 0
````
