### PR TITLE
New label: Handy

### DIFF
--- a/fragments/labels/handy.sh
+++ b/fragments/labels/handy.sh
@@ -1,0 +1,15 @@
+handy)
+    # Handy - A free, open source, and extensible speech-to-text application
+    # https://github.com/cjpais/Handy
+    name="Handy"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(downloadURLFromGit "cjpais" "Handy")
+        appNewVersion=$(versionFromGit "cjpais" "Handy")
+    else
+        # Handy is only available for Apple Silicon (arm64) Macs
+        downloadURL=""
+        appNewVersion=""
+    fi
+    expectedTeamID="UWFLB4GC25"
+    ;;

--- a/fragments/labels/handy.sh
+++ b/fragments/labels/handy.sh
@@ -7,9 +7,9 @@ handy)
         downloadURL=$(downloadURLFromGit "cjpais" "Handy")
         appNewVersion=$(versionFromGit "cjpais" "Handy")
     else
-        # Handy is only available for Apple Silicon (arm64) Macs
-        printlog "Handy is only compatible with Apple Silicon (arm64) Macs." ERROR
-        cleanupAndExit 1 "Handy requires Apple Silicon" ERROR
+        archiveName="x64.dmg"
+        downloadURL=$(downloadURLFromGit "cjpais" "Handy")
+        appNewVersion=$(versionFromGit "cjpais" "Handy")
     fi
     expectedTeamID="UWFLB4GC25"
     ;;

--- a/fragments/labels/handy.sh
+++ b/fragments/labels/handy.sh
@@ -1,6 +1,4 @@
 handy)
-    # Handy - A free, open source, and extensible speech-to-text application
-    # https://github.com/cjpais/Handy
     name="Handy"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then

--- a/fragments/labels/handy.sh
+++ b/fragments/labels/handy.sh
@@ -8,8 +8,8 @@ handy)
         appNewVersion=$(versionFromGit "cjpais" "Handy")
     else
         # Handy is only available for Apple Silicon (arm64) Macs
-        downloadURL=""
-        appNewVersion=""
+        printlog "Handy is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 1 "Handy requires Apple Silicon" ERROR
     fi
     expectedTeamID="UWFLB4GC25"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes.

**Additional context** Add any other context about the label or fix here.

