### PR TITLE
feat(gather2): Add the latest `gather2` product

### DIFF
--- a/fragments/labels/gather2.sh
+++ b/fragments/labels/gather2.sh
@@ -1,0 +1,8 @@
+gather2)
+    name="Gather"
+    type="dmg"
+    appNewVersion=$(getJSONValue "$(curl -fsL 'https://api.v2.gather.town/api/v2/releases/desktop/latest')" "version")
+    downloadURL="https://api.v2.gather.town/api/v2/releases/latest/macos/v2"
+    expectedTeamID="W28UKP642P"
+    ;;
+

--- a/fragments/labels/gather2.sh
+++ b/fragments/labels/gather2.sh
@@ -1,4 +1,5 @@
-gather2)
+gather2|\
+gathertown)
     name="GatherV2"
     type="dmg"
     appNewVersion=$(getJSONValue "$(curl -fsL 'https://api.v2.gather.town/api/v2/releases/desktop/latest')" "version")

--- a/fragments/labels/gather2.sh
+++ b/fragments/labels/gather2.sh
@@ -1,5 +1,5 @@
 gather2)
-    name="Gather"
+    name="GatherV2"
     type="dmg"
     appNewVersion=$(getJSONValue "$(curl -fsL 'https://api.v2.gather.town/api/v2/releases/desktop/latest')" "version")
     downloadURL="https://api.v2.gather.town/api/v2/releases/latest/macos/v2"


