### PR TITLE
Add Firecut for Davinci Resolve

### DIFF
--- a/fragments/labels/firecutfordavinciresolve.sh
+++ b/fragments/labels/firecutfordavinciresolve.sh
@@ -1,5 +1,5 @@
 firecutfordavinciresolve)
-    name="Firecut for DaVinci Resolve"
+    name="FireCut for DaVinci Resolve"
     type="dmg"
     downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r')"
     appNewVersion=$(echo $downloadURL | awk -F "." '{print$7}' | sed 's/v//' | sed 's/_/./g')

--- a/fragments/labels/firecutfordavinciresolve.sh
+++ b/fragments/labels/firecutfordavinciresolve.sh
@@ -1,0 +1,8 @@
+firecutfordavinciresolve)
+    name="Firecut for DaVinci Resolve"
+    type="dmg"
+    downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r')"
+    appNewVersion=$(echo $downloadURL | awk -F "." '{print$7}' | sed 's/v//' | sed 's/_/./g')
+    expectedTeamID="7ASRSVAEMS"
+    blockingProcesses=( "Resolve" )
+    ;;

--- a/fragments/labels/firecutfordavinciresolve.sh
+++ b/fragments/labels/firecutfordavinciresolve.sh
@@ -5,7 +5,7 @@ firecutfordavinciresolve)
         downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
     else
         downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_intel/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
-    if
+    fi
     appNewVersion=$(echo $downloadURL | awk -F "." '{print$7}' | sed 's/v//' | sed 's/_/./g')
     expectedTeamID="7ASRSVAEMS"
     blockingProcesses=( "Resolve" )

--- a/fragments/labels/firecutfordavinciresolve.sh
+++ b/fragments/labels/firecutfordavinciresolve.sh
@@ -1,7 +1,11 @@
 firecutfordavinciresolve)
     name="FireCut for DaVinci Resolve"
     type="dmg"
-    downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
+    else
+        downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_intel/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
+    if
     appNewVersion=$(echo $downloadURL | awk -F "." '{print$7}' | sed 's/v//' | sed 's/_/./g')
     expectedTeamID="7ASRSVAEMS"
     blockingProcesses=( "Resolve" )

--- a/fragments/labels/firecutfordavinciresolve.sh
+++ b/fragments/labels/firecutfordavinciresolve.sh
@@ -1,7 +1,7 @@
 firecutfordavinciresolve)
     name="FireCut for DaVinci Resolve"
     type="dmg"
-    downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r')"
+    downloadURL="$(curl -fsIL https://firecut.ai/downloads/davinci/apple_silicon/ | grep -i ^location | awk '{print $2}' | tr -d '\r' | grep "https://" | tail -1)"
     appNewVersion=$(echo $downloadURL | awk -F "." '{print$7}' | sed 's/v//' | sed 's/_/./g')
     expectedTeamID="7ASRSVAEMS"
     blockingProcesses=( "Resolve" )


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 

