### PR TITLE
Fix eclipsetemurin8 label to use Adoptium API for downloadURL instead

### DIFF
--- a/fragments/labels/eclipsetemurin8.sh
+++ b/fragments/labels/eclipsetemurin8.sh
@@ -1,8 +1,10 @@
 eclipsetemurin8)
     name="Temurin 8"
     type="pkg"
-    downloadURL="$(downloadURLFromGit adoptium temurin8-binaries)"
-    appNewVersion="$(downloadURLFromGit adoptium temurin8-binaries | grep -oE 'jdk8u[0-9]+-b[0-9]+' | sed 's/jdk//')"
+    # releases for JDK 8 LTS are only built for x64 architecture
+    downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/8/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=x64")" '[0].binary.installer.link')
+    archiveName="$(basename "$downloadURL")"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk8u[0-9]+-b[0-9]+' | sed 's/jdk//')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Info.plist" ]; then echo "8u$(/usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/Eclipse Temurin 1.8.0_//')"; fi }
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
`downloadURLFromGit` is not reliable, as the latest Eclipse Temurin MacOS binaries are not necessarily built/available when the latest git tag is available. Generally MacOS Binaries are not available for some time initially. This causes the logic to populate the downloadURL to be wrong defaulting to downloading the root url `downloadURL=https://github.com/` . See https://github.com/Installomator/Installomator/issues/2753#issuecomment-3832791261

A robust solution is use the offical Adoptium API to lookup the latest Eclipse Temurin JDK releases for the respective architecture, operating system, etc for which a build is available. Their API is documented here https://api.adoptium.net/q/swagger-ui/#/Assets/getLatestAssets

This is a partial fix for #2753 for which all other eclipsetemurin labels are also affected.

See
* https://github.com/Installomator/Installomator/pull/2895
* https://github.com/Installomator/Installomator/pull/2896
* https://github.com/Installomator/Installomator/pull/2775

Note that Adoptium did not provide native binaries on Apple Silicon for Temurin 8 - the Intel x64 binaries are used instead.



**Installomator log**
```
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : setting variable from argument DEBUG=1
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : Total items in argumentsArray: 1
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : argumentsArray: DEBUG=1
2026-05-01 15:46:32 : REQ   : eclipsetemurin8 : ################## Start Installomator v. 10.9beta, date 2026-05-01
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : ################## Version: 10.9beta
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : ################## Date: 2026-05-01
2026-05-01 15:46:32 : INFO  : eclipsetemurin8 : ################## eclipsetemurin8
2026-05-01 15:46:32 : DEBUG : eclipsetemurin8 : DEBUG mode 1 enabled.
2026-05-01 15:46:33 : INFO  : eclipsetemurin8 : Reading arguments again: DEBUG=1
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : argument: DEBUG=1
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : name=Temurin 8
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : appName=
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : type=pkg
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : archiveName=OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : downloadURL=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : curlOptions=
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : appNewVersion=8u482-b08
2026-05-01 15:46:33 : DEBUG : eclipsetemurin8 : appCustomVersion function: Defined. 
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : versionKey=CFBundleShortVersionString
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : packageID=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : pkgName=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : choiceChangesXML=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : expectedTeamID=JCDTMS22B4
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : blockingProcesses=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : installerTool=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : CLIInstaller=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : CLIArguments=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : updateTool=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : updateToolArguments=
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : updateToolRunAsCurrentUser=
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : NOTIFY=success
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : LOGGING=DEBUG
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Label type: pkg
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : archiveName: OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : no blocking processes defined, using Temurin 8 as default
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Custom App Version detection is used, found 8u482-b08
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : appversion: 8u482-b08
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Latest version of Temurin 8 is 8u482-b08
2026-05-01 15:46:34 : WARN  : eclipsetemurin8 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg exists and DEBUG mode 1 enabled, skipping download
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : DEBUG mode 1, not checking for blocking processes
2026-05-01 15:46:34 : REQ   : eclipsetemurin8 : Installing Temurin 8
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Verifying: OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : File list: -rw-r--r--@ 1 <USER>  staff   103M Feb 15 19:29 OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : File type: OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg: xar archive compressed TOC: 5566, SHA-1 checksum
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : spctlOut is OpenJDK8U-jdk_x64_mac_hotspot_8u482b08.pkg: accepted
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : source=Notarized Developer ID
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-05-01 15:46:34 : DEBUG : eclipsetemurin8 : DEBUG enabled, skipping installation
2026-05-01 15:46:34 : INFO  : eclipsetemurin8 : Finishing...
2026-05-01 15:46:37 : INFO  : eclipsetemurin8 : Custom App Version detection is used, found 8u482-b08
2026-05-01 15:46:37 : REQ   : eclipsetemurin8 : Installed Temurin 8, version 8u482-b08
2026-05-01 15:46:37 : INFO  : eclipsetemurin8 : notifying
2026-05-01 15:46:37 : DEBUG : eclipsetemurin8 : DEBUG mode 1, not reopening anything
2026-05-01 15:46:37 : REQ   : eclipsetemurin8 : All done!
2026-05-01 15:46:37 : REQ   : eclipsetemurin8 : ################## End Installomator, exit code 0 
```