### PR TITLE
New label: FreeCAD

### DIFF
--- a/fragments/labels/freecad.sh
+++ b/fragments/labels/freecad.sh
@@ -1,0 +1,13 @@
+freecad)
+    name="FreeCAD"
+    type="dmg"
+    if [[ $(arch) == i386 ]]; then
+        archiveName="FreeCAD.*x86_64.*\.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        archiveName="FreeCAD.*arm64.*\.dmg"
+    fi
+    appCustomVersion(){ if [ -f "/Applications/FreeCAD.app/Contents/Info.plist" ]; then /usr/bin/defaults read "/Applications/FreeCAD.app/Contents/Info.plist" "CFBundleVersion" | awk -F'-' '{print $1}'; fi }
+    downloadURL="$(downloadURLFromGit FreeCAD FreeCAD)"
+    appNewVersion="$(versionFromGit FreeCAD FreeCAD)"
+    expectedTeamID="289DJRF23X"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
`archiveName` is regex in order to support both different architectures and to support future package  file name changes as FreeCAD gets updated (biggest example is the `py311` tag at the end of the file name will change in the future as the bundled Python version gets updated.
`appCustomVersion` is needed here as `CFBundleVersion` includes the revision number while the Git release does not, and `CFBundleShortVersionString` is not set.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
% sudo ./Installomator.sh freecad DEBUG=0 LOGGING=INFO
2026-03-03 16:47:19 : INFO  : freecad : setting variable from argument DEBUG=0
2026-03-03 16:47:19 : INFO  : freecad : setting variable from argument LOGGING=INFO
2026-03-03 16:47:19 : INFO  : freecad : Total items in argumentsArray: 2
2026-03-03 16:47:19 : INFO  : freecad : argumentsArray: DEBUG=0 LOGGING=INFO
2026-03-03 16:47:19 : REQ   : freecad : ################## Start Installomator v. 10.9beta, date 2026-03-03
2026-03-03 16:47:19 : INFO  : freecad : ################## Version: 10.9beta
2026-03-03 16:47:20 : INFO  : freecad : ################## Date: 2026-03-03
2026-03-03 16:47:20 : INFO  : freecad : ################## freecad
2026-03-03 16:47:21 : INFO  : freecad : Reading arguments again: DEBUG=0 LOGGING=INFO
2026-03-03 16:47:21 : INFO  : freecad : BLOCKING_PROCESS_ACTION=tell_user
2026-03-03 16:47:21 : INFO  : freecad : NOTIFY=success
2026-03-03 16:47:21 : INFO  : freecad : LOGGING=INFO
2026-03-03 16:47:21 : INFO  : freecad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-03 16:47:21 : INFO  : freecad : Label type: dmg
2026-03-03 16:47:21 : INFO  : freecad : archiveName: FreeCAD.*arm64.*\.dmg
2026-03-03 16:47:21 : INFO  : freecad : no blocking processes defined, using FreeCAD as default
2026-03-03 16:47:21 : INFO  : freecad : Custom App Version detection is used, found 
2026-03-03 16:47:21 : INFO  : freecad : appversion: 
2026-03-03 16:47:21 : INFO  : freecad : Latest version of FreeCAD is 1.0.2
2026-03-03 16:47:22 : REQ   : freecad : Downloading https://github.com/FreeCAD/FreeCAD/releases/download/1.0.2/FreeCAD_1.0.2-conda-macOS-arm64-py311.dmg to FreeCAD.*arm64.*\.dmg
2026-03-03 16:47:53 : INFO  : freecad : Downloaded FreeCAD.*arm64.*\.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is \7b3e8bf58214e1c06b9d7e2735a5069c34ce4f54 – Size is 655708 kB
2026-03-03 16:47:54 : REQ   : freecad : no more blocking processes, continue with update
2026-03-03 16:47:54 : REQ   : freecad : Installing FreeCAD
2026-03-03 16:47:54 : INFO  : freecad : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.zljywaDlBG/FreeCAD.*arm64.*\.dmg
2026-03-03 16:48:40 : INFO  : freecad : Mounted: /Volumes/FreeCAD 1
2026-03-03 16:48:40 : INFO  : freecad : Verifying: /Volumes/FreeCAD 1/FreeCAD.app
2026-03-03 16:51:28 : INFO  : freecad : Team ID matching: 289DJRF23X (expected: 289DJRF23X )
2026-03-03 16:51:28 : INFO  : freecad : Installing FreeCAD version  on versionKey CFBundleShortVersionString.
2026-03-03 16:51:28 : INFO  : freecad : Copy /Volumes/FreeCAD 1/FreeCAD.app to /Applications
2026-03-03 16:54:19 : WARN  : freecad : Changing owner to aahgr
2026-03-03 16:54:23 : INFO  : freecad : Finishing...
2026-03-03 16:54:26 : INFO  : freecad : Custom App Version detection is used, found 1.0.2
2026-03-03 16:54:26 : REQ   : freecad : Installed FreeCAD
2026-03-03 16:54:26 : INFO  : freecad : notifying
2026-03-03 16:54:27 : INFO  : freecad : Installomator did not close any apps, so no need to reopen any apps.
2026-03-03 16:54:27 : REQ   : freecad : All done!
2026-03-03 16:54:27 : REQ   : freecad : ################## End Installomator, exit code 0 

% sudo ./Installomator.sh freecad DEBUG=0 LOGGING=INFO
2026-03-03 16:54:38 : INFO  : freecad : setting variable from argument DEBUG=0
2026-03-03 16:54:38 : INFO  : freecad : setting variable from argument LOGGING=INFO
2026-03-03 16:54:38 : INFO  : freecad : Total items in argumentsArray: 2
2026-03-03 16:54:38 : INFO  : freecad : argumentsArray: DEBUG=0 LOGGING=INFO
2026-03-03 16:54:38 : REQ   : freecad : ################## Start Installomator v. 10.9beta, date 2026-03-03
2026-03-03 16:54:38 : INFO  : freecad : ################## Version: 10.9beta
2026-03-03 16:54:38 : INFO  : freecad : ################## Date: 2026-03-03
2026-03-03 16:54:38 : INFO  : freecad : ################## freecad
2026-03-03 16:54:39 : INFO  : freecad : Reading arguments again: DEBUG=0 LOGGING=INFO
2026-03-03 16:54:40 : INFO  : freecad : BLOCKING_PROCESS_ACTION=tell_user
2026-03-03 16:54:40 : INFO  : freecad : NOTIFY=success
2026-03-03 16:54:40 : INFO  : freecad : LOGGING=INFO
2026-03-03 16:54:40 : INFO  : freecad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-03 16:54:40 : INFO  : freecad : Label type: dmg
2026-03-03 16:54:40 : INFO  : freecad : archiveName: FreeCAD.*arm64.*\.dmg
2026-03-03 16:54:40 : INFO  : freecad : no blocking processes defined, using FreeCAD as default
2026-03-03 16:54:40 : INFO  : freecad : Custom App Version detection is used, found 1.0.2
2026-03-03 16:54:40 : INFO  : freecad : appversion: 1.0.2
2026-03-03 16:54:40 : INFO  : freecad : Latest version of FreeCAD is 1.0.2
2026-03-03 16:54:40 : INFO  : freecad : There is no newer version available.
2026-03-03 16:54:40 : INFO  : freecad : Installomator did not close any apps, so no need to reopen any apps.
2026-03-03 16:54:40 : REQ   : freecad : No newer version.
2026-03-03 16:54:40 : REQ   : freecad : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
