### PR TITLE
displaylink-manager-label-update

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -1,7 +1,6 @@
 displaylinkmanager)
     name="DisplayLink Manager"
     type="pkg"
-    packageID="com.displaylink.displaylinkmanagerapp"
     appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'DisplayLink%20Manager%20Graphics%20Connectivity[0-9.]*-Release' | head -1 | sed 's/DisplayLink%20Manager%20Graphics%20Connectivity//' | sed 's/-Release//')
     productPage=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'href="/products/displaylink-manager-graphics-connectivity-[^"]*?filetype=exe"' | head -1 | sed 's/href="//' | sed 's/"$//' | sed 's/?filetype=exe/?filetype=pkg/')
     downloadURL="https://www.synaptics.com$(curl -sfL "https://www.synaptics.com${productPage}" | grep -o '/sites/default/files/exe_files/[^"]*\.pkg' | head -1)"

--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -1,8 +1,9 @@
 displaylinkmanager)
     name="DisplayLink Manager"
     type="pkg"
-    #packageID="com.displaylink.displaylinkmanagerapp"
-    downloadURL=https://www.synaptics.com$(redirect=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 'class="download-link">Download' | sed 's/.*href="//' | sed 's/".*//') && curl -sfL "https://www.synaptics.com$redirect" | grep 'class="no-link"' | awk -F 'href="' '{print $2}' | awk -F '"' '{print $1}')
-    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -m 1 "Release:" | cut -d ' ' -f2)
+    packageID="com.displaylink.displaylinkmanagerapp"
+    appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'DisplayLink%20Manager%20Graphics%20Connectivity[0-9.]*-Release' | head -1 | sed 's/DisplayLink%20Manager%20Graphics%20Connectivity//' | sed 's/-Release//')
+    productPage=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'href="/products/displaylink-manager-graphics-connectivity-[^"]*?filetype=exe"' | head -1 | sed 's/href="//' | sed 's/"$//' | sed 's/?filetype=exe/?filetype=pkg/')
+    downloadURL="https://www.synaptics.com$(curl -sfL "https://www.synaptics.com${productPage}" | grep -o '/sites/default/files/exe_files/[^"]*\.pkg' | head -1)"
     expectedTeamID="73YQY62QM3"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh displaylinkmanager DEBUG=0
2026-01-05 12:06:51 : INFO  : displaylinkmanager : setting variable from argument DEBUG=0
2026-01-05 12:06:51 : INFO  : displaylinkmanager : Total items in argumentsArray: 1
2026-01-05 12:06:51 : INFO  : displaylinkmanager : argumentsArray: DEBUG=0
2026-01-05 12:06:51 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.9beta, date 2026-01-05
2026-01-05 12:06:51 : INFO  : displaylinkmanager : ################## Version: 10.9beta
2026-01-05 12:06:51 : INFO  : displaylinkmanager : ################## Date: 2026-01-05
2026-01-05 12:06:51 : INFO  : displaylinkmanager : ################## displaylinkmanager
2026-01-05 12:06:53 : INFO  : displaylinkmanager : Reading arguments again: DEBUG=0
2026-01-05 12:06:53 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-01-05 12:06:53 : INFO  : displaylinkmanager : NOTIFY=success
2026-01-05 12:06:53 : INFO  : displaylinkmanager : LOGGING=INFO
2026-01-05 12:06:53 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-05 12:06:53 : INFO  : displaylinkmanager : Label type: pkg
2026-01-05 12:06:53 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.pkg
2026-01-05 12:06:53 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2026-01-05 12:06:53 : INFO  : displaylinkmanager : No version found using packageID com.displaylink.displaylinkmanagerapp
2026-01-05 12:06:53 : INFO  : displaylinkmanager : name: DisplayLink Manager, appName: DisplayLink Manager.app
2026-01-05 12:06:54 : WARN  : displaylinkmanager : No previous app found
2026-01-05 12:06:54 : WARN  : displaylinkmanager : could not find DisplayLink Manager.app
2026-01-05 12:06:54 : INFO  : displaylinkmanager : appversion:
2026-01-05 12:06:54 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 15.0
2026-01-05 12:06:54 : REQ   : displaylinkmanager : Downloading https://www.synaptics.com/sites/default/files/exe_files/2025-12/DisplayLink%20Manager%20Graphics%20Connectivity15.0-EXE.pkg to DisplayLink Manager.pkg
2026-01-05 12:06:55 : INFO  : displaylinkmanager : Downloaded DisplayLink Manager.pkg – Type is  xar archive compressed TOC – SHA is 5747ba5e13fe0fb5c3eb05928ad7ccc842dee94f – Size is 9012 kB
2026-01-05 12:06:55 : REQ   : displaylinkmanager : no more blocking processes, continue with update
2026-01-05 12:06:55 : REQ   : displaylinkmanager : Installing DisplayLink Manager
2026-01-05 12:06:55 : INFO  : displaylinkmanager : Verifying: DisplayLink Manager.pkg
2026-01-05 12:06:55 : INFO  : displaylinkmanager : Team ID: 73YQY62QM3 (expected: 73YQY62QM3 )
2026-01-05 12:06:55 : INFO  : displaylinkmanager : Installing DisplayLink Manager.pkg to /
2026-01-05 12:07:03 : INFO  : displaylinkmanager : Finishing...
2026-01-05 12:07:06 : INFO  : displaylinkmanager : found packageID com.displaylink.displaylinkmanagerapp installed, version 15.0.0
2026-01-05 12:07:06 : REQ   : displaylinkmanager : Installed DisplayLink Manager, version 15.0
2026-01-05 12:07:06 : INFO  : displaylinkmanager : notifying
2026-01-05 12:07:06 : INFO  : displaylinkmanager : Installomator did not close any apps, so no need to reopen any apps.
2026-01-05 12:07:06 : REQ   : displaylinkmanager : All done!
2026-01-05 12:07:06 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0

```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

This pull request fixes issues with previous issue requests, [#2573](https://github.com/Installomator/Installomator/issues/2573) and [#2717](https://github.com/Installomator/Installomator/issues/2717).

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The primary improvement in the new Installomator label is that it correctly downloads the macOS .pkg file instead of the Windows .EXE file that was causing the "no usable signature" verification error. The old label's HTML scraping logic was inadvertently following download links that led to Windows executables, while the new label explicitly modifies the query parameter from ?filetype=exe to ?filetype=pkg before following the product page redirect to ensure it retrieves the correct macOS package. Additionally, the new label improves version detection by extracting the version number directly from release notes filenames rather than searching for inconsistent "Release:" text, uses sequential variable assignments instead of nested command substitution for better error handling and debugging, and re-enables the packageID field, which allows Installomator to properly verify installation status. These changes transform a failing installation script into one that successfully downloads, verifies, and installs the DisplayLink Manager software on macOS systems.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
