### PR TITLE
fix(gather): Update `expectedTeamId`, `appNewVersion`, `downloadUrl`

### DIFF
--- a/fragments/labels/gather.sh
+++ b/fragments/labels/gather.sh
@@ -2,9 +2,8 @@ gather|\
 gathertown)
     name="Gather"
     type="dmg"
-    appNewVersion="$(versionFromGit gathertown gather-town-desktop-releases)"
-    downloadURL="$(downloadURLFromGit gathertown gather-town-desktop-releases)"
-    archiveName="Gather-${appNewVersion}-universal.dmg"
-    expectedTeamID="69MCJ5CRDW"
+    appNewVersion=$(getJSONValue "$(curl -fsL 'https://api.gather.town/api/v2/releases/desktop/latest')" "version")
+    downloadURL="https://api.v2.gather.town/api/v2/releases/latest/macos/v1"
+    expectedTeamID="W28UKP642P"
     ;;
 

--- a/fragments/labels/gather.sh
+++ b/fragments/labels/gather.sh
@@ -1,5 +1,4 @@
-gather|\
-gathertown)
+gather)
     name="Gather"
     type="dmg"
     appNewVersion=$(getJSONValue "$(curl -fsL 'https://api.gather.town/api/v2/releases/desktop/latest')" "version")


### PR DESCRIPTION
Hey folks - I work @gathertown - we've made some updates that cause installation via Installometer to fail. This addresses that issue, and uses our public endpoints for determining version info and installer urls - just like we do in-app, and via [gather.town/download](https://gather.town/download). This should be much more reliable.

---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
We've updated our apple developer account used to sign our apps - as such, expectedTeamId needs updating. Further, this is no longer our most recent product, so I've removed the `gathertown` alias.

Fixes https://github.com/Installomator/Installomator/issues/2909

**Installomator log** 

