### PR TITLE
Update iTerm blocking process

### DIFF
--- a/fragments/labels/iterm2.sh
+++ b/fragments/labels/iterm2.sh
@@ -4,5 +4,4 @@ iterm2)
     downloadURL="https://iterm2.com/downloads/stable/latest"
     appNewVersion=$(curl -is https://iterm2.com/downloads/stable/latest | grep location: | grep -o "iTerm2.*zip" | cut -d "-" -f 2 | cut -d '.' -f1 | sed 's/_/./g')
     expectedTeamID="H7V7XYVQ7D"
-    blockingProcesses ( "iTerm" "iTerm2" )
     ;;

--- a/fragments/labels/iterm2.sh
+++ b/fragments/labels/iterm2.sh
@@ -4,4 +4,5 @@ iterm2)
     downloadURL="https://iterm2.com/downloads/stable/latest"
     appNewVersion=$(curl -is https://iterm2.com/downloads/stable/latest | grep location: | grep -o "iTerm2.*zip" | cut -d "-" -f 2 | cut -d '.' -f1 | sed 's/_/./g')
     expectedTeamID="H7V7XYVQ7D"
+    blockingProcesses ( "iTerm" "iTerm2" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes (but it seems #1847 was in error)

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
% utils/assemble.sh iterm2
2026-01-21 14:35:25 : INFO  : iterm2 : Total items in argumentsArray: 0
2026-01-21 14:35:25 : INFO  : iterm2 : argumentsArray:
2026-01-21 14:35:25 : REQ   : iterm2 : ################## Start Installomator v. 10.9beta, date 2026-01-21
2026-01-21 14:35:25 : INFO  : iterm2 : ################## Version: 10.9beta
2026-01-21 14:35:25 : INFO  : iterm2 : ################## Date: 2026-01-21
2026-01-21 14:35:25 : INFO  : iterm2 : ################## iterm2
2026-01-21 14:35:25 : DEBUG : iterm2 : DEBUG mode 1 enabled.
2026-01-21 14:35:26 : INFO  : iterm2 : Reading arguments again:
2026-01-21 14:35:26 : DEBUG : iterm2 : name=iTerm
2026-01-21 14:35:26 : DEBUG : iterm2 : appName=
2026-01-21 14:35:26 : DEBUG : iterm2 : type=zip
2026-01-21 14:35:26 : DEBUG : iterm2 : archiveName=
2026-01-21 14:35:26 : DEBUG : iterm2 : downloadURL=https://iterm2.com/downloads/stable/latest
2026-01-21 14:35:26 : DEBUG : iterm2 : curlOptions=
2026-01-21 14:35:26 : DEBUG : iterm2 : appNewVersion=3.6.6
2026-01-21 14:35:26 : DEBUG : iterm2 : appCustomVersion function: Not defined
2026-01-21 14:35:26 : DEBUG : iterm2 : versionKey=CFBundleShortVersionString
2026-01-21 14:35:26 : DEBUG : iterm2 : packageID=
2026-01-21 14:35:26 : DEBUG : iterm2 : pkgName=
2026-01-21 14:35:27 : DEBUG : iterm2 : choiceChangesXML=
2026-01-21 14:35:27 : DEBUG : iterm2 : expectedTeamID=H7V7XYVQ7D
2026-01-21 14:35:27 : DEBUG : iterm2 : blockingProcesses=iTerm iTerm2
2026-01-21 14:35:27 : DEBUG : iterm2 : installerTool=
2026-01-21 14:35:27 : DEBUG : iterm2 : CLIInstaller=
2026-01-21 14:35:27 : DEBUG : iterm2 : CLIArguments=
2026-01-21 14:35:27 : DEBUG : iterm2 : updateTool=
2026-01-21 14:35:27 : DEBUG : iterm2 : updateToolArguments=
2026-01-21 14:35:27 : DEBUG : iterm2 : updateToolRunAsCurrentUser=
2026-01-21 14:35:27 : INFO  : iterm2 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-21 14:35:27 : INFO  : iterm2 : NOTIFY=success
2026-01-21 14:35:27 : INFO  : iterm2 : LOGGING=DEBUG
2026-01-21 14:35:27 : INFO  : iterm2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-21 14:35:27 : INFO  : iterm2 : Label type: zip
2026-01-21 14:35:27 : INFO  : iterm2 : archiveName: iTerm.zip
2026-01-21 14:35:27 : DEBUG : iterm2 : Changing directory to /Users/hessf/Git/Installomator/build
2026-01-21 14:35:27 : INFO  : iterm2 : App(s) found: /Applications/iTerm.app
2026-01-21 14:35:27 : INFO  : iterm2 : found app at /Applications/iTerm.app, version 3.6.6, on versionKey CFBundleShortVersionString
2026-01-21 14:35:27 : INFO  : iterm2 : appversion: 3.6.6
2026-01-21 14:35:27 : INFO  : iterm2 : Latest version of iTerm is 3.6.6
2026-01-21 14:35:27 : WARN  : iterm2 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-01-21 14:35:27 : REQ   : iterm2 : Downloading https://iterm2.com/downloads/stable/latest to iTerm.zip
2026-01-21 14:35:27 : DEBUG : iterm2 : No Dialog connection, just download
2026-01-21 14:35:32 : INFO  : iterm2 : Downloaded iTerm.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is dd6076679e34e0394248fa147a4887a61e1b2721 – Size is 52340 kB
2026-01-21 14:35:32 : DEBUG : iterm2 : DEBUG mode 1, not checking for blocking processes
2026-01-21 14:35:32 : REQ   : iterm2 : Installing iTerm
2026-01-21 14:35:32 : INFO  : iterm2 : Unzipping iTerm.zip
2026-01-21 14:35:33 : INFO  : iterm2 : Verifying: /Users/hessf/Git/Installomator/build/iTerm.app
2026-01-21 14:35:33 : DEBUG : iterm2 : App size: 137M	/Users/hessf/Git/Installomator/build/iTerm.app
2026-01-21 14:35:33 : DEBUG : iterm2 : Debugging enabled, App Verification output was:
/Users/hessf/Git/Installomator/build/iTerm.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: GEORGE NACHMAN (H7V7XYVQ7D)

2026-01-21 14:35:33 : INFO  : iterm2 : Team ID matching: H7V7XYVQ7D (expected: H7V7XYVQ7D )
2026-01-21 14:35:33 : INFO  : iterm2 : Downloaded version of iTerm is 3.6.6 on versionKey CFBundleShortVersionString, same as installed.
2026-01-21 14:35:33 : DEBUG : iterm2 : DEBUG mode 1, not reopening anything
2026-01-21 14:35:33 : REG   : iterm2 : No new version to install
2026-01-21 14:35:33 : REQ   : iterm2 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
