### PR TITLE
Fix eclipsetemurin11 label to use Adoptium API for downloadURL instead

### DIFF
--- a/fragments/labels/eclipsetemurin11.sh
+++ b/fragments/labels/eclipsetemurin11.sh
@@ -2,12 +2,13 @@ eclipsetemurin11)
     name="Temurin 11"
     type="pkg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="OpenJDK11U-jdk_aarch64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="aarch64"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="OpenJDK11U-jdk_x64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="x64"
     fi
-    downloadURL="$(downloadURLFromGit adoptium temurin11-binaries)"
-    appNewVersion="$(downloadURLFromGit adoptium temurin11-binaries | grep -oE 'jdk-11(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/11/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=${cpu_arch}")" '[0].binary.installer.link')
+    archiveName="$(basename "$downloadURL")"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-11(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //'; fi }
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
`downloadURLFromGit` is not reliable, as the latest Eclipse Temurin MacOS binaries are not necessarily built/available when the latest git tag is available. Generally MacOS Binaries are not available for some time initially. This causes the logic to populate the downloadURL to be wrong defaulting to downloading the root url `downloadURL=https://github.com/` . See https://github.com/Installomator/Installomator/issues/2753#issuecomment-3832791261

A robust solution is use the offical Adoptium API to lookup the latest Eclipse Temurin JDK releases for the respective architecture, operating system, etc for which a build is available. Their API is documented here https://api.adoptium.net/q/swagger-ui/#/Assets/getLatestAssets

This is a partial fix for #2753 for which all other eclipsetemurin labels are also affected. See
* https://github.com/Installomator/Installomator/pull/2894
* https://github.com/Installomator/Installomator/pull/2896
* https://github.com/Installomator/Installomator/pull/2775

**Installomator log**
```
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : setting variable from argument DEBUG=1
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : Total items in argumentsArray: 1
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : argumentsArray: DEBUG=1
2026-05-01 15:30:26 : REQ   : eclipsetemurin11 : ################## Start Installomator v. 10.9beta, date 2026-05-01
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : ################## Version: 10.9beta
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : ################## Date: 2026-05-01
2026-05-01 15:30:26 : INFO  : eclipsetemurin11 : ################## eclipsetemurin11
2026-05-01 15:30:26 : DEBUG : eclipsetemurin11 : DEBUG mode 1 enabled.
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : Reading arguments again: DEBUG=1
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : argument: DEBUG=1
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : name=Temurin 11
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : appName=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : type=pkg
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : archiveName=OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : downloadURL=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : curlOptions=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : appNewVersion=11.0.31+11
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : appCustomVersion function: Defined. 
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : versionKey=CFBundleShortVersionString
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : packageID=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : pkgName=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : choiceChangesXML=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : expectedTeamID=JCDTMS22B4
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : blockingProcesses=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : installerTool=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : CLIInstaller=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : CLIArguments=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : updateTool=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : updateToolArguments=
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : updateToolRunAsCurrentUser=
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : NOTIFY=success
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : LOGGING=DEBUG
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : Label type: pkg
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : archiveName: OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : no blocking processes defined, using Temurin 11 as default
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : Custom App Version detection is used, found 11.0.30+7
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : appversion: 11.0.30+7
2026-05-01 15:30:27 : INFO  : eclipsetemurin11 : Latest version of Temurin 11 is 11.0.31+11
2026-05-01 15:30:27 : REQ   : eclipsetemurin11 : Downloading https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg to OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:27 : DEBUG : eclipsetemurin11 : No Dialog connection, just download
2026-05-01 15:30:43 : INFO  : eclipsetemurin11 : Downloaded OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg – Type is  xar archive compressed TOC – SHA is 3cf3074052b93a192428a3299d0e89963242a5ab – Size is 181180 kB
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : DEBUG mode 1, not checking for blocking processes
2026-05-01 15:30:43 : REQ   : eclipsetemurin11 : Installing Temurin 11
2026-05-01 15:30:43 : INFO  : eclipsetemurin11 : Verifying: OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : File list: -rw-r--r--@ 1 <USER>  staff   176M May  1 15:30 OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : File type: OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg: xar archive compressed TOC: 5571, SHA-1 checksum
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : spctlOut is OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.pkg: accepted
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : source=Notarized Developer ID
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-05-01 15:30:43 : INFO  : eclipsetemurin11 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-05-01 15:30:43 : DEBUG : eclipsetemurin11 : DEBUG enabled, skipping installation
2026-05-01 15:30:43 : INFO  : eclipsetemurin11 : Finishing...
2026-05-01 15:30:46 : INFO  : eclipsetemurin11 : Custom App Version detection is used, found 11.0.30+7
2026-05-01 15:30:46 : REQ   : eclipsetemurin11 : Installed Temurin 11, version 11.0.31+11
2026-05-01 15:30:46 : INFO  : eclipsetemurin11 : notifying
2026-05-01 15:30:47 : DEBUG : eclipsetemurin11 : DEBUG mode 1, not reopening anything
2026-05-01 15:30:47 : REQ   : eclipsetemurin11 : All done!
2026-05-01 15:30:47 : REQ   : eclipsetemurin11 : ################## End Installomator, exit code 0 
```