**Installomator log** 
No app installed:
```
➜  Installomator git:(add_firecutfordavinciresolve) ✗ sudo ./assemble.sh firecutfordavinciresolve NOTIFY=success  NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
Password:
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : setting variable from argument NOTIFY=success
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : setting variable from argument NOTIFY_DIALOG=1
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : setting variable from argument SYSTEMOWNER=1
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : setting variable from argument DEBUG=0
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : Total items in argumentsArray: 4
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : argumentsArray: NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-01-26 11:08:04 : REQ   : firecutfordavinciresolve : ################## Start Installomator v. 10.9beta, date 2026-01-26
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : ################## Version: 10.9beta
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : ################## Date: 2026-01-26
2026-01-26 11:08:04 : INFO  : firecutfordavinciresolve : ################## firecutfordavinciresolve
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : Reading arguments again: NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : BLOCKING_PROCESS_ACTION=tell_user
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : NOTIFY=success
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : LOGGING=INFO
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : Label type: dmg
2026-01-26 11:08:05 : INFO  : firecutfordavinciresolve : archiveName: Firecut for DaVinci Resolve.dmg
2026-01-26 11:08:06 : INFO  : firecutfordavinciresolve : name: Firecut for DaVinci Resolve, appName: Firecut for DaVinci Resolve.app
2026-01-26 11:08:06 : WARN  : firecutfordavinciresolve : No previous app found
2026-01-26 11:08:06 : WARN  : firecutfordavinciresolve : could not find Firecut for DaVinci Resolve.app
2026-01-26 11:08:06 : INFO  : firecutfordavinciresolve : appversion: 
2026-01-26 11:08:06 : INFO  : firecutfordavinciresolve : Latest version of Firecut for DaVinci Resolve is 2.4.2
2026-01-26 11:08:06 : REQ   : firecutfordavinciresolve : Downloading https://davinci-dl.firecut.ai/FireCut_DR_Dist/v2_4_2/FireCut.for.DaVinci.Resolve.v2_4_2.arm64.dmg to Firecut for DaVinci Resolve.dmg
2026-01-26 11:08:15 : INFO  : firecutfordavinciresolve : Downloaded Firecut for DaVinci Resolve.dmg – Type is  zlib compressed data – SHA is 94da905bbc2de9714291b9c758ff7c5b1f597df3 – Size is 197420 kB
2026-01-26 11:08:16 : REQ   : firecutfordavinciresolve : no more blocking processes, continue with update
2026-01-26 11:08:16 : REQ   : firecutfordavinciresolve : Installing Firecut for DaVinci Resolve
2026-01-26 11:08:16 : INFO  : firecutfordavinciresolve : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MQ4uZWg6gl/Firecut for DaVinci Resolve.dmg
2026-01-26 11:08:19 : INFO  : firecutfordavinciresolve : Mounted: /Volumes/FireCut for DaVinci Resolve
2026-01-26 11:08:19 : INFO  : firecutfordavinciresolve : Verifying: /Volumes/FireCut for DaVinci Resolve/Firecut for DaVinci Resolve.app
2026-01-26 11:08:21 : INFO  : firecutfordavinciresolve : Team ID matching: 7ASRSVAEMS (expected: 7ASRSVAEMS )
2026-01-26 11:08:21 : INFO  : firecutfordavinciresolve : Installing Firecut for DaVinci Resolve version 2.4.2 on versionKey CFBundleShortVersionString.
2026-01-26 11:08:21 : INFO  : firecutfordavinciresolve : App has LSMinimumSystemVersion: 12.0
2026-01-26 11:08:21 : INFO  : firecutfordavinciresolve : Copy /Volumes/FireCut for DaVinci Resolve 1/Firecut for DaVinci Resolve.app to /Applications
2026-01-26 11:08:21 : WARN  : firecutfordavinciresolve : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2026-01-26 11:08:21 : INFO  : firecutfordavinciresolve : Finishing...
2026-01-26 11:08:25 : INFO  : firecutfordavinciresolve : App(s) found: /Applications/Firecut for DaVinci Resolve.app
2026-01-26 11:08:25 : INFO  : firecutfordavinciresolve : found app at /Applications/Firecut for DaVinci Resolve.app, version 2.4.2, on versionKey CFBundleShortVersionString
2026-01-26 11:08:25 : REQ   : firecutfordavinciresolve : Installed Firecut for DaVinci Resolve, version 2.4.2
2026-01-26 11:08:25 : INFO  : firecutfordavinciresolve : notifying
2026-01-26 11:08:26 : INFO  : firecutfordavinciresolve : Installomator did not close any apps, so no need to reopen any apps.
2026-01-26 11:08:26 : REQ   : firecutfordavinciresolve : All done!
2026-01-26 11:08:26 : REQ   : firecutfordavinciresolve : ################## End Installomator, exit code 0 
```

Latest app already installed:
```
➜  Installomator git:(add_firecutfordavinciresolve) ✗ sudo ./assemble.sh firecutfordavinciresolve NOTIFY=success  NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : setting variable from argument NOTIFY=success
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : setting variable from argument NOTIFY_DIALOG=1
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : setting variable from argument SYSTEMOWNER=1
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : setting variable from argument DEBUG=0
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : Total items in argumentsArray: 4
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : argumentsArray: NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-01-26 11:08:50 : REQ   : firecutfordavinciresolve : ################## Start Installomator v. 10.9beta, date 2026-01-26
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : ################## Version: 10.9beta
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : ################## Date: 2026-01-26
2026-01-26 11:08:50 : INFO  : firecutfordavinciresolve : ################## firecutfordavinciresolve
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : Reading arguments again: NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : BLOCKING_PROCESS_ACTION=tell_user
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : NOTIFY=success
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : LOGGING=INFO
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : Label type: dmg
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : archiveName: Firecut for DaVinci Resolve.dmg
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : App(s) found: /Applications/Firecut for DaVinci Resolve.app
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : found app at /Applications/Firecut for DaVinci Resolve.app, version 2.4.2, on versionKey CFBundleShortVersionString
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : appversion: 2.4.2
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : Latest version of Firecut for DaVinci Resolve is 2.4.2
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : There is no newer version available.
2026-01-26 11:08:51 : INFO  : firecutfordavinciresolve : Installomator did not close any apps, so no need to reopen any apps.
2026-01-26 11:08:51 : REQ   : firecutfordavinciresolve : No newer version.
2026-01-26 11:08:51 : REQ   : firecutfordavinciresolve : ################## End Installomator, exit code 0 
```