### PR TITLE
Update affinityapp.sh

### DIFF
--- a/fragments/labels/affinityapp.sh
+++ b/fragments/labels/affinityapp.sh
@@ -3,5 +3,6 @@ affinityapp)
     type="dmg"
     appName="Affinity.app"
     downloadURL="https://downloads.affinity.studio/Affinity.dmg"
+    appNewVersion=$(curl -fsL "https://affinity-update.s3.amazonaws.com/mac2/retail/studiopro.xml" | xpath '//rss/channel/item/sparkle:deltas/enclosure/@sparkle:shortVersionString' 2>/dev/null | cut -d '"' -f 2)
     expectedTeamID="5HD2ARTBFS"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes 

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Added `appNewVersion`

**Installomator log** 
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


````
./assemble.sh affinityapp
2026-04-17 23:04:57 : INFO  : affinityapp : Total items in argumentsArray: 0
2026-04-17 23:04:57 : INFO  : affinityapp : argumentsArray:
2026-04-17 23:04:58 : REQ   : affinityapp : ################## Start Installomator v. 10.9beta, date 2026-04-17
2026-04-17 23:04:58 : INFO  : affinityapp : ################## Version: 10.9beta
2026-04-17 23:04:58 : INFO  : affinityapp : ################## Date: 2026-04-17
2026-04-17 23:04:58 : INFO  : affinityapp : ################## affinityapp
2026-04-17 23:04:58 : DEBUG : affinityapp : DEBUG mode 1 enabled.
2026-04-17 23:04:58 : INFO  : affinityapp : Reading arguments again:
2026-04-17 23:04:58 : DEBUG : affinityapp : name=Affinity
2026-04-17 23:04:58 : DEBUG : affinityapp : appName=Affinity.app
2026-04-17 23:04:58 : DEBUG : affinityapp : type=dmg
2026-04-17 23:04:58 : DEBUG : affinityapp : archiveName=
2026-04-17 23:04:58 : DEBUG : affinityapp : downloadURL=https://downloads.affinity.studio/Affinity.dmg
2026-04-17 23:04:58 : DEBUG : affinityapp : curlOptions=
2026-04-17 23:04:58 : DEBUG : affinityapp : appNewVersion=3.2.0
2026-04-17 23:04:58 : DEBUG : affinityapp : appCustomVersion function: Not defined
2026-04-17 23:04:58 : DEBUG : affinityapp : versionKey=CFBundleShortVersionString
2026-04-17 23:04:58 : DEBUG : affinityapp : packageID=
2026-04-17 23:04:58 : DEBUG : affinityapp : pkgName=
2026-04-17 23:04:58 : DEBUG : affinityapp : choiceChangesXML=
2026-04-17 23:04:58 : DEBUG : affinityapp : expectedTeamID=5HD2ARTBFS
2026-04-17 23:04:58 : DEBUG : affinityapp : blockingProcesses=
2026-04-17 23:04:58 : DEBUG : affinityapp : installerTool=
2026-04-17 23:04:58 : DEBUG : affinityapp : CLIInstaller=
2026-04-17 23:04:58 : DEBUG : affinityapp : CLIArguments=
2026-04-17 23:04:58 : DEBUG : affinityapp : updateTool=
2026-04-17 23:04:58 : DEBUG : affinityapp : updateToolArguments=
2026-04-17 23:04:58 : DEBUG : affinityapp : updateToolRunAsCurrentUser=
2026-04-17 23:04:58 : INFO  : affinityapp : BLOCKING_PROCESS_ACTION=tell_user
2026-04-17 23:04:58 : INFO  : affinityapp : NOTIFY=success
2026-04-17 23:04:58 : INFO  : affinityapp : LOGGING=DEBUG
2026-04-17 23:04:58 : INFO  : affinityapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-17 23:04:58 : INFO  : affinityapp : Label type: dmg
2026-04-17 23:04:58 : INFO  : affinityapp : archiveName: Affinity.dmg
2026-04-17 23:04:58 : INFO  : affinityapp : no blocking processes defined, using Affinity as default
2026-04-17 23:04:58 : DEBUG : affinityapp : Changing directory to /Users/h.lans/Developer/GitHub/Installomator/build
2026-04-17 23:04:58 : INFO  : affinityapp : name: Affinity, appName: Affinity.app
2026-04-17 23:04:58 : INFO  : affinityapp : App(s) found: /Users/h.lans/Downloads/Affinity.app
2026-04-17 23:04:58 : WARN  : affinityapp : could not determine location of Affinity.app
2026-04-17 23:04:58 : INFO  : affinityapp : appversion:
2026-04-17 23:04:58 : INFO  : affinityapp : Latest version of Affinity is 3.2.0
2026-04-17 23:04:58 : REQ   : affinityapp : Downloading https://downloads.affinity.studio/Affinity.dmg to Affinity.dmg
2026-04-17 23:04:58 : DEBUG : affinityapp : No Dialog connection, just download
2026-04-17 23:06:11 : INFO  : affinityapp : Downloaded Affinity.dmg – Type is  zlib compressed data – SHA is 527c8b6dd62f6073f0abe46caacefaa94868d8bf – Size is 983188 kB
2026-04-17 23:06:11 : DEBUG : affinityapp : DEBUG mode 1, not checking for blocking processes
2026-04-17 23:06:11 : REQ   : affinityapp : Installing Affinity
2026-04-17 23:06:11 : INFO  : affinityapp : Mounting /Users/h.lans/Developer/GitHub/Installomator/build/Affinity.dmg
2026-04-17 23:06:16 : DEBUG : affinityapp : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified CRC32 $04EF6FE0
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified CRC32 $F9D32228
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified CRC32 $6380426B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
verified CRC32 $5373BC79
/dev/disk5          	Apple_partition_scheme
/dev/disk5s1        	Apple_partition_map
/dev/disk5s2        	Apple_HFS                      	/Volumes/Affinity 1

