### PR TITLE
Add filemakerpro21 label

### DIFF
--- a/fragments/labels/filemakerpro21.sh
+++ b/fragments/labels/filemakerpro21.sh
@@ -1,0 +1,8 @@
+filemakerpro21)
+    name="FileMaker Pro"
+    type="dmg"
+    versionKey="BuildVersion"
+    downloadURL=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO21MAC\"' | tail -1 | sed "s|.*url\":\"\(.*\)\".*|\\1|")
+    appNewVersion=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO21MAC\"' | tail -1 | sed "s|.*fmp_\(.*\).dmg.*|\\1|")
+    expectedTeamID="J6K4T76U7W"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes modifying
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
The goal is to allow to download a specific version of the FileMakerPro version to be compatible with specific server versions.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
filemakerpro21
```
2026-01-20 16:19:14 : INFO  : filemakerpro21 : Total items in argumentsArray: 0
2026-01-20 16:19:14 : INFO  : filemakerpro21 : argumentsArray:
2026-01-20 16:19:14 : REQ   : filemakerpro21 : ################## Start Installomator v. 10.9beta, date 2026-01-20
2026-01-20 16:19:14 : INFO  : filemakerpro21 : ################## Version: 10.9beta
2026-01-20 16:19:14 : INFO  : filemakerpro21 : ################## Date: 2026-01-20
2026-01-20 16:19:14 : INFO  : filemakerpro21 : ################## filemakerpro21
2026-01-20 16:19:14 : DEBUG : filemakerpro21 : DEBUG mode 1 enabled.
2026-01-20 16:19:15 : INFO  : filemakerpro21 : Reading arguments again:
2026-01-20 16:19:15 : DEBUG : filemakerpro21 : name=FileMaker Pro
2026-01-20 16:19:15 : DEBUG : filemakerpro21 : appName=
2026-01-20 16:19:15 : DEBUG : filemakerpro21 : type=dmg
2026-01-20 16:19:15 : DEBUG : filemakerpro21 : archiveName=
2026-01-20 16:19:15 : DEBUG : filemakerpro21 : downloadURL=https://downloads.claris.com/esd/fmp_21.1.3.301.dmg
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : curlOptions=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : appNewVersion=21.1.3.301
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : appCustomVersion function: Not defined
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : versionKey=BuildVersion
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : packageID=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : pkgName=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : choiceChangesXML=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : expectedTeamID=J6K4T76U7W
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : blockingProcesses=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : installerTool=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : CLIInstaller=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : CLIArguments=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : updateTool=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : updateToolArguments=
2026-01-20 16:19:16 : DEBUG : filemakerpro21 : updateToolRunAsCurrentUser=
2026-01-20 16:19:16 : INFO  : filemakerpro21 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-20 16:19:16 : INFO  : filemakerpro21 : NOTIFY=success
2026-01-20 16:19:16 : INFO  : filemakerpro21 : LOGGING=DEBUG
2026-01-20 16:19:16 : INFO  : filemakerpro21 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-20 16:19:16 : INFO  : filemakerpro21 : Label type: dmg
2026-01-20 16:19:16 : INFO  : filemakerpro21 : archiveName: FileMaker Pro.dmg
2026-01-20 16:19:16 : INFO  : filemakerpro21 : no blocking processes defined, using FileMaker Pro as default
2026-01-20 16:19:17 : DEBUG : filemakerpro21 : Changing directory to /Users/nilon/Documents/Git/Installomator/build
2026-01-20 16:19:17 : INFO  : filemakerpro21 : App(s) found: /Applications/FileMaker Pro.app
2026-01-20 16:19:17 : INFO  : filemakerpro21 : found app at /Applications/FileMaker Pro.app, version 22.0.4.406, on versionKey BuildVersion
2026-01-20 16:19:17 : INFO  : filemakerpro21 : appversion: 22.0.4.406
2026-01-20 16:19:17 : INFO  : filemakerpro21 : Latest version of FileMaker Pro is 21.1.3.301
2026-01-20 16:19:17 : REQ   : filemakerpro21 : Downloading https://downloads.claris.com/esd/fmp_21.1.3.301.dmg to FileMaker Pro.dmg
2026-01-20 16:19:17 : DEBUG : filemakerpro21 : No Dialog connection, just download
2026-01-20 16:19:31 : INFO  : filemakerpro21 : Downloaded FileMaker Pro.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 79ac77b33a8015e2aacc7a6fab2ecf0d4a964b55 – Size is 263168 kB
2026-01-20 16:19:31 : DEBUG : filemakerpro21 : DEBUG mode 1, not checking for blocking processes
2026-01-20 16:19:32 : REQ   : filemakerpro21 : Installing FileMaker Pro
2026-01-20 16:19:32 : INFO  : filemakerpro21 : Mounting /Users/nilon/Documents/Git/Installomator/build/FileMaker Pro.dmg
2026-01-20 16:19:50 : DEBUG : filemakerpro21 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DF633AF3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B8491C39
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $23255162
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $00EB59E7
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $23255162
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9E513A22
verified   CRC32 $6E0A7AAB
/dev/disk17             GUID_partition_scheme
/dev/disk17s1           Apple_HFS                       /Volumes/FileMaker Pro 21 1

2026-01-20 16:19:50 : INFO  : filemakerpro21 : Mounted: /Volumes/FileMaker Pro 21 1
2026-01-20 16:19:50 : INFO  : filemakerpro21 : Verifying: /Volumes/FileMaker Pro 21 1/FileMaker Pro.app
2026-01-20 16:19:50 : DEBUG : filemakerpro21 : App size: 835M   /Volumes/FileMaker Pro 21 1/FileMaker Pro.app
2026-01-20 16:21:11 : DEBUG : filemakerpro21 : Debugging enabled, App Verification output was:
/Volumes/FileMaker Pro 21 1/FileMaker Pro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Claris International Inc. (J6K4T76U7W)

2026-01-20 16:21:11 : INFO  : filemakerpro21 : Team ID matching: J6K4T76U7W (expected: J6K4T76U7W )
2026-01-20 16:21:11 : INFO  : filemakerpro21 : Downloaded version of FileMaker Pro is 21.1.3.301 on versionKey BuildVersion (replacing version 22.0.4.406).
2026-01-20 16:21:11 : INFO  : filemakerpro21 : App has LSMinimumSystemVersion: 13.0
2026-01-20 16:21:11 : DEBUG : filemakerpro21 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-01-20 16:21:11 : INFO  : filemakerpro21 : Finishing...
2026-01-20 16:21:14 : INFO  : filemakerpro21 : App(s) found: /Applications/FileMaker Pro.app
2026-01-20 16:21:14 : INFO  : filemakerpro21 : found app at /Applications/FileMaker Pro.app, version 22.0.4.406, on versionKey BuildVersion
2026-01-20 16:21:14 : REQ   : filemakerpro21 : Installed FileMaker Pro, version 21.1.3.301
2026-01-20 16:21:14 : INFO  : filemakerpro21 : notifying
2026-01-20 16:21:15 : DEBUG : filemakerpro21 : Unmounting /Volumes/FileMaker Pro 21 1
2026-01-20 16:21:26 : DEBUG : filemakerpro21 : Debugging enabled, Unmounting output was:
"disk17" ejected.
2026-01-20 16:21:27 : DEBUG : filemakerpro21 : DEBUG mode 1, not reopening anything
2026-01-20 16:21:27 : REQ   : filemakerpro21 : All done!
2026-01-20 16:21:27 : REQ   : filemakerpro21 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
