### PR TITLE
New-label-LosslessCut

### DIFF
--- a/fragments/labels/losslesscut.sh
+++ b/fragments/labels/losslesscut.sh
@@ -1,0 +1,13 @@
+losslesscut)
+    name="LosslessCut"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="LosslessCut-mac-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="LosslessCut-mac-x64.dmg"
+    fi
+    versionKey="CFBundleShortVersionString"
+    downloadURL=$(downloadURLFromGit mifi lossless-cut)
+    appNewVersion=$(versionFromGit mifi lossless-cut)
+    expectedTeamID="46F6T3M669"
+    ;;


### PR DESCRIPTION
2026-01-21 22:05:48 : INFO  : losslesscut : setting variable from argument DEBUG=0
2026-01-21 22:05:48 : INFO  : losslesscut : Total items in argumentsArray: 1
2026-01-21 22:05:48 : INFO  : losslesscut : argumentsArray: DEBUG=0
2026-01-21 22:05:48 : REQ   : losslesscut : ################## Start Installomator v. 10.9beta, date 2026-01-21
2026-01-21 22:05:48 : INFO  : losslesscut : ################## Version: 10.9beta
2026-01-21 22:05:48 : INFO  : losslesscut : ################## Date: 2026-01-21
2026-01-21 22:05:48 : INFO  : losslesscut : ################## losslesscut
2026-01-21 22:05:50 : INFO  : losslesscut : Reading arguments again: DEBUG=0
2026-01-21 22:05:50 : INFO  : losslesscut : BLOCKING_PROCESS_ACTION=tell_user
2026-01-21 22:05:50 : INFO  : losslesscut : NOTIFY=success
2026-01-21 22:05:50 : INFO  : losslesscut : LOGGING=INFO
2026-01-21 22:05:50 : INFO  : losslesscut : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-21 22:05:50 : INFO  : losslesscut : Label type: dmg
2026-01-21 22:05:50 : INFO  : losslesscut : archiveName: LosslessCut-mac-arm64.dmg
2026-01-21 22:05:51 : INFO  : losslesscut : no blocking processes defined, using LosslessCut as default
2026-01-21 22:05:51 : INFO  : losslesscut : name: LosslessCut, appName: LosslessCut.app
2026-01-21 22:05:51 : WARN  : losslesscut : No previous app found
2026-01-21 22:05:51 : WARN  : losslesscut : could not find LosslessCut.app
2026-01-21 22:05:51 : INFO  : losslesscut : appversion:
2026-01-21 22:05:51 : INFO  : losslesscut : Latest version of LosslessCut is 3.67.2
2026-01-21 22:05:51 : REQ   : losslesscut : Downloading https://github.com/mifi/lossless-cut/releases/download/v3.67.2/LosslessCut-mac-arm64.dmg to LosslessCut-mac-arm64.dmg
2026-01-21 22:05:57 : INFO  : losslesscut : Downloaded LosslessCut-mac-arm64.dmg – Type is  zlib compressed data – SHA is 40bd30284a80093e6d02a51d8d26c6c8039a3788 – Size is 164512 kB
2026-01-21 22:05:57 : REQ   : losslesscut : no more blocking processes, continue with update
2026-01-21 22:05:57 : REQ   : losslesscut : Installing LosslessCut
2026-01-21 22:05:57 : INFO  : losslesscut : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wDV9g1e6kC/LosslessCut-mac-arm64.dmg
2026-01-21 22:06:01 : INFO  : losslesscut : Mounted: /Volumes/LosslessCut 3.67.2-arm64 2
2026-01-21 22:06:01 : INFO  : losslesscut : Verifying: /Volumes/LosslessCut 3.67.2-arm64 2/LosslessCut.app
2026-01-21 22:06:05 : INFO  : losslesscut : Team ID matching: 46F6T3M669 (expected: 46F6T3M669 )
2026-01-21 22:06:05 : INFO  : losslesscut : Installing LosslessCut version 3.67.2 on versionKey CFBundleShortVersionString.
2026-01-21 22:06:05 : INFO  : losslesscut : App has LSMinimumSystemVersion: 12.0
2026-01-21 22:06:05 : INFO  : losslesscut : Copy /Volumes/LosslessCut 3.67.2-arm64 2/LosslessCut.app to /Applications
2026-01-21 22:06:06 : WARN  : losslesscut : Changing owner to user
2026-01-21 22:06:07 : INFO  : losslesscut : Finishing...
2026-01-21 22:06:10 : INFO  : losslesscut : App(s) found: /Applications/LosslessCut.app
2026-01-21 22:06:10 : INFO  : losslesscut : found app at /Applications/LosslessCut.app, version 3.67.2, on versionKey CFBundleShortVersionString
2026-01-21 22:06:10 : REQ   : losslesscut : Installed LosslessCut, version 3.67.2
2026-01-21 22:06:10 : INFO  : losslesscut : notifying
2026-01-21 22:06:11 : INFO  : losslesscut : Installomator did not close any apps, so no need to reopen any apps.
2026-01-21 22:06:11 : REQ   : losslesscut : All done!
2026-01-21 22:06:11 : REQ   : losslesscut : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
