### PR TITLE
Update flexoptixapp.sh

### DIFF
--- a/fragments/labels/flexoptixapp.sh
+++ b/fragments/labels/flexoptixapp.sh
@@ -1,7 +1,12 @@
 flexoptixapp)
     name="FLEXOPTIX App"
     type="dmg"
-    downloadURL="https://flexbox.reconfigure.me/download/electron/mac/x64/current"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*App-(.*)\.dmg/\1/g')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://flexbox.reconfigure.me/download/electron/mac/arm64/current"
+        appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*App-(.*)\-arm.*/\1/g')
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://flexbox.reconfigure.me/download/electron/mac/x64/current"
+        appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i ^location | sed -E 's/.*App-(.*)\.dmg/\1/g')
+    fi
     expectedTeamID="C5JETSFPHL"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Fix label: handle arch-specific downloads (arm64/x64)

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

2026-03-04 18:14:10 : INFO  : flexoptixapp : setting variable from argument DEBUG=0
2026-03-04 18:14:10 : INFO  : flexoptixapp : Total items in argumentsArray: 1
2026-03-04 18:14:10 : INFO  : flexoptixapp : argumentsArray: DEBUG=0
2026-03-04 18:14:10 : REQ   : flexoptixapp : ################## Start Installomator v. 11.0beta2, date 2026-03-04
2026-03-04 18:14:10 : INFO  : flexoptixapp : ################## Version: 11.0beta2
2026-03-04 18:14:10 : INFO  : flexoptixapp : ################## Date: 2026-03-04
2026-03-04 18:14:10 : INFO  : flexoptixapp : ################## flexoptixapp
2026-03-04 18:14:11 : INFO  : flexoptixapp : Reading arguments again: DEBUG=0
2026-03-04 18:14:11 : INFO  : flexoptixapp : BLOCKING_PROCESS_ACTION=tell_user
2026-03-04 18:14:11 : INFO  : flexoptixapp : NOTIFY=success
2026-03-04 18:14:11 : INFO  : flexoptixapp : LOGGING=INFO
2026-03-04 18:14:11 : INFO  : flexoptixapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-04 18:14:11 : INFO  : flexoptixapp : Label type: dmg
2026-03-04 18:14:11 : INFO  : flexoptixapp : archiveName: FLEXOPTIX App.dmg
2026-03-04 18:14:11 : INFO  : flexoptixapp : no blocking processes defined, using FLEXOPTIX App as default
2026-03-04 18:14:11 : INFO  : flexoptixapp : name: FLEXOPTIX App, appName: FLEXOPTIX App.app
2026-03-04 18:14:11 : INFO  : flexoptixapp : App(s) found: /Users/savvas/Desktop/Mosyle/PKGs/N+K/FLEXOPTIX App.app
2026-03-04 18:14:11 : WARN  : flexoptixapp : could not determine location of FLEXOPTIX App.app
2026-03-04 18:14:11 : INFO  : flexoptixapp : appversion: 
2026-03-04 18:14:11 : INFO  : flexoptixapp : Latest version of FLEXOPTIX App is 5.59.0-latest
2026-03-04 18:14:11 : REQ   : flexoptixapp : Downloading https://flexbox.reconfigure.me/download/electron/mac/arm64/current to FLEXOPTIX App.dmg
2026-03-04 18:14:13 : INFO  : flexoptixapp : Downloaded FLEXOPTIX App.dmg – Type is  zlib compressed data – SHA is 9292e2e3757cc8d73d5a17705cc2e1c6a02a1b5e – Size is 131432 kB
2026-03-04 18:14:13 : REQ   : flexoptixapp : no more blocking processes, continue with update
2026-03-04 18:14:13 : REQ   : flexoptixapp : Installing FLEXOPTIX App
2026-03-04 18:14:13 : INFO  : flexoptixapp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.aJW7IC9keT/FLEXOPTIX App.dmg
2026-03-04 18:14:15 : INFO  : flexoptixapp : Mounted: /Volumes/FLEXOPTIX App 5.59.0-latest-arm64
2026-03-04 18:14:15 : INFO  : flexoptixapp : Verifying: /Volumes/FLEXOPTIX App 5.59.0-latest-arm64/FLEXOPTIX App.app
2026-03-04 18:14:16 : INFO  : flexoptixapp : Team ID matching: C5JETSFPHL (expected: C5JETSFPHL )
2026-03-04 18:14:16 : INFO  : flexoptixapp : Installing FLEXOPTIX App version 5.59.0-latest on versionKey CFBundleShortVersionString.
2026-03-04 18:14:16 : INFO  : flexoptixapp : App has LSMinimumSystemVersion: 11.0
2026-03-04 18:14:16 : INFO  : flexoptixapp : Copy /Volumes/FLEXOPTIX App 5.59.0-latest-arm64/FLEXOPTIX App.app to /Applications
2026-03-04 18:14:17 : WARN  : flexoptixapp : Changing owner to savvas
2026-03-04 18:14:17 : INFO  : flexoptixapp : Finishing...
2026-03-04 18:14:20 : INFO  : flexoptixapp : App(s) found: /Applications/FLEXOPTIX App.app
2026-03-04 18:14:20 : INFO  : flexoptixapp : found app at /Applications/FLEXOPTIX App.app, version 5.59.0-latest, on versionKey CFBundleShortVersionString
2026-03-04 18:14:20 : REQ   : flexoptixapp : Installed FLEXOPTIX App, version 5.59.0-latest
2026-03-04 18:14:20 : INFO  : flexoptixapp : notifying
2026-03-04 18:14:20 : INFO  : flexoptixapp : Swift Dialog notification
ERROR: Notifications are not allowed for this application
ERROR: Notifications are not allowed for this application
2026-03-04 18:14:21 : INFO  : flexoptixapp : Installomator did not close any apps, so no need to reopen any apps.
2026-03-04 18:14:21 : REQ   : flexoptixapp : All done!
2026-03-04 18:14:21 : REQ   : flexoptixapp : ################## End Installomator, exit code 0 

