### PR TITLE
Jamf MDM SwiftDialog (00_Prepare_SwiftDialog.sh) script updates

### DIFF
--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -80,7 +80,7 @@ echo "icon: $icon"
 echo "overlayicon: $overlayicon"
 
 # display first screen
-dialogCMD=("$dialogBinary"
+dialogCMD=(
            --title none
            --icon "$icon"
            --overlayicon "$overlayicon"
@@ -94,7 +94,10 @@ dialogCMD=("$dialogBinary"
 
 echo "dialogCMD: ${dialogCMD[@]}"
 
-"${dialogCMD[@]}" &
+
+$dialogBinary \
+${dialogCMD[@]} \
+&
 
 echo "$(date +%F\ %T) : SwiftDialog started!"
 

--- a/MDM/Jamf/00_Prepare_SwiftDialog.sh
+++ b/MDM/Jamf/00_Prepare_SwiftDialog.sh
@@ -92,7 +92,7 @@ dialogCMD=(
            --commandfile "$dialog_command_file"
 )
 
-echo "dialogCMD: ${dialogCMD[@]}"
+echo Executing: $dialogBinary "${dialogCMD[@]}"
 
 
 $dialogBinary \


### PR DESCRIPTION
Updated the command execution for SwiftDialog to use a more consistent syntax.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
no
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
This is to fix the Jamf helper script to display a dialog during self service installs. swiftDialog 3.0.0 doesn't like the binary to be called within the command for some reason so I made some slight tweaks so it will work properly. 
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
