### PR TITLE
Update captureone.sh

### DIFF
--- a/fragments/labels/captureone.sh
+++ b/fragments/labels/captureone.sh
@@ -1,9 +1,8 @@
 captureone|captureonepro)
     name="Capture One"
     type="dmg"
-    appName="Capture One.app"
-    blockingProcesses=("Capture One")
+    captureoneSparkle=$(curl -fsL "https://www.captureone.com/update/capture-one-mac.xml")
+    downloadURL=$(echo "${captureoneSparkle}" | xmllint --xpath "string(//item[1]/enclosure/@url)" - 2>/dev/null)
+    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*Mac\.([0-9.]+)\.dmg/\1/')
     expectedTeamID="5WTDB5F65L"
-    downloadURL=$(curl -fsL "https://www.captureone.com/en/account/download/trial-confirmation?intent=trial-pro" | grep -Eo 'https://downloads\.captureone\.pro/d/mac/[A-Za-z0-9]+/CaptureOne\.Mac\.[0-9\.]+\.dmg' | head -1)
-    appNewVersion=$(echo "$downloadURL" | sed -n 's/.*CaptureOne\.Mac\.\([0-9.]*\)\.dmg.*/\1/p')
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Changes label to use the app's sparkle update feed rather than the website, should be a bit faster and more reliable. Remove redundant app name and blocking process as the default yields the same.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-04-08 10:08:52 : INFO  : captureone : Total items in argumentsArray: 0
2026-04-08 10:08:52 : INFO  : captureone : argumentsArray: 
2026-04-08 10:08:52 : REQ   : captureone : ################## Start Installomator v. 10.9beta, date 2026-04-08
2026-04-08 10:08:52 : INFO  : captureone : ################## Version: 10.9beta
2026-04-08 10:08:52 : INFO  : captureone : ################## Date: 2026-04-08
2026-04-08 10:08:52 : INFO  : captureone : ################## captureone
2026-04-08 10:08:52 : DEBUG : captureone : DEBUG mode 1 enabled.
2026-04-08 10:08:52 : INFO  : captureone : SwiftDialog is not installed, clear cmd file var
2026-04-08 10:08:54 : INFO  : captureone : Reading arguments again: 
2026-04-08 10:08:54 : DEBUG : captureone : name=Capture One
2026-04-08 10:08:54 : DEBUG : captureone : appName=
2026-04-08 10:08:54 : DEBUG : captureone : type=dmg
2026-04-08 10:08:54 : DEBUG : captureone : archiveName=
2026-04-08 10:08:54 : DEBUG : captureone : downloadURL=https://downloads.captureone.pro/d/mac/a215d5efade6b75be5f68079ae3ab72e27850f3a/CaptureOne.Mac.16.7.5.7.dmg
2026-04-08 10:08:54 : DEBUG : captureone : curlOptions=
2026-04-08 10:08:54 : DEBUG : captureone : appNewVersion=16.7.5.7
2026-04-08 10:08:54 : DEBUG : captureone : appCustomVersion function: Not defined
2026-04-08 10:08:54 : DEBUG : captureone : versionKey=CFBundleShortVersionString
2026-04-08 10:08:54 : DEBUG : captureone : packageID=
2026-04-08 10:08:54 : DEBUG : captureone : pkgName=
2026-04-08 10:08:54 : DEBUG : captureone : choiceChangesXML=
2026-04-08 10:08:54 : DEBUG : captureone : expectedTeamID=5WTDB5F65L
2026-04-08 10:08:54 : DEBUG : captureone : blockingProcesses=
2026-04-08 10:08:54 : DEBUG : captureone : installerTool=
2026-04-08 10:08:54 : DEBUG : captureone : CLIInstaller=
2026-04-08 10:08:54 : DEBUG : captureone : CLIArguments=
2026-04-08 10:08:54 : DEBUG : captureone : updateTool=
2026-04-08 10:08:54 : DEBUG : captureone : updateToolArguments=
2026-04-08 10:08:54 : DEBUG : captureone : updateToolRunAsCurrentUser=
2026-04-08 10:08:54 : INFO  : captureone : BLOCKING_PROCESS_ACTION=tell_user
2026-04-08 10:08:54 : INFO  : captureone : NOTIFY=success
2026-04-08 10:08:54 : INFO  : captureone : LOGGING=DEBUG
2026-04-08 10:08:54 : INFO  : captureone : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-08 10:08:54 : INFO  : captureone : Label type: dmg
2026-04-08 10:08:54 : INFO  : captureone : archiveName: Capture One.dmg
2026-04-08 10:08:54 : INFO  : captureone : no blocking processes defined, using Capture One as default
2026-04-08 10:08:54 : DEBUG : captureone : Changing directory to /Users/ndurso/Documents/GitHub/Installomator/build
2026-04-08 10:08:54 : INFO  : captureone : name: Capture One, appName: Capture One.app
2026-04-08 10:08:54 : WARN  : captureone : No previous app found
2026-04-08 10:08:54 : WARN  : captureone : could not find Capture One.app
2026-04-08 10:08:54 : INFO  : captureone : appversion: 
2026-04-08 10:08:54 : INFO  : captureone : Latest version of Capture One is 16.7.5.7
2026-04-08 10:08:54 : REQ   : captureone : Downloading https://downloads.captureone.pro/d/mac/a215d5efade6b75be5f68079ae3ab72e27850f3a/CaptureOne.Mac.16.7.5.7.dmg to Capture One.dmg
2026-04-08 10:08:54 : DEBUG : captureone : No Dialog connection, just download
2026-04-08 10:13:20 : INFO  : captureone : Downloaded Capture One.dmg – Type is  zlib compressed data – SHA is a215d5efade6b75be5f68079ae3ab72e27850f3a – Size is 1246044 kB
2026-04-08 10:13:20 : DEBUG : captureone : DEBUG mode 1, not checking for blocking processes
2026-04-08 10:13:20 : REQ   : captureone : Installing Capture One
2026-04-08 10:13:20 : INFO  : captureone : Mounting /Users/ndurso/Documents/GitHub/Installomator/build/Capture One.dmg
2026-04-08 10:13:26 : DEBUG : captureone : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $200FD965
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $251365E5
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5D1BC4C8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $AC926FCA
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5D1BC4C8
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $21A5D9B9
verified   CRC32 $A7AE5CD4
/dev/disk3          	GUID_partition_scheme
/dev/disk3s1        	EFI
/dev/disk3s2        	Apple_HFS                      	/Volumes/Capture One

