### PR TITLE
ffmpegmartinriedl_new_label

### DIFF
--- a/fragments/labels/ffmpegmartinriedl.sh
+++ b/fragments/labels/ffmpegmartinriedl.sh
@@ -1,0 +1,12 @@
+ffmpegmartinriedl)
+    name="FFmpeg"
+    type="pkg"
+    if [[ $(arch) == arm64 ]]; then
+        archDir="arm64"
+    else
+        archDir="amd64"
+    fi
+    downloadURL="https://ffmpeg.martin-riedl.de/redirect/latest/macos/${archDir}/release/ffmpeg.pkg"
+    appNewVersion=$( /usr/bin/curl -fs https://ffmpeg.martin-riedl.de/ | /usr/bin/awk '/Download Release Build/{found=1} found && /Release:/{match($0,/[0-9]+\.[0-9]+(\.[0-9]+)?/); print substr($0,RSTART,RLENGTH); exit}' )
+    expectedTeamID="KU3N25YGLU"
+    ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh ffmpegmartinriedl DEBUG=0
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : setting variable from argument DEBUG=0
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : Total items in argumentsArray: 1
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : argumentsArray: DEBUG=0
2026-04-14 13:53:11 : REQ   : ffmpegmartinriedl : ################## Start Installomator v. 10.9beta, date 2026-04-14
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : ################## Version: 10.9beta
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : ################## Date: 2026-04-14
2026-04-14 13:53:11 : INFO  : ffmpegmartinriedl : ################## ffmpegmartinriedl
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : Reading arguments again: DEBUG=0
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : BLOCKING_PROCESS_ACTION=tell_user
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : NOTIFY=success
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : LOGGING=INFO
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : Label type: pkg
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : archiveName: FFmpeg.pkg
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : no blocking processes defined, using FFmpeg as default
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : name: FFmpeg, appName: FFmpeg.app
2026-04-14 13:53:12 : WARN  : ffmpegmartinriedl : No previous app found
2026-04-14 13:53:12 : WARN  : ffmpegmartinriedl : could not find FFmpeg.app
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : appversion:
2026-04-14 13:53:12 : INFO  : ffmpegmartinriedl : Latest version of FFmpeg is 8.1
2026-04-14 13:53:12 : REQ   : ffmpegmartinriedl : Downloading https://ffmpeg.martin-riedl.de/redirect/latest/macos/arm64/release/ffmpeg.pkg to FFmpeg.pkg
2026-04-14 13:53:16 : INFO  : ffmpegmartinriedl : Downloaded FFmpeg.pkg – Type is  xar archive compressed TOC – SHA is 32faabef952d13706d62c83f8fed40b407711ae7 – Size is 26596 kB
2026-04-14 13:53:16 : REQ   : ffmpegmartinriedl : no more blocking processes, continue with update
2026-04-14 13:53:16 : REQ   : ffmpegmartinriedl : Installing FFmpeg
2026-04-14 13:53:16 : INFO  : ffmpegmartinriedl : Verifying: FFmpeg.pkg
2026-04-14 13:53:16 : INFO  : ffmpegmartinriedl : Team ID: KU3N25YGLU (expected: KU3N25YGLU )
2026-04-14 13:53:16 : INFO  : ffmpegmartinriedl : Installing FFmpeg.pkg to /
2026-04-14 13:53:20 : INFO  : ffmpegmartinriedl : Finishing...
2026-04-14 13:53:23 : INFO  : ffmpegmartinriedl : name: FFmpeg, appName: FFmpeg.app
2026-04-14 13:53:23 : WARN  : ffmpegmartinriedl : No previous app found
2026-04-14 13:53:23 : WARN  : ffmpegmartinriedl : could not find FFmpeg.app
2026-04-14 13:53:23 : REQ   : ffmpegmartinriedl : Installed FFmpeg, version 8.1
2026-04-14 13:53:23 : INFO  : ffmpegmartinriedl : notifying
2026-04-14 13:53:24 : INFO  : ffmpegmartinriedl : Installomator did not close any apps, so no need to reopen any apps.
2026-04-14 13:53:24 : REQ   : ffmpegmartinriedl : All done!
2026-04-14 13:53:24 : REQ   : ffmpegmartinriedl : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

I added a new Installomator label for FFmpeg using the macOS release package published by martin-riedl.de. The label detects Apple Silicon vs. Intel, pulls the matching .pkg, and checks the vendor site for the latest release version.
FFmpeg is a widely used open-source multimedia framework for converting, streaming, and processing audio and video. On macOS, this package installs the command-line tools so admins and power users can work with media files without needing a separate app bundle.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
