### PR TITLE
Added Google Web Designer

### DIFF
--- a/fragments/labels/googlewebdesigner.sh
+++ b/fragments/labels/googlewebdesigner.sh
@@ -1,0 +1,7 @@
+googlewebdesigner)
+    name="Google Web Designer"
+    type="dmg"
+    downloadURL="https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg"
+    appNewVersion=$(curl -fs https://support.google.com/webdesigner/topic/6350071\?hl\=en | tr '<' '\n' |  grep -o "Shell Build.*$" | grep -o "[0-9].*[0-9]" | sort --version-sort | tail -1)
+    expectedTeamID="EQHXZ8M8AV"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

appNewVersion is currently not up to date, due to online Release Notes being behind. I haven't manage to find another way to read the latest version.
Good to know is that the installed app has the "Shell Build" as its version number, not the actual embedded version.


**Installomator log** 
With out previous app:
```➜  Installomator git:(add_googlewebdesigner) sudo ./assemble.sh googlewebdesigner NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 11:25:07 : INFO  : googlewebdesigner : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-02-10 11:25:07 : INFO  : googlewebdesigner : setting variable from argument NOTIFY=success
2026-02-10 11:25:07 : INFO  : googlewebdesigner : setting variable from argument NOTIFY_DIALOG=1
2026-02-10 11:25:07 : INFO  : googlewebdesigner : setting variable from argument SYSTEMOWNER=1
2026-02-10 11:25:07 : INFO  : googlewebdesigner : setting variable from argument DEBUG=0
2026-02-10 11:25:07 : INFO  : googlewebdesigner : Total items in argumentsArray: 5
2026-02-10 11:25:07 : INFO  : googlewebdesigner : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 11:25:07 : REQ   : googlewebdesigner : ################## Start Installomator v. 10.9beta, date 2026-02-10
2026-02-10 11:25:07 : INFO  : googlewebdesigner : ################## Version: 10.9beta
2026-02-10 11:25:07 : INFO  : googlewebdesigner : ################## Date: 2026-02-10
2026-02-10 11:25:07 : INFO  : googlewebdesigner : ################## googlewebdesigner
2026-02-10 11:25:08 : INFO  : googlewebdesigner : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 11:25:08 : INFO  : googlewebdesigner : BLOCKING_PROCESS_ACTION=tell_user
2026-02-10 11:25:08 : INFO  : googlewebdesigner : NOTIFY=success
2026-02-10 11:25:08 : INFO  : googlewebdesigner : LOGGING=INFO
2026-02-10 11:25:08 : INFO  : googlewebdesigner : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-10 11:25:08 : INFO  : googlewebdesigner : Label type: dmg
2026-02-10 11:25:08 : INFO  : googlewebdesigner : archiveName: Google Web Designer.dmg
2026-02-10 11:25:08 : INFO  : googlewebdesigner : no blocking processes defined, using Google Web Designer as default
2026-02-10 11:25:08 : INFO  : googlewebdesigner : name: Google Web Designer, appName: Google Web Designer.app
2026-02-10 11:25:09 : WARN  : googlewebdesigner : No previous app found
2026-02-10 11:25:09 : WARN  : googlewebdesigner : could not find Google Web Designer.app
2026-02-10 11:25:09 : INFO  : googlewebdesigner : appversion: 
2026-02-10 11:25:09 : INFO  : googlewebdesigner : Latest version of Google Web Designer is 14.0.1.0
2026-02-10 11:25:09 : REQ   : googlewebdesigner : Downloading https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg to Google Web Designer.dmg
2026-02-10 11:25:13 : INFO  : googlewebdesigner : Downloaded Google Web Designer.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is d1f011b70df5084406ad3cb36b8a06ad45dc1c9b – Size is 131276 kB
2026-02-10 11:25:13 : REQ   : googlewebdesigner : no more blocking processes, continue with update
2026-02-10 11:25:13 : REQ   : googlewebdesigner : Installing Google Web Designer
2026-02-10 11:25:13 : INFO  : googlewebdesigner : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.oKWLlV6WTk/Google Web Designer.dmg
2026-02-10 11:25:20 : INFO  : googlewebdesigner : Mounted: /Volumes/Google Web Designer
2026-02-10 11:25:20 : INFO  : googlewebdesigner : Verifying: /Volumes/Google Web Designer/Google Web Designer.app
2026-02-10 11:25:28 : INFO  : googlewebdesigner : Team ID matching: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2026-02-10 11:25:29 : INFO  : googlewebdesigner : Installing Google Web Designer version 14.2.4.0 on versionKey CFBundleShortVersionString.
2026-02-10 11:25:29 : INFO  : googlewebdesigner : App has LSMinimumSystemVersion: 10.15
2026-02-10 11:25:29 : INFO  : googlewebdesigner : Copy /Volumes/Google Web Designer/Google Web Designer.app to /Applications
2026-02-10 11:25:33 : WARN  : googlewebdesigner : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2026-02-10 11:25:33 : INFO  : googlewebdesigner : Finishing...
2026-02-10 11:25:36 : INFO  : googlewebdesigner : App(s) found: /Applications/Google Web Designer.app
2026-02-10 11:25:36 : INFO  : googlewebdesigner : found app at /Applications/Google Web Designer.app, version 14.2.4.0, on versionKey CFBundleShortVersionString
2026-02-10 11:25:37 : REQ   : googlewebdesigner : Installed Google Web Designer, version 14.2.4.0
2026-02-10 11:25:37 : INFO  : googlewebdesigner : notifying
2026-02-10 11:25:37 : INFO  : googlewebdesigner : Installomator did not close any apps, so no need to reopen any apps.
2026-02-10 11:25:37 : REQ   : googlewebdesigner : All done!
2026-02-10 11:25:37 : REQ   : googlewebdesigner : ################## End Installomator, exit code 0 
```

With latest version installed. *Note that it's redownloaded due to bad info on Google's release notes*
```
➜  Installomator git:(deploy) sudo ./assemble.sh googlewebdesigner NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 12:59:03 : INFO  : googlewebdesigner : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-02-10 12:59:03 : INFO  : googlewebdesigner : setting variable from argument NOTIFY=success
2026-02-10 12:59:03 : INFO  : googlewebdesigner : setting variable from argument NOTIFY_DIALOG=1
2026-02-10 12:59:03 : INFO  : googlewebdesigner : setting variable from argument SYSTEMOWNER=1
2026-02-10 12:59:03 : INFO  : googlewebdesigner : setting variable from argument DEBUG=0
2026-02-10 12:59:04 : INFO  : googlewebdesigner : Total items in argumentsArray: 5
2026-02-10 12:59:04 : INFO  : googlewebdesigner : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 12:59:04 : REQ   : googlewebdesigner : ################## Start Installomator v. 10.9beta, date 2026-02-10
2026-02-10 12:59:04 : INFO  : googlewebdesigner : ################## Version: 10.9beta
2026-02-10 12:59:04 : INFO  : googlewebdesigner : ################## Date: 2026-02-10
2026-02-10 12:59:04 : INFO  : googlewebdesigner : ################## googlewebdesigner
2026-02-10 12:59:04 : INFO  : googlewebdesigner : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 SYSTEMOWNER=1 DEBUG=0
2026-02-10 12:59:04 : INFO  : googlewebdesigner : BLOCKING_PROCESS_ACTION=tell_user
2026-02-10 12:59:04 : INFO  : googlewebdesigner : NOTIFY=success
2026-02-10 12:59:05 : INFO  : googlewebdesigner : LOGGING=INFO
2026-02-10 12:59:05 : INFO  : googlewebdesigner : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-10 12:59:05 : INFO  : googlewebdesigner : Label type: dmg
2026-02-10 12:59:05 : INFO  : googlewebdesigner : archiveName: Google Web Designer.dmg
2026-02-10 12:59:05 : INFO  : googlewebdesigner : no blocking processes defined, using Google Web Designer as default
2026-02-10 12:59:05 : INFO  : googlewebdesigner : App(s) found: /Applications/Google Web Designer.app
2026-02-10 12:59:05 : INFO  : googlewebdesigner : found app at /Applications/Google Web Designer.app, version 14.2.4.0, on versionKey CFBundleShortVersionString
2026-02-10 12:59:05 : INFO  : googlewebdesigner : appversion: 14.2.4.0
2026-02-10 12:59:05 : INFO  : googlewebdesigner : Latest version of Google Web Designer is 14.0.1.0
2026-02-10 12:59:05 : REQ   : googlewebdesigner : Downloading https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg to Google Web Designer.dmg
2026-02-10 12:59:09 : INFO  : googlewebdesigner : Downloaded Google Web Designer.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is d1f011b70df5084406ad3cb36b8a06ad45dc1c9b – Size is 131756 kB
2026-02-10 12:59:09 : REQ   : googlewebdesigner : no more blocking processes, continue with update
2026-02-10 12:59:09 : REQ   : googlewebdesigner : Installing Google Web Designer
2026-02-10 12:59:09 : INFO  : googlewebdesigner : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1L2sGQmtsT/Google Web Designer.dmg
2026-02-10 12:59:16 : INFO  : googlewebdesigner : Mounted: /Volumes/Google Web Designer
2026-02-10 12:59:16 : INFO  : googlewebdesigner : Verifying: /Volumes/Google Web Designer/Google Web Designer.app
2026-02-10 12:59:25 : INFO  : googlewebdesigner : Team ID matching: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2026-02-10 12:59:25 : INFO  : googlewebdesigner : Downloaded version of Google Web Designer is 14.2.4.0 on versionKey CFBundleShortVersionString, same as installed.
2026-02-10 12:59:25 : INFO  : googlewebdesigner : Installomator did not close any apps, so no need to reopen any apps.
2026-02-10 12:59:25 : REQ   : googlewebdesigner : ################## End Installomator, exit code 0 
```