```
❯ sudo ./assemble.sh gather DEBUG=1
2026-05-04 15:34:45 : INFO  : gather : setting variable from argument DEBUG=1
2026-05-04 15:34:45 : INFO  : gather : Total items in argumentsArray: 1
2026-05-04 15:34:45 : INFO  : gather : argumentsArray: DEBUG=1
2026-05-04 15:34:45 : REQ   : gather : ################## Start Installomator v. 10.9beta, date 2026-05-04
2026-05-04 15:34:45 : INFO  : gather : ################## Version: 10.9beta
2026-05-04 15:34:45 : INFO  : gather : ################## Date: 2026-05-04
2026-05-04 15:34:45 : INFO  : gather : ################## gather
2026-05-04 15:34:45 : DEBUG : gather : DEBUG mode 1 enabled.
2026-05-04 15:34:45 : INFO  : gather : SwiftDialog is not installed, clear cmd file var
2026-05-04 15:34:46 : INFO  : gather : Reading arguments again: DEBUG=1
2026-05-04 15:34:46 : DEBUG : gather : argument: DEBUG=1
2026-05-04 15:34:46 : DEBUG : gather : name=Gather
2026-05-04 15:34:46 : DEBUG : gather : appName=
2026-05-04 15:34:46 : DEBUG : gather : type=dmg
2026-05-04 15:34:46 : DEBUG : gather : archiveName=
2026-05-04 15:34:46 : DEBUG : gather : downloadURL=https://api.v2.gather.town/api/v2/releases/latest/macos/v1
2026-05-04 15:34:46 : DEBUG : gather : curlOptions=
2026-05-04 15:34:46 : DEBUG : gather : appNewVersion=1.37.1
2026-05-04 15:34:46 : DEBUG : gather : appCustomVersion function: Not defined
2026-05-04 15:34:46 : DEBUG : gather : versionKey=CFBundleShortVersionString
2026-05-04 15:34:46 : DEBUG : gather : packageID=
2026-05-04 15:34:47 : DEBUG : gather : pkgName=
2026-05-04 15:34:47 : DEBUG : gather : choiceChangesXML=
2026-05-04 15:34:47 : DEBUG : gather : expectedTeamID=W28UKP642P
2026-05-04 15:34:47 : DEBUG : gather : blockingProcesses=
2026-05-04 15:34:47 : DEBUG : gather : installerTool=
2026-05-04 15:34:47 : DEBUG : gather : CLIInstaller=
2026-05-04 15:34:47 : DEBUG : gather : CLIArguments=
2026-05-04 15:34:47 : DEBUG : gather : updateTool=
2026-05-04 15:34:47 : DEBUG : gather : updateToolArguments=
2026-05-04 15:34:47 : DEBUG : gather : updateToolRunAsCurrentUser=
2026-05-04 15:34:47 : INFO  : gather : BLOCKING_PROCESS_ACTION=tell_user
2026-05-04 15:34:47 : INFO  : gather : NOTIFY=success
2026-05-04 15:34:47 : INFO  : gather : LOGGING=DEBUG
2026-05-04 15:34:47 : INFO  : gather : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-04 15:34:47 : INFO  : gather : Label type: dmg
2026-05-04 15:34:47 : INFO  : gather : archiveName: Gather.dmg
2026-05-04 15:34:47 : INFO  : gather : no blocking processes defined, using Gather as default
2026-05-04 15:34:47 : DEBUG : gather : Changing directory to /Users/bgreenier/src/Installomator/build
2026-05-04 15:34:47 : INFO  : gather : App(s) found: /Applications/Gather.app
2026-05-04 15:34:47 : INFO  : gather : found app at /Applications/Gather.app, version 1.35.1, on versionKey CFBundleShortVersionString
2026-05-04 15:34:47 : INFO  : gather : appversion: 1.35.1
2026-05-04 15:34:47 : INFO  : gather : Latest version of Gather is 1.37.1
2026-05-04 15:34:47 : REQ   : gather : Downloading https://api.v2.gather.town/api/v2/releases/latest/macos/v1 to Gather.dmg
2026-05-04 15:34:47 : DEBUG : gather : No Dialog connection, just download
2026-05-04 15:34:50 : INFO  : gather : Downloaded Gather.dmg – Type is  zlib compressed data – SHA is 2c3051128b5095486517ad53ca0b510f4cf8e8ef – Size is 277000 kB
2026-05-04 15:34:50 : DEBUG : gather : DEBUG mode 1, not checking for blocking processes
2026-05-04 15:34:50 : REQ   : gather : Installing Gather
2026-05-04 15:34:50 : INFO  : gather : Mounting /Users/bgreenier/src/Installomator/build/Gather.dmg
2026-05-04 15:34:53 : DEBUG : gather : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $C7ED9B8C
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $6F4E7CA7
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $69783BEB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $8252BA13
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $69783BEB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $5AF954AE
verified   CRC32 $7D689A08
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Gather 1.37.1-universal

2026-05-04 15:34:53 : INFO  : gather : Mounted: /Volumes/Gather 1.37.1-universal
2026-05-04 15:34:53 : INFO  : gather : Verifying: /Volumes/Gather 1.37.1-universal/Gather.app
2026-05-04 15:34:53 : DEBUG : gather : App size: 682M	/Volumes/Gather 1.37.1-universal/Gather.app
2026-05-04 15:34:55 : DEBUG : gather : Debugging enabled, App Verification output was:
/Volumes/Gather 1.37.1-universal/Gather.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Gather Presence, Inc. (W28UKP642P)

2026-05-04 15:34:55 : INFO  : gather : Team ID matching: W28UKP642P (expected: W28UKP642P )
2026-05-04 15:34:55 : INFO  : gather : Downloaded version of Gather is 1.37.1 on versionKey CFBundleShortVersionString (replacing version 1.35.1).
2026-05-04 15:34:55 : INFO  : gather : App has LSMinimumSystemVersion: 11.0
2026-05-04 15:34:55 : DEBUG : gather : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-04 15:34:56 : INFO  : gather : Finishing...
2026-05-04 15:34:59 : INFO  : gather : App(s) found: /Applications/Gather.app
2026-05-04 15:34:59 : INFO  : gather : found app at /Applications/Gather.app, version 1.35.1, on versionKey CFBundleShortVersionString
2026-05-04 15:34:59 : REQ   : gather : Installed Gather, version 1.37.1
2026-05-04 15:34:59 : INFO  : gather : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-05-04 15:34:59 : DEBUG : gather : Unmounting /Volumes/Gather 1.37.1-universal
2026-05-04 15:34:59 : DEBUG : gather : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-05-04 15:34:59 : DEBUG : gather : DEBUG mode 1, not reopening anything
2026-05-04 15:34:59 : REQ   : gather : All done!
2026-05-04 15:34:59 : REQ   : gather : ################## End Installomator, exit code 0
```