### PR TITLE
Create Box Drive labels with appNewVersion and feeds for multiple deployment scenarios

### DIFF
--- a/fragments/labels/boxdrive_alpha.sh
+++ b/fragments/labels/boxdrive_alpha.sh
@@ -1,0 +1,33 @@
+boxdrive_alpha)
+    get_http_code() {
+      /usr/bin/curl -sI -o /dev/null -w '%{http_code}' "$1"
+    }
+    find_latest_autoupdate_feed() {
+      local base="https://cdn07.boxcdn.net/Autoupdate"
+      local n=6          # start where "today" is
+      local max=20       # safety cap so we never loop forever
+      local code
+      while (( n <= max )); do
+        code=$(get_http_code "${base}${n}.json")
+        if [[ "$code" == "200" ]]; then
+          ((n++))
+        else
+          # first non-200 means the previous one was the last good feed
+          echo $((n-1))
+          return 0
+        fi
+      done
+      # if we hit the cap, just return the cap (or you can error)
+      echo "$max"
+    }
+    name="Box"
+    type="pkg"
+    latestN=$(find_latest_autoupdate_feed)
+    updateURL="https://cdn07.boxcdn.net/Autoupdate${latestN}.json"
+    updateFeedData=$(/usr/bin/curl -fsL  "${updateURL}")
+    updateFeedVersion="alpha"
+    updateFeedVersion=$(getJSONValue "${updateFeedData}" "mac.${updateFeedVersion}")
+    appNewVersion=$(getJSONValue "${updateFeedVersion}" "version")
+    downloadURL=$(getJSONValue "${updateFeedVersion}" '["download-url"]')
+    expectedTeamID="M683GB7CPW"
+    ;;

--- a/fragments/labels/boxdrive_beta.sh
+++ b/fragments/labels/boxdrive_beta.sh
@@ -1,0 +1,33 @@
+boxdrive_beta)
+    get_http_code() {
+      /usr/bin/curl -sI -o /dev/null -w '%{http_code}' "$1"
+    }
+    find_latest_autoupdate_feed() {
+      local base="https://cdn07.boxcdn.net/Autoupdate"
+      local n=6          # start where "today" is
+      local max=20       # safety cap so we never loop forever
+      local code
+      while (( n <= max )); do
+        code=$(get_http_code "${base}${n}.json")
+        if [[ "$code" == "200" ]]; then
+          ((n++))
+        else
+          # first non-200 means the previous one was the last good feed
+          echo $((n-1))
+          return 0
+        fi
+      done
+      # if we hit the cap, just return the cap (or you can error)
+      echo "$max"
+    }
+    name="Box"
+    type="pkg"
+    latestN=$(find_latest_autoupdate_feed)
+    updateURL="https://cdn07.boxcdn.net/Autoupdate${latestN}.json"
+    updateFeedData=$(/usr/bin/curl -fsL  "${updateURL}")
+    updateFeedVersion="beta"
+    updateFeedVersion=$(getJSONValue "${updateFeedData}" "mac.${updateFeedVersion}")
+    appNewVersion=$(getJSONValue "${updateFeedVersion}" "version")
+    downloadURL=$(getJSONValue "${updateFeedVersion}" '["download-url"]')
+    expectedTeamID="M683GB7CPW"
+    ;;

--- a/fragments/labels/boxdrive_eap.sh
+++ b/fragments/labels/boxdrive_eap.sh
@@ -1,0 +1,33 @@
+boxdrive_eap)
+    get_http_code() {
+      /usr/bin/curl -sI -o /dev/null -w '%{http_code}' "$1"
+    }
+    find_latest_autoupdate_feed() {
+      local base="https://cdn07.boxcdn.net/Autoupdate"
+      local n=6          # start where "today" is
+      local max=20       # safety cap so we never loop forever
+      local code
+      while (( n <= max )); do
+        code=$(get_http_code "${base}${n}.json")
+        if [[ "$code" == "200" ]]; then
+          ((n++))
+        else
+          # first non-200 means the previous one was the last good feed
+          echo $((n-1))
+          return 0
+        fi
+      done
+      # if we hit the cap, just return the cap (or you can error)
+      echo "$max"
+    }
+    name="Box"
+    type="pkg"
+    latestN=$(find_latest_autoupdate_feed)
+    updateURL="https://cdn07.boxcdn.net/Autoupdate${latestN}.json"
+    updateFeedData=$(/usr/bin/curl -fsL  "${updateURL}")
+    updateFeedVersion="eap"
+    updateFeedVersion=$(getJSONValue "${updateFeedData}" "mac.${updateFeedVersion}")
+    appNewVersion=$(getJSONValue "${updateFeedVersion}" "version")
+    downloadURL=$(getJSONValue "${updateFeedVersion}" '["download-url"]')
+    expectedTeamID="M683GB7CPW"
+    ;;

