### PR TITLE
Fix 'podman' label downloading wrong architecture

### DIFF
--- a/fragments/labels/podman.sh
+++ b/fragments/labels/podman.sh
@@ -1,8 +1,8 @@
 podman)
     name="Podman"
     type="pkg"
+    archiveName="podman-installer-macos-universal.pkg"
     downloadURL=$(downloadURLFromGit containers podman)
     appNewVersion=$(versionFromGit containers podman)
-    archiveName="podman-installer-macos-universal.pkg"
     expectedTeamID="HYSCB8KRL2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
`downloadURLFromGit()` uses `archiveName` to filter GitHub release assets. When `archiveName` was set after `downloadURL`, the function fell back to matching by file extension only, grabbing the first asset of the wrong architecture (e.g. amd64/arm64 vs universal)

This is a partial fix for #2809 for which `podmandesktop` and `podmandesktopairgap` labels are also affected. See
* https://github.com/Installomator/Installomator/pull/2877
* https://github.com/Installomator/Installomator/pull/2878

**Installomator log** 
```
2026-04-29 19:13:36 : INFO  : podman : setting variable from argument DEBUG=1
2026-04-29 19:13:36 : INFO  : podman : Total items in argumentsArray: 1
2026-04-29 19:13:36 : INFO  : podman : argumentsArray: DEBUG=1
2026-04-29 19:13:36 : REQ   : podman : ################## Start Installomator v. 10.9beta, date 2026-04-29
2026-04-29 19:13:36 : INFO  : podman : ################## Version: 10.9beta
2026-04-29 19:13:36 : INFO  : podman : ################## Date: 2026-04-29
2026-04-29 19:13:36 : INFO  : podman : ################## podman
2026-04-29 19:13:36 : DEBUG : podman : DEBUG mode 1 enabled.
2026-04-29 19:13:39 : INFO  : podman : Reading arguments again: DEBUG=1
2026-04-29 19:13:39 : DEBUG : podman : argument: DEBUG=1
2026-04-29 19:13:39 : DEBUG : podman : name=Podman
2026-04-29 19:13:39 : DEBUG : podman : appName=
2026-04-29 19:13:39 : DEBUG : podman : type=pkg
2026-04-29 19:13:39 : DEBUG : podman : archiveName=podman-installer-macos-universal.pkg
2026-04-29 19:13:39 : DEBUG : podman : downloadURL=https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-macos-universal.pkg
2026-04-29 19:13:39 : DEBUG : podman : curlOptions=
2026-04-29 19:13:39 : DEBUG : podman : appNewVersion=5.8.2
2026-04-29 19:13:39 : DEBUG : podman : appCustomVersion function: Not defined
2026-04-29 19:13:39 : DEBUG : podman : versionKey=CFBundleShortVersionString
2026-04-29 19:13:39 : DEBUG : podman : packageID=
2026-04-29 19:13:39 : DEBUG : podman : pkgName=
2026-04-29 19:13:39 : DEBUG : podman : choiceChangesXML=
2026-04-29 19:13:39 : DEBUG : podman : expectedTeamID=HYSCB8KRL2
2026-04-29 19:13:39 : DEBUG : podman : blockingProcesses=
2026-04-29 19:13:39 : DEBUG : podman : installerTool=
2026-04-29 19:13:39 : DEBUG : podman : CLIInstaller=
2026-04-29 19:13:39 : DEBUG : podman : CLIArguments=
2026-04-29 19:13:39 : DEBUG : podman : updateTool=
2026-04-29 19:13:39 : DEBUG : podman : updateToolArguments=
2026-04-29 19:13:39 : DEBUG : podman : updateToolRunAsCurrentUser=
2026-04-29 19:13:39 : INFO  : podman : BLOCKING_PROCESS_ACTION=tell_user
2026-04-29 19:13:39 : INFO  : podman : NOTIFY=success
2026-04-29 19:13:39 : INFO  : podman : LOGGING=DEBUG
2026-04-29 19:13:39 : INFO  : podman : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-29 19:13:39 : INFO  : podman : Label type: pkg
2026-04-29 19:13:39 : INFO  : podman : archiveName: podman-installer-macos-universal.pkg
2026-04-29 19:13:39 : INFO  : podman : no blocking processes defined, using Podman as default
2026-04-29 19:13:39 : DEBUG : podman : Changing directory to /Users/.../git/github/Installomator/Installomator/build
2026-04-29 19:13:39 : INFO  : podman : name: Podman, appName: Podman.app
2026-04-29 19:13:39 : INFO  : podman : App(s) found: /Library/Application Support/JamfAppInstallers/com.jamf.appinstallers.PodmanDesktop/db/StatusReport/Podman Desktop.app�/Applications/Podman Desktop.app�
2026-04-29 19:13:39 : WARN  : podman : could not determine location of Podman.app
2026-04-29 19:13:39 : INFO  : podman : appversion: 
2026-04-29 19:13:39 : INFO  : podman : Latest version of Podman is 5.8.2
2026-04-29 19:13:39 : INFO  : podman : podman-installer-macos-universal.pkg exists and DEBUG mode 1 enabled, skipping download
2026-04-29 19:13:39 : DEBUG : podman : DEBUG mode 1, not checking for blocking processes
2026-04-29 19:13:39 : REQ   : podman : Installing Podman
2026-04-29 19:13:39 : INFO  : podman : Verifying: podman-installer-macos-universal.pkg
2026-04-29 19:13:40 : DEBUG : podman : File list: -rw-r--r--@ 1 ...  staff    82M 18 Mar 11:17 podman-installer-macos-universal.pkg
2026-04-29 19:13:40 : DEBUG : podman : File type: podman-installer-macos-universal.pkg: xar archive compressed TOC: 4949, SHA-1 checksum
2026-04-29 19:13:40 : DEBUG : podman : spctlOut is podman-installer-macos-universal.pkg: accepted
2026-04-29 19:13:40 : DEBUG : podman : source=Notarized Developer ID
2026-04-29 19:13:40 : DEBUG : podman : origin=Developer ID Installer: Red Hat, Inc. (HYSCB8KRL2)
2026-04-29 19:13:40 : INFO  : podman : Team ID: HYSCB8KRL2 (expected: HYSCB8KRL2 )
2026-04-29 19:13:40 : DEBUG : podman : DEBUG enabled, skipping installation
2026-04-29 19:13:40 : INFO  : podman : Finishing...
2026-04-29 19:13:43 : INFO  : podman : name: Podman, appName: Podman.app
2026-04-29 19:13:43 : INFO  : podman : App(s) found: /Library/Application Support/JamfAppInstallers/com.jamf.appinstallers.PodmanDesktop/db/StatusReport/Podman Desktop.app�/Applications/Podman Desktop.app�
2026-04-29 19:13:43 : WARN  : podman : could not determine location of Podman.app
2026-04-29 19:13:43 : REQ   : podman : Installed Podman, version 5.8.2
2026-04-29 19:13:43 : INFO  : podman : notifying
2026-04-29 19:13:44 : DEBUG : podman : DEBUG mode 1, not reopening anything
2026-04-29 19:13:44 : REQ   : podman : All done!
2026-04-29 19:13:44 : REQ   : podman : ################## End Installomator, exit code 0 
```
