### PR TITLE
Using `iconv` to remove non-ASCII characters before `awk` in DND (do not disturb)

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -921,8 +921,8 @@ finishing() {
 # KeyNote, PowerPoint, Zoom, or Webex.
 # See: https://developer.apple.com/documentation/iokit/iopmlib_h/iopmassertiontypes
 hasDisplaySleepAssertion() {
-    # Get the names of all apps with active display sleep assertions
-    local apps="$(/usr/bin/pmset -g assertions | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
+    # Get the names of all apps with active display sleep assertions (removing non-ASCII characters before awk)
+    local apps="$(/usr/bin/pmset -g assertions | perl -C -Mutf8 -pe 's/[^\x00-\x7F]//g' | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
 
     if [[ ! "${apps}" ]]; then
         # No display sleep assertions detected

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -922,7 +922,7 @@ finishing() {
 # See: https://developer.apple.com/documentation/iokit/iopmlib_h/iopmassertiontypes
 hasDisplaySleepAssertion() {
     # Get the names of all apps with active display sleep assertions (removing non-ASCII characters before awk)
-    local apps="$(/usr/bin/pmset -g assertions | perl -C -Mutf8 -pe 's/[^\x00-\x7F]//g' | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
+    local apps="$(/usr/bin/pmset -g assertions | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
 
     if [[ ! "${apps}" ]]; then
         # No display sleep assertions detected


### PR DESCRIPTION
`awk` on macOS cannot handle multi-byt characters, and on international systems `pmset` might return keyboard names with these forbidden characters in them, and that will make `awk` fail. `perl` to the rescue for removing all non-ASCII characters (we know from the list of apps we are trying to test for, that we do not have non-ASCII characters in any of those names).

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
no
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
Minor improvement
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
➜  ~ sudo Installomator/utils/assemble.sh VLC DEBUG=0 INTERRUPT_DND="no" 
2026-03-23 22:22:07 : INFO  : vlc : setting variable from argument DEBUG=0
2026-03-23 22:22:07 : INFO  : vlc : setting variable from argument INTERRUPT_DND=no
2026-03-23 22:22:07 : INFO  : vlc : Total items in argumentsArray: 2
2026-03-23 22:22:07 : INFO  : vlc : argumentsArray: DEBUG=0 INTERRUPT_DND=no
2026-03-23 22:22:07 : REQ   : vlc : ################## Start Installomator v. 10.9beta, date 2026-03-23
2026-03-23 22:22:07 : INFO  : vlc : ################## Version: 10.9beta
2026-03-23 22:22:07 : INFO  : vlc : ################## Date: 2026-03-23
2026-03-23 22:22:07 : INFO  : vlc : ################## vlc
2026-03-23 22:22:08 : INFO  : vlc : Reading arguments again: DEBUG=0 INTERRUPT_DND=no
2026-03-23 22:22:08 : INFO  : vlc : Display sleep assertion detected by Mahjong Titan.
2026-03-23 22:22:08 : INFO  : vlc : Installomator did not close any apps, so no need to reopen any apps.
2026-03-23 22:22:08 : ERROR : vlc : ERROR: active display sleep assertion detected, aborting
2026-03-23 22:22:08 : REQ   : vlc : ################## End Installomator, exit code 24 

➜  ~ sudo Installomator/utils/assemble.sh VLC DEBUG=0 INTERRUPT_DND="no"
2026-03-23 22:22:52 : INFO  : vlc : setting variable from argument DEBUG=0
2026-03-23 22:22:52 : INFO  : vlc : setting variable from argument INTERRUPT_DND=no
2026-03-23 22:22:52 : INFO  : vlc : Total items in argumentsArray: 2
2026-03-23 22:22:52 : INFO  : vlc : argumentsArray: DEBUG=0 INTERRUPT_DND=no
2026-03-23 22:22:52 : REQ   : vlc : ################## Start Installomator v. 10.9beta, date 2026-03-23
2026-03-23 22:22:52 : INFO  : vlc : ################## Version: 10.9beta
2026-03-23 22:22:52 : INFO  : vlc : ################## Date: 2026-03-23
2026-03-23 22:22:52 : INFO  : vlc : ################## vlc
2026-03-23 22:22:52 : INFO  : vlc : Reading arguments again: DEBUG=0 INTERRUPT_DND=no
2026-03-23 22:22:52 : INFO  : vlc : BLOCKING_PROCESS_ACTION=tell_user
2026-03-23 22:22:52 : INFO  : vlc : NOTIFY=success
2026-03-23 22:22:52 : INFO  : vlc : LOGGING=INFO
2026-03-23 22:22:52 : INFO  : vlc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-23 22:22:52 : INFO  : vlc : Label type: dmg
2026-03-23 22:22:52 : INFO  : vlc : archiveName: VLC.dmg
2026-03-23 22:22:52 : INFO  : vlc : no blocking processes defined, using VLC as default
2026-03-23 22:22:52 : INFO  : vlc : name: VLC, appName: VLC.app
2026-03-23 22:22:53 : INFO  : vlc : App(s) found: /Users/st/Applications/VLC.app
2026-03-23 22:22:53 : WARN  : vlc : could not determine location of VLC.app
2026-03-23 22:22:53 : INFO  : vlc : appversion: 
2026-03-23 22:22:53 : INFO  : vlc : Latest version of VLC is 3.0.23
2026-03-23 22:22:53 : REQ   : vlc : Downloading https://get.videolan.org/vlc/3.0.23/macosx/vlc-3.0.23-universal.dmg to VLC.dmg
2026-03-23 22:22:58 : INFO  : vlc : Downloaded VLC.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 027ed7d28e2390a6718a5c68f6e783be76fd5ffd – Size is 98716 kB
2026-03-23 22:22:59 : REQ   : vlc : no more blocking processes, continue with update
2026-03-23 22:22:59 : REQ   : vlc : Installing VLC
2026-03-23 22:22:59 : INFO  : vlc : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.0c2a7TwDSZ/VLC.dmg
2026-03-23 22:23:04 : INFO  : vlc : Mounted: /Volumes/VLC media player
2026-03-23 22:23:04 : INFO  : vlc : Verifying: /Volumes/VLC media player/VLC.app
2026-03-23 22:23:21 : INFO  : vlc : Team ID matching: 75GAHG3SZQ (expected: 75GAHG3SZQ )
2026-03-23 22:23:21 : INFO  : vlc : Installing VLC version 3.0.23 on versionKey CFBundleShortVersionString.
2026-03-23 22:23:21 : INFO  : vlc : App has LSMinimumSystemVersion: 10.7.5
2026-03-23 22:23:21 : INFO  : vlc : Copy /Volumes/VLC media player/VLC.app to /Applications
2026-03-23 22:23:31 : WARN  : vlc : Changing owner to st
2026-03-23 22:23:31 : INFO  : vlc : Finishing...
2026-03-23 22:23:34 : INFO  : vlc : App(s) found: /Applications/VLC.app
2026-03-23 22:23:34 : INFO  : vlc : found app at /Applications/VLC.app, version 3.0.23, on versionKey CFBundleShortVersionString
2026-03-23 22:23:34 : REQ   : vlc : Installed VLC, version 3.0.23
2026-03-23 22:23:34 : INFO  : vlc : notifying
2026-03-23 22:23:45 : INFO  : vlc : Installomator did not close any apps, so no need to reopen any apps.
2026-03-23 22:23:45 : REQ   : vlc : All done!
2026-03-23 22:23:45 : REQ   : vlc : ################## End Installomator, exit code 0 
```

Output shows that `awk` works by returning an app name. Quitting that app, makes a perfect run.