### PR TITLE
apachenetbeans-label-update

### DIFF
--- a/fragments/labels/apachenetbeans.sh
+++ b/fragments/labels/apachenetbeans.sh
@@ -7,6 +7,6 @@ apachenetbeans)
         archiveName="Apache-NetBeans-[0-9]*-x86_64.pkg"
     fi
     downloadURL="$(downloadURLFromGit Friends-of-Apache-NetBeans netbeans-installers)"
-    appNewVersion="$(versionFromGit Friends-of-Apache-NetBeans netbeans-installers)"
-    expectedTeamID="3KH8VFSK7Q"
+    appNewVersion=$(curl -sLI "https://github.com/Friends-of-Apache-NetBeans/netbeans-installers/releases/latest" | grep -i "^location" | tr "/" "\n" | tail -1 | sed -E 's/v([0-9]+).*/\1/')
+    expectedTeamID="44YNN9Q525"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh apachenetbeans DEBUG=1
2026-02-10 12:45:59 : INFO  : apachenetbeans : setting variable from argument DEBUG=1
2026-02-10 12:45:59 : INFO  : apachenetbeans : Total items in argumentsArray: 1
2026-02-10 12:45:59 : INFO  : apachenetbeans : argumentsArray: DEBUG=1
2026-02-10 12:45:59 : REQ   : apachenetbeans : ################## Start Installomator v. 10.9beta, date 2026-02-10
2026-02-10 12:45:59 : INFO  : apachenetbeans : ################## Version: 10.9beta
2026-02-10 12:46:00 : INFO  : apachenetbeans : ################## Date: 2026-02-10
2026-02-10 12:46:00 : INFO  : apachenetbeans : ################## apachenetbeans
2026-02-10 12:46:00 : DEBUG : apachenetbeans : DEBUG mode 1 enabled.
2026-02-10 12:46:01 : INFO  : apachenetbeans : Reading arguments again: DEBUG=1
2026-02-10 12:46:01 : DEBUG : apachenetbeans : argument: DEBUG=1
2026-02-10 12:46:01 : DEBUG : apachenetbeans : name=Apache NetBeans
2026-02-10 12:46:01 : DEBUG : apachenetbeans : appName=
2026-02-10 12:46:01 : DEBUG : apachenetbeans : type=pkg
2026-02-10 12:46:01 : DEBUG : apachenetbeans : archiveName=Apache-NetBeans-[0-9]*-arm64.pkg
2026-02-10 12:46:01 : DEBUG : apachenetbeans : downloadURL=https://github.com/Friends-of-Apache-NetBeans/netbeans-installers/releases/download/v28-build2/Apache-NetBeans-28-arm64.pkg
2026-02-10 12:46:01 : DEBUG : apachenetbeans : curlOptions=
2026-02-10 12:46:01 : DEBUG : apachenetbeans : appNewVersion=28
2026-02-10 12:46:01 : DEBUG : apachenetbeans : appCustomVersion function: Not defined
2026-02-10 12:46:01 : DEBUG : apachenetbeans : versionKey=CFBundleShortVersionString
2026-02-10 12:46:01 : DEBUG : apachenetbeans : packageID=
2026-02-10 12:46:01 : DEBUG : apachenetbeans : pkgName=
2026-02-10 12:46:01 : DEBUG : apachenetbeans : choiceChangesXML=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : expectedTeamID=44YNN9Q525
2026-02-10 12:46:02 : DEBUG : apachenetbeans : blockingProcesses=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : installerTool=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : CLIInstaller=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : CLIArguments=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : updateTool=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : updateToolArguments=
2026-02-10 12:46:02 : DEBUG : apachenetbeans : updateToolRunAsCurrentUser=
2026-02-10 12:46:02 : INFO  : apachenetbeans : BLOCKING_PROCESS_ACTION=tell_user
2026-02-10 12:46:02 : INFO  : apachenetbeans : NOTIFY=success
2026-02-10 12:46:02 : INFO  : apachenetbeans : LOGGING=DEBUG
2026-02-10 12:46:02 : INFO  : apachenetbeans : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-10 12:46:02 : INFO  : apachenetbeans : Label type: pkg
2026-02-10 12:46:02 : INFO  : apachenetbeans : archiveName: Apache-NetBeans-[0-9]*-arm64.pkg
2026-02-10 12:46:02 : INFO  : apachenetbeans : no blocking processes defined, using Apache NetBeans as default
2026-02-10 12:46:02 : DEBUG : apachenetbeans : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-02-10 12:46:02 : INFO  : apachenetbeans : name: Apache NetBeans, appName: Apache NetBeans.app
2026-02-10 12:46:02 : WARN  : apachenetbeans : No previous app found
2026-02-10 12:46:02 : WARN  : apachenetbeans : could not find Apache NetBeans.app
2026-02-10 12:46:02 : INFO  : apachenetbeans : appversion:
2026-02-10 12:46:02 : INFO  : apachenetbeans : Latest version of Apache NetBeans is 28
2026-02-10 12:46:02 : REQ   : apachenetbeans : Downloading https://github.com/Friends-of-Apache-NetBeans/netbeans-installers/releases/download/v28-build2/Apache-NetBeans-28-arm64.pkg to Apache-NetBeans-[0-9]*-arm64.pkg
2026-02-10 12:46:02 : DEBUG : apachenetbeans : No Dialog connection, just download
2026-02-10 12:46:22 : INFO  : apachenetbeans : Downloaded Apache-NetBeans-[0-9]*-arm64.pkg – Type is  xar archive compressed TOC – SHA is d02d72f60a488a387a1ef30a9c8d48747ed643ec – Size is 737724 kB
2026-02-10 12:46:22 : DEBUG : apachenetbeans : DEBUG mode 1, not checking for blocking processes
2026-02-10 12:46:23 : REQ   : apachenetbeans : Installing Apache NetBeans
2026-02-10 12:46:23 : INFO  : apachenetbeans : Verifying: Apache-NetBeans-[0-9]*-arm64.pkg
2026-02-10 12:46:23 : DEBUG : apachenetbeans : File list: -rw-r--r--  1 root  staff   706M Feb 10 12:46 Apache-NetBeans-[0-9]*-arm64.pkg
2026-02-10 12:46:23 : DEBUG : apachenetbeans : File type: Apache-NetBeans-[0-9]*-arm64.pkg: xar archive compressed TOC: 4251, SHA-1 checksum
2026-02-10 12:46:23 : DEBUG : apachenetbeans : spctlOut is Apache-NetBeans-[0-9]*-arm64.pkg: accepted
2026-02-10 12:46:23 : DEBUG : apachenetbeans : source=Notarized Developer ID
2026-02-10 12:46:23 : DEBUG : apachenetbeans : origin=Developer ID Installer: Stichting Friends of Apache NetBeans (44YNN9Q525)
2026-02-10 12:46:23 : INFO  : apachenetbeans : Team ID: 44YNN9Q525 (expected: 44YNN9Q525 )
2026-02-10 12:46:23 : DEBUG : apachenetbeans : DEBUG enabled, skipping installation
2026-02-10 12:46:23 : INFO  : apachenetbeans : Finishing...
2026-02-10 12:46:26 : INFO  : apachenetbeans : name: Apache NetBeans, appName: Apache NetBeans.app
2026-02-10 12:46:26 : WARN  : apachenetbeans : No previous app found
2026-02-10 12:46:26 : WARN  : apachenetbeans : could not find Apache NetBeans.app
2026-02-10 12:46:26 : REQ   : apachenetbeans : Installed Apache NetBeans, version 28
2026-02-10 12:46:26 : INFO  : apachenetbeans : notifying
2026-02-10 12:46:27 : DEBUG : apachenetbeans : DEBUG mode 1, not reopening anything
2026-02-10 12:46:27 : REQ   : apachenetbeans : All done!
2026-02-10 12:46:27 : REQ   : apachenetbeans : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

Updated the Apache NetBeans label to fix two issues: corrected the Team ID from 3KH8VFSK7Q to 44YNN9Q525 (matching the actual signing certificate from Stichting Friends of Apache NetBeans), and fixed version detection, which was incorrectly parsing v28-build2 as 282 instead of 28.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