2026-04-08 10:13:26 : INFO  : captureone : Mounted: /Volumes/Capture One
2026-04-08 10:13:26 : INFO  : captureone : Verifying: /Volumes/Capture One/Capture One.app
2026-04-08 10:13:26 : DEBUG : captureone : App size: 1.6G	/Volumes/Capture One/Capture One.app
2026-04-08 10:13:49 : DEBUG : captureone : Debugging enabled, App Verification output was:
/Volumes/Capture One/Capture One.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Capture One A/S (5WTDB5F65L)

2026-04-08 10:13:49 : INFO  : captureone : Team ID matching: 5WTDB5F65L (expected: 5WTDB5F65L )
2026-04-08 10:13:49 : INFO  : captureone : Installing Capture One version 16.7.5.7 on versionKey CFBundleShortVersionString.
2026-04-08 10:13:49 : INFO  : captureone : App has LSMinimumSystemVersion: 14.0
2026-04-08 10:13:49 : DEBUG : captureone : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-08 10:13:49 : INFO  : captureone : Finishing...
2026-04-08 10:13:52 : INFO  : captureone : name: Capture One, appName: Capture One.app
2026-04-08 10:13:52 : WARN  : captureone : No previous app found
2026-04-08 10:13:52 : WARN  : captureone : could not find Capture One.app
2026-04-08 10:13:52 : REQ   : captureone : Installed Capture One, version 16.7.5.7
2026-04-08 10:13:52 : INFO  : captureone : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-04-08 10:13:52 : DEBUG : captureone : Unmounting /Volumes/Capture One
2026-04-08 10:13:52 : DEBUG : captureone : Debugging enabled, Unmounting output was:
"disk3" ejected.
2026-04-08 10:13:52 : DEBUG : captureone : DEBUG mode 1, not reopening anything
2026-04-08 10:13:52 : REQ   : captureone : All done!
2026-04-08 10:13:52 : REQ   : captureone : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