### PR DESCRIPTION
Hey folks - I @gathertown - we ship and maintain two products now - this adds the latest one ("GatherV2"). This uses our public endpoints for determining version info and installer urls - just like we do in-app, and via [gather.town/download](https://gather.town/download).

---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
This moves the `gathertown` label that's being removed in #2910 to this, as it's our latest product that we'd expect new folks to onboard to. The existing `gather` product is still supported for the time being though.

**Installomator log** 

```
❯ sudo ./assemble.sh gather2 DEBUG=1
2026-05-04 15:47:08 : INFO  : gather2 : setting variable from argument DEBUG=1
2026-05-04 15:47:08 : INFO  : gather2 : Total items in argumentsArray: 1
2026-05-04 15:47:08 : INFO  : gather2 : argumentsArray: DEBUG=1
2026-05-04 15:47:08 : REQ   : gather2 : ################## Start Installomator v. 10.9beta, date 2026-05-04
2026-05-04 15:47:08 : INFO  : gather2 : ################## Version: 10.9beta
2026-05-04 15:47:09 : INFO  : gather2 : ################## Date: 2026-05-04
2026-05-04 15:47:09 : INFO  : gather2 : ################## gather2
2026-05-04 15:47:09 : DEBUG : gather2 : DEBUG mode 1 enabled.
2026-05-04 15:47:09 : INFO  : gather2 : SwiftDialog is not installed, clear cmd file var
2026-05-04 15:47:09 : INFO  : gather2 : Reading arguments again: DEBUG=1
2026-05-04 15:47:09 : DEBUG : gather2 : argument: DEBUG=1
2026-05-04 15:47:09 : DEBUG : gather2 : name=GatherV2
2026-05-04 15:47:09 : DEBUG : gather2 : appName=
2026-05-04 15:47:09 : DEBUG : gather2 : type=dmg
2026-05-04 15:47:09 : DEBUG : gather2 : archiveName=
2026-05-04 15:47:09 : DEBUG : gather2 : downloadURL=https://api.v2.gather.town/api/v2/releases/latest/macos/v2
2026-05-04 15:47:09 : DEBUG : gather2 : curlOptions=
2026-05-04 15:47:09 : DEBUG : gather2 : appNewVersion=0.43.0
2026-05-04 15:47:09 : DEBUG : gather2 : appCustomVersion function: Not defined
2026-05-04 15:47:09 : DEBUG : gather2 : versionKey=CFBundleShortVersionString
2026-05-04 15:47:09 : DEBUG : gather2 : packageID=
2026-05-04 15:47:10 : DEBUG : gather2 : pkgName=
2026-05-04 15:47:10 : DEBUG : gather2 : choiceChangesXML=
2026-05-04 15:47:10 : DEBUG : gather2 : expectedTeamID=W28UKP642P
2026-05-04 15:47:10 : DEBUG : gather2 : blockingProcesses=
2026-05-04 15:47:10 : DEBUG : gather2 : installerTool=
2026-05-04 15:47:10 : DEBUG : gather2 : CLIInstaller=
2026-05-04 15:47:10 : DEBUG : gather2 : CLIArguments=
2026-05-04 15:47:10 : DEBUG : gather2 : updateTool=
2026-05-04 15:47:10 : DEBUG : gather2 : updateToolArguments=
2026-05-04 15:47:10 : DEBUG : gather2 : updateToolRunAsCurrentUser=
2026-05-04 15:47:10 : INFO  : gather2 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-04 15:47:10 : INFO  : gather2 : NOTIFY=success
2026-05-04 15:47:10 : INFO  : gather2 : LOGGING=DEBUG
2026-05-04 15:47:10 : INFO  : gather2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-04 15:47:10 : INFO  : gather2 : Label type: dmg
2026-05-04 15:47:10 : INFO  : gather2 : archiveName: GatherV2.dmg
2026-05-04 15:47:10 : INFO  : gather2 : no blocking processes defined, using GatherV2 as default
2026-05-04 15:47:10 : DEBUG : gather2 : Changing directory to /Users/bgreenier/src/Installomator/build
2026-05-04 15:47:10 : INFO  : gather2 : App(s) found: /Applications/GatherV2.app
2026-05-04 15:47:10 : INFO  : gather2 : found app at /Applications/GatherV2.app, version 0.44.1-beta, on versionKey CFBundleShortVersionString
2026-05-04 15:47:10 : INFO  : gather2 : appversion: 0.44.1-beta
2026-05-04 15:47:10 : INFO  : gather2 : Latest version of GatherV2 is 0.43.0
2026-05-04 15:47:10 : INFO  : gather2 : GatherV2.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-04 15:47:10 : DEBUG : gather2 : DEBUG mode 1, not checking for blocking processes
2026-05-04 15:47:10 : REQ   : gather2 : Installing GatherV2
2026-05-04 15:47:10 : INFO  : gather2 : Mounting /Users/bgreenier/src/Installomator/build/GatherV2.dmg
2026-05-04 15:47:11 : DEBUG : gather2 : Debugging enabled, dmgmount output was:
expected   CRC32 $E2BF9F4E
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/GatherV2 0.43.0-universal

2026-05-04 15:47:11 : INFO  : gather2 : Mounted: /Volumes/GatherV2 0.43.0-universal
2026-05-04 15:47:11 : INFO  : gather2 : Verifying: /Volumes/GatherV2 0.43.0-universal/GatherV2.app
2026-05-04 15:47:11 : DEBUG : gather2 : App size: 622M	/Volumes/GatherV2 0.43.0-universal/GatherV2.app
2026-05-04 15:47:13 : DEBUG : gather2 : Debugging enabled, App Verification output was:
/Volumes/GatherV2 0.43.0-universal/GatherV2.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: Gather Presence, Inc. (W28UKP642P)

2026-05-04 15:47:13 : INFO  : gather2 : Team ID matching: W28UKP642P (expected: W28UKP642P )
2026-05-04 15:47:13 : INFO  : gather2 : Downloaded version of GatherV2 is 0.43.0 on versionKey CFBundleShortVersionString (replacing version 0.44.1-beta).
2026-05-04 15:47:13 : INFO  : gather2 : App has LSMinimumSystemVersion: 12.0
2026-05-04 15:47:13 : DEBUG : gather2 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-04 15:47:13 : INFO  : gather2 : Finishing...
2026-05-04 15:47:16 : INFO  : gather2 : App(s) found: /Applications/GatherV2.app
2026-05-04 15:47:16 : INFO  : gather2 : found app at /Applications/GatherV2.app, version 0.44.1-beta, on versionKey CFBundleShortVersionString
2026-05-04 15:47:16 : REQ   : gather2 : Installed GatherV2, version 0.43.0
2026-05-04 15:47:16 : INFO  : gather2 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-05-04 15:47:17 : DEBUG : gather2 : Unmounting /Volumes/GatherV2 0.43.0-universal
2026-05-04 15:47:17 : DEBUG : gather2 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-05-04 15:47:17 : DEBUG : gather2 : DEBUG mode 1, not reopening anything
2026-05-04 15:47:17 : REQ   : gather2 : All done!
2026-05-04 15:47:17 : REQ   : gather2 : ################## End Installomator, exit code 0
```