### PR TITLE
fix: Additional code quality improvements

### DIFF
--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -287,7 +287,7 @@ else
     else
         printlog "No Dialog connection, just download" DEBUG
         curlDownload=$(curl -v -fsL --show-error ${curlOptions} "$downloadURL" -o "$archiveName" 2>&1)
-        curlDownloadStatus=$(echo $?)
+        curlDownloadStatus=$?
     fi
 
     # Trying to detect proxy or web filter on downloaded file


### PR DESCRIPTION
## Summary
Additional code quality fixes in fragments/functions.sh and fragments/main.sh

### Bug Fixes
1. Fixed invalid '2=INFO' syntax - cannot assign to positional parameters. Used ${2:-INFO} default expansion instead
2. Fixed spctlout -> spctlOut variable casing inconsistency

### Code Style
3. Replaced =$(echo $?) with =$? in 9 places - the echo is unnecessary

### Testing
- Assembled script passes zsh -n syntax check
- Changes per CONTRIBUTING.md guidelines
