### PR TITLE
Fix citrixworkspace.sh

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -1,9 +1,23 @@
 citrixworkspace)
     name="Citrix Workspace"
-    type="pkg"
-    parseURL=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/DownloadURL)' -)
-    downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod/$parseURL
-    appNewVersion=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/Version)' -)
+    type="pkgInDmg"
+    curlOptions=( --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36" )
+    parseURL() {
+        urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
+        htmlDocument=$(curl -s -L "$urlToParse" $curlOptions)
+        xmllint --html --xpath \
+            "string(//a[contains(@class, 'ctx-dl-link')]/@rel)" \
+            2>/dev/null <(print "$htmlDocument")
+    }
+    downloadURL="https:$(parseURL)"
+    newVersionString() {
+        urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
+        htmlDocument=$(curl -fs "$urlToParse" $curlOptions)
+        xmllint --html --xpath \
+            "string(//div[@class='ctx-dl-content']/p[starts-with(., 'Version')])" \
+            2>/dev/null <(print "$htmlDocument")
+    }
+    appNewVersion=$(newVersionString | sed -nE 's/.*Version ([0-9.]+).*/\1/p')
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;

--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -5,17 +5,13 @@ citrixworkspace)
     parseURL() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
         htmlDocument=$(curl -s -L "$urlToParse" $curlOptions)
