### PR TITLE
fix garminexpress appNewVersion

### DIFF
--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -3,6 +3,6 @@ garminexpress)
     blockingProcesses=( "Garmin Express" "Garmin Express Service" )
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
-    appNewVersion="$(curl -fsL https://support.garmin.com/en-US/\?faq\=4QVp7mKSIA1LDk5fc1OHX8 | grep latest | grep -o "{.*}" | jq -r '.faq.content' | xmllint --html - 2>/dev/null | grep -o "for Mac: .* as" | grep -o "[0-9].*[0-9]").0"
+    appNewVersion="$(curl -fsL https://support.garmin.com/en-US/\?faq\=4QVp7mKSIA1LDk5fc1OHX8 | grep latest | grep -o "{.*}" | jq -r '.apiData.faq.content' | xmllint --html - 2>/dev/null | grep -o "for Mac: .* as" | grep -o "[0-9].*[0-9]").0"
     expectedTeamID="72ES32VZUA"
     ;;

--- a/fragments/labels/garminexpress.sh
+++ b/fragments/labels/garminexpress.sh
@@ -3,6 +3,7 @@ garminexpress)
     blockingProcesses=( "Garmin Express" "Garmin Express Service" )
     type="pkgInDmg"
     downloadURL="https://download.garmin.com/omt/express/GarminExpress.dmg"
-    appNewVersion="$(curl -fsL https://support.garmin.com/en-US/\?faq\=4QVp7mKSIA1LDk5fc1OHX8 | grep latest | grep -o "{.*}" | jq -r '.apiData.faq.content' | xmllint --html - 2>/dev/null | grep -o "for Mac: .* as" | grep -o "[0-9].*[0-9]").0"
+    garminJSON="$(curl -fsL https://support.garmin.com/en-US/\?faq\=4QVp7mKSIA1LDk5fc1OHX8 | grep latest | grep -o "{.*}")"
+    appNewVersion="$(getJSONValue "$garminJSON" "apiData" "faq" "content" | xmllint --html - 2>/dev/null | grep -o "for Mac: .* as" | grep -o "[0-9].*[0-9]").0"
     expectedTeamID="72ES32VZUA"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
Garmin seem to have change the formatting of their info website

**Installomator log** 
With the lastest version already installed:
```
2026-03-09 17:45:39 : INFO  : garminexpress : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-03-09 17:45:39 : INFO  : garminexpress : setting variable from argument NOTIFY=success
2026-03-09 17:45:39 : INFO  : garminexpress : setting variable from argument NOTIFY_DIALOG=1
2026-03-09 17:45:39 : INFO  : garminexpress : setting variable from argument DEBUG=0
2026-03-09 17:45:39 : INFO  : garminexpress : setting variable from argument INTERRUPT_DND=no
2026-03-09 17:45:39 : INFO  : garminexpress : Total items in argumentsArray: 5
2026-03-09 17:45:39 : INFO  : garminexpress : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 INTERRUPT_DND=no
2026-03-09 17:45:39 : REQ   : garminexpress : ################## Start Installomator v. 10.9beta, date 2026-03-09
2026-03-09 17:45:39 : INFO  : garminexpress : ################## Version: 10.9beta
2026-03-09 17:45:39 : INFO  : garminexpress : ################## Date: 2026-03-09
2026-03-09 17:45:39 : INFO  : garminexpress : ################## garminexpress
2026-03-09 17:45:40 : INFO  : garminexpress : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 INTERRUPT_DND=no
2026-03-09 17:45:40 : INFO  : garminexpress : BLOCKING_PROCESS_ACTION=tell_user
2026-03-09 17:45:40 : INFO  : garminexpress : NOTIFY=success
2026-03-09 17:45:40 : INFO  : garminexpress : LOGGING=INFO
2026-03-09 17:45:40 : INFO  : garminexpress : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-09 17:45:40 : INFO  : garminexpress : Label type: pkgInDmg
2026-03-09 17:45:40 : INFO  : garminexpress : archiveName: Garmin Express.dmg
2026-03-09 17:45:40 : INFO  : garminexpress : App(s) found: /Applications/Garmin Express.app
2026-03-09 17:45:40 : INFO  : garminexpress : found app at /Applications/Garmin Express.app, version 7.28.0.0, on versionKey CFBundleShortVersionString
2026-03-09 17:45:40 : INFO  : garminexpress : appversion: 7.28.0.0
2026-03-09 17:45:40 : INFO  : garminexpress : Latest version of Garmin Express is 7.28.0.0
2026-03-09 17:45:40 : INFO  : garminexpress : There is no newer version available.
2026-03-09 17:45:40 : INFO  : garminexpress : Installomator did not close any apps, so no need to reopen any apps.
2026-03-09 17:45:40 : REQ   : garminexpress : No newer version.
2026-03-09 17:45:40 : REQ   : garminexpress : ################## End Installomator, exit code 0
```