### PR TITLE
Update praat.sh

### DIFF
--- a/fragments/labels/praat.sh
+++ b/fragments/labels/praat.sh
@@ -1,7 +1,7 @@
 praat)
     name="Praat"
     type="dmg"
-    praatVersion="$(curl -fs https://www.fon.hum.uva.nl/praat/download_mac.html | grep "for Intel and Apple Silicon):" | cut -d '_' -f2 | cut -c15-)" 
+    praatVersion="$(curl -fs https://www.fon.hum.uva.nl/praat/download_mac.html | grep "64-bit edition" | cut -d ">" -f4 | cut -d "_" -f1 | cut -c 6-)"
     downloadURL="https://www.fon.hum.uva.nl/praat/praat${praatVersion}_mac.dmg"
     appNewVersion="${praatVersion:0:1}.${praatVersion:1:1}.${praatVersion:2:2}"
     expectedTeamID="J9C6R9XA5W"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes, I modified my own label.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes,

**Additional context** Add any other context about the label or fix here.
They changed information on the site that I used to grab the version. Updated that. 


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**


2026-01-27 08:51:44 : INFO  : praat : setting variable from argument DEBUG=1
2026-01-27 08:51:44 : INFO  : praat : Total items in argumentsArray: 1
2026-01-27 08:51:44 : INFO  : praat : argumentsArray: DEBUG=1
2026-01-27 08:51:44 : REQ   : praat : ################## Start Installomator v. 10.9beta, date 2026-01-27
2026-01-27 08:51:44 : INFO  : praat : ################## Version: 10.9beta
2026-01-27 08:51:44 : INFO  : praat : ################## Date: 2026-01-27
2026-01-27 08:51:44 : INFO  : praat : ################## praat
2026-01-27 08:51:44 : DEBUG : praat : DEBUG mode 1 enabled.
2026-01-27 08:51:45 : INFO  : praat : Reading arguments again: DEBUG=1
2026-01-27 08:51:45 : DEBUG : praat : argument: DEBUG=1
2026-01-27 08:51:45 : DEBUG : praat : name=Praat
2026-01-27 08:51:45 : DEBUG : praat : appName=
2026-01-27 08:51:45 : DEBUG : praat : type=dmg
2026-01-27 08:51:45 : DEBUG : praat : archiveName=
2026-01-27 08:51:45 : DEBUG : praat : downloadURL=https://www.fon.hum.uva.nl/praat/praat6458_mac.dmg
2026-01-27 08:51:45 : DEBUG : praat : curlOptions=
2026-01-27 08:51:45 : DEBUG : praat : appNewVersion=6.4.58
2026-01-27 08:51:45 : DEBUG : praat : appCustomVersion function: Not defined
2026-01-27 08:51:45 : DEBUG : praat : versionKey=CFBundleShortVersionString
2026-01-27 08:51:45 : DEBUG : praat : packageID=
2026-01-27 08:51:45 : DEBUG : praat : pkgName=
2026-01-27 08:51:45 : DEBUG : praat : choiceChangesXML=
2026-01-27 08:51:45 : DEBUG : praat : expectedTeamID=J9C6R9XA5W
2026-01-27 08:51:45 : DEBUG : praat : blockingProcesses=
2026-01-27 08:51:45 : DEBUG : praat : installerTool=
2026-01-27 08:51:45 : DEBUG : praat : CLIInstaller=
2026-01-27 08:51:45 : DEBUG : praat : CLIArguments=
2026-01-27 08:51:45 : DEBUG : praat : updateTool=
2026-01-27 08:51:45 : DEBUG : praat : updateToolArguments=
2026-01-27 08:51:45 : DEBUG : praat : updateToolRunAsCurrentUser=
2026-01-27 08:51:45 : INFO  : praat : BLOCKING_PROCESS_ACTION=tell_user
2026-01-27 08:51:45 : INFO  : praat : NOTIFY=success
2026-01-27 08:51:45 : INFO  : praat : LOGGING=DEBUG
2026-01-27 08:51:45 : INFO  : praat : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-27 08:51:45 : INFO  : praat : Label type: dmg
2026-01-27 08:51:45 : INFO  : praat : archiveName: Praat.dmg
2026-01-27 08:51:45 : INFO  : praat : no blocking processes defined, using Praat as default
2026-01-27 08:51:45 : DEBUG : praat : Changing directory to /Users/andreaslundberg/Documents/GitHub/Installomator/build
2026-01-27 08:51:45 : INFO  : praat : name: Praat, appName: Praat.app
2026-01-27 08:51:45 : WARN  : praat : No previous app found
2026-01-27 08:51:45 : WARN  : praat : could not find Praat.app
2026-01-27 08:51:45 : INFO  : praat : appversion: 
2026-01-27 08:51:45 : INFO  : praat : Latest version of Praat is 6.4.58
2026-01-27 08:51:45 : REQ   : praat : Downloading https://www.fon.hum.uva.nl/praat/praat6458_mac.dmg to Praat.dmg
2026-01-27 08:51:45 : DEBUG : praat : No Dialog connection, just download
2026-01-27 08:51:50 : INFO  : praat : Downloaded Praat.dmg – Type is  zlib compressed data – SHA is 6dcf288c6aa700f6932f339165ca8452f44a4c8d – Size is 45776 kB
2026-01-27 08:51:50 : DEBUG : praat : DEBUG mode 1, not checking for blocking processes
2026-01-27 08:51:50 : REQ   : praat : Installing Praat
2026-01-27 08:51:50 : INFO  : praat : Mounting /Users/andreaslundberg/Documents/GitHub/Installomator/build/Praat.dmg
2026-01-27 08:51:54 : DEBUG : praat : Debugging enabled, dmgmount output was:
Beräknar kontrollsumma för Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verifierade   CRC32 $4D18C921
Beräknar kontrollsumma för GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verifierade   CRC32 $1BE81721
Beräknar kontrollsumma för GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verifierade   CRC32 $FAA6495C
Beräknar kontrollsumma för  (Apple_Free : 3)…
(Apple_Free : 3): verifierade   CRC32 $00000000
Beräknar kontrollsumma för disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verifierade   CRC32 $3214F9BF
Beräknar kontrollsumma för  (Apple_Free : 5)…
(Apple_Free : 5): verifierade   CRC32 $00000000
Beräknar kontrollsumma för GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verifierade   CRC32 $FAA6495C
Beräknar kontrollsumma för GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verifierade   CRC32 $34BB9F3C
verifierade   CRC32 $D95CB1E2
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/Praat_6458

