### PR TITLE
Fix eclipsetemurin17 label to use Adoptium API for downloadURL instead

### DIFF
--- a/fragments/labels/eclipsetemurin17.sh
+++ b/fragments/labels/eclipsetemurin17.sh
@@ -2,12 +2,13 @@ eclipsetemurin17)
     name="Temurin 17"
     type="pkg"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="OpenJDK17U-jdk_aarch64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="aarch64"
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="OpenJDK17U-jdk_x64_mac_hotspot_[0-9._]+\.pkg"
+        cpu_arch="x64"
     fi
-    downloadURL="$(downloadURLFromGit adoptium temurin17-binaries)"
-    appNewVersion="$(downloadURLFromGit adoptium temurin17-binaries | grep -oE 'jdk-17(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/17/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=${cpu_arch}")" '[0].binary.installer.link')
+    archiveName="$(basename "$downloadURL")"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-17(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //'; fi }
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
`downloadURLFromGit` is not reliable, as the latest Eclipse Temurin MacOS binaries are not necessarily built/available when the latest git tag is available. Generally MacOS Binaries are not available for some time initially. This causes the logic to populate the downloadURL to be wrong defaulting to downloading the root url `downloadURL=https://github.com/` . See https://github.com/Installomator/Installomator/issues/2753#issuecomment-3832791261

A robust solution is use the offical Adoptium API to lookup the latest Eclipse Temurin JDK releases for the respective architecture, operating system, etc for which a build is available. Their API is documented here https://api.adoptium.net/q/swagger-ui/#/Assets/getLatestAssets

This is a partial fix for #2753 for which all other eclipsetemurin labels are also affected. See
* https://github.com/Installomator/Installomator/pull/2775
* https://github.com/Installomator/Installomator/pull/2894
* https://github.com/Installomator/Installomator/pull/2895

**Installomator log**
```
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : setting variable from argument DEBUG=1
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : Total items in argumentsArray: 1
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : argumentsArray: DEBUG=1
2026-05-01 15:50:54 : REQ   : eclipsetemurin17 : ################## Start Installomator v. 10.9beta, date 2026-05-01
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : ################## Version: 10.9beta
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : ################## Date: 2026-05-01
2026-05-01 15:50:54 : INFO  : eclipsetemurin17 : ################## eclipsetemurin17
2026-05-01 15:50:54 : DEBUG : eclipsetemurin17 : DEBUG mode 1 enabled.
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : Reading arguments again: DEBUG=1
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : argument: DEBUG=1
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : name=Temurin 17
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : appName=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : type=pkg
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : archiveName=OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : downloadURL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : curlOptions=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : appNewVersion=17.0.19+10
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : appCustomVersion function: Defined. 
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : versionKey=CFBundleShortVersionString
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : packageID=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : pkgName=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : choiceChangesXML=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : expectedTeamID=JCDTMS22B4
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : blockingProcesses=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : installerTool=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : CLIInstaller=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : CLIArguments=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : updateTool=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : updateToolArguments=
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : updateToolRunAsCurrentUser=
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : NOTIFY=success
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : LOGGING=DEBUG
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : Label type: pkg
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : archiveName: OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : no blocking processes defined, using Temurin 17 as default
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : Custom App Version detection is used, found 17.0.18+8
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : appversion: 17.0.18+8
2026-05-01 15:50:56 : INFO  : eclipsetemurin17 : Latest version of Temurin 17 is 17.0.19+10
2026-05-01 15:50:56 : REQ   : eclipsetemurin17 : Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg to OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:50:56 : DEBUG : eclipsetemurin17 : No Dialog connection, just download
2026-05-01 15:51:15 : INFO  : eclipsetemurin17 : Downloaded OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg – Type is  xar archive compressed TOC – SHA is 1737ce23306ee3a7d3052f87a6a4b25bea833b62 – Size is 196860 kB
2026-05-01 15:51:15 : DEBUG : eclipsetemurin17 : DEBUG mode 1, not checking for blocking processes
2026-05-01 15:51:15 : REQ   : eclipsetemurin17 : Installing Temurin 17
2026-05-01 15:51:15 : INFO  : eclipsetemurin17 : Verifying: OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:51:15 : DEBUG : eclipsetemurin17 : File list: -rw-r--r--@ 1 <USER>  staff   178M May  1 15:51 OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg
2026-05-01 15:51:15 : DEBUG : eclipsetemurin17 : File type: OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg: xar archive compressed TOC: 5542, SHA-1 checksum
2026-05-01 15:51:16 : DEBUG : eclipsetemurin17 : spctlOut is OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.pkg: accepted
2026-05-01 15:51:16 : DEBUG : eclipsetemurin17 : source=Notarized Developer ID
2026-05-01 15:51:16 : DEBUG : eclipsetemurin17 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-05-01 15:51:16 : INFO  : eclipsetemurin17 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-05-01 15:51:16 : DEBUG : eclipsetemurin17 : DEBUG enabled, skipping installation
2026-05-01 15:51:16 : INFO  : eclipsetemurin17 : Finishing...
2026-05-01 15:51:19 : INFO  : eclipsetemurin17 : Custom App Version detection is used, found 17.0.18+8
2026-05-01 15:51:19 : REQ   : eclipsetemurin17 : Installed Temurin 17, version 17.0.19+10
2026-05-01 15:51:19 : INFO  : eclipsetemurin17 : notifying
2026-05-01 15:51:19 : DEBUG : eclipsetemurin17 : DEBUG mode 1, not reopening anything
2026-05-01 15:51:19 : REQ   : eclipsetemurin17 : All done!
2026-05-01 15:51:19 : REQ   : eclipsetemurin17 : ################## End Installomator, exit code 0 
```