### PR TITLE
anki-new-label

### DIFF
--- a/fragments/labels/anki.sh
+++ b/fragments/labels/anki.sh
@@ -1,0 +1,7 @@
+anki)
+    name="Anki"
+    type="dmg"
+    appNewVersion=$(curl -fs "https://apps.ankiweb.net" | grep -o '/download/[0-9.]\+/' | head -1 | sed 's|/download/||;s|/||')
+    downloadURL="https://github.com/ankitects/anki/releases/download/${appNewVersion}/anki-launcher-${appNewVersion}-mac.dmg"
+    expectedTeamID="7ZM8SLJM4P"
+    ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh anki DEBUG=0
2026-01-16 09:35:15 : INFO  : anki : setting variable from argument DEBUG=0
2026-01-16 09:35:15 : INFO  : anki : Total items in argumentsArray: 1
2026-01-16 09:35:15 : INFO  : anki : argumentsArray: DEBUG=0
2026-01-16 09:35:15 : REQ   : anki : ################## Start Installomator v. 10.9beta, date 2026-01-16
2026-01-16 09:35:15 : INFO  : anki : ################## Version: 10.9beta
2026-01-16 09:35:15 : INFO  : anki : ################## Date: 2026-01-16
2026-01-16 09:35:15 : INFO  : anki : ################## anki
2026-01-16 09:35:15 : INFO  : anki : Reading arguments again: DEBUG=0
2026-01-16 09:35:16 : INFO  : anki : BLOCKING_PROCESS_ACTION=tell_user
2026-01-16 09:35:16 : INFO  : anki : NOTIFY=success
2026-01-16 09:35:16 : INFO  : anki : LOGGING=INFO
2026-01-16 09:35:16 : INFO  : anki : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-16 09:35:16 : INFO  : anki : Label type: dmg
2026-01-16 09:35:16 : INFO  : anki : archiveName: Anki.dmg
2026-01-16 09:35:16 : INFO  : anki : no blocking processes defined, using Anki as default
2026-01-16 09:35:16 : INFO  : anki : name: Anki, appName: Anki.app
2026-01-16 09:35:16 : WARN  : anki : No previous app found
2026-01-16 09:35:16 : WARN  : anki : could not find Anki.app
2026-01-16 09:35:16 : INFO  : anki : appversion:
2026-01-16 09:35:16 : INFO  : anki : Latest version of Anki is 25.09
2026-01-16 09:35:16 : REQ   : anki : Downloading https://github.com/ankitects/anki/releases/download/25.09/anki-launcher-25.09-mac.dmg to Anki.dmg
2026-01-16 09:35:18 : INFO  : anki : Downloaded Anki.dmg – Type is  lzfse encoded, lzvn compressed – SHA is e6dbfd035f405fdbacadce386380a9ad44df6b73 – Size is 32656 kB
2026-01-16 09:35:18 : REQ   : anki : no more blocking processes, continue with update
2026-01-16 09:35:18 : REQ   : anki : Installing Anki
2026-01-16 09:35:18 : INFO  : anki : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.lv1Zd97OGi/Anki.dmg
2026-01-16 09:35:22 : INFO  : anki : Mounted: /Volumes/Anki
2026-01-16 09:35:22 : INFO  : anki : Verifying: /Volumes/Anki/Anki.app
2026-01-16 09:35:23 : INFO  : anki : Team ID matching: 7ZM8SLJM4P (expected: 7ZM8SLJM4P )
2026-01-16 09:35:23 : INFO  : anki : Installing Anki version 25.09 on versionKey CFBundleShortVersionString.
2026-01-16 09:35:23 : INFO  : anki : App has LSMinimumSystemVersion: 12
2026-01-16 09:35:23 : INFO  : anki : Copy /Volumes/Anki/Anki.app to /Applications
2026-01-16 09:35:23 : WARN  : anki : Changing owner to u0105821
2026-01-16 09:35:23 : INFO  : anki : Finishing...
2026-01-16 09:35:26 : INFO  : anki : App(s) found: /Applications/Anki.app
2026-01-16 09:35:26 : INFO  : anki : found app at /Applications/Anki.app, version 25.09, on versionKey CFBundleShortVersionString
2026-01-16 09:35:26 : REQ   : anki : Installed Anki, version 25.09
2026-01-16 09:35:26 : INFO  : anki : notifying
2026-01-16 09:35:27 : INFO  : anki : Installomator did not close any apps, so no need to reopen any apps.
2026-01-16 09:35:27 : REQ   : anki : All done!
2026-01-16 09:35:27 : REQ   : anki : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes, there is a pull request, but it has issues.New Label: Anki #2654

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The new label is cleaner and more reliable: instead of chasing GitHub’s redirect headers and then stripping the Location URL down to only major.minor, it scrapes the official Anki download page for the full version string and uses that exact value to construct the GitHub release asset URL — which aligns with how the Anki team publishes releases. That makes version detection less brittle (no dependence on -L redirect headers or fragile path-splitting) and preserves the complete version instead of truncating it. It also uses curl -fs (fail on HTTP errors) and a precise grep to improve failure behavior and parsing accuracy. Functionally, the expectedTeamID and DMG download template remain unchanged, but the new approach is simpler, faster, and more robust against changes in redirect behavior or version formatting. Note that GitHub can contain tags/releases not yet reflected on the official site (or vice versa), so for maximum reliability, the label should keep the official site as the canonical version source.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
