### PR TITLE
Improved logging with function name on each line

### DIFF
--- a/fragments/arguments.sh
+++ b/fragments/arguments.sh
@@ -1,3 +1,4 @@
+yelp "arguments.sh file content"
 # NOTE: check minimal macOS requirement
 autoload is-at-least
 
@@ -130,6 +131,7 @@ if [[ ! -x $DIALOG_CMD ]]; then
 fi
 
 # MARK: labels in case statement
+yelp "Processing label: $label"
 case $label in
 longversion)
     # print the script version

--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -112,7 +112,7 @@ printlog(){
     # then post to Datadog's HTTPs endpoint.
     if [[ -n $datadogAPI && ${levels[$log_priority]} -ge ${levels[$datadogLoggingLevel]} ]]; then
         while IFS= read -r logmessage; do
-            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : Installomator-${label} : ${VERSIONDATE//-/} : $SESSION : ${logmessage}" > /dev/null
+            curl -s -X POST https://http-intake.logs.datadoghq.com/v1/input -H "Content-Type: text/plain" -H "DD-API-KEY: $datadogAPI" -d "${log_priority} : $mdmURL : Installomator-${label} : ${VERSIONDATE//-/} : $SESSION : [${funcstack[2]}] ${logmessage}" > /dev/null
         done <<< "$log_message"
     fi
 
@@ -120,12 +120,25 @@ printlog(){
     if [[ ${levels[$log_priority]} -ge ${levels[$LOGGING]} ]]; then
         while IFS= read -r logmessage; do
             if [[ "$(whoami)" == "root" ]]; then
-                echo "$timestamp" : "${log_priority}${space_char} : $label : ${logmessage}" | tee -a $log_location
+                echo "$timestamp" : "${log_priority}${space_char} : $label : [${funcstack[2]}] ${logmessage}" | tee -a $log_location
             else
-                echo "$timestamp" : "${log_priority}${space_char} : $label : ${logmessage}"
+                echo "$timestamp" : "${log_priority}${space_char} : $label : [${funcstack[2]}] ${logmessage}"
             fi
         done <<< "$log_message"
     fi
+}
+
+# yelp is a helper function to print function and line numbers to the DEBUG log
+# Example: yelp # prints function name and line no.
+# Example: yelp "Some text" # to tell where script is
+yelp () {
+	# $funcfiletrace has format:  file:line
+	# funcstack[1] current function name [2] caller function
+	if [[ -n ${1} ]]; then
+		printlog "Here: [${funcstack[2]}]:${funcfiletrace[1]##*:} – $*" DEBUG
+	else
+		printlog "Here: [${funcstack[2]}]:${funcfiletrace[1]##*:}" DEBUG
+	fi
 }
 
 # Used to remove dupplicate lines in large log output,
@@ -153,6 +166,7 @@ deduplicatelogs() {
 
 # will get the latest release download from a github repo
 downloadURLFromGit() { # $1 git user name, $2 git repo name
+    printlog "Arguments: $*" DEBUG # print function name and arguments
     gitusername=${1?:"no git user name"}
     gitreponame=${2?:"no git repo name"}
 
@@ -187,6 +201,7 @@ downloadURLFromGit() { # $1 git user name, $2 git repo name
 
 versionFromGit() {
     # credit: Søren Theilgaard (@theilgaard)
+    printlog "Arguments: $*" DEBUG # print function name and arguments
     # $1 git user name, $2 git repo name
     gitusername=${1?:"no git user name"}
     gitreponame=${2?:"no git repo name"}
@@ -228,6 +243,7 @@ getJSONValue() {
 
 getAppVersion() {
     # modified by: Søren Theilgaard (@theilgaard) and Isaac Ordonez
+    yelp "Arguments not needed"
 
     # If label contain function appCustomVersion, we use that and return
     if type 'appCustomVersion' 2>/dev/null | grep -q 'function'; then
@@ -310,6 +326,8 @@ getAppVersion() {
 }
 
 checkRunningProcesses() {
+    yelp "Arguments: $*"
+
     # don't check in DEBUG mode 1
     if [[ $DEBUG -eq 1 ]]; then
         printlog "DEBUG mode 1, not checking for blocking processes" DEBUG
@@ -326,6 +344,7 @@ checkRunningProcesses() {
 
                 case $BLOCKING_PROCESS_ACTION in
                     quit|quit_kill)
+                        yelp "quit|quit_kill"
                         printlog "telling app $x to quit"
                         runAsUser osascript -e "tell app \"$x\" to quit"
                         if [[ $i > 2 && $BLOCKING_PROCESS_ACTION = "quit_kill" ]]; then
@@ -338,11 +357,13 @@ checkRunningProcesses() {
                         fi
                         ;;
                     kill)
+                      yelp "kill"
                       printlog "killing process $x"
                       pkill $x
                       sleep 5
                       ;;
                     prompt_user|prompt_user_then_kill)
+                      yelp "prompt_user|prompt_user_then_kill"
                       button=$(displaydialog "Quit “$x” to continue updating? $([[ -n $appNewVersion ]] && echo "Version $appversion is installed, but version $appNewVersion is available.") (Leave this dialogue if you want to activate this update later)." "The application “$x” needs to be updated.")
                       if [[ $button = "Not Now" ]]; then
                         appClosed=0
@@ -370,6 +391,7 @@ checkRunningProcesses() {
                       fi
                       ;;
                     prompt_user_loop)
+                      yelp "prompt_user_loop"
                       button=$(displaydialog "Quit “$x” to continue updating? $([[ -n $appNewVersion ]] && echo "Version $appversion is installed, but version $appNewVersion is available.") (Click “Not Now” to be asked in 1 hour, or leave this open until you are ready)." "The application “$x” needs to be updated.")
                       if [[ $button = "Not Now" ]]; then
                         if [[ $i < 2 ]]; then
@@ -388,6 +410,7 @@ checkRunningProcesses() {
                       fi
                       ;;
                     tell_user|tell_user_then_kill)
+                      yelp "tell_user|tell_user_then_kill"
                       button=$(displaydialogContinue "Quit “$x” to continue updating? (This is an important update). Wait for notification of update before launching app again." "The application “$x” needs to be updated.")
                       printlog "telling app $x to quit"
                       runAsUser osascript -e "tell app \"$x\" to quit"
@@ -400,6 +423,7 @@ checkRunningProcesses() {
                       fi
                       ;;
                     silent_fail)
+                      yelp "silent_fail"
                       appClosed=0
                       cleanupAndExit 12 "blocking process '$x' found, aborting" ERROR
                       ;;
@@ -419,6 +443,7 @@ checkRunningProcesses() {
 }
 
 reopenClosedProcess() {
+    yelp "Arguments not needed"
     # If Installomator closed any processes, let's get the app opened again
     # credit: Søren Theilgaard (@theilgaard)
 
@@ -448,6 +473,8 @@ reopenClosedProcess() {
 }
 
 installAppWithPath() { # $1: path to app to install in $targetDir $2: path to folder (with app inside) to copy to $targetDir
+    yelp "Arguments: $*"
+
     # modified by: Søren Theilgaard (@theilgaard)
     appPath=${1?:"no path to app"}
     # If $2 ends in "/" then a folderName has not been specified so don't set it.
@@ -593,6 +620,8 @@ installAppWithPath() { # $1: path to app to install in $targetDir $2: path to fo
 }
 
 mountDMG() {
+    yelp "Arguments not needed"
+
     # mount the dmg
     printlog "Mounting $tmpDir/$archiveName"
     # always pipe 'Y\n' in case the dmg requires an agreement
@@ -614,11 +643,13 @@ mountDMG() {
 }
 
 installFromDMG() {
+    yelp "Arguments not needed"
     mountDMG
     installAppWithPath "$dmgmount/$appName" "$dmgmount/$folderName"
 }
 
 installFromPKG() {
+    yelp "Arguments not needed"
     # verify with spctl
     printlog "Verifying: $archiveName"
     updateDialog "wait" "Verifying..."
@@ -738,6 +769,7 @@ installFromPKG() {
 }
 
 installFromZIP() {
+    yelp "Arguments not needed"
     # unzip the archive
     printlog "Unzipping $archiveName"
 
@@ -756,6 +788,7 @@ installFromZIP() {
 }
 
 installFromTBZ() {
+    yelp "Arguments not needed"
     # unzip the archive
     printlog "Unzipping $archiveName"
     tar -xf "$archiveName"
@@ -763,6 +796,8 @@ installFromTBZ() {
 }
 
 installPkgInDmg() {
+    yelp "Arguments not needed"
+
     mountDMG
     # locate pkg in dmg
     if [[ -z $pkgName ]]; then
@@ -796,6 +831,8 @@ installPkgInDmg() {
 }
 
 installPkgInZip() {
+    yelp "Arguments not needed"
+
     # unzip the archive
     printlog "Unzipping $archiveName"
     tar -xf "$archiveName"
@@ -833,6 +870,8 @@ installPkgInZip() {
 }
 
 installAppInDmgInZip() {
+    yelp "Arguments not needed"
+
     # unzip the archive
     printlog "Unzipping $archiveName"
     tar -xf "$archiveName"
@@ -921,6 +960,8 @@ finishing() {
 # KeyNote, PowerPoint, Zoom, or Webex.
 # See: https://developer.apple.com/documentation/iokit/iopmlib_h/iopmassertiontypes
 hasDisplaySleepAssertion() {
+    yelp "Arguments not needed"
+
     # Get the names of all apps with active display sleep assertions
     local apps="$(/usr/bin/pmset -g assertions | /usr/bin/awk '/NoDisplaySleepAssertion | PreventUserIdleDisplaySleep/ && match($0,/\(.+\)/) && ! /coreaudiod/ {gsub(/^.*\(/,"",$0); gsub(/\).*$/,"",$0); print};')"
 
@@ -1014,11 +1055,14 @@ readPKGInstallPipe() {
 }
 
 killProcess() {
+    yelp "Arguments: $*"
     # will silently kill the specified PID
     builtin kill $1 2>/dev/null
 }
 
 updateDialog() {
+    yelp "Arguments: $*"
+
     local state=$1
     local message=$2
     local listitem=${3:-$DIALOG_LIST_ITEM_NAME}

--- a/fragments/main.sh
+++ b/fragments/main.sh
@@ -4,6 +4,7 @@
     cleanupAndExit 1 "unknown label $label" ERROR
     ;;
 esac
+yelp "Entering main.sh content, after label $label processed"
 
 # MARK: reading arguments again
 printlog "Reading arguments again: ${argumentsArray[*]}" INFO
@@ -166,6 +167,7 @@ if [ -z "$appName" ]; then
     # when not given derive from name
     appName="$name.app"
 fi
+printlog "appName: $appName" INFO
 
 if [ -z "$targetDir" ]; then
     case $type in
@@ -182,11 +184,13 @@ if [ -z "$targetDir" ]; then
             ;;
     esac
 fi
+printlog "targetDir: $targetDir" INFO
 
 if [[ -z $blockingProcesses ]]; then
     printlog "no blocking processes defined, using $name as default" INFO
     blockingProcesses=( $name )
 fi
+printlog "blockingProcesses: $blockingProcesses[*]" INFO
 
 # MARK: determine tmp dir
 if [ "$DEBUG" -eq 1 ]; then
@@ -204,6 +208,7 @@ if ! cd "$tmpDir"; then
 fi
 
 # MARK: get installed version
+yelp "Getting installed version of app, if any"
 getAppVersion
 printlog "appversion: $appversion"
 
@@ -351,6 +356,7 @@ if [ -n "$installerTool" ]; then
     appName="$installerTool"
 fi
 
+yelp "Installation type: $type"
 case $type in
     dmg)
         installFromDMG
@@ -378,6 +384,7 @@ case $type in
         ;;
 esac
 
+yelp "Installation of $name should be done, now finishing up."
 updateDialog "wait" "Finishing..."
 
 # MARK: Finishing — print installed application location and version


### PR DESCRIPTION
In my own scripts for navigating the log output it helps a great deal to get the function name in the log output. `funcstack[2]` will get that from the calling function.

An extra function `yelp` is added that will output to DEBUG log only with whatever text is parsed to it.

Calls to `yelp` is added in most functions, making it easier to precisely follow in the log how the script is moving between functions.

Since Installomator has been my reference as a script for a long time, I thought I would add it here as well. In any future situation with added features I think it will be of great assistance here as well.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
all in `fragments`
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
Added logging feature
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Showing a shorter DEBUG log where app is already installed (so `yelp` lines are included, as well as function name in square brackets):
```
➜  build: sudo ./Installomator.sh VLC DEBUG=0 LOGGING=DEBUG
2026-03-31 12:45:41 : DEBUG :  : [yelp] Here: []:1456 – arguments.sh file content
2026-03-31 12:45:41 : INFO  : vlc : [] setting variable from argument DEBUG=0
2026-03-31 12:45:41 : INFO  : vlc : [] setting variable from argument LOGGING=DEBUG
2026-03-31 12:45:41 : INFO  : vlc : [] Total items in argumentsArray: 2
2026-03-31 12:45:41 : INFO  : vlc : [] argumentsArray: DEBUG=0 LOGGING=DEBUG
2026-03-31 12:45:41 : REQ   : vlc : [] ################## Start Installomator v. 10.9beta, date 2026-03-31
2026-03-31 12:45:41 : INFO  : vlc : [] ################## Version: 10.9beta
2026-03-31 12:45:41 : INFO  : vlc : [] ################## Date: 2026-03-31
2026-03-31 12:45:41 : INFO  : vlc : [] ################## vlc
2026-03-31 12:45:41 : DEBUG : vlc : [yelp] Here: []:1589 – Processing label: vlc
2026-03-31 12:45:42 : DEBUG : vlc : [yelp] Here: []:11939 – Entering main.sh content, after label vlc processed
2026-03-31 12:45:42 : INFO  : vlc : [] Reading arguments again: DEBUG=0 LOGGING=DEBUG
2026-03-31 12:45:42 : DEBUG : vlc : [] argument: DEBUG=0
2026-03-31 12:45:42 : DEBUG : vlc : [] argument: LOGGING=DEBUG
2026-03-31 12:45:42 : DEBUG : vlc : [] name=VLC
2026-03-31 12:45:42 : DEBUG : vlc : [] appName=
2026-03-31 12:45:42 : DEBUG : vlc : [] type=dmg
2026-03-31 12:45:42 : DEBUG : vlc : [] archiveName=
2026-03-31 12:45:42 : DEBUG : vlc : [] downloadURL=https://get.videolan.org/vlc/3.0.23/macosx/vlc-3.0.23-universal.dmg
2026-03-31 12:45:42 : DEBUG : vlc : [] curlOptions=
2026-03-31 12:45:42 : DEBUG : vlc : [] appNewVersion=3.0.23
2026-03-31 12:45:42 : DEBUG : vlc : [] appCustomVersion function: Not defined
2026-03-31 12:45:42 : DEBUG : vlc : [] versionKey=CFBundleShortVersionString
2026-03-31 12:45:42 : DEBUG : vlc : [] packageID=
2026-03-31 12:45:42 : DEBUG : vlc : [] pkgName=
2026-03-31 12:45:42 : DEBUG : vlc : [] choiceChangesXML=
2026-03-31 12:45:42 : DEBUG : vlc : [] expectedTeamID=75GAHG3SZQ
2026-03-31 12:45:42 : DEBUG : vlc : [] blockingProcesses=
2026-03-31 12:45:42 : DEBUG : vlc : [] installerTool=
2026-03-31 12:45:42 : DEBUG : vlc : [] CLIInstaller=
2026-03-31 12:45:42 : DEBUG : vlc : [] CLIArguments=
2026-03-31 12:45:42 : DEBUG : vlc : [] updateTool=
2026-03-31 12:45:42 : DEBUG : vlc : [] updateToolArguments=
2026-03-31 12:45:42 : DEBUG : vlc : [] updateToolRunAsCurrentUser=
2026-03-31 12:45:42 : INFO  : vlc : [] BLOCKING_PROCESS_ACTION=tell_user
2026-03-31 12:45:42 : INFO  : vlc : [] NOTIFY=success
2026-03-31 12:45:42 : INFO  : vlc : [] LOGGING=DEBUG
2026-03-31 12:45:42 : INFO  : vlc : [] LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-31 12:45:42 : INFO  : vlc : [] Label type: dmg
2026-03-31 12:45:42 : INFO  : vlc : [] archiveName: VLC.dmg
2026-03-31 12:45:42 : INFO  : vlc : [] appName: VLC.app
2026-03-31 12:45:42 : INFO  : vlc : [] targetDir: /Applications
2026-03-31 12:45:42 : INFO  : vlc : [] no blocking processes defined, using VLC as default
2026-03-31 12:45:42 : INFO  : vlc : [] blockingProcesses: VLC
2026-03-31 12:45:42 : DEBUG : vlc : [] Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OK9eh4Y73C
2026-03-31 12:45:42 : DEBUG : vlc : [yelp] Here: []:12143 – Getting installed version of app, if any
2026-03-31 12:45:42 : DEBUG : vlc : [yelp] Here: [getAppVersion]:599 – Arguments not needed
2026-03-31 12:45:42 : INFO  : vlc : [getAppVersion] App(s) found: /Applications/VLC.app
2026-03-31 12:45:42 : INFO  : vlc : [getAppVersion] found app at /Applications/VLC.app, version 3.0.23, on versionKey CFBundleShortVersionString
2026-03-31 12:45:42 : INFO  : vlc : [] appversion: 3.0.23
2026-03-31 12:45:42 : INFO  : vlc : [] Latest version of VLC is 3.0.23
2026-03-31 12:45:42 : INFO  : vlc : [] There is no newer version available.
2026-03-31 12:45:42 : DEBUG : vlc : [cleanupAndExit] Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OK9eh4Y73C
2026-03-31 12:45:42 : DEBUG : vlc : [cleanupAndExit] Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.OK9eh4Y73C
2026-03-31 12:45:42 : DEBUG : vlc : [yelp] Here: [reopenClosedProcess]:799 – Arguments not needed
2026-03-31 12:45:42 : INFO  : vlc : [reopenClosedProcess] Installomator did not close any apps, so no need to reopen any apps.
2026-03-31 12:45:42 : REQ   : vlc : [cleanupAndExit] No newer version.
2026-03-31 12:45:42 : DEBUG : vlc : [yelp] Here: [updateDialog]:1417 – Arguments: success 
2026-03-31 12:45:42 : REQ   : vlc : [cleanupAndExit] ################## End Installomator, exit code 0 
```
