### PR TITLE
Switch veracrypt to standard GitHub download

### DIFF
--- a/fragments/labels/veracrypt.sh
+++ b/fragments/labels/veracrypt.sh
@@ -2,8 +2,7 @@ veracrypt|\
 veracrypt-macfuse)
     name="VeraCrypt"
     type="pkgInDmg"
-    archiveName="VeraCrypt_[0-9.].*\.dmg"
-    downloadURL=$(curl -sfL "https://api.github.com/repos/veracrypt/VeraCrypt/releases" | awk -F '"' "/browser_download_url/ && /$archiveName\"/ { print \$4; exit }")
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*_([0-9.]*.*)\.dmg/\1/g')
+    downloadURL="$(downloadURLFromGit veracrypt VeraCrypt)"
+    appNewVersion="$(versionFromGit veracrypt VeraCrypt)"
     expectedTeamID="Z933746L2S"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Previous label used an url that was hitting a API restriction 

**Installomator log** 

Without app:
```
➜  Installomator git:(switch_veracrypt_to_standard_github_download) ✗ sudo ./assemble.sh veracrypt NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:29:28 : INFO  : veracrypt : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-04-23 14:29:28 : INFO  : veracrypt : setting variable from argument NOTIFY=success
2026-04-23 14:29:28 : INFO  : veracrypt : setting variable from argument NOTIFY_DIALOG=1
2026-04-23 14:29:28 : INFO  : veracrypt : setting variable from argument INTERRUPT_DND=yes
2026-04-23 14:29:28 : INFO  : veracrypt : setting variable from argument DEBUG=0
2026-04-23 14:29:28 : INFO  : veracrypt : Total items in argumentsArray: 5
2026-04-23 14:29:28 : INFO  : veracrypt : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:29:28 : REQ   : veracrypt : ################## Start Installomator v. 10.9beta, date 2026-04-23
2026-04-23 14:29:28 : INFO  : veracrypt : ################## Version: 10.9beta
2026-04-23 14:29:28 : INFO  : veracrypt : ################## Date: 2026-04-23
2026-04-23 14:29:28 : INFO  : veracrypt : ################## veracrypt
2026-04-23 14:29:30 : INFO  : veracrypt : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:29:30 : INFO  : veracrypt : BLOCKING_PROCESS_ACTION=tell_user
2026-04-23 14:29:30 : INFO  : veracrypt : NOTIFY=success
2026-04-23 14:29:30 : INFO  : veracrypt : LOGGING=INFO
2026-04-23 14:29:30 : INFO  : veracrypt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-23 14:29:30 : INFO  : veracrypt : Label type: pkgInDmg
2026-04-23 14:29:31 : INFO  : veracrypt : archiveName: VeraCrypt.dmg
2026-04-23 14:29:31 : INFO  : veracrypt : no blocking processes defined, using VeraCrypt as default
2026-04-23 14:29:31 : INFO  : veracrypt : name: VeraCrypt, appName: VeraCrypt.app
2026-04-23 14:29:31 : WARN  : veracrypt : No previous app found
2026-04-23 14:29:31 : WARN  : veracrypt : could not find VeraCrypt.app
2026-04-23 14:29:31 : INFO  : veracrypt : appversion: 
2026-04-23 14:29:31 : INFO  : veracrypt : Latest version of VeraCrypt is 1.26.24
2026-04-23 14:29:31 : REQ   : veracrypt : Downloading https://github.com/veracrypt/VeraCrypt/releases/download/VeraCrypt_1.26.24/VeraCrypt_1.26.24.dmg to VeraCrypt.dmg
2026-04-23 14:29:31 : INFO  : veracrypt : Downloaded VeraCrypt.dmg – Type is  zlib compressed data – SHA is 212a981ddcf4404b5e160660e5187c7270e81615 – Size is 22188 kB
2026-04-23 14:29:31 : REQ   : veracrypt : no more blocking processes, continue with update
2026-04-23 14:29:31 : REQ   : veracrypt : Installing VeraCrypt
2026-04-23 14:29:31 : INFO  : veracrypt : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.XG9zulI6HF/VeraCrypt.dmg
2026-04-23 14:29:33 : INFO  : veracrypt : Mounted: /Volumes/VeraCrypt for OSX
2026-04-23 14:29:33 : INFO  : veracrypt : found pkg: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2026-04-23 14:29:33 : INFO  : veracrypt : Verifying: /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg
2026-04-23 14:29:33 : INFO  : veracrypt : Team ID: Z933746L2S (expected: Z933746L2S )
2026-04-23 14:29:33 : INFO  : veracrypt : Installing /Volumes/VeraCrypt for OSX/VeraCrypt_Installer.pkg to /
2026-04-23 14:29:37 : INFO  : veracrypt : Finishing...
2026-04-23 14:29:40 : INFO  : veracrypt : App(s) found: /Applications/VeraCrypt.app
2026-04-23 14:29:40 : INFO  : veracrypt : found app at /Applications/VeraCrypt.app, version 1.26.24, on versionKey CFBundleShortVersionString
2026-04-23 14:29:40 : REQ   : veracrypt : Installed VeraCrypt, version 1.26.24
2026-04-23 14:29:40 : INFO  : veracrypt : notifying
2026-04-23 14:29:41 : INFO  : veracrypt : Installomator did not close any apps, so no need to reopen any apps.
2026-04-23 14:29:41 : REQ   : veracrypt : All done!
2026-04-23 14:29:41 : REQ   : veracrypt : ################## End Installomator, exit code 0 
```

