### PR TITLE
New Label: sonicpi

### DIFF
--- a/fragments/labels/sonicpi.sh
+++ b/fragments/labels/sonicpi.sh
@@ -1,0 +1,15 @@
+sonicpi)
+    name="Sonic Pi"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://sonic-pi.net$(curl -sfL "https://sonic-pi.net/" | xmllint --html --format - 2>/dev/null | grep -o "\/files.*Sonic-Pi-for-Mac-arm64.*.dmg")"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://sonic-pi.net$(curl -sfL "https://sonic-pi.net/" | xmllint --html --format - 2>/dev/null | grep -o "\/files.*Sonic-Pi-for-Mac-x64.*.dmg")"
+    fi
+    if [[ $(arch) == "arm64" ]]; then
+        appNewVersion=$(curl -sfL "https://sonic-pi.net/" | xmllint --html --format - 2>/dev/null | grep -o "\/.*Sonic-Pi-for-Mac-arm64.*.dmg" | grep -Eo '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{0,2}' | head -n1)
+    elif [[ $(arch) == "i386" ]]; then
+        appNewVersion=$(curl -sfL "https://sonic-pi.net/" | xmllint --html --format - 2>/dev/null | grep -o "\/.*Sonic-Pi-for-Mac-x64.*.dmg" | grep -Eo '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{0,2}' | head -n1)
+    fi
+    expectedTeamID="MM65S3L4NG"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
```
2026-03-06 15:24:55 : INFO  : sonicpi : Total items in argumentsArray: 0
2026-03-06 15:24:55 : INFO  : sonicpi : argumentsArray: 
2026-03-06 15:24:55 : REQ   : sonicpi : ################## Start Installomator v. 10.9beta, date 2026-03-06
2026-03-06 15:24:55 : INFO  : sonicpi : ################## Version: 10.9beta
2026-03-06 15:24:55 : INFO  : sonicpi : ################## Date: 2026-03-06
2026-03-06 15:24:55 : INFO  : sonicpi : ################## sonicpi
2026-03-06 15:24:55 : DEBUG : sonicpi : DEBUG mode 1 enabled.
2026-03-06 15:24:56 : INFO  : sonicpi : Reading arguments again: 
2026-03-06 15:24:56 : DEBUG : sonicpi : name=Sonic Pi
2026-03-06 15:24:56 : DEBUG : sonicpi : appName=
2026-03-06 15:24:56 : DEBUG : sonicpi : type=dmg
2026-03-06 15:24:56 : DEBUG : sonicpi : archiveName=
2026-03-06 15:24:56 : DEBUG : sonicpi : downloadURL=https://sonic-pi.net/files/releases/v4.6.0/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg
2026-03-06 15:24:56 : DEBUG : sonicpi : curlOptions=
2026-03-06 15:24:56 : DEBUG : sonicpi : appNewVersion=4.6.0
2026-03-06 15:24:56 : DEBUG : sonicpi : appCustomVersion function: Not defined
2026-03-06 15:24:56 : DEBUG : sonicpi : versionKey=CFBundleShortVersionString
2026-03-06 15:24:56 : DEBUG : sonicpi : packageID=
2026-03-06 15:24:56 : DEBUG : sonicpi : pkgName=
2026-03-06 15:24:56 : DEBUG : sonicpi : choiceChangesXML=
2026-03-06 15:24:56 : DEBUG : sonicpi : expectedTeamID=MM65S3L4NG
2026-03-06 15:24:56 : DEBUG : sonicpi : blockingProcesses=
2026-03-06 15:24:56 : DEBUG : sonicpi : installerTool=
2026-03-06 15:24:56 : DEBUG : sonicpi : CLIInstaller=
2026-03-06 15:24:56 : DEBUG : sonicpi : CLIArguments=
2026-03-06 15:24:56 : DEBUG : sonicpi : updateTool=
2026-03-06 15:24:56 : DEBUG : sonicpi : updateToolArguments=
2026-03-06 15:24:56 : DEBUG : sonicpi : updateToolRunAsCurrentUser=
2026-03-06 15:24:56 : INFO  : sonicpi : BLOCKING_PROCESS_ACTION=tell_user
2026-03-06 15:24:57 : INFO  : sonicpi : NOTIFY=success
2026-03-06 15:24:57 : INFO  : sonicpi : LOGGING=DEBUG
2026-03-06 15:24:57 : INFO  : sonicpi : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-06 15:24:57 : INFO  : sonicpi : Label type: dmg
2026-03-06 15:24:57 : INFO  : sonicpi : archiveName: Sonic Pi.dmg
2026-03-06 15:24:57 : INFO  : sonicpi : no blocking processes defined, using Sonic Pi as default
2026-03-06 15:24:57 : DEBUG : sonicpi : Changing directory to /Users/cmgeorge/Documents/GitHub/Installomator/build
2026-03-06 15:24:57 : INFO  : sonicpi : name: Sonic Pi, appName: Sonic Pi.app
2026-03-06 15:24:57 : WARN  : sonicpi : No previous app found
2026-03-06 15:24:57 : WARN  : sonicpi : could not find Sonic Pi.app
2026-03-06 15:24:57 : INFO  : sonicpi : appversion: 
2026-03-06 15:24:57 : INFO  : sonicpi : Latest version of Sonic Pi is 4.6.0
2026-03-06 15:24:57 : REQ   : sonicpi : Downloading https://sonic-pi.net/files/releases/v4.6.0/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg to Sonic Pi.dmg
2026-03-06 15:24:57 : DEBUG : sonicpi : No Dialog connection, just download
2026-03-06 15:26:16 : INFO  : sonicpi : Downloaded Sonic Pi.dmg – Type is  XZ compressed data, checksum NONE – SHA is 60af65c2120e9b3118d46ec1a1af9b0a0fbcb060 – Size is 164604 kB
2026-03-06 15:26:16 : DEBUG : sonicpi : DEBUG mode 1, not checking for blocking processes
2026-03-06 15:26:16 : REQ   : sonicpi : Installing Sonic Pi
2026-03-06 15:26:16 : INFO  : sonicpi : Mounting /Users/cmgeorge/Documents/GitHub/Installomator/build/Sonic Pi.dmg
2026-03-06 15:26:21 : DEBUG : sonicpi : Debugging enabled, dmgmount output was:
License Main Source Code (contents of app/ directory) The MIT License
(MIT) Copyright (c) 2012 - 2025 Samuel Aaron and contributors
(sam@sonic-pi.net) Permission is hereby granted, free of charge,
to any person obtaining a copy of this software and associated
documentation files (the "Software"), to deal in the Software without
restriction, including without limitation the rights to use, copy,
modify, merge, publish, distribute, sublicense, and/or sell copies
of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions: The above
copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.  THE SOFTWARE
IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

GPL Compliance As Sonic Pi links with and contains GPLv3-licensed
software, distributors of Sonic Pi GUI binaries must comply with
the terms of the GPL.

Samples (contents of etc/samples/) All the bundled samples are
individually licensed under a CC0 1.0 Universal Public Domain
Dedication. They have all been obtained from freesound.org and links
to their sources can be found in the file etc/samples/README.md
http://creativecommons.org/publicdomain/zero/1.0/

Wavetables (contents of etc/wavetables/ All the bundled wavetable
samples are individually licensed under a CC0 1.0 Universal Public
Domain Dedication. They have been obtained from the Adventure Kid
site.

Font The font used in the GUI is Hack released under the Hack Open
Font License v2.0

Docs, Tutorial and Examples (contents of etc/doc/ and etc/examples
directories) All the examples (in etc/examples) and contents of the
doc directory including the articles and the tutorial are copyright
by Sam Aaron unless a specific author is stated with the comment #
coded by ... in which case the copyright is associated with that
author (2023) and the content is released under the CC BY-SA 4.0
license: http://creativecommons.org/licenses/by-sa/4.0/

Synth Designs (contents of etc/synthdefs/ directory) The bundled
synth designs (synthdefs) are licensed under the MIT License with
the following exceptions, which are licensed under the GNU General
Public License v3: etc/synthdefs/designs/supercollider/bass_foundation.scd
etc/synthdefs/designs/supercollider/bass_highend.scd
etc/synthdefs/designs/supercollider/winwood_lead.scd
etc/synthdefs/designs/supercollider/organ_tonewheel.scd

See their source files for links to the original designs.

Bundled Software The following is a list of the software included
in Sonic Pi with their relevant licenses:

Unlinked software Ruby - Ruby License SuperCollider - GNU General
Public License v3 Erlang - Erlang Public License Elixir - Apache
License, Version 2.0 Aubio - GNU General Public License v3 esbuild
- MIT License tailwind - MIT License

Dynamically Linked Libraries for GUI Qt - GNU Lesser General Public
License v2.1 QScintilla2 - GNU General Public License v2 KISS FFT
- BSD 3-Clause License Tracy - BSD 3-Clause License ghc_filesystem
- MIT License kissnet - MIT License liblo - GNU Lesser General
Public License v2.1 boost (subset used by SuperCollider's scsynth)
- Boost Software License 1.0 (BSL-1.0) TLSF - GNU Lesser General
Public License v2.1

Dynamically Linked Libraries for Aubio ogg - BSD 3-Clause License
opus - BSD 3-Clause License flac - GNU Lesser General Public License
v2.1 vorbis - BSD 3-Clause License libsndfile - GNU Lesser General
Public License v2.1

Included Ruby Libraries for Spider Language Server (contents of
app/server/ruby/vendor/) ActiveSupport - MIT License Atomic - Apache
License, Version 2.0 Blankslate - MIT License i81n - MIT License
Kramdown - MIT License Locale - Ruby License Memoist - MIT License
Metaclass - MIT License MiniTest - Ruby License Mocha - MIT License
Multi JSON - MIT License Polyglot - MIT License Rouge - MIT License
Ruby Beautify - MIT License Ruby Prof - BSD 2-Clause License Rugged
- MIT License Text - MIT License Thread Safe - Apache License,
Version 2.0 Tomlrb - MIT License WaveFile - MIT License

Dynamically Linked Libraries for Tau IO Server NIFs sp_midi - MIT
License sp_link - MIT License Ableton Link - GNU General Public
License v2 RtMidi - MIT License + sharing request

Included Elixir Libraries for Tau IO Server (contents of
app/server/beam/tau/deps/): bunt - MIT License castore - Apache
License, Version 2.0 connection - Apache License, Version 2.0 cowboy
- ISC License cowboy_telemetry - Apache License, Version 2.0 cowlib
- ISC License credo - MIT License db_connection - Apache License,
Version 2.0 decimal - Apache License, Version 2.0 ecto - Apache
License, Version 2.0 ecto_sql - Apache License, Version 2.0 eflambe
- Apache License, Version 2.0 esbuild - MIT License exsync - BSD
3-Clause License file_system - WTFPL flame_on - MIT License floki
- MIT License gettext - Apache License, Version 2.0 heroicons - MIT
License html_entities - MIT License jason - Apache License, Version
2.0 logger_file_backend - MIT License mime - Apache License, Version
2.0 petal_components - MIT License phoenix - MIT License phoenix_ecto
- MIT License phoenix_html - MIT License phoenix_live_dashboard -
MIT License phoenix_live_reload - MIT License phoenix_live_view -
MIT License phoenix_pubsub - MIT License phoenix_template - MIT
License phoenix_view - MIT License plug - Apache License, Version
2.0 plug_cowboy - Apache License, Version 2.0 plug_crypto - Apache
License, Version 2.0 ranch - ISC License rustler - MIT License
tailwind - MIT License telemetry - Apache License, Version 2.0
telemetry_metrics - Apache License, Version 2.0 telemetry_poller -
Apache License, Version 2.0 toml - Apache License, Version 2.0
websock - MIT License websock_adapter - MIT License

Last Log repeated 2 times
Included Javascript Libraries for Tau IO Server (contents of
app/server/beam/tau/assets/vendor/): Alpine.js - MIT License topbar
- MIT License Hydra Synth - GNU General Public License v3 P5.js -
GNU General Public License v2.1

Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $58550D10
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $139DD3AB
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $59EB3819
verified   CRC32 $9E45D85A
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_HFS                      	/Volumes/Sonic Pi for Mac ARM64 v4.6.0

2026-03-06 15:26:21 : INFO  : sonicpi : Mounted: /Volumes/Sonic Pi for Mac ARM64 v4.6.0
2026-03-06 15:26:21 : INFO  : sonicpi : Verifying: /Volumes/Sonic Pi for Mac ARM64 v4.6.0/Sonic Pi.app
2026-03-06 15:26:21 : DEBUG : sonicpi : App size: 487M	/Volumes/Sonic Pi for Mac ARM64 v4.6.0/Sonic Pi.app
2026-03-06 15:26:40 : DEBUG : sonicpi : Debugging enabled, App Verification output was:
/Volumes/Sonic Pi for Mac ARM64 v4.6.0/Sonic Pi.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Samuel Aaron (MM65S3L4NG)

2026-03-06 15:26:40 : INFO  : sonicpi : Team ID matching: MM65S3L4NG (expected: MM65S3L4NG )
2026-03-06 15:26:40 : INFO  : sonicpi : Installing Sonic Pi version 4.6.0 on versionKey CFBundleShortVersionString.
2026-03-06 15:26:40 : INFO  : sonicpi : App has LSMinimumSystemVersion: 13
2026-03-06 15:26:40 : DEBUG : sonicpi : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-03-06 15:26:40 : INFO  : sonicpi : Finishing...
2026-03-06 15:26:43 : INFO  : sonicpi : name: Sonic Pi, appName: Sonic Pi.app
2026-03-06 15:26:43 : WARN  : sonicpi : No previous app found
2026-03-06 15:26:43 : WARN  : sonicpi : could not find Sonic Pi.app
2026-03-06 15:26:43 : REQ   : sonicpi : Installed Sonic Pi, version 4.6.0
2026-03-06 15:26:43 : INFO  : sonicpi : notifying
2026-03-06 15:26:43 : DEBUG : sonicpi : Unmounting /Volumes/Sonic Pi for Mac ARM64 v4.6.0
2026-03-06 15:26:43 : DEBUG : sonicpi : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-03-06 15:26:43 : DEBUG : sonicpi : DEBUG mode 1, not reopening anything
2026-03-06 15:26:43 : REQ   : sonicpi : All done!
2026-03-06 15:26:43 : REQ   : sonicpi : ################## End Installomator, exit code 0
```