### PR TITLE
sigil-new-label

### DIFF
--- a/fragments/labels/sigil.sh
+++ b/fragments/labels/sigil.sh
@@ -1,0 +1,12 @@
+sigil)
+    name="Sigil"
+    type="tbz"
+    if [[ "$arch" == "arm64" ]]; then
+        archiveName="Mac-arm64.txz"
+    else
+        archiveName="Mac-x86_64.txz"
+    fi
+    downloadURL=$(downloadURLFromGit Sigil-Ebook Sigil)
+    appNewVersion=$(versionFromGit Sigil-Ebook Sigil)
+    expectedTeamID="2SMCVQU3CJ"
+    ;;


### PR DESCRIPTION
output
```
sudo Installomator/utils/assemble.sh sigil DEBUG=0
2026-04-24 09:57:53 : INFO  : sigil : setting variable from argument DEBUG=0
2026-04-24 09:57:53 : INFO  : sigil : Total items in argumentsArray: 1
2026-04-24 09:57:53 : INFO  : sigil : argumentsArray: DEBUG=0
2026-04-24 09:57:53 : REQ   : sigil : ################## Start Installomator v. 10.9beta, date 2026-04-24
2026-04-24 09:57:53 : INFO  : sigil : ################## Version: 10.9beta
2026-04-24 09:57:53 : INFO  : sigil : ################## Date: 2026-04-24
2026-04-24 09:57:53 : INFO  : sigil : ################## sigil
2026-04-24 09:57:54 : INFO  : sigil : Reading arguments again: DEBUG=0
2026-04-24 09:57:54 : INFO  : sigil : BLOCKING_PROCESS_ACTION=tell_user
2026-04-24 09:57:54 : INFO  : sigil : NOTIFY=success
2026-04-24 09:57:54 : INFO  : sigil : LOGGING=INFO
2026-04-24 09:57:54 : INFO  : sigil : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-24 09:57:54 : INFO  : sigil : Label type: tbz
2026-04-24 09:57:54 : INFO  : sigil : archiveName: Mac-x86_64.txz
2026-04-24 09:57:54 : INFO  : sigil : no blocking processes defined, using Sigil as default
2026-04-24 09:57:54 : INFO  : sigil : name: Sigil, appName: Sigil.app
2026-04-24 09:57:54 : INFO  : sigil : App(s) found: /Users/u0105821/Downloads/Sigil.app
2026-04-24 09:57:54 : WARN  : sigil : could not determine location of Sigil.app
2026-04-24 09:57:54 : INFO  : sigil : appversion:
2026-04-24 09:57:54 : INFO  : sigil : Latest version of Sigil is 2.7.6
2026-04-24 09:57:55 : REQ   : sigil : Downloading https://github.com/Sigil-Ebook/Sigil/releases/download/2.7.6/Sigil.app-2.7.6-Mac-x86_64.txz to Mac-x86_64.txz
2026-04-24 09:57:59 : INFO  : sigil : Downloaded Mac-x86_64.txz – Type is  XZ compressed data, checksum CRC64 – SHA is 0c78170cf6fc8b0695781cdc9b00d18389b6d583 – Size is 148236 kB
2026-04-24 09:57:59 : REQ   : sigil : no more blocking processes, continue with update
2026-04-24 09:57:59 : REQ   : sigil : Installing Sigil
2026-04-24 09:57:59 : INFO  : sigil : Unzipping Mac-x86_64.txz
2026-04-24 09:58:09 : INFO  : sigil : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NYbCTUfhAJ/Sigil.app
2026-04-24 09:58:11 : INFO  : sigil : Team ID matching: 2SMCVQU3CJ (expected: 2SMCVQU3CJ )
2026-04-24 09:58:11 : INFO  : sigil : Installing Sigil version 2.7.6 on versionKey CFBundleShortVersionString.
2026-04-24 09:58:11 : INFO  : sigil : App has LSMinimumSystemVersion: 13.0
2026-04-24 09:58:11 : INFO  : sigil : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.NYbCTUfhAJ/Sigil.app to /Applications
2026-04-24 09:58:14 : WARN  : sigil : Changing owner to u0105821
2026-04-24 09:58:15 : INFO  : sigil : Finishing...
2026-04-24 09:58:18 : INFO  : sigil : App(s) found: /Applications/Sigil.app
2026-04-24 09:58:18 : INFO  : sigil : found app at /Applications/Sigil.app, version 2.7.6, on versionKey CFBundleShortVersionString
2026-04-24 09:58:18 : REQ   : sigil : Installed Sigil, version 2.7.6
2026-04-24 09:58:18 : INFO  : sigil : notifying
2026-04-24 09:58:19 : INFO  : sigil : Installomator did not close any apps, so no need to reopen any apps.
2026-04-24 09:58:19 : REQ   : sigil : All done!
2026-04-24 09:58:19 : REQ   : sigil : ################## End Installomator, exit code 0
```

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This PR adds a new Installomator label for Sigil, a free and open-source EPUB ebook editor maintained by the Sigil-Ebook project on GitHub. The label uses downloadURLFromGit and versionFromGit to pull the latest release from the Sigil-Ebook/Sigil repository, with architecture-aware archive selection between Mac-arm64.txz and Mac-x86_64.txz. The macOS releases are both signed and notarized by the developer under Team ID 2SMCVQU3CJ (Kevin Hendricks). The label type is set to tbz, which Installomator uses to handle .txz archives via the same extraction path.

Sigil is a free, open-source EPUB ebook editor available as a native macOS application for both Apple silicon and Intel Macs. It requires macOS 13 (Ventura) or later and is distributed as a signed and notarized .txz archive via the project's GitHub releases page. Sigil supports both EPUB 2 and EPUB 3 formats, and includes a code view for direct HTML/CSS editing alongside its visual editing interface.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
