### PR TITLE
Fix smart quotes in bruno.sh

### DIFF
--- a/fragments/labels/bruno.sh
+++ b/fragments/labels/bruno.sh
@@ -2,9 +2,9 @@ bruno)
     # https://github.com/usebruno/bruno; https://www.usebruno.com/
     name="Bruno"
     type="dmg"
-    if [[ $(arch) == “arm64” ]]; then
+    if [[ $(arch) == "arm64" ]]; then
         archiveName="bruno_[0-9.]*_arm64_mac.dmg"
-    elif [[ $(arch) == “i386” ]]; then
+    elif [[ $(arch) == "i386" ]]; then
         archiveName="bruno_[0-9.]*_x64_mac.dmg"
     fi
     downloadURL="$(downloadURLFromGit usebruno bruno)"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Replaced smart quotes with standard ASCII double quotes in the `bruno` label's `arch` comparisons.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```text
2026-04-08 04:06:26 : INFO  : bruno : setting variable from argument DEBUG=2
2026-04-08 04:06:26 : INFO  : bruno : Total items in argumentsArray: 1
2026-04-08 04:06:26 : INFO  : bruno : argumentsArray: DEBUG=2
2026-04-08 04:06:26 : REQ   : bruno : ################## Start Installomator v. 10.9beta, date 2026-04-08
2026-04-08 04:06:26 : INFO  : bruno : ################## Version: 10.9beta
2026-04-08 04:06:26 : INFO  : bruno : ################## Date: 2026-04-08
2026-04-08 04:06:26 : INFO  : bruno : ################## bruno
2026-04-08 04:06:26 : DEBUG : bruno : DEBUG mode 2 enabled.
2026-04-08 04:06:28 : INFO  : bruno : Reading arguments again: DEBUG=2
2026-04-08 04:06:28 : DEBUG : bruno : argument: DEBUG=2
2026-04-08 04:06:28 : DEBUG : bruno : name=Bruno
2026-04-08 04:06:28 : DEBUG : bruno : appName=
2026-04-08 04:06:28 : DEBUG : bruno : type=dmg
2026-04-08 04:06:28 : DEBUG : bruno : archiveName=bruno_[0-9.]*_arm64_mac.dmg
2026-04-08 04:06:28 : DEBUG : bruno : downloadURL=https://github.com/usebruno/bruno/releases/download/v3.2.2/bruno_3.2.2_arm64_mac.dmg
2026-04-08 04:06:28 : DEBUG : bruno : curlOptions=
2026-04-08 04:06:28 : DEBUG : bruno : appNewVersion=3.2.2
2026-04-08 04:06:28 : DEBUG : bruno : appCustomVersion function: Not defined
2026-04-08 04:06:28 : DEBUG : bruno : versionKey=CFBundleShortVersionString
2026-04-08 04:06:28 : DEBUG : bruno : packageID=
2026-04-08 04:06:28 : DEBUG : bruno : pkgName=
2026-04-08 04:06:28 : DEBUG : bruno : choiceChangesXML=
2026-04-08 04:06:28 : DEBUG : bruno : expectedTeamID=W7LPPWA48L
2026-04-08 04:06:28 : DEBUG : bruno : blockingProcesses=
2026-04-08 04:06:28 : DEBUG : bruno : installerTool=
2026-04-08 04:06:28 : DEBUG : bruno : CLIInstaller=
2026-04-08 04:06:28 : DEBUG : bruno : CLIArguments=
2026-04-08 04:06:28 : DEBUG : bruno : updateTool=
2026-04-08 04:06:28 : DEBUG : bruno : updateToolArguments=
2026-04-08 04:06:28 : DEBUG : bruno : updateToolRunAsCurrentUser=
2026-04-08 04:06:28 : INFO  : bruno : BLOCKING_PROCESS_ACTION=tell_user
2026-04-08 04:06:28 : INFO  : bruno : NOTIFY=success
2026-04-08 04:06:28 : INFO  : bruno : LOGGING=DEBUG
2026-04-08 04:06:28 : INFO  : bruno : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-08 04:06:28 : INFO  : bruno : Label type: dmg
2026-04-08 04:06:28 : INFO  : bruno : archiveName: bruno_[0-9.]*_arm64_mac.dmg
2026-04-08 04:06:28 : INFO  : bruno : no blocking processes defined, using Bruno as default
2026-04-08 04:06:29 : DEBUG : bruno : Changing directory to /var/folders/jj/tkbqqrv1339001htcghk1g740000gp/T/tmp.hC8BwxnJPP
2026-04-08 04:06:29 : INFO  : bruno : name: Bruno, appName: Bruno.app
2026-04-08 04:06:29 : WARN  : bruno : No previous app found
2026-04-08 04:06:29 : WARN  : bruno : could not find Bruno.app
2026-04-08 04:06:29 : INFO  : bruno : appversion: 
2026-04-08 04:06:29 : INFO  : bruno : Latest version of Bruno is 3.2.2
2026-04-08 04:06:29 : REQ   : bruno : Downloading https://github.com/usebruno/bruno/releases/download/v3.2.2/bruno_3.2.2_arm64_mac.dmg to bruno_[0-9.]*_arm64_mac.dmg
2026-04-08 04:06:29 : DEBUG : bruno : No Dialog connection, just download
2026-04-08 04:06:34 : INFO  : bruno : Downloaded bruno_[0-9.]*_arm64_mac.dmg – Type is  zlib compressed data – SHA is 1b337657d36f0e2a88b6ee86054c5c1c525c8163 – Size is 163932 kB
2026-04-08 04:06:34 : REQ   : bruno : no more blocking processes, continue with update
2026-04-08 04:06:34 : REQ   : bruno : Installing Bruno
2026-04-08 04:06:34 : INFO  : bruno : Mounting /var/folders/jj/tkbqqrv1339001htcghk1g740000gp/T/tmp.hC8BwxnJPP/bruno_[0-9.]*_arm64_mac.dmg
2026-04-08 04:06:38 : DEBUG : bruno : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D3EAD834
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $EC3521AA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $63C3A87A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $3D644763
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $63C3A87A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $F73BFA25
verified   CRC32 $5DC39596
/dev/disk8              GUID_partition_scheme
/dev/disk8s1            Apple_APFS
/dev/disk9              EF57347C-0000-11AA-AA11-0030654
/dev/disk9s1            41504653-0000-11AA-AA11-0030654 /Volumes/Bruno 3.2.2-arm64

