### PR TITLE
Fix eclipsetemurin21 label to use Adoptium API for downloadURL instead

### DIFF
--- a/fragments/labels/eclipsetemurin21.sh
+++ b/fragments/labels/eclipsetemurin21.sh
@@ -2,13 +2,13 @@ eclipsetemurin21)
     name="Temurin 21"
     type="pkg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="OpenJDK21U-jdk_aarch64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="aarch64"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="OpenJDK21U-jdk_x64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="x64"
     fi
-    downloadURL="$(downloadURLFromGit adoptium temurin21-binaries)"
-    appNewVersion="$(downloadURLFromGit adoptium temurin21-binaries | grep -oE 'jdk-21(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/21/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=${cpu_arch}")" '[0].binary.installer.link')
+    archiveName="$(basename "$downloadURL")"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-21(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //; s/-LTS//'; fi }
     ;;
-


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
 
`downloadURLFromGit` is not reliable, as the latest Eclipse Temurin MacOS binaries are not necessarily built/available when the latest git tag is available. Generally MacOS Binaries are not available for some time initially. This causes the logic to populate the downloadURL to be wrong defaulting to downloading the root url `downloadURL=https://github.com/` . See https://github.com/Installomator/Installomator/issues/2753#issuecomment-3832791261

A robust solution is use the offical Adoptium API to lookup the latest Eclipse Temurin JDK releases for the respective architecture, operating system, etc for which a build is available. Their API is documented here https://api.adoptium.net/q/swagger-ui/#/Assets/getLatestAssets

This is a partial fix for #2753 for which all other eclipsetemurin labels are also affected. See
* https://github.com/Installomator/Installomator/pull/2894
* https://github.com/Installomator/Installomator/pull/2895
* https://github.com/Installomator/Installomator/pull/2896


**Installomator log** 
```
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : setting variable from argument DEBUG=1
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : Total items in argumentsArray: 1
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : argumentsArray: DEBUG=1
2026-05-01 15:53:44 : REQ   : eclipsetemurin21 : ################## Start Installomator v. 10.9beta, date 2026-05-01
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : ################## Version: 10.9beta
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : ################## Date: 2026-05-01
2026-05-01 15:53:44 : INFO  : eclipsetemurin21 : ################## eclipsetemurin21
2026-05-01 15:53:44 : DEBUG : eclipsetemurin21 : DEBUG mode 1 enabled.
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : Reading arguments again: DEBUG=1
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : argument: DEBUG=1
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : name=Temurin 21
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : appName=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : type=pkg
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : archiveName=OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : downloadURL=https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : curlOptions=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : appNewVersion=21.0.11+10
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : appCustomVersion function: Defined. 
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : versionKey=CFBundleShortVersionString
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : packageID=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : pkgName=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : choiceChangesXML=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : expectedTeamID=JCDTMS22B4
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : blockingProcesses=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : installerTool=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : CLIInstaller=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : CLIArguments=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : updateTool=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : updateToolArguments=
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : updateToolRunAsCurrentUser=
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : NOTIFY=success
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : LOGGING=DEBUG
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : Label type: pkg
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : archiveName: OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : no blocking processes defined, using Temurin 21 as default
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : Custom App Version detection is used, found 21.0.11+10
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : appversion: 21.0.11+10
2026-05-01 15:53:46 : INFO  : eclipsetemurin21 : Latest version of Temurin 21 is 21.0.11+10
2026-05-01 15:53:46 : WARN  : eclipsetemurin21 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-01 15:53:46 : REQ   : eclipsetemurin21 : Downloading https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg to OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:53:46 : DEBUG : eclipsetemurin21 : No Dialog connection, just download
2026-05-01 15:54:05 : INFO  : eclipsetemurin21 : Downloaded OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg – Type is  xar archive compressed TOC – SHA is 45e74af08530dc3523a1e6ea547502b752fe5a84 – Size is 197356 kB
2026-05-01 15:54:05 : DEBUG : eclipsetemurin21 : DEBUG mode 1, not checking for blocking processes
2026-05-01 15:54:05 : REQ   : eclipsetemurin21 : Installing Temurin 21
2026-05-01 15:54:05 : INFO  : eclipsetemurin21 : Verifying: OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:54:05 : DEBUG : eclipsetemurin21 : File list: -rw-r--r--@ 1 <USER>  staff   191M May  1 15:54 OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg
2026-05-01 15:54:05 : DEBUG : eclipsetemurin21 : File type: OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg: xar archive compressed TOC: 5531, SHA-1 checksum
2026-05-01 15:54:06 : DEBUG : eclipsetemurin21 : spctlOut is OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.pkg: accepted
2026-05-01 15:54:06 : DEBUG : eclipsetemurin21 : source=Notarized Developer ID
2026-05-01 15:54:06 : DEBUG : eclipsetemurin21 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-05-01 15:54:06 : INFO  : eclipsetemurin21 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-05-01 15:54:06 : DEBUG : eclipsetemurin21 : DEBUG enabled, skipping installation
2026-05-01 15:54:06 : INFO  : eclipsetemurin21 : Finishing...
2026-05-01 15:54:09 : INFO  : eclipsetemurin21 : Custom App Version detection is used, found 21.0.11+10
2026-05-01 15:54:09 : REQ   : eclipsetemurin21 : Installed Temurin 21, version 21.0.11+10
2026-05-01 15:54:09 : INFO  : eclipsetemurin21 : notifying
2026-05-01 15:54:09 : DEBUG : eclipsetemurin21 : DEBUG mode 1, not reopening anything
2026-05-01 15:54:09 : REQ   : eclipsetemurin21 : All done!
2026-05-01 15:54:09 : REQ   : eclipsetemurin21 : ################## End Installomator, exit code 0 
```
