### PR TITLE
Add label for Conductor

### DIFF
--- a/fragments/labels/conductor.sh
+++ b/fragments/labels/conductor.sh
@@ -1,7 +1,11 @@
 conductor)
     name="Conductor"
     type="dmg"
-    downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64"
+    else
+        downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-x86_64"
+    fi
     appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^content-disposition" | sed 's/.*Conductor_\([0-9.]*\)_.*/\1/')
     expectedTeamID="27XN666UJ7"
     ;;

--- a/fragments/labels/conductor.sh
+++ b/fragments/labels/conductor.sh
@@ -1,0 +1,7 @@
+conductor)
+    name="Conductor"
+    type="dmg"
+    downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64"
+    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^content-disposition" | sed 's/.*Conductor_\([0-9.]*\)_.*/\1/')
+    expectedTeamID="27XN666UJ7"
+    ;;

--- a/fragments/labels/conductor.sh
+++ b/fragments/labels/conductor.sh
@@ -2,10 +2,11 @@ conductor)
     name="Conductor"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64"
+        cnArch="aarch64"
     else
-        downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-x86_64"
+        cnArch="x86_64"
     fi
-    appNewVersion=$(curl -fsIL "$downloadURL" | grep -i "^content-disposition" | sed 's/.*Conductor_\([0-9.]*\)_.*/\1/')
+    downloadURL="https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-${cnArch}"
+    appNewVersion=$(curl -fsL "https://cdn.crabnebula.app/update/melty/conductor/darwin-${cnArch}/0.0.0" | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
     expectedTeamID="27XN666UJ7"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.

---
**Have you confirmed this pull request is not a duplicate?**

Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes. Only `fragments/labels/conductor.sh` is added.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes. 4-space indentation, LF line endings, trailing whitespace trimmed, final newline present.

**Additional context**

[Conductor](https://www.conductor.build/) is a macOS app for running parallel AI coding agents (Codex, Claude Code) in isolated workspaces.

Conductor is distributed via [CrabNebula Cloud](https://crabnebula.app/). There is a stable "latest" redirect URL that always resolves to the current release asset:

```
https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64
```

Version is parsed from the `Content-Disposition` header returned by the redirect (e.g. `Conductor_0.43.0_aarch64.dmg`). Confirmed returning `0.43.0` at time of submission.

**Installomator log**

```
2026-03-24 12:01:03 : INFO  : conductor : setting variable from argument DEBUG=0
2026-03-24 12:01:03 : INFO  : conductor : Total items in argumentsArray: 1
2026-03-24 12:01:03 : INFO  : conductor : argumentsArray: DEBUG=0
2026-03-24 12:01:03 : REQ   : conductor : ################## Start Installomator v. 10.9beta, date 2026-03-24
2026-03-24 12:01:03 : INFO  : conductor : ################## Version: 10.9beta
2026-03-24 12:01:03 : INFO  : conductor : ################## Date: 2026-03-24
2026-03-24 12:01:03 : INFO  : conductor : ################## conductor
2026-03-24 12:01:04 : INFO  : conductor : Reading arguments again: DEBUG=0
2026-03-24 12:01:04 : INFO  : conductor : BLOCKING_PROCESS_ACTION=tell_user
2026-03-24 12:01:04 : INFO  : conductor : NOTIFY=success
2026-03-24 12:01:04 : INFO  : conductor : LOGGING=INFO
2026-03-24 12:01:04 : INFO  : conductor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-24 12:01:04 : INFO  : conductor : Label type: dmg
2026-03-24 12:01:04 : INFO  : conductor : archiveName: Conductor.dmg
2026-03-24 12:01:04 : INFO  : conductor : no blocking processes defined, using Conductor as default
2026-03-24 12:01:04 : INFO  : conductor : name: Conductor, appName: Conductor.app
2026-03-24 12:01:04 : WARN  : conductor : No previous app found
2026-03-24 12:01:04 : WARN  : conductor : could not find Conductor.app
2026-03-24 12:01:04 : INFO  : conductor : appversion:
2026-03-24 12:01:04 : INFO  : conductor : Latest version of Conductor is 0.43.0
2026-03-24 12:01:04 : REQ   : conductor : Downloading https://cdn.crabnebula.app/download/melty/conductor/latest/platform/dmg-aarch64 to Conductor.dmg
2026-03-24 12:01:09 : INFO  : conductor : Downloaded Conductor.dmg – Type is  zlib compressed data – SHA is 9151b71bcfc80bc1d34e0caeda5a36d2b0cfbf9e – Size is 213312 kB
2026-03-24 12:01:09 : REQ   : conductor : no more blocking processes, continue with update
2026-03-24 12:01:09 : REQ   : conductor : Installing Conductor
2026-03-24 12:01:09 : INFO  : conductor : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.8pWyaY6UXI/Conductor.dmg
2026-03-24 12:01:11 : INFO  : conductor : Mounted: /Volumes/Conductor
2026-03-24 12:01:11 : INFO  : conductor : Verifying: /Volumes/Conductor/Conductor.app
2026-03-24 12:01:13 : INFO  : conductor : Team ID matching: 27XN666UJ7 (expected: 27XN666UJ7 )
2026-03-24 12:01:13 : INFO  : conductor : Installing Conductor version 0.43.0 on versionKey CFBundleShortVersionString.
2026-03-24 12:01:13 : INFO  : conductor : App has LSMinimumSystemVersion: 10.13
2026-03-24 12:01:13 : INFO  : conductor : Copy /Volumes/Conductor/Conductor.app to /Applications
2026-03-24 12:01:13 : WARN  : conductor : Changing owner to kellan
2026-03-24 12:01:13 : INFO  : conductor : Finishing...
2026-03-24 12:01:16 : INFO  : conductor : App(s) found: /Applications/Conductor.app
2026-03-24 12:01:16 : INFO  : conductor : found app at /Applications/Conductor.app, version 0.43.0, on versionKey CFBundleShortVersionString
2026-03-24 12:01:16 : REQ   : conductor : Installed Conductor, version 0.43.0
2026-03-24 12:01:16 : INFO  : conductor : notifying
2026-03-24 12:01:17 : INFO  : conductor : Installomator did not close any apps, so no need to reopen any apps.
2026-03-24 12:01:17 : REQ   : conductor : All done!
2026-03-24 12:01:17 : REQ   : conductor : ################## End Installomator, exit code 0
```
