### PR TITLE
password-utility-new-label

### DIFF
--- a/fragments/labels/passwordutility.sh
+++ b/fragments/labels/passwordutility.sh
@@ -1,7 +1,6 @@
 passwordutility)
     name="Password Utility"
     type="pkg"
-    packageID="com.twocanoes.PasswordUtility"
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/Password_Utility.pkg"
     expectedTeamID="UXP6YEHSPW"
     ;;

--- a/fragments/labels/passwordutility.sh
+++ b/fragments/labels/passwordutility.sh
@@ -2,5 +2,6 @@ passwordutility)
     name="Password Utility"
     type="pkg"
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/Password_Utility.pkg"
+    appNewVersion=$(curl -fsL "https://data.twocanoes.com/api/version_info" | sed -n 's/.*"com.twocanoes.PasswordUtility".*"version":"\([^"]*\)".*/\1/p')
     expectedTeamID="UXP6YEHSPW"
     ;;

--- a/fragments/labels/passwordutility.sh
+++ b/fragments/labels/passwordutility.sh
@@ -1,0 +1,7 @@
+passwordutility)
+    name="Password Utility"
+    type="pkg"
+    packageID="com.twocanoes.PasswordUtility"
+    downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/Password_Utility.pkg"
+    expectedTeamID="UXP6YEHSPW"
+    ;;

--- a/fragments/labels/passwordutility.sh
+++ b/fragments/labels/passwordutility.sh
@@ -5,3 +5,4 @@ passwordutility)
     appNewVersion=$(curl -fsL "https://data.twocanoes.com/api/version_info" | sed -n 's/.*"com.twocanoes.PasswordUtility".*"version":"\([^"]*\)".*/\1/p')
     expectedTeamID="UXP6YEHSPW"
     ;;
+


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh passwordutility DEBUG=0
2026-01-22 13:49:00 : INFO  : passwordutility : setting variable from argument DEBUG=0
2026-01-22 13:49:00 : INFO  : passwordutility : Total items in argumentsArray: 1
2026-01-22 13:49:00 : INFO  : passwordutility : argumentsArray: DEBUG=0
2026-01-22 13:49:00 : REQ   : passwordutility : ################## Start Installomator v. 10.9beta, date 2026-01-22
2026-01-22 13:49:00 : INFO  : passwordutility : ################## Version: 10.9beta
2026-01-22 13:49:00 : INFO  : passwordutility : ################## Date: 2026-01-22
2026-01-22 13:49:00 : INFO  : passwordutility : ################## passwordutility
2026-01-22 13:49:00 : INFO  : passwordutility : Reading arguments again: DEBUG=0
2026-01-22 13:49:00 : INFO  : passwordutility : BLOCKING_PROCESS_ACTION=tell_user
2026-01-22 13:49:00 : INFO  : passwordutility : NOTIFY=success
2026-01-22 13:49:00 : INFO  : passwordutility : LOGGING=INFO
2026-01-22 13:49:00 : INFO  : passwordutility : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-22 13:49:00 : INFO  : passwordutility : Label type: pkg
2026-01-22 13:49:00 : INFO  : passwordutility : archiveName: Password Utility.pkg
2026-01-22 13:49:00 : INFO  : passwordutility : no blocking processes defined, using Password Utility as default
2026-01-22 13:49:01 : INFO  : passwordutility : No version found using packageID com.twocanoes.PasswordUtility
2026-01-22 13:49:01 : INFO  : passwordutility : name: Password Utility, appName: Password Utility.app
2026-01-22 13:49:01 : WARN  : passwordutility : No previous app found
2026-01-22 13:49:01 : WARN  : passwordutility : could not find Password Utility.app
2026-01-22 13:49:01 : INFO  : passwordutility : appversion:
2026-01-22 13:49:01 : INFO  : passwordutility : Latest version not specified.
2026-01-22 13:49:01 : REQ   : passwordutility : Downloading https://twocanoes-software-updates.s3.amazonaws.com/Password_Utility.pkg to Password Utility.pkg
2026-01-22 13:49:02 : INFO  : passwordutility : Downloaded Password Utility.pkg – Type is  xar archive compressed TOC – SHA is 8156279495c7545a061a421c63372aeeb500b395 – Size is 1612 kB
2026-01-22 13:49:02 : REQ   : passwordutility : no more blocking processes, continue with update
2026-01-22 13:49:02 : REQ   : passwordutility : Installing Password Utility
2026-01-22 13:49:02 : INFO  : passwordutility : Verifying: Password Utility.pkg
2026-01-22 13:49:02 : INFO  : passwordutility : Team ID: UXP6YEHSPW (expected: UXP6YEHSPW )
2026-01-22 13:49:02 : INFO  : passwordutility : Installing Password Utility.pkg to /
2026-01-22 13:49:13 : INFO  : passwordutility : Finishing...
2026-01-22 13:49:16 : INFO  : passwordutility : No version found using packageID com.twocanoes.PasswordUtility
2026-01-22 13:49:16 : INFO  : passwordutility : App(s) found: /Applications/Password Utility.app
2026-01-22 13:49:16 : INFO  : passwordutility : found app at /Applications/Password Utility.app, version 1.1, on versionKey CFBundleShortVersionString
2026-01-22 13:49:16 : REQ   : passwordutility : Installed Password Utility
2026-01-22 13:49:16 : INFO  : passwordutility : notifying
2026-01-22 13:49:16 : INFO  : passwordutility : Installomator did not close any apps, so no need to reopen any apps.
2026-01-22 13:49:16 : REQ   : passwordutility : All done!
2026-01-22 13:49:16 : REQ   : passwordutility : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

Password Utility from Twocanoes Software is a macOS tool designed to enable a passwordless experience by automating local password entry, boosting security, and simplifying management. It securely stores the local user password in the keychain, allowing users to leverage Touch ID for sudo commands and to paste passwords without manually typing them. Additionally, it facilitates automatic FileVault unlocking after restarts to keep remote Macs accessible, while providing visibility into secure token and volume owner status.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
