### PR TITLE
Create Kiro Label

### DIFF
--- a/fragments/labels/kiro.sh
+++ b/fragments/labels/kiro.sh
@@ -1,0 +1,11 @@
+kiro)
+    name="Kiro"
+    type="dmg"
+    appNewVersion=$(curl -fsL "https://kiro.dev/changelog/ide/" | grep -oE '0\.[0-9]+\.[0-9]+' | head -1)
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/${appNewVersion}/kiro-ide-${appNewVersion}-stable-darwin-arm64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://prod.download.desktop.kiro.dev/releases/stable/darwin-x64/signed/${appNewVersion}/kiro-ide-${appNewVersion}-stable-darwin-x64.dmg"
+    fi
+    expectedTeamID="94KV3E626L"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
 ./assemble.sh kiro

2026-01-29 11:45:04 : INFO  : kiro : Total items in argumentsArray: 0
2026-01-29 11:45:04 : INFO  : kiro : argumentsArray: 
2026-01-29 11:45:04 : REQ   : kiro : ################## Start Installomator v. 10.9beta, date 2026-01-29
2026-01-29 11:45:04 : INFO  : kiro : ################## Version: 10.9beta
2026-01-29 11:45:04 : INFO  : kiro : ################## Date: 2026-01-29
2026-01-29 11:45:04 : INFO  : kiro : ################## kiro
2026-01-29 11:45:04 : DEBUG : kiro : DEBUG mode 1 enabled.
2026-01-29 11:45:05 : INFO  : kiro : Reading arguments again: 
2026-01-29 11:45:05 : DEBUG : kiro : name=Kiro
2026-01-29 11:45:05 : DEBUG : kiro : appName=
2026-01-29 11:45:05 : DEBUG : kiro : type=dmg
2026-01-29 11:45:05 : DEBUG : kiro : archiveName=
2026-01-29 11:45:05 : DEBUG : kiro : downloadURL=https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/0.8.206/kiro-ide-0.8.206-stable-darwin-arm64.dmg
2026-01-29 11:45:05 : DEBUG : kiro : curlOptions=
2026-01-29 11:45:05 : DEBUG : kiro : appNewVersion=0.8.206
2026-01-29 11:45:05 : DEBUG : kiro : appCustomVersion function: Not defined
2026-01-29 11:45:05 : DEBUG : kiro : versionKey=CFBundleShortVersionString
2026-01-29 11:45:05 : DEBUG : kiro : packageID=
2026-01-29 11:45:05 : DEBUG : kiro : pkgName=
2026-01-29 11:45:05 : DEBUG : kiro : choiceChangesXML=
2026-01-29 11:45:05 : DEBUG : kiro : expectedTeamID=94KV3E626L
2026-01-29 11:45:05 : DEBUG : kiro : blockingProcesses=
2026-01-29 11:45:05 : DEBUG : kiro : installerTool=
2026-01-29 11:45:05 : DEBUG : kiro : CLIInstaller=
2026-01-29 11:45:05 : DEBUG : kiro : CLIArguments=
2026-01-29 11:45:05 : DEBUG : kiro : updateTool=
2026-01-29 11:45:05 : DEBUG : kiro : updateToolArguments=
2026-01-29 11:45:05 : DEBUG : kiro : updateToolRunAsCurrentUser=
2026-01-29 11:45:05 : INFO  : kiro : BLOCKING_PROCESS_ACTION=tell_user
2026-01-29 11:45:05 : INFO  : kiro : NOTIFY=success
2026-01-29 11:45:05 : INFO  : kiro : LOGGING=DEBUG
2026-01-29 11:45:05 : INFO  : kiro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-29 11:45:05 : INFO  : kiro : Label type: dmg
2026-01-29 11:45:05 : INFO  : kiro : archiveName: Kiro.dmg
2026-01-29 11:45:05 : INFO  : kiro : no blocking processes defined, using Kiro as default
2026-01-29 11:45:05 : DEBUG : kiro : Changing directory to /Users/naschenbrenner/Documents/GitHub/Installomator/build
2026-01-29 11:45:05 : INFO  : kiro : App(s) found: /Applications/Kiro.app
2026-01-29 11:45:05 : INFO  : kiro : found app at /Applications/Kiro.app, version 0.8.206, on versionKey CFBundleShortVersionString
2026-01-29 11:45:05 : INFO  : kiro : appversion: 0.8.206
2026-01-29 11:45:05 : INFO  : kiro : Latest version of Kiro is 0.8.206
2026-01-29 11:45:05 : WARN  : kiro : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-01-29 11:45:05 : INFO  : kiro : Kiro.dmg exists and DEBUG mode 1 enabled, skipping download
2026-01-29 11:45:05 : DEBUG : kiro : DEBUG mode 1, not checking for blocking processes
2026-01-29 11:45:05 : REQ   : kiro : Installing Kiro
2026-01-29 11:45:05 : INFO  : kiro : Mounting /Users/naschenbrenner/Documents/GitHub/Installomator/build/Kiro.dmg
2026-01-29 11:45:06 : DEBUG : kiro : Debugging enabled, dmgmount output was:
expected   CRC32 $B345BAF2
/dev/disk15         	GUID_partition_scheme
/dev/disk15s1       	Apple_APFS
/dev/disk16         	EF57347C-0000-11AA-AA11-0030654
/dev/disk16s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Kiro

2026-01-29 11:45:06 : INFO  : kiro : Mounted: /Volumes/Kiro
2026-01-29 11:45:06 : INFO  : kiro : Verifying: /Volumes/Kiro/Kiro.app
2026-01-29 11:45:06 : DEBUG : kiro : App size: 698M	/Volumes/Kiro/Kiro.app
2026-01-29 11:45:08 : DEBUG : kiro : Debugging enabled, App Verification output was:
/Volumes/Kiro/Kiro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: AMZN Mobile LLC (94KV3E626L)

2026-01-29 11:45:08 : INFO  : kiro : Team ID matching: 94KV3E626L (expected: 94KV3E626L )
2026-01-29 11:45:08 : INFO  : kiro : Downloaded version of Kiro is 0.8.206 on versionKey CFBundleShortVersionString, same as installed.
2026-01-29 11:45:08 : DEBUG : kiro : Unmounting /Volumes/Kiro
2026-01-29 11:45:19 : DEBUG : kiro : Debugging enabled, Unmounting output was:
"disk15" ejected.
2026-01-29 11:45:19 : DEBUG : kiro : DEBUG mode 1, not reopening anything
2026-01-29 11:45:19 : REG   : kiro : No new version to install
2026-01-29 11:45:19 : REQ   : kiro : ################## End Installomator, exit code 0 
```
