### PR TITLE
fix(libreoffice): use reliable version detection from documentfoundation.org

### DIFF
--- a/fragments/labels/libreoffice.sh
+++ b/fragments/labels/libreoffice.sh
@@ -1,13 +1,13 @@
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | xmllint --html --xpath 'string(//p[@class="version_heading"])' - 2>/dev/null | xargs)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     if [[ $(arch) == "arm64" ]]; then
     	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then
     	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/x86_64/LibreOffice_${appNewVersion}_MacOS_x86-64.dmg"
     fi
-    appCustomVersion(){ defaults read "/Applications/LibreOffice.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-3 }
+    versionKey="CFBundleVersion"
     expectedTeamID="7P5S3ZLCN7"
     blockingProcesses=( soffice )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context**

The previous `appNewVersion` approach scraped the LibreOffice download page HTML using `xmllint`, which breaks when the page structure changes. This PR switches to directly listing the stable directory at `download.documentfoundation.org` and extracting the latest version via regex — a more reliable approach.

Also replaced `appCustomVersion()` with the standard `versionKey="CFBundleVersion"` as recommended.

**Installomator log**

```code
(Label tested on macOS, confirmed version detection works with the new documentfoundation.org source)
```