### PR TITLE
Update axurerp10.sh

### DIFF
--- a/fragments/labels/axurerp10.sh
+++ b/fragments/labels/axurerp10.sh
@@ -2,11 +2,11 @@ axurerp10)
     name="Axure RP 10"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -s https://www.axure.com/release-history/rp10 | grep dmg | sed -n 's/.*href="\([^"]*\)".*/\1/p' | sed 's/ *$//' | grep arm64)
+        downloadURL=$(curl -s https://www.axure.com/release-history/rp10 | grep -oE 'https://[^ ]+.dmg' | grep arm64 | head -n 1)
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL=$(curl -s https://www.axure.com/release-history/rp10 | grep dmg | sed -n 's/.*href="\([^"]*\)".*/\1/p' | sed 's/ *$//' | grep -v arm64)
+        downloadURL=$(curl -s https://www.axure.com/release-history/rp10 | grep -oE 'https://[^ ]+.dmg' | grep -v arm64 | head -n 1)
     fi
-    appNewVersion=$( curl -sL https://www.axure.com/release-history/rp10 | grep -Eo '[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}' -m 1 )
+    appNewVersion=$(curl -sL https://www.axure.com/release-history/rp10 | grep -oE '[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}\.[0-9]{1,4}' | head -n 1)
     expectedTeamID="HUMW6UU796"
     versionKey="CFBundleVersion"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Fixed downloadURL and appNewVersion variables

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Fixes #2694 

```
./assemble.sh axurerp10
2026-02-05 14:51:13 : INFO  : axurerp10 : Total items in argumentsArray: 0
2026-02-05 14:51:13 : INFO  : axurerp10 : argumentsArray: 
2026-02-05 14:51:13 : REQ   : axurerp10 : ################## Start Installomator v. 10.9beta, date 2026-02-05
2026-02-05 14:51:13 : INFO  : axurerp10 : ################## Version: 10.9beta
2026-02-05 14:51:13 : INFO  : axurerp10 : ################## Date: 2026-02-05
2026-02-05 14:51:13 : INFO  : axurerp10 : ################## axurerp10
2026-02-05 14:51:13 : DEBUG : axurerp10 : DEBUG mode 1 enabled.
2026-02-05 14:51:14 : INFO  : axurerp10 : Reading arguments again: 
2026-02-05 14:51:14 : DEBUG : axurerp10 : name=Axure RP 10
2026-02-05 14:51:14 : DEBUG : axurerp10 : appName=
2026-02-05 14:51:14 : DEBUG : axurerp10 : type=dmg
2026-02-05 14:51:14 : DEBUG : axurerp10 : archiveName=
2026-02-05 14:51:14 : DEBUG : axurerp10 : downloadURL=https://axure.cachefly.net/versions/10-0/AxureRP-Setup-arm64-3929.dmg
2026-02-05 14:51:14 : DEBUG : axurerp10 : curlOptions=
2026-02-05 14:51:14 : DEBUG : axurerp10 : appNewVersion=10.0.0.3929
2026-02-05 14:51:14 : DEBUG : axurerp10 : appCustomVersion function: Not defined
2026-02-05 14:51:14 : DEBUG : axurerp10 : versionKey=CFBundleVersion
2026-02-05 14:51:14 : DEBUG : axurerp10 : packageID=
2026-02-05 14:51:14 : DEBUG : axurerp10 : pkgName=
2026-02-05 14:51:14 : DEBUG : axurerp10 : choiceChangesXML=
2026-02-05 14:51:14 : DEBUG : axurerp10 : expectedTeamID=HUMW6UU796
2026-02-05 14:51:14 : DEBUG : axurerp10 : blockingProcesses=
2026-02-05 14:51:14 : DEBUG : axurerp10 : installerTool=
2026-02-05 14:51:14 : DEBUG : axurerp10 : CLIInstaller=
2026-02-05 14:51:14 : DEBUG : axurerp10 : CLIArguments=
2026-02-05 14:51:14 : DEBUG : axurerp10 : updateTool=
2026-02-05 14:51:14 : DEBUG : axurerp10 : updateToolArguments=
2026-02-05 14:51:14 : DEBUG : axurerp10 : updateToolRunAsCurrentUser=
2026-02-05 14:51:14 : INFO  : axurerp10 : BLOCKING_PROCESS_ACTION=tell_user
2026-02-05 14:51:14 : INFO  : axurerp10 : NOTIFY=success
2026-02-05 14:51:14 : INFO  : axurerp10 : LOGGING=DEBUG
2026-02-05 14:51:14 : INFO  : axurerp10 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-05 14:51:14 : INFO  : axurerp10 : Label type: dmg
2026-02-05 14:51:14 : INFO  : axurerp10 : archiveName: Axure RP 10.dmg
2026-02-05 14:51:14 : INFO  : axurerp10 : no blocking processes defined, using Axure RP 10 as default
2026-02-05 14:51:14 : DEBUG : axurerp10 : Changing directory to /Users/jaredschwager/Repositories/jschwager/Installomator/build
2026-02-05 14:51:14 : INFO  : axurerp10 : name: Axure RP 10, appName: Axure RP 10.app
2026-02-05 14:51:14 : WARN  : axurerp10 : No previous app found
2026-02-05 14:51:14 : WARN  : axurerp10 : could not find Axure RP 10.app
2026-02-05 14:51:14 : INFO  : axurerp10 : appversion: 
2026-02-05 14:51:14 : INFO  : axurerp10 : Latest version of Axure RP 10 is 10.0.0.3929
2026-02-05 14:51:14 : REQ   : axurerp10 : Downloading https://axure.cachefly.net/versions/10-0/AxureRP-Setup-arm64-3929.dmg to Axure RP 10.dmg
2026-02-05 14:51:14 : DEBUG : axurerp10 : No Dialog connection, just download
2026-02-05 14:51:18 : INFO  : axurerp10 : Downloaded Axure RP 10.dmg – Type is  zlib compressed data – SHA is b8629aa41f4f32ac7d7f9c04a43837364603b8be – Size is 131836 kB
2026-02-05 14:51:18 : DEBUG : axurerp10 : DEBUG mode 1, not checking for blocking processes
2026-02-05 14:51:18 : REQ   : axurerp10 : Installing Axure RP 10
2026-02-05 14:51:18 : INFO  : axurerp10 : Mounting /Users/jaredschwager/Repositories/jschwager/Installomator/build/Axure RP 10.dmg
2026-02-05 14:51:22 : DEBUG : axurerp10 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $11EC6902
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $12817B23
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D92AB472
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $8942B6E8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D92AB472
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $47EB1502
verified   CRC32 $243D8BE7
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Axure RP 10

2026-02-05 14:51:22 : INFO  : axurerp10 : Mounted: /Volumes/Axure RP 10
2026-02-05 14:51:22 : INFO  : axurerp10 : Verifying: /Volumes/Axure RP 10/Axure RP 10.app
2026-02-05 14:51:22 : DEBUG : axurerp10 : App size: 277M	/Volumes/Axure RP 10/Axure RP 10.app
2026-02-05 14:51:25 : DEBUG : axurerp10 : Debugging enabled, App Verification output was:
/Volumes/Axure RP 10/Axure RP 10.app: accepted
source=Developer ID
origin=Developer ID Application: Axure Software Solutions, Inc. (HUMW6UU796)

2026-02-05 14:51:25 : INFO  : axurerp10 : Team ID matching: HUMW6UU796 (expected: HUMW6UU796 )
2026-02-05 14:51:25 : INFO  : axurerp10 : Installing Axure RP 10 version 10.0.0.3929 on versionKey CFBundleVersion.
2026-02-05 14:51:25 : INFO  : axurerp10 : App has LSMinimumSystemVersion: 10.13.0
2026-02-05 14:51:25 : DEBUG : axurerp10 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-05 14:51:25 : INFO  : axurerp10 : Finishing...
2026-02-05 14:51:28 : INFO  : axurerp10 : name: Axure RP 10, appName: Axure RP 10.app
2026-02-05 14:51:28 : WARN  : axurerp10 : No previous app found
2026-02-05 14:51:28 : WARN  : axurerp10 : could not find Axure RP 10.app
2026-02-05 14:51:28 : REQ   : axurerp10 : Installed Axure RP 10, version 10.0.0.3929
2026-02-05 14:51:28 : INFO  : axurerp10 : notifying
2026-02-05 14:51:28 : DEBUG : axurerp10 : Unmounting /Volumes/Axure RP 10
2026-02-05 14:51:39 : DEBUG : axurerp10 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-02-05 14:51:39 : DEBUG : axurerp10 : DEBUG mode 1, not reopening anything
2026-02-05 14:51:39 : REQ   : axurerp10 : All done!
2026-02-05 14:51:39 : REQ   : axurerp10 : ################## End Installomator, exit code 0
```