### PR TITLE
New-Label-Mixxx

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -349,7 +349,7 @@ if [[ $(/usr/bin/arch) == "arm64" ]]; then
     fi
 fi
 VERSION="10.9beta"
-VERSIONDATE="2025-12-23"
+VERSIONDATE="2026-02-16"
 
 # MARK: Functions
 
@@ -7684,6 +7684,19 @@ mist)
     appNewVersion=$(versionFromGit "ninxsoft" "mist")
     expectedTeamID="7K3HVCLV7Z"
     blockingProcesses=( NONE )
+    ;;
+mixxx)
+    name="Mixxx"
+    type="dmg"
+    packageID="org.mixxx.mixxx"
+    appNewVersion=$(versionFromGit mixxxdj mixxx)
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosarm.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosintel.dmg"
+    fi
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="JBLRSP95FC"
     ;;
 mkuser)
     name="mkuser"

--- a/Labels.txt
+++ b/Labels.txt
@@ -634,6 +634,7 @@ minisim
 miro
 mist
 mist-cli
+mixxx
 mkuser
 mmhmm
 mmhmm-desktop

--- a/fragments/labels/mixxx.sh
+++ b/fragments/labels/mixxx.sh
@@ -1,0 +1,13 @@
+mixxx)
+    name="Mixxx"
+    type="dmg"
+    packageID="org.mixxx.mixxx"
+    appNewVersion=$(versionFromGit mixxxdj mixxx)
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosarm.dmg"
+    elif [[ $(arch) == i386 ]]; then
+        downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosintel.dmg"
+    fi
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="JBLRSP95FC"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

sudo /Users/user/Documents/GitHub/Installomator/utils/assemble.sh mixxx
2026-02-16 00:23:59 : INFO  : mixxx : Total items in argumentsArray: 0
2026-02-16 00:23:59 : INFO  : mixxx : argumentsArray: 
2026-02-16 00:23:59 : REQ   : mixxx : ################## Start Installomator v. 10.9beta, date 2026-02-16
2026-02-16 00:23:59 : INFO  : mixxx : ################## Version: 10.9beta
2026-02-16 00:23:59 : INFO  : mixxx : ################## Date: 2026-02-16
2026-02-16 00:23:59 : INFO  : mixxx : ################## mixxx
2026-02-16 00:23:59 : DEBUG : mixxx : DEBUG mode 1 enabled.
2026-02-16 00:24:00 : INFO  : mixxx : Reading arguments again: 
2026-02-16 00:24:00 : DEBUG : mixxx : name=Mixxx
2026-02-16 00:24:00 : DEBUG : mixxx : appName=
2026-02-16 00:24:00 : DEBUG : mixxx : type=dmg
2026-02-16 00:24:00 : DEBUG : mixxx : archiveName=
2026-02-16 00:24:00 : DEBUG : mixxx : downloadURL=https://downloads.mixxx.org/releases/2.5.4/mixxx-2.5.4-macosarm.dmg
2026-02-16 00:24:00 : DEBUG : mixxx : curlOptions=
2026-02-16 00:24:00 : DEBUG : mixxx : appNewVersion=2.5.4
2026-02-16 00:24:00 : DEBUG : mixxx : appCustomVersion function: Not defined
2026-02-16 00:24:00 : DEBUG : mixxx : versionKey=CFBundleShortVersionString
2026-02-16 00:24:00 : DEBUG : mixxx : packageID=org.mixxx.mixxx
2026-02-16 00:24:00 : DEBUG : mixxx : pkgName=
2026-02-16 00:24:00 : DEBUG : mixxx : choiceChangesXML=
2026-02-16 00:24:00 : DEBUG : mixxx : expectedTeamID=JBLRSP95FC
2026-02-16 00:24:01 : DEBUG : mixxx : blockingProcesses=
2026-02-16 00:24:01 : DEBUG : mixxx : installerTool=
2026-02-16 00:24:01 : DEBUG : mixxx : CLIInstaller=
2026-02-16 00:24:01 : DEBUG : mixxx : CLIArguments=
2026-02-16 00:24:01 : DEBUG : mixxx : updateTool=
2026-02-16 00:24:01 : DEBUG : mixxx : updateToolArguments=
2026-02-16 00:24:01 : DEBUG : mixxx : updateToolRunAsCurrentUser=
2026-02-16 00:24:01 : INFO  : mixxx : BLOCKING_PROCESS_ACTION=tell_user
2026-02-16 00:24:01 : INFO  : mixxx : NOTIFY=success
2026-02-16 00:24:01 : INFO  : mixxx : LOGGING=DEBUG
2026-02-16 00:24:01 : INFO  : mixxx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-16 00:24:01 : INFO  : mixxx : Label type: dmg
2026-02-16 00:24:01 : INFO  : mixxx : archiveName: Mixxx.dmg
2026-02-16 00:24:01 : INFO  : mixxx : no blocking processes defined, using Mixxx as default
2026-02-16 00:24:01 : DEBUG : mixxx : Changing directory to /Users/user/Documents/GitHub/Installomator/build
2026-02-16 00:24:01 : INFO  : mixxx : No version found using packageID org.mixxx.mixxx
2026-02-16 00:24:01 : INFO  : mixxx : App(s) found: /Applications/Mixxx.app
2026-02-16 00:24:01 : INFO  : mixxx : found app at /Applications/Mixxx.app, version 2.5.4, on versionKey CFBundleShortVersionString
2026-02-16 00:24:01 : INFO  : mixxx : appversion: 2.5.4
2026-02-16 00:24:01 : INFO  : mixxx : Latest version of Mixxx is 2.5.4
2026-02-16 00:24:01 : WARN  : mixxx : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-02-16 00:24:01 : INFO  : mixxx : Mixxx.dmg exists and DEBUG mode 1 enabled, skipping download
2026-02-16 00:24:01 : DEBUG : mixxx : DEBUG mode 1, not checking for blocking processes
2026-02-16 00:24:01 : REQ   : mixxx : Installing Mixxx
2026-02-16 00:24:01 : INFO  : mixxx : Mounting /Users/user/Documents/GitHub/Installomator/build/Mixxx.dmg
2026-02-16 00:24:01 : DEBUG : mixxx : Debugging enabled, dmgmount output was:
Mixxx 2.5.4, Digital DJ'ing software.  Copyright (C) 2001-2025 Mixxx
...... 
......
......
(iii) you comply with the terms of Section 6 of the GNU Lesser
General
Public License version 2.1.
Moreover, you may apply this exception to a modified version of the
Library, provided that such modification does not involve copying
material from the Library into the modified Library's header files
unless such material is limited to (i) numerical parameters; (ii)
data structure layouts; (iii) accessors; and (iv) small macros,
templates and inline functions of five lines or less in length.
Furthermore, you are not required to apply this additional permission
to a modified version of the Library.

