### PR TITLE
Fix Topaz Gigapixel AI appNewVersion

### DIFF
--- a/fragments/labels/topazgigapixel.sh
+++ b/fragments/labels/topazgigapixel.sh
@@ -3,9 +3,9 @@ topazgigapixelai)
     # credit: Tully Jagoe
     name="Topaz Gigapixel AI"
     type="pkg"
-    appNewVersion=$(curl -fs https://www.topazlabs.com/downloads | grep  -o 'gigaVersion = "v.*"' | grep -o ' "v.*"' | sed -E 's/[v|"| ]//g')
     versionKey="CFBundleShortVersionString"
     downloadURL="https://topazlabs.com/d/gigapixel/latest/mac/full"
-    archiveName="TopazGigapixelAI-${appNewVersion}.pkg"
+    archiveName=$(curl -fsIL $downloadURL | grep -i ^location | awk -F "/" '{print $NF}')
+    appNewVersion=$(grep -oi "[0-9].*[0-9]" <<< $archiveName)
     expectedTeamID="3G3JE37ZHF"
     ;;

--- a/fragments/labels/topazgigapixel.sh
+++ b/fragments/labels/topazgigapixel.sh
@@ -1,6 +1,5 @@
 topazgigapixel|\
 topazgigapixelai)
-    # credit: Tully Jagoe
     name="Topaz Gigapixel AI"
     type="pkg"
     versionKey="CFBundleShortVersionString"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The previous way, to check the download page for appNewVersion, lags. I t seems like Topaz doesn't update that as soon as they release a new version.
Fortunately the version number is written in the archie name.

**Installomator log** 
BEFORE fix (with latest version installed):
```
➜  Installomator git:(main) ✗ sudo ./assemble.sh topazgigapixelai BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success  NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:00:46 : INFO  : topazgigapixelai : setting variable from argument BLOCKING_PROCESS_ACTION=silent_fail
2026-01-14 12:00:46 : INFO  : topazgigapixelai : setting variable from argument NOTIFY=success
2026-01-14 12:00:46 : INFO  : topazgigapixelai : setting variable from argument NOTIFY_DIALOG=1
2026-01-14 12:00:46 : INFO  : topazgigapixelai : setting variable from argument DEBUG=0
2026-01-14 12:00:46 : INFO  : topazgigapixelai : Total items in argumentsArray: 4
2026-01-14 12:00:46 : INFO  : topazgigapixelai : argumentsArray: BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:00:46 : REQ   : topazgigapixelai : ################## Start Installomator v. 10.9beta, date 2026-01-14
2026-01-14 12:00:46 : INFO  : topazgigapixelai : ################## Version: 10.9beta
2026-01-14 12:00:46 : INFO  : topazgigapixelai : ################## Date: 2026-01-14
2026-01-14 12:00:46 : INFO  : topazgigapixelai : ################## topazgigapixelai
2026-01-14 12:00:47 : INFO  : topazgigapixelai : Reading arguments again: BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:00:47 : INFO  : topazgigapixelai : BLOCKING_PROCESS_ACTION=silent_fail
2026-01-14 12:00:47 : INFO  : topazgigapixelai : NOTIFY=success
2026-01-14 12:00:47 : INFO  : topazgigapixelai : LOGGING=INFO
2026-01-14 12:00:47 : INFO  : topazgigapixelai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-14 12:00:47 : INFO  : topazgigapixelai : Label type: pkg
2026-01-14 12:00:47 : INFO  : topazgigapixelai : archiveName: TopazGigapixelAI-8.4.2.pkg
2026-01-14 12:00:47 : INFO  : topazgigapixelai : no blocking processes defined, using Topaz Gigapixel AI as default
2026-01-14 12:00:47 : INFO  : topazgigapixelai : App(s) found: /Applications/Topaz Gigapixel AI.app
2026-01-14 12:00:47 : INFO  : topazgigapixelai : found app at /Applications/Topaz Gigapixel AI.app, version 8.4.4, on versionKey CFBundleShortVersionString
2026-01-14 12:00:47 : INFO  : topazgigapixelai : appversion: 8.4.4
2026-01-14 12:00:47 : INFO  : topazgigapixelai : Latest version of Topaz Gigapixel AI is 8.4.2
2026-01-14 12:00:47 : REQ   : topazgigapixelai : Downloading https://topazlabs.com/d/gigapixel/latest/mac/full to TopazGigapixelAI-8.4.2.pkg
2026-01-14 12:00:52 : INFO  : topazgigapixelai : Downloaded TopazGigapixelAI-8.4.2.pkg – Type is  xar archive compressed TOC – SHA is 9b8b757af8ea6364129a4b385aee57cf92a17945 – Size is 396832 kB
2026-01-14 12:00:52 : REQ   : topazgigapixelai : no more blocking processes, continue with update
2026-01-14 12:00:52 : REQ   : topazgigapixelai : Installing Topaz Gigapixel AI
2026-01-14 12:00:52 : INFO  : topazgigapixelai : Verifying: TopazGigapixelAI-8.4.2.pkg
2026-01-14 12:00:53 : INFO  : topazgigapixelai : Team ID: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2026-01-14 12:00:53 : INFO  : topazgigapixelai : Installing TopazGigapixelAI-8.4.2.pkg to /
2026-01-14 12:04:51 : INFO  : topazgigapixelai : Finishing...
2026-01-14 12:04:54 : INFO  : topazgigapixelai : App(s) found: /Applications/Topaz Gigapixel AI.app
2026-01-14 12:04:54 : INFO  : topazgigapixelai : found app at /Applications/Topaz Gigapixel AI.app, version 8.4.4, on versionKey CFBundleShortVersionString
2026-01-14 12:04:54 : REQ   : topazgigapixelai : Installed Topaz Gigapixel AI, version 8.4.2
2026-01-14 12:04:54 : INFO  : topazgigapixelai : notifying
2026-01-14 12:04:55 : INFO  : topazgigapixelai : Installomator did not close any apps, so no need to reopen any apps.
2026-01-14 12:04:55 : REQ   : topazgigapixelai : All done!
2026-01-14 12:04:55 : REQ   : topazgigapixelai : ################## End Installomator, exit code 0 
```

