### PR TITLE
Update sassafraskeyaccess.sh

### DIFF
--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,14 +1,14 @@
 keyaccess)
     name="KeyAccess"
     type="pkg"
-    keyaccessHost="INSERT_YOUR_SERVER_IP_HERE"
+    keyaccessHost="" # INSERT_YOUR_SERVER_IP_HERE
     downloadURL="https://download.sassafras.com/software/release/current/Installers/MacOS/Client/ksp-client.pkg"
     appNewVersion="$(curl -s "https://solutions.teamdynamix.com/TDClient/1965/Portal/KB/ArticleDet?ID=169236" | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)+' | sort -V | tail -1)"
     expectedTeamID="7Z2KSDFMVY"
     # Application is not installed in /Applications
     appName="Library/KeyAccess/KeyAccess.app"
     # Allowing for setting host as it is the only setting required for a fresh install.
-    if [[ -n $keyaccessHost ]]; then
-        defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"
+   if [[ ! -f "/Library/Preferences/com.sassafras.KeyAccess.plist" ]]; then
+    defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"
     fi
     ;;

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,14 +1,14 @@
 keyaccess)
     name="KeyAccess"
     type="pkg"
-    downloadStore="$(curl -sL "http://www.sassafras.com/client-download/" | tr '>' '\n')"
-    downloadURL="$(echo "$downloadStore" | grep "https.*ksp-client.*pkg" | cut -d '"' -f 2)"
-    appNewVersion="$(echo "$downloadStore" | grep "KeyAccess.*for Mac" | cut -d ' ' -f 2)"
+    keyaccessHost="INSERT_YOUR_SERVER_IP_HERE"
+    downloadURL="https://download.sassafras.com/software/release/current/Installers/MacOS/Client/ksp-client.pkg"
+    appNewVersion="$(curl -s "https://solutions.teamdynamix.com/TDClient/1965/Portal/KB/ArticleDet?ID=169236" | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)+' | sort -V | tail -1)"
     expectedTeamID="7Z2KSDFMVY"
-    BLOCKING_PROCESS_ACTION=ignore
-    blockingProcesses=( NONE )
     # Application is not installed in /Applications
     appName="Library/KeyAccess/KeyAccess.app"
-    # Don't forget to at least set the host, or nothing will happen.
-    # defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "host.name"
+    # Allowing for setting host as it is the only setting required for a fresh install.
+    if [[ -n $keyaccessHost ]]; then
+        defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"
+    fi
     ;;

--- a/fragments/labels/sassafraskeyaccess.sh
+++ b/fragments/labels/sassafraskeyaccess.sh
@@ -1,14 +1,8 @@
 keyaccess)
     name="KeyAccess"
     type="pkg"
-    keyaccessHost="" # INSERT_YOUR_SERVER_IP_HERE
     downloadURL="https://download.sassafras.com/software/release/current/Installers/MacOS/Client/ksp-client.pkg"
     appNewVersion="$(curl -s "https://solutions.teamdynamix.com/TDClient/1965/Portal/KB/ArticleDet?ID=169236" | grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+)+' | sort -V | tail -1)"
     expectedTeamID="7Z2KSDFMVY"
-    # Application is not installed in /Applications
     appName="Library/KeyAccess/KeyAccess.app"
-    # Allowing for setting host as it is the only setting required for a fresh install.
-   if [[ ! -f "/Library/Preferences/com.sassafras.KeyAccess.plist" ]]; then
-    defaults write /Library/Preferences/com.sassafras.KeyAccess host -string "${keyaccessHost}"
-    fi
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** yes

