### PR TITLE
Update xeroxworkcentre7800.sh

### DIFF
--- a/fragments/labels/xeroxworkcentre7800.sh
+++ b/fragments/labels/xeroxworkcentre7800.sh
@@ -2,7 +2,7 @@ xeroxprintandscan|\
 xeroxworkcentre7800)
     name="XeroxWorkCentre"
     type="pkgInDmg"
-    appCustomVersion(){ lpinfo -m | grep 783 | tail -n 1 | awk -F ', ' '{print $2}' }
+    appCustomVersion(){ defaults read "/Library/Printers/Xerox/PDEs/XeroxFeatures.plugin/Contents/Info" CFBundleShortVersionString }
     appNewVersion=$( curl -fsL "https://www.support.xerox.com/nl-nl/product/workcentre-7800-series/downloads?platform=macOS14" | grep .dmg | head -n 1 | awk -F '_' '{print $2}' )
     downloadURL=$( curl -fsL "https://www.support.xerox.com/nl-nl/product/workcentre-7800-series/downloads?platform=macOS14" | xmllint --html --format - 2>/dev/null | grep -o "https://.*XeroxDrivers.*.dmg" )
     expectedTeamID="G59Y3XFNFR"


### PR DESCRIPTION
Change the appCustomVersion to be less reliant on a specific model number

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Modifying a fragment in the labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Manually edited the command in the existing label

**Additional context** Add any other context about the label or fix here.
Previous `appCustomVersion` was reliant on a specific Xerox model.  This command gets the same result without relying on a model that may not be included in a future driver pack.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
[username] Installomator-10.8 % sudo sh ./assemble.sh xeroxprintandscan DEBUG=0
Password:
./assemble.sh: line 16: zparseopts: command not found
./assemble.sh: line 18: (I)(-h|--help): syntax error in expression (error token is "(-h|--help)")
./assemble.sh: line 23: (I)(-s|--script): syntax error in expression (error token is "(-s|--script)")
./assemble.sh: line 25: (I)(-p|--pkg): syntax error in expression (error token is "(-p|--pkg)")
./assemble.sh: line 27: (I)(-n|--notarize): syntax error in expression (error token is "(-n|--notarize)")
./assemble.sh: line 30: (I)(-r|--run): syntax error in expression (error token is "(-r|--run)")
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : setting variable from argument DEBUG=0
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : Total items in argumentsArray: 1
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : argumentsArray: DEBUG=0
2026-01-30 10:12:47 : REQ   : xeroxprintandscan : ################## Start Installomator v. 10.8, date 2026-01-30
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : ################## Version: 10.8
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : ################## Date: 2026-01-30
2026-01-30 10:12:47 : INFO  : xeroxprintandscan : ################## xeroxprintandscan
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : Reading arguments again: DEBUG=0
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : BLOCKING_PROCESS_ACTION=tell_user
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : NOTIFY=success
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : LOGGING=INFO
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : Label type: pkgInDmg
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : archiveName: XeroxWorkCentre.dmg
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : Custom App Version detection is used, found 5.18.0
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : appversion: 5.18.0
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : Latest version of XeroxWorkCentre is 5.18.0
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : There is no newer version available.
2026-01-30 10:12:49 : INFO  : xeroxprintandscan : Installomator did not close any apps, so no need to reopen any apps.
2026-01-30 10:12:49 : REQ   : xeroxprintandscan : No newer version.
2026-01-30 10:12:49 : REQ   : xeroxprintandscan : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
