### PR TITLE
Fix bitrix24 label

### DIFF
--- a/fragments/labels/bitrix24.sh
+++ b/fragments/labels/bitrix24.sh
@@ -2,7 +2,11 @@ bitrix24)
      name="Bitrix24"
      type="dmg"
      archiveName="bitrix24_desktop.dmg"
-     downloadURL="https://dl.bitrix24.com/b24/bitrix24_desktop.dmg"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL="https://dl.bitrix24.com/b24/bitrix24_desktop.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL="https://dl.bitrix24.com/b24/bitrix24_desktop_arm.dmg"
+    fi
      appNewVersion="$(curl -fs "https://www.bitrix24.com/osx_version.php" | xpath 'string(//rss/channel/item/title)' 2>/dev/null)"
      expectedTeamID="5B3T3A994N"
      ;;

--- a/fragments/labels/bitrix24.sh
+++ b/fragments/labels/bitrix24.sh
@@ -1,12 +1,12 @@
 bitrix24)
-     name="Bitrix24"
-     type="dmg"
-     archiveName="bitrix24_desktop.dmg"
+    name="Bitrix24"
+    type="dmg"
+    archiveName="bitrix24_desktop.dmg"
     if [[ $(arch) == i386 ]]; then
         downloadURL="https://dl.bitrix24.com/b24/bitrix24_desktop.dmg"
     elif [[ $(arch) == arm64 ]]; then
         downloadURL="https://dl.bitrix24.com/b24/bitrix24_desktop_arm.dmg"
     fi
-     appNewVersion="$(curl -fs "https://www.bitrix24.com/osx_version.php" | xpath 'string(//rss/channel/item/title)' 2>/dev/null)"
-     expectedTeamID="5B3T3A994N"
+    appNewVersion="$(curl -fs "https://www.bitrix24.com/osx_version.php" | xpath 'string(//rss/channel/item/title)' 2>/dev/null)"
+    expectedTeamID="5B3T3A994N"
      ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Updated logic to provide different downloadURL depending on CPU architecture

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Fixes #2722 

