### PR TITLE
Update codemeter.sh

### DIFF
--- a/fragments/labels/codemeter.sh
+++ b/fragments/labels/codemeter.sh
@@ -1,12 +1,12 @@
-codemeter)
+ccodemeter)
     name="CodeMeter"
     type="pkgInDmg"
     archiveName="CmInstall.pkg"
     appCustomVersion(){ defaults read "/Applications/Codemeter.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-2 }
     html_page_source="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware.html"
-    macos_value=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo -m1 ' 12"> <option value=".*?"' | cut -d '"' -f3)
+    macos_value=$(curl -fs "$html_page_source" | xmllint --html --recover --nowarning --xpath 'string((//optgroup[starts-with(@label,"macOS")])[1]/option[1]/@value)' - 2>/dev/null;)
     downloadHTML="https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/$macos_value.html"
     downloadURL="https://www.wibu.com"$(curl -fs $downloadHTML | xmllint --html --format - 2>/dev/null | grep -Eo 'rel="nofollow" href=".*?"' | cut -d '"' -f4)
-    appNewVersion=$(curl -fs $html_page_source | xmllint --html --format - 2>/dev/null | grep -Eo "option value=\"$macos_value\" style=\"\">Version .*?\"" | sed -E 's/.*Version (.*) \| 2.*/\1/g')
+    appNewVersion=$(curl -fs "$html_page_source" | xmllint --html --format - 2>/dev/null | grep -Eo "option value=\"$macos_value\" style=\"\">Version .*?\"" | sed -E 's/.*Version ([0-9]+\.[0-9]+).*/\1/')
     expectedTeamID="2SE7W37452"
     ;;

--- a/fragments/labels/codemeter.sh
+++ b/fragments/labels/codemeter.sh
@@ -1,4 +1,4 @@
-ccodemeter)
+codemeter)
     name="CodeMeter"
     type="pkgInDmg"
     archiveName="CmInstall.pkg"


### PR DESCRIPTION
Label adjusted so that the latest version is detected and downloaded.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

2026-01-31 11:19:10 : INFO  : codemeter : setting variable from argument DEBUG=0
2026-01-31 11:19:10 : INFO  : codemeter : Total items in argumentsArray: 1
2026-01-31 11:19:10 : INFO  : codemeter : argumentsArray: DEBUG=0
2026-01-31 11:19:10 : REQ   : codemeter : ################## Start Installomator v. 11.0beta2, date 2026-01-31
2026-01-31 11:19:10 : INFO  : codemeter : ################## Version: 11.0beta2
2026-01-31 11:19:10 : INFO  : codemeter : ################## Date: 2026-01-31
2026-01-31 11:19:10 : INFO  : codemeter : ################## codemeter
2026-01-31 11:19:14 : INFO  : codemeter : Reading arguments again: DEBUG=0
2026-01-31 11:19:14 : INFO  : codemeter : BLOCKING_PROCESS_ACTION=tell_user
2026-01-31 11:19:14 : INFO  : codemeter : NOTIFY=success
2026-01-31 11:19:14 : INFO  : codemeter : LOGGING=INFO
2026-01-31 11:19:14 : INFO  : codemeter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-31 11:19:14 : INFO  : codemeter : Label type: pkgInDmg
2026-01-31 11:19:14 : INFO  : codemeter : archiveName: CmInstall.pkg
2026-01-31 11:19:14 : INFO  : codemeter : no blocking processes defined, using CodeMeter as default
2026-01-31 11:19:14 : INFO  : codemeter : Custom App Version detection is used, found 8.20
2026-01-31 11:19:14 : INFO  : codemeter : appversion: 8.20
2026-01-31 11:19:14 : INFO  : codemeter : Latest version of CodeMeter is 8.40c
2026-01-31 11:19:14 : REQ   : codemeter : Downloading https://www.wibu.com/de/support/anwendersoftware/anwendersoftware/file/download/16715.html?tx_wibudownloads_downloadlist%5BdirectDownload%5D=directDownload&amp;tx_wibudownloads_downloadlist%5BuseAwsS3%5D=0&amp;cHash=8dba7ab094dec6267346f04fce2a2bcd to CmInstall.pkg
2026-01-31 11:19:19 : INFO  : codemeter : Downloaded CmInstall.pkg – Type is  zlib compressed data – SHA is 273ce94db248b4257775f6edef92679dcf8ad7d7 – Size is 98744 kB
2026-01-31 11:19:19 : REQ   : codemeter : no more blocking processes, continue with update
2026-01-31 11:19:19 : REQ   : codemeter : Installing CodeMeter
2026-01-31 11:19:19 : INFO  : codemeter : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.VEhwJTofRZ/CmInstall.pkg
2026-01-31 11:19:19 : INFO  : codemeter : Mounted: /Volumes/CM-Install
2026-01-31 11:19:19 : INFO  : codemeter : found pkg: /Volumes/CM-Install/CmInstall.pkg
2026-01-31 11:19:19 : INFO  : codemeter : Verifying: /Volumes/CM-Install/CmInstall.pkg
2026-01-31 11:19:20 : INFO  : codemeter : Team ID: 2SE7W37452 (expected: 2SE7W37452 )
2026-01-31 11:19:20 : INFO  : codemeter : Installing /Volumes/CM-Install/CmInstall.pkg to /
2026-01-31 11:19:33 : INFO  : codemeter : Finishing...
2026-01-31 11:19:36 : INFO  : codemeter : Custom App Version detection is used, found 8.40
2026-01-31 11:19:36 : REQ   : codemeter : Installed CodeMeter, version 8.40c
2026-01-31 11:19:36 : INFO  : codemeter : notifying
2026-01-31 11:19:37 : INFO  : codemeter : Swift Dialog notification
2026-01-31 11:19:37 : INFO  : codemeter : Installomator did not close any apps, so no need to reopen any apps.
2026-01-31 11:19:37 : REQ   : codemeter : All done!
2026-01-31 11:19:37 : REQ   : codemeter : ################## End Installomator, exit code 0 