**Additional context** Add any other context about the label or fix here. updates label to use new download URL and version number location

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2026-02-27 16:58:26 : INFO  : keyaccess : Total items in argumentsArray: 0
2026-02-27 16:58:26 : INFO  : keyaccess : argumentsArray: 
2026-02-27 16:58:26 : REQ   : keyaccess : ################## Start Installomator v. 10.9beta, date 2025-12-23
2026-02-27 16:58:26 : INFO  : keyaccess : ################## Version: 10.9beta
2026-02-27 16:58:26 : INFO  : keyaccess : ################## Date: 2025-12-23
2026-02-27 16:58:26 : INFO  : keyaccess : ################## keyaccess
2026-02-27 16:58:26 : DEBUG : keyaccess : DEBUG mode 1 enabled.
2026-02-27 16:58:27 : INFO  : keyaccess : Reading arguments again: 
2026-02-27 16:58:27 : DEBUG : keyaccess : name=KeyAccess
2026-02-27 16:58:27 : DEBUG : keyaccess : appName=Library/KeyAccess/KeyAccess.app
2026-02-27 16:58:27 : DEBUG : keyaccess : type=pkg
2026-02-27 16:58:27 : DEBUG : keyaccess : archiveName=
2026-02-27 16:58:27 : DEBUG : keyaccess : downloadURL=https://download.sassafras.com/software/release/current/Installers/MacOS/Client/ksp-client.pkg
2026-02-27 16:58:27 : DEBUG : keyaccess : curlOptions=
2026-02-27 16:58:27 : DEBUG : keyaccess : appNewVersion=8.1.0.2
2026-02-27 16:58:27 : DEBUG : keyaccess : appCustomVersion function: Not defined
2026-02-27 16:58:27 : DEBUG : keyaccess : versionKey=CFBundleShortVersionString
2026-02-27 16:58:27 : DEBUG : keyaccess : packageID=
2026-02-27 16:58:28 : DEBUG : keyaccess : pkgName=
2026-02-27 16:58:28 : DEBUG : keyaccess : choiceChangesXML=
2026-02-27 16:58:28 : DEBUG : keyaccess : expectedTeamID=7Z2KSDFMVY
2026-02-27 16:58:28 : DEBUG : keyaccess : blockingProcesses=
2026-02-27 16:58:28 : DEBUG : keyaccess : installerTool=
2026-02-27 16:58:28 : DEBUG : keyaccess : CLIInstaller=
2026-02-27 16:58:28 : DEBUG : keyaccess : CLIArguments=
2026-02-27 16:58:28 : DEBUG : keyaccess : updateTool=
2026-02-27 16:58:28 : DEBUG : keyaccess : updateToolArguments=
2026-02-27 16:58:28 : DEBUG : keyaccess : updateToolRunAsCurrentUser=
2026-02-27 16:58:28 : INFO  : keyaccess : BLOCKING_PROCESS_ACTION=tell_user
2026-02-27 16:58:28 : INFO  : keyaccess : NOTIFY=success
2026-02-27 16:58:28 : INFO  : keyaccess : LOGGING=DEBUG
2026-02-27 16:58:28 : INFO  : keyaccess : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-02-27 16:58:28 : INFO  : keyaccess : Label type: pkg
2026-02-27 16:58:28 : INFO  : keyaccess : archiveName: KeyAccess.pkg
2026-02-27 16:58:28 : INFO  : keyaccess : no blocking processes defined, using KeyAccess as default
2026-02-27 16:58:28 : DEBUG : keyaccess : Changing directory to /Users/coreyg/Documents/GitHub/Installomator
2026-02-27 16:58:28 : INFO  : keyaccess : App(s) found: //Library/KeyAccess/KeyAccess.app
2026-02-27 16:58:28 : INFO  : keyaccess : found app at //Library/KeyAccess/KeyAccess.app, version 8.1.0.2, on versionKey CFBundleShortVersionString
2026-02-27 16:58:28 : INFO  : keyaccess : appversion: 8.1.0.2
2026-02-27 16:58:28 : INFO  : keyaccess : Latest version of KeyAccess is 8.1.0.2
2026-02-27 16:58:28 : WARN  : keyaccess : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-02-27 16:58:28 : REQ   : keyaccess : Downloading https://download.sassafras.com/software/release/current/Installers/MacOS/Client/ksp-client.pkg to KeyAccess.pkg
2026-02-27 16:58:28 : DEBUG : keyaccess : No Dialog connection, just download
2026-02-27 16:58:28 : INFO  : keyaccess : Downloaded KeyAccess.pkg – Type is  xar archive compressed TOC – SHA is 0ce075d7db1b8d6eda41567e42a73e8c33fc7c45 – Size is 3552 kB
2026-02-27 16:58:28 : DEBUG : keyaccess : DEBUG mode 1, not checking for blocking processes
2026-02-27 16:58:28 : REQ   : keyaccess : Installing KeyAccess
2026-02-27 16:58:28 : INFO  : keyaccess : Verifying: KeyAccess.pkg
2026-02-27 16:58:28 : DEBUG : keyaccess : File list: -rw-r--r--@ 1 root  staff   3.5M Feb 27 16:58 KeyAccess.pkg
2026-02-27 16:58:28 : DEBUG : keyaccess : File type: KeyAccess.pkg: xar archive compressed TOC: 5933, SHA-1 checksum
2026-02-27 16:58:29 : DEBUG : keyaccess : spctlOut is KeyAccess.pkg: accepted
2026-02-27 16:58:29 : DEBUG : keyaccess : source=Notarized Developer ID
2026-02-27 16:58:29 : DEBUG : keyaccess : override=security disabled
2026-02-27 16:58:29 : DEBUG : keyaccess : origin=Developer ID Installer: Sassafras Software, Inc. (7Z2KSDFMVY)
2026-02-27 16:58:29 : INFO  : keyaccess : Team ID: 7Z2KSDFMVY (expected: 7Z2KSDFMVY )
2026-02-27 16:58:29 : DEBUG : keyaccess : DEBUG enabled, skipping installation
2026-02-27 16:58:29 : INFO  : keyaccess : Finishing...
2026-02-27 16:58:32 : INFO  : keyaccess : App(s) found: //Library/KeyAccess/KeyAccess.app
2026-02-27 16:58:32 : INFO  : keyaccess : found app at //Library/KeyAccess/KeyAccess.app, version 8.1.0.2, on versionKey CFBundleShortVersionString
2026-02-27 16:58:32 : REQ   : keyaccess : Installed KeyAccess, version 8.1.0.2
2026-02-27 16:58:32 : INFO  : keyaccess : notifying
2026-02-27 16:58:32 : DEBUG : keyaccess : DEBUG mode 1, not reopening anything
2026-02-27 16:58:32 : REQ   : keyaccess : All done!
2026-02-27 16:58:32 : REQ   : keyaccess : ################## End Installomator, exit code 0 
```