This label will install [Handy](https://handy.computer/), _the free and open source app for speech to text_.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

No issues.

```code
# sudo utils/assemble.sh handy DEBUG=1
2026-03-11 14:27:03 : INFO  : handy : setting variable from argument DEBUG=1
2026-03-11 14:27:03 : INFO  : handy : Total items in argumentsArray: 1
2026-03-11 14:27:03 : INFO  : handy : argumentsArray: DEBUG=1
2026-03-11 14:27:03 : REQ   : handy : ################## Start Installomator v. 10.9beta, date 2026-03-11
2026-03-11 14:27:03 : INFO  : handy : ################## Version: 10.9beta
2026-03-11 14:27:03 : INFO  : handy : ################## Date: 2026-03-11
2026-03-11 14:27:03 : INFO  : handy : ################## handy
2026-03-11 14:27:03 : DEBUG : handy : DEBUG mode 1 enabled.
2026-03-11 14:27:05 : INFO  : handy : Reading arguments again: DEBUG=1
2026-03-11 14:27:05 : DEBUG : handy : argument: DEBUG=1
2026-03-11 14:27:05 : DEBUG : handy : name=Handy
2026-03-11 14:27:05 : DEBUG : handy : appName=
2026-03-11 14:27:05 : DEBUG : handy : type=dmg
2026-03-11 14:27:05 : DEBUG : handy : archiveName=
2026-03-11 14:27:05 : DEBUG : handy : downloadURL=https://github.com/cjpais/Handy/releases/download/v0.7.10/Handy_0.7.10_aarch64.dmg
2026-03-11 14:27:05 : DEBUG : handy : curlOptions=
2026-03-11 14:27:05 : DEBUG : handy : appNewVersion=0.7.10
2026-03-11 14:27:05 : DEBUG : handy : appCustomVersion function: Not defined
2026-03-11 14:27:05 : DEBUG : handy : versionKey=CFBundleShortVersionString
2026-03-11 14:27:05 : DEBUG : handy : packageID=
2026-03-11 14:27:05 : DEBUG : handy : pkgName=
2026-03-11 14:27:05 : DEBUG : handy : choiceChangesXML=
2026-03-11 14:27:05 : DEBUG : handy : expectedTeamID=UWFLB4GC25
2026-03-11 14:27:05 : DEBUG : handy : blockingProcesses=
2026-03-11 14:27:05 : DEBUG : handy : installerTool=
2026-03-11 14:27:05 : DEBUG : handy : CLIInstaller=
2026-03-11 14:27:05 : DEBUG : handy : CLIArguments=
2026-03-11 14:27:05 : DEBUG : handy : updateTool=
2026-03-11 14:27:05 : DEBUG : handy : updateToolArguments=
2026-03-11 14:27:05 : DEBUG : handy : updateToolRunAsCurrentUser=
2026-03-11 14:27:05 : INFO  : handy : BLOCKING_PROCESS_ACTION=tell_user
2026-03-11 14:27:05 : INFO  : handy : NOTIFY=success
2026-03-11 14:27:05 : INFO  : handy : LOGGING=DEBUG
2026-03-11 14:27:05 : INFO  : handy : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-11 14:27:05 : INFO  : handy : Label type: dmg
2026-03-11 14:27:05 : INFO  : handy : archiveName: Handy.dmg
2026-03-11 14:27:05 : INFO  : handy : no blocking processes defined, using Handy as default
2026-03-11 14:27:05 : DEBUG : handy : Changing directory to /Users/hbokh/Projects/Apple/Github/Installomator/build
2026-03-11 14:27:05 : INFO  : handy : name: Handy, appName: Handy.app
2026-03-11 14:27:05 : WARN  : handy : No previous app found
2026-03-11 14:27:05 : WARN  : handy : could not find Handy.app
2026-03-11 14:27:05 : INFO  : handy : appversion:
2026-03-11 14:27:05 : INFO  : handy : Latest version of Handy is 0.7.10
2026-03-11 14:27:05 : REQ   : handy : Downloading https://github.com/cjpais/Handy/releases/download/v0.7.10/Handy_0.7.10_aarch64.dmg to Handy.dmg
2026-03-11 14:27:05 : DEBUG : handy : No Dialog connection, just download
2026-03-11 14:27:10 : INFO  : handy : Downloaded Handy.dmg – Type is  zlib compressed data – SHA is e462f2317fb628cb51e6b52f57413096f11f6b3d – Size is 16328 kB
2026-03-11 14:27:10 : DEBUG : handy : DEBUG mode 1, not checking for blocking processes
2026-03-11 14:27:10 : REQ   : handy : Installing Handy
2026-03-11 14:27:10 : INFO  : handy : Mounting /Users/hbokh/Projects/Apple/Github/Installomator/build/Handy.dmg
2026-03-11 14:27:13 : DEBUG : handy : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $C32B4D1B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $A3C38BDA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $600AC631
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified CRC32 $FC352805
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $600AC631
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $5C3D9054
verified CRC32 $0C7E8F1C
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Handy

2026-03-11 14:27:13 : INFO  : handy : Mounted: /Volumes/Handy
2026-03-11 14:27:13 : INFO  : handy : Verifying: /Volumes/Handy/Handy.app
2026-03-11 14:27:13 : DEBUG : handy : App size:  33M	/Volumes/Handy/Handy.app
2026-03-11 14:27:13 : DEBUG : handy : Debugging enabled, App Verification output was:
/Volumes/Handy/Handy.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Christopher Pais (UWFLB4GC25)

2026-03-11 14:27:13 : INFO  : handy : Team ID matching: UWFLB4GC25 (expected: UWFLB4GC25 )
2026-03-11 14:27:13 : INFO  : handy : Installing Handy version 0.7.10 on versionKey CFBundleShortVersionString.
2026-03-11 14:27:13 : INFO  : handy : App has LSMinimumSystemVersion: 10.13
2026-03-11 14:27:13 : DEBUG : handy : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-03-11 14:27:13 : INFO  : handy : Finishing...
2026-03-11 14:27:16 : INFO  : handy : name: Handy, appName: Handy.app
2026-03-11 14:27:16 : WARN  : handy : No previous app found
2026-03-11 14:27:16 : WARN  : handy : could not find Handy.app
2026-03-11 14:27:16 : REQ   : handy : Installed Handy, version 0.7.10
2026-03-11 14:27:16 : INFO  : handy : notifying
2026-03-11 14:27:17 : DEBUG : handy : Unmounting /Volumes/Handy
2026-03-11 14:27:17 : DEBUG : handy : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-03-11 14:27:17 : DEBUG : handy : DEBUG mode 1, not reopening anything
2026-03-11 14:27:17 : REQ   : handy : All done!
2026-03-11 14:27:17 : REQ   : handy : ################## End Installomator, exit code 0
```