2026-04-08 04:06:38 : INFO  : bruno : Mounted: /Volumes/Bruno 3.2.2-arm64
2026-04-08 04:06:38 : INFO  : bruno : Verifying: /Volumes/Bruno 3.2.2-arm64/Bruno.app
2026-04-08 04:06:38 : DEBUG : bruno : App size: 438M    /Volumes/Bruno 3.2.2-arm64/Bruno.app
2026-04-08 04:06:39 : DEBUG : bruno : Debugging enabled, App Verification output was:
/Volumes/Bruno 3.2.2-arm64/Bruno.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Anoop MD (W7LPPWA48L)

2026-04-08 04:06:39 : INFO  : bruno : Team ID matching: W7LPPWA48L (expected: W7LPPWA48L )
2026-04-08 04:06:39 : INFO  : bruno : Installing Bruno version 3.2.2 on versionKey CFBundleShortVersionString.
2026-04-08 04:06:39 : INFO  : bruno : App has LSMinimumSystemVersion: 11.0
2026-04-08 04:06:39 : DEBUG : bruno : DEBUG mode 2 enabled, not installing anything, exiting
2026-04-08 04:06:40 : DEBUG : bruno : Unmounting /Volumes/Bruno 3.2.2-arm64
2026-04-08 04:06:40 : DEBUG : bruno : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-04-08 04:06:40 : DEBUG : bruno : Deleting /var/folders/jj/tkbqqrv1339001htcghk1g740000gp/T/tmp.hC8BwxnJPP
2026-04-08 04:06:40 : DEBUG : bruno : Debugging enabled, Deleting tmpDir output was:
/var/folders/jj/tkbqqrv1339001htcghk1g740000gp/T/tmp.hC8BwxnJPP/bruno_[0-9.]*_arm64_mac.dmg
2026-04-08 04:06:40 : DEBUG : bruno : /var/folders/jj/tkbqqrv1339001htcghk1g740000gp/T/tmp.hC8BwxnJPP
2026-04-08 04:06:40 : INFO  : bruno : Installomator did not close any apps, so no need to reopen any apps.
2026-04-08 04:06:40 : INFO  : bruno : 
2026-04-08 04:06:40 : REQ   : bruno : ################## End Installomator, exit code 0 
