### PR TITLE
sketch-label-update

### DIFF
--- a/fragments/labels/sketch.sh
+++ b/fragments/labels/sketch.sh
@@ -1,7 +1,7 @@
 sketch)
     name="Sketch"
     type="zip"
-    downloadURL=$(curl -sf https://www.sketch.com/downloads/mac/ | grep -m 1 'href="https://download.sketch.com' | tr '"' "\n" | grep -E "https.*.zip")
-    appNewVersion=$(echo "$downloadURL" | awk -F'-' '{ print $2 }')
+    downloadURL=$(curl -sfL https://www.sketch.com/downloads/mac/ | grep -o 'https://download.sketch.com[^"]*\.zip' | head -1)
+    appNewVersion=$(curl -sfL https://www.sketch.com/downloads/mac/ | grep -o 'sketch-[0-9.-]*\.zip' | head -1 | sed 's/sketch-//;s/\.zip//;s/-[0-9]*$//')
     expectedTeamID="WUGMZZ5K46"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh sketch DEBUG=0
2026-01-05 12:43:10 : INFO  : sketch : setting variable from argument DEBUG=0
2026-01-05 12:43:10 : INFO  : sketch : Total items in argumentsArray: 1
2026-01-05 12:43:10 : INFO  : sketch : argumentsArray: DEBUG=0
2026-01-05 12:43:10 : REQ   : sketch : ################## Start Installomator v. 10.9beta, date 2026-01-05
2026-01-05 12:43:10 : INFO  : sketch : ################## Version: 10.9beta
2026-01-05 12:43:10 : INFO  : sketch : ################## Date: 2026-01-05
2026-01-05 12:43:10 : INFO  : sketch : ################## sketch
2026-01-05 12:43:11 : INFO  : sketch : Reading arguments again: DEBUG=0
2026-01-05 12:43:11 : INFO  : sketch : BLOCKING_PROCESS_ACTION=tell_user
2026-01-05 12:43:11 : INFO  : sketch : NOTIFY=success
2026-01-05 12:43:11 : INFO  : sketch : LOGGING=INFO
2026-01-05 12:43:11 : INFO  : sketch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-05 12:43:11 : INFO  : sketch : Label type: zip
2026-01-05 12:43:11 : INFO  : sketch : archiveName: Sketch.zip
2026-01-05 12:43:11 : INFO  : sketch : no blocking processes defined, using Sketch as default
2026-01-05 12:43:11 : INFO  : sketch : name: Sketch, appName: Sketch.app
2026-01-05 12:43:11 : WARN  : sketch : No previous app found
2026-01-05 12:43:11 : WARN  : sketch : could not find Sketch.app
2026-01-05 12:43:11 : INFO  : sketch : appversion:
2026-01-05 12:43:11 : INFO  : sketch : Latest version of Sketch is 2025.3.2
2026-01-05 12:43:11 : REQ   : sketch : Downloading https://download.sketch.com/sketch-2025.3.2-221149.zip to Sketch.zip
2026-01-05 12:43:14 : INFO  : sketch : Downloaded Sketch.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 4091cb3fee0e832d7932a3371674172314591b5f – Size is 115168 kB
2026-01-05 12:43:15 : REQ   : sketch : no more blocking processes, continue with update
2026-01-05 12:43:15 : REQ   : sketch : Installing Sketch
2026-01-05 12:43:15 : INFO  : sketch : Unzipping Sketch.zip
2026-01-05 12:43:16 : INFO  : sketch : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.0vcVQaEkO4/Sketch.app
2026-01-05 12:43:17 : INFO  : sketch : Team ID matching: WUGMZZ5K46 (expected: WUGMZZ5K46 )
2026-01-05 12:43:17 : INFO  : sketch : Installing Sketch version 2025.3.2 on versionKey CFBundleShortVersionString.
2026-01-05 12:43:17 : INFO  : sketch : App has LSMinimumSystemVersion: 14.0.0
2026-01-05 12:43:17 : INFO  : sketch : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.0vcVQaEkO4/Sketch.app to /Applications
2026-01-05 12:43:19 : WARN  : sketch : Changing owner to u0105821
2026-01-05 12:43:20 : INFO  : sketch : Finishing...
2026-01-05 12:43:23 : INFO  : sketch : App(s) found: /Applications/Sketch.app
2026-01-05 12:43:23 : INFO  : sketch : found app at /Applications/Sketch.app, version 2025.3.2, on versionKey CFBundleShortVersionString
2026-01-05 12:43:23 : REQ   : sketch : Installed Sketch, version 2025.3.2
2026-01-05 12:43:23 : INFO  : sketch : notifying
2026-01-05 12:43:24 : INFO  : sketch : Installomator did not close any apps, so no need to reopen any apps.
2026-01-05 12:43:24 : REQ   : sketch : All done!
2026-01-05 12:43:24 : REQ   : sketch : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

 Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The new label improves reliability by adding the -L flag to follow redirects, using more precise regex patterns with grep -o and head -1 to ensure only one URL is captured (preventing duplicate matches), and simplifying the download URL extraction by removing the unnecessary tr command. The version detection is enhanced by parsing the filename directly from the website rather than relying on the downloadURL variable, making it independent and more robust. The sed-based version extraction also properly strips the build number suffix (e.g., extracting 2025.3.2 from sketch-2025.3.2-221149.zip) instead of the simpler awk approach that could fail with different filename formats.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
