### PR TITLE
Fix jamovi label: switch to dl.jamovi.org and add arm64/x64 arch support

### DIFF
--- a/fragments/labels/jamovi.sh
+++ b/fragments/labels/jamovi.sh
@@ -2,19 +2,20 @@ jamovi)
     name="jamovi"
     type="dmg"
     baseURL="https://dl.jamovi.org"
-    
     if [[ $(arch) == "arm64" ]]; then
-    archSuffix="arm64"
+        archSuffix="arm64"
     elif [[ $(arch) == "i386" ]]; then
-    archSuffix="x64"
+        archSuffix="x64"
     else
-    printlog "ERROR: Unsupported architecture $(arch) for jamovi label" ERROR
-    exit 1
+        printlog "ERROR: Unsupported architecture $(arch) for jamovi label" ERROR
+        exit 1
     fi
     if [[ -n $jamoviLatest ]]; then
-    downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.[7-9][^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
+        downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.[7-9][^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
     else
-    downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.6[^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
+        downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.6[^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
     fi
     downloadURL="${baseURL}/${downloadFile}"
     appNewVersion="$(echo "$downloadFile" | cut -d '-' -f 2)"
+    expectedTeamID="9NCBP559AB"
+    ;;

--- a/fragments/labels/jamovi.sh
+++ b/fragments/labels/jamovi.sh
@@ -1,27 +1,27 @@
 jamovi)
     name="jamovi"
     type="dmg"
-    baseURL="https://www.jamovi.org"
+    baseURL="https://dl.jamovi.org"
 
-    # Detect architecture for separate arm64/x64 DMGs
     if [[ "$(arch)" == "arm64" ]]; then
         archSuffix="arm64"
     else
         archSuffix="x64"
     fi
 
-    # solid (stable) is listed first, current (latest) is listed second
     if [[ -n $jamoviLatest ]]; then
-        downloadPath=$(curl -sf "${baseURL}/download.html" \
-            | grep -o "/downloads/jamovi-[^\"]*-macos-${archSuffix}\.dmg" \
-            | tail -1)
+        # current = 2.7.x series (odd minor)
+        downloadFile=$(curl -sf "${baseURL}/" \
+            | grep -o "jamovi-2\.[7-9][^\"]*-macos-${archSuffix}\.dmg" \
+            | sort -V | tail -1)
     else
-        downloadPath=$(curl -sf "${baseURL}/download.html" \
-            | grep -o "/downloads/jamovi-[^\"]*-macos-${archSuffix}\.dmg" \
-            | head -1)
+        # solid = 2.6.x series (even minor)
+        downloadFile=$(curl -sf "${baseURL}/" \
+            | grep -o "jamovi-2\.6[^\"]*-macos-${archSuffix}\.dmg" \
+            | sort -V | tail -1)
     fi
 
-    downloadURL="${baseURL}${downloadPath}"
-    appNewVersion="$(echo "$downloadPath" | cut -d '-' -f 2)"
+    downloadURL="${baseURL}/${downloadFile}"
+    appNewVersion="$(echo "$downloadFile" | cut -d '-' -f 2)"
     expectedTeamID="9NCBP559AB"
     ;;

--- a/fragments/labels/jamovi.sh
+++ b/fragments/labels/jamovi.sh
@@ -1,14 +1,27 @@
 jamovi)
     name="jamovi"
     type="dmg"
-    downloadURL="http://www.jamovi.org"
-    if [[ -n $jamoviLatest ]]; then
-        downloadURL="${downloadURL}$(curl -s "$downloadURL/download.html" | grep macos | grep "download-button" | head -1 | cut -d '"' -f 4)"
+    baseURL="https://www.jamovi.org"
+
+    # Detect architecture for separate arm64/x64 DMGs
+    if [[ "$(arch)" == "arm64" ]]; then
+        archSuffix="arm64"
     else
-        downloadURL="${downloadURL}$(curl -s "$downloadURL/download.html" | grep macos | grep "download-button" | tail -1 | cut -d '"' -f 4)"
+        archSuffix="x64"
     fi
-    # The above is a cheat, they list both the "Latest" version and the "Solid" version twice on the page, but in opposing order.
-    #     I'm also assuming they mean Latest = beta, and Solid = Stable.
-    appNewVersion="$(echo $downloadPATH | cut -d '-' -f 2)"
+
+    # solid (stable) is listed first, current (latest) is listed second
+    if [[ -n $jamoviLatest ]]; then
+        downloadPath=$(curl -sf "${baseURL}/download.html" \
+            | grep -o "/downloads/jamovi-[^\"]*-macos-${archSuffix}\.dmg" \
+            | tail -1)
+    else
+        downloadPath=$(curl -sf "${baseURL}/download.html" \
+            | grep -o "/downloads/jamovi-[^\"]*-macos-${archSuffix}\.dmg" \
+            | head -1)
+    fi
+
+    downloadURL="${baseURL}${downloadPath}"
+    appNewVersion="$(echo "$downloadPath" | cut -d '-' -f 2)"
     expectedTeamID="9NCBP559AB"
     ;;

--- a/fragments/labels/jamovi.sh
+++ b/fragments/labels/jamovi.sh
@@ -2,26 +2,19 @@ jamovi)
     name="jamovi"
     type="dmg"
     baseURL="https://dl.jamovi.org"
-
-    if [[ "$(arch)" == "arm64" ]]; then
-        archSuffix="arm64"
+    
+    if [[ $(arch) == "arm64" ]]; then
+    archSuffix="arm64"
+    elif [[ $(arch) == "i386" ]]; then
+    archSuffix="x64"
     else
-        archSuffix="x64"
+    printlog "ERROR: Unsupported architecture $(arch) for jamovi label" ERROR
+    exit 1
     fi
-
     if [[ -n $jamoviLatest ]]; then
-        # current = 2.7.x series (odd minor)
-        downloadFile=$(curl -sf "${baseURL}/" \
-            | grep -o "jamovi-2\.[7-9][^\"]*-macos-${archSuffix}\.dmg" \
-            | sort -V | tail -1)
+    downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.[7-9][^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
     else
-        # solid = 2.6.x series (even minor)
-        downloadFile=$(curl -sf "${baseURL}/" \
-            | grep -o "jamovi-2\.6[^\"]*-macos-${archSuffix}\.dmg" \
-            | sort -V | tail -1)
+    downloadFile=$(curl -sf "${baseURL}/" | grep -o "jamovi-2\.6[^\"]*-macos-${archSuffix}\.dmg" | sort -V | tail -1)
     fi
-
     downloadURL="${baseURL}/${downloadFile}"
     appNewVersion="$(echo "$downloadFile" | cut -d '-' -f 2)"
-    expectedTeamID="9NCBP559AB"
-    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**Yes

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The jamovi download page (jamovi.org/download.html) now renders its 
download links via JavaScript, making curl-based HTML parsing unreliable 
(returns empty string, causing downloadURL to fall back to the homepage).

This fix switches to the static directory index at https://dl.jamovi.org/ 
which is reliably parseable with curl. It also adds proper arm64/x64 
architecture detection since jamovi now distributes separate DMGs per arch.
Additionally fixes appNewVersion which referenced undefined $downloadPATH.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Script result: 2026-03-19 11:28:44 : REQ   :  : shifting arguments for Jamf
2026-03-19 11:28:44 : INFO  : jamovi : Total items in argumentsArray: 0
2026-03-19 11:28:44 : INFO  : jamovi : argumentsArray: 
2026-03-19 11:28:44 : REQ   : jamovi : ################## Start Installomator v. 10.8, date 2025-03-28
2026-03-19 11:28:46 : REQ   : jamovi : Downloading https://dl.jamovi.org/jamovi-2.6.46.0-macos-arm64.dmg to jamovi.dmg
2026-03-19 11:29:04 : REQ   : jamovi : Installing jamovi
2026-03-19 11:29:34 : REQ   : jamovi : Installed jamovi, version 2.6.46.0
2026-03-19 11:29:36 : REQ   : jamovi : All done!
2026-03-19 11:29:36 : REQ   : jamovi : ################## End Installomator, exit code 0 


Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

n/a
