### PR TITLE
Create GOVERNANCE.md definition to create a new community reviewer role

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,63 @@
+# Governance
+
+This project is maintained by a small group of core maintainers, with support from community contributors and reviewers. The goal is to keep the project healthy, responsive, and welcoming while maintaining quality and stability.
+
+## Roles
+
+### Contributors
+
+Anyone can contribute by:
+
+* Opening issues
+* Submitting pull requests
+* Suggesting improvements
+* Reporting bugs
+
+No special permissions are required. Contributors participate through the standard GitHub workflow.
+
+---
+
+### Community Reviewers
+
+Trusted contributors who help keep PRs moving.
+
+Responsibilities:
+
+* Review and comment on pull requests
+* Provide constructive feedback
+* Approve PRs
+* Help contributors update their PRs
+
+Community Reviewers have **Write access**, but cannot merge into protected branches.
+
+---
+
+### Maintainers
+
+Core team responsible for merging and publishing releases.
+
+Responsibilities:
+
+* Merge approved PRs
+* Maintain release quality
+* Manage project infrastructure (CI, automation, etc.)
+* Make final decisions when needed
+
+Maintainers have **Admin or Maintain permissions**.
+
+---
+
+## Pull Request Workflow
+
+1. Contributor submits a PR
+2. Community Reviewer or Maintainer reviews and provides feedback
+3. Once approved, a Maintainer merges the PR
+
+Branch protection ensures that only Maintainers can merge into protected branches.
+
+---
+
+## Becoming a Reviewer or Maintainer
+
+* Reviewers: invited based on consistent contributions and helpful feedback
+* Maintainers: selected from Reviewers who demonstrate interest in long-term support of the project, deep familiarity with the project, and a history of contributions.


### PR DESCRIPTION
New governance definition to add a new Community Reviewer role to help with reviewing and approving PRs.

A community reviewer role would be allowed to approve PRs so they are ready for maintainers to merge. The community reviewer role needs write access to approve PRs in a way that counts toward protected branch rules. Branch protection rules will be used so that PRs must be approved, only reviewers or maintainers can approve, and only maintainers can merge PRs. Branch protection rules can only be edited by maintainers and admins. 

I can't submit a new branch rule as a PR but the instructions are below.

**Creating the branch rule:**
Go to Settings → Branches
Add or edit a Branch protection rule for the branch (e.g., main). We'll enable these on main, release, and dev.

Enable these:
✅ Require a pull request before merging
✅ Require approvals
✅ Require status checks to pass (like the LF check)
✅ Restrict who can push to matching branches

Then configure the restriction so that:
Only Admins (or a specific Maintainers team) can push directly to the branch. Since merging a PR is effectively a push to the branch, this limits who can merge.