### PR TITLE
Fix sipgateclinq label

### DIFF
--- a/fragments/labels/sipgateclinq.sh
+++ b/fragments/labels/sipgateclinq.sh
@@ -1,8 +1,8 @@
 sipgateclinq)
-    name="Sipgate CLINQ"
+    name="Sipgate"
     type="dmg"
     appNewVersion=$(curl -fs -L https://desktop.download.sipgate.com/latest-mac.yml | sed -n 's/version: \(.*\)/\1/p')
-    downloadURL="https://desktop.download.sipgate.com/sipgate%20CLINQ-${appNewVersion}.dmg"
+    downloadURL="https://desktop.download.sipgate.com/sipgate.dmg"
     expectedTeamID="K4L4M6DD76"
 ;;
 

--- a/fragments/labels/sipgateclinq.sh
+++ b/fragments/labels/sipgateclinq.sh
@@ -4,5 +4,4 @@ sipgateclinq)
     appNewVersion=$(curl -fs -L https://desktop.download.sipgate.com/latest-mac.yml | sed -n 's/version: \(.*\)/\1/p')
     downloadURL="https://desktop.download.sipgate.com/sipgate.dmg"
     expectedTeamID="K4L4M6DD76"
-;;
-
+    ;;


### PR DESCRIPTION
Fixed downloadURL and name

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Fixes #2739

```
./assemble.sh sipgateclinq
2026-02-03 20:33:09 : INFO  : sipgateclinq : Total items in argumentsArray: 0
2026-02-03 20:33:09 : INFO  : sipgateclinq : argumentsArray: 
2026-02-03 20:33:09 : REQ   : sipgateclinq : ################## Start Installomator v. 10.9beta, date 2026-02-03
2026-02-03 20:33:09 : INFO  : sipgateclinq : ################## Version: 10.9beta
2026-02-03 20:33:09 : INFO  : sipgateclinq : ################## Date: 2026-02-03
2026-02-03 20:33:09 : INFO  : sipgateclinq : ################## sipgateclinq
2026-02-03 20:33:09 : DEBUG : sipgateclinq : DEBUG mode 1 enabled.
2026-02-03 20:33:10 : INFO  : sipgateclinq : Reading arguments again: 
2026-02-03 20:33:10 : DEBUG : sipgateclinq : name=Sipgate
2026-02-03 20:33:10 : DEBUG : sipgateclinq : appName=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : type=dmg
2026-02-03 20:33:10 : DEBUG : sipgateclinq : archiveName=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : downloadURL=https://desktop.download.sipgate.com/sipgate.dmg
2026-02-03 20:33:10 : DEBUG : sipgateclinq : curlOptions=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : appNewVersion=2.32.0
2026-02-03 20:33:10 : DEBUG : sipgateclinq : appCustomVersion function: Not defined
2026-02-03 20:33:10 : DEBUG : sipgateclinq : versionKey=CFBundleShortVersionString
2026-02-03 20:33:10 : DEBUG : sipgateclinq : packageID=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : pkgName=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : choiceChangesXML=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : expectedTeamID=K4L4M6DD76
2026-02-03 20:33:10 : DEBUG : sipgateclinq : blockingProcesses=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : installerTool=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : CLIInstaller=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : CLIArguments=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : updateTool=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : updateToolArguments=
2026-02-03 20:33:10 : DEBUG : sipgateclinq : updateToolRunAsCurrentUser=
2026-02-03 20:33:10 : INFO  : sipgateclinq : BLOCKING_PROCESS_ACTION=tell_user
2026-02-03 20:33:10 : INFO  : sipgateclinq : NOTIFY=success
2026-02-03 20:33:10 : INFO  : sipgateclinq : LOGGING=DEBUG
2026-02-03 20:33:10 : INFO  : sipgateclinq : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-03 20:33:10 : INFO  : sipgateclinq : Label type: dmg
2026-02-03 20:33:10 : INFO  : sipgateclinq : archiveName: Sipgate.dmg
2026-02-03 20:33:10 : INFO  : sipgateclinq : no blocking processes defined, using Sipgate as default
2026-02-03 20:33:10 : DEBUG : sipgateclinq : Changing directory to /Users/jaredschwager/Documents/Repositories/Installomator/build
2026-02-03 20:33:10 : INFO  : sipgateclinq : name: Sipgate, appName: Sipgate.app
2026-02-03 20:33:10 : WARN  : sipgateclinq : No previous app found
2026-02-03 20:33:10 : WARN  : sipgateclinq : could not find Sipgate.app
2026-02-03 20:33:10 : INFO  : sipgateclinq : appversion: 
2026-02-03 20:33:10 : INFO  : sipgateclinq : Latest version of Sipgate is 2.32.0
2026-02-03 20:33:10 : REQ   : sipgateclinq : Downloading https://desktop.download.sipgate.com/sipgate.dmg to Sipgate.dmg
2026-02-03 20:33:10 : DEBUG : sipgateclinq : No Dialog connection, just download
2026-02-03 20:33:13 : INFO  : sipgateclinq : Downloaded Sipgate.dmg – Type is  zlib compressed data – SHA is ee25ef7dbf580fa40c9de28a0cd2220b1bcdec1a – Size is 232508 kB
2026-02-03 20:33:13 : DEBUG : sipgateclinq : DEBUG mode 1, not checking for blocking processes
2026-02-03 20:33:13 : REQ   : sipgateclinq : Installing Sipgate
2026-02-03 20:33:13 : INFO  : sipgateclinq : Mounting /Users/jaredschwager/Documents/Repositories/Installomator/build/Sipgate.dmg
2026-02-03 20:33:16 : DEBUG : sipgateclinq : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $72809083
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0DD89920
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9409A1EB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $5A3D542C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9409A1EB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $3B6B4412
verified   CRC32 $8757DE18
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/sipgate 2.32.0-universal 1

2026-02-03 20:33:16 : INFO  : sipgateclinq : Mounted: /Volumes/sipgate 2.32.0-universal 1
2026-02-03 20:33:16 : INFO  : sipgateclinq : Verifying: /Volumes/sipgate 2.32.0-universal 1/Sipgate.app
2026-02-03 20:33:16 : DEBUG : sipgateclinq : App size: 503M	/Volumes/sipgate 2.32.0-universal 1/Sipgate.app
2026-02-03 20:33:18 : DEBUG : sipgateclinq : Debugging enabled, App Verification output was:
/Volumes/sipgate 2.32.0-universal 1/Sipgate.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: sipgate GmbH (K4L4M6DD76)

2026-02-03 20:33:18 : INFO  : sipgateclinq : Team ID matching: K4L4M6DD76 (expected: K4L4M6DD76 )
2026-02-03 20:33:18 : INFO  : sipgateclinq : Installing Sipgate version 2.32.0 on versionKey CFBundleShortVersionString.
2026-02-03 20:33:18 : INFO  : sipgateclinq : App has LSMinimumSystemVersion: 12.0
2026-02-03 20:33:18 : DEBUG : sipgateclinq : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-03 20:33:18 : INFO  : sipgateclinq : Finishing...
2026-02-03 20:33:21 : INFO  : sipgateclinq : name: Sipgate, appName: Sipgate.app
2026-02-03 20:33:21 : WARN  : sipgateclinq : No previous app found
2026-02-03 20:33:21 : WARN  : sipgateclinq : could not find Sipgate.app
2026-02-03 20:33:21 : REQ   : sipgateclinq : Installed Sipgate, version 2.32.0
2026-02-03 20:33:21 : INFO  : sipgateclinq : notifying
2026-02-03 20:33:22 : DEBUG : sipgateclinq : Unmounting /Volumes/sipgate 2.32.0-universal 1
2026-02-03 20:33:22 : DEBUG : sipgateclinq : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-02-03 20:33:22 : DEBUG : sipgateclinq : DEBUG mode 1, not reopening anything
2026-02-03 20:33:22 : REQ   : sipgateclinq : All done!
2026-02-03 20:33:22 : REQ   : sipgateclinq : ################## End Installomator, exit code 0
```