### PR TITLE
Label 1Password8 - Added appCustomVersion

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -6,5 +6,6 @@
     appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]" | cut -d - -f 1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    appCustomVersion(){ defaults read "/Applications/1Password.app/Contents/Info.plist" CFBundleShortVersionString }
     #forcefulQuit=YES
     ;;

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -7,5 +7,4 @@
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     appCustomVersion(){ defaults read "/Applications/1Password.app/Contents/Info.plist" CFBundleShortVersionString }
-    #forcefulQuit=YES
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes (VS Code plugin)

**Additional context** Add any other context about the label or fix here.
The default method of detecting the existing installation version is not functioning correctly for the 1password8 label.  See logs here where the returned version is "0".  This is causing the Installomator script to think there is ALWAYS an update.

```
2026-02-26 11:56:25 : INFO  : 1password8 : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user
2026-02-26 11:56:25 : INFO  : 1password8 : setting variable from argument NOTIFY=silent
2026-02-26 11:56:25 : INFO  : 1password8 : Total items in argumentsArray: 2
2026-02-26 11:56:25 : INFO  : 1password8 : argumentsArray: BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent
2026-02-26 11:56:25 : REQ   : 1password8 : ################## Start Installomator v. 10.9beta, date 2025-12-23
2026-02-26 11:56:25 : INFO  : 1password8 : ################## Version: 10.9beta
2026-02-26 11:56:25 : INFO  : 1password8 : ################## Date: 2025-12-23
2026-02-26 11:56:25 : INFO  : 1password8 : ################## 1password8
2026-02-26 11:56:25 : INFO  : 1password8 : Reading arguments again: BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent
2026-02-26 11:56:26 : INFO  : 1password8 : BLOCKING_PROCESS_ACTION=prompt_user
2026-02-26 11:56:26 : INFO  : 1password8 : NOTIFY=silent
2026-02-26 11:56:26 : INFO  : 1password8 : LOGGING=INFO
2026-02-26 11:56:26 : INFO  : 1password8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-26 11:56:26 : INFO  : 1password8 : Label type: pkg
2026-02-26 11:56:26 : INFO  : 1password8 : archiveName: 1Password.pkg
2026-02-26 11:56:26 : INFO  : 1password8 : found packageID com.1password.1password installed, version 0
2026-02-26 11:56:26 : INFO  : 1password8 : appversion: 0
2026-02-26 11:56:26 : INFO  : 1password8 : Latest version of 1Password is 8.12.6
2026-02-26 11:56:26 : REQ   : 1password8 : Downloading https://downloads.1password.com/mac/1Password.pkg to 1Password.pkg
2026-02-26 11:57:19 : INFO  : 1password8 : Downloaded 1Password.pkg – Type is  xar archive compressed TOC – SHA is 8ad28cfe1783a3ccf1007cc1022b6a076b0033b3 – Size is 360732 kB
2026-02-26 11:57:19 : INFO  : 1password8 : found blocking process 1Password
2026-02-26 11:57:25 : INFO  : 1password8 : Installomator did not close any apps, so no need to reopen any apps.
2026-02-26 11:57:25 : ERROR : 1password8 : ERROR: user aborted update
2026-02-26 11:57:25 : REQ   : 1password8 : ################## End Installomator, exit code 10 
```


**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
Installomator/utils/assemble.sh 1password8 DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent
2026-02-26 12:24:43 : INFO  : 1password8 : setting variable from argument DEBUG=0
2026-02-26 12:24:43 : INFO  : 1password8 : setting variable from argument BLOCKING_PROCESS_ACTION=prompt_user
2026-02-26 12:24:43 : INFO  : 1password8 : setting variable from argument NOTIFY=silent
2026-02-26 12:24:43 : INFO  : 1password8 : Total items in argumentsArray: 3
2026-02-26 12:24:43 : INFO  : 1password8 : argumentsArray: DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent
2026-02-26 12:24:43 : REQ   : 1password8 : ################## Start Installomator v. 10.9beta, date 2026-02-26
2026-02-26 12:24:43 : INFO  : 1password8 : ################## Version: 10.9beta
2026-02-26 12:24:43 : INFO  : 1password8 : ################## Date: 2026-02-26
2026-02-26 12:24:43 : INFO  : 1password8 : ################## 1password8
2026-02-26 12:24:44 : INFO  : 1password8 : Reading arguments again: DEBUG=0 BLOCKING_PROCESS_ACTION=prompt_user NOTIFY=silent
2026-02-26 12:24:44 : INFO  : 1password8 : BLOCKING_PROCESS_ACTION=prompt_user
2026-02-26 12:24:44 : INFO  : 1password8 : NOTIFY=silent
2026-02-26 12:24:44 : INFO  : 1password8 : LOGGING=INFO
2026-02-26 12:24:44 : INFO  : 1password8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-26 12:24:44 : INFO  : 1password8 : Label type: pkg
2026-02-26 12:24:44 : INFO  : 1password8 : archiveName: 1Password.pkg
2026-02-26 12:24:44 : INFO  : 1password8 : Custom App Version detection is used, found 8.12.4
2026-02-26 12:24:44 : INFO  : 1password8 : appversion: 8.12.4
2026-02-26 12:24:44 : INFO  : 1password8 : Latest version of 1Password is 8.12.6
2026-02-26 12:24:44 : REQ   : 1password8 : Downloading https://downloads.1password.com/mac/1Password.pkg to 1Password.pkg
2026-02-26 12:25:33 : INFO  : 1password8 : Downloaded 1Password.pkg – Type is  xar archive compressed TOC – SHA is 8ad28cfe1783a3ccf1007cc1022b6a076b0033b3 – Size is 360560 kB
2026-02-26 12:25:33 : INFO  : 1password8 : found blocking process 1Password
2026-02-26 12:25:36 : INFO  : 1password8 : Installomator did not close any apps, so no need to reopen any apps.
2026-02-26 12:25:36 : ERROR : 1password8 : ERROR: user aborted update
2026-02-26 12:25:36 : REQ   : 1password8 : ################## End Installomator, exit code 10 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2426 