### PR TITLE
Add wisenetwave label

### DIFF
--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -1,0 +1,17 @@
+wisenetwave)
+    # Wisenet Wave VMS Client (Hanwha Vision)
+    # Download page: https://sync.wavevms.com/download/macos
+    # Versions API: https://sync.wavevms.com/api/utils/downloads-releases
+    # Only targeting macos_arm64 client build; x86_64 exists but is not needed.
+
+    name="Wisenet Wave"
+    type="dmg"
+    releaseData=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
+    appNewVersion=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['releases']['version'])")
+    buildNumber=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['releases']['buildNumber'])")
+    fileName=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(next(i['fileName'] for i in d['releases']['installers'] if i['platform']=='macos_arm64' and i['appType']=='client'))")
+    downloadURL="https://updates.wavevms.com/hanwha/${buildNumber}/macos/${fileName}"
+    appName="Wisenet WAVE.app"
+    blockingProcesses=( "Wisenet WAVE" )
+    expectedTeamID="L6FE34GJWM"
+    ;;

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -1,9 +1,7 @@
 wisenetwave)
-    # Wisenet Wave VMS Client (Hanwha Vision)
-    # Download page: https://sync.wavevms.com/download/macos
-    # Versions API: https://sync.wavevms.com/api/utils/downloads-releases
-    # Only targeting macos_arm64 client build; x86_64 exists but is not needed.
-
+    if [[ $(/usr/bin/arch) != "arm64" ]]; then
+        cleanupAndExit 76 "wisenetwave is only available for Apple Silicon (arm64)" ERROR
+    fi
     name="Wisenet Wave"
     type="dmg"
     releaseData=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -7,9 +7,10 @@ wisenetwave)
     name="Wisenet Wave"
     type="dmg"
     releaseData=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
-    appNewVersion=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['releases']['version'])")
-    buildNumber=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['releases']['buildNumber'])")
-    fileName=$(echo "$releaseData" | python3 -c "import json,sys; d=json.load(sys.stdin); print(next(i['fileName'] for i in d['releases']['installers'] if i['platform']=='macos_arm64' and i['appType']=='client'))")
+    releasesChunk=$(echo "$releaseData" | grep -o '"releases":{.*')
+    appNewVersion=$(echo "$releasesChunk" | grep -o '"version":"[0-9.]*"' | head -1 | cut -d'"' -f4)
+    buildNumber=$(echo "$releasesChunk" | grep -o '"buildNumber":"[0-9]*"' | head -1 | cut -d'"' -f4)
+    fileName=$(echo "$releasesChunk" | grep -o '"fileName":"wave-client-[^"]*-macos_arm64\.dmg"' | head -1 | cut -d'"' -f4)
     downloadURL="https://updates.wavevms.com/hanwha/${buildNumber}/macos/${fileName}"
     appName="Wisenet WAVE.app"
     blockingProcesses=( "Wisenet WAVE" )

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -1,5 +1,5 @@
 wisenetwave)
-    name="Wisenet Wave"
+    name="Wisenet WAVE"
     type="dmg"
     releaseJSON=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
     releasesChunk=$(echo "$releaseJSON" | grep -o '"releases":{.*')

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -1,15 +1,23 @@
 wisenetwave)
-    if [[ $(/usr/bin/arch) != "arm64" ]]; then
-        cleanupAndExit 76 "wisenetwave is only available for Apple Silicon (arm64)" ERROR
-    fi
     name="Wisenet Wave"
     type="dmg"
-    releaseData=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
-    releasesChunk=$(echo "$releaseData" | grep -o '"releases":{.*')
-    appNewVersion=$(echo "$releasesChunk" | grep -o '"version":"[0-9.]*"' | head -1 | cut -d'"' -f4)
-    buildNumber=$(echo "$releasesChunk" | grep -o '"buildNumber":"[0-9]*"' | head -1 | cut -d'"' -f4)
-    fileName=$(echo "$releasesChunk" | grep -o '"fileName":"wave-client-[^"]*-macos_arm64\.dmg"' | head -1 | cut -d'"' -f4)
-    downloadURL="https://updates.wavevms.com/hanwha/${buildNumber}/macos/${fileName}"
+    releaseJSON=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
+    appNewVersion=$(osascript -l JavaScript \
+        -e "const data = JSON.parse(\`${releaseJSON}\`)" \
+        -e "data.releases.version")
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(osascript -l JavaScript \
+            -e "const data = JSON.parse(\`${releaseJSON}\`)" \
+            -e "const r = data.releases" \
+            -e "const i = r.installers.find(i => i.platform === 'macos_arm64' && i.appType === 'client')" \
+            -e "data.updatesPrefix + '/' + r.buildNumber + '/' + i.path")
+    else
+        downloadURL=$(osascript -l JavaScript \
+            -e "const data = JSON.parse(\`${releaseJSON}\`)" \
+            -e "const r = data.releases" \
+            -e "const i = r.installers.find(i => i.platform === 'macos_x64' && i.appType === 'client')" \
+            -e "data.updatesPrefix + '/' + r.buildNumber + '/' + i.path")
+    fi
     appName="Wisenet WAVE.app"
     blockingProcesses=( "Wisenet WAVE" )
     expectedTeamID="L6FE34GJWM"

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -12,7 +12,5 @@ wisenetwave)
         installerPath=$(echo "$releasesChunk" | grep -o '"path":"[^"]*macos_x64[^"]*\.dmg"' | head -1 | cut -d'"' -f4)
     fi
     downloadURL="${updatesPrefix}/${buildNumber}/${installerPath}"