2026-03-04 18:14:23 : INFO  : flexoptixapp : setting variable from argument DEBUG=0
2026-03-04 18:14:23 : INFO  : flexoptixapp : Total items in argumentsArray: 1
2026-03-04 18:14:23 : INFO  : flexoptixapp : argumentsArray: DEBUG=0
2026-03-04 18:14:23 : REQ   : flexoptixapp : ################## Start Installomator v. 11.0beta2, date 2026-03-04
2026-03-04 18:14:23 : INFO  : flexoptixapp : ################## Version: 11.0beta2
2026-03-04 18:14:23 : INFO  : flexoptixapp : ################## Date: 2026-03-04
2026-03-04 18:14:23 : INFO  : flexoptixapp : ################## flexoptixapp
2026-03-04 18:14:23 : INFO  : flexoptixapp : Reading arguments again: DEBUG=0
2026-03-04 18:14:23 : INFO  : flexoptixapp : BLOCKING_PROCESS_ACTION=tell_user
2026-03-04 18:14:23 : INFO  : flexoptixapp : NOTIFY=success
2026-03-04 18:14:23 : INFO  : flexoptixapp : LOGGING=INFO
2026-03-04 18:14:23 : INFO  : flexoptixapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-04 18:14:23 : INFO  : flexoptixapp : Label type: dmg
2026-03-04 18:14:23 : INFO  : flexoptixapp : archiveName: FLEXOPTIX App.dmg
2026-03-04 18:14:23 : INFO  : flexoptixapp : no blocking processes defined, using FLEXOPTIX App as default
2026-03-04 18:14:23 : INFO  : flexoptixapp : App(s) found: /Applications/FLEXOPTIX App.app
2026-03-04 18:14:23 : INFO  : flexoptixapp : found app at /Applications/FLEXOPTIX App.app, version 5.59.0-latest, on versionKey CFBundleShortVersionString
2026-03-04 18:14:23 : INFO  : flexoptixapp : appversion: 5.59.0-latest
2026-03-04 18:14:23 : INFO  : flexoptixapp : Latest version of FLEXOPTIX App is 5.59.0-latest
2026-03-04 18:14:23 : INFO  : flexoptixapp : There is no newer version available.
2026-03-04 18:14:23 : INFO  : flexoptixapp : Installomator did not close any apps, so no need to reopen any apps.
2026-03-04 18:14:23 : REQ   : flexoptixapp : No newer version.
2026-03-04 18:14:24 : REQ   : flexoptixapp : ################## End Installomator, exit code 0 


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
