### PR TITLE
cursorai-updated-label

### DIFF
--- a/fragments/labels/cursorai.sh
+++ b/fragments/labels/cursorai.sh
@@ -1,8 +1,7 @@
 cursorai)
     name="Cursor"
     type="dmg"
-    appNewVersion=$(curl -sL "https://www.cursor.com/changelog" | xmllint --html -xpath "//article[1]" - 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n 1)
     downloadURL=$(curl -fsL "https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable" | grep -o '"downloadUrl":"[^"]*"' | sed 's/"downloadUrl":"\([^"]*\)"/\1/')
+    appNewVersion=$(curl -fsL "https://www.cursor.com/api/download?platform=darwin-universal&releaseTrack=stable" | grep -o '"version":"[^"]*"' | sed 's/"version":"\([^"]*\)"/\1/')
     expectedTeamID="VDXQ22DGB9"
-    blockingProcesses=( "Cursor" )
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh cursorai DEBUG=1
2026-01-30 11:57:46 : INFO  : cursorai : setting variable from argument DEBUG=1
2026-01-30 11:57:46 : INFO  : cursorai : Total items in argumentsArray: 1
2026-01-30 11:57:46 : INFO  : cursorai : argumentsArray: DEBUG=1
2026-01-30 11:57:46 : REQ   : cursorai : ################## Start Installomator v. 10.9beta, date 2026-01-30
2026-01-30 11:57:46 : INFO  : cursorai : ################## Version: 10.9beta
2026-01-30 11:57:46 : INFO  : cursorai : ################## Date: 2026-01-30
2026-01-30 11:57:46 : INFO  : cursorai : ################## cursorai
2026-01-30 11:57:46 : DEBUG : cursorai : DEBUG mode 1 enabled.
2026-01-30 11:57:47 : INFO  : cursorai : Reading arguments again: DEBUG=1
2026-01-30 11:57:47 : DEBUG : cursorai : argument: DEBUG=1
2026-01-30 11:57:47 : DEBUG : cursorai : name=Cursor
2026-01-30 11:57:47 : DEBUG : cursorai : appName=
2026-01-30 11:57:47 : DEBUG : cursorai : type=dmg
2026-01-30 11:57:47 : DEBUG : cursorai : archiveName=
2026-01-30 11:57:47 : DEBUG : cursorai : downloadURL=https://downloads.cursor.com/production/cf8353edc265f5e46b798bfb276861d0bf3bf129/darwin/universal/Cursor-darwin-universal.dmg
2026-01-30 11:57:47 : DEBUG : cursorai : curlOptions=
2026-01-30 11:57:47 : DEBUG : cursorai : appNewVersion=2.3.35
2026-01-30 11:57:47 : DEBUG : cursorai : appCustomVersion function: Not defined
2026-01-30 11:57:47 : DEBUG : cursorai : versionKey=CFBundleShortVersionString
2026-01-30 11:57:47 : DEBUG : cursorai : packageID=
2026-01-30 11:57:47 : DEBUG : cursorai : pkgName=
2026-01-30 11:57:47 : DEBUG : cursorai : choiceChangesXML=
2026-01-30 11:57:47 : DEBUG : cursorai : expectedTeamID=VDXQ22DGB9
2026-01-30 11:57:47 : DEBUG : cursorai : blockingProcesses=
2026-01-30 11:57:47 : DEBUG : cursorai : installerTool=
2026-01-30 11:57:47 : DEBUG : cursorai : CLIInstaller=
2026-01-30 11:57:47 : DEBUG : cursorai : CLIArguments=
2026-01-30 11:57:47 : DEBUG : cursorai : updateTool=
2026-01-30 11:57:48 : DEBUG : cursorai : updateToolArguments=
2026-01-30 11:57:48 : DEBUG : cursorai : updateToolRunAsCurrentUser=
2026-01-30 11:57:48 : INFO  : cursorai : BLOCKING_PROCESS_ACTION=tell_user
2026-01-30 11:57:48 : INFO  : cursorai : NOTIFY=success
2026-01-30 11:57:48 : INFO  : cursorai : LOGGING=DEBUG
2026-01-30 11:57:48 : INFO  : cursorai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-30 11:57:48 : INFO  : cursorai : Label type: dmg
2026-01-30 11:57:48 : INFO  : cursorai : archiveName: Cursor.dmg
2026-01-30 11:57:48 : INFO  : cursorai : no blocking processes defined, using Cursor as default
2026-01-30 11:57:48 : DEBUG : cursorai : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-01-30 11:57:48 : INFO  : cursorai : name: Cursor, appName: Cursor.app
2026-01-30 11:57:48 : WARN  : cursorai : No previous app found
2026-01-30 11:57:48 : WARN  : cursorai : could not find Cursor.app
2026-01-30 11:57:48 : INFO  : cursorai : appversion:
2026-01-30 11:57:48 : INFO  : cursorai : Latest version of Cursor is 2.3.35
2026-01-30 11:57:48 : REQ   : cursorai : Downloading https://downloads.cursor.com/production/cf8353edc265f5e46b798bfb276861d0bf3bf129/darwin/universal/Cursor-darwin-universal.dmg to Cursor.dmg
2026-01-30 11:57:48 : DEBUG : cursorai : No Dialog connection, just download
2026-01-30 11:58:00 : INFO  : cursorai : Downloaded Cursor.dmg – Type is  zlib compressed data – SHA is 3fdbfa7ffefad99b1f05686f380bac913ff1e49f – Size is 344732 kB
2026-01-30 11:58:00 : DEBUG : cursorai : DEBUG mode 1, not checking for blocking processes
2026-01-30 11:58:00 : REQ   : cursorai : Installing Cursor
2026-01-30 11:58:00 : INFO  : cursorai : Mounting /Users/u0105821/git/github/Installomator/build/Cursor.dmg
2026-01-30 11:58:05 : DEBUG : cursorai : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $FB1040E9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $5C2C9AFA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CC458761
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $2AE98D35
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CC458761
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $65EA4347
verified   CRC32 $4DAEEDB0
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/Cursor Installer

