### PR TITLE
Label beekeeperstudio create

### DIFF
--- a/fragments/labels/beekeeperstudio.sh
+++ b/fragments/labels/beekeeperstudio.sh
@@ -1,7 +1,11 @@
 beekeeperstudio)
     name="Beekeeper Studio"
     type="dmg"
-    downloadURL="$(downloadURLFromGit beekeeper-studio beekeeper-studio)"
     appNewVersion="$(versionFromGit beekeeper-studio beekeeper-studio)"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${appNewVersion}/Beekeeper-Studio-${appNewVersion}-arm64.dmg"
+    else
+        downloadURL="https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${appNewVersion}/Beekeeper-Studio-${appNewVersion}.dmg"
+    fi
     expectedTeamID="7KK583U8H2"
     ;;

--- a/fragments/labels/beekeeperstudio.sh
+++ b/fragments/labels/beekeeperstudio.sh
@@ -1,0 +1,7 @@
+beekeeperstudio)
+    name="Beekeeper Studio"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit beekeeper-studio beekeeper-studio)"
+    appNewVersion="$(versionFromGit beekeeper-studio beekeeper-studio)"
+    expectedTeamID="7KK583U8H2"
+    ;;

--- a/fragments/labels/beekeeperstudio.sh
+++ b/fragments/labels/beekeeperstudio.sh
@@ -3,9 +3,10 @@ beekeeperstudio)
     type="dmg"
     appNewVersion="$(versionFromGit beekeeper-studio beekeeper-studio)"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${appNewVersion}/Beekeeper-Studio-${appNewVersion}-arm64.dmg"
+        archiveName="Beekeeper-Studio-${appNewVersion}-arm64.dmg"
     else
-        downloadURL="https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v${appNewVersion}/Beekeeper-Studio-${appNewVersion}.dmg"
+        archiveName="Beekeeper-Studio-${appNewVersion}.dmg"
     fi
+    downloadURL="$(downloadURLFromGit beekeeper-studio beekeeper-studio)"
     expectedTeamID="7KK583U8H2"
     ;;

--- a/fragments/labels/zettlr.sh
+++ b/fragments/labels/zettlr.sh
@@ -1,7 +1,0 @@
-zettlr)
-    name="Zettlr"
-    type="dmg"
-    downloadURL=$(downloadURLFromGit Zettlr Zettlr)
-    appNewVersion=$(versionFromGit Zettlr Zettlr)
-    expectedTeamID="QS52BN8W68"
-    ;;

