### PR TITLE
Add kommodo

### DIFF
--- a/fragments/labels/kommodoscreenrecorder.sh
+++ b/fragments/labels/kommodoscreenrecorder.sh
@@ -1,0 +1,15 @@
+kommodo|\
+kommodoscreenrecorder)
+    name="Kommodo Screen Recorder"
+    type="pkg"
+    archiveName="KommodoScreenRecorder.pkg"
+    packageID="com.komodo.electron.app"
+    if [[ $(arch) == "arm64" ]]; then
+        appNewVersion=$(curl -fs "https://api.prod.komododecks.com/api/v2/releases/arm64/latest-mac.yml" | awk '/^version:/ {print $2}')
+        downloadURL="https://releases.komododecks.com/prod/electron/${appNewVersion}/kommodo-screen-recorder-${appNewVersion}-arm.pkg"
+    elif [[ $(arch) == "i386" ]]; then
+        appNewVersion=$(curl -fs "https://api.prod.komododecks.com/api/v2/releases/x64/latest-mac.yml" | awk '/^version:/ {print $2}')
+        downloadURL="https://releases.komododecks.com/prod/electron/${appNewVersion}/kommodo-screen-recorder-${appNewVersion}-intel.pkg"
+    fi
+    expectedTeamID="3M6U87VP9P"
+    ;;

--- a/fragments/labels/kommodoscreenrecorder.sh
+++ b/fragments/labels/kommodoscreenrecorder.sh
@@ -3,7 +3,6 @@ kommodoscreenrecorder)
     name="Kommodo Screen Recorder"
     type="pkg"
     archiveName="KommodoScreenRecorder.pkg"
