### PR TITLE
Create codex.sh

### DIFF
--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -1,0 +1,6 @@
+codex)
+    name="Codex"
+    type="dmg"
+    downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    expectedTeamID="2DC432GLL2"
+    ;;

--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -1,6 +1,14 @@
 codex)
     name="Codex"
     type="dmg"
-    downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    elif typeset -f cleanupAndExit >/dev/null 2>&1; then
+        printlog "Codex is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 1 "Codex requires Apple Silicon" ERROR
+    else
+        downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    fi
+    appNewVersion="$(curl -fs "https://persistent.oaistatic.com/codex-app-prod/appcast.xml" | grep -o '<sparkle:shortVersionString>[^<]*' | head -1 | cut -d '>' -f 2)"
     expectedTeamID="2DC432GLL2"
     ;;

--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -3,11 +3,9 @@ codex)
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
-    elif typeset -f cleanupAndExit >/dev/null 2>&1; then
-        printlog "Codex is only compatible with Apple Silicon (arm64) Macs." ERROR
-        cleanupAndExit 1 "Codex requires Apple Silicon" ERROR
     else
-        downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+        printlog "Codex is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Codex requires Apple Silicon" ERROR
     fi
     appNewVersion="$(curl -fs "https://persistent.oaistatic.com/codex-app-prod/appcast.xml" | grep -o '<sparkle:shortVersionString>[^<]*' | head -1 | cut -d '>' -f 2)"
     expectedTeamID="2DC432GLL2"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Adds a minimal `codex` DMG label using the official OpenAI download URL and Team ID. A stable public `appNewVersion` source was not found, so the label follows the existing DMG pattern that reads the mounted app version after download.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```text
2026-04-08 07:39:17 : INFO  : codex : setting variable from argument DEBUG=0
2026-04-08 07:39:17 : INFO  : codex : Total items in argumentsArray: 1
2026-04-08 07:39:17 : INFO  : codex : argumentsArray: DEBUG=0
2026-04-08 07:39:17 : REQ   : codex : ################## Start Installomator v. 10.9beta, date 2026-04-08
2026-04-08 07:39:17 : INFO  : codex : ################## Version: 10.9beta
2026-04-08 07:39:17 : INFO  : codex : ################## Date: 2026-04-08
2026-04-08 07:39:17 : INFO  : codex : ################## codex
2026-04-08 07:39:18 : INFO  : codex : Reading arguments again: DEBUG=0
2026-04-08 07:39:18 : INFO  : codex : BLOCKING_PROCESS_ACTION=tell_user
2026-04-08 07:39:18 : INFO  : codex : NOTIFY=success
2026-04-08 07:39:18 : INFO  : codex : LOGGING=INFO
2026-04-08 07:39:18 : INFO  : codex : Label type: dmg
2026-04-08 07:39:18 : INFO  : codex : archiveName: Codex.dmg
2026-04-08 07:39:18 : INFO  : codex : no blocking processes defined, using Codex as default
2026-04-08 07:39:18 : INFO  : codex : name: Codex, appName: Codex.app
2026-04-08 07:39:18 : WARN  : codex : No previous app found
2026-04-08 07:39:18 : WARN  : codex : could not find Codex.app
2026-04-08 07:39:18 : INFO  : codex : appversion: 
2026-04-08 07:39:18 : INFO  : codex : Latest version not specified.
2026-04-08 07:39:19 : REQ   : codex : Downloading https://persistent.oaistatic.com/codex-app-prod/Codex.dmg to Codex.dmg
2026-04-08 07:39:22 : INFO  : codex : Downloaded Codex.dmg – Type is  zlib compressed data – SHA is 203574ed325baa0b7847b51c00eb366262915ab1 – Size is 197592 kB
2026-04-08 07:39:22 : REQ   : codex : no more blocking processes, continue with update
2026-04-08 07:39:22 : REQ   : codex : Installing Codex
2026-04-08 07:39:22 : INFO  : codex : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.iuC3MWMYJU/Codex.dmg
2026-04-08 07:39:25 : INFO  : codex : Mounted: /Volumes/Codex Installer
2026-04-08 07:39:25 : INFO  : codex : Verifying: /Volumes/Codex Installer/Codex.app
2026-04-08 07:39:26 : INFO  : codex : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2026-04-08 07:39:26 : INFO  : codex : Installing Codex version 26.325.31654 on versionKey CFBundleShortVersionString.
2026-04-08 07:39:26 : INFO  : codex : App has LSMinimumSystemVersion: 12.0
2026-04-08 07:39:26 : INFO  : codex : Copy /Volumes/Codex Installer/Codex.app to /Applications
2026-04-08 07:39:28 : WARN  : codex : Changing owner to fcdtest
2026-04-08 07:39:28 : INFO  : codex : Finishing...
2026-04-08 07:39:31 : INFO  : codex : App(s) found: /Applications/Codex.app
2026-04-08 07:39:31 : INFO  : codex : found app at /Applications/Codex.app, version 26.325.31654, on versionKey CFBundleShortVersionString
2026-04-08 07:39:31 : REQ   : codex : Installed Codex, version 26.325.31654
2026-04-08 07:39:31 : INFO  : codex : notifying
2026-04-08 07:39:31 : INFO  : codex : Installomator did not close any apps, so no need to reopen any apps.
2026-04-08 07:39:31 : REQ   : codex : All done!
2026-04-08 07:39:31 : REQ   : codex : ################## End Installomator, exit code 0 
```
