### PR TITLE
Add escrowbuddy label for Escrow Buddy (FileVault key remediation)

### DIFF
--- a/fragments/labels/escrowbuddy.sh
+++ b/fragments/labels/escrowbuddy.sh
@@ -1,9 +1,10 @@
-escrowbuddy)
+escrowbuddy|\
+escrow-buddy)
     name="Escrow Buddy"
     type="pkg"
-    archiveName="Escrow.Buddy-[0-9.]*.pkg"
     packageID="com.netflix.Escrow-Buddy"
-    appNewVersion=$(versionFromGit macadmins escrow-buddy )
-    downloadURL=$(downloadURLFromGit macadmins escrow-buddy )
+    downloadURL="$(downloadURLFromGit "macadmins" "escrow-buddy")"
+    appNewVersion="$(versionFromGit "macadmins" "escrow-buddy")"
     expectedTeamID="T4SK8ZXCXG"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
## Summary

New label **escrowbuddy** (alias **escrow-buddy**) for [Escrow Buddy](https://github.com/macadmins/escrow-buddy) — authorization plugin that remediates missing FileVault recovery keys and escrows them to MDM (e.g. Intune).

## Label details

| Variable | Value |
|----------|--------|
| **name** | Escrow Buddy |
| **type** | pkg |
| **downloadURL** | `downloadURLFromGit "macadmins" "escrow-buddy"` |
| **appNewVersion** | `versionFromGit "macadmins" "escrow-buddy"` |
| **packageID** | com.netflix.Escrow-Buddy |
| **expectedTeamID** | T4SK8ZXCXG (Mac Admins Open Source) |
| **blockingProcesses** | NONE |

- **Distribution:** Single PKG per release from GitHub (macadmins/escrow-buddy). Quoted org/repo in GitHub helpers (repo name has hyphen).
- **Security:** PKG signed and notarized by vendor ([FAQ](https://github.com/macadmins/escrow-buddy/wiki/FAQ)). expectedTeamID verified with `spctl -a -vv -t install` on downloaded PKG. Installomator enforces Team ID (exit 5 on mismatch).

## Why this label

- No GUI; system/auth plugin. Fits “Installomator + MDM script per label” workflows.
- Common use: Intune (and other MDMs) for FileVault key escrow remediation.

## Testing

| Step | Result |
|------|--------|
| Build | `./utils/assemble.sh escrowbuddy` — exit 0 |
| Install | `sudo ./utils/assemble.sh escrowbuddy DEBUG=0` — exit 0 (install or up-to-date) |
| Idempotency | Second run: up-to-date, no re-download, exit 0 |

**Tested on:** macOS 14.x (Sonoma), Intel Mac. Apple Silicon: same PKG (single asset); label is arch-agnostic; not tested on ARM.

Terminal output (build + install + idempotency) is in the comment below.