-    packageID="com.komodo.electron.app"
     if [[ $(arch) == "arm64" ]]; then
         appNewVersion=$(curl -fs "https://api.prod.komododecks.com/api/v2/releases/arm64/latest-mac.yml" | awk '/^version:/ {print $2}')
         downloadURL="https://releases.komododecks.com/prod/electron/${appNewVersion}/kommodo-screen-recorder-${appNewVersion}-arm.pkg"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Adds a label for Kommodo Screen Recorder (https://kommodo.ai), an Electron-based screen recorder. Ships signed + notarized `.pkg` installers per arch (Apple Silicon and Intel). Latest-version discovery uses the app's electron-updater feed (`latest-mac.yml` per arch) and the `.pkg` URL is constructed from the published artifact naming scheme on `releases.komododecks.com`. Label exposes both `kommodo` and `kommodoscreenrecorder` as aliases.

**Installomator log**

```
2026-04-20 09:07:18 : INFO  : kommodo : setting variable from argument DEBUG=1
2026-04-20 09:07:18 : INFO  : kommodo : Total items in argumentsArray: 1
2026-04-20 09:07:18 : INFO  : kommodo : argumentsArray: DEBUG=1
2026-04-20 09:07:18 : REQ   : kommodo : ################## Start Installomator v. 10.9beta, date 2026-04-20
2026-04-20 09:07:18 : INFO  : kommodo : ################## Version: 10.9beta
2026-04-20 09:07:18 : INFO  : kommodo : ################## Date: 2026-04-20
2026-04-20 09:07:18 : INFO  : kommodo : ################## kommodo
2026-04-20 09:07:18 : DEBUG : kommodo : DEBUG mode 1 enabled.
2026-04-20 09:07:18 : INFO  : kommodo : SwiftDialog is not installed, clear cmd file var
2026-04-20 09:07:19 : INFO  : kommodo : Reading arguments again: DEBUG=1
2026-04-20 09:07:19 : DEBUG : kommodo : argument: DEBUG=1
2026-04-20 09:07:19 : DEBUG : kommodo : name=Kommodo Screen Recorder
2026-04-20 09:07:19 : DEBUG : kommodo : appName=
2026-04-20 09:07:19 : DEBUG : kommodo : type=pkg
2026-04-20 09:07:19 : DEBUG : kommodo : archiveName=KommodoScreenRecorder.pkg
2026-04-20 09:07:19 : DEBUG : kommodo : downloadURL=https://releases.komododecks.com/prod/electron/2.9.5/kommodo-screen-recorder-2.9.5-arm.pkg
2026-04-20 09:07:19 : DEBUG : kommodo : curlOptions=
2026-04-20 09:07:19 : DEBUG : kommodo : appNewVersion=2.9.5
2026-04-20 09:07:19 : DEBUG : kommodo : appCustomVersion function: Not defined
2026-04-20 09:07:19 : DEBUG : kommodo : versionKey=CFBundleShortVersionString
2026-04-20 09:07:19 : DEBUG : kommodo : packageID=com.komodo.electron.app
2026-04-20 09:07:19 : DEBUG : kommodo : pkgName=
2026-04-20 09:07:19 : DEBUG : kommodo : choiceChangesXML=
2026-04-20 09:07:19 : DEBUG : kommodo : expectedTeamID=3M6U87VP9P
2026-04-20 09:07:19 : DEBUG : kommodo : blockingProcesses=
2026-04-20 09:07:19 : DEBUG : kommodo : installerTool=
2026-04-20 09:07:19 : DEBUG : kommodo : CLIInstaller=
2026-04-20 09:07:19 : DEBUG : kommodo : CLIArguments=
2026-04-20 09:07:19 : DEBUG : kommodo : updateTool=
2026-04-20 09:07:19 : DEBUG : kommodo : updateToolArguments=
2026-04-20 09:07:19 : DEBUG : kommodo : updateToolRunAsCurrentUser=
2026-04-20 09:07:19 : INFO  : kommodo : BLOCKING_PROCESS_ACTION=tell_user
2026-04-20 09:07:19 : INFO  : kommodo : NOTIFY=success
2026-04-20 09:07:19 : INFO  : kommodo : LOGGING=DEBUG
2026-04-20 09:07:19 : INFO  : kommodo : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-20 09:07:19 : INFO  : kommodo : Label type: pkg
2026-04-20 09:07:19 : INFO  : kommodo : archiveName: KommodoScreenRecorder.pkg
2026-04-20 09:07:19 : INFO  : kommodo : no blocking processes defined, using Kommodo Screen Recorder as default
2026-04-20 09:07:19 : DEBUG : kommodo : Changing directory to ./build
2026-04-20 09:07:19 : INFO  : kommodo : No version found using packageID com.komodo.electron.app
2026-04-20 09:07:19 : INFO  : kommodo : App(s) found: /Applications/Kommodo Screen Recorder.app
2026-04-20 09:07:19 : INFO  : kommodo : found app at /Applications/Kommodo Screen Recorder.app, version 2.9.5, on versionKey CFBundleShortVersionString
2026-04-20 09:07:19 : INFO  : kommodo : appversion: 2.9.5
2026-04-20 09:07:19 : INFO  : kommodo : Latest version of Kommodo Screen Recorder is 2.9.5
2026-04-20 09:07:19 : WARN  : kommodo : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-04-20 09:07:19 : REQ   : kommodo : Downloading https://releases.komododecks.com/prod/electron/2.9.5/kommodo-screen-recorder-2.9.5-arm.pkg to KommodoScreenRecorder.pkg
2026-04-20 09:07:19 : DEBUG : kommodo : No Dialog connection, just download
2026-04-20 09:07:25 : INFO  : kommodo : Downloaded KommodoScreenRecorder.pkg – Type is  xar archive compressed TOC – SHA is de7d6c9de3cff3630420383b4acff1d3252c842e – Size is 164308 kB
2026-04-20 09:07:25 : DEBUG : kommodo : DEBUG mode 1, not checking for blocking processes
2026-04-20 09:07:25 : REQ   : kommodo : Installing Kommodo Screen Recorder
2026-04-20 09:07:25 : INFO  : kommodo : Verifying: KommodoScreenRecorder.pkg
2026-04-20 09:07:25 : DEBUG : kommodo : File list: -rw-r--r--  1 root  staff   156M Apr 20 09:07 KommodoScreenRecorder.pkg
2026-04-20 09:07:25 : DEBUG : kommodo : File type: KommodoScreenRecorder.pkg: xar archive compressed TOC: 4361, SHA-1 checksum
2026-04-20 09:07:25 : DEBUG : kommodo : spctlOut is KommodoScreenRecorder.pkg: accepted
2026-04-20 09:07:25 : DEBUG : kommodo : source=Notarized Developer ID
2026-04-20 09:07:25 : DEBUG : kommodo : origin=Developer ID Installer: Investio (3M6U87VP9P)
2026-04-20 09:07:25 : INFO  : kommodo : Team ID: 3M6U87VP9P (expected: 3M6U87VP9P )
2026-04-20 09:07:25 : INFO  : kommodo : Checking package version.
Error encountered while creating ./build/KommodoScreenRecorder.pkg_pkg. Error 2: No such file or directory
cat: ./build/KommodoScreenRecorder.pkg_pkg/Distribution: No such file or directory
rm: ./build/KommodoScreenRecorder.pkg_pkg: No such file or directory
2026-04-20 09:07:25 : INFO  : kommodo : Downloaded package com.komodo.electron.app version 
2026-04-20 09:07:25 : DEBUG : kommodo : DEBUG enabled, skipping installation
2026-04-20 09:07:25 : INFO  : kommodo : Finishing...
2026-04-20 09:07:28 : INFO  : kommodo : No version found using packageID com.komodo.electron.app
2026-04-20 09:07:28 : INFO  : kommodo : App(s) found: /Applications/Kommodo Screen Recorder.app
2026-04-20 09:07:28 : INFO  : kommodo : found app at /Applications/Kommodo Screen Recorder.app, version 2.9.5, on versionKey CFBundleShortVersionString
2026-04-20 09:07:28 : REQ   : kommodo : Installed Kommodo Screen Recorder
2026-04-20 09:07:28 : INFO  : kommodo : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-04-20 09:07:29 : DEBUG : kommodo : DEBUG mode 1, not reopening anything
2026-04-20 09:07:29 : REQ   : kommodo : All done!
2026-04-20 09:07:29 : REQ   : kommodo : ################## End Installomator, exit code 0 
```