### PR TITLE
sketchup-2026-label-update

### DIFF
--- a/fragments/labels/sketchup2026.sh
+++ b/fragments/labels/sketchup2026.sh
@@ -1,10 +1,10 @@
 sketchup2026)
     name="SketchUp 2026"
     type="dmg"
-    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2026[^"]*.dmg')"
+    downloadURL=$(curl -sI https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg | grep -i '^location:' | awk '{print $2}' | tr -d '\r')
     folderName="SketchUp 2026"
     appName="${folderName}/SketchUp.app"
-    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    appNewVersion=$(echo "$downloadURL" | grep -o '2026-[0-9]*-[0-9]*-[0-9]*' | sed 's/2026-/26./;s/-/./g')
     versionKey="CFBundleVersion"
     expectedTeamID="J8PVMCY7KL"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh sketchup2026 DEBUG=0
2026-01-05 13:16:06 : INFO  : sketchup2026 : setting variable from argument DEBUG=0
2026-01-05 13:16:06 : INFO  : sketchup2026 : Total items in argumentsArray: 1
2026-01-05 13:16:06 : INFO  : sketchup2026 : argumentsArray: DEBUG=0
2026-01-05 13:16:06 : REQ   : sketchup2026 : ################## Start Installomator v. 10.9beta, date 2026-01-05
2026-01-05 13:16:06 : INFO  : sketchup2026 : ################## Version: 10.9beta
2026-01-05 13:16:06 : INFO  : sketchup2026 : ################## Date: 2026-01-05
2026-01-05 13:16:06 : INFO  : sketchup2026 : ################## sketchup2026
2026-01-05 13:16:07 : INFO  : sketchup2026 : Reading arguments again: DEBUG=0
2026-01-05 13:16:07 : INFO  : sketchup2026 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-05 13:16:07 : INFO  : sketchup2026 : NOTIFY=success
2026-01-05 13:16:07 : INFO  : sketchup2026 : LOGGING=INFO
2026-01-05 13:16:07 : INFO  : sketchup2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-05 13:16:07 : INFO  : sketchup2026 : Label type: dmg
2026-01-05 13:16:07 : INFO  : sketchup2026 : archiveName: SketchUp 2026.dmg
2026-01-05 13:16:07 : INFO  : sketchup2026 : no blocking processes defined, using SketchUp 2026 as default
2026-01-05 13:16:07 : INFO  : sketchup2026 : name: SketchUp 2026, appName: SketchUp 2026/SketchUp.app
2026-01-05 13:16:08 : WARN  : sketchup2026 : No previous app found
2026-01-05 13:16:08 : WARN  : sketchup2026 : could not find SketchUp 2026/SketchUp.app
2026-01-05 13:16:08 : INFO  : sketchup2026 : appversion:
2026-01-05 13:16:08 : INFO  : sketchup2026 : Latest version of SketchUp 2026 is 26.1.188.46
2026-01-05 13:16:08 : REQ   : sketchup2026 : Downloading https://download.sketchup.com/SketchUp-2026-1-188-46.dmg to SketchUp 2026.dmg
2026-01-05 13:16:45 : INFO  : sketchup2026 : Downloaded SketchUp 2026.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 0875f095b647c3d8907d64cbfb11b5c143b77eea – Size is 1491736 kB
2026-01-05 13:16:45 : REQ   : sketchup2026 : no more blocking processes, continue with update
2026-01-05 13:16:45 : REQ   : sketchup2026 : Installing SketchUp 2026
2026-01-05 13:16:45 : INFO  : sketchup2026 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.l9MDdk0UZB/SketchUp 2026.dmg
2026-01-05 13:17:57 : INFO  : sketchup2026 : Mounted: /Volumes/SketchUp 2026
2026-01-05 13:17:57 : INFO  : sketchup2026 : Verifying: /Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app
2026-01-05 13:19:59 : INFO  : sketchup2026 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2026-01-05 13:19:59 : INFO  : sketchup2026 : Installing SketchUp 2026 version 26.1.188 on versionKey CFBundleVersion.
2026-01-05 13:19:59 : INFO  : sketchup2026 : App has LSMinimumSystemVersion: 13.0
2026-01-05 13:19:59 : INFO  : sketchup2026 : Copy /Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app to /Applications
2026-01-05 13:22:37 : WARN  : sketchup2026 : Changing owner to u0105821
2026-01-05 13:22:42 : INFO  : sketchup2026 : Finishing...
2026-01-05 13:22:45 : INFO  : sketchup2026 : App(s) found: /Applications/SketchUp 2026/SketchUp.app
2026-01-05 13:22:45 : INFO  : sketchup2026 : found app at /Applications/SketchUp 2026/SketchUp.app, version 26.1.188, on versionKey CFBundleVersion
2026-01-05 13:22:45 : REQ   : sketchup2026 : Installed SketchUp 2026, version 26.1.188
2026-01-05 13:22:45 : INFO  : sketchup2026 : notifying
2026-01-05 13:22:46 : INFO  : sketchup2026 : Installomator did not close any apps, so no need to reopen any apps.
2026-01-05 13:22:46 : REQ   : sketchup2026 : All done!
2026-01-05 13:22:46 : REQ   : sketchup2026 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The new label dramatically improves performance by using a HEAD request (curl -sI) to get the redirect location from HTTP headers instead of downloading the entire HTML page, making it nearly instant versus several seconds. It replaces the unreliable HTML scraping approach (which was returning empty results) with a direct redirect URL that consistently works. The version extraction is simplified by removing the complex conditional awk logic with year calculations, replacing it with a straightforward sed substitution that converts 2026-1-188-46 to 26.1.188.46. The new approach is faster, more reliable, and uses a cleaner, more maintainable code structure.

This fixes issues and is an update to the problem ticket: https://github.com/Installomator/Installomator/issues/2697

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
