### PR TITLE
Fix 'podmandesktop' label downloading wrong architecture

### DIFF
--- a/fragments/labels/podmandesktop.sh
+++ b/fragments/labels/podmandesktop.sh
@@ -1,8 +1,8 @@
 podmandesktop)
     name="Podman Desktop"
     type="dmg"
-    downloadURL=$(downloadURLFromGit containers podman-desktop)
     appNewVersion=$(versionFromGit containers podman-desktop)
-    archiveName=" podman-desktop-$appNewVersion-universal.dmg"
+    archiveName="podman-desktop-$appNewVersion-universal.dmg"
+    downloadURL=$(downloadURLFromGit containers podman-desktop)
     expectedTeamID="HYSCB8KRL2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
`downloadURLFromGit()` uses `archiveName` to filter GitHub release assets. When `archiveName` was set after `downloadURL`, the function fell back to matching by file extension only, grabbing the first asset of the wrong architecture (e.g. amd64/arm64 vs universal)

Also removes the leading whitespace in `archiveName`

This is a partial fix for #2809 for which `podman` and `podmandesktopairgap` are also affected. See 
See
* https://github.com/Installomator/Installomator/pull/2810
* https://github.com/Installomator/Installomator/pull/2877

**Installomator log** 
```
2026-04-29 19:22:22 : INFO  : podmandesktop : setting variable from argument DEBUG=1
2026-04-29 19:22:22 : INFO  : podmandesktop : Total items in argumentsArray: 1
2026-04-29 19:22:22 : INFO  : podmandesktop : argumentsArray: DEBUG=1
2026-04-29 19:22:22 : REQ   : podmandesktop : ################## Start Installomator v. 10.9beta, date 2026-04-29
2026-04-29 19:22:22 : INFO  : podmandesktop : ################## Version: 10.9beta
2026-04-29 19:22:22 : INFO  : podmandesktop : ################## Date: 2026-04-29
2026-04-29 19:22:22 : INFO  : podmandesktop : ################## podmandesktop
2026-04-29 19:22:22 : DEBUG : podmandesktop : DEBUG mode 1 enabled.
2026-04-29 19:22:23 : INFO  : podmandesktop : Reading arguments again: DEBUG=1
2026-04-29 19:22:23 : DEBUG : podmandesktop : argument: DEBUG=1
2026-04-29 19:22:23 : DEBUG : podmandesktop : name=Podman Desktop
2026-04-29 19:22:23 : DEBUG : podmandesktop : appName=
2026-04-29 19:22:23 : DEBUG : podmandesktop : type=dmg
2026-04-29 19:22:23 : DEBUG : podmandesktop : archiveName=podman-desktop-1.27.1-universal.dmg
2026-04-29 19:22:23 : DEBUG : podmandesktop : downloadURL=https://github.com/podman-desktop/podman-desktop/releases/download/v1.27.1/podman-desktop-1.27.1-universal.dmg
2026-04-29 19:22:23 : DEBUG : podmandesktop : curlOptions=
2026-04-29 19:22:23 : DEBUG : podmandesktop : appNewVersion=1.27.1
2026-04-29 19:22:23 : DEBUG : podmandesktop : appCustomVersion function: Not defined
2026-04-29 19:22:23 : DEBUG : podmandesktop : versionKey=CFBundleShortVersionString
2026-04-29 19:22:23 : DEBUG : podmandesktop : packageID=
2026-04-29 19:22:23 : DEBUG : podmandesktop : pkgName=
2026-04-29 19:22:23 : DEBUG : podmandesktop : choiceChangesXML=
2026-04-29 19:22:23 : DEBUG : podmandesktop : expectedTeamID=HYSCB8KRL2
2026-04-29 19:22:23 : DEBUG : podmandesktop : blockingProcesses=
2026-04-29 19:22:23 : DEBUG : podmandesktop : installerTool=
2026-04-29 19:22:23 : DEBUG : podmandesktop : CLIInstaller=
2026-04-29 19:22:23 : DEBUG : podmandesktop : CLIArguments=
2026-04-29 19:22:23 : DEBUG : podmandesktop : updateTool=
2026-04-29 19:22:23 : DEBUG : podmandesktop : updateToolArguments=
2026-04-29 19:22:23 : DEBUG : podmandesktop : updateToolRunAsCurrentUser=
2026-04-29 19:22:23 : INFO  : podmandesktop : BLOCKING_PROCESS_ACTION=tell_user
2026-04-29 19:22:23 : INFO  : podmandesktop : NOTIFY=success
2026-04-29 19:22:23 : INFO  : podmandesktop : LOGGING=DEBUG
2026-04-29 19:22:23 : INFO  : podmandesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-29 19:22:23 : INFO  : podmandesktop : Label type: dmg
2026-04-29 19:22:23 : INFO  : podmandesktop : archiveName: podman-desktop-1.27.1-universal.dmg
2026-04-29 19:22:23 : INFO  : podmandesktop : no blocking processes defined, using Podman Desktop as default
2026-04-29 19:22:23 : DEBUG : podmandesktop : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-04-29 19:22:23 : INFO  : podmandesktop : App(s) found: /Applications/Podman Desktop.app
2026-04-29 19:22:23 : INFO  : podmandesktop : found app at /Applications/Podman Desktop.app, version 1.26.2, on versionKey CFBundleShortVersionString
2026-04-29 19:22:23 : INFO  : podmandesktop : appversion: 1.26.2
2026-04-29 19:22:23 : INFO  : podmandesktop : Latest version of Podman Desktop is 1.27.1
2026-04-29 19:22:23 : INFO  : podmandesktop : podman-desktop-1.27.1-universal.dmg exists and DEBUG mode 1 enabled, skipping download
2026-04-29 19:22:23 : DEBUG : podmandesktop : DEBUG mode 1, not checking for blocking processes
2026-04-29 19:22:23 : REQ   : podmandesktop : Installing Podman Desktop
2026-04-29 19:22:23 : INFO  : podmandesktop : Mounting /Users/<USER>/git/github/Installomator/Installomator/build/podman-desktop-1.27.1-universal.dmg
2026-04-29 19:22:24 : DEBUG : podmandesktop : Debugging enabled, dmgmount output was:
expected   CRC32 $D87682CF
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Podman Desktop 1.27.1-universal

2026-04-29 19:22:24 : INFO  : podmandesktop : Mounted: /Volumes/Podman Desktop 1.27.1-universal
2026-04-29 19:22:24 : INFO  : podmandesktop : Verifying: /Volumes/Podman Desktop 1.27.1-universal/Podman Desktop.app
2026-04-29 19:22:24 : DEBUG : podmandesktop : App size: 703M	/Volumes/Podman Desktop 1.27.1-universal/Podman Desktop.app
2026-04-29 19:22:27 : DEBUG : podmandesktop : Debugging enabled, App Verification output was:
/Volumes/Podman Desktop 1.27.1-universal/Podman Desktop.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Red Hat, Inc. (HYSCB8KRL2)

2026-04-29 19:22:27 : INFO  : podmandesktop : Team ID matching: HYSCB8KRL2 (expected: HYSCB8KRL2 )
2026-04-29 19:22:27 : INFO  : podmandesktop : Downloaded version of Podman Desktop is 1.27.1 on versionKey CFBundleShortVersionString (replacing version 1.26.2).
2026-04-29 19:22:27 : INFO  : podmandesktop : App has LSMinimumSystemVersion: 12.0
2026-04-29 19:22:27 : DEBUG : podmandesktop : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-04-29 19:22:27 : INFO  : podmandesktop : Finishing...
2026-04-29 19:22:30 : INFO  : podmandesktop : App(s) found: /Applications/Podman Desktop.app
2026-04-29 19:22:30 : INFO  : podmandesktop : found app at /Applications/Podman Desktop.app, version 1.26.2, on versionKey CFBundleShortVersionString
2026-04-29 19:22:30 : REQ   : podmandesktop : Installed Podman Desktop, version 1.27.1
2026-04-29 19:22:30 : INFO  : podmandesktop : notifying
2026-04-29 19:22:31 : DEBUG : podmandesktop : Unmounting /Volumes/Podman Desktop 1.27.1-universal
2026-04-29 19:22:31 : DEBUG : podmandesktop : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-04-29 19:22:31 : DEBUG : podmandesktop : DEBUG mode 1, not reopening anything
2026-04-29 19:22:31 : REQ   : podmandesktop : All done!
2026-04-29 19:22:31 : REQ   : podmandesktop : ################## End Installomator, exit code 0 
```
