### PR TITLE
Fix raycast appNewVersion

### DIFF
--- a/fragments/labels/raycast.sh
+++ b/fragments/labels/raycast.sh
@@ -2,6 +2,6 @@ raycast)
     name="Raycast"
     type="dmg"
     downloadURL="https://www.raycast.com/download"
-    appNewVersion="$( curl -fsIL "https://www.raycast.com/download" | grep -i ^location | grep Raycast_ | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' )"
+    appNewVersion="$( curl -fsIL "https://www.raycast.com/download" | grep -i ^location | grep -m1 Raycast_ | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' )"
     expectedTeamID="SY64MV22J9"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
The current implementation is parsing the latest version from the HTTP redirects. Currently there are two redirects, resulting in appNewVersion including the latest version twice. This change takes the latest version number from the first of the redirects if there are multiple.

**Installomator log** 
```
2026-03-23 10:52:26 : INFO  : raycast : setting variable from argument DEBUG=0
2026-03-23 10:52:26 : INFO  : raycast : Total items in argumentsArray: 1
2026-03-23 10:52:26 : INFO  : raycast : argumentsArray: DEBUG=0
2026-03-23 10:52:26 : REQ   : raycast : ################## Start Installomator v. 10.9beta, date 2026-03-23
2026-03-23 10:52:26 : INFO  : raycast : ################## Version: 10.9beta
2026-03-23 10:52:26 : INFO  : raycast : ################## Date: 2026-03-23
2026-03-23 10:52:26 : INFO  : raycast : ################## raycast
2026-03-23 10:52:27 : INFO  : raycast : Reading arguments again: DEBUG=0
2026-03-23 10:52:27 : INFO  : raycast : BLOCKING_PROCESS_ACTION=tell_user
2026-03-23 10:52:27 : INFO  : raycast : NOTIFY=success
2026-03-23 10:52:27 : INFO  : raycast : LOGGING=INFO
2026-03-23 10:52:27 : INFO  : raycast : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-23 10:52:27 : INFO  : raycast : Label type: dmg
2026-03-23 10:52:27 : INFO  : raycast : archiveName: Raycast.dmg
2026-03-23 10:52:27 : INFO  : raycast : no blocking processes defined, using Raycast as default
2026-03-23 10:52:27 : INFO  : raycast : App(s) found: /Applications/Raycast.app
2026-03-23 10:52:27 : INFO  : raycast : found app at /Applications/Raycast.app, version 1.104.10, on versionKey CFBundleShortVersionString
2026-03-23 10:52:27 : INFO  : raycast : appversion: 1.104.10
2026-03-23 10:52:27 : INFO  : raycast : Latest version of Raycast is 1.104.10
2026-03-23 10:52:27 : INFO  : raycast : There is no newer version available.
2026-03-23 10:52:27 : INFO  : raycast : Installomator did not close any apps, so no need to reopen any apps.
2026-03-23 10:52:27 : REQ   : raycast : No newer version.
2026-03-23 10:52:27 : REQ   : raycast : ################## End Installomator, exit code 0 
```