### PR TITLE
Fix: Label realvncserver downloadURL

### DIFF
--- a/fragments/labels/realvncserver.sh
+++ b/fragments/labels/realvncserver.sh
@@ -4,7 +4,7 @@ realvncserver)
     appName="VNC Server.app"
     type="pkg"
     packageID="com.realvnc.vncserver.pkg"
-    downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/vnc/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"
-    appNewVersion="$(echo ${downloadURL} | sed -n 's:.*VNC-Server-\(.*\)-MacOSX.*:\1:p')"
+    downloadURL="https://downloads.realvnc.com/download/file/vnc.files/VNC-Server-Latest-MacOSX-universal.pkg"
+    appNewVersion="$(curl -sL https://realvnc.zendesk.com/api/v2/help_center/en-us/articles/5835892358941.json | sed -n 's/.*VNC-Server-\([0-9.]*\)-MacOSX.*/\1/p')"
     expectedTeamID="ZNCQ8JEH7X"
     ;;

--- a/fragments/labels/realvncserver.sh
+++ b/fragments/labels/realvncserver.sh
@@ -1,10 +1,9 @@
 vncconnect|\
 realvncserver)
-    name="Real VNC Server"
-    appName="VNC Server.app"
+    name="RealVNC Server"
     type="pkg"
-    packageID="com.realvnc.vncserver.pkg"
-    downloadURL="https://downloads.realvnc.com/download/file/vnc.files/VNC-Server-Latest-MacOSX-universal.pkg"
+    targetDir="/Applications/RealVNC"
     appNewVersion="$(curl -sL https://realvnc.zendesk.com/api/v2/help_center/en-us/articles/5835892358941.json | sed -n 's/.*VNC-Server-\([0-9.]*\)-MacOSX.*/\1/p')"
+    downloadURL="https://downloads.realvnc.com/download/file/vnc.files/VNC-Server-$appNewVersion-MacOSX-universal.pkg"
     expectedTeamID="ZNCQ8JEH7X"
     ;;

--- a/fragments/labels/realvncviewer.sh
+++ b/fragments/labels/realvncviewer.sh
@@ -1,5 +1,5 @@
 realvncviewer)
-        name="Real VNC Viewer"
+    name="Real VNC Viewer"
     appName="VNC Viewer.app"
     type="dmg"
     downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/viewer/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"

--- a/fragments/labels/realvncviewer.sh
+++ b/fragments/labels/realvncviewer.sh
@@ -1,8 +1,8 @@
 realvncviewer)
-    name="Real VNC Viewer"
+        name="Real VNC Viewer"
     appName="VNC Viewer.app"
     type="dmg"
-    downloadURL="https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-Latest-MacOSX-universal.dmg"
-    appNewVersion="$(curl -sL https://realvnc.zendesk.com/api/v2/help_center/en-us/articles/5835892358941.json | sed -n 's/.*VNC-Viewer-\([0-9.]*\)-MacOSX.*/\1/p')"
+    downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/viewer/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"
+    appNewVersion="$(echo $downloadURL | sed -n 's:.*VNC-Viewer-\(.*\)-MacOSX.*:\1:p')"
     expectedTeamID="ZNCQ8JEH7X"
     ;;

--- a/fragments/labels/realvncviewer.sh
+++ b/fragments/labels/realvncviewer.sh
@@ -2,7 +2,7 @@ realvncviewer)
     name="Real VNC Viewer"
     appName="VNC Viewer.app"
     type="dmg"