With latest version installed:
```
➜  Installomator git:(switch_veracrypt_to_standard_github_download) ✗ sudo ./assemble.sh veracrypt NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:30:15 : INFO  : veracrypt : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-04-23 14:30:16 : INFO  : veracrypt : setting variable from argument NOTIFY=success
2026-04-23 14:30:16 : INFO  : veracrypt : setting variable from argument NOTIFY_DIALOG=1
2026-04-23 14:30:16 : INFO  : veracrypt : setting variable from argument INTERRUPT_DND=yes
2026-04-23 14:30:16 : INFO  : veracrypt : setting variable from argument DEBUG=0
2026-04-23 14:30:16 : INFO  : veracrypt : Total items in argumentsArray: 5
2026-04-23 14:30:16 : INFO  : veracrypt : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:30:16 : REQ   : veracrypt : ################## Start Installomator v. 10.9beta, date 2026-04-23
2026-04-23 14:30:16 : INFO  : veracrypt : ################## Version: 10.9beta
2026-04-23 14:30:16 : INFO  : veracrypt : ################## Date: 2026-04-23
2026-04-23 14:30:16 : INFO  : veracrypt : ################## veracrypt
2026-04-23 14:30:18 : INFO  : veracrypt : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 INTERRUPT_DND=yes DEBUG=0
2026-04-23 14:30:18 : INFO  : veracrypt : BLOCKING_PROCESS_ACTION=tell_user
2026-04-23 14:30:18 : INFO  : veracrypt : NOTIFY=success
2026-04-23 14:30:18 : INFO  : veracrypt : LOGGING=INFO
2026-04-23 14:30:18 : INFO  : veracrypt : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-23 14:30:18 : INFO  : veracrypt : Label type: pkgInDmg
2026-04-23 14:30:18 : INFO  : veracrypt : archiveName: VeraCrypt.dmg
2026-04-23 14:30:18 : INFO  : veracrypt : no blocking processes defined, using VeraCrypt as default
2026-04-23 14:30:18 : INFO  : veracrypt : App(s) found: /Applications/VeraCrypt.app
2026-04-23 14:30:18 : INFO  : veracrypt : found app at /Applications/VeraCrypt.app, version 1.26.24, on versionKey CFBundleShortVersionString
2026-04-23 14:30:18 : INFO  : veracrypt : appversion: 1.26.24
2026-04-23 14:30:18 : INFO  : veracrypt : Latest version of VeraCrypt is 1.26.24
2026-04-23 14:30:18 : INFO  : veracrypt : There is no newer version available.
2026-04-23 14:30:18 : INFO  : veracrypt : Installomator did not close any apps, so no need to reopen any apps.
2026-04-23 14:30:18 : REQ   : veracrypt : No newer version.
2026-04-23 14:30:18 : REQ   : veracrypt : ################## End Installomator, exit code 0 
```