### PR TITLE
Fix label logitechoptionsplusoffline

### DIFF
--- a/fragments/labels/logitechoptionsplusoffline.sh
+++ b/fragments/labels/logitechoptionsplusoffline.sh
@@ -5,9 +5,9 @@ logitechoptionsplusoffline)
     installerTool="logioptionsplus_installer_offline.app"
     type="zip"
     downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip"
-    # Latest version of Logi Options+ requires macOS 12+
+    # Latest version of Logi Options+ requires macOS 13+
     # If older macOS is specified in the url for appNewVersion, it will never correspond to the installed version
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-12.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-13.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Update minimum macOS version to 13.0 so correct version is returned in appNewVersion var. This mirrors changes made in #2539 for the standard logitechoptionsplus label.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./assemble.sh logitechoptionsplusoffline
2026-02-11 09:47:08 : INFO  : logitechoptionsplusoffline : Total items in argumentsArray: 0
2026-02-11 09:47:08 : INFO  : logitechoptionsplusoffline : argumentsArray: 
2026-02-11 09:47:08 : REQ   : logitechoptionsplusoffline : ################## Start Installomator v. 10.9beta, date 2026-02-11
2026-02-11 09:47:08 : INFO  : logitechoptionsplusoffline : ################## Version: 10.9beta
2026-02-11 09:47:08 : INFO  : logitechoptionsplusoffline : ################## Date: 2026-02-11
2026-02-11 09:47:08 : INFO  : logitechoptionsplusoffline : ################## logitechoptionsplusoffline
2026-02-11 09:47:08 : DEBUG : logitechoptionsplusoffline : DEBUG mode 1 enabled.
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : Reading arguments again: 
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : name=Logi Options+
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : appName=logioptionsplus.app
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : type=zip
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : archiveName=logioptionsplus_installer_offline.zip
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : curlOptions=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : appNewVersion=1.99.834046
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : appCustomVersion function: Not defined
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : versionKey=CFBundleShortVersionString
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : packageID=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : pkgName=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : choiceChangesXML=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : expectedTeamID=QED4VVPZWA
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : blockingProcesses=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : installerTool=logioptionsplus_installer_offline.app
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : CLIInstaller=logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : CLIArguments=--quiet
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : updateTool=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : updateToolArguments=
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : updateToolRunAsCurrentUser=
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : BLOCKING_PROCESS_ACTION=tell_user
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : NOTIFY=success
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : LOGGING=DEBUG
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : Label type: zip
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : archiveName: logioptionsplus_installer_offline.zip
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : no blocking processes defined, using Logi Options+ as default
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : Changing directory to /Users/jaredschwager/Repositories/jschwager/Installomator/build
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : name: Logi Options+, appName: logioptionsplus.app
2026-02-11 09:47:09 : WARN  : logitechoptionsplusoffline : No previous app found
2026-02-11 09:47:09 : WARN  : logitechoptionsplusoffline : could not find logioptionsplus.app
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : appversion: 
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : Latest version of Logi Options+ is 1.99.834046
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : logioptionsplus_installer_offline.zip exists and DEBUG mode 1 enabled, skipping download
2026-02-11 09:47:09 : DEBUG : logitechoptionsplusoffline : DEBUG mode 1, not checking for blocking processes
2026-02-11 09:47:09 : REQ   : logitechoptionsplusoffline : Installing Logi Options+
2026-02-11 09:47:09 : REQ   : logitechoptionsplusoffline : installerTool used: logioptionsplus_installer_offline.app
2026-02-11 09:47:09 : INFO  : logitechoptionsplusoffline : Unzipping logioptionsplus_installer_offline.zip
2026-02-11 09:47:10 : INFO  : logitechoptionsplusoffline : Verifying: /Users/jaredschwager/Repositories/jschwager/Installomator/build/logioptionsplus_installer_offline.app
2026-02-11 09:47:10 : DEBUG : logitechoptionsplusoffline : App size: 1.1G	/Users/jaredschwager/Repositories/jschwager/Installomator/build/logioptionsplus_installer_offline.app
2026-02-11 09:47:11 : DEBUG : logitechoptionsplusoffline : Debugging enabled, App Verification output was:
/Users/jaredschwager/Repositories/jschwager/Installomator/build/logioptionsplus_installer_offline.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2026-02-11 09:47:11 : INFO  : logitechoptionsplusoffline : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-02-11 09:47:11.984 defaults[4245:74772] 
The domain/default pair of (/Users/jaredschwager/Repositories/jschwager/Installomator/build/logioptionsplus_installer_offline.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-02-11 09:47:11 : INFO  : logitechoptionsplusoffline : Installing Logi Options+ version  on versionKey CFBundleShortVersionString.
2026-02-11 09:47:12 : INFO  : logitechoptionsplusoffline : App has LSMinimumSystemVersion: 13.0
2026-02-11 09:47:12 : DEBUG : logitechoptionsplusoffline : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-02-11 09:47:12 : INFO  : logitechoptionsplusoffline : Finishing...
2026-02-11 09:47:15 : INFO  : logitechoptionsplusoffline : name: Logi Options+, appName: logioptionsplus_installer_offline.app
2026-02-11 09:47:15 : WARN  : logitechoptionsplusoffline : No previous app found
2026-02-11 09:47:15 : WARN  : logitechoptionsplusoffline : could not find logioptionsplus_installer_offline.app
2026-02-11 09:47:15 : REQ   : logitechoptionsplusoffline : Installed Logi Options+
2026-02-11 09:47:15 : INFO  : logitechoptionsplusoffline : notifying
2026-02-11 09:47:15 : DEBUG : logitechoptionsplusoffline : DEBUG mode 1, not reopening anything
2026-02-11 09:47:15 : REQ   : logitechoptionsplusoffline : All done!
2026-02-11 09:47:15 : REQ   : logitechoptionsplusoffline : ################## End Installomator, exit code 0
```