2026-01-30 11:58:05 : INFO  : cursorai : Mounted: /Volumes/Cursor Installer
2026-01-30 11:58:05 : INFO  : cursorai : Verifying: /Volumes/Cursor Installer/Cursor.app
2026-01-30 11:58:05 : DEBUG : cursorai : App size: 902M	/Volumes/Cursor Installer/Cursor.app
2026-01-30 11:58:11 : DEBUG : cursorai : Debugging enabled, App Verification output was:
/Volumes/Cursor Installer/Cursor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Hilary Stout (VDXQ22DGB9)

2026-01-30 11:58:11 : INFO  : cursorai : Team ID matching: VDXQ22DGB9 (expected: VDXQ22DGB9 )
2026-01-30 11:58:11 : INFO  : cursorai : Installing Cursor version 2.3.35 on versionKey CFBundleShortVersionString.
2026-01-30 11:58:11 : INFO  : cursorai : App has LSMinimumSystemVersion: 11.0
2026-01-30 11:58:11 : DEBUG : cursorai : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-01-30 11:58:11 : INFO  : cursorai : Finishing...
2026-01-30 11:58:14 : INFO  : cursorai : name: Cursor, appName: Cursor.app
2026-01-30 11:58:14 : WARN  : cursorai : No previous app found
2026-01-30 11:58:14 : WARN  : cursorai : could not find Cursor.app
2026-01-30 11:58:14 : REQ   : cursorai : Installed Cursor, version 2.3.35
2026-01-30 11:58:14 : INFO  : cursorai : notifying
2026-01-30 11:58:14 : DEBUG : cursorai : Unmounting /Volumes/Cursor Installer
2026-01-30 11:58:15 : DEBUG : cursorai : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-01-30 11:58:15 : DEBUG : cursorai : DEBUG mode 1, not reopening anything
2026-01-30 11:58:15 : REQ   : cursorai : All done!
2026-01-30 11:58:15 : REQ   : cursorai : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The updated Cursor installomator label simplifies and improves reliability by consolidating both the download URL and version detection to use the same Cursor API endpoint (https://www.cursor.com/api/download). The original version unnecessarily scraped the changelog page using xmllint and xpath to extract the version number, which was fragile, required additional dependencies, and could break if the HTML structure changed. The new version retrieves both the direct download URL and the accurate version number (in full X.Y.Z format like 2.3.35) from a single, stable JSON API response, eliminating the need for HTML parsing tools and reducing the risk of version detection errors. Additionally, the blockingProcesses parameter was removed since Installomator automatically uses the app name ("Cursor") as the default blocking process when none is explicitly defined, making the label cleaner without sacrificing functionality.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