-    downloadURL="$(curl -sL https://www.realvnc.com/en/connect/download/viewer/ | grep -i 'download-link-path-macos' | sed -r 's/.*href="([^"]+).*/\1/g')"
-    appNewVersion="$(echo $downloadURL | sed -n 's:.*VNC-Viewer-\(.*\)-MacOSX.*:\1:p')"
+    downloadURL="https://downloads.realvnc.com/download/file/viewer.files/VNC-Viewer-Latest-MacOSX-universal.dmg"
+    appNewVersion="$(curl -sL https://realvnc.zendesk.com/api/v2/help_center/en-us/articles/5835892358941.json | sed -n 's/.*VNC-Viewer-\([0-9.]*\)-MacOSX.*/\1/p')"
     expectedTeamID="ZNCQ8JEH7X"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** YES

**Additional context** Add any other context about the label or fix here.

While the download URLs are not generated dynamically they point to the latest version. The one for the server is not pointing to the latest as my tests showed that the app was not installed to the right directory, but the version is obtained dynamically and the URL is constructed that way.

Based this PR solution off https://github.com/autopkg/foigus-recipes/issues/162

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes #2672


### Log

```
2026-03-02 19:43:12 : INFO  : realvncserver : Total items in argumentsArray: 0
2026-03-02 19:43:12 : INFO  : realvncserver : argumentsArray: 
2026-03-02 19:43:12 : REQ   : realvncserver : ################## Start Installomator v. 10.9beta, date 2025-12-23
2026-03-02 19:43:12 : INFO  : realvncserver : ################## Version: 10.9beta
2026-03-02 19:43:12 : INFO  : realvncserver : ################## Date: 2025-12-23
2026-03-02 19:43:12 : INFO  : realvncserver : ################## realvncserver
2026-03-02 19:43:12 : INFO  : realvncserver : SwiftDialog is not installed, clear cmd file var
2026-03-02 19:43:13 : INFO  : realvncserver : Reading arguments again: 
2026-03-02 19:43:13 : INFO  : realvncserver : BLOCKING_PROCESS_ACTION=tell_user
2026-03-02 19:43:13 : INFO  : realvncserver : NOTIFY=success
2026-03-02 19:43:13 : INFO  : realvncserver : LOGGING=INFO
2026-03-02 19:43:13 : INFO  : realvncserver : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-02 19:43:13 : INFO  : realvncserver : Label type: pkg
2026-03-02 19:43:13 : INFO  : realvncserver : archiveName: RealVNC Server.pkg
2026-03-02 19:43:13 : INFO  : realvncserver : no blocking processes defined, using RealVNC Server as default
2026-03-02 19:43:13 : INFO  : realvncserver : name: RealVNC Server, appName: RealVNC Server.app
2026-03-02 19:43:13 : WARN  : realvncserver : No previous app found
2026-03-02 19:43:13 : WARN  : realvncserver : could not find RealVNC Server.app
2026-03-02 19:43:13 : INFO  : realvncserver : appversion: 
2026-03-02 19:43:13 : INFO  : realvncserver : Latest version of RealVNC Server is 7.16.0
2026-03-02 19:43:13 : REQ   : realvncserver : Downloading https://downloads.realvnc.com/download/file/vnc.files/VNC-Server-7.16.0-MacOSX-universal.pkg to RealVNC Server.pkg
2026-03-02 19:43:14 : INFO  : realvncserver : Downloaded RealVNC Server.pkg – Type is  xar archive compressed TOC – SHA is dade56e0c579d6caedfd27e0fc2b924bb064bc3d – Size is 17792 kB
2026-03-02 19:43:14 : REQ   : realvncserver : no more blocking processes, continue with update
2026-03-02 19:43:14 : REQ   : realvncserver : Installing RealVNC Server
2026-03-02 19:43:14 : INFO  : realvncserver : Verifying: RealVNC Server.pkg
2026-03-02 19:43:14 : INFO  : realvncserver : Team ID: ZNCQ8JEH7X (expected: ZNCQ8JEH7X )
2026-03-02 19:43:14 : INFO  : realvncserver : Installing RealVNC Server.pkg to /Applications/RealVNC
2026-03-02 19:43:15 : INFO  : realvncserver : Finishing...
2026-03-02 19:43:18 : INFO  : realvncserver : name: RealVNC Server, appName: RealVNC Server.app
2026-03-02 19:43:18 : WARN  : realvncserver : No previous app found
2026-03-02 19:43:18 : WARN  : realvncserver : could not find RealVNC Server.app
2026-03-02 19:43:18 : REQ   : realvncserver : Installed RealVNC Server, version 7.16.0
2026-03-02 19:43:18 : INFO  : realvncserver : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-03-02 19:43:18 : INFO  : realvncserver : Installomator did not close any apps, so no need to reopen any apps.
2026-03-02 19:43:18 : REQ   : realvncserver : All done!
2026-03-02 19:43:18 : REQ   : realvncserver : ################## End Installomator, exit code 0 
```