### PR TITLE
thoriumreader_new_label

### DIFF
--- a/fragments/labels/thoriumreader.sh
+++ b/fragments/labels/thoriumreader.sh
@@ -1,0 +1,11 @@
+thoriumreader)
+    name="Thorium"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(downloadURLFromGit edrlab thorium-reader arm64.dmg)
+    else
+        downloadURL=$(downloadURLFromGit edrlab thorium-reader .dmg | grep -v arm64)
+    fi
+    appNewVersion=$(versionFromGit edrlab thorium-reader)
+    expectedTeamID="327YA3JNGT"
+    ;;


### PR DESCRIPTION
output
```
# sudo Installomator/utils/assemble.sh thoriumreader DEBUG=0
2026-03-16 11:59:03 : INFO  : thoriumreader : setting variable from argument DEBUG=0
2026-03-16 11:59:03 : INFO  : thoriumreader : Total items in argumentsArray: 1
2026-03-16 11:59:03 : INFO  : thoriumreader : argumentsArray: DEBUG=0
2026-03-16 11:59:03 : REQ   : thoriumreader : ################## Start Installomator v. 10.9beta, date 2026-03-16
2026-03-16 11:59:03 : INFO  : thoriumreader : ################## Version: 10.9beta
2026-03-16 11:59:03 : INFO  : thoriumreader : ################## Date: 2026-03-16
2026-03-16 11:59:04 : INFO  : thoriumreader : ################## thoriumreader
2026-03-16 11:59:05 : INFO  : thoriumreader : Reading arguments again: DEBUG=0
2026-03-16 11:59:05 : INFO  : thoriumreader : BLOCKING_PROCESS_ACTION=tell_user
2026-03-16 11:59:05 : INFO  : thoriumreader : NOTIFY=success
2026-03-16 11:59:05 : INFO  : thoriumreader : LOGGING=INFO
2026-03-16 11:59:05 : INFO  : thoriumreader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-16 11:59:05 : INFO  : thoriumreader : Label type: dmg
2026-03-16 11:59:05 : INFO  : thoriumreader : archiveName: Thorium.dmg
2026-03-16 11:59:05 : INFO  : thoriumreader : no blocking processes defined, using Thorium as default
2026-03-16 11:59:05 : INFO  : thoriumreader : name: Thorium, appName: Thorium.app
2026-03-16 11:59:06 : WARN  : thoriumreader : No previous app found
2026-03-16 11:59:06 : WARN  : thoriumreader : could not find Thorium.app
2026-03-16 11:59:06 : INFO  : thoriumreader : appversion:
2026-03-16 11:59:06 : INFO  : thoriumreader : Latest version of Thorium is 3.3.0
2026-03-16 11:59:06 : REQ   : thoriumreader : Downloading https://github.com/edrlab/thorium-reader/releases/download/v3.3.0/Thorium-3.3.0-arm64.dmg to Thorium.dmg
2026-03-16 11:59:10 : INFO  : thoriumreader : Downloaded Thorium.dmg – Type is  zlib compressed data – SHA is f1b746380daeb8cbb6a99d0289f614709e3ce330 – Size is 148428 kB
2026-03-16 11:59:10 : REQ   : thoriumreader : no more blocking processes, continue with update
2026-03-16 11:59:10 : REQ   : thoriumreader : Installing Thorium
2026-03-16 11:59:10 : INFO  : thoriumreader : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wCH7EljWNS/Thorium.dmg
2026-03-16 11:59:13 : INFO  : thoriumreader : Mounted: /Volumes/Thorium 3.3.0-arm64 1
2026-03-16 11:59:13 : INFO  : thoriumreader : Verifying: /Volumes/Thorium 3.3.0-arm64 1/Thorium.app
2026-03-16 11:59:15 : INFO  : thoriumreader : Team ID matching: 327YA3JNGT (expected: 327YA3JNGT )
2026-03-16 11:59:15 : INFO  : thoriumreader : Installing Thorium version 3.3.0 on versionKey CFBundleShortVersionString.
2026-03-16 11:59:15 : INFO  : thoriumreader : App has LSMinimumSystemVersion: 12.0
2026-03-16 11:59:15 : INFO  : thoriumreader : Copy /Volumes/Thorium 3.3.0-arm64 1/Thorium.app to /Applications
2026-03-16 11:59:17 : WARN  : thoriumreader : Changing owner to u0105821
2026-03-16 11:59:17 : INFO  : thoriumreader : Finishing...
2026-03-16 11:59:20 : INFO  : thoriumreader : App(s) found: /Applications/Thorium.app
2026-03-16 11:59:20 : INFO  : thoriumreader : found app at /Applications/Thorium.app, version 3.3.0, on versionKey CFBundleShortVersionString
2026-03-16 11:59:20 : REQ   : thoriumreader : Installed Thorium, version 3.3.0
2026-03-16 11:59:20 : INFO  : thoriumreader : notifying
2026-03-16 11:59:21 : INFO  : thoriumreader : Installomator did not close any apps, so no need to reopen any apps.
2026-03-16 11:59:21 : REQ   : thoriumreader : All done!
2026-03-16 11:59:21 : REQ   : thoriumreader : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This pull request adds a new Installomator label for Thorium Reader, an open-source eBook reading application developed by EDRLab. The label downloads the latest release from the project's GitHub repository, supports both Intel and Apple Silicon architectures by selecting the appropriate DMG, and determines the installed version using the GitHub release version. The label also verifies the application using the developer Team ID 327YA3JNGT.

Thorium Reader for macOS is a desktop application used to read digital publications such as EPUB, PDF, and DAISY accessible books. It supports features including bookmarks, annotations, text-to-speech, and accessibility tools for screen readers like VoiceOver. The application is distributed as a DMG and runs locally without requiring background services or bundled software.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