-    appName="Wisenet WAVE.app"
-    blockingProcesses=( "Wisenet WAVE" )
     expectedTeamID="L6FE34GJWM"
     ;;

--- a/fragments/labels/wisenetwave.sh
+++ b/fragments/labels/wisenetwave.sh
@@ -2,22 +2,16 @@ wisenetwave)
     name="Wisenet Wave"
     type="dmg"
     releaseJSON=$(curl -fs "https://sync.wavevms.com/api/utils/downloads-releases")
-    appNewVersion=$(osascript -l JavaScript \
-        -e "const data = JSON.parse(\`${releaseJSON}\`)" \
-        -e "data.releases.version")
+    releasesChunk=$(echo "$releaseJSON" | grep -o '"releases":{.*')
+    appNewVersion=$(getJSONValue "$releaseJSON" "releases.version")
+    buildNumber=$(getJSONValue "$releaseJSON" "releases.buildNumber")
+    updatesPrefix=$(getJSONValue "$releaseJSON" "updatesPrefix")
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(osascript -l JavaScript \
-            -e "const data = JSON.parse(\`${releaseJSON}\`)" \
-            -e "const r = data.releases" \
-            -e "const i = r.installers.find(i => i.platform === 'macos_arm64' && i.appType === 'client')" \
-            -e "data.updatesPrefix + '/' + r.buildNumber + '/' + i.path")
+        installerPath=$(echo "$releasesChunk" | grep -o '"path":"[^"]*macos_arm64[^"]*\.dmg"' | head -1 | cut -d'"' -f4)
     else
-        downloadURL=$(osascript -l JavaScript \
-            -e "const data = JSON.parse(\`${releaseJSON}\`)" \
-            -e "const r = data.releases" \
-            -e "const i = r.installers.find(i => i.platform === 'macos_x64' && i.appType === 'client')" \
-            -e "data.updatesPrefix + '/' + r.buildNumber + '/' + i.path")
+        installerPath=$(echo "$releasesChunk" | grep -o '"path":"[^"]*macos_x64[^"]*\.dmg"' | head -1 | cut -d'"' -f4)
     fi
+    downloadURL="${updatesPrefix}/${buildNumber}/${installerPath}"
     appName="Wisenet WAVE.app"
     blockingProcesses=( "Wisenet WAVE" )
     expectedTeamID="L6FE34GJWM"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — new label added at `fragments/labels/wisenetwave.sh`

**Did you use our editorconfig file?**
Yes

**Additional context**
New label for Wisenet Wave VMS Client by Hanwha Vision. Targets the macOS ARM64 client only (x86_64 exists but is not needed for this deployment).

- Version and download URL are resolved dynamically from the Hanwha releases API (`https://sync.wavevms.com/api/utils/downloads-releases`)
- Parsing uses grep/sed only — no python3 dependency
- The `releases` chunk is extracted first to avoid picking up beta versions that appear earlier in the JSON response
- App name: `Wisenet WAVE.app` | Team ID: `L6FE34GJWM`

**Installomator log**
2026-04-30 09:13:15 : REQ   : wisenetwave : ################## Start Installomator v. 10.9beta, date 2026-04-17
2026-04-30 09:13:18 : DEBUG : wisenetwave : name=Wisenet Wave
2026-04-30 09:13:18 : DEBUG : wisenetwave : appName=Wisenet WAVE.app
2026-04-30 09:13:18 : DEBUG : wisenetwave : type=dmg
2026-04-30 09:13:18 : DEBUG : wisenetwave : downloadURL=https://updates.wavevms.com/hanwha/41290/macos/wave-client-6.0.5.41290-macos_arm64.dmg
2026-04-30 09:13:18 : DEBUG : wisenetwave : appNewVersion=6.0.5.41290
2026-04-30 09:13:18 : DEBUG : wisenetwave : expectedTeamID=L6FE34GJWM
2026-04-30 09:13:18 : DEBUG : wisenetwave : blockingProcesses=Wisenet WAVE
2026-04-30 09:13:18 : INFO  : wisenetwave : App(s) found: /Applications/Wisenet WAVE.app
2026-04-30 09:13:18 : INFO  : wisenetwave : found app at /Applications/Wisenet WAVE.app, version 6.0.5, on versionKey CFBundleShortVersionString
2026-04-30 09:13:18 : INFO  : wisenetwave : Latest version of Wisenet Wave is 6.0.5.41290
2026-04-30 09:13:41 : INFO  : wisenetwave : Team ID matching: L6FE34GJWM (expected: L6FE34GJWM)
2026-04-30 09:13:41 : INFO  : wisenetwave : Downloaded version of Wisenet Wave is 6.0.5 on versionKey CFBundleShortVersionString, same as installed.
2026-04-30 09:13:41 : REG   : wisenetwave : No new version to install
2026-04-30 09:13:41 : REQ   : wisenetwave : ################## End Installomator, exit code 0