2026-01-27 08:51:54 : INFO  : praat : Mounted: /Volumes/Praat_6458
2026-01-27 08:51:54 : INFO  : praat : Verifying: /Volumes/Praat_6458/Praat.app
2026-01-27 08:51:54 : DEBUG : praat : App size: 108M    /Volumes/Praat_6458/Praat.app
2026-01-27 08:51:54 : DEBUG : praat : Debugging enabled, App Verification output was:
/Volumes/Praat_6458/Praat.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Paul Boersma (J9C6R9XA5W)

2026-01-27 08:51:54 : INFO  : praat : Team ID matching: J9C6R9XA5W (expected: J9C6R9XA5W )
2026-01-27 08:51:54 : INFO  : praat : Installing Praat version 6.4.58 on versionKey CFBundleShortVersionString.
2026-01-27 08:51:54 : INFO  : praat : App has LSMinimumSystemVersion: 10.15
2026-01-27 08:51:54 : DEBUG : praat : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-01-27 08:51:54 : INFO  : praat : Finishing...
2026-01-27 08:51:57 : INFO  : praat : name: Praat, appName: Praat.app
2026-01-27 08:51:58 : WARN  : praat : No previous app found
2026-01-27 08:51:58 : WARN  : praat : could not find Praat.app
2026-01-27 08:51:58 : REQ   : praat : Installed Praat, version 6.4.58
2026-01-27 08:51:58 : INFO  : praat : notifying
2026-01-27 08:51:58 : DEBUG : praat : Unmounting /Volumes/Praat_6458
2026-01-27 08:51:58 : DEBUG : praat : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-01-27 08:51:58 : DEBUG : praat : DEBUG mode 1, not reopening anything
2026-01-27 08:51:58 : REQ   : praat : All done!
2026-01-27 08:51:58 : REQ   : praat : ################## End Installomator, exit code 0 




Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")