2026-04-17 23:06:16 : INFO  : affinityapp : Mounted: /Volumes/Affinity 1
2026-04-17 23:06:16 : INFO  : affinityapp : Verifying: /Volumes/Affinity 1/Affinity.app
2026-04-17 23:06:16 : DEBUG : affinityapp : App size: 3.4G	/Volumes/Affinity 1/Affinity.app
2026-04-17 23:06:32 : DEBUG : affinityapp : Debugging enabled, App Verification output was:
/Volumes/Affinity 1/Affinity.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Canva Pty Ltd (5HD2ARTBFS)

2026-04-17 23:06:32 : INFO  : affinityapp : Team ID matching: 5HD2ARTBFS (expected: 5HD2ARTBFS )
2026-04-17 23:06:32 : INFO  : affinityapp : Installing Affinity version 3.2.0 on versionKey CFBundleShortVersionString.
2026-04-17 23:06:32 : INFO  : affinityapp : App has LSMinimumSystemVersion: 10.15
2026-04-17 23:06:32 : DEBUG : affinityapp : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-17 23:06:32 : INFO  : affinityapp : Finishing...
2026-04-17 23:06:35 : INFO  : affinityapp : name: Affinity, appName: Affinity.app
2026-04-17 23:06:35 : INFO  : affinityapp : App(s) found: /Users/h.lans/Downloads/Affinity.app
2026-04-17 23:06:35 : WARN  : affinityapp : could not determine location of Affinity.app
2026-04-17 23:06:35 : REQ   : affinityapp : Installed Affinity, version 3.2.0
2026-04-17 23:06:35 : INFO  : affinityapp : notifying
2026-04-17 23:06:36 : DEBUG : affinityapp : Unmounting /Volumes/Affinity 1
2026-04-17 23:06:36 : DEBUG : affinityapp : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-04-17 23:06:36 : DEBUG : affinityapp : DEBUG mode 1, not reopening anything
2026-04-17 23:06:36 : REQ   : affinityapp : All done!
2026-04-17 23:06:36 : REQ   : affinityapp : ################## End Installomator, exit code 0
````