### PR TITLE
espanso-label-update

### DIFF
--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -6,6 +6,5 @@ espanso)
     pkgName="espanso/Espanso.dmg"
     downloadURL="$(downloadURLFromGit espanso espanso)"
     appNewVersion="$(versionFromGit espanso espanso)"
-    blockingProcesses=( "Espanso" "espanso" )
     expectedTeamID="6424323YUH"
     ;;

--- a/fragments/labels/espanso.sh
+++ b/fragments/labels/espanso.sh
@@ -1,13 +1,11 @@
 espanso)
     name="Espanso"
-    type="zip"
-    if [[ "$(arch)" == "arm64" ]]; then
-        archiveName="Espanso-Mac-M1.zip"
-    else
-        archiveName="Espanso-Mac-Intel.zip"
-    fi
+    type="appInDmgInZip"
+    appName="Espanso.app"
+    archiveName="Espanso-Mac-Universal.zip"
+    pkgName="espanso/Espanso.dmg"
     downloadURL="$(downloadURLFromGit espanso espanso)"
     appNewVersion="$(versionFromGit espanso espanso)"
     blockingProcesses=( "Espanso" "espanso" )
-    expectedTeamID="K839T4T5BY"
+    expectedTeamID="6424323YUH"
     ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh espanso DEBUG=0
2026-04-22 12:33:02 : INFO  : espanso : setting variable from argument DEBUG=0
2026-04-22 12:33:02 : INFO  : espanso : Total items in argumentsArray: 1
2026-04-22 12:33:02 : INFO  : espanso : argumentsArray: DEBUG=0
2026-04-22 12:33:02 : REQ   : espanso : ################## Start Installomator v. 10.9beta, date 2026-04-22
2026-04-22 12:33:02 : INFO  : espanso : ################## Version: 10.9beta
2026-04-22 12:33:02 : INFO  : espanso : ################## Date: 2026-04-22
2026-04-22 12:33:02 : INFO  : espanso : ################## espanso
2026-04-22 12:33:04 : INFO  : espanso : Reading arguments again: DEBUG=0
2026-04-22 12:33:04 : INFO  : espanso : BLOCKING_PROCESS_ACTION=tell_user
2026-04-22 12:33:04 : INFO  : espanso : NOTIFY=success
2026-04-22 12:33:04 : INFO  : espanso : LOGGING=INFO
2026-04-22 12:33:04 : INFO  : espanso : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-22 12:33:04 : INFO  : espanso : Label type: appInDmgInZip
2026-04-22 12:33:04 : INFO  : espanso : archiveName: Espanso-Mac-Universal.zip
2026-04-22 12:33:04 : INFO  : espanso : name: Espanso, appName: Espanso.app
2026-04-22 12:33:04 : WARN  : espanso : No previous app found
2026-04-22 12:33:04 : WARN  : espanso : could not find Espanso.app
2026-04-22 12:33:04 : INFO  : espanso : appversion:
2026-04-22 12:33:04 : INFO  : espanso : Latest version of Espanso is 2.3.0
2026-04-22 12:33:04 : REQ   : espanso : Downloading https://github.com/espanso/espanso/releases/download/v2.3.0/Espanso-Mac-Universal.zip to Espanso-Mac-Universal.zip
2026-04-22 12:33:05 : INFO  : espanso : Downloaded Espanso-Mac-Universal.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is d4dd25477e26581458e3883024230c5f64edd965 – Size is 14748 kB
2026-04-22 12:33:06 : REQ   : espanso : no more blocking processes, continue with update
2026-04-22 12:33:06 : REQ   : espanso : Installing Espanso
2026-04-22 12:33:06 : INFO  : espanso : Unzipping Espanso-Mac-Universal.zip
2026-04-22 12:33:06 : INFO  : espanso : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.PH5HLyIwIa/espanso/Espanso.dmg
2026-04-22 12:33:10 : INFO  : espanso : Mounted: /Volumes/Espanso.app
2026-04-22 12:33:10 : INFO  : espanso : Verifying: /Volumes/Espanso.app/Espanso.app
2026-04-22 12:33:11 : INFO  : espanso : Team ID matching: 6424323YUH (expected: 6424323YUH )
2026-04-22 12:33:11 : INFO  : espanso : Installing Espanso version 2.3.0 on versionKey CFBundleShortVersionString.
2026-04-22 12:33:11 : INFO  : espanso : Copy /Volumes/Espanso.app/Espanso.app to /Applications
2026-04-22 12:33:11 : WARN  : espanso : Changing owner to u0105821
2026-04-22 12:33:11 : INFO  : espanso : Finishing...
2026-04-22 12:33:14 : INFO  : espanso : App(s) found: /Applications/Espanso.app
2026-04-22 12:33:14 : INFO  : espanso : found app at /Applications/Espanso.app, version 2.3.0, on versionKey CFBundleShortVersionString
2026-04-22 12:33:14 : REQ   : espanso : Installed Espanso, version 2.3.0
2026-04-22 12:33:14 : INFO  : espanso : notifying
2026-04-22 12:33:14 : INFO  : espanso : Installomator did not close any apps, so no need to reopen any apps.
2026-04-22 12:33:14 : REQ   : espanso : All done!
2026-04-22 12:33:15 : REQ   : espanso : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes, it is a duplicate, but the previous pull request https://github.com/Installomator/Installomator/pull/2408 does NOT address all the recent issues and doesn't work properly with the latest releases.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update adds a new Installomator label for Espanso, enabling automated installation and updates directly from the official GitHub releases. It leverages Installomator’s built-in GitHub functions to dynamically resolve the latest version and download URL, reducing maintenance overhead and eliminating the need for hardcoded values. The label supports the universal macOS build distributed as a ZIP containing a DMG, ensures clean installation by accounting for active Espanso processes, and validates the app’s code signature via the expected Team ID to maintain security and integrity during deployment.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