expected   CRC32 $1E3FDE7D
/dev/disk57         	GUID_partition_scheme
/dev/disk57s1       	Apple_HFS                      	/Volumes/mixxx-2.5.4

2026-02-16 00:24:02 : INFO  : mixxx : Mounted: /Volumes/mixxx-2.5.4
2026-02-16 00:24:02 : INFO  : mixxx : Verifying: /Volumes/mixxx-2.5.4/Mixxx.app
2026-02-16 00:24:02 : DEBUG : mixxx : App size: 174M	/Volumes/mixxx-2.5.4/Mixxx.app
2026-02-16 00:24:04 : DEBUG : mixxx : Debugging enabled, App Verification output was:
/Volumes/mixxx-2.5.4/Mixxx.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Daniel Schuermann (JBLRSP95FC)

2026-02-16 00:24:04 : INFO  : mixxx : Team ID matching: JBLRSP95FC (expected: JBLRSP95FC )
2026-02-16 00:24:04 : INFO  : mixxx : Downloaded version of Mixxx is 2.5.4 on versionKey CFBundleShortVersionString, same as installed.
2026-02-16 00:24:04 : DEBUG : mixxx : Unmounting /Volumes/mixxx-2.5.4
2026-02-16 00:24:04 : DEBUG : mixxx : Debugging enabled, Unmounting output was:
"disk57" ejected.
2026-02-16 00:24:04 : DEBUG : mixxx : DEBUG mode 1, not reopening anything
2026-02-16 00:24:04 : REG   : mixxx : No new version to install
2026-02-16 00:24:04 : REQ   : mixxx : ################## End Installomator, exit code 0 

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