-        xmllint --html --xpath \
-            "string(//a[contains(@class, 'ctx-dl-link')]/@rel)" \
-            2>/dev/null <(print "$htmlDocument")
+        xmllint --html --xpath "string(//a[contains(@class, 'ctx-dl-link')]/@rel)" 2>/dev/null <(print "$htmlDocument")
     }
     downloadURL="https:$(parseURL)"
     newVersionString() {
         urlToParse='https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html'
         htmlDocument=$(curl -fs "$urlToParse" $curlOptions)
-        xmllint --html --xpath \
-            "string(//div[@class='ctx-dl-content']/p[starts-with(., 'Version')])" \
-            2>/dev/null <(print "$htmlDocument")
+        xmllint --html --xpath "string(//div[@class='ctx-dl-content']/p[starts-with(., 'Version')])" 2>/dev/null <(print "$htmlDocument")
     }
     appNewVersion=$(newVersionString | sed -nE 's/.*Version ([0-9.]+).*/\1/p')
     versionKey="CitrixVersionString"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Updates the `citrixworkspace` label to use the current Citrix Mac download page and handle the installer as `pkgInDmg`.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```text
2026-04-08 04:34:36 : INFO  : citrixworkspace : setting variable from argument DEBUG=2
2026-04-08 04:34:36 : INFO  : citrixworkspace : Total items in argumentsArray: 1
2026-04-08 04:34:36 : INFO  : citrixworkspace : argumentsArray: DEBUG=2
2026-04-08 04:34:36 : REQ   : citrixworkspace : ################## Start Installomator v. 10.9b5, date 2026-01-08
2026-04-08 04:34:36 : INFO  : citrixworkspace : ################## Version: 10.9b5
2026-04-08 04:34:37 : INFO  : citrixworkspace : ################## Date: 2026-01-08
2026-04-08 04:34:37 : INFO  : citrixworkspace : ################## citrixworkspace
2026-04-08 04:34:37 : DEBUG : citrixworkspace : DEBUG mode 2 enabled.
2026-04-08 04:34:40 : INFO  : citrixworkspace : Reading arguments again: DEBUG=2
2026-04-08 04:34:40 : DEBUG : citrixworkspace : argument: DEBUG=2
2026-04-08 04:34:40 : DEBUG : citrixworkspace : name=Citrix Workspace
2026-04-08 04:34:40 : DEBUG : citrixworkspace : appName=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : type=pkgInDmg
2026-04-08 04:34:40 : DEBUG : citrixworkspace : archiveName=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : downloadURL=https://downloads.citrix.com/25826/CitrixWorkspaceApp.dmg?__gda__=exp=1775640878~acl=/*~hmac=2504b0ebf111f27c2bde5501f03d6b221e8c3420559a262910a43a21d2bb85a8
2026-04-08 04:34:40 : DEBUG : citrixworkspace : curlOptions=--user-agent Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
2026-04-08 04:34:40 : DEBUG : citrixworkspace : appNewVersion=25.11.1.42
2026-04-08 04:34:40 : DEBUG : citrixworkspace : appCustomVersion function: Not defined
2026-04-08 04:34:40 : DEBUG : citrixworkspace : versionKey=CitrixVersionString
2026-04-08 04:34:40 : DEBUG : citrixworkspace : packageID=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : pkgName=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : choiceChangesXML=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : expectedTeamID=S272Y5R93J
2026-04-08 04:34:40 : DEBUG : citrixworkspace : blockingProcesses=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : installerTool=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : CLIInstaller=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : CLIArguments=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : updateTool=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : updateToolArguments=
2026-04-08 04:34:40 : DEBUG : citrixworkspace : updateToolRunAsCurrentUser=
2026-04-08 04:34:40 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2026-04-08 04:34:40 : INFO  : citrixworkspace : NOTIFY=success
2026-04-08 04:34:41 : INFO  : citrixworkspace : LOGGING=DEBUG
2026-04-08 04:34:41 : INFO  : citrixworkspace : Label type: pkgInDmg
2026-04-08 04:34:41 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2026-04-08 04:34:41 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2026-04-08 04:34:41 : DEBUG : citrixworkspace : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2rYkz1xQWY
2026-04-08 04:34:41 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2026-04-08 04:34:41 : WARN  : citrixworkspace : No previous app found
2026-04-08 04:34:41 : WARN  : citrixworkspace : could not find Citrix Workspace.app
2026-04-08 04:34:41 : INFO  : citrixworkspace : appversion:
2026-04-08 04:34:41 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 25.11.1.42
2026-04-08 04:34:41 : REQ   : citrixworkspace : Downloading https://downloads.citrix.com/25826/CitrixWorkspaceApp.dmg?__gda__=exp=1775640878~acl=/*~hmac=2504b0ebf111f27c2bde5501f03d6b221e8c3420559a262910a43a21d2bb85a8 to Citrix Workspace.dmg
2026-04-08 04:34:41 : DEBUG : citrixworkspace : No Dialog connection, just download
2026-04-08 04:34:49 : INFO  : citrixworkspace : Downloaded Citrix Workspace.dmg – Type is  zlib compressed data – SHA is 2dc504fb511187bb08fb94a76f3963a8e100dae5 – Size is 328392 kB
2026-04-08 04:34:49 : REQ   : citrixworkspace : no more blocking processes, continue with update
2026-04-08 04:34:50 : REQ   : citrixworkspace : Installing Citrix Workspace
2026-04-08 04:34:50 : INFO  : citrixworkspace : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2rYkz1xQWY/Citrix Workspace.dmg
2026-04-08 04:34:51 : DEBUG : citrixworkspace : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $CBD92579
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $D26EA3A9
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified   CRC32 $7567A866
verified   CRC32 $75FD76AC
/dev/disk4              Apple_partition_scheme
/dev/disk4s1            Apple_partition_map
/dev/disk4s2            Apple_HFS                       /Volumes/Citrix Workspace

2026-04-08 04:34:51 : INFO  : citrixworkspace : Mounted: /Volumes/Citrix Workspace
2026-04-08 04:34:51 : DEBUG : citrixworkspace : Found pkg(s):
/Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-04-08 04:34:51 : INFO  : citrixworkspace : found pkg: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-04-08 04:34:51 : INFO  : citrixworkspace : Verifying: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-04-08 04:34:51 : DEBUG : citrixworkspace : File list: -rw-r--r--@ 1 icsadmin  wheel   289M Jan 19 03:44 /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-04-08 04:34:51 : DEBUG : citrixworkspace : File type: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: xar archive compressed TOC: 7141, SHA-1 checksum
2026-04-08 04:34:52 : DEBUG : citrixworkspace : spctlOut is /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: accepted
2026-04-08 04:34:52 : DEBUG : citrixworkspace : source=Notarized Developer ID
2026-04-08 04:34:52 : DEBUG : citrixworkspace : origin=Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)
2026-04-08 04:34:52 : INFO  : citrixworkspace : Team ID: S272Y5R93J (expected: S272Y5R93J )
2026-04-08 04:34:52 : DEBUG : citrixworkspace : Unmounting /Volumes/Citrix Workspace
2026-04-08 04:34:52 : DEBUG : citrixworkspace : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-04-08 04:34:52 : DEBUG : citrixworkspace : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2rYkz1xQWY
2026-04-08 04:34:52 : DEBUG : citrixworkspace : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2rYkz1xQWY/Citrix Workspace.dmg
2026-04-08 04:34:52 : DEBUG : citrixworkspace : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.2rYkz1xQWY
2026-04-08 04:34:52 : INFO  : citrixworkspace : Installomator did not close any apps, so no need to reopen any apps.
2026-04-08 04:34:52 : DEBUG : citrixworkspace : DEBUG mode 2 enabled, exiting
2026-04-08 04:34:53 : REQ   : citrixworkspace : ################## End Installomator, exit code 0
