### PR TITLE
Update postman.sh

### DIFF
--- a/fragments/labels/postman.sh
+++ b/fragments/labels/postman.sh
@@ -7,6 +7,6 @@ postman)
 	elif [[ $(arch) == "i386" ]]; then
 		downloadURL="https://dl.pstmn.io/download/latest/osx_64"
 	fi
-	appNewVersion=$(getJSONValue "$(curl -fsL 'https://www.postman.com/mkapi/release.json?t=')" 'notes[0].version')
+	appNewVersion=$(getJSONValue "$(curl -fsL 'https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json')" 'notes[0].version')
     expectedTeamID="H7H8Q7M5CK"
     ;;

--- a/fragments/labels/postman.sh
+++ b/fragments/labels/postman.sh
@@ -3,10 +3,10 @@ postman)
     type="zip"
     curlOptions=( -H "accept-encoding: gzip, deflate, br")
     if [[ $(arch) == "arm64" ]]; then
-    	downloadURL="https://dl.pstmn.io/download/latest/osx_arm64"
+        downloadURL="https://dl.pstmn.io/download/latest/osx_arm64"
 	elif [[ $(arch) == "i386" ]]; then
-		downloadURL="https://dl.pstmn.io/download/latest/osx_64"
+        downloadURL="https://dl.pstmn.io/download/latest/osx_64"
 	fi
-	appNewVersion=$(getJSONValue "$(curl -fsL 'https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json')" 'notes[0].version')
+    appNewVersion=$(getJSONValue "$(curl -fsL 'https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json')" 'notes[0].version')
     expectedTeamID="H7H8Q7M5CK"
     ;;

--- a/fragments/labels/postman.sh
+++ b/fragments/labels/postman.sh
@@ -4,9 +4,9 @@ postman)
     curlOptions=( -H "accept-encoding: gzip, deflate, br")
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://dl.pstmn.io/download/latest/osx_arm64"
-	elif [[ $(arch) == "i386" ]]; then
+    elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://dl.pstmn.io/download/latest/osx_64"
-	fi
+    fi
     appNewVersion=$(getJSONValue "$(curl -fsL 'https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json')" 'notes[0].version')
     expectedTeamID="H7H8Q7M5CK"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The current appNewVersion URL doesn't seem to be up to date anymore (https://www.postman.com/mkapi/release.json?t=). It lists version 12.1.1 as the latest version, but 12.4.0 is the latest version according to the release notes (https://www.postman.com/release-notes/postman-app/).

https://mkt.cdn.postman.com/www-next/release-notes/app-release-notes.json seems to be a better source in order to find the latest version of Postman. However, the latest version that's currently available to download is 12.3.6, but that's probably a cdn issue since 12.4.0 is listed as released today (March 30, 2026).

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-03-30 12:28:16 : INFO  : postman : setting variable from argument DEBUG=0
2026-03-30 12:28:16 : INFO  : postman : Total items in argumentsArray: 1
2026-03-30 12:28:16 : INFO  : postman : argumentsArray: DEBUG=0
2026-03-30 12:28:16 : REQ   : postman : ################## Start Installomator v. 10.9beta, date 2026-03-30
2026-03-30 12:28:16 : INFO  : postman : ################## Version: 10.9beta
2026-03-30 12:28:16 : INFO  : postman : ################## Date: 2026-03-30
2026-03-30 12:28:16 : INFO  : postman : ################## postman
2026-03-30 12:28:16 : INFO  : postman : SwiftDialog is not installed, clear cmd file var
2026-03-30 12:28:17 : INFO  : postman : Reading arguments again: DEBUG=0
2026-03-30 12:28:17 : INFO  : postman : BLOCKING_PROCESS_ACTION=tell_user
2026-03-30 12:28:17 : INFO  : postman : NOTIFY=success
2026-03-30 12:28:17 : INFO  : postman : LOGGING=INFO
2026-03-30 12:28:17 : INFO  : postman : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-30 12:28:18 : INFO  : postman : Label type: zip
2026-03-30 12:28:18 : INFO  : postman : archiveName: Postman.zip
2026-03-30 12:28:18 : INFO  : postman : no blocking processes defined, using Postman as default
2026-03-30 12:28:18 : INFO  : postman : name: Postman, appName: Postman.app
2026-03-30 12:28:18 : INFO  : postman : App(s) found: /Users/kryptonit/Documents/github/Installomator/build/Postman.app
2026-03-30 12:28:18 : WARN  : postman : could not determine location of Postman.app
2026-03-30 12:28:18 : INFO  : postman : appversion: 
2026-03-30 12:28:18 : INFO  : postman : Latest version of Postman is 12.4.0
2026-03-30 12:28:18 : REQ   : postman : Downloading https://dl.pstmn.io/download/latest/osx_arm64 to Postman.zip
2026-03-30 12:28:21 : INFO  : postman : Downloaded Postman.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 30f5b76546e380178456c15deb95bf1f0c9f3613 – Size is 131576 kB
2026-03-30 12:28:21 : REQ   : postman : no more blocking processes, continue with update
2026-03-30 12:28:21 : REQ   : postman : Installing Postman
2026-03-30 12:28:21 : INFO  : postman : Unzipping Postman.zip
2026-03-30 12:28:22 : INFO  : postman : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.GJyndnGIPz/Postman.app
2026-03-30 12:28:23 : INFO  : postman : Team ID matching: H7H8Q7M5CK (expected: H7H8Q7M5CK )
2026-03-30 12:28:23 : INFO  : postman : Installing Postman version 12.3.6 on versionKey CFBundleShortVersionString.
2026-03-30 12:28:23 : INFO  : postman : App has LSMinimumSystemVersion: 11.0
2026-03-30 12:28:23 : INFO  : postman : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.GJyndnGIPz/Postman.app to /Applications
2026-03-30 12:28:23 : WARN  : postman : Changing owner to kryptonit
2026-03-30 12:28:23 : INFO  : postman : Finishing...
2026-03-30 12:28:26 : INFO  : postman : App(s) found: /Applications/Postman.app
2026-03-30 12:28:26 : INFO  : postman : found app at /Applications/Postman.app, version 12.3.6, on versionKey CFBundleShortVersionString
2026-03-30 12:28:26 : REQ   : postman : Installed Postman, version 12.3.6
2026-03-30 12:28:26 : INFO  : postman : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-03-30 12:28:27 : INFO  : postman : Installomator did not close any apps, so no need to reopen any apps.
2026-03-30 12:28:27 : REQ   : postman : All done!
2026-03-30 12:28:27 : REQ   : postman : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A