2026-01-31 11:31:42 : INFO  : codemeter : setting variable from argument DEBUG=0
2026-01-31 11:31:42 : INFO  : codemeter : Total items in argumentsArray: 1
2026-01-31 11:31:42 : INFO  : codemeter : argumentsArray: DEBUG=0
2026-01-31 11:31:42 : REQ   : codemeter : ################## Start Installomator v. 11.0beta2, date 2026-01-31
2026-01-31 11:31:42 : INFO  : codemeter : ################## Version: 11.0beta2
2026-01-31 11:31:42 : INFO  : codemeter : ################## Date: 2026-01-31
2026-01-31 11:31:42 : INFO  : codemeter : ################## codemeter
2026-01-31 11:31:45 : INFO  : codemeter : Reading arguments again: DEBUG=0
2026-01-31 11:31:45 : INFO  : codemeter : BLOCKING_PROCESS_ACTION=tell_user
2026-01-31 11:31:45 : INFO  : codemeter : NOTIFY=success
2026-01-31 11:31:45 : INFO  : codemeter : LOGGING=INFO
2026-01-31 11:31:45 : INFO  : codemeter : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-31 11:31:45 : INFO  : codemeter : Label type: pkgInDmg
2026-01-31 11:31:45 : INFO  : codemeter : archiveName: CmInstall.pkg
2026-01-31 11:31:45 : INFO  : codemeter : no blocking processes defined, using CodeMeter as default
2026-01-31 11:31:45 : INFO  : codemeter : Custom App Version detection is used, found 8.40
2026-01-31 11:31:45 : INFO  : codemeter : appversion: 8.40
2026-01-31 11:31:45 : INFO  : codemeter : Latest version of CodeMeter is 8.40
2026-01-31 11:31:45 : INFO  : codemeter : There is no newer version available.
2026-01-31 11:31:46 : INFO  : codemeter : Installomator did not close any apps, so no need to reopen any apps.
2026-01-31 11:31:46 : REQ   : codemeter : No newer version.
2026-01-31 11:31:46 : REQ   : codemeter : ################## End Installomator, exit code 0 