### PR TITLE
Fix: 1password8 label app new version source

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -1,7 +1,6 @@
 1password8)
     name="1Password"
     type="pkg"
-    packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
     appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
     expectedTeamID="2BUA8C4S2C"

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -3,7 +3,7 @@
     type="pkg"
     packageID="com.1password.1password"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
-    appNewVersion=$(curl -s https://releases.1password.com/mac/ | grep "1Password for Mac" | head -n 1 | grep -o ">Updated to.*on<" | grep -oE "[0-9].*[0-9]" | cut -d - -f 1)
+    appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     #forcefulQuit=YES

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -5,5 +5,4 @@
     appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
-    #forcefulQuit=YES
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
An update to where the new version pulls from on the 1password8 label. Uses an RSS feed of release notes that should be more reliable for text parsing (assuming 1Password maintains its structure). Current code is pulling the beta release version number, leading to a cycle of constant updates, as the normal release is downloading/installing. Currently 8.12.5 is the release but the appNewVersion code is pulling 8.12.6 from the website.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```2026-03-06 15:23:25 : INFO  : 1password8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-06 15:23:25 : INFO  : 1password8 : Label type: pkg
2026-03-06 15:23:25 : INFO  : 1password8 : archiveName: 1Password.pkg
2026-03-06 15:23:25 : INFO  : 1password8 : No version found using packageID com.1password.1password
2026-03-06 15:23:25 : INFO  : 1password8 : name: 1Password, appName: 1Password.app
2026-03-06 15:23:25 : WARN  : 1password8 : No previous app found
2026-03-06 15:23:25 : WARN  : 1password8 : could not find 1Password.app
2026-03-06 15:23:25 : INFO  : 1password8 : appversion: 
2026-03-06 15:23:25 : INFO  : 1password8 : Latest version of 1Password is 8.12.5
2026-03-06 15:23:25 : REQ   : 1password8 : Downloading https://downloads.1password.com/mac/1Password.pkg to 1Password.pkg
2026-03-06 15:23:38 : INFO  : 1password8 : Downloaded 1Password.pkg – Type is  xar archive compressed TOC – SHA is 8ad28cfe1783a3ccf1007cc1022b6a076b0033b3 – Size is 360908 kB
2026-03-06 15:23:38 : REQ   : 1password8 : no more blocking processes, continue with update
2026-03-06 15:23:38 : REQ   : 1password8 : Installing 1Password
2026-03-06 15:23:38 : INFO  : 1password8 : Verifying: 1Password.pkg
2026-03-06 15:23:38 : INFO  : 1password8 : Team ID: 2BUA8C4S2C (expected: 2BUA8C4S2C )
2026-03-06 15:23:38 : INFO  : 1password8 : Installing 1Password.pkg to /
2026-03-06 15:23:45 : INFO  : 1password8 : Finishing...
2026-03-06 15:23:48 : INFO  : 1password8 : found packageID com.1password.1password installed, version 0
2026-03-06 15:23:48 : REQ   : 1password8 : Installed 1Password, version 8.12.5
2026-03-06 15:23:48 : INFO  : 1password8 : notifying
2026-03-06 15:23:48 : INFO  : 1password8 : Installomator did not close any apps, so no need to reopen any apps.
2026-03-06 15:23:48 : REQ   : 1password8 : All done!
2026-03-06 15:23:49 : REQ   : 1password8 : ################## End Installomator, exit code 0 
```


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
