### PR TITLE
feat: add setupchecklist label for Jamf Setup Checklist

### DIFF
--- a/fragments/labels/setupchecklist.sh
+++ b/fragments/labels/setupchecklist.sh
@@ -1,0 +1,9 @@
+setupchecklist)
+    name="Setup Checklist"
+    type="pkg"
+    packageID="com.jamf.setupchecklist"
+    downloadURL=$(downloadURLFromGit Jamf-Concepts Setup-Checklist)
+    appNewVersion=$(versionFromGit Jamf-Concepts Setup-Checklist)
+    expectedTeamID="483DWKW443"
+    blockingProcesses=( NONE )
+    ;;


### PR DESCRIPTION
## Summary

Adds a new label `setupchecklist` for installing [Jamf Setup Checklist](https://github.com/Jamf-Concepts/Setup-Checklist) via Installomator.

## What is Setup Checklist?

Setup Checklist is a companion app for Jamf Setup Manager that provides a post-enrollment checklist UI for user-facing tasks after the initial device setup completes. It guides users through:

- Signing into apps (Chrome, Google Drive, etc.)
- Granting necessary permissions (File Provider extensions, etc.)
- Completing post-enrollment configuration steps

## Label Details

| Field | Value |
|-------|-------|
| Label name | `setupchecklist` |
| Type | `pkg` |
| Package ID | `com.jamf.setupchecklist` |
| Download source | `github.com/Jamf-Concepts/Setup-Checklist` |
| Expected Team ID | `483DWKW443` (Jamf Software) |

## Testing

Verified against the latest release (v0.3.2beta released 2026-03-05):
- Download URL resolves correctly via `downloadURLFromGit`
- Version detection works via `versionFromGit`
- Team ID matches the signed package

## Related

- [Jamf Setup Checklist Repository](https://github.com/Jamf-Concepts/Setup-Checklist)
- [Jamf Setup Manager](https://github.com/jamf/Setup-Manager) (companion tool)