### PR TITLE
adobedigitaleditions-label-update

### DIFF
--- a/fragments/labels/adobedigitaleditions.sh
+++ b/fragments/labels/adobedigitaleditions.sh
@@ -1,7 +1,9 @@
 adobedigitaleditions)
     name="Adobe Digital Editions"
     type="pkgInDmg"
-    downloadURL=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep -oE 'https[^"]+\.dmg')
-    appNewVersion=$(curl -fs https://www.adobe.com/solutions/ebook/digital-editions/download.html | grep -o 'Adobe Digital Editions.*Installers' | awk -F' ' '{ print $4 }')
+    packageID="com.adobe.digitaleditions"
+    downloadPage=$(curl -fsL "https://www.adobe.com/solutions/ebook/digital-editions/download.html")
+    downloadURL=$(echo "$downloadPage" | grep -oE 'https://[^"'\''[:space:]]*\.dmg' | grep -v "\.exe" | head -1)
+    appNewVersion=$(echo "$downloadPage" | grep -o 'Adobe Digital Editions.*Installers' | awk -F' ' '{ print $4 }')
     expectedTeamID="JQ525L2MZD"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh adobedigitaleditions DEBUG=0
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : setting variable from argument DEBUG=0
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : Total items in argumentsArray: 1
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : argumentsArray: DEBUG=0
2026-01-07 08:32:31 : REQ   : adobedigitaleditions : ################## Start Installomator v. 10.9beta, date 2026-01-07
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : ################## Version: 10.9beta
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : ################## Date: 2026-01-07
2026-01-07 08:32:31 : INFO  : adobedigitaleditions : ################## adobedigitaleditions
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : Reading arguments again: DEBUG=0
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : BLOCKING_PROCESS_ACTION=tell_user
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : NOTIFY=success
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : LOGGING=INFO
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : Label type: pkgInDmg
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : archiveName: Adobe Digital Editions.dmg
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : no blocking processes defined, using Adobe Digital Editions as default
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : No version found using packageID com.adobe.digitaleditions
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : name: Adobe Digital Editions, appName: Adobe Digital Editions.app
2026-01-07 08:32:32 : WARN  : adobedigitaleditions : No previous app found
2026-01-07 08:32:32 : WARN  : adobedigitaleditions : could not find Adobe Digital Editions.app
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : appversion:
2026-01-07 08:32:32 : INFO  : adobedigitaleditions : Latest version of Adobe Digital Editions is 4.5.12
2026-01-07 08:32:32 : REQ   : adobedigitaleditions : Downloading https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_4.5_Installer.dmg to Adobe Digital Editions.dmg
2026-01-07 08:32:33 : INFO  : adobedigitaleditions : Downloaded Adobe Digital Editions.dmg – Type is  zlib compressed data – SHA is a75477d0813f4997a24a20729ce91f470899cff0 – Size is 27604 kB
2026-01-07 08:32:34 : REQ   : adobedigitaleditions : no more blocking processes, continue with update
2026-01-07 08:32:34 : REQ   : adobedigitaleditions : Installing Adobe Digital Editions
2026-01-07 08:32:34 : INFO  : adobedigitaleditions : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.sLzdzO5U9j/Adobe Digital Editions.dmg
2026-01-07 08:32:37 : INFO  : adobedigitaleditions : Mounted: /Volumes/ADE 4.5
2026-01-07 08:32:37 : INFO  : adobedigitaleditions : found pkg: /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2026-01-07 08:32:37 : INFO  : adobedigitaleditions : Verifying: /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg
2026-01-07 08:32:38 : INFO  : adobedigitaleditions : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2026-01-07 08:32:38 : INFO  : adobedigitaleditions : Installing /Volumes/ADE 4.5/Digital Editions 4.5 Installer.pkg to /
2026-01-07 08:33:04 : INFO  : adobedigitaleditions : Finishing...
2026-01-07 08:33:07 : INFO  : adobedigitaleditions : No version found using packageID com.adobe.digitaleditions
2026-01-07 08:33:07 : INFO  : adobedigitaleditions : App(s) found: /Applications/Adobe Digital Editions.app
2026-01-07 08:33:07 : INFO  : adobedigitaleditions : found app at /Applications/Adobe Digital Editions.app, version 4.5.12, on versionKey CFBundleShortVersionString
2026-01-07 08:33:07 : REQ   : adobedigitaleditions : Installed Adobe Digital Editions, version 4.5.12
2026-01-07 08:33:07 : INFO  : adobedigitaleditions : notifying
2026-01-07 08:33:08 : INFO  : adobedigitaleditions : Installomator did not close any apps, so no need to reopen any apps.
2026-01-07 08:33:08 : REQ   : adobedigitaleditions : All done!
2026-01-07 08:33:08 : REQ   : adobedigitaleditions : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes, creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The new Installomator label improves upon the old version in several key ways: it's more efficient by fetching Adobe's download page only once instead of twice (reducing network requests by 50%), it's more reliable by adding the -L flag to follow redirects and explicitly filtering out Windows .exe files with grep -v "\.exe" to prevent downloading the wrong installer, it uses a more precise regex pattern that excludes whitespace and quotes to safely extract only the macOS DMG URL, and it includes the packageID for better post-installation validation. These changes make the label faster, more robust against Adobe's page structure changes, and eliminate the risk of accidentally downloading the Windows installer instead of the Mac version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
