### PR TITLE
Create jamfsetupmanager label

### DIFF
--- a/fragments/labels/jamfsetupmanager.sh
+++ b/fragments/labels/jamfsetupmanager.sh
@@ -1,0 +1,7 @@
+jamfsetupmanager)
+    name="Setup Manager"
+    type="pkg"
+    downloadURL=$(downloadURLFromGit jamf Setup-Manager)
+    appNewVersion=$(versionFromGit jamf Setup-Manager)
+    expectedTeamID="483DWKW443"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2026-04-29 14:28:13 : INFO  : jamfsetupmanager : setting variable from argument DEBUG=1
2026-04-29 14:28:13 : INFO  : jamfsetupmanager : Total items in argumentsArray: 1
2026-04-29 14:28:13 : INFO  : jamfsetupmanager : argumentsArray: DEBUG=1
2026-04-29 14:28:13 : REQ   : jamfsetupmanager : ################## Start Installomator v. 10.9beta, date 2026-04-29
2026-04-29 14:28:13 : INFO  : jamfsetupmanager : ################## Version: 10.9beta
2026-04-29 14:28:14 : INFO  : jamfsetupmanager : ################## Date: 2026-04-29
2026-04-29 14:28:14 : INFO  : jamfsetupmanager : ################## jamfsetupmanager
2026-04-29 14:28:14 : DEBUG : jamfsetupmanager : DEBUG mode 1 enabled.
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : Reading arguments again: DEBUG=1
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : argument: DEBUG=1
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : name=Setup Manager
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : appName=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : type=pkg
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : archiveName=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : downloadURL=https://github.com/jamf/Setup-Manager/releases/download/v1.4.5/Setup.Manager-1.4.5-646.pkg
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : curlOptions=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : appNewVersion=1.4.5
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : appCustomVersion function: Not defined
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : versionKey=CFBundleShortVersionString
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : packageID=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : pkgName=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : choiceChangesXML=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : expectedTeamID=483DWKW443
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : blockingProcesses=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : installerTool=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : CLIInstaller=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : CLIArguments=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : updateTool=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : updateToolArguments=
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : updateToolRunAsCurrentUser=
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : NOTIFY=success
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : LOGGING=DEBUG
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : Label type: pkg
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : archiveName: Setup Manager.pkg
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : no blocking processes defined, using Setup Manager as default
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : Changing directory to ./build
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : App(s) found: /Applications/Utilities/Setup Manager.app
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : found app at /Applications/Utilities/Setup Manager.app, version 1.4.5, on versionKey CFBundleShortVersionString
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : appversion: 1.4.5
2026-04-29 14:28:15 : INFO  : jamfsetupmanager : Latest version of Setup Manager is 1.4.5
2026-04-29 14:28:15 : WARN  : jamfsetupmanager : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-04-29 14:28:15 : REQ   : jamfsetupmanager : Downloading https://github.com/jamf/Setup-Manager/releases/download/v1.4.5/Setup.Manager-1.4.5-646.pkg to Setup Manager.pkg
2026-04-29 14:28:15 : DEBUG : jamfsetupmanager : No Dialog connection, just download
2026-04-29 14:28:16 : INFO  : jamfsetupmanager : Downloaded Setup Manager.pkg – Type is  xar archive compressed TOC – SHA is 1818eab9dbec500cd8c70f996f3ed612ecb6042a – Size is 1836 kB
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : DEBUG mode 1, not checking for blocking processes
2026-04-29 14:28:16 : REQ   : jamfsetupmanager : Installing Setup Manager
2026-04-29 14:28:16 : INFO  : jamfsetupmanager : Verifying: Setup Manager.pkg
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : File list: -rw-r--r--  1 root  MCC\Domain Users   1.8M Apr 29 14:28 Setup Manager.pkg
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : File type: Setup Manager.pkg: xar archive compressed TOC: 4884, SHA-1 checksum
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : spctlOut is Setup Manager.pkg: accepted
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : source=Notarized Developer ID
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : origin=Developer ID Installer: JAMF Software (483DWKW443)
2026-04-29 14:28:16 : INFO  : jamfsetupmanager : Team ID: 483DWKW443 (expected: 483DWKW443 )
2026-04-29 14:28:16 : DEBUG : jamfsetupmanager : DEBUG enabled, skipping installation
2026-04-29 14:28:16 : INFO  : jamfsetupmanager : Finishing...
2026-04-29 14:28:19 : INFO  : jamfsetupmanager : App(s) found: /Applications/Utilities/Setup Manager.app
2026-04-29 14:28:19 : INFO  : jamfsetupmanager : found app at /Applications/Utilities/Setup Manager.app, version 1.4.5, on versionKey CFBundleShortVersionString
2026-04-29 14:28:19 : REQ   : jamfsetupmanager : Installed Setup Manager, version 1.4.5
2026-04-29 14:28:19 : INFO  : jamfsetupmanager : notifying
2026-04-29 14:28:19 : DEBUG : jamfsetupmanager : DEBUG mode 1, not reopening anything
2026-04-29 14:28:19 : REQ   : jamfsetupmanager : All done!
2026-04-29 14:28:19 : REQ   : jamfsetupmanager : ################## End Installomator, exit code 0 
```