### PR TITLE
New-label-Archaeology

### DIFF
--- a/fragments/labels/archaeology.sh
+++ b/fragments/labels/archaeology.sh
@@ -1,0 +1,7 @@
+archaeology)
+    name="Archaeology"
+    type="dmg"
+    downloadURL="https://www.mothersruin.com/software/downloads/Archaeology.dmg"
+    appNewVersion=$(curl -fs https://mothersruin.com/software/Archaeology/data/ArchaeologyVersionInfo.plist | grep -A1 CFBundleShortVersionString | tail -1 | sed -E 's/.*>([0-9.]*)<.*/\1/g')
+    expectedTeamID="936EB786NH"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

sudo /Users/user/Documents/GitHub/Installomator/utils/assemble.sh archaeology 2026-02-11 16:53:31 : INFO  : archaeology : Total items in argumentsArray: 0 2026-02-11 16:53:31 : INFO  : archaeology : argumentsArray:
2026-02-11 16:53:31 : REQ   : archaeology : ################## Start Installomator v. 10.9beta, date 2026-02-11
2026-02-11 16:53:31 : INFO  : archaeology : ################## Version: 10.9beta
2026-02-11 16:53:31 : INFO  : archaeology : ################## Date: 2026-02-11
2026-02-11 16:53:31 : INFO  : archaeology : ################## archaeology
2026-02-11 16:53:31 : DEBUG : archaeology : DEBUG mode 1 enabled.
2026-02-11 16:53:33 : INFO  : archaeology : Reading arguments again:
2026-02-11 16:53:33 : DEBUG : archaeology : name=Archaeology
2026-02-11 16:53:33 : DEBUG : archaeology : appName=
2026-02-11 16:53:33 : DEBUG : archaeology : type=dmg
2026-02-11 16:53:33 : DEBUG : archaeology : archiveName=
2026-02-11 16:53:33 : DEBUG : archaeology : downloadURL=https://www.mothersruin.com/software/downloads/Archaeology.dmg
2026-02-11 16:53:33 : DEBUG : archaeology : curlOptions=
2026-02-11 16:53:33 : DEBUG : archaeology : appNewVersion=1.5
2026-02-11 16:53:33 : DEBUG : archaeology : appCustomVersion function: Not defined
2026-02-11 16:53:33 : DEBUG : archaeology : versionKey=CFBundleShortVersionString
2026-02-11 16:53:33 : DEBUG : archaeology : packageID=
2026-02-11 16:53:33 : DEBUG : archaeology : pkgName=
2026-02-11 16:53:33 : DEBUG : archaeology : choiceChangesXML=
2026-02-11 16:53:33 : DEBUG : archaeology : expectedTeamID=936EB786NH
2026-02-11 16:53:33 : DEBUG : archaeology : blockingProcesses=
2026-02-11 16:53:33 : DEBUG : archaeology : installerTool=
2026-02-11 16:53:33 : DEBUG : archaeology : CLIInstaller=
2026-02-11 16:53:33 : DEBUG : archaeology : CLIArguments=
2026-02-11 16:53:34 : DEBUG : archaeology : updateTool=
2026-02-11 16:53:34 : DEBUG : archaeology : updateToolArguments=
2026-02-11 16:53:34 : DEBUG : archaeology : updateToolRunAsCurrentUser=
2026-02-11 16:53:34 : INFO  : archaeology : BLOCKING_PROCESS_ACTION=tell_user
2026-02-11 16:53:34 : INFO  : archaeology : NOTIFY=success
2026-02-11 16:53:34 : INFO  : archaeology : LOGGING=DEBUG
2026-02-11 16:53:34 : INFO  : archaeology : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-11 16:53:34 : INFO  : archaeology : Label type: dmg
2026-02-11 16:53:34 : INFO  : archaeology : archiveName: Archaeology.dmg
2026-02-11 16:53:34 : INFO  : archaeology : no blocking processes defined, using Archaeology as default
2026-02-11 16:53:34 : DEBUG : archaeology : Changing directory to /Users/thch/Documents/GitHub/Installomator/build
2026-02-11 16:53:34 : INFO  : archaeology : name: Archaeology, appName: Archaeology.app
2026-02-11 16:53:34 : WARN  : archaeology : No previous app found
2026-02-11 16:53:34 : WARN  : archaeology : could not find Archaeology.app
2026-02-11 16:53:34 : INFO  : archaeology : appversion:
2026-02-11 16:53:34 : INFO  : archaeology : Latest version of Archaeology is 1.5
2026-02-11 16:53:34 : REQ   : archaeology : Downloading https://www.mothersruin.com/software/downloads/Archaeology.dmg to Archaeology.dmg
2026-02-11 16:53:34 : DEBUG : archaeology : No Dialog connection, just download
2026-02-11 16:53:40 : INFO  : archaeology : Downloaded Archaeology.dmg – Type is  zlib compressed data – SHA is 780f6fffc62c4510e76ca3e91e68ef4d17c2a6cd – Size is 5132 kB
2026-02-11 16:53:40 : DEBUG : archaeology : DEBUG mode 1, not checking for blocking processes
2026-02-11 16:53:40 : REQ   : archaeology : Installing Archaeology
2026-02-11 16:53:40 : INFO  : archaeology : Mounting /Users/thch/Documents/GitHub/Installomator/build/Archaeology.dmg
2026-02-11 16:53:44 : DEBUG : archaeology : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $346BEA18
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0EA2ED07
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $60E82F28
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $9426A09A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $60E82F28
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $832182D7
verified   CRC32 $9D77AFAD
/dev/disk58         	GUID_partition_scheme
/dev/disk58s1       	Apple_HFS                      	/Volumes/Archaeology 1.5

2026-02-11 16:53:44 : INFO  : archaeology : Mounted: /Volumes/Archaeology 1.5 2026-02-11 16:53:44 : INFO  : archaeology : Verifying: /Volumes/Archaeology 1.5/Archaeology.app 2026-02-11 16:53:44 : DEBUG : archaeology : App size:  12M	/Volumes/Archaeology 1.5/Archaeology.app 2026-02-11 16:53:44 : DEBUG : archaeology : Debugging enabled, App Verification output was: /Volumes/Archaeology 1.5/Archaeology.app: accepted source=Notarized Developer ID
origin=Developer ID Application: Randy Saldinger (936EB786NH)

2026-02-11 16:53:44 : INFO  : archaeology : Team ID matching: 936EB786NH (expected: 936EB786NH ) 2026-02-11 16:53:44 : INFO  : archaeology : Installing Archaeology version 1.5 on versionKey CFBundleShortVersionString. 2026-02-11 16:53:44 : INFO  : archaeology : App has LSMinimumSystemVersion: 13.0 2026-02-11 16:53:44 : DEBUG : archaeology : DEBUG mode 1 enabled, skipping remove, copy and chown steps 2026-02-11 16:53:44 : INFO  : archaeology : Finishing... 2026-02-11 16:53:47 : INFO  : archaeology : name: Archaeology, appName: Archaeology.app 2026-02-11 16:53:48 : WARN  : archaeology : No previous app found 2026-02-11 16:53:48 : WARN  : archaeology : could not find Archaeology.app
2026-02-11 16:53:48 : REQ   : archaeology : Installed Archaeology, version 1.5
2026-02-11 16:53:48 : INFO  : archaeology : notifying
2026-02-11 16:53:48 : DEBUG : archaeology : Unmounting /Volumes/Archaeology 1.5
2026-02-11 16:53:48 : DEBUG : archaeology : Debugging enabled, Unmounting output was:
"disk58" ejected.
2026-02-11 16:53:48 : DEBUG : archaeology : DEBUG mode 1, not reopening anything
2026-02-11 16:53:48 : REQ   : archaeology : All done!
2026-02-11 16:53:48 : REQ   : archaeology : ################## End Installomator, exit code 0


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
