### PR TITLE
label zettlr create

### DIFF
--- a/fragments/labels/zettlr.sh
+++ b/fragments/labels/zettlr.sh
@@ -1,11 +1,12 @@
 zettlr)
     name="Zettlr"
     type="dmg"
-    appNewVersion=$(versionFromGit Zettlr Zettlr)
+    appNewVersion="$(versionFromGit Zettlr Zettlr)"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://github.com/Zettlr/Zettlr/releases/download/v${appNewVersion}/Zettlr-${appNewVersion}-arm64.dmg"
+        archiveName="Zettlr-${appNewVersion}-arm64.dmg"
     else
-        downloadURL="https://github.com/Zettlr/Zettlr/releases/download/v${appNewVersion}/Zettlr-${appNewVersion}-x64.dmg"
+        archiveName="Zettlr-${appNewVersion}-x64.dmg"
     fi
+    downloadURL="$(downloadURLFromGit Zettlr Zettlr)"
     expectedTeamID="QS52BN8W68"
     ;;

--- a/fragments/labels/zettlr.sh
+++ b/fragments/labels/zettlr.sh
@@ -1,7 +1,11 @@
 zettlr)
     name="Zettlr"
     type="dmg"
-    downloadURL=$(downloadURLFromGit Zettlr Zettlr)
     appNewVersion=$(versionFromGit Zettlr Zettlr)
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://github.com/Zettlr/Zettlr/releases/download/v${appNewVersion}/Zettlr-${appNewVersion}-arm64.dmg"
+    else
+        downloadURL="https://github.com/Zettlr/Zettlr/releases/download/v${appNewVersion}/Zettlr-${appNewVersion}-x64.dmg"
+    fi
     expectedTeamID="QS52BN8W68"
     ;;

--- a/fragments/labels/zettlr.sh
+++ b/fragments/labels/zettlr.sh
@@ -1,0 +1,7 @@
+zettlr)
+    name="Zettlr"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit Zettlr Zettlr)
+    appNewVersion=$(versionFromGit Zettlr Zettlr)
+    expectedTeamID="QS52BN8W68"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
This is a new app label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Output:
```
./utils/assemble.sh zettlr DEBUG=0 INSTALL=force
2026-04-30 13:44:28 : INFO  : zettlr : setting variable from argument DEBUG=0
2026-04-30 13:44:28 : INFO  : zettlr : setting variable from argument INSTALL=force
2026-04-30 13:44:28 : INFO  : zettlr : Total items in argumentsArray: 2
2026-04-30 13:44:28 : INFO  : zettlr : argumentsArray: DEBUG=0 INSTALL=force
2026-04-30 13:44:28 : REQ   : zettlr : ################## Start Installomator v. 10.9beta, date 2026-04-30
2026-04-30 13:44:28 : INFO  : zettlr : ################## Version: 10.9beta
2026-04-30 13:44:28 : INFO  : zettlr : ################## Date: 2026-04-30
2026-04-30 13:44:28 : INFO  : zettlr : ################## zettlr
2026-04-30 13:44:29 : INFO  : zettlr : Reading arguments again: DEBUG=0 INSTALL=force
2026-04-30 13:44:30 : INFO  : zettlr : BLOCKING_PROCESS_ACTION=tell_user
2026-04-30 13:44:30 : INFO  : zettlr : NOTIFY=success
2026-04-30 13:44:30 : INFO  : zettlr : LOGGING=INFO
2026-04-30 13:44:30 : INFO  : zettlr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-30 13:44:30 : INFO  : zettlr : Label type: dmg
2026-04-30 13:44:30 : INFO  : zettlr : archiveName: Zettlr.dmg
2026-04-30 13:44:30 : INFO  : zettlr : no blocking processes defined, using Zettlr as default
2026-04-30 13:44:30 : INFO  : zettlr : App(s) found: /Applications/Zettlr.app
2026-04-30 13:44:30 : INFO  : zettlr : found app at /Applications/Zettlr.app, version 4.4.0, on versionKey CFBundleShortVersionString
2026-04-30 13:44:30 : INFO  : zettlr : appversion: 4.4.0
2026-04-30 13:44:30 : INFO  : zettlr : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-04-30 13:44:30 : INFO  : zettlr : Latest version of Zettlr is 4.4.0
2026-04-30 13:44:30 : INFO  : zettlr : There is no newer version available.
2026-04-30 13:44:30 : REQ   : zettlr : Downloading https://github.com/Zettlr/Zettlr/releases/download/v4.4.0/Zettlr-4.4.0-arm64.dmg to Zettlr.dmg
2026-04-30 13:44:40 : INFO  : zettlr : Downloaded Zettlr.dmg – Type is  zlib compressed data – SHA is 24222b5edd5a8651f9d798d72393fdba4ae0b061 – Size is 181008 kB
2026-04-30 13:44:40 : REQ   : zettlr : no more blocking processes, continue with update
2026-04-30 13:44:40 : REQ   : zettlr : Installing Zettlr
2026-04-30 13:44:40 : INFO  : zettlr : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.x4UYsGZgqG/Zettlr.dmg
2026-04-30 13:44:44 : INFO  : zettlr : Mounted: /Volumes/Zettlr 4.4.0-arm64
2026-04-30 13:44:44 : INFO  : zettlr : Verifying: /Volumes/Zettlr 4.4.0-arm64/Zettlr.app
2026-04-30 13:44:46 : INFO  : zettlr : Team ID matching: QS52BN8W68 (expected: QS52BN8W68 )
2026-04-30 13:44:46 : INFO  : zettlr : Downloaded version of Zettlr is 4.4.0 on versionKey CFBundleShortVersionString, same as installed.
2026-04-30 13:44:46 : INFO  : zettlr : Using force to install anyway.
2026-04-30 13:44:46 : INFO  : zettlr : App has LSMinimumSystemVersion: 12.0
2026-04-30 13:44:46 : WARN  : zettlr : Removing existing /Applications/Zettlr.app
2026-04-30 13:44:48 : INFO  : zettlr : Copy /Volumes/Zettlr 4.4.0-arm64/Zettlr.app to /Applications
2026-04-30 13:44:49 : WARN  : zettlr : Changing owner to brendon.m
2026-04-30 13:44:50 : INFO  : zettlr : Finishing...
2026-04-30 13:44:53 : INFO  : zettlr : App(s) found: /Applications/Zettlr.app
2026-04-30 13:44:53 : INFO  : zettlr : found app at /Applications/Zettlr.app, version 4.4.0, on versionKey CFBundleShortVersionString
2026-04-30 13:44:53 : REQ   : zettlr : Installed Zettlr, version 4.4.0
2026-04-30 13:44:53 : INFO  : zettlr : notifying
2026-04-30 13:44:53 : INFO  : zettlr : Installomator did not close any apps, so no need to reopen any apps.
2026-04-30 13:44:53 : REQ   : zettlr : All done!
2026-04-30 13:44:53 : REQ   : zettlr : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
None