### PR TITLE
Update overflow.sh

### DIFF
--- a/fragments/labels/overflow.sh
+++ b/fragments/labels/overflow.sh
@@ -1,7 +1,7 @@
 overflow)
     name="Overflow"
     type="dmg"
-    downloadURL="$(curl -sL 'https://overflow.io/download/' | awk -F '"' '/app-updates.overflow.io\/packages\/updates\/osx_64/ { print $8; exit }')"
+    downloadURL="$(curl -LsS https://overflow.io/download/ | grep -oE 'https://[^"]+\.dmg'))"
     appNewVersion=$(echo "$downloadURL" | awk -F '-|[.]dmg' '{ print $(NF-1) }')
     expectedTeamID="7TK7YSGJFF"
     versionKey="CFBundleShortVersionString"

--- a/fragments/labels/overflow.sh
+++ b/fragments/labels/overflow.sh
@@ -1,7 +1,7 @@
 overflow)
     name="Overflow"
     type="dmg"
-    downloadURL="$(curl -LsS https://overflow.io/download/ | grep -oE 'https://[^"]+\.dmg'))"
+    downloadURL="$(curl -LsS https://overflow.io/download/ | grep -oE 'https://[^"]+\.dmg')"
     appNewVersion=$(echo "$downloadURL" | awk -F '-|[.]dmg' '{ print $(NF-1) }')
     expectedTeamID="7TK7YSGJFF"
     versionKey="CFBundleShortVersionString"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
