### PR TITLE
Add filemakerpro20 label

### DIFF
--- a/fragments/labels/filemakerpro20.sh
+++ b/fragments/labels/filemakerpro20.sh
@@ -1,0 +1,8 @@
+filemakerpro20)
+    name="FileMaker Pro"
+    type="dmg"
+    versionKey="BuildVersion"
+    downloadURL=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO20MAC\"' | tail -1 | sed "s|.*url\":\"\(.*\)\".*|\\1|")
+    appNewVersion=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO20MAC\"' | tail -1 | sed "s|.*fmp_\(.*\).dmg.*|\\1|")
+    expectedTeamID="J6K4T76U7W"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes modifying
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
The goal is to allow to download a specific version of the FileMakerPro version to be compatible with specific server versions.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
filemakerpro20
```
2026-01-20 16:16:39 : INFO  : filemakerpro20 : Total items in argumentsArray: 0
2026-01-20 16:16:39 : INFO  : filemakerpro20 : argumentsArray:
2026-01-20 16:16:39 : REQ   : filemakerpro20 : ################## Start Installomator v. 10.9beta, date 2026-01-20
2026-01-20 16:16:39 : INFO  : filemakerpro20 : ################## Version: 10.9beta
2026-01-20 16:16:39 : INFO  : filemakerpro20 : ################## Date: 2026-01-20
2026-01-20 16:16:39 : INFO  : filemakerpro20 : ################## filemakerpro20
2026-01-20 16:16:39 : DEBUG : filemakerpro20 : DEBUG mode 1 enabled.
2026-01-20 16:16:40 : INFO  : filemakerpro20 : Reading arguments again:
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : name=FileMaker Pro
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : appName=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : type=dmg
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : archiveName=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : downloadURL=https://downloads.claris.com/esd/fmp_20.3.2.201.dmg
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : curlOptions=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : appNewVersion=20.3.2.201
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : appCustomVersion function: Not defined
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : versionKey=BuildVersion
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : packageID=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : pkgName=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : choiceChangesXML=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : expectedTeamID=J6K4T76U7W
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : blockingProcesses=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : installerTool=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : CLIInstaller=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : CLIArguments=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : updateTool=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : updateToolArguments=
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : updateToolRunAsCurrentUser=
2026-01-20 16:16:41 : INFO  : filemakerpro20 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-20 16:16:41 : INFO  : filemakerpro20 : NOTIFY=success
2026-01-20 16:16:41 : INFO  : filemakerpro20 : LOGGING=DEBUG
2026-01-20 16:16:41 : INFO  : filemakerpro20 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-20 16:16:41 : INFO  : filemakerpro20 : Label type: dmg
2026-01-20 16:16:41 : INFO  : filemakerpro20 : archiveName: FileMaker Pro.dmg
2026-01-20 16:16:41 : INFO  : filemakerpro20 : no blocking processes defined, using FileMaker Pro as default
2026-01-20 16:16:41 : DEBUG : filemakerpro20 : Changing directory to /Users/nilon/Documents/Git/Installomator/build
2026-01-20 16:16:41 : INFO  : filemakerpro20 : App(s) found: /Applications/FileMaker Pro.app
2026-01-20 16:16:41 : INFO  : filemakerpro20 : found app at /Applications/FileMaker Pro.app, version 22.0.4.406, on versionKey BuildVersion
2026-01-20 16:16:41 : INFO  : filemakerpro20 : appversion: 22.0.4.406
2026-01-20 16:16:41 : INFO  : filemakerpro20 : Latest version of FileMaker Pro is 20.3.2.201
2026-01-20 16:16:41 : REQ   : filemakerpro20 : Downloading https://downloads.claris.com/esd/fmp_20.3.2.201.dmg to FileMaker Pro.dmg
2026-01-20 16:16:42 : DEBUG : filemakerpro20 : No Dialog connection, just download
2026-01-20 16:16:55 : INFO  : filemakerpro20 : Downloaded FileMaker Pro.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 0dc80b065ca4da72586ecff3f4fa03bc1bdc3fe8 – Size is 197628 kB
2026-01-20 16:16:55 : DEBUG : filemakerpro20 : DEBUG mode 1, not checking for blocking processes
2026-01-20 16:16:55 : REQ   : filemakerpro20 : Installing FileMaker Pro
2026-01-20 16:16:55 : INFO  : filemakerpro20 : Mounting /Users/nilon/Documents/Git/Installomator/build/FileMaker Pro.dmg
2026-01-20 16:17:12 : DEBUG : filemakerpro20 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DF633AF3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $C00A87A9
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $82EA140E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $304AA517
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $82EA140E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E612A1B2
verified   CRC32 $31F6FDE4
/dev/disk17             GUID_partition_scheme
/dev/disk17s1           Apple_HFS                       /Volumes/FileMaker Pro 20

2026-01-20 16:17:12 : INFO  : filemakerpro20 : Mounted: /Volumes/FileMaker Pro 20
2026-01-20 16:17:12 : INFO  : filemakerpro20 : Verifying: /Volumes/FileMaker Pro 20/FileMaker Pro.app
2026-01-20 16:17:12 : DEBUG : filemakerpro20 : App size: 713M   /Volumes/FileMaker Pro 20/FileMaker Pro.app
2026-01-20 16:18:33 : DEBUG : filemakerpro20 : Debugging enabled, App Verification output was:
/Volumes/FileMaker Pro 20/FileMaker Pro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Claris International Inc. (J6K4T76U7W)

2026-01-20 16:18:34 : INFO  : filemakerpro20 : Team ID matching: J6K4T76U7W (expected: J6K4T76U7W )
2026-01-20 16:18:34 : INFO  : filemakerpro20 : Downloaded version of FileMaker Pro is 20.3.2.201 on versionKey BuildVersion (replacing version 22.0.4.406).
2026-01-20 16:18:34 : INFO  : filemakerpro20 : App has LSMinimumSystemVersion: 11.0
2026-01-20 16:18:34 : DEBUG : filemakerpro20 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-01-20 16:18:34 : INFO  : filemakerpro20 : Finishing...
2026-01-20 16:18:37 : INFO  : filemakerpro20 : App(s) found: /Applications/FileMaker Pro.app
2026-01-20 16:18:37 : INFO  : filemakerpro20 : found app at /Applications/FileMaker Pro.app, version 22.0.4.406, on versionKey BuildVersion
2026-01-20 16:18:37 : REQ   : filemakerpro20 : Installed FileMaker Pro, version 20.3.2.201
2026-01-20 16:18:37 : INFO  : filemakerpro20 : notifying
2026-01-20 16:18:37 : DEBUG : filemakerpro20 : Unmounting /Volumes/FileMaker Pro 20
2026-01-20 16:18:47 : DEBUG : filemakerpro20 : Debugging enabled, Unmounting output was:
"disk17" ejected.
2026-01-20 16:18:47 : DEBUG : filemakerpro20 : DEBUG mode 1, not reopening anything
2026-01-20 16:18:47 : REQ   : filemakerpro20 : All done!
2026-01-20 16:18:47 : REQ   : filemakerpro20 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")