### PR TITLE
New-label-Session-Desktop

### DIFF
--- a/fragments/labels/sessiondesktop.sh
+++ b/fragments/labels/sessiondesktop.sh
@@ -1,0 +1,13 @@
+sessiondesktop)
+    name="Session"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="session-desktop-mac-arm64-[0-9.]*.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="session-desktop-mac-x64-[0-9.]*.dmg"
+    fi
+    versionKey="CFBundleShortVersionString"
+    downloadURL=$(downloadURLFromGit session-foundation session-desktop)
+    appNewVersion=$(versionFromGit session-foundation session-desktop)
+    expectedTeamID="SUQ8J2PCT7"
+    ;;


### PR DESCRIPTION
2026-01-21 22:11:40 : INFO  : sessiondesktop : setting variable from argument DEBUG=0
2026-01-21 22:11:40 : INFO  : sessiondesktop : Total items in argumentsArray: 1
2026-01-21 22:11:40 : INFO  : sessiondesktop : argumentsArray: DEBUG=0
2026-01-21 22:11:40 : REQ   : sessiondesktop : ################## Start Installomator v. 10.9beta, date 2026-01-21
2026-01-21 22:11:40 : INFO  : sessiondesktop : ################## Version: 10.9beta
2026-01-21 22:11:40 : INFO  : sessiondesktop : ################## Date: 2026-01-21
2026-01-21 22:11:40 : INFO  : sessiondesktop : ################## sessiondesktop
2026-01-21 22:11:42 : INFO  : sessiondesktop : Reading arguments again: DEBUG=0
2026-01-21 22:11:42 : INFO  : sessiondesktop : BLOCKING_PROCESS_ACTION=tell_user
2026-01-21 22:11:42 : INFO  : sessiondesktop : NOTIFY=success
2026-01-21 22:11:42 : INFO  : sessiondesktop : LOGGING=INFO
2026-01-21 22:11:42 : INFO  : sessiondesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-21 22:11:42 : INFO  : sessiondesktop : Label type: dmg
2026-01-21 22:11:42 : INFO  : sessiondesktop : archiveName: session-desktop-mac-arm64-[0-9.]*.dmg
2026-01-21 22:11:42 : INFO  : sessiondesktop : no blocking processes defined, using Session as default
2026-01-21 22:11:42 : INFO  : sessiondesktop : name: Session, appName: Session.app
2026-01-21 22:11:42 : INFO  : sessiondesktop : App(s) found: /Users/thch/Downloads/Session.app
2026-01-21 22:11:42 : WARN  : sessiondesktop : could not determine location of Session.app
2026-01-21 22:11:42 : INFO  : sessiondesktop : appversion:
2026-01-21 22:11:42 : INFO  : sessiondesktop : Latest version of Session is 1.17.6
2026-01-21 22:11:42 : REQ   : sessiondesktop : Downloading https://github.com/session-foundation/session-desktop/releases/download/v1.17.6/session-desktop-mac-arm64-1.17.6.dmg to session-desktop-mac-arm64-[0-9.]*.dmg
2026-01-21 22:11:48 : INFO  : sessiondesktop : Downloaded session-desktop-mac-arm64-[0-9.]*.dmg – Type is  zlib compressed data – SHA is 29187c1a71804f68307b33a435595afbf6a01093 – Size is 148296 kB
2026-01-21 22:11:48 : REQ   : sessiondesktop : no more blocking processes, continue with update
2026-01-21 22:11:48 : REQ   : sessiondesktop : Installing Session
2026-01-21 22:11:48 : INFO  : sessiondesktop : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oVzEpPf8cZ/session-desktop-mac-arm64-[0-9.]*.dmg
2026-01-21 22:11:51 : INFO  : sessiondesktop : Mounted: /Volumes/Session 1.17.6-arm64 2
2026-01-21 22:11:51 : INFO  : sessiondesktop : Verifying: /Volumes/Session 1.17.6-arm64 2/Session.app
2026-01-21 22:11:52 : INFO  : sessiondesktop : Team ID matching: SUQ8J2PCT7 (expected: SUQ8J2PCT7 )
2026-01-21 22:11:52 : INFO  : sessiondesktop : Installing Session version 1.17.6 on versionKey CFBundleShortVersionString.
2026-01-21 22:11:52 : INFO  : sessiondesktop : App has LSMinimumSystemVersion: 13.0.0
2026-01-21 22:11:52 : INFO  : sessiondesktop : Copy /Volumes/Session 1.17.6-arm64 2/Session.app to /Applications
2026-01-21 22:11:53 : WARN  : sessiondesktop : Changing owner to user
2026-01-21 22:11:53 : INFO  : sessiondesktop : Finishing...
2026-01-21 22:11:56 : INFO  : sessiondesktop : App(s) found: /Applications/Session.app
2026-01-21 22:11:56 : INFO  : sessiondesktop : found app at /Applications/Session.app, version 1.17.6, on versionKey CFBundleShortVersionString
2026-01-21 22:11:56 : REQ   : sessiondesktop : Installed Session, version 1.17.6
2026-01-21 22:11:56 : INFO  : sessiondesktop : notifying
2026-01-21 22:11:57 : INFO  : sessiondesktop : Installomator did not close any apps, so no need to reopen any apps.
2026-01-21 22:11:57 : REQ   : sessiondesktop : All done!
2026-01-21 22:11:57 : REQ   : sessiondesktop : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