```
./assemble.sh bitrix24                                                                                     
2026-02-03 20:50:52 : INFO  : bitrix24 : Total items in argumentsArray: 0
2026-02-03 20:50:52 : INFO  : bitrix24 : argumentsArray: 
2026-02-03 20:50:52 : REQ   : bitrix24 : ################## Start Installomator v. 10.9beta, date 2026-02-03
2026-02-03 20:50:52 : INFO  : bitrix24 : ################## Version: 10.9beta
2026-02-03 20:50:52 : INFO  : bitrix24 : ################## Date: 2026-02-03
2026-02-03 20:50:52 : INFO  : bitrix24 : ################## bitrix24
2026-02-03 20:50:52 : DEBUG : bitrix24 : DEBUG mode 1 enabled.
2026-02-03 20:50:52 : INFO  : bitrix24 : Reading arguments again: 
2026-02-03 20:50:52 : DEBUG : bitrix24 : name=Bitrix24
2026-02-03 20:50:52 : DEBUG : bitrix24 : appName=
2026-02-03 20:50:52 : DEBUG : bitrix24 : type=dmg
2026-02-03 20:50:52 : DEBUG : bitrix24 : archiveName=bitrix24_desktop.dmg
2026-02-03 20:50:52 : DEBUG : bitrix24 : downloadURL=https://dl.bitrix24.com/b24/bitrix24_desktop_arm.dmg
2026-02-03 20:50:53 : DEBUG : bitrix24 : curlOptions=
2026-02-03 20:50:53 : DEBUG : bitrix24 : appNewVersion=20.0.28
2026-02-03 20:50:53 : DEBUG : bitrix24 : appCustomVersion function: Not defined
2026-02-03 20:50:53 : DEBUG : bitrix24 : versionKey=CFBundleShortVersionString
2026-02-03 20:50:53 : DEBUG : bitrix24 : packageID=
2026-02-03 20:50:53 : DEBUG : bitrix24 : pkgName=
2026-02-03 20:50:53 : DEBUG : bitrix24 : choiceChangesXML=
2026-02-03 20:50:53 : DEBUG : bitrix24 : expectedTeamID=5B3T3A994N
2026-02-03 20:50:53 : DEBUG : bitrix24 : blockingProcesses=
2026-02-03 20:50:53 : DEBUG : bitrix24 : installerTool=
2026-02-03 20:50:53 : DEBUG : bitrix24 : CLIInstaller=
2026-02-03 20:50:53 : DEBUG : bitrix24 : CLIArguments=
2026-02-03 20:50:53 : DEBUG : bitrix24 : updateTool=
2026-02-03 20:50:53 : DEBUG : bitrix24 : updateToolArguments=
2026-02-03 20:50:53 : DEBUG : bitrix24 : updateToolRunAsCurrentUser=
2026-02-03 20:50:53 : INFO  : bitrix24 : BLOCKING_PROCESS_ACTION=tell_user
2026-02-03 20:50:53 : INFO  : bitrix24 : NOTIFY=success
2026-02-03 20:50:53 : INFO  : bitrix24 : LOGGING=DEBUG
2026-02-03 20:50:53 : INFO  : bitrix24 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-03 20:50:53 : INFO  : bitrix24 : Label type: dmg
2026-02-03 20:50:53 : INFO  : bitrix24 : archiveName: bitrix24_desktop.dmg
2026-02-03 20:50:53 : INFO  : bitrix24 : no blocking processes defined, using Bitrix24 as default
2026-02-03 20:50:53 : DEBUG : bitrix24 : Changing directory to /Users/jaredschwager/Documents/Repositories/Installomator/build
2026-02-03 20:50:53 : INFO  : bitrix24 : name: Bitrix24, appName: Bitrix24.app
2026-02-03 20:50:53 : WARN  : bitrix24 : No previous app found
2026-02-03 20:50:53 : WARN  : bitrix24 : could not find Bitrix24.app
2026-02-03 20:50:53 : INFO  : bitrix24 : appversion: 
2026-02-03 20:50:53 : INFO  : bitrix24 : Latest version of Bitrix24 is 20.0.28
2026-02-03 20:50:53 : REQ   : bitrix24 : Downloading https://dl.bitrix24.com/b24/bitrix24_desktop_arm.dmg to bitrix24_desktop.dmg
2026-02-03 20:50:53 : DEBUG : bitrix24 : No Dialog connection, just download
2026-02-03 20:50:59 : INFO  : bitrix24 : Downloaded bitrix24_desktop.dmg – Type is  XZ compressed data, checksum NONE – SHA is d2d2c94e20683027ae7557418d0466b0725681cf – Size is 213624 kB
2026-02-03 20:50:59 : DEBUG : bitrix24 : DEBUG mode 1, not checking for blocking processes
2026-02-03 20:50:59 : REQ   : bitrix24 : Installing Bitrix24
2026-02-03 20:50:59 : INFO  : bitrix24 : Mounting /Users/jaredschwager/Documents/Repositories/Installomator/build/bitrix24_desktop.dmg
2026-02-03 20:51:04 : DEBUG : bitrix24 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $97741718
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $B2A408AC
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified   CRC32 $9F4D3093
verified   CRC32 $AA913B44
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/Bitrix24 for macOS

2026-02-03 20:51:04 : INFO  : bitrix24 : Mounted: /Volumes/Bitrix24 for macOS
2026-02-03 20:51:04 : INFO  : bitrix24 : Verifying: /Volumes/Bitrix24 for macOS/Bitrix24.app
2026-02-03 20:51:04 : DEBUG : bitrix24 : App size: 751M	/Volumes/Bitrix24 for macOS/Bitrix24.app
2026-02-03 20:51:20 : DEBUG : bitrix24 : Debugging enabled, App Verification output was:
/Volumes/Bitrix24 for macOS/Bitrix24.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bitrix, Inc. (5B3T3A994N)

2026-02-03 20:51:20 : INFO  : bitrix24 : Team ID matching: 5B3T3A994N (expected: 5B3T3A994N )
2026-02-03 20:51:20 : INFO  : bitrix24 : Installing Bitrix24 version 20.0.28 on versionKey CFBundleShortVersionString.
2026-02-03 20:51:20 : INFO  : bitrix24 : App has LSMinimumSystemVersion: 12.0
2026-02-03 20:51:20 : DEBUG : bitrix24 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-03 20:51:20 : INFO  : bitrix24 : Finishing...
2026-02-03 20:51:23 : INFO  : bitrix24 : name: Bitrix24, appName: Bitrix24.app
2026-02-03 20:51:24 : WARN  : bitrix24 : No previous app found
2026-02-03 20:51:24 : WARN  : bitrix24 : could not find Bitrix24.app
2026-02-03 20:51:24 : REQ   : bitrix24 : Installed Bitrix24, version 20.0.28
2026-02-03 20:51:24 : INFO  : bitrix24 : notifying
2026-02-03 20:51:24 : DEBUG : bitrix24 : Unmounting /Volumes/Bitrix24 for macOS
2026-02-03 20:51:24 : DEBUG : bitrix24 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-02-03 20:51:24 : DEBUG : bitrix24 : DEBUG mode 1, not reopening anything
2026-02-03 20:51:24 : REQ   : bitrix24 : All done!
2026-02-03 20:51:24 : REQ   : bitrix24 : ################## End Installomator, exit code 0 
```