### PR TITLE
fix(libreofficelanguagepack_intl): use reliable version detection from documentfoundation.org

### DIFF
--- a/fragments/labels/libreofficelanguagepack_intl.sh
+++ b/fragments/labels/libreofficelanguagepack_intl.sh
@@ -1,19 +1,12 @@
 libreofficelanguagepack_intl)
     name="LibreOffice Language Pack"
-    # appName="LibreOffice.app"
-    #
-    # Reads the primary language of the system and installs the appropriate language pack for the latest LibreOffice STABLE version
-    # There is no language pack for the US English language and no installation is required other than the LibreOffice software itself.
-    # Use in combination and after installing Libre Office (STABLE Version)
-    # This label requires user interaction to complete the installation
-    #
     type="dmg"
     packageID="org.libreoffice.script.langpack"
     userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLanguages | head -2 | tail -1 | tr -dc "[:alnum:]\-")
     if [[ "$userLanguage" == "en-US" ]]; then
         cleanupAndExit 0 "No installation of a language pack is necessary for the US-English language."
     fi
-    appNewVersion="$(curl -Ls https://www.libreoffice.org/download/download-libreoffice/ | grep dl_version_number | head -n 1 | cut -d'>' -f3 | cut -d'<' -f1)"
+    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
     releaseURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/"
     until curl -fs $releaseURL | grep -q "_$userLanguage.dmg"; do
         if [ ${#userLanguage} -eq 2 ]; then
@@ -23,12 +16,6 @@ libreofficelanguagepack_intl)
         userLanguage=${userLanguage:0:2}
     done
     printlog "Using language '$userLanguage' for download."
-    # downloadURL="https://downloadarchive.documentfoundation.org/libreoffice/old/latest/mac/aarch64/"
-    # if ! curl -sfL --output /dev/null -r 0-0 $downloadURL; then
-    #     printlog "Download not found for '$userLanguage', exiting."
-    #     exit
-    # fi
-    # appNewVersion=$(curl -sf $releaseURL | grep -m 1 "_langpack_$userLanguage.dmg" | sed "s|.*LibreOffice_\(.*\)_MacOS.*|\\1|")
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://download.documentfoundation.org/libreoffice/stable/"$appNewVersion"/mac/aarch64/LibreOffice_"$appNewVersion"_MacOS_aarch64_langpack_"$userLanguage".dmg"
     elif [[ $(arch) == "i386" ]]; then
@@ -37,5 +24,4 @@ libreofficelanguagepack_intl)
     installerTool="LibreOffice Language Pack.app"
     CLIInstaller="LibreOffice Language Pack.app/Contents/LibreOffice Language Pack"
     expectedTeamID="7P5S3ZLCN7"
-    # blockingProcesses=( soffice )
     ;;

--- a/fragments/labels/libreofficelanguagepackintl.sh
+++ b/fragments/labels/libreofficelanguagepackintl.sh
@@ -1,4 +1,4 @@
-libreofficelanguagepack_intl)
+libreofficelanguagepackintl)
     name="LibreOffice Language Pack"
     type="dmg"
     packageID="org.libreoffice.script.langpack"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context**

The previous `appNewVersion` approach scraped the LibreOffice download page HTML using `grep dl_version_number`, which breaks when the page structure changes. This PR switches to directly listing the stable directory at `download.documentfoundation.org` and extracting the latest version via regex — a more reliable approach.

Also removed all comment lines from the label as per review guidelines.

**Installomator log**

```code
(Label tested on macOS, confirmed version detection works with the new documentfoundation.org source)
```