### PR TITLE
fix(1passwordcli): exclude beta versions, install stable only

### DIFF
--- a/fragments/labels/1passwordcli.sh
+++ b/fragments/labels/1passwordcli.sh
@@ -2,7 +2,7 @@
     name="1Password CLI"
     type="pkg"
     #packageID="com.1password.op"
-    downloadURL=$(curl -fs https://app-updates.agilebits.com/product_history/CLI2 | grep -m 1 -i op_apple_universal | cut -d'"' -f 2)
+    downloadURL=$(curl -fs https://app-updates.agilebits.com/product_history/CLI2 | grep -i op_apple_universal | grep -v -i beta | head -1 | cut -d'"' -f 2)
     appNewVersion=$(echo $downloadURL | sed -E 's/.*\/[a-zA-Z_]*([0-9.]*)\..*/\1/g')
     appCustomVersion(){ /usr/local/bin/op -v }
     expectedTeamID="2BUA8C4S2C"


### PR DESCRIPTION
### Issue

product_history/CLI2 lists newest first; beta releases are included and often appears before stable. 

### Fix 

Add `grep -v beta | head -1` to select first stable URL. Same pattern as openvpnconnectv3 label.

- Fixes #1687 (version mismatch / reinstall loop when beta installed) 
- Addresses scriptingosx feedback on #1688 (ignore betas per Installomator policy)

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes #1687
Fixes #1688

```bash
❯ sudo ./utils/assemble.sh 1passwordcli DEBUG=1
Password:
2026-03-13 13:22:57 : INFO  : 1passwordcli : setting variable from argument DEBUG=1
2026-03-13 13:22:57 : INFO  : 1passwordcli : Total items in argumentsArray: 1
2026-03-13 13:22:57 : INFO  : 1passwordcli : argumentsArray: DEBUG=1
2026-03-13 13:22:57 : REQ   : 1passwordcli : ################## Start Installomator v. 10.9beta, date 2026-03-13
2026-03-13 13:22:57 : INFO  : 1passwordcli : ################## Version: 10.9beta
2026-03-13 13:22:57 : INFO  : 1passwordcli : ################## Date: 2026-03-13
2026-03-13 13:22:57 : INFO  : 1passwordcli : ################## 1passwordcli
2026-03-13 13:22:57 : DEBUG : 1passwordcli : DEBUG mode 1 enabled.
2026-03-13 13:22:59 : INFO  : 1passwordcli : Reading arguments again: DEBUG=1
2026-03-13 13:22:59 : DEBUG : 1passwordcli : argument: DEBUG=1
2026-03-13 13:22:59 : DEBUG : 1passwordcli : name=1Password CLI
2026-03-13 13:22:59 : DEBUG : 1passwordcli : appName=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : type=pkg
2026-03-13 13:22:59 : DEBUG : 1passwordcli : archiveName=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : downloadURL=https://cache.agilebits.com/dist/1P/op2/pkg/v2.32.1/op_apple_universal_v2.32.1.pkg
2026-03-13 13:22:59 : DEBUG : 1passwordcli : curlOptions=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : appNewVersion=2.32.1
2026-03-13 13:22:59 : DEBUG : 1passwordcli : appCustomVersion function: Defined.
2026-03-13 13:22:59 : DEBUG : 1passwordcli : versionKey=CFBundleShortVersionString
2026-03-13 13:22:59 : DEBUG : 1passwordcli : packageID=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : pkgName=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : choiceChangesXML=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : expectedTeamID=2BUA8C4S2C
2026-03-13 13:22:59 : DEBUG : 1passwordcli : blockingProcesses=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : installerTool=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : CLIInstaller=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : CLIArguments=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : updateTool=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : updateToolArguments=
2026-03-13 13:22:59 : DEBUG : 1passwordcli : updateToolRunAsCurrentUser=
2026-03-13 13:22:59 : INFO  : 1passwordcli : BLOCKING_PROCESS_ACTION=tell_user
2026-03-13 13:22:59 : INFO  : 1passwordcli : NOTIFY=success
2026-03-13 13:22:59 : INFO  : 1passwordcli : LOGGING=DEBUG
2026-03-13 13:22:59 : INFO  : 1passwordcli : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-13 13:22:59 : INFO  : 1passwordcli : Label type: pkg
2026-03-13 13:22:59 : INFO  : 1passwordcli : archiveName: 1Password CLI.pkg
2026-03-13 13:22:59 : INFO  : 1passwordcli : no blocking processes defined, using 1Password CLI as default
2026-03-13 13:22:59 : DEBUG : 1passwordcli : Changing directory to /Users/kellan/workspace/Installomator/build
appCustomVersion: no such file or directory: /usr/local/bin/op
2026-03-13 13:22:59 : INFO  : 1passwordcli : Custom App Version detection is used, found
2026-03-13 13:22:59 : INFO  : 1passwordcli : appversion:
2026-03-13 13:22:59 : INFO  : 1passwordcli : Latest version of 1Password CLI is 2.32.1
2026-03-13 13:22:59 : INFO  : 1passwordcli : 1Password CLI.pkg exists and DEBUG mode 1 enabled, skipping download
2026-03-13 13:22:59 : DEBUG : 1passwordcli : DEBUG mode 1, not checking for blocking processes
2026-03-13 13:22:59 : REQ   : 1passwordcli : Installing 1Password CLI
2026-03-13 13:22:59 : INFO  : 1passwordcli : Verifying: 1Password CLI.pkg
2026-03-13 13:22:59 : DEBUG : 1passwordcli : File list: -rw-r--r--  1 kellan  staff    26M Mar 13 12:59 1Password CLI.pkg
2026-03-13 13:22:59 : DEBUG : 1passwordcli : File type: 1Password CLI.pkg: xar archive compressed TOC: 4817, SHA-1 checksum
2026-03-13 13:23:00 : DEBUG : 1passwordcli : spctlOut is 1Password CLI.pkg: accepted
2026-03-13 13:23:00 : DEBUG : 1passwordcli : source=Notarized Developer ID
2026-03-13 13:23:00 : DEBUG : 1passwordcli : origin=Developer ID Installer: AgileBits Inc. (2BUA8C4S2C)
2026-03-13 13:23:00 : INFO  : 1passwordcli : Team ID: 2BUA8C4S2C (expected: 2BUA8C4S2C )
2026-03-13 13:23:00 : DEBUG : 1passwordcli : DEBUG enabled, skipping installation
2026-03-13 13:23:00 : INFO  : 1passwordcli : Finishing...
appCustomVersion: no such file or directory: /usr/local/bin/op
2026-03-13 13:23:03 : INFO  : 1passwordcli : Custom App Version detection is used, found
2026-03-13 13:23:03 : REQ   : 1passwordcli : Installed 1Password CLI, version 2.32.1
2026-03-13 13:23:03 : INFO  : 1passwordcli : notifying
2026-03-13 13:23:03 : DEBUG : 1passwordcli : DEBUG mode 1, not reopening anything
2026-03-13 13:23:03 : REQ   : 1passwordcli : All done!
2026-03-13 13:23:03 : REQ   : 1passwordcli : ################## End Installomator, exit code 0
```