### PR TITLE
Fix 'podmandesktopairgap' label downloading wrong architecture

### DIFF
--- a/fragments/labels/podmandesktopairgap.sh
+++ b/fragments/labels/podmandesktopairgap.sh
@@ -1,12 +1,12 @@
 podmandesktopairgap)
     name="Podman Desktop"
     type="dmg"
-    downloadURL=$(downloadURLFromGit containers podman-desktop)
     appNewVersion=$(versionFromGit containers podman-desktop)
     if [[ $(arch) == "arm64" ]]; then
         archiveName="podman-desktop-airgap-$appNewVersion-arm64.dmg"
     elif [[ $(arch) == "i386" ]]; then
         archiveName="podman-desktop-airgap-$appNewVersion-x64.dmg"
     fi
+    downloadURL=$(downloadURLFromGit containers podman-desktop)
     expectedTeamID="HYSCB8KRL2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
`downloadURLFromGit()` uses `archiveName` to filter GitHub release assets. When `archiveName` was set after `downloadURL`, the function fell back to matching by file extension only, grabbing the first asset of the wrong architecture (e.g. amd64/arm64)

This is a partial fix for #2809 for which `podman` and `podmandesktop` labels are also affected. See
* https://github.com/Installomator/Installomator/pull/2810
* https://github.com/Installomator/Installomator/pull/2878

**Installomator log** 

```
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : setting variable from argument DEBUG=1
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : Total items in argumentsArray: 1
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : argumentsArray: DEBUG=1
2026-04-29 19:05:57 : REQ   : podmandesktopairgap : ################## Start Installomator v. 10.9beta, date 2026-04-29
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : ################## Version: 10.9beta
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : ################## Date: 2026-04-29
2026-04-29 19:05:57 : INFO  : podmandesktopairgap : ################## podmandesktopairgap
2026-04-29 19:05:58 : DEBUG : podmandesktopairgap : DEBUG mode 1 enabled.
2026-04-29 19:06:00 : INFO  : podmandesktopairgap : Reading arguments again: DEBUG=1
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : argument: DEBUG=1
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : name=Podman Desktop
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : appName=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : type=dmg
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : archiveName=podman-desktop-airgap-1.27.1-arm64.dmg
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : downloadURL=https://github.com/podman-desktop/podman-desktop/releases/download/v1.27.1/podman-desktop-airgap-1.27.1-arm64.dmg
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : curlOptions=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : appNewVersion=1.27.1
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : appCustomVersion function: Not defined
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : versionKey=CFBundleShortVersionString
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : packageID=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : pkgName=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : choiceChangesXML=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : expectedTeamID=HYSCB8KRL2
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : blockingProcesses=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : installerTool=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : CLIInstaller=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : CLIArguments=
2026-04-29 19:06:00 : DEBUG : podmandesktopairgap : updateTool=
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : updateToolArguments=
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : updateToolRunAsCurrentUser=
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : BLOCKING_PROCESS_ACTION=tell_user
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : NOTIFY=success
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : LOGGING=DEBUG
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : Label type: dmg
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : archiveName: podman-desktop-airgap-1.27.1-arm64.dmg
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : no blocking processes defined, using Podman Desktop as default
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : Changing directory to /Users/.../git/github/Installomator/Installomator/build
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : App(s) found: /Applications/Podman Desktop.app
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : found app at /Applications/Podman Desktop.app, version 1.26.2, on versionKey CFBundleShortVersionString
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : appversion: 1.26.2
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : Latest version of Podman Desktop is 1.27.1
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : podman-desktop-airgap-1.27.1-arm64.dmg exists and DEBUG mode 1 enabled, skipping download
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : DEBUG mode 1, not checking for blocking processes
2026-04-29 19:06:01 : REQ   : podmandesktopairgap : Installing Podman Desktop
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : Mounting /Users/.../git/github/Installomator/Installomator/build/podman-desktop-airgap-1.27.1-arm64.dmg
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : Debugging enabled, dmgmount output was:
expected   CRC32 $5B14E387
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Podman Desktop 1.27.1-arm64

2026-04-29 19:06:01 : INFO  : podmandesktopairgap : Mounted: /Volumes/Podman Desktop 1.27.1-arm64
2026-04-29 19:06:01 : INFO  : podmandesktopairgap : Verifying: /Volumes/Podman Desktop 1.27.1-arm64/Podman Desktop.app
2026-04-29 19:06:01 : DEBUG : podmandesktopairgap : App size: 1.4G	/Volumes/Podman Desktop 1.27.1-arm64/Podman Desktop.app
2026-04-29 19:06:04 : DEBUG : podmandesktopairgap : Debugging enabled, App Verification output was:
/Volumes/Podman Desktop 1.27.1-arm64/Podman Desktop.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Red Hat, Inc. (HYSCB8KRL2)

2026-04-29 19:06:04 : INFO  : podmandesktopairgap : Team ID matching: HYSCB8KRL2 (expected: HYSCB8KRL2 )
2026-04-29 19:06:04 : INFO  : podmandesktopairgap : Downloaded version of Podman Desktop is 1.27.1 on versionKey CFBundleShortVersionString (replacing version 1.26.2).
2026-04-29 19:06:04 : INFO  : podmandesktopairgap : App has LSMinimumSystemVersion: 12.0
2026-04-29 19:06:04 : DEBUG : podmandesktopairgap : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-29 19:06:04 : INFO  : podmandesktopairgap : Finishing...
2026-04-29 19:06:07 : INFO  : podmandesktopairgap : App(s) found: /Applications/Podman Desktop.app
2026-04-29 19:06:07 : INFO  : podmandesktopairgap : found app at /Applications/Podman Desktop.app, version 1.26.2, on versionKey CFBundleShortVersionString
2026-04-29 19:06:07 : REQ   : podmandesktopairgap : Installed Podman Desktop, version 1.27.1
2026-04-29 19:06:07 : INFO  : podmandesktopairgap : notifying
2026-04-29 19:06:08 : DEBUG : podmandesktopairgap : Unmounting /Volumes/Podman Desktop 1.27.1-arm64
2026-04-29 19:06:08 : DEBUG : podmandesktopairgap : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-04-29 19:06:08 : DEBUG : podmandesktopairgap : DEBUG mode 1, not reopening anything
2026-04-29 19:06:08 : REQ   : podmandesktopairgap : All done!
2026-04-29 19:06:08 : REQ   : podmandesktopairgap : ################## End Installomator, exit code 0 
```

