### PR TITLE
Fix protondrive appNewVersion

### DIFF
--- a/fragments/labels/protondrive.sh
+++ b/fragments/labels/protondrive.sh
@@ -1,7 +1,7 @@
 protondrive)
     name="Proton Drive"
     type="dmg"
-    appNewVersion=$(curl -fs "https://proton.me/download/drive/macos/appcast.xml" | sed -n 's/.*<sparkle:shortVersionString>\(.*\)<\/sparkle:shortVersionString>.*/\1/p')
+    appNewVersion=$(curl -fs "https://proton.me/download/drive/macos/appcast.xml" | xmllint --xpath "string(//item[*[local-name()='channel' and text()='stable']]/*[local-name()='shortVersionString'])" -)
     downloadURL="https://proton.me/download/drive/macos/$appNewVersion/ProtonDrive-$appNewVersion.dmg"
     expectedTeamID="2SB5Z68H26"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
The sed method worked until the RSS got a gradual-rollout item added resulting in two version numbers inside, but with xmllint we can parse the stable version number from the XML.

**Installomator log**
```
2026-03-23 10:36:48 : INFO  : protondrive : setting variable from argument DEBUG=0
2026-03-23 10:36:48 : INFO  : protondrive : Total items in argumentsArray: 1
2026-03-23 10:36:48 : INFO  : protondrive : argumentsArray: DEBUG=0
2026-03-23 10:36:48 : REQ   : protondrive : ################## Start Installomator v. 10.9beta, date 2026-03-23
2026-03-23 10:36:48 : INFO  : protondrive : ################## Version: 10.9beta
2026-03-23 10:36:48 : INFO  : protondrive : ################## Date: 2026-03-23
2026-03-23 10:36:48 : INFO  : protondrive : ################## protondrive
2026-03-23 10:36:48 : INFO  : protondrive : Reading arguments again: DEBUG=0
2026-03-23 10:36:48 : INFO  : protondrive : BLOCKING_PROCESS_ACTION=tell_user
2026-03-23 10:36:48 : INFO  : protondrive : NOTIFY=success
2026-03-23 10:36:49 : INFO  : protondrive : LOGGING=INFO
2026-03-23 10:36:49 : INFO  : protondrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-23 10:36:49 : INFO  : protondrive : Label type: dmg
2026-03-23 10:36:49 : INFO  : protondrive : archiveName: Proton Drive.dmg
2026-03-23 10:36:49 : INFO  : protondrive : no blocking processes defined, using Proton Drive as default
2026-03-23 10:36:49 : INFO  : protondrive : App(s) found: /Applications/Proton Drive.app
2026-03-23 10:36:49 : INFO  : protondrive : found app at /Applications/Proton Drive.app, version 2.10.3, on versionKey CFBundleShortVersionString
2026-03-23 10:36:49 : INFO  : protondrive : appversion: 2.10.3
2026-03-23 10:36:49 : INFO  : protondrive : Latest version of Proton Drive is 2.10.3
2026-03-23 10:36:49 : INFO  : protondrive : There is no newer version available.
2026-03-23 10:36:49 : INFO  : protondrive : Installomator did not close any apps, so no need to reopen any apps.
2026-03-23 10:36:49 : REQ   : protondrive : No newer version.
2026-03-23 10:36:49 : REQ   : protondrive : ################## End Installomator, exit code 0 ```