### PR TITLE
python-label-update

### DIFF
--- a/fragments/labels/python.sh
+++ b/fragments/labels/python.sh
@@ -1,17 +1,17 @@
 python)
     name="Python"
     type="pkg"
-    appNewVersion="$( curl --compressed -s "https://www.python.org/downloads/macos/" | awk '/Latest Python 3 Release - Python/{gsub(/<\/?[^>]+(>|$)/, ""); print $NF}' )"
-    archiveName="$( curl -s "https://www.python.org/ftp/python/$appNewVersion/" | grep -om 1 "\"python.*macos.*\.pkg\"" | tr -d \" )"
+    pageContent=$(curl -sL --compressed https://www.python.org/downloads/macos/)
+    appNewVersion=$(echo "$pageContent" | grep -oE 'Latest Python 3 Release - Python [0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+    shortVersion=$(echo "$appNewVersion" | cut -d '.' -f1,2)
+    archiveName="python-${appNewVersion}-macos11.pkg"
     downloadURL="https://www.python.org/ftp/python/$appNewVersion/$archiveName"
-    shortVersion=$( cut -d '.' -f1,2 <<< $appNewVersion )
     packageID="org.python.Python.PythonFramework-$shortVersion"
     expectedTeamID="BMM5U3QVKW"
-    blockingProcesses=( "IDLE" "Python Launcher" )
+    blockingProcesses=("IDLE" "Python Launcher")
     versionKey="CFBundleVersion"
     appCustomVersion() {
-        if [ -d "/Library/Frameworks/Python.framework/Versions/$shortVersion/Resources/Python.app/" ]; then
-            /usr/bin/defaults read "/Library/Frameworks/Python.framework/Versions/$shortVersion/Resources/Python.app/Contents/Info" CFBundleVersion
-        fi
+        frameworkPath="/Library/Frameworks/Python.framework/Versions/$shortVersion/Resources/Python.app/Contents/Info"
+        [[ -f "${frameworkPath}.plist" ]] && /usr/bin/defaults read "$frameworkPath" CFBundleVersion
     }
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh python DEBUG=1
2026-02-04 10:57:08 : INFO  : python : setting variable from argument DEBUG=1
2026-02-04 10:57:08 : INFO  : python : Total items in argumentsArray: 1
2026-02-04 10:57:08 : INFO  : python : argumentsArray: DEBUG=1
2026-02-04 10:57:08 : REQ   : python : ################## Start Installomator v. 10.9beta, date 2026-02-04
2026-02-04 10:57:09 : INFO  : python : ################## Version: 10.9beta
2026-02-04 10:57:09 : INFO  : python : ################## Date: 2026-02-04
2026-02-04 10:57:09 : INFO  : python : ################## python
2026-02-04 10:57:09 : DEBUG : python : DEBUG mode 1 enabled.
2026-02-04 10:57:09 : INFO  : python : Reading arguments again: DEBUG=1
2026-02-04 10:57:09 : DEBUG : python : argument: DEBUG=1
2026-02-04 10:57:09 : DEBUG : python : name=Python
2026-02-04 10:57:09 : DEBUG : python : appName=
2026-02-04 10:57:09 : DEBUG : python : type=pkg
2026-02-04 10:57:09 : DEBUG : python : archiveName=python-3.14.3-macos11.pkg
2026-02-04 10:57:09 : DEBUG : python : downloadURL=https://www.python.org/ftp/python/3.14.3/python-3.14.3-macos11.pkg
2026-02-04 10:57:09 : DEBUG : python : curlOptions=
2026-02-04 10:57:09 : DEBUG : python : appNewVersion=3.14.3
2026-02-04 10:57:09 : DEBUG : python : appCustomVersion function: Defined.
2026-02-04 10:57:09 : DEBUG : python : versionKey=CFBundleVersion
2026-02-04 10:57:09 : DEBUG : python : packageID=org.python.Python.PythonFramework-3.14
2026-02-04 10:57:09 : DEBUG : python : pkgName=
2026-02-04 10:57:09 : DEBUG : python : choiceChangesXML=
2026-02-04 10:57:09 : DEBUG : python : expectedTeamID=BMM5U3QVKW
2026-02-04 10:57:09 : DEBUG : python : blockingProcesses=IDLE Python Launcher
2026-02-04 10:57:09 : DEBUG : python : installerTool=
2026-02-04 10:57:09 : DEBUG : python : CLIInstaller=
2026-02-04 10:57:09 : DEBUG : python : CLIArguments=
2026-02-04 10:57:09 : DEBUG : python : updateTool=
2026-02-04 10:57:09 : DEBUG : python : updateToolArguments=
2026-02-04 10:57:09 : DEBUG : python : updateToolRunAsCurrentUser=
2026-02-04 10:57:09 : INFO  : python : BLOCKING_PROCESS_ACTION=tell_user
2026-02-04 10:57:09 : INFO  : python : NOTIFY=success
2026-02-04 10:57:09 : INFO  : python : LOGGING=DEBUG
2026-02-04 10:57:09 : INFO  : python : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-04 10:57:10 : INFO  : python : Label type: pkg
2026-02-04 10:57:10 : INFO  : python : archiveName: python-3.14.3-macos11.pkg
2026-02-04 10:57:10 : DEBUG : python : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-02-04 10:57:10 : INFO  : python : Custom App Version detection is used, found 3.14.3
2026-02-04 10:57:10 : INFO  : python : appversion: 3.14.3
2026-02-04 10:57:10 : INFO  : python : Latest version of Python is 3.14.3
2026-02-04 10:57:10 : WARN  : python : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-02-04 10:57:10 : REQ   : python : Downloading https://www.python.org/ftp/python/3.14.3/python-3.14.3-macos11.pkg to python-3.14.3-macos11.pkg
2026-02-04 10:57:10 : DEBUG : python : No Dialog connection, just download
2026-02-04 10:57:12 : INFO  : python : Downloaded python-3.14.3-macos11.pkg – Type is  xar archive compressed TOC – SHA is d10fc815253b19f000b4240e3f1732818ef6f866 – Size is 82364 kB
2026-02-04 10:57:12 : DEBUG : python : DEBUG mode 1, not checking for blocking processes
2026-02-04 10:57:12 : REQ   : python : Installing Python
2026-02-04 10:57:12 : INFO  : python : Verifying: python-3.14.3-macos11.pkg
2026-02-04 10:57:12 : DEBUG : python : File list: -rw-r--r--  1 root  staff    72M Feb  4 10:57 python-3.14.3-macos11.pkg
2026-02-04 10:57:12 : DEBUG : python : File type: python-3.14.3-macos11.pkg: xar archive compressed TOC: 6806, SHA-1 checksum
2026-02-04 10:57:12 : DEBUG : python : spctlOut is python-3.14.3-macos11.pkg: accepted
2026-02-04 10:57:12 : DEBUG : python : source=Notarized Developer ID
2026-02-04 10:57:12 : DEBUG : python : origin=Developer ID Installer: Python Software Foundation (BMM5U3QVKW)
2026-02-04 10:57:12 : INFO  : python : Team ID: BMM5U3QVKW (expected: BMM5U3QVKW )
2026-02-04 10:57:12 : INFO  : python : Checking package version.
2026-02-04 10:57:13 : INFO  : python : Downloaded package org.python.Python.PythonFramework-3.14 version 0
2026-02-04 10:57:13 : DEBUG : python : DEBUG enabled, skipping installation
2026-02-04 10:57:13 : INFO  : python : Finishing...
2026-02-04 10:57:16 : INFO  : python : Custom App Version detection is used, found 3.14.3
2026-02-04 10:57:16 : REQ   : python : Installed Python, version 0
2026-02-04 10:57:16 : INFO  : python : notifying
2026-02-04 10:57:16 : DEBUG : python : DEBUG mode 1, not reopening anything
2026-02-04 10:57:16 : REQ   : python : All done!
2026-02-04 10:57:16 : REQ   : python : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

This update improves reliability and simplifies the Python label logic by implementing more robust version detection with explicit regex patterns instead of awk parsing, eliminating a redundant curl request by reusing cached page content for both version detection and archive name construction, using a predictable hardcoded archive naming pattern (python-${appNewVersion}-macos11.pkg) that matches Python's consistent release format, and fixing the appCustomVersion() function to properly check for the .plist file existence before attempting to read it, preventing errors when the framework is not installed.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