--- a/fragments/labels/boxdrive_enterprise.sh
+++ b/fragments/labels/boxdrive_enterprise.sh
@@ -1,0 +1,33 @@
+boxdrive_enterprise)
+    get_http_code() {
+      /usr/bin/curl -sI -o /dev/null -w '%{http_code}' "$1"
+    }
+    find_latest_autoupdate_feed() {
+      local base="https://cdn07.boxcdn.net/Autoupdate"
+      local n=6          # start where "today" is
+      local max=20       # safety cap so we never loop forever
+      local code
+      while (( n <= max )); do
+        code=$(get_http_code "${base}${n}.json")
+        if [[ "$code" == "200" ]]; then
+          ((n++))
+        else
+          # first non-200 means the previous one was the last good feed
+          echo $((n-1))
+          return 0
+        fi
+      done
+      # if we hit the cap, just return the cap (or you can error)
+      echo "$max"
+    }
+    name="Box"
+    type="pkg"
+    latestN=$(find_latest_autoupdate_feed)
+    updateURL="https://cdn07.boxcdn.net/Autoupdate${latestN}.json"
+    updateFeedData=$(/usr/bin/curl -fsL  "${updateURL}")
+    updateFeedVersion="enterprise"
+    updateFeedVersion=$(getJSONValue "${updateFeedData}" "mac.${updateFeedVersion}")
+    appNewVersion=$(getJSONValue "${updateFeedVersion}" "version")
+    downloadURL=$(getJSONValue "${updateFeedVersion}" '["download-url"]')
+    expectedTeamID="M683GB7CPW"
+    ;;

--- a/fragments/labels/boxdrive_free.sh
+++ b/fragments/labels/boxdrive_free.sh
@@ -1,0 +1,33 @@
+boxdrive_free)
+    get_http_code() {
+      /usr/bin/curl -sI -o /dev/null -w '%{http_code}' "$1"
+    }
+    find_latest_autoupdate_feed() {
+      local base="https://cdn07.boxcdn.net/Autoupdate"
+      local n=6          # start where "today" is
+      local max=20       # safety cap so we never loop forever
+      local code
+      while (( n <= max )); do
+        code=$(get_http_code "${base}${n}.json")
+        if [[ "$code" == "200" ]]; then
+          ((n++))
+        else
+          # first non-200 means the previous one was the last good feed
+          echo $((n-1))
+          return 0
+        fi
+      done
+      # if we hit the cap, just return the cap (or you can error)
+      echo "$max"
+    }
+    name="Box"
+    type="pkg"
+    latestN=$(find_latest_autoupdate_feed)
+    updateURL="https://cdn07.boxcdn.net/Autoupdate${latestN}.json"
+    updateFeedData=$(/usr/bin/curl -fsL  "${updateURL}")
+    updateFeedVersion="free"
+    updateFeedVersion=$(getJSONValue "${updateFeedData}" "mac.${updateFeedVersion}")
+    appNewVersion=$(getJSONValue "${updateFeedVersion}" "version")
+    downloadURL=$(getJSONValue "${updateFeedVersion}" '["download-url"]')
+    expectedTeamID="M683GB7CPW"
+    ;;


### PR DESCRIPTION
Added 5 new Box Drive labels that can get various deployment versions: alpha, beta, eap, enterprise or free.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
This added the appNewVersion key to Box Drive and it adds the ability to pull various deployment options:
alpha, beta, eap, enterprise, free.

Box keeps revving the version feed URL, so I also tired to future proof the update feed URL for when Box inevitably breaks the feed by changing the URL. So, that meant a little bit more code in each label. Let me know if you prefer that not be in the label and I can strip it down to just the working URL for today.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

