### PR TITLE
Update rstudio.sh

### DIFF
--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -1,7 +1,8 @@
 rstudio)
     name="RStudio"
     type="dmg"
-    downloadURL=$(curl -s -L "https://posit.co/download/rstudio-desktop/" | grep -m 1 -Eio 'href="https://download1.rstudio.org/electron/macos/RStudio-(.*).dmg"' | cut -c7- | sed -e 's/"$//')
-    appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.-]*)\..*/\1/g' | sed 's/-/+/' )
+    downloadPage=$(curl -s "https://docs.posit.co/supported-versions/rstudio.html" | grep -E "https.*Installers" | head -n 1 | grep -oE 'https?://[^"]+')
+    downloadURL=$(curl -s "$downloadPage" | grep -E "macos.*dmg" | head -1 | grep -oE 'https?://[^"]+')
+    appNewVersion=$(echo "$downloadPage" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\+[0-9]+')
     expectedTeamID="FYF2F5GFX4"
     ;;

--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -1,8 +1,7 @@
 rstudio)
     name="RStudio"
     type="dmg"
-    downloadPage=$(curl -s "https://docs.posit.co/supported-versions/rstudio.html" | grep -E "https.*Installers" | head -n 1 | grep -oE 'https?://[^"]+')
-    downloadURL=$(curl -s "$downloadPage" | grep -E "macos.*dmg" | head -1 | grep -oE 'https?://[^"]+')
-    appNewVersion=$(echo "$downloadPage" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\+[0-9]+')
+    downloadURL="https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg"
+    appNewVersion=$(curl -sfI "$downloadURL" | grep -i "^location" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\-[0-9]+' | sed 's/-/+/')
     expectedTeamID="FYF2F5GFX4"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
The old download page changed recently in way that made scraping URLs difficult. I had to do 2 steps (from `downloadPage` to `downloadURL`) to get the download URL.

**Installomator log** 
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

````
./assemble.sh rstudio
2026-04-17 00:37:39 : INFO  : rstudio : Total items in argumentsArray: 0
2026-04-17 00:37:39 : INFO  : rstudio : argumentsArray: 
2026-04-17 00:37:39 : REQ   : rstudio : ################## Start Installomator v. 10.9beta, date 2026-04-17
2026-04-17 00:37:39 : INFO  : rstudio : ################## Version: 10.9beta
2026-04-17 00:37:39 : INFO  : rstudio : ################## Date: 2026-04-17
2026-04-17 00:37:39 : INFO  : rstudio : ################## rstudio
2026-04-17 00:37:39 : DEBUG : rstudio : DEBUG mode 1 enabled.
2026-04-17 00:37:40 : INFO  : rstudio : Reading arguments again: 
2026-04-17 00:37:40 : DEBUG : rstudio : name=RStudio
2026-04-17 00:37:40 : DEBUG : rstudio : appName=
2026-04-17 00:37:40 : DEBUG : rstudio : type=dmg
2026-04-17 00:37:40 : DEBUG : rstudio : archiveName=
2026-04-17 00:37:40 : DEBUG : rstudio : downloadURL=https://s3.amazonaws.com/rstudio-ide-build/electron/macos/RStudio-2026.01.2-418.dmg
2026-04-17 00:37:40 : DEBUG : rstudio : curlOptions=
2026-04-17 00:37:40 : DEBUG : rstudio : appNewVersion=2026.01.2+418
2026-04-17 00:37:40 : DEBUG : rstudio : appCustomVersion function: Not defined
2026-04-17 00:37:40 : DEBUG : rstudio : versionKey=CFBundleShortVersionString
2026-04-17 00:37:40 : DEBUG : rstudio : packageID=
2026-04-17 00:37:40 : DEBUG : rstudio : pkgName=
2026-04-17 00:37:40 : DEBUG : rstudio : choiceChangesXML=
2026-04-17 00:37:40 : DEBUG : rstudio : expectedTeamID=FYF2F5GFX4
2026-04-17 00:37:40 : DEBUG : rstudio : blockingProcesses=
2026-04-17 00:37:40 : DEBUG : rstudio : installerTool=
2026-04-17 00:37:40 : DEBUG : rstudio : CLIInstaller=
2026-04-17 00:37:40 : DEBUG : rstudio : CLIArguments=
2026-04-17 00:37:40 : DEBUG : rstudio : updateTool=
2026-04-17 00:37:40 : DEBUG : rstudio : updateToolArguments=
2026-04-17 00:37:40 : DEBUG : rstudio : updateToolRunAsCurrentUser=
2026-04-17 00:37:40 : INFO  : rstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-04-17 00:37:40 : INFO  : rstudio : NOTIFY=success
2026-04-17 00:37:40 : INFO  : rstudio : LOGGING=DEBUG
2026-04-17 00:37:40 : INFO  : rstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-17 00:37:40 : INFO  : rstudio : Label type: dmg
2026-04-17 00:37:40 : INFO  : rstudio : archiveName: RStudio.dmg
2026-04-17 00:37:40 : INFO  : rstudio : no blocking processes defined, using RStudio as default
2026-04-17 00:37:40 : DEBUG : rstudio : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2026-04-17 00:37:40 : INFO  : rstudio : name: RStudio, appName: RStudio.app
2026-04-17 00:37:40 : WARN  : rstudio : No previous app found
2026-04-17 00:37:40 : WARN  : rstudio : could not find RStudio.app
2026-04-17 00:37:40 : INFO  : rstudio : appversion: 
2026-04-17 00:37:40 : INFO  : rstudio : Latest version of RStudio is 2026.01.2+418
2026-04-17 00:37:40 : REQ   : rstudio : Downloading https://s3.amazonaws.com/rstudio-ide-build/electron/macos/RStudio-2026.01.2-418.dmg to RStudio.dmg
2026-04-17 00:37:40 : DEBUG : rstudio : No Dialog connection, just download
2026-04-17 00:38:20 : INFO  : rstudio : Downloaded RStudio.dmg – Type is  zlib compressed data – SHA is a1f3d48ddbe4f6a8c92d9b00b3dcdb456864c724 – Size is 655640 kB
2026-04-17 00:38:20 : DEBUG : rstudio : DEBUG mode 1, not checking for blocking processes
2026-04-17 00:38:20 : REQ   : rstudio : Installing RStudio
2026-04-17 00:38:20 : INFO  : rstudio : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/RStudio.dmg
2026-04-17 00:38:26 : DEBUG : rstudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $6FF13BD8
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $EF7D5482
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $FF441339
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $859CEA97
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $FF441339
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $1ED903D8
verified CRC32 $D0D81989
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/RStudio-2026.01.2-418

2026-04-17 00:38:26 : INFO  : rstudio : Mounted: /Volumes/RStudio-2026.01.2-418
2026-04-17 00:38:26 : INFO  : rstudio : Verifying: /Volumes/RStudio-2026.01.2-418/RStudio.app
2026-04-17 00:38:26 : DEBUG : rstudio : App size: 1.5G	/Volumes/RStudio-2026.01.2-418/RStudio.app
2026-04-17 00:38:31 : DEBUG : rstudio : Debugging enabled, App Verification output was:
/Volumes/RStudio-2026.01.2-418/RStudio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: RStudio Inc. (FYF2F5GFX4)

2026-04-17 00:38:31 : INFO  : rstudio : Team ID matching: FYF2F5GFX4 (expected: FYF2F5GFX4 )
2026-04-17 00:38:31 : INFO  : rstudio : Installing RStudio version 2026.01.2+418 on versionKey CFBundleShortVersionString.
2026-04-17 00:38:31 : INFO  : rstudio : App has LSMinimumSystemVersion: 12.0
2026-04-17 00:38:31 : DEBUG : rstudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-17 00:38:31 : INFO  : rstudio : Finishing...
2026-04-17 00:38:34 : INFO  : rstudio : name: RStudio, appName: RStudio.app
2026-04-17 00:38:34 : WARN  : rstudio : No previous app found
2026-04-17 00:38:34 : WARN  : rstudio : could not find RStudio.app
2026-04-17 00:38:34 : REQ   : rstudio : Installed RStudio, version 2026.01.2+418
2026-04-17 00:38:34 : INFO  : rstudio : notifying
2026-04-17 00:38:34 : DEBUG : rstudio : Unmounting /Volumes/RStudio-2026.01.2-418
2026-04-17 00:38:34 : DEBUG : rstudio : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-04-17 00:38:34 : DEBUG : rstudio : DEBUG mode 1, not reopening anything
2026-04-17 00:38:34 : REQ   : rstudio : All done!
2026-04-17 00:38:34 : REQ   : rstudio : ################## End Installomator, exit code 0
````
