### PR TITLE
Add filemakerpro22 label

### DIFF
--- a/fragments/labels/filemakerpro22.sh
+++ b/fragments/labels/filemakerpro22.sh
@@ -1,0 +1,8 @@
+filemakerpro22)
+    name="FileMaker Pro"
+    type="dmg"
+    versionKey="BuildVersion"
+    downloadURL=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO22MAC\"' | tail -1 | sed "s|.*url\":\"\(.*\)\".*|\\1|")
+    appNewVersion=$(curl -fs https://www.filemaker.com/redirects/ss.txt | grep '\"PRO22MAC\"' | tail -1 | sed "s|.*fmp_\(.*\).dmg.*|\\1|")
+    expectedTeamID="J6K4T76U7W"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes modifying
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
The goal is to allow to download a specific version of the FileMakerPro version to be compatible with specific server versions.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
filemakerpro22
```
2026-01-20 16:22:24 : INFO  : filemakerpro22 : Total items in argumentsArray: 0
2026-01-20 16:22:24 : INFO  : filemakerpro22 : argumentsArray:
2026-01-20 16:22:24 : REQ   : filemakerpro22 : ################## Start Installomator v. 10.9beta, date 2026-01-20
2026-01-20 16:22:24 : INFO  : filemakerpro22 : ################## Version: 10.9beta
2026-01-20 16:22:24 : INFO  : filemakerpro22 : ################## Date: 2026-01-20
2026-01-20 16:22:24 : INFO  : filemakerpro22 : ################## filemakerpro22
2026-01-20 16:22:24 : DEBUG : filemakerpro22 : DEBUG mode 1 enabled.
2026-01-20 16:22:25 : INFO  : filemakerpro22 : Reading arguments again:
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : name=FileMaker Pro
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : appName=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : type=dmg
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : archiveName=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : downloadURL=https://downloads.claris.com/esd/fmp_22.0.4.406.dmg
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : curlOptions=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : appNewVersion=22.0.4.406
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : appCustomVersion function: Not defined
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : versionKey=BuildVersion
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : packageID=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : pkgName=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : choiceChangesXML=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : expectedTeamID=J6K4T76U7W
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : blockingProcesses=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : installerTool=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : CLIInstaller=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : CLIArguments=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : updateTool=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : updateToolArguments=
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : updateToolRunAsCurrentUser=
2026-01-20 16:22:26 : INFO  : filemakerpro22 : BLOCKING_PROCESS_ACTION=tell_user
2026-01-20 16:22:26 : INFO  : filemakerpro22 : NOTIFY=success
2026-01-20 16:22:26 : INFO  : filemakerpro22 : LOGGING=DEBUG
2026-01-20 16:22:26 : INFO  : filemakerpro22 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-01-20 16:22:26 : INFO  : filemakerpro22 : Label type: dmg
2026-01-20 16:22:26 : INFO  : filemakerpro22 : archiveName: FileMaker Pro.dmg
2026-01-20 16:22:26 : INFO  : filemakerpro22 : no blocking processes defined, using FileMaker Pro as default
2026-01-20 16:22:26 : DEBUG : filemakerpro22 : Changing directory to /Users/nilon/Documents/Git/Installomator/build
2026-01-20 16:22:26 : INFO  : filemakerpro22 : App(s) found: /Applications/FileMaker Pro.app
2026-01-20 16:22:27 : INFO  : filemakerpro22 : found app at /Applications/FileMaker Pro.app, version 22.0.4.406, on versionKey BuildVersion
2026-01-20 16:22:27 : INFO  : filemakerpro22 : appversion: 22.0.4.406
2026-01-20 16:22:27 : INFO  : filemakerpro22 : Latest version of FileMaker Pro is 22.0.4.406
2026-01-20 16:22:27 : WARN  : filemakerpro22 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-01-20 16:22:27 : REQ   : filemakerpro22 : Downloading https://downloads.claris.com/esd/fmp_22.0.4.406.dmg to FileMaker Pro.dmg
2026-01-20 16:22:27 : DEBUG : filemakerpro22 : No Dialog connection, just download
2026-01-20 16:22:36 : INFO  : filemakerpro22 : Downloaded FileMaker Pro.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 97382df3776775abf26539afd061acaea07f9686 – Size is 262328 kB
2026-01-20 16:22:36 : DEBUG : filemakerpro22 : DEBUG mode 1, not checking for blocking processes
2026-01-20 16:22:36 : REQ   : filemakerpro22 : Installing FileMaker Pro
2026-01-20 16:22:36 : INFO  : filemakerpro22 : Mounting /Users/nilon/Documents/Git/Installomator/build/FileMaker Pro.dmg
2026-01-20 16:22:59 : DEBUG : filemakerpro22 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DF633AF3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $45C752BC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7C3B8FAA
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $F68F6607
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7C3B8FAA
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $63DF74A7
verified   CRC32 $7C351E82
/dev/disk17             GUID_partition_scheme
/dev/disk17s1           Apple_HFS                       /Volumes/FileMaker Pro 22

2026-01-20 16:22:59 : INFO  : filemakerpro22 : Mounted: /Volumes/FileMaker Pro 22
2026-01-20 16:22:59 : INFO  : filemakerpro22 : Verifying: /Volumes/FileMaker Pro 22/FileMaker Pro.app
2026-01-20 16:22:59 : DEBUG : filemakerpro22 : App size: 858M   /Volumes/FileMaker Pro 22/FileMaker Pro.app
2026-01-20 16:24:32 : DEBUG : filemakerpro22 : Debugging enabled, App Verification output was:
/Volumes/FileMaker Pro 22/FileMaker Pro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Claris International Inc. (J6K4T76U7W)

2026-01-20 16:24:32 : INFO  : filemakerpro22 : Team ID matching: J6K4T76U7W (expected: J6K4T76U7W )
2026-01-20 16:24:32 : INFO  : filemakerpro22 : Downloaded version of FileMaker Pro is 22.0.4.406 on versionKey BuildVersion, same as installed.
2026-01-20 16:24:32 : DEBUG : filemakerpro22 : Unmounting /Volumes/FileMaker Pro 22
2026-01-20 16:24:35 : DEBUG : filemakerpro22 : Debugging enabled, Unmounting output was:
"disk17" ejected.
2026-01-20 16:24:35 : DEBUG : filemakerpro22 : DEBUG mode 1, not reopening anything
2026-01-20 16:24:35 : REG   : filemakerpro22 : No new version to install
2026-01-20 16:24:36 : REQ   : filemakerpro22 : ################## End Installomator, exit code 0
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
