### PR TITLE
Add --subset option to assemble.sh

### DIFF
--- a/subsetList.txt
+++ b/subsetList.txt
@@ -1,0 +1,13 @@
+# reference this file by running: assemble.sh --subest /path/to/subsetList.txt
+androidstudio
+apachenetbeans
+coconutbattery
+dialog
+dockutil
+jamfsetupmanager
+maxonapp
+microsoftdefender
+omnidisksweeper
+python
+splashtopbusiness
+splashtopstreamer

--- a/utils/assemble.sh
+++ b/utils/assemble.sh
@@ -13,10 +13,10 @@ dev_keychain_label="notary-scriptingosx"
 
 # parse arguments
 
-zparseopts -D -E -a opts r -run s -script p -pkg n -notarize h -help -labels+:=label_args l+:=label_args
+zparseopts -D -E -a opts r -run s -script p -pkg n -notarize h -help -subset:=subset_arg -labels+:=label_args l+:=label_args
 
 if (( ${opts[(I)(-h|--help)]} )); then
-  echo "usage: assemble.sh [--script|--pkg|--notarize] [-labels path/to/labels ...] [arguments...]"
+  echo "usage: assemble.sh [--script|--pkg|--notarize] [--subset path/to/subsetList] [--labels path/to/labels ...] [arguments...]"
   echo
   echo "builds and runs the installomator script from the fragements."
   echo "additional arguments are passed into the Installomator script for testing."
@@ -49,6 +49,12 @@ if (( ${opts[(I)(-r|--run)]} )); then
     runScript=1
 fi
 
+# --subset option generates the script with a specified list 
+# of labels instead of all labels in the labels directory. 
+# The path to the list is passed as an argument to the option.
+if (( ${#subset_arg} )); then
+  subset_path=${subset_arg[-1]}
+fi
 
 
 label_flags=( -l --labels )
@@ -105,7 +111,18 @@ cat "$fragments_dir/arguments.sh" >> $destination_file
 # all the labels
 for lpath in $label_paths; do
     if [[ -d $lpath ]]; then
-        cat "$lpath"/*.sh >> $destination_file
+        if [[ -n $subset_path ]]; then
+            # read the subset list and filter the labels
+            while IFS= read -r label; do
+                label_file="$lpath/$label.sh"
+                if [[ -e $label_file ]]; then
+                    cat "$label_file" >> $destination_file
+                fi
+            done < "$subset_path"
+        else
+            # add all labels in the directory
+            cat "$lpath"/*.sh >> $destination_file
+        fi
     else
         echo "# $lpath not a directory, skipping..."
     fi


### PR DESCRIPTION
Add an optional parameter to supply a list of labels to filter when assembling installomator.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
This is not a label Pull Request. This is to add an additional feature to the assemble.sh script.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
I've been using this add-on for a few months, I figured I should share it up and see if you wanted to add it to the codebase.

This adds a `--subset /path/to/list.txt` parameter option to the assemble.sh script. This new allows the use of a filter list that contains only the labels you intend to use. I use Installomator by adding the script directly to Jamf Pro's Scripts section and trigger that script via a set of policies. The full installomator script weighs in at 576k. My filtered version is 81k, and contains only the software we deploy and manage in our environment. Since I'm transmitting the script to each endpoint every time it runs, this is a worthwhile savings for us. 

I also included a sample list file. I did not update the documentation.

I understand if this is not a feature you wish to add, but I figured I have it, I might as well give you the option.

---
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
Installomator % ./assemble.sh --subset ./subsetList.txt    
2026-04-30 14:10:33 : REQ   :  : no label provided, printing labels
androidstudio
apachenetbeans
coconutbattery
dialog
dockutil
maxonapp
microsoftdefender
microsoftdefenderatp
omnidisksweeper
python
splashtopbusiness
splashtopstreamer
swiftdialog
```