### PR TITLE
New CODEOWNERS definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# =========================================================
+# CODEOWNERS — INSTALLOMATOR
+# =========================================================
+
+# Default: all files require core maintainer approval
+* @installomator/core-maintainers


### PR DESCRIPTION
To support the new governance model, This CODEOWNERS file will be used by new branch rules requiring a core maintainer to be the only one who can accept a PR. By defining code owners, we can use the branch rule for PRs that they require "an approval from a code owner".