### PR TITLE
fix(labels): use reliable version detection for libreoffice and languagepack

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -6522,7 +6522,7 @@ libericajdk8ltsfull)
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     if [[ $(arch) == "arm64" ]]; then
     	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then
@@ -6547,7 +6547,7 @@ libreofficelanguagepack_intl)
     if [[ "$userLanguage" == "en-US" ]]; then
         cleanupAndExit 0 "No installation of a language pack is necessary for the US-English language."
     fi
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
     until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do
         if [ ${#userLanguage} -eq 2 ]; then

--- a/fragments/labels/libreoffice.sh
+++ b/fragments/labels/libreoffice.sh
@@ -1,7 +1,7 @@
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     if [[ $(arch) == "arm64" ]]; then
     	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then

--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -13,7 +13,7 @@ libreofficelanguagepack_intl)
     if [[ "$userLanguage" == "en-US" ]]; then
         cleanupAndExit 0 "No installation of a language pack is necessary for the US-English language."
     fi
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
     until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do
         if [ ${#userLanguage} -eq 2 ]; then


### PR DESCRIPTION
Fixes #2863

## Problem

The `libreoffice` app label fails to download because `appNewVersion` is empty. The previous version detection scraped `dl_version_number` from `libreoffice.org/download/download-libreoffice/`, but this class no longer exists in the page source.

This results in broken download URLs:
```
https://download.documentfoundation.org/libreoffice/stable//mac/aarch64/LibreOffice__MacOS_aarch64.dmg
```
(note the double slashes `//` and missing version `__`)

## Changes

- **File 1**: `fragments/labels/libreoffice.sh`
- **File 2**: `fragments/labels/libreofficelanguagepack_intl.sh`
- **File 3**: `Installomator.sh` (libreoffice block)
- **File 4**: `Installomator.sh` (libreofficelanguagepack_intl block)

Replaced the broken website scraping:
```bash
curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | ...
```

With a reliable directory listing parse:
```bash
curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1
```

This parses the directory index at `download.documentfoundation.org/libreoffice/stable/` which lists all available versions and returns the latest one (e.g., `26.2.2`).

## Verification

Tested the new command:
```
$ curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1
26.2.2
```

The resulting download URL is now correct:
```
https://download.documentfoundation.org/libreoffice/stable/26.2.2/mac/aarch64/LibreOffice_26.2.2_MacOS_aarch64.dmg
```
