### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# =========================================================
-# CODEOWNERS — INSTALLOMATOR
-# =========================================================
-
-# Default: all files require core maintainer approval
-* @installomator/core-maintainers


### PR DESCRIPTION
Undoing code owner config, we're not going to be using it for PR approvals.