### PR TITLE
Sketchup 2026 Labe Update

### DIFF
--- a/fragments/labels/sketchup2026.sh
+++ b/fragments/labels/sketchup2026.sh
@@ -1,10 +1,10 @@
 sketchup2026)
     name="SketchUp 2026"
     type="dmg"
-    downloadURL="$(curl -s https://sketchup.trimble.com/en/download/all | grep -o 'https://download.sketchup.com/SketchUp-2026[^"]*.dmg')"
+    downloadURL=$(curl -sfL https://www.sketchup.com/download/all | grep -o 'https://sketchup.trimble.com/sketchup/2026/SketchUpPro-dmg' | head -1 | xargs -I {} curl -sfLI -o /dev/null -w '%{url_effective}' {})
     folderName="SketchUp 2026"
     appName="${folderName}/SketchUp.app"
-    appNewVersion=$(echo "$downloadURL" | grep -o 'SketchUp-20[0-9][0-9]-[0-9]*-[0-9]*' | awk -F '-' '{year=substr($2, 3, 2); if (year >= 24) printf "%d.0.%s", year, $NF; else printf "%d.%s", year+2000, $NF}')
+    appNewVersion=$(echo "$downloadURL" | grep -o '2026-[0-9]*-[0-9]*-[0-9]*' | sed 's/2026-/26./;s/-/./g')
     versionKey="CFBundleVersion"
     expectedTeamID="J8PVMCY7KL"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh sketchup2026 DEBUG=1
2026-02-05 12:07:23 : REQ   : sketchup2026 : ################## Start Installomator v. 10.6beta, date 2026-02-05
2026-02-05 12:07:23 : INFO  : sketchup2026 : ################## Version: 10.6beta
2026-02-05 12:07:23 : INFO  : sketchup2026 : ################## Date: 2026-02-05
2026-02-05 12:07:23 : INFO  : sketchup2026 : ################## sketchup2026
2026-02-05 12:07:23 : DEBUG : sketchup2026 : DEBUG mode 1 enabled.
2026-02-05 12:07:24 : INFO  : sketchup2026 : setting variable from argument DEBUG=1
2026-02-05 12:07:24 : DEBUG : sketchup2026 : name=SketchUp 2026
2026-02-05 12:07:24 : DEBUG : sketchup2026 : appName=SketchUp 2026/SketchUp.app
2026-02-05 12:07:24 : DEBUG : sketchup2026 : type=dmg
2026-02-05 12:07:24 : DEBUG : sketchup2026 : archiveName=
2026-02-05 12:07:24 : DEBUG : sketchup2026 : downloadURL=https://download.sketchup.com/SketchUp-2026-1-188-46.dmg
2026-02-05 12:07:24 : DEBUG : sketchup2026 : curlOptions=
2026-02-05 12:07:24 : DEBUG : sketchup2026 : appNewVersion=26.1.188.46
2026-02-05 12:07:25 : DEBUG : sketchup2026 : appCustomVersion function: Not defined
2026-02-05 12:07:25 : DEBUG : sketchup2026 : versionKey=CFBundleVersion
2026-02-05 12:07:25 : DEBUG : sketchup2026 : packageID=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : pkgName=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : choiceChangesXML=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : expectedTeamID=J8PVMCY7KL
2026-02-05 12:07:25 : DEBUG : sketchup2026 : blockingProcesses=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : installerTool=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : CLIInstaller=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : CLIArguments=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : updateTool=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : updateToolArguments=
2026-02-05 12:07:25 : DEBUG : sketchup2026 : updateToolRunAsCurrentUser=
2026-02-05 12:07:25 : INFO  : sketchup2026 : BLOCKING_PROCESS_ACTION=tell_user
2026-02-05 12:07:25 : INFO  : sketchup2026 : NOTIFY=success
2026-02-05 12:07:25 : INFO  : sketchup2026 : LOGGING=DEBUG
2026-02-05 12:07:25 : INFO  : sketchup2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-05 12:07:25 : INFO  : sketchup2026 : Label type: dmg
2026-02-05 12:07:25 : INFO  : sketchup2026 : archiveName: SketchUp 2026.dmg
2026-02-05 12:07:25 : INFO  : sketchup2026 : no blocking processes defined, using SketchUp 2026 as default
2026-02-05 12:07:25 : DEBUG : sketchup2026 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-02-05 12:07:25 : INFO  : sketchup2026 : name: SketchUp 2026, appName: SketchUp 2026/SketchUp.app
2026-02-05 12:07:25.508 mdfind[67126:5551236] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2026-02-05 12:07:25.509 mdfind[67126:5551236] [UserQueryParser] Loading keywords and predicates for locale "en"
2026-02-05 12:07:25.709 mdfind[67126:5551236] Couldn't determine the mapping between prefab keywords and predicates.
2026-02-05 12:07:25 : WARN  : sketchup2026 : No previous app found
2026-02-05 12:07:25 : WARN  : sketchup2026 : could not find SketchUp 2026/SketchUp.app
2026-02-05 12:07:25 : INFO  : sketchup2026 : appversion:
2026-02-05 12:07:25 : INFO  : sketchup2026 : Latest version of SketchUp 2026 is 26.1.188.46
2026-02-05 12:07:25 : REQ   : sketchup2026 : Downloading https://download.sketchup.com/SketchUp-2026-1-188-46.dmg to SketchUp 2026.dmg
2026-02-05 12:07:25 : DEBUG : sketchup2026 : No Dialog connection, just download
2026-02-05 12:07:59 : DEBUG : sketchup2026 : File list: -rw-r--r--  1 root  staff   1.4G Feb  5 12:07 SketchUp 2026.dmg
2026-02-05 12:07:59 : DEBUG : sketchup2026 : File type: SketchUp 2026.dmg: bzip2 compressed data, block size = 100k
2026-02-05 12:07:59 : DEBUG : sketchup2026 : curl output was:
* Host download.sketchup.com:443 was resolved.
* IPv6: (none)
* IPv4: 18.164.174.35, 18.164.174.72, 18.164.174.119, 18.164.174.14
*   Trying 18.164.174.35:443...
* Connected to download.sketchup.com (18.164.174.35) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
} [326 bytes data]
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [3793 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-AES128-GCM-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.sketchup.com
*  start date: Dec 14 00:00:00 2025 GMT
*  expire date: Jan 12 23:59:59 2027 GMT
*  subjectAltName: host "download.sketchup.com" matched cert's "*.sketchup.com"
*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://download.sketchup.com/SketchUp-2026-1-188-46.dmg
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: download.sketchup.com]
* [HTTP/2] [1] [:path: /SketchUp-2026-1-188-46.dmg]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /SketchUp-2026-1-188-46.dmg HTTP/2
> Host: download.sketchup.com
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 1513333677
< date: Thu, 05 Feb 2026 01:40:58 GMT
< last-modified: Mon, 15 Dec 2025 20:50:02 GMT
< etag: "369a041e3a015556df6af851711333e8"
< x-amz-server-side-encryption: AES256
< x-amz-version-id: Rho_I_aV6UUoj3NMqwbVebSyJw9U0RYZ
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Hit from cloudfront
< via: 1.1 b27b5ffaa5523a69ae1316bfc6babf92.cloudfront.net (CloudFront)
< x-amz-cf-pop: LAX53-P4
< x-amz-cf-id: GZJ10wGdSroDumcIlzOG7EAmmIudH4TCzz7PDL_iuX1f8hp2gqkWcg==
< age: 62789
<
{ [8192 bytes data]
* Connection #0 to host download.sketchup.com left intact

2026-02-05 12:07:59 : DEBUG : sketchup2026 : DEBUG mode 1, not checking for blocking processes
2026-02-05 12:08:00 : REQ   : sketchup2026 : Installing SketchUp 2026
2026-02-05 12:08:00 : INFO  : sketchup2026 : Mounting /Users/u0105821/git/github/Installomator/build/SketchUp 2026.dmg
2026-02-05 12:09:15 : DEBUG : sketchup2026 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D0FAC742
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $32F9A354
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $BCF2DF45
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $D4ABEA41
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $BCF2DF45
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $2F5E2AB9
verified   CRC32 $933B1122
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	EFI
/dev/disk8s2        	Apple_HFS                      	/Volumes/SketchUp 2026

2026-02-05 12:09:15 : INFO  : sketchup2026 : Mounted: /Volumes/SketchUp 2026
2026-02-05 12:09:15 : INFO  : sketchup2026 : Verifying: /Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app
2026-02-05 12:09:16 : DEBUG : sketchup2026 : App size: 2.3G	/Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app
2026-02-05 12:11:19 : DEBUG : sketchup2026 : Debugging enabled, App Verification output was:
/Volumes/SketchUp 2026/SketchUp 2026/SketchUp.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Trimble Inc. (J8PVMCY7KL)

2026-02-05 12:11:19 : INFO  : sketchup2026 : Team ID matching: J8PVMCY7KL (expected: J8PVMCY7KL )
2026-02-05 12:11:19 : INFO  : sketchup2026 : Installing SketchUp 2026 version 26.1.188 on versionKey CFBundleVersion.
2026-02-05 12:11:19 : INFO  : sketchup2026 : App has LSMinimumSystemVersion: 13.0
2026-02-05 12:11:19 : DEBUG : sketchup2026 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-05 12:11:19 : INFO  : sketchup2026 : Finishing...
2026-02-05 12:11:22 : INFO  : sketchup2026 : name: SketchUp 2026, appName: SketchUp 2026/SketchUp.app
2026-02-05 12:11:22.749 mdfind[68300:5559549] [UserQueryParser] Loading keywords and predicates for locale "en_US"
2026-02-05 12:11:22.751 mdfind[68300:5559549] [UserQueryParser] Loading keywords and predicates for locale "en"
2026-02-05 12:11:22.853 mdfind[68300:5559549] Couldn't determine the mapping between prefab keywords and predicates.
2026-02-05 12:11:22 : WARN  : sketchup2026 : No previous app found
2026-02-05 12:11:23 : WARN  : sketchup2026 : could not find SketchUp 2026/SketchUp.app
2026-02-05 12:11:23 : REQ   : sketchup2026 : Installed SketchUp 2026, version 26.1.188
2026-02-05 12:11:23 : INFO  : sketchup2026 : notifying
2026-02-05 12:11:23 : DEBUG : sketchup2026 : Unmounting /Volumes/SketchUp 2026
2026-02-05 12:11:23 : DEBUG : sketchup2026 : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-02-05 12:11:23 : DEBUG : sketchup2026 : DEBUG mode 1, not reopening anything
2026-02-05 12:11:23 : REQ   : sketchup2026 : All done!
2026-02-05 12:11:23 : REQ   : sketchup2026 : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes, I will close the previous pull request because it is no longer functional. Here’s the link to the pull request: https://github.com/Installomator/Installomator/pull/2714

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update fixes the broken download URL detection by switching from the deprecated `/en/download/all` endpoint to the current `/download/all` page and updating the URL pattern matching to handle Trimble's new redirect-based download system. The version parsing has been simplified to directly extract and format the version number from the new URL structure (2026-X-X-X format), improving reliability and maintainability.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
