### PR TITLE
remotedesktopmanager label merge and fix

### DIFF
--- a/fragments/labels/remotedesktopmanager.sh
+++ b/fragments/labels/remotedesktopmanager.sh
@@ -1,0 +1,11 @@
+remotedesktopmanager|\
+remotedesktopmanagerfree|\
+remotedesktopmanagerenterprise)
+    name="Remote Desktop Manager"
+    type="dmg"
+    productInfo=$(curl -fsL "https://devolutions.net/productinfo.htm" | tr -d '\r')
+    downloadURL=$(printf '%s\n' "$productInfo" | awk -F= '/^RDMMacbin\.Url=/{print $2; exit}')
+    appNewVersion=$(printf '%s\n' "$productInfo" | awk -F= '/^RDMMacbin\.Version=/{print $2; exit}')
+    expectedTeamID="N592S9ASDB"
+    blockingProcesses=( $name )
+    ;;

--- a/fragments/labels/remotedesktopmanager.sh
+++ b/fragments/labels/remotedesktopmanager.sh
@@ -7,5 +7,4 @@ remotedesktopmanagerenterprise)
     downloadURL=$(printf '%s\n' "$productInfo" | awk -F= '/^RDMMacbin\.Url=/{print $2; exit}')
     appNewVersion=$(printf '%s\n' "$productInfo" | awk -F= '/^RDMMacbin\.Version=/{print $2; exit}')
     expectedTeamID="N592S9ASDB"
-    blockingProcesses=( $name )
     ;;

--- a/fragments/labels/remotedesktopmanagerenterprise.sh
+++ b/fragments/labels/remotedesktopmanagerenterprise.sh
@@ -1,8 +1,0 @@
-remotedesktopmanagerenterprise)
-    name="Remote Desktop Manager"
-    type="dmg"
-    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/download/thank-you/ | sed -n 's/.*"RDMMacbin\.Url":"\([^"]*\)".*/\1/p' | head -1)
-    appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
-    expectedTeamID="N592S9ASDB"
-    blockingProcesses=( "$name" )
-    ;;

--- a/fragments/labels/remotedesktopmanagerfree.sh
+++ b/fragments/labels/remotedesktopmanagerfree.sh
@@ -1,7 +1,0 @@
-remotedesktopmanagerfree)
-    name="Remote Desktop Manager"
-    type="dmg"
-    downloadURL=$(curl -fsL https://devolutions.net/remote-desktop-manager/download/thank-you/\?platform\=RDMMacbin\&edition\=free\&os\=macos | grep "const productInfo" | grep -oe "{.*}" | jq -r '."RDMMacbin.Url"')
-    appNewVersion=$(echo "$downloadURL" | sed -E 's/.*\.Mac\.([0-9.]*)\.dmg/\1/g')
-    expectedTeamID="N592S9ASDB"
-    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
the label no longer works, the download url has changed, in addition to that both remotedesktopmanagerfree.sh and remotedesktopmanagerenterprise.sh have been merged into a single remotedesktopmanager.sh due to the fact that there is no longer a different package for each version, the label includes the old labels to maintain backwards compatibility.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Output:
```
./utils/assemble.sh remotedesktopmanager DEBUG=0 INSTALL=force
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : setting variable from argument DEBUG=0
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : setting variable from argument INSTALL=force
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : Total items in argumentsArray: 2
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : argumentsArray: DEBUG=0 INSTALL=force
2026-04-30 12:34:49 : REQ   : remotedesktopmanager : ################## Start Installomator v. 10.9beta, date 2026-04-30
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : ################## Version: 10.9beta
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : ################## Date: 2026-04-30
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : ################## remotedesktopmanager
2026-04-30 12:34:49 : INFO  : remotedesktopmanager : Reading arguments again: DEBUG=0 INSTALL=force
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : NOTIFY=success
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : LOGGING=INFO
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : Label type: dmg
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : archiveName: Remote Desktop Manager.dmg
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : App(s) found: /Applications/Remote Desktop Manager.app
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : found app at /Applications/Remote Desktop Manager.app, version 2026.1.11.4, on versionKey CFBundleShortVersionString
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : appversion: 2026.1.11.4
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : Latest version of Remote Desktop Manager is 2026.1.11.4
2026-04-30 12:34:50 : INFO  : remotedesktopmanager : There is no newer version available.
2026-04-30 12:34:50 : REQ   : remotedesktopmanager : Downloading https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2026.1.11.4.dmg to Remote Desktop Manager.dmg
2026-04-30 12:35:09 : INFO  : remotedesktopmanager : Downloaded Remote Desktop Manager.dmg – Type is  zlib compressed data – SHA is 8d18532d1c63fab54a8629bb12f8a1098d1e849d – Size is 352864 kB
2026-04-30 12:35:09 : REQ   : remotedesktopmanager : no more blocking processes, continue with update
2026-04-30 12:35:09 : REQ   : remotedesktopmanager : Installing Remote Desktop Manager
2026-04-30 12:35:09 : INFO  : remotedesktopmanager : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.12FVoPnLI0/Remote Desktop Manager.dmg
2026-04-30 12:35:14 : INFO  : remotedesktopmanager : Mounted: /Volumes/Remote Desktop Manager.app Installer
2026-04-30 12:35:14 : INFO  : remotedesktopmanager : Verifying: /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app
2026-04-30 12:35:19 : INFO  : remotedesktopmanager : Team ID matching: N592S9ASDB (expected: N592S9ASDB )
2026-04-30 12:35:19 : INFO  : remotedesktopmanager : Downloaded version of Remote Desktop Manager is 2026.1.11.4 on versionKey CFBundleShortVersionString, same as installed.
2026-04-30 12:35:19 : INFO  : remotedesktopmanager : Using force to install anyway.
2026-04-30 12:35:19 : INFO  : remotedesktopmanager : App has LSMinimumSystemVersion: 12.0
2026-04-30 12:35:19 : WARN  : remotedesktopmanager : Removing existing /Applications/Remote Desktop Manager.app
2026-04-30 12:35:20 : INFO  : remotedesktopmanager : Copy /Volumes/Remote Desktop Manager.app Installer/Remote Desktop Manager.app to /Applications
2026-04-30 12:35:23 : WARN  : remotedesktopmanager : Changing owner to brendon.m
2026-04-30 12:35:23 : INFO  : remotedesktopmanager : Finishing...
2026-04-30 12:35:26 : INFO  : remotedesktopmanager : App(s) found: /Applications/Remote Desktop Manager.app
2026-04-30 12:35:26 : INFO  : remotedesktopmanager : found app at /Applications/Remote Desktop Manager.app, version 2026.1.11.4, on versionKey CFBundleShortVersionString
2026-04-30 12:35:26 : REQ   : remotedesktopmanager : Installed Remote Desktop Manager, version 2026.1.11.4
2026-04-30 12:35:26 : INFO  : remotedesktopmanager : notifying
2026-04-30 12:35:26 : INFO  : remotedesktopmanager : Installomator did not close any apps, so no need to reopen any apps.
2026-04-30 12:35:27 : REQ   : remotedesktopmanager : All done!
2026-04-30 12:35:27 : REQ   : remotedesktopmanager : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #2085