### PR TITLE
Update polleverywhere.sh

### DIFF
--- a/fragments/labels/polleverywhere.sh
+++ b/fragments/labels/polleverywhere.sh
@@ -1,7 +1,7 @@
 polleverywhere)
     name="Poll Everywhere"
     type="dmg"
-    downloadURL="https://www.polleverywhere.com/app.dmg"
-    appNewVersion=""
+    downloadURL="$(curl -fs https://www.polleverywhere.com/app/releases/mac | grep -i mac-stable | grep -o -i -E "https.*" | cut -d '"' -f1 | head -n 1)"
+    appNewVersion="$(echo $downloadURL | cut -d "/" -f5)"
     expectedTeamID="W48F3X5M8W"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
-Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
-Modifying an existing label: polleverywhere

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
-Yes and the readme in the utils folder.

**Additional context** Add any other context about the label or fix here.
-Original download link translates to a login page now. Found a list of versions that the dev provides and new label parses that pages for the latest version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
-No issues submitted that I'm aware of.

Output of label run:

./assemble.sh -l ~/Documents/InstallomatorLabels polleverywhere
2026-04-16 16:16:35 : INFO  : polleverywhere : Total items in argumentsArray: 0
2026-04-16 16:16:35 : INFO  : polleverywhere : argumentsArray: 
2026-04-16 16:16:35 : REQ   : polleverywhere : ################## Start Installomator v. 10.9beta, date 2026-04-16
2026-04-16 16:16:35 : INFO  : polleverywhere : ################## Version: 10.9beta
2026-04-16 16:16:35 : INFO  : polleverywhere : ################## Date: 2026-04-16
2026-04-16 16:16:35 : INFO  : polleverywhere : ################## polleverywhere
2026-04-16 16:16:35 : DEBUG : polleverywhere : DEBUG mode 1 enabled.
2026-04-16 16:16:37 : INFO  : polleverywhere : Reading arguments again: 
2026-04-16 16:16:37 : DEBUG : polleverywhere : name=Poll Everywhere
2026-04-16 16:16:37 : DEBUG : polleverywhere : appName=
2026-04-16 16:16:37 : DEBUG : polleverywhere : type=dmg
2026-04-16 16:16:37 : DEBUG : polleverywhere : archiveName=
2026-04-16 16:16:37 : DEBUG : polleverywhere : downloadURL=https://polleverywhere-app.s3.amazonaws.com/mac-stable/4.0.1/pollev.dmg
2026-04-16 16:16:37 : DEBUG : polleverywhere : curlOptions=
2026-04-16 16:16:37 : DEBUG : polleverywhere : appNewVersion=4.0.1
2026-04-16 16:16:37 : DEBUG : polleverywhere : appCustomVersion function: Not defined
2026-04-16 16:16:37 : DEBUG : polleverywhere : versionKey=CFBundleShortVersionString
2026-04-16 16:16:37 : DEBUG : polleverywhere : packageID=
2026-04-16 16:16:37 : DEBUG : polleverywhere : pkgName=
2026-04-16 16:16:37 : DEBUG : polleverywhere : choiceChangesXML=
2026-04-16 16:16:37 : DEBUG : polleverywhere : expectedTeamID=W48F3X5M8W
2026-04-16 16:16:37 : DEBUG : polleverywhere : blockingProcesses=
2026-04-16 16:16:37 : DEBUG : polleverywhere : installerTool=
2026-04-16 16:16:37 : DEBUG : polleverywhere : CLIInstaller=
2026-04-16 16:16:37 : DEBUG : polleverywhere : CLIArguments=
2026-04-16 16:16:37 : DEBUG : polleverywhere : updateTool=
2026-04-16 16:16:37 : DEBUG : polleverywhere : updateToolArguments=
2026-04-16 16:16:37 : DEBUG : polleverywhere : updateToolRunAsCurrentUser=
2026-04-16 16:16:37 : INFO  : polleverywhere : BLOCKING_PROCESS_ACTION=tell_user
2026-04-16 16:16:37 : INFO  : polleverywhere : NOTIFY=success
2026-04-16 16:16:37 : INFO  : polleverywhere : LOGGING=DEBUG
2026-04-16 16:16:37 : INFO  : polleverywhere : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-16 16:16:37 : INFO  : polleverywhere : Label type: dmg
2026-04-16 16:16:37 : INFO  : polleverywhere : archiveName: Poll Everywhere.dmg
2026-04-16 16:16:37 : INFO  : polleverywhere : no blocking processes defined, using Poll Everywhere as default
2026-04-16 16:16:37 : DEBUG : polleverywhere : Changing directory to /Users/davisbr/Desktop/Installomator-main/build
2026-04-16 16:16:37 : INFO  : polleverywhere : name: Poll Everywhere, appName: Poll Everywhere.app
2026-04-16 16:16:37 : WARN  : polleverywhere : No previous app found
2026-04-16 16:16:37 : WARN  : polleverywhere : could not find Poll Everywhere.app
2026-04-16 16:16:37 : INFO  : polleverywhere : appversion: 
2026-04-16 16:16:37 : INFO  : polleverywhere : Latest version of Poll Everywhere is 4.0.1
2026-04-16 16:16:37 : REQ   : polleverywhere : Downloading https://polleverywhere-app.s3.amazonaws.com/mac-stable/4.0.1/pollev.dmg to Poll Everywhere.dmg
2026-04-16 16:16:37 : DEBUG : polleverywhere : No Dialog connection, just download
2026-04-16 16:16:38 : INFO  : polleverywhere : Downloaded Poll Everywhere.dmg – Type is  zlib compressed data – SHA is 954b8dd0e3b163148872f4406682cdb5c760f872 – Size is 3052 kB
2026-04-16 16:16:38 : DEBUG : polleverywhere : DEBUG mode 1, not checking for blocking processes
2026-04-16 16:16:38 : REQ   : polleverywhere : Installing Poll Everywhere
2026-04-16 16:16:38 : INFO  : polleverywhere : Mounting /Users/davisbr/Desktop/Installomator-main/build/Poll Everywhere.dmg
2026-04-16 16:16:42 : DEBUG : polleverywhere : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $9A1DC65A
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E61BAEC3
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7BFB8D2E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $FA3FD0D5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7BFB8D2E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $C3DC66A3
verified   CRC32 $19CF8851
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Poll Everywhere

