### PR TITLE
sketchup-2025-label-update

### DIFF
--- a/fragments/labels/sketchup2025.sh
+++ b/fragments/labels/sketchup2025.sh
@@ -1,10 +1,10 @@
 sketchup2025)
     name="SketchUp 2025"
     type="dmg"
-    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2025[^"]*.dmg')"
+    downloadURL=$(curl -sfL https://www.sketchup.com/download/all | grep -o 'https://download.sketchup.com/SketchUp-2025[^"]*.dmg' | head -1)
     folderName="SketchUp 2025"
     appName="${folderName}/SketchUp.app"
-    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    appNewVersion=$(echo "$downloadURL" | grep -o '2025-[0-9]*-[0-9]*-[0-9]*' | sed 's/2025-/25./;s/-/./g')
     versionKey="CFBundleVersion"
     expectedTeamID="J8PVMCY7KL"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh sketchup2025 DEBUG=0
2026-01-05 13:56:49 : INFO  : sketchup2025 : setting variable from argument DEBUG=0
2026-01-05 13:56:49 : INFO  : sketchup2025 : Total items in argumentsArray: 1
2026-01-05 13:56:49 : INFO  : sketchup2025 : argumentsArray: DEBUG=0
2026-01-05 13:56:49 : REQ   : sketchup2025 : ################## Start Installomator v. 10.9beta, date 2026-01-05
2026-01-05 13:56:49 : INFO  : sketchup2025 : ################## Version: 10.9beta
2026-01-05 13:56:50 : INFO  : sketchup2025 : ################## Date: 2026-01-05
2026-01-05 13:56:50 : INFO  : sketchup2025 : ################## sketchup2025
2026-01-05 13:56:51 : INFO  : sketchup2025 : Reading arguments again: DEBUG=0
2026-01-05 13:56:51 : INFO  : sketchup2025 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-05 13:56:51 : INFO  : sketchup2025 : NOTIFY=success
2026-01-05 13:56:51 : INFO  : sketchup2025 : LOGGING=INFO
2026-01-05 13:56:51 : INFO  : sketchup2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-05 13:56:51 : INFO  : sketchup2025 : Label type: dmg
2026-01-05 13:56:51 : INFO  : sketchup2025 : archiveName: SketchUp 2025.dmg
2026-01-05 13:56:51 : INFO  : sketchup2025 : no blocking processes defined, using SketchUp 2025 as default
2026-01-05 13:56:51 : INFO  : sketchup2025 : name: SketchUp 2025, appName: SketchUp 2025/SketchUp.app
2026-01-05 13:56:51 : WARN  : sketchup2025 : No previous app found
2026-01-05 13:56:51 : WARN  : sketchup2025 : could not find SketchUp 2025/SketchUp.app
2026-01-05 13:56:51 : INFO  : sketchup2025 : appversion:
2026-01-05 13:56:51 : INFO  : sketchup2025 : Latest version of SketchUp 2025 is 25.0.659.288
2026-01-05 13:56:51 : REQ   : sketchup2025 : Downloading https://download.sketchup.com/SketchUp-2025-0-659-288.dmg to SketchUp 2025.dmg
2026-01-05 13:57:34 : INFO  : sketchup2025 : Downloaded SketchUp 2025.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 1615da994017fbb2b09bf839000f1d54085023b6 – Size is 1687596 kB
2026-01-05 13:57:34 : REQ   : sketchup2025 : no more blocking processes, continue with update
2026-01-05 13:57:34 : REQ   : sketchup2025 : Installing SketchUp 2025
2026-01-05 13:57:34 : INFO  : sketchup2025 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.rEJWAOwZnZ/SketchUp 2025.dmg
2026-01-05 13:58:54 : INFO  : sketchup2025 : Mounted: /Volumes/SketchUp 2025
2026-01-05 13:58:54 : INFO  : sketchup2025 : Verifying: /Volumes/SketchUp 2025/SketchUp 2025/SketchUp.app
2026-01-05 14:01:12 : INFO  : sketchup2025 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2026-01-05 14:01:12 : INFO  : sketchup2025 : Installing SketchUp 2025 version 25.0.659 on versionKey CFBundleVersion.
2026-01-05 14:01:12 : INFO  : sketchup2025 : App has LSMinimumSystemVersion: 11.7
2026-01-05 14:01:12 : INFO  : sketchup2025 : Copy /Volumes/SketchUp 2025/SketchUp 2025/SketchUp.app to /Applications
2026-01-05 14:04:09 : WARN  : sketchup2025 : Changing owner to u0105821
2026-01-05 14:04:14 : INFO  : sketchup2025 : Finishing...
2026-01-05 14:04:17 : INFO  : sketchup2025 : App(s) found: /Applications/SketchUp 2025/SketchUp.app
2026-01-05 14:04:17 : INFO  : sketchup2025 : found app at /Applications/SketchUp 2025/SketchUp.app, version 25.0.659, on versionKey CFBundleVersion
2026-01-05 14:04:17 : REQ   : sketchup2025 : Installed SketchUp 2025, version 25.0.659
2026-01-05 14:04:17 : INFO  : sketchup2025 : notifying
2026-01-05 14:04:18 : INFO  : sketchup2025 : Installomator did not close any apps, so no need to reopen any apps.
2026-01-05 14:04:18 : REQ   : sketchup2025 : All done!
2026-01-05 14:04:18 : REQ   : sketchup2025 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The new label improves reliability by adding the -f flag for proper error handling and -L to follow any redirects, and includes head -1 to ensure only a single URL is captured even if multiple matches exist. The version extraction is simplified by replacing the complex conditional awk logic with year calculations with straightforward sed substitution that converts 2025-0-659-288 to 25.0.659.288. The code is cleaner and more maintainable while removing unnecessary quote wrapping around the downloadURL assignment.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