**Example label run:**
```
./utils/assemble.sh boxdrive_eap
2026-01-03 15:50:59 : INFO  : boxdrive_eap : Total items in argumentsArray: 0
2026-01-03 15:50:59 : INFO  : boxdrive_eap : argumentsArray: 
2026-01-03 15:50:59 : REQ   : boxdrive_eap : ################## Start Installomator v. 10.9beta, date 2026-01-03
2026-01-03 15:50:59 : INFO  : boxdrive_eap : ################## Version: 10.9beta
2026-01-03 15:50:59 : INFO  : boxdrive_eap : ################## Date: 2026-01-03
2026-01-03 15:50:59 : INFO  : boxdrive_eap : ################## boxdrive_eap
2026-01-03 15:50:59 : DEBUG : boxdrive_eap : DEBUG mode 1 enabled.
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Reading arguments again: 
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : name=Box
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : appName=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : type=pkg
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : archiveName=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : downloadURL=https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-2.49.255.pkg
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : curlOptions=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : appNewVersion=2.49.255
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : appCustomVersion function: Not defined
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : versionKey=CFBundleShortVersionString
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : packageID=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : pkgName=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : choiceChangesXML=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : expectedTeamID=M683GB7CPW
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : blockingProcesses=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : installerTool=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : CLIInstaller=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : CLIArguments=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : updateTool=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : updateToolArguments=
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : updateToolRunAsCurrentUser=
2026-01-03 15:51:00 : INFO  : boxdrive_eap : BLOCKING_PROCESS_ACTION=tell_user
2026-01-03 15:51:00 : INFO  : boxdrive_eap : NOTIFY=success
2026-01-03 15:51:00 : INFO  : boxdrive_eap : LOGGING=DEBUG
2026-01-03 15:51:00 : INFO  : boxdrive_eap : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Label type: pkg
2026-01-03 15:51:00 : INFO  : boxdrive_eap : archiveName: Box.pkg
2026-01-03 15:51:00 : INFO  : boxdrive_eap : no blocking processes defined, using Box as default
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-01-03 15:51:00 : INFO  : boxdrive_eap : App(s) found: /Applications/Box.app
2026-01-03 15:51:00 : INFO  : boxdrive_eap : found app at /Applications/Box.app, version 2.49.249, on versionKey CFBundleShortVersionString
2026-01-03 15:51:00 : INFO  : boxdrive_eap : appversion: 2.49.249
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Latest version of Box is 2.49.255
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Box.pkg exists and DEBUG mode 1 enabled, skipping download
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : DEBUG mode 1, not checking for blocking processes
2026-01-03 15:51:00 : REQ   : boxdrive_eap : Installing Box
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Verifying: Box.pkg
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : File list: -rw-r--r--  1 gilburns  staff    57M Jan  3 15:15 Box.pkg
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : File type: Box.pkg: xar archive compressed TOC: 5334, SHA-1 checksum
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : spctlOut is Box.pkg: accepted
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : source=Notarized Developer ID
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : origin=Developer ID Installer: Box, Inc. (M683GB7CPW)
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Team ID: M683GB7CPW (expected: M683GB7CPW )
2026-01-03 15:51:00 : DEBUG : boxdrive_eap : DEBUG enabled, skipping installation
2026-01-03 15:51:00 : INFO  : boxdrive_eap : Finishing...
2026-01-03 15:51:03 : INFO  : boxdrive_eap : App(s) found: /Applications/Box.app
2026-01-03 15:51:03 : INFO  : boxdrive_eap : found app at /Applications/Box.app, version 2.49.249, on versionKey CFBundleShortVersionString
2026-01-03 15:51:03 : REQ   : boxdrive_eap : Installed Box, version 2.49.255
2026-01-03 15:51:03 : INFO  : boxdrive_eap : notifying
2026-01-03 15:51:03 : DEBUG : boxdrive_eap : DEBUG mode 1, not reopening anything
2026-01-03 15:51:03 : REQ   : boxdrive_eap : All done!
2026-01-03 15:51:03 : REQ   : boxdrive_eap : ################## End Installomator, exit code 0 

```
