### PR TITLE
fix logitechghub appNewVersion

### DIFF
--- a/fragments/labels/logitechghub.sh
+++ b/fragments/labels/logitechghub.sh
@@ -6,9 +6,9 @@ logighub)
     installerTool="lghub_installer.app"
     type="zip"
     versionKey="CFBundleVersion"
-    onlineHTMLinfo=$(curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.logi.com/api/v2/help_center/en-us/articles.json\?label_names\=webcontent\=productdownload,webproduct\=b972df0c-7db0-11e9-b911-fb4b2d0df96c,webos\=mac-macos-x-15.0 | jq -r '.articles.[0].body')
+    onlineHTMLinfo=$(curl -fs https://support.logi.com/api/v2/help_center/en-us/articles.json\?label_names\=webcontent\=productdownload,webproduct\=b972df0c-7db0-11e9-b911-fb4b2d0df96c,webos\=mac-macos-x-15.0 | jq -r '.articles|sort_by(.id)|map(select(.name=="Logitech G HUB")).[].body')
     downloadURL=$(echo ${onlineHTMLinfo} | xmllint --html --xpath 'string(//div/div/ul/div/a/@href)' -)
-    appNewVersion=$(echo ${onlineHTMLinfo} | xmllint --html --xpath 'string(//li[b/span= "Software Version: "])' - | tail -1 | awk '{print$3}' -)
+    appNewVersion=$(echo ${onlineHTMLinfo} | grep "Software Version" | grep -o "[0-9].*[0-9]" | sort | tail -1)
     CLIInstaller="lghub_installer.app/Contents/MacOS/lghub_installer"
     CLIArguments=(--silent)
     expectedTeamID="QED4VVPZWA"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Previous method worked a while, until Logi decided to add an older version with a higher id in the json.
This just bluntly sorts for the latest version, and pick the download url for the highest id (so far all id have the same download url).
I also removed the curl -H part, since that part isn't needed anymore.

**Installomator log**
With the latest version already installed:
```
➜  Installomator git:(deploy) ✗ sudo ./assemble.sh logitechghub NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0 INTERRUPT_DND=no
2026-03-10 09:21:14 : INFO  : logitechghub : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-03-10 09:21:14 : INFO  : logitechghub : setting variable from argument NOTIFY=success
2026-03-10 09:21:14 : INFO  : logitechghub : setting variable from argument NOTIFY_DIALOG=1
2026-03-10 09:21:14 : INFO  : logitechghub : setting variable from argument DEBUG=0
2026-03-10 09:21:14 : INFO  : logitechghub : setting variable from argument INTERRUPT_DND=no
2026-03-10 09:21:14 : INFO  : logitechghub : Total items in argumentsArray: 5
2026-03-10 09:21:14 : INFO  : logitechghub : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 INTERRUPT_DND=no
2026-03-10 09:21:14 : REQ   : logitechghub : ################## Start Installomator v. 10.9beta, date 2026-03-10
2026-03-10 09:21:14 : INFO  : logitechghub : ################## Version: 10.9beta
2026-03-10 09:21:14 : INFO  : logitechghub : ################## Date: 2026-03-10
2026-03-10 09:21:14 : INFO  : logitechghub : ################## logitechghub
2026-03-10 09:21:14 : INFO  : logitechghub : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 INTERRUPT_DND=no
2026-03-10 09:21:14 : INFO  : logitechghub : BLOCKING_PROCESS_ACTION=tell_user
2026-03-10 09:21:14 : INFO  : logitechghub : NOTIFY=success
2026-03-10 09:21:14 : INFO  : logitechghub : LOGGING=INFO
2026-03-10 09:21:14 : INFO  : logitechghub : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-10 09:21:14 : INFO  : logitechghub : Label type: zip
2026-03-10 09:21:14 : INFO  : logitechghub : archiveName: lghub_installer.zip
2026-03-10 09:21:14 : INFO  : logitechghub : no blocking processes defined, using Logi G-HUB as default
2026-03-10 09:21:14 : INFO  : logitechghub : App(s) found: /Applications/lghub.app
2026-03-10 09:21:14 : INFO  : logitechghub : found app at /Applications/lghub.app, version 2026.1.829723, on versionKey CFBundleVersion
2026-03-10 09:21:14 : INFO  : logitechghub : appversion: 2026.1.829723
2026-03-10 09:21:14 : INFO  : logitechghub : Latest version of Logi G-HUB is 2026.1.829723
2026-03-10 09:21:14 : INFO  : logitechghub : There is no newer version available.
2026-03-10 09:21:14 : INFO  : logitechghub : Installomator did not close any apps, so no need to reopen any apps.
2026-03-10 09:21:14 : REQ   : logitechghub : No newer version.
2026-03-10 09:21:14 : REQ   : logitechghub : ################## End Installomator, exit code 0 
```