### PR TITLE
Fix arcbrowser appNewVersion

### DIFF
--- a/fragments/labels/arcbrowser.sh
+++ b/fragments/labels/arcbrowser.sh
@@ -2,6 +2,6 @@ arcbrowser)
 name="Arc"
 type="dmg"
 downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
-appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*/\1/')"
+appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -iE '^location:.*-[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.dmg' | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)-[0-9]+.*/\1/')"
 expectedTeamID="S6N382Y83G"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes.

**Additional context**
Fixes appNewVersion in arcbrowser label.

Old:
```
➜ curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*/\1/'
location: https://arc.net/release/Arc-latest.dmg
1.126.1-72660
```

New:
```
➜ curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -iE '^location:.*-[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.dmg' | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)-[0-9]+.*/\1/'
1.126.1
```

There were two issues with the appNewVersion:
1. It included extra line which broke checking for new version completely.
2. The app reports the version number without the build number at the end (`-72660`)


**Installomator log**

```
2026-01-08 14:17:06 : INFO  : arcbrowser : Total items in argumentsArray: 0
2026-01-08 14:17:06 : INFO  : arcbrowser : argumentsArray:
2026-01-08 14:17:06 : REQ   : arcbrowser : ################## Start Installomator v. 10.9beta, date 2026-01-08
2026-01-08 14:17:06 : INFO  : arcbrowser : ################## Version: 10.9beta
2026-01-08 14:17:06 : INFO  : arcbrowser : ################## Date: 2026-01-08
2026-01-08 14:17:06 : INFO  : arcbrowser : ################## arcbrowser
2026-01-08 14:17:07 : INFO  : arcbrowser : Reading arguments again:
2026-01-08 14:17:07 : INFO  : arcbrowser : BLOCKING_PROCESS_ACTION=tell_user
2026-01-08 14:17:07 : INFO  : arcbrowser : NOTIFY=success
2026-01-08 14:17:07 : INFO  : arcbrowser : LOGGING=DEBUG
2026-01-08 14:17:07 : INFO  : arcbrowser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-08 14:17:07 : INFO  : arcbrowser : Label type: dmg
2026-01-08 14:17:07 : INFO  : arcbrowser : archiveName: Arc.dmg
2026-01-08 14:17:07 : INFO  : arcbrowser : no blocking processes defined, using Arc as default
2026-01-08 14:17:07 : INFO  : arcbrowser : App(s) found: /Applications/Arc.app
2026-01-08 14:17:07 : INFO  : arcbrowser : found app at /Applications/Arc.app, version 1.126.1, on versionKey CFBundleShortVersionString
2026-01-08 14:17:07 : INFO  : arcbrowser : appversion: 1.126.1
2026-01-08 14:17:07 : INFO  : arcbrowser : Latest version of Arc is 1.126.1
2026-01-08 14:17:07 : WARN  : arcbrowser : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-01-08 14:17:07 : REQ   : arcbrowser : Downloading https://releases.arc.net/release/Arc-latest.dmg to Arc.dmg
2026-01-08 14:17:12 : INFO  : arcbrowser : Downloaded Arc.dmg – Type is  zlib compressed data – SHA is e7ad695b5eb6d5e6f23806a3f5c2730f443f4012 – Size is 419668 kB
2026-01-08 14:17:12 : REQ   : arcbrowser : Installing Arc
2026-01-08 14:17:12 : INFO  : arcbrowser : Mounting /Projects/Installomator/build/Arc.dmg
2026-01-08 14:17:16 : INFO  : arcbrowser : Mounted: /Volumes/Arc
2026-01-08 14:17:16 : INFO  : arcbrowser : Verifying: /Volumes/Arc/Arc.app
2026-01-08 14:17:19 : INFO  : arcbrowser : Team ID matching: S6N382Y83G (expected: S6N382Y83G )
2026-01-08 14:17:19 : INFO  : arcbrowser : Downloaded version of Arc is 1.126.1 on versionKey CFBundleShortVersionString, same as installed.
2026-01-08 14:17:19 : REG   : arcbrowser : No new version to install
2026-01-08 14:17:19 : REQ   : arcbrowser : ################## End Installomator, exit code 0
```