### PR TITLE
Update libreoffice.sh

### DIFF
--- a/fragments/labels/libreoffice.sh
+++ b/fragments/labels/libreoffice.sh
@@ -1,7 +1,7 @@
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | xmllint --html --xpath 'string(//p[@class="version_heading"])' - 2>/dev/null | xargs)"
     if [[ $(arch) == "arm64" ]]; then
     	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
The appNewVersion variable has stopped working. Likely due to HTML changes at the URL source. This change fixes the appNewVersion variable.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-04-14 09:21:03 : INFO  : libreoffice : setting variable from argument DEBUG=0
2026-04-14 09:21:03 : INFO  : libreoffice : Total items in argumentsArray: 1
2026-04-14 09:21:03 : INFO  : libreoffice : argumentsArray: DEBUG=0
2026-04-14 09:21:03 : REQ   : libreoffice : ################## Start Installomator v. 10.9beta, date 2026-04-14
2026-04-14 09:21:03 : INFO  : libreoffice : ################## Version: 10.9beta
2026-04-14 09:21:03 : INFO  : libreoffice : ################## Date: 2026-04-14
2026-04-14 09:21:03 : INFO  : libreoffice : ################## libreoffice
2026-04-14 09:21:03 : INFO  : libreoffice : SwiftDialog is not installed, clear cmd file var
2026-04-14 09:21:03 : INFO  : libreoffice : Reading arguments again: DEBUG=0
2026-04-14 09:21:03 : INFO  : libreoffice : BLOCKING_PROCESS_ACTION=tell_user
2026-04-14 09:21:04 : INFO  : libreoffice : NOTIFY=success
2026-04-14 09:21:04 : INFO  : libreoffice : LOGGING=INFO
2026-04-14 09:21:04 : INFO  : libreoffice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-14 09:21:04 : INFO  : libreoffice : Label type: dmg
2026-04-14 09:21:04 : INFO  : libreoffice : archiveName: LibreOffice.dmg
2026-04-14 09:21:04.124 defaults[84378:13307521] 
The domain/default pair of (/Applications/LibreOffice.app/Contents/Info.plist, CFBundleVersion) does not exist
2026-04-14 09:21:04 : INFO  : libreoffice : Custom App Version detection is used, found 
2026-04-14 09:21:04 : INFO  : libreoffice : appversion: 
2026-04-14 09:21:04 : INFO  : libreoffice : Latest version of LibreOffice is 26.2.2
2026-04-14 09:21:04 : REQ   : libreoffice : Downloading https://download.documentfoundation.org/libreoffice/stable/26.2.2/mac/aarch64/LibreOffice_26.2.2_MacOS_aarch64.dmg to LibreOffice.dmg
2026-04-14 09:21:09 : INFO  : libreoffice : Downloaded LibreOffice.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 253c26b02fb657a3cb9cd5e89a7ee740bcba2d07 – Size is 295916 kB
2026-04-14 09:21:09 : REQ   : libreoffice : no more blocking processes, continue with update
2026-04-14 09:21:09 : REQ   : libreoffice : Installing LibreOffice
2026-04-14 09:21:09 : INFO  : libreoffice : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.WiGFgDpmjJ/LibreOffice.dmg
2026-04-14 09:21:11 : INFO  : libreoffice : Mounted: /Volumes/LibreOffice
2026-04-14 09:21:11 : INFO  : libreoffice : Verifying: /Volumes/LibreOffice/LibreOffice.app
2026-04-14 09:21:19 : INFO  : libreoffice : Team ID matching: 7P5S3ZLCN7 (expected: 7P5S3ZLCN7 )
2026-04-14 09:21:19 : INFO  : libreoffice : Installing LibreOffice version 26.2.2.2 on versionKey CFBundleShortVersionString.
2026-04-14 09:21:19 : INFO  : libreoffice : App has LSMinimumSystemVersion: 11.0.0
2026-04-14 09:21:19 : INFO  : libreoffice : Copy /Volumes/LibreOffice/LibreOffice.app to /Applications
2026-04-14 09:21:30 : WARN  : libreoffice : Changing owner to kryptonit
2026-04-14 09:21:31 : INFO  : libreoffice : Finishing...
2026-04-14 09:21:34 : INFO  : libreoffice : Custom App Version detection is used, found 26.2.2
2026-04-14 09:21:34 : REQ   : libreoffice : Installed LibreOffice, version 26.2.2.2
2026-04-14 09:21:34 : INFO  : libreoffice : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-04-14 09:21:35 : INFO  : libreoffice : Installomator did not close any apps, so no need to reopen any apps.
2026-04-14 09:21:35 : REQ   : libreoffice : All done!
2026-04-14 09:21:35 : REQ   : libreoffice : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A