### PR TITLE
Add eclipsetemurin25 label for Eclipse Temurin JDK 25 LTS

### DIFF
--- a/fragments/labels/eclipsetemurin25.sh
+++ b/fragments/labels/eclipsetemurin25.sh
@@ -1,0 +1,14 @@
+eclipsetemurin25)
+    name="Temurin 25"
+    type="pkg"
+    if [[ $(arch) == "arm64" ]]; then
+        cpu_arch="aarch64"
+    elif [[ $(arch) == "i386" ]]; then
+        cpu_arch="x64"
+    fi
+    downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/25/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=${cpu_arch}")" '[0].binary.installer.link')
+    archiveName="$(basename "$downloadURL")"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-21(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    expectedTeamID="JCDTMS22B4"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //; s/-LTS//'; fi }
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**

Adds `eclipsetemurin25`label (Eclipse Temurin JDK 25 LTS) in addition to the preexisting `eclipsetemurin{8,11,17,25}` Java LTS labels. This uses the Adoptium API as per the following PRs - See #2753

* https://github.com/Installomator/Installomator/pull/2894
* https://github.com/Installomator/Installomator/pull/2895
* https://github.com/Installomator/Installomator/pull/2896
* https://github.com/Installomator/Installomator/pull/2775

**Installomator log** 

```
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : setting variable from argument DEBUG=1
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : Total items in argumentsArray: 1
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : argumentsArray: DEBUG=1
2026-05-01 15:27:02 : REQ   : eclipsetemurin25 : ################## Start Installomator v. 10.9beta, date 2026-05-01
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : ################## Version: 10.9beta
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : ################## Date: 2026-05-01
2026-05-01 15:27:02 : INFO  : eclipsetemurin25 : ################## eclipsetemurin25
2026-05-01 15:27:02 : DEBUG : eclipsetemurin25 : DEBUG mode 1 enabled.
2026-05-01 15:27:03 : INFO  : eclipsetemurin25 : Reading arguments again: DEBUG=1
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : argument: DEBUG=1
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : name=Temurin 25
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : appName=
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : type=pkg
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : archiveName=OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : downloadURL=https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : curlOptions=
2026-05-01 15:27:03 : DEBUG : eclipsetemurin25 : appNewVersion=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : appCustomVersion function: Defined. 
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : versionKey=CFBundleShortVersionString
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : packageID=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : pkgName=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : choiceChangesXML=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : expectedTeamID=JCDTMS22B4
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : blockingProcesses=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : installerTool=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : CLIInstaller=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : CLIArguments=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : updateTool=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : updateToolArguments=
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : updateToolRunAsCurrentUser=
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : NOTIFY=success
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : LOGGING=DEBUG
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Label type: pkg
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : archiveName: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : no blocking processes defined, using Temurin 25 as default
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Custom App Version detection is used, found 25.0.2+10
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : appversion: 25.0.2+10
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Latest version not specified.
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg exists and DEBUG mode 1 enabled, skipping download
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : DEBUG mode 1, not checking for blocking processes
2026-05-01 15:27:04 : REQ   : eclipsetemurin25 : Installing Temurin 25
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Verifying: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : File list: -rw-r--r--@ 1 <USER>  staff   131M May  1 15:18 OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : File type: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg: xar archive compressed TOC: 5562, SHA-1 checksum
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : spctlOut is OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.pkg: accepted
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : source=Notarized Developer ID
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-05-01 15:27:04 : DEBUG : eclipsetemurin25 : DEBUG enabled, skipping installation
2026-05-01 15:27:04 : INFO  : eclipsetemurin25 : Finishing...
2026-05-01 15:27:07 : INFO  : eclipsetemurin25 : Custom App Version detection is used, found 25.0.2+10
2026-05-01 15:27:07 : REQ   : eclipsetemurin25 : Installed Temurin 25
2026-05-01 15:27:07 : INFO  : eclipsetemurin25 : notifying
2026-05-01 15:27:07 : DEBUG : eclipsetemurin25 : DEBUG mode 1, not reopening anything
2026-05-01 15:27:07 : REQ   : eclipsetemurin25 : All done!
2026-05-01 15:27:08 : REQ   : eclipsetemurin25 : ################## End Installomator, exit code 0 
```
