### PR TITLE
nextcloud-label-update

### DIFF
--- a/fragments/labels/nextcloud.sh
+++ b/fragments/labels/nextcloud.sh
@@ -1,7 +1,7 @@
 nextcloud)
-    name="nextcloud"
+    name="Nextcloud"
     type="pkg"
-    archiveName="Nextcloud-[0-9.]*-macOS-vfs.pkg"
+    archiveName="Nextcloud-[0-9.]+\.pkg"
     downloadURL=$(downloadURLFromGit nextcloud-releases desktop)
     appNewVersion=$(versionFromGit nextcloud-releases desktop)
     expectedTeamID="NKUJUXUJ3B"


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh nextcloud DEBUG=0
2026-03-31 08:42:59 : INFO  : nextcloud : setting variable from argument DEBUG=0
2026-03-31 08:42:59 : INFO  : nextcloud : Total items in argumentsArray: 1
2026-03-31 08:42:59 : INFO  : nextcloud : argumentsArray: DEBUG=0
2026-03-31 08:42:59 : REQ   : nextcloud : ################## Start Installomator v. 10.9beta, date 2026-03-31
2026-03-31 08:42:59 : INFO  : nextcloud : ################## Version: 10.9beta
2026-03-31 08:42:59 : INFO  : nextcloud : ################## Date: 2026-03-31
2026-03-31 08:42:59 : INFO  : nextcloud : ################## nextcloud
2026-03-31 08:43:01 : INFO  : nextcloud : Reading arguments again: DEBUG=0
2026-03-31 08:43:01 : INFO  : nextcloud : BLOCKING_PROCESS_ACTION=tell_user
2026-03-31 08:43:01 : INFO  : nextcloud : NOTIFY=success
2026-03-31 08:43:01 : INFO  : nextcloud : LOGGING=INFO
2026-03-31 08:43:01 : INFO  : nextcloud : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-31 08:43:01 : INFO  : nextcloud : Label type: pkg
2026-03-31 08:43:01 : INFO  : nextcloud : archiveName: Nextcloud-[0-9.]+\.pkg
2026-03-31 08:43:01 : INFO  : nextcloud : no blocking processes defined, using Nextcloud as default
2026-03-31 08:43:01 : INFO  : nextcloud : name: Nextcloud, appName: Nextcloud.app
2026-03-31 08:43:01 : WARN  : nextcloud : No previous app found
2026-03-31 08:43:01 : WARN  : nextcloud : could not find Nextcloud.app
2026-03-31 08:43:01 : INFO  : nextcloud : appversion:
2026-03-31 08:43:01 : INFO  : nextcloud : Latest version of Nextcloud is 33.0.1
2026-03-31 08:43:01 : REQ   : nextcloud : Downloading https://github.com/nextcloud-releases/desktop/releases/download/v33.0.1/Nextcloud-33.0.1.pkg to Nextcloud-[0-9.]+\.pkg
2026-03-31 08:43:12 : INFO  : nextcloud : Downloaded Nextcloud-[0-9.]+\.pkg – Type is  xar archive compressed TOC – SHA is \58d0260dbfc364a7c48a2beffa7b7efe723ade18 – Size is 377020 kB
2026-03-31 08:43:12 : REQ   : nextcloud : no more blocking processes, continue with update
2026-03-31 08:43:12 : REQ   : nextcloud : Installing Nextcloud
2026-03-31 08:43:12 : INFO  : nextcloud : Verifying: Nextcloud-[0-9.]+\.pkg
2026-03-31 08:43:12 : INFO  : nextcloud : Team ID: NKUJUXUJ3B (expected: NKUJUXUJ3B )
2026-03-31 08:43:12 : INFO  : nextcloud : Installing Nextcloud-[0-9.]+\.pkg to /
2026-03-31 08:43:34 : INFO  : nextcloud : Finishing...
2026-03-31 08:43:37 : INFO  : nextcloud : App(s) found: /Applications/Nextcloud.app
2026-03-31 08:43:37 : INFO  : nextcloud : found app at /Applications/Nextcloud.app, version 33.0.1, on versionKey CFBundleShortVersionString
2026-03-31 08:43:38 : REQ   : nextcloud : Installed Nextcloud, version 33.0.1
2026-03-31 08:43:38 : INFO  : nextcloud : notifying
2026-03-31 08:43:38 : INFO  : nextcloud : Installomator did not close any apps, so no need to reopen any apps.
2026-03-31 08:43:38 : REQ   : nextcloud : All done!
2026-03-31 08:43:38 : REQ   : nextcloud : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update standardizes the label name capitalization and simplifies the archive matching logic by tightening the regex pattern to align with current Nextcloud package naming conventions. It removes legacy suffix handling (-macOS-vfs) that is no longer used, improving reliability when detecting and downloading the correct installer. Overall, this reduces the chance of mismatches and ensures better compatibility with upstream releases.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
