### PR TITLE
gimp-label-update

### DIFF
--- a/fragments/labels/gimp.sh
+++ b/fragments/labels/gimp.sh
@@ -1,15 +1,11 @@
 gimp)
     name="GIMP"
     type="dmg"
-    gimpDetails="$(curl -fs "https://www.gimp.org/gimp_versions.json")"
-    appNewVersion="$(getJSONValue "$gimpDetails" "STABLE[0].version")"
-    dlVersion="$(echo "${appNewVersion}" | cut -d'.' -f1-2)"
-    [[ "$(getJSONValue "$gimpDetails" "STABLE[0].macos[0].filename")" == *"x86_64"* ]] && gimpDmgx86_64="$(getJSONValue "$gimpDetails" "STABLE[0].macos[0].filename")" && gimpDmgArm64="$(getJSONValue "$gimpDetails" "STABLE[0].macos[1].filename")"
-    [[ "$(getJSONValue "$gimpDetails" "STABLE[0].macos[0].filename")" == *"arm64"* ]] && gimpDmgArm64="$(getJSONValue "$gimpDetails" "STABLE[0].macos[0].filename")" && gimpDmgx86_64="$(getJSONValue "$gimpDetails" "STABLE[0].macos[1].filename")"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://download.gimp.org/gimp/v${dlVersion}/macos/${gimpDmgArm64}"
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-arm64.dmg")
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://download.gimp.org/gimp/v${dlVersion}/macos/${gimpDmgx86_64}"
+        downloadURL=https://$(curl -fs https://www.gimp.org/downloads/ | grep -m 1 -o "download.*gimp-.*-x86_64.dmg")
     fi
+    appNewVersion=$(echo $downloadURL | cut -d "-" -f 2)
     expectedTeamID="T25BQ8HSJF"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh gimp DEBUG=0
2026-03-31 09:54:48 : INFO  : gimp : setting variable from argument DEBUG=0
2026-03-31 09:54:48 : INFO  : gimp : Total items in argumentsArray: 1
2026-03-31 09:54:48 : INFO  : gimp : argumentsArray: DEBUG=0
2026-03-31 09:54:48 : REQ   : gimp : ################## Start Installomator v. 10.9beta, date 2026-03-31
2026-03-31 09:54:48 : INFO  : gimp : ################## Version: 10.9beta
2026-03-31 09:54:48 : INFO  : gimp : ################## Date: 2026-03-31
2026-03-31 09:54:48 : INFO  : gimp : ################## gimp
2026-03-31 09:54:49 : INFO  : gimp : Reading arguments again: DEBUG=0
2026-03-31 09:54:49 : INFO  : gimp : BLOCKING_PROCESS_ACTION=tell_user
2026-03-31 09:54:49 : INFO  : gimp : NOTIFY=success
2026-03-31 09:54:49 : INFO  : gimp : LOGGING=INFO
2026-03-31 09:54:49 : INFO  : gimp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-03-31 09:54:49 : INFO  : gimp : Label type: dmg
2026-03-31 09:54:49 : INFO  : gimp : archiveName: GIMP.dmg
2026-03-31 09:54:49 : INFO  : gimp : no blocking processes defined, using GIMP as default
2026-03-31 09:54:49 : INFO  : gimp : name: GIMP, appName: GIMP.app
2026-03-31 09:54:50 : WARN  : gimp : No previous app found
2026-03-31 09:54:50 : WARN  : gimp : could not find GIMP.app
2026-03-31 09:54:50 : INFO  : gimp : appversion:
2026-03-31 09:54:50 : INFO  : gimp : Latest version of GIMP is 3.2.0
2026-03-31 09:54:50 : REQ   : gimp : Downloading https://download.gimp.org/gimp/v3.2/macos/gimp-3.2.0-arm64.dmg to GIMP.dmg
2026-03-31 09:54:57 : INFO  : gimp : Downloaded GIMP.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 5d1b45d389ec0989ed2eaeebf5a001061e3b0d7f – Size is 229564 kB
2026-03-31 09:54:57 : REQ   : gimp : no more blocking processes, continue with update
2026-03-31 09:54:57 : REQ   : gimp : Installing GIMP
2026-03-31 09:54:57 : INFO  : gimp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.50InuZXWbH/GIMP.dmg
2026-03-31 09:55:01 : INFO  : gimp : Mounted: /Volumes/GIMP 3.2.0 Install
2026-03-31 09:55:01 : INFO  : gimp : Verifying: /Volumes/GIMP 3.2.0 Install/GIMP.app
2026-03-31 09:55:18 : INFO  : gimp : Team ID matching: T25BQ8HSJF (expected: T25BQ8HSJF )
2026-03-31 09:55:18 : INFO  : gimp : Installing GIMP version 3.2.0 on versionKey CFBundleShortVersionString.
2026-03-31 09:55:18 : INFO  : gimp : App has LSMinimumSystemVersion: 11.0
2026-03-31 09:55:18 : INFO  : gimp : Copy /Volumes/GIMP 3.2.0 Install/GIMP.app to /Applications
2026-03-31 09:56:49 : WARN  : gimp : Changing owner to u0105821
2026-03-31 09:57:09 : INFO  : gimp : Finishing...
2026-03-31 09:57:12 : INFO  : gimp : App(s) found: /Applications/GIMP.app
2026-03-31 09:57:12 : INFO  : gimp : found app at /Applications/GIMP.app, version 3.2.0, on versionKey CFBundleShortVersionString
2026-03-31 09:57:12 : REQ   : gimp : Installed GIMP, version 3.2.0
2026-03-31 09:57:12 : INFO  : gimp : notifying
2026-03-31 09:57:13 : INFO  : gimp : Installomator did not close any apps, so no need to reopen any apps.
2026-03-31 09:57:13 : REQ   : gimp : All done!
2026-03-31 09:57:14 : REQ   : gimp : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

No

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update replaces the JSON-based version lookup with a simpler and more resilient approach by scraping the official GIMP downloads page for architecture-specific DMG links. It removes dependency on the gimp_versions.json structure, reducing breakage risk when upstream APIs change, and streamlines version detection by parsing directly from the download URL. The logic is now more concise and easier to maintain while preserving correct architecture targeting.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
