### PR TITLE
Remove Warp Terminal label from labels.txt as its no longer supported

### DIFF
--- a/Labels.txt
+++ b/Labels.txt
@@ -1052,7 +1052,6 @@ vscodium
 vysor
 wacomdrivers
 wallyezflash
-warp
 wavescentral
 weasis
 webcatalog


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Its editing labels.txt

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes.

**Additional context** Add any other context about the label or fix here.
This just removed warp from the labels.txt file as this is no longer supported and is misleading.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
N/A

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A
