### PR TITLE
kicad-new-label

### DIFF
--- a/fragments/labels/kicad.sh
+++ b/fragments/labels/kicad.sh
@@ -7,4 +7,5 @@ kicad)
     appName="${folderName}/KiCad.app"
     versionKey="CFBundleShortVersionString"
     expectedTeamID="9FQDHNY6U2"
+    blockingProcesses=("GerbView" "bitmap2component" "KiCad" "pl_editor" "pcb_calculator" "pcbnew" "eeschema")
     ;;

--- a/fragments/labels/kicad.sh
+++ b/fragments/labels/kicad.sh
@@ -1,0 +1,10 @@
+kicad)
+    name="KiCad"
+    type="dmg"
+    appNewVersion=$(curl -s "https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
+    downloadURL="https://github.com/KiCad/kicad-source-mirror/releases/download/${appNewVersion}/kicad-unified-universal-${appNewVersion}.dmg"
+    folderName="KiCad"
+    appName="${folderName}/KiCad.app"
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="9FQDHNY6U2"
+    ;;

--- a/fragments/labels/kicad.sh
+++ b/fragments/labels/kicad.sh
@@ -1,8 +1,9 @@
 kicad)
     name="KiCad"
     type="dmg"
-    appNewVersion=$(curl -s "https://api.github.com/repos/KiCad/kicad-source-mirror/releases/latest" | grep '"tag_name":' | cut -d'"' -f4)
-    downloadURL="https://github.com/KiCad/kicad-source-mirror/releases/download/${appNewVersion}/kicad-unified-universal-${appNewVersion}.dmg"
+    archiveName="kicad-unified-universal-"
+    downloadURL="$(downloadURLFromGit KiCad kicad-source-mirror)"
+    appNewVersion="$(versionFromGit KiCad kicad-source-mirror)"
     folderName="KiCad"
     appName="${folderName}/KiCad.app"
     versionKey="CFBundleShortVersionString"

--- a/fragments/labels/kicad.sh
+++ b/fragments/labels/kicad.sh
@@ -7,5 +7,5 @@ kicad)
     appName="${folderName}/KiCad.app"
     versionKey="CFBundleShortVersionString"
     expectedTeamID="9FQDHNY6U2"
-    blockingProcesses=("GerbView" "bitmap2component" "KiCad" "pl_editor" "pcb_calculator" "pcbnew" "eeschema")
+    blockingProcesses=("gerbview" "bitmap2component" "kicad" "pl_editor" "pcb_calculator" "pcbnew" "eeschema")
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh kicad DEBUG=0
2026-04-24 08:11:58 : INFO  : kicad : setting variable from argument DEBUG=0
2026-04-24 08:11:58 : INFO  : kicad : Total items in argumentsArray: 1
2026-04-24 08:11:58 : INFO  : kicad : argumentsArray: DEBUG=0
2026-04-24 08:11:58 : REQ   : kicad : ################## Start Installomator v. 10.9beta, date 2026-04-24
2026-04-24 08:11:58 : INFO  : kicad : ################## Version: 10.9beta
2026-04-24 08:11:59 : INFO  : kicad : ################## Date: 2026-04-24
2026-04-24 08:11:59 : INFO  : kicad : ################## kicad
2026-04-24 08:12:01 : INFO  : kicad : Reading arguments again: DEBUG=0
2026-04-24 08:12:01 : INFO  : kicad : BLOCKING_PROCESS_ACTION=tell_user
2026-04-24 08:12:01 : INFO  : kicad : NOTIFY=success
2026-04-24 08:12:01 : INFO  : kicad : LOGGING=INFO
2026-04-24 08:12:01 : INFO  : kicad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-24 08:12:01 : INFO  : kicad : Label type: dmg
2026-04-24 08:12:01 : INFO  : kicad : archiveName: kicad-unified-universal-
2026-04-24 08:12:01 : INFO  : kicad : name: KiCad, appName: KiCad/KiCad.app
2026-04-24 08:12:01 : WARN  : kicad : No previous app found
2026-04-24 08:12:01 : WARN  : kicad : could not find KiCad/KiCad.app
2026-04-24 08:12:01 : INFO  : kicad : appversion: 
2026-04-24 08:12:01 : INFO  : kicad : Latest version of KiCad is 10.0.1
2026-04-24 08:12:01 : REQ   : kicad : Downloading https://github.com/KiCad/kicad-source-mirror/releases/download/10.0.1/kicad-unified-universal-10.0.1.dmg to kicad-unified-universal-
2026-04-24 08:12:38 : INFO  : kicad : Downloaded kicad-unified-universal- – Type is  lzfse encoded, lzvn compressed – SHA is a88d9f4303b12fd576c71390a24b3ab9774ae23e – Size is 1360652 kB
2026-04-24 08:12:38 : REQ   : kicad : no more blocking processes, continue with update
2026-04-24 08:12:38 : REQ   : kicad : Installing KiCad
2026-04-24 08:12:38 : INFO  : kicad : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.Su7rtbKbJ2/kicad-unified-universal-
2026-04-24 08:12:46 : INFO  : kicad : Mounted: /Volumes/KiCad
2026-04-24 08:12:46 : INFO  : kicad : Verifying: /Volumes/KiCad/KiCad/KiCad.app
2026-04-24 08:13:06 : INFO  : kicad : Team ID matching: 9FQDHNY6U2 (expected: 9FQDHNY6U2 )
2026-04-24 08:13:06 : INFO  : kicad : Installing KiCad version 10.0.1 on versionKey CFBundleShortVersionString.
2026-04-24 08:13:06 : INFO  : kicad : Copy /Volumes/KiCad/KiCad/KiCad.app to /Applications
2026-04-24 08:13:56 : WARN  : kicad : Changing owner to u0105821
2026-04-24 08:14:04 : INFO  : kicad : Finishing...
2026-04-24 08:14:07 : INFO  : kicad : App(s) found: /Applications/KiCad/KiCad.app
2026-04-24 08:14:07 : INFO  : kicad : found app at /Applications/KiCad/KiCad.app, version 10.0.1, on versionKey CFBundleShortVersionString
2026-04-24 08:14:07 : REQ   : kicad : Installed KiCad, version 10.0.1
2026-04-24 08:14:07 : INFO  : kicad : notifying
2026-04-24 08:14:18 : INFO  : kicad : Installomator did not close any apps, so no need to reopen any apps.
2026-04-24 08:14:18 : REQ   : kicad : All done!
2026-04-24 08:14:18 : REQ   : kicad : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Creating pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

I've created a new Installomator label for KiCad, an open-source electronics design automation suite. This label pulls the latest release from the official KiCad GitHub repository and installs the universal macOS DMG package. The label is configured to verify the installation using KiCad's expected Team ID (9FQDHNY6U2).

KiCad is a cross-platform electronics design automation suite for schematic capture and PCB layout design. The macOS version is distributed as a universal DMG containing KiCad.app, which installs into a KiCad folder structure. This label targets the unified universal build that supports both Intel and Apple Silicon Macs.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
