### PR TITLE
Update Camtasia name to include year 2024

### DIFF
--- a/fragments/labels/camtasia2024.sh
+++ b/fragments/labels/camtasia2024.sh
@@ -1,5 +1,5 @@
 camtasia2024)
-    name="Camtasia"
+    name="Camtasia 2024"
     type="dmg"
     sparkleData=$(curl -fsL -H 'User-Agent: Camtasia/2024.0.0' 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=camtasiamac&ver=2024.0.0&lang=enu&os=mac')
     appNewVersion=$(


### PR DESCRIPTION
This application is still called "Camtasia 2024" so the current label is broken since even though it downloads the right file, it errors out because with the name being "Camtasia", it is then looking for "Camtasia.app" rather than "Camtasia 2024.app".

The name change of dropping the year only starts with 2025 and on.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
