### PR TITLE
New wisprflow label

### DIFF
--- a/fragments/labels/wisprflow.sh
+++ b/fragments/labels/wisprflow.sh
@@ -1,0 +1,12 @@
+wisprflow)
+    name="Wispr Flow"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://dl.wisprflow.ai/mac-apple/latest"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://dl.wisprflow.ai/mac-intel/latest"
+    fi
+    appNewVersion="$(curl -sIL "$downloadURL" | grep -i "^location:" | sed 's/.*Flow-v\([0-9.]*\).dmg.*/\1/')"
+    expectedTeamID="C9VQZ78H85"
+    blockingProcesses=( "Wispr Flow" )
+    ;;

--- a/fragments/labels/wisprflow.sh
+++ b/fragments/labels/wisprflow.sh
@@ -8,5 +8,4 @@ wisprflow)
     fi
     appNewVersion="$(curl -sIL "$downloadURL" | grep -i "^location:" | sed 's/.*Flow-v\([0-9.]*\).dmg.*/\1/')"
     expectedTeamID="C9VQZ78H85"
-    blockingProcesses=( "Wispr Flow" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./assemble.sh wisprflow
2026-02-10 11:03:02 : INFO  : wisprflow : Total items in argumentsArray: 0
2026-02-10 11:03:02 : INFO  : wisprflow : argumentsArray: 
2026-02-10 11:03:02 : REQ   : wisprflow : ################## Start Installomator v. 10.9beta, date 2026-02-10
2026-02-10 11:03:02 : INFO  : wisprflow : ################## Version: 10.9beta
2026-02-10 11:03:02 : INFO  : wisprflow : ################## Date: 2026-02-10
2026-02-10 11:03:02 : INFO  : wisprflow : ################## wisprflow
2026-02-10 11:03:02 : DEBUG : wisprflow : DEBUG mode 1 enabled.
2026-02-10 11:03:03 : INFO  : wisprflow : Reading arguments again: 
2026-02-10 11:03:03 : DEBUG : wisprflow : name=Wispr Flow
2026-02-10 11:03:03 : DEBUG : wisprflow : appName=
2026-02-10 11:03:03 : DEBUG : wisprflow : type=dmg
2026-02-10 11:03:03 : DEBUG : wisprflow : archiveName=
2026-02-10 11:03:03 : DEBUG : wisprflow : downloadURL=https://dl.wisprflow.ai/mac-apple/latest
2026-02-10 11:03:03 : DEBUG : wisprflow : curlOptions=
2026-02-10 11:03:03 : DEBUG : wisprflow : appNewVersion=1.4.268
2026-02-10 11:03:03 : DEBUG : wisprflow : appCustomVersion function: Not defined
2026-02-10 11:03:03 : DEBUG : wisprflow : versionKey=CFBundleShortVersionString
2026-02-10 11:03:03 : DEBUG : wisprflow : packageID=
2026-02-10 11:03:03 : DEBUG : wisprflow : pkgName=
2026-02-10 11:03:03 : DEBUG : wisprflow : choiceChangesXML=
2026-02-10 11:03:03 : DEBUG : wisprflow : expectedTeamID=C9VQZ78H85
2026-02-10 11:03:03 : DEBUG : wisprflow : blockingProcesses=Wispr Flow
2026-02-10 11:03:03 : DEBUG : wisprflow : installerTool=
2026-02-10 11:03:03 : DEBUG : wisprflow : CLIInstaller=
2026-02-10 11:03:03 : DEBUG : wisprflow : CLIArguments=
2026-02-10 11:03:03 : DEBUG : wisprflow : updateTool=
2026-02-10 11:03:03 : DEBUG : wisprflow : updateToolArguments=
2026-02-10 11:03:03 : DEBUG : wisprflow : updateToolRunAsCurrentUser=
2026-02-10 11:03:03 : INFO  : wisprflow : BLOCKING_PROCESS_ACTION=tell_user
2026-02-10 11:03:03 : INFO  : wisprflow : NOTIFY=success
2026-02-10 11:03:03 : INFO  : wisprflow : LOGGING=DEBUG
2026-02-10 11:03:03 : INFO  : wisprflow : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-10 11:03:03 : INFO  : wisprflow : Label type: dmg
2026-02-10 11:03:03 : INFO  : wisprflow : archiveName: Wispr Flow.dmg
2026-02-10 11:03:03 : DEBUG : wisprflow : Changing directory to /Users/jaredschwager/Repositories/jschwager/Installomator/build
2026-02-10 11:03:03 : INFO  : wisprflow : name: Wispr Flow, appName: Wispr Flow.app
2026-02-10 11:03:03 : WARN  : wisprflow : No previous app found
2026-02-10 11:03:03 : WARN  : wisprflow : could not find Wispr Flow.app
2026-02-10 11:03:03 : INFO  : wisprflow : appversion: 
2026-02-10 11:03:03 : INFO  : wisprflow : Latest version of Wispr Flow is 1.4.268
2026-02-10 11:03:03 : REQ   : wisprflow : Downloading https://dl.wisprflow.ai/mac-apple/latest to Wispr Flow.dmg
2026-02-10 11:03:03 : DEBUG : wisprflow : No Dialog connection, just download
2026-02-10 11:03:07 : INFO  : wisprflow : Downloaded Wispr Flow.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 0507ca471898be343b29f462366e08a1127298e6 – Size is 379564 kB
2026-02-10 11:03:07 : DEBUG : wisprflow : DEBUG mode 1, not checking for blocking processes
2026-02-10 11:03:07 : REQ   : wisprflow : Installing Wispr Flow
2026-02-10 11:03:07 : INFO  : wisprflow : Mounting /Users/jaredschwager/Repositories/jschwager/Installomator/build/Wispr Flow.dmg
2026-02-10 11:03:13 : DEBUG : wisprflow : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8DCAB7B9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $BA879626
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $527E13E6
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $D1EB9C81
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $527E13E6
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CA2D4360
verified   CRC32 $171EECC0
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Flow-v1.4.268

2026-02-10 11:03:13 : INFO  : wisprflow : Mounted: /Volumes/Flow-v1.4.268
2026-02-10 11:03:13 : INFO  : wisprflow : Verifying: /Volumes/Flow-v1.4.268/Wispr Flow.app
2026-02-10 11:03:13 : DEBUG : wisprflow : App size: 568M	/Volumes/Flow-v1.4.268/Wispr Flow.app
2026-02-10 11:03:15 : DEBUG : wisprflow : Debugging enabled, App Verification output was:
/Volumes/Flow-v1.4.268/Wispr Flow.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Wispr AI INC (C9VQZ78H85)

2026-02-10 11:03:15 : INFO  : wisprflow : Team ID matching: C9VQZ78H85 (expected: C9VQZ78H85 )
2026-02-10 11:03:15 : INFO  : wisprflow : Installing Wispr Flow version 1.4.268 on versionKey CFBundleShortVersionString.
2026-02-10 11:03:15 : INFO  : wisprflow : App has LSMinimumSystemVersion: 12.0
2026-02-10 11:03:15 : DEBUG : wisprflow : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-10 11:03:15 : INFO  : wisprflow : Finishing...
2026-02-10 11:03:18 : INFO  : wisprflow : name: Wispr Flow, appName: Wispr Flow.app
2026-02-10 11:03:18 : WARN  : wisprflow : No previous app found
2026-02-10 11:03:18 : WARN  : wisprflow : could not find Wispr Flow.app
2026-02-10 11:03:18 : REQ   : wisprflow : Installed Wispr Flow, version 1.4.268
2026-02-10 11:03:18 : INFO  : wisprflow : notifying
2026-02-10 11:03:18 : DEBUG : wisprflow : Unmounting /Volumes/Flow-v1.4.268
2026-02-10 11:03:18 : DEBUG : wisprflow : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-02-10 11:03:18 : DEBUG : wisprflow : DEBUG mode 1, not reopening anything
2026-02-10 11:03:19 : REQ   : wisprflow : All done!
2026-02-10 11:03:19 : REQ   : wisprflow : ################## End Installomator, exit code 0
```