### PR TITLE
Fix iterm2 blockingProcesses

### DIFF
--- a/fragments/labels/iterm2.sh
+++ b/fragments/labels/iterm2.sh
@@ -4,5 +4,5 @@ iterm2)
     downloadURL="https://iterm2.com/downloads/stable/latest"
     appNewVersion=$(curl -is https://iterm2.com/downloads/stable/latest | grep location: | grep -o "iTerm2.*zip" | cut -d "-" -f 2 | cut -d '.' -f1 | sed 's/_/./g')
     expectedTeamID="H7V7XYVQ7D"
-    blockingProcesses ( "iTerm" "iTerm2" )
+    blockingProcesses=( "iTerm" "iTerm2" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Because of a missing = sign the blocking processes were not applied.
```2026-05-04 16:26:41 : INFO  : iterm2 : no blocking processes defined, using iTerm as default```


**Installomator log**
```
sudo ./Installomator.sh iterm2 appNewVersion=10 DEBUG=0
Password:
2026-05-04 16:39:48 : INFO  : iterm2 : setting variable from argument appNewVersion=10
2026-05-04 16:39:48 : INFO  : iterm2 : setting variable from argument DEBUG=0
2026-05-04 16:39:48 : INFO  : iterm2 : Total items in argumentsArray: 2
2026-05-04 16:39:48 : INFO  : iterm2 : argumentsArray: appNewVersion=10 DEBUG=0
2026-05-04 16:39:48 : REQ   : iterm2 : ################## Start Installomator v. 10.9beta, date 2026-05-04
2026-05-04 16:39:48 : INFO  : iterm2 : ################## Version: 10.9beta
2026-05-04 16:39:48 : INFO  : iterm2 : ################## Date: 2026-05-04
2026-05-04 16:39:48 : INFO  : iterm2 : ################## iterm2
2026-05-04 16:39:49 : INFO  : iterm2 : Reading arguments again: appNewVersion=10 DEBUG=0
2026-05-04 16:39:49 : INFO  : iterm2 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-04 16:39:49 : INFO  : iterm2 : NOTIFY=success
2026-05-04 16:39:49 : INFO  : iterm2 : LOGGING=INFO
2026-05-04 16:39:49 : INFO  : iterm2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-04 16:39:49 : INFO  : iterm2 : Label type: zip
2026-05-04 16:39:49 : INFO  : iterm2 : archiveName: iTerm.zip
2026-05-04 16:39:49 : INFO  : iterm2 : App(s) found: /Applications/iTerm.app
2026-05-04 16:39:49 : INFO  : iterm2 : found app at /Applications/iTerm.app, version 3.6.10, on versionKey CFBundleShortVersionString
2026-05-04 16:39:49 : INFO  : iterm2 : appversion: 3.6.10
2026-05-04 16:39:49 : INFO  : iterm2 : Latest version of iTerm is 10
2026-05-04 16:39:49 : REQ   : iterm2 : Downloading https://iterm2.com/downloads/stable/latest to iTerm.zip
2026-05-04 16:39:53 : INFO  : iterm2 : Downloaded iTerm.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is bdc45f31c6b36acb2e754f0af1851421ffc872be – Size is 44580 kB
2026-05-04 16:39:53 : INFO  : iterm2 : found blocking process iTerm2
2026-05-04 16:40:00 : INFO  : iterm2 : telling app iTerm2 to quit
2026-05-04 16:40:03 : INFO  : iterm2 : waiting 30 seconds for processes to quit
2026-05-04 16:40:33 : REQ   : iterm2 : no more blocking processes, continue with update
2026-05-04 16:40:33 : REQ   : iterm2 : Installing iTerm
2026-05-04 16:40:33 : INFO  : iterm2 : Unzipping iTerm.zip
2026-05-04 16:40:34 : INFO  : iterm2 : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.AFIB6cuSJo/iTerm.app
2026-05-04 16:40:34 : INFO  : iterm2 : Team ID matching: H7V7XYVQ7D (expected: H7V7XYVQ7D )
2026-05-04 16:40:34 : INFO  : iterm2 : Downloaded version of iTerm is 3.6.10 on versionKey CFBundleShortVersionString, same as installed.
2026-05-04 16:40:35 : INFO  : iterm2 : Telling app iTerm.app to open
2026-05-04 16:40:35 : INFO  : iterm2 : Reopened iTerm.app as maartenwijnants
2026-05-04 16:40:35 : REQ   : iterm2 : ################## End Installomator, exit code 0
 ```