AFTER fix (with latest version installed):
```
➜  Installomator git:(fix_topazgigapixel_appNewVersion) ✗ sudo ./assemble.sh topazgigapixelai BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success  NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:09:10 : INFO  : topazgigapixelai : setting variable from argument BLOCKING_PROCESS_ACTION=silent_fail
2026-01-14 12:09:10 : INFO  : topazgigapixelai : setting variable from argument NOTIFY=success
2026-01-14 12:09:10 : INFO  : topazgigapixelai : setting variable from argument NOTIFY_DIALOG=1
2026-01-14 12:09:10 : INFO  : topazgigapixelai : setting variable from argument DEBUG=0
2026-01-14 12:09:10 : INFO  : topazgigapixelai : Total items in argumentsArray: 4
2026-01-14 12:09:10 : INFO  : topazgigapixelai : argumentsArray: BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:09:10 : REQ   : topazgigapixelai : ################## Start Installomator v. 10.9beta, date 2026-01-14
2026-01-14 12:09:10 : INFO  : topazgigapixelai : ################## Version: 10.9beta
2026-01-14 12:09:10 : INFO  : topazgigapixelai : ################## Date: 2026-01-14
2026-01-14 12:09:10 : INFO  : topazgigapixelai : ################## topazgigapixelai
2026-01-14 12:09:11 : INFO  : topazgigapixelai : Reading arguments again: BLOCKING_PROCESS_ACTION=silent_fail NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-01-14 12:09:11 : INFO  : topazgigapixelai : BLOCKING_PROCESS_ACTION=silent_fail
2026-01-14 12:09:11 : INFO  : topazgigapixelai : NOTIFY=success
2026-01-14 12:09:11 : INFO  : topazgigapixelai : LOGGING=INFO
2026-01-14 12:09:11 : INFO  : topazgigapixelai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-14 12:09:11 : INFO  : topazgigapixelai : Label type: pkg
2026-01-14 12:09:11 : INFO  : topazgigapixelai : archiveName: TopazGigapixelAI-8.4.4.pkg
2026-01-14 12:09:11 : INFO  : topazgigapixelai : no blocking processes defined, using Topaz Gigapixel AI as default
2026-01-14 12:09:11 : INFO  : topazgigapixelai : App(s) found: /Applications/Topaz Gigapixel AI.app
2026-01-14 12:09:11 : INFO  : topazgigapixelai : found app at /Applications/Topaz Gigapixel AI.app, version 8.4.4, on versionKey CFBundleShortVersionString
2026-01-14 12:09:11 : INFO  : topazgigapixelai : appversion: 8.4.4
2026-01-14 12:09:11 : INFO  : topazgigapixelai : Latest version of Topaz Gigapixel AI is 8.4.4
2026-01-14 12:09:11 : INFO  : topazgigapixelai : There is no newer version available.
2026-01-14 12:09:11 : INFO  : topazgigapixelai : Installomator did not close any apps, so no need to reopen any apps.
2026-01-14 12:09:11 : REQ   : topazgigapixelai : No newer version.
2026-01-14 12:09:11 : REQ   : topazgigapixelai : ################## End Installomator, exit code 0 
```