2026-04-16 16:16:42 : INFO  : polleverywhere : Mounted: /Volumes/Poll Everywhere
2026-04-16 16:16:42 : INFO  : polleverywhere : Verifying: /Volumes/Poll Everywhere/Poll Everywhere.app
2026-04-16 16:16:42 : DEBUG : polleverywhere : App size: 6.5M	/Volumes/Poll Everywhere/Poll Everywhere.app
2026-04-16 16:16:42 : DEBUG : polleverywhere : Debugging enabled, App Verification output was:
/Volumes/Poll Everywhere/Poll Everywhere.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Poll Everywhere, Inc. (W48F3X5M8W)

2026-04-16 16:16:42 : INFO  : polleverywhere : Team ID matching: W48F3X5M8W (expected: W48F3X5M8W )
2026-04-16 16:16:42.506 defaults[80289:2634007] 
The domain/default pair of (/Volumes/Poll Everywhere/Poll Everywhere.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-04-16 16:16:42 : INFO  : polleverywhere : Installing Poll Everywhere version  on versionKey CFBundleShortVersionString.
2026-04-16 16:16:42 : INFO  : polleverywhere : App has LSMinimumSystemVersion: 14.6
2026-04-16 16:16:42 : DEBUG : polleverywhere : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-16 16:16:42 : INFO  : polleverywhere : Finishing...
2026-04-16 16:16:45 : INFO  : polleverywhere : name: Poll Everywhere, appName: Poll Everywhere.app
2026-04-16 16:16:45 : WARN  : polleverywhere : No previous app found
2026-04-16 16:16:45 : WARN  : polleverywhere : could not find Poll Everywhere.app
2026-04-16 16:16:45 : REQ   : polleverywhere : Installed Poll Everywhere
2026-04-16 16:16:45 : INFO  : polleverywhere : notifying
2026-04-16 16:16:45 : DEBUG : polleverywhere : Unmounting /Volumes/Poll Everywhere
2026-04-16 16:16:56 : DEBUG : polleverywhere : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-04-16 16:16:56 : DEBUG : polleverywhere : DEBUG mode 1, not reopening anything
2026-04-16 16:16:56 : REQ   : polleverywhere : All done!
2026-04-16 16:16:56 : REQ   : polleverywhere : ################## End Installomator, exit code 0 