--- a/fragments/labels/zettlr.sh
+++ b/fragments/labels/zettlr.sh
@@ -1,0 +1,7 @@
+zettlr)
+    name="Zettlr"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit Zettlr Zettlr)
+    appNewVersion=$(versionFromGit Zettlr Zettlr)
+    expectedTeamID="QS52BN8W68"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
This is the addition of a new label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Output:
```
./utils/assemble.sh beekeeperstudio DEBUG=0 INSTALL=force
2026-04-30 16:49:43 : INFO  : beekeeperstudio : setting variable from argument DEBUG=0
2026-04-30 16:49:43 : INFO  : beekeeperstudio : setting variable from argument INSTALL=force
2026-04-30 16:49:43 : INFO  : beekeeperstudio : Total items in argumentsArray: 2
2026-04-30 16:49:43 : INFO  : beekeeperstudio : argumentsArray: DEBUG=0 INSTALL=force
2026-04-30 16:49:43 : REQ   : beekeeperstudio : ################## Start Installomator v. 10.9beta, date 2026-04-30
2026-04-30 16:49:43 : INFO  : beekeeperstudio : ################## Version: 10.9beta
2026-04-30 16:49:43 : INFO  : beekeeperstudio : ################## Date: 2026-04-30
2026-04-30 16:49:43 : INFO  : beekeeperstudio : ################## beekeeperstudio
2026-04-30 16:49:45 : INFO  : beekeeperstudio : Reading arguments again: DEBUG=0 INSTALL=force
2026-04-30 16:49:45 : INFO  : beekeeperstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-04-30 16:49:45 : INFO  : beekeeperstudio : NOTIFY=success
2026-04-30 16:49:45 : INFO  : beekeeperstudio : LOGGING=INFO
2026-04-30 16:49:45 : INFO  : beekeeperstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-04-30 16:49:45 : INFO  : beekeeperstudio : Label type: dmg
2026-04-30 16:49:45 : INFO  : beekeeperstudio : archiveName: Beekeeper Studio.dmg
2026-04-30 16:49:45 : INFO  : beekeeperstudio : no blocking processes defined, using Beekeeper Studio as default
2026-04-30 16:49:45 : INFO  : beekeeperstudio : App(s) found: /Applications/Beekeeper Studio.app
2026-04-30 16:49:45 : INFO  : beekeeperstudio : found app at /Applications/Beekeeper Studio.app, version 5.7.2, on versionKey CFBundleShortVersionString
2026-04-30 16:49:45 : INFO  : beekeeperstudio : appversion: 5.7.2
2026-04-30 16:49:45 : INFO  : beekeeperstudio : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-04-30 16:49:45 : INFO  : beekeeperstudio : Latest version of Beekeeper Studio is 5.7.2
2026-04-30 16:49:45 : INFO  : beekeeperstudio : There is no newer version available.
2026-04-30 16:49:45 : REQ   : beekeeperstudio : Downloading https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.7.2/Beekeeper-Studio-5.7.2-arm64.dmg to Beekeeper Studio.dmg
2026-04-30 16:50:03 : INFO  : beekeeperstudio : Downloaded Beekeeper Studio.dmg – Type is  zlib compressed data – SHA is 1381a992922b5d445c17235e0ceb5cdd209f68ca – Size is 344256 kB
2026-04-30 16:50:04 : REQ   : beekeeperstudio : no more blocking processes, continue with update
2026-04-30 16:50:04 : REQ   : beekeeperstudio : Installing Beekeeper Studio
2026-04-30 16:50:04 : INFO  : beekeeperstudio : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.EWfemZxbMb/Beekeeper Studio.dmg
2026-04-30 16:50:09 : INFO  : beekeeperstudio : Mounted: /Volumes/Beekeeper Studio 5.7.2-arm64
2026-04-30 16:50:09 : INFO  : beekeeperstudio : Verifying: /Volumes/Beekeeper Studio 5.7.2-arm64/Beekeeper Studio.app
2026-04-30 16:50:12 : INFO  : beekeeperstudio : Team ID matching: 7KK583U8H2 (expected: 7KK583U8H2 )
2026-04-30 16:50:12 : INFO  : beekeeperstudio : Downloaded version of Beekeeper Studio is 5.7.2 on versionKey CFBundleShortVersionString, same as installed.
2026-04-30 16:50:12 : INFO  : beekeeperstudio : Using force to install anyway.
2026-04-30 16:50:12 : INFO  : beekeeperstudio : App has LSMinimumSystemVersion: 12.0
2026-04-30 16:50:12 : WARN  : beekeeperstudio : Removing existing /Applications/Beekeeper Studio.app
2026-04-30 16:50:13 : INFO  : beekeeperstudio : Copy /Volumes/Beekeeper Studio 5.7.2-arm64/Beekeeper Studio.app to /Applications
2026-04-30 16:50:16 : WARN  : beekeeperstudio : Changing owner to brendon.m
2026-04-30 16:50:16 : INFO  : beekeeperstudio : Finishing...
2026-04-30 16:50:19 : INFO  : beekeeperstudio : App(s) found: /Applications/Beekeeper Studio.app
2026-04-30 16:50:19 : INFO  : beekeeperstudio : found app at /Applications/Beekeeper Studio.app, version 5.7.2, on versionKey CFBundleShortVersionString
2026-04-30 16:50:19 : REQ   : beekeeperstudio : Installed Beekeeper Studio, version 5.7.2
2026-04-30 16:50:19 : INFO  : beekeeperstudio : notifying
2026-04-30 16:50:20 : INFO  : beekeeperstudio : Installomator did not close any apps, so no need to reopen any apps.
2026-04-30 16:50:20 : REQ   : beekeeperstudio : All done!
2026-04-30 16:50:20 : REQ   : beekeeperstudio : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