Fixing the downloadURL parsing and making it significantly simpler in the process.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
% utils/assemble.sh overflow DEBUG=1     
2026-03-15 11:56:29 : INFO  : overflow : setting variable from argument DEBUG=1
2026-03-15 11:56:29 : INFO  : overflow : Total items in argumentsArray: 1
2026-03-15 11:56:29 : INFO  : overflow : argumentsArray: DEBUG=1
2026-03-15 11:56:29 : REQ   : overflow : ################## Start Installomator v. 10.9beta, date 2026-03-15
2026-03-15 11:56:29 : INFO  : overflow : ################## Version: 10.9beta
2026-03-15 11:56:29 : INFO  : overflow : ################## Date: 2026-03-15
2026-03-15 11:56:29 : INFO  : overflow : ################## overflow
2026-03-15 11:56:29 : DEBUG : overflow : DEBUG mode 1 enabled.
2026-03-15 11:56:29 : INFO  : overflow : SwiftDialog is not installed, clear cmd file var
2026-03-15 11:56:30 : INFO  : overflow : Reading arguments again: DEBUG=1
2026-03-15 11:56:30 : DEBUG : overflow : argument: DEBUG=1
2026-03-15 11:56:30 : DEBUG : overflow : name=Overflow
2026-03-15 11:56:30 : DEBUG : overflow : appName=
2026-03-15 11:56:30 : DEBUG : overflow : type=dmg
2026-03-15 11:56:30 : DEBUG : overflow : archiveName=
2026-03-15 11:56:30 : DEBUG : overflow : downloadURL=https://app-updates.overflow.io/packages/updates/osx_64/a8ff69aba62e8e11c04a0861f9c4b32bd53a135e/Overflow-3.5.410.dmg)
2026-03-15 11:56:30 : DEBUG : overflow : curlOptions=
2026-03-15 11:56:30 : DEBUG : overflow : appNewVersion=3.5.410
2026-03-15 11:56:30 : DEBUG : overflow : appCustomVersion function: Not defined
2026-03-15 11:56:30 : DEBUG : overflow : versionKey=CFBundleShortVersionString
2026-03-15 11:56:30 : DEBUG : overflow : packageID=
2026-03-15 11:56:30 : DEBUG : overflow : pkgName=
2026-03-15 11:56:30 : DEBUG : overflow : choiceChangesXML=
2026-03-15 11:56:30 : DEBUG : overflow : expectedTeamID=7TK7YSGJFF
2026-03-15 11:56:30 : DEBUG : overflow : blockingProcesses=
2026-03-15 11:56:30 : DEBUG : overflow : installerTool=
2026-03-15 11:56:30 : DEBUG : overflow : CLIInstaller=
2026-03-15 11:56:30 : DEBUG : overflow : CLIArguments=
2026-03-15 11:56:30 : DEBUG : overflow : updateTool=
2026-03-15 11:56:30 : DEBUG : overflow : updateToolArguments=
2026-03-15 11:56:30 : DEBUG : overflow : updateToolRunAsCurrentUser=
2026-03-15 11:56:30 : INFO  : overflow : BLOCKING_PROCESS_ACTION=tell_user
2026-03-15 11:56:30 : INFO  : overflow : NOTIFY=success
2026-03-15 11:56:30 : INFO  : overflow : LOGGING=DEBUG
2026-03-15 11:56:31 : INFO  : overflow : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-15 11:56:31 : INFO  : overflow : Label type: dmg
2026-03-15 11:56:31 : INFO  : overflow : archiveName: Overflow.dmg
2026-03-15 11:56:31 : INFO  : overflow : no blocking processes defined, using Overflow as default
2026-03-15 11:56:31 : DEBUG : overflow : Changing directory to /Users/dkuehling/GitHub/Installomator/build
2026-03-15 11:56:31 : INFO  : overflow : App(s) found: /Applications/Overflow.app
2026-03-15 11:56:31 : INFO  : overflow : found app at /Applications/Overflow.app, version 3.5.410, on versionKey CFBundleShortVersionString
2026-03-15 11:56:31 : INFO  : overflow : appversion: 3.5.410
2026-03-15 11:56:31 : INFO  : overflow : Latest version of Overflow is 3.5.410
2026-03-15 11:56:31 : WARN  : overflow : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-03-15 11:56:31 : INFO  : overflow : Overflow.dmg exists and DEBUG mode 1 enabled, skipping download
2026-03-15 11:56:31 : DEBUG : overflow : DEBUG mode 1, not checking for blocking processes
2026-03-15 11:56:31 : REQ   : overflow : Installing Overflow
2026-03-15 11:56:31 : INFO  : overflow : Mounting /Users/dkuehling/GitHub/Installomator/build/Overflow.dmg
2026-03-15 11:56:31 : DEBUG : overflow : Debugging enabled, dmgmount output was:
expected   CRC32 $97D3FE77
/dev/disk8              GUID_partition_scheme
/dev/disk8s1            Apple_HFS                       /Volumes/Overflow

2026-03-15 11:56:31 : INFO  : overflow : Mounted: /Volumes/Overflow
2026-03-15 11:56:31 : INFO  : overflow : Verifying: /Volumes/Overflow/Overflow.app
2026-03-15 11:56:31 : DEBUG : overflow : App size: 698M /Volumes/Overflow/Overflow.app
2026-03-15 11:56:35 : DEBUG : overflow : Debugging enabled, App Verification output was:
/Volumes/Overflow/Overflow.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: PROTOIO INC. (7TK7YSGJFF)

2026-03-15 11:56:35 : INFO  : overflow : Team ID matching: 7TK7YSGJFF (expected: 7TK7YSGJFF )
2026-03-15 11:56:35 : INFO  : overflow : Downloaded version of Overflow is 3.5.410 on versionKey CFBundleShortVersionString, same as installed.
2026-03-15 11:56:35 : DEBUG : overflow : Unmounting /Volumes/Overflow
2026-03-15 11:56:35 : DEBUG : overflow : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-03-15 11:56:35 : DEBUG : overflow : DEBUG mode 1, not reopening anything
2026-03-15 11:56:35 : REG   : overflow : No new version to install
2026-03-15 11:56:35 : REQ   : overflow : ################## End Installomator, exit code 0
```