### PR TITLE
dymoconnectdesktop : url has changed, and pkg has arm and x86 version.

### DIFF
--- a/fragments/labels/dymoconnectdesktop.sh
+++ b/fragments/labels/dymoconnectdesktop.sh
@@ -2,7 +2,11 @@ dymoconnectdesktop)
     name="DYMO Connect"
     type="pkg"
     appNewVersion=$(curl -s https://formulae.brew.sh/cask/dymo-connect | grep -o 'Current version:.*[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
-    archiveName="DCDMac${appNewVersion}.pkg"
-    downloadURL="https://download.dymo.com/dymo/Software/Mac/DCDMac${appNewVersion}.pkg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="DCDMac${appNewVersion}-Arm64.pkg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="DCDMac${appNewVersion}-X64.pkg"
+    fi
+    downloadURL="https://dymoreleasecontent.blob.core.windows.net/dymo-release/DCDMAC/${archiveName}"
     expectedTeamID="N3S6676K3E"
     ;;


### PR DESCRIPTION
output of running label:

~ % sudo /Users/Shared/Installomator.sh dymoconnectdesktop DEBUG=1 2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : setting variable from argument DEBUG=1 2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : Total items in argumentsArray: 1 2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : argumentsArray: DEBUG=1
2026-02-19 16:14:52 : REQ   : dymoconnectdesktop : ################## Start Installomator v. 10.8.5a, date 2026-02-19
2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : ################## Version: 10.8.5a
2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : ################## Date: 2026-02-19
2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : ################## dymoconnectdesktop
2026-02-19 16:14:52 : DEBUG : dymoconnectdesktop : DEBUG mode 1 enabled.
2026-02-19 16:14:52 : INFO  : dymoconnectdesktop : Reading arguments again: DEBUG=1
2026-02-19 16:14:52 : DEBUG : dymoconnectdesktop : argument: DEBUG=1
2026-02-19 16:14:52 : DEBUG : dymoconnectdesktop : name=DYMO Connect
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : appName=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : type=pkg
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : archiveName=DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : downloadURL=https://dymoreleasecontent.blob.core.windows.net/dymo-release/DCDMAC/DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : curlOptions=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : appNewVersion=1.6.0.41
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : appCustomVersion function: Not defined
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : versionKey=CFBundleShortVersionString
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : packageID=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : pkgName=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : choiceChangesXML=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : expectedTeamID=N3S6676K3E
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : blockingProcesses=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : installerTool=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : CLIInstaller=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : CLIArguments=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : updateTool=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : updateToolArguments=
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : updateToolRunAsCurrentUser=
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : BLOCKING_PROCESS_ACTION=prompt_user
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : NOTIFY=success
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : LOGGING=DEBUG
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : LOGO=/Applications/Workspace ONE Intelligent Hub.app/Contents/Resources/AppIcon.icns
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : Label type: pkg
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : archiveName: DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : no blocking processes defined, using DYMO Connect as default
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : Changing directory to /Users/Shared/AutoCacheDBO
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : name: DYMO Connect, appName: DYMO Connect.app
2026-02-19 16:14:53 : WARN  : dymoconnectdesktop : No previous app found
2026-02-19 16:14:53 : WARN  : dymoconnectdesktop : could not find DYMO Connect.app
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : appversion:
2026-02-19 16:14:53 : INFO  : dymoconnectdesktop : Latest version of DYMO Connect is 1.6.0.41
2026-02-19 16:14:53 : REQ   : dymoconnectdesktop : Downloading https://dymoreleasecontent.blob.core.windows.net/dymo-release/DCDMAC/DCDMac1.6.0.41-Arm64.pkg to DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:14:53 : DEBUG : dymoconnectdesktop : No Dialog connection, just download
2026-02-19 16:15:51 : INFO  : dymoconnectdesktop : Downloaded DCDMac1.6.0.41-Arm64.pkg – Type is  xar archive compressed TOC – SHA is b430cf77602b50523bf6f1faa5bc01a9931f0e0a – Size is 262428 kB
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : DEBUG mode 1, not checking for blocking processes
2026-02-19 16:15:51 : REQ   : dymoconnectdesktop : Installing DYMO Connect
2026-02-19 16:15:51 : INFO  : dymoconnectdesktop : Verifying: DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : File list: -rw-r--r--  1 root  wheel   253M 19 feb. 16:15 DCDMac1.6.0.41-Arm64.pkg
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : File type: DCDMac1.6.0.41-Arm64.pkg: xar archive compressed TOC: 7515, SHA-1 checksum
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : spctlOut is DCDMac1.6.0.41-Arm64.pkg: accepted
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : source=Notarized Developer ID
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : origin=Developer ID Installer: Sanford, L.P. (N3S6676K3E)
2026-02-19 16:15:51 : INFO  : dymoconnectdesktop : Team ID: N3S6676K3E (expected: N3S6676K3E )
2026-02-19 16:15:51 : DEBUG : dymoconnectdesktop : DEBUG enabled, skipping installation
2026-02-19 16:15:51 : INFO  : dymoconnectdesktop : Finishing...
2026-02-19 16:15:54 : INFO  : dymoconnectdesktop : name: DYMO Connect, appName: DYMO Connect.app
2026-02-19 16:15:54 : WARN  : dymoconnectdesktop : No previous app found
2026-02-19 16:15:54 : WARN  : dymoconnectdesktop : could not find DYMO Connect.app
2026-02-19 16:15:54 : REQ   : dymoconnectdesktop : Installed DYMO Connect, version 1.6.0.41
2026-02-19 16:15:54 : INFO  : dymoconnectdesktop : notifying
2026-02-19 16:15:54 : DEBUG : dymoconnectdesktop : DEBUG mode 1, not reopening anything
2026-02-19 16:15:54 : REQ   : dymoconnectdesktop : All done!
2026-02-19 16:15:54 : REQ   : dymoconnectdesktop : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
only label dymoconnectdesktop

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
no

**Additional context** Add any other context about the label or fix here.


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Old label did not download correctly (all urls failed), I assume Dymo has moved download site.