### PR TITLE
fix(linear): Update downloadUrl to new universal URL

### DIFF
--- a/fragments/labels/linear.sh
+++ b/fragments/labels/linear.sh
@@ -1,12 +1,8 @@
 linear)
     name="Linear"
     type="dmg"
-    if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://desktop.linear.app/mac/dmg/arm64"
-    elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://desktop.linear.app/mac/dmg"
-    fi
-    appNewVersion=$(curl -sIkL $downloadURL | sed -r '/filename=/!d;s/.*filename=(.*)$/\1/' | awk '{print $2}')
+    downloadURL="https://releases.linear.app/mac"
+    appNewVersion=$(curl -sIkL $downloadURL | sed -r '/filename=/!d;s/.*filename=(.*)$/\1/' | awk -F'-' '{print $2}')
     expectedTeamID="7VZ2S3V9RV"
     versionKey="CFBundleShortVersionString"
     appName="Linear.app"

--- a/fragments/labels/linear.sh
+++ b/fragments/labels/linear.sh
@@ -7,3 +7,4 @@ linear)
     versionKey="CFBundleShortVersionString"
     blockingProcesses=( "Linear" "Linear Helper" )
     ;;
+    

--- a/fragments/labels/linear.sh
+++ b/fragments/labels/linear.sh
@@ -8,4 +8,3 @@ linear)
     appName="Linear.app"
     blockingProcesses=( "Linear" )
     ;;
-    

--- a/fragments/labels/linear.sh
+++ b/fragments/labels/linear.sh
@@ -7,4 +7,3 @@ linear)
     versionKey="CFBundleShortVersionString"
     blockingProcesses=( "Linear" "Linear Helper" )
     ;;
-    

--- a/fragments/labels/linear.sh
+++ b/fragments/labels/linear.sh
@@ -5,6 +5,5 @@ linear)
     appNewVersion=$(curl -sIkL $downloadURL | sed -r '/filename=/!d;s/.*filename=(.*)$/\1/' | awk -F'-' '{print $2}')
     expectedTeamID="7VZ2S3V9RV"
     versionKey="CFBundleShortVersionString"
-    appName="Linear.app"
-    blockingProcesses=( "Linear" )
+    blockingProcesses=( "Linear" "Linear Helper" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** 
Linear download URL has been changed to https://releases.linear.app/mac (universal package, formerly https://desktop.linear.app/mac/dmg/arm64 and https://desktop.linear.app/mac/dmg) leading to new versions no longer being discovered.

**Installomator log**

```shell
sudo ./Installomator.sh linear DEBUG=0
2026-05-06 16:15:26 : INFO  : linear : setting variable from argument DEBUG=0
2026-05-06 16:15:26 : INFO  : linear : Total items in argumentsArray: 1
2026-05-06 16:15:26 : INFO  : linear : argumentsArray: DEBUG=0
2026-05-06 16:15:26 : REQ   : linear : ################## Start Installomator v. 10.9beta, date 2026-05-06
2026-05-06 16:15:26 : INFO  : linear : ################## Version: 10.9beta
2026-05-06 16:15:26 : INFO  : linear : ################## Date: 2026-05-06
2026-05-06 16:15:26 : INFO  : linear : ################## linear
2026-05-06 16:15:27 : INFO  : linear : Reading arguments again: DEBUG=0
2026-05-06 16:15:28 : INFO  : linear : BLOCKING_PROCESS_ACTION=tell_user
2026-05-06 16:15:28 : INFO  : linear : NOTIFY=success
2026-05-06 16:15:28 : INFO  : linear : LOGGING=INFO
2026-05-06 16:15:28 : INFO  : linear : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-06 16:15:28 : INFO  : linear : Label type: dmg
2026-05-06 16:15:28 : INFO  : linear : archiveName: Linear.dmg
2026-05-06 16:15:28 : INFO  : linear : App(s) found: /Applications/Linear.app
2026-05-06 16:15:28 : INFO  : linear : found app at /Applications/Linear.app, version 1.28.13, on versionKey CFBundleShortVersionString
2026-05-06 16:15:28 : INFO  : linear : appversion: 1.28.13
2026-05-06 16:15:28 : INFO  : linear : Latest version of Linear is 1.30.0
2026-05-06 16:15:28 : REQ   : linear : Downloading https://releases.linear.app/mac to Linear.dmg
2026-05-06 16:15:34 : INFO  : linear : Downloaded Linear.dmg – Type is  zlib compressed data – SHA is 98bde3f8c97aa4046b981393b31c6fa1aa181620 – Size is 230256 kB
2026-05-06 16:15:34 : REQ   : linear : no more blocking processes, continue with update
2026-05-06 16:15:34 : REQ   : linear : Installing Linear
2026-05-06 16:15:34 : INFO  : linear : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MQvmQOF2Qa/Linear.dmg
2026-05-06 16:15:39 : INFO  : linear : Mounted: /Volumes/Linear
2026-05-06 16:15:39 : INFO  : linear : Verifying: /Volumes/Linear/Linear.app
2026-05-06 16:15:43 : INFO  : linear : Team ID matching: 7VZ2S3V9RV (expected: 7VZ2S3V9RV )
2026-05-06 16:15:43 : INFO  : linear : Downloaded version of Linear is 1.30.0 on versionKey CFBundleShortVersionString (replacing version 1.28.13).
2026-05-06 16:15:43 : INFO  : linear : App has LSMinimumSystemVersion: 12.0
2026-05-06 16:15:43 : WARN  : linear : Removing existing /Applications/Linear.app
2026-05-06 16:15:43 : INFO  : linear : Copy /Volumes/Linear/Linear.app to /Applications
2026-05-06 16:15:45 : WARN  : linear : Changing owner to xxx
2026-05-06 16:15:45 : INFO  : linear : Finishing...
2026-05-06 16:15:48 : INFO  : linear : App(s) found: /Applications/Linear.app
2026-05-06 16:15:48 : INFO  : linear : found app at /Applications/Linear.app, version 1.30.0, on versionKey CFBundleShortVersionString
2026-05-06 16:15:48 : REQ   : linear : Installed Linear, version 1.30.0
2026-05-06 16:15:48 : INFO  : linear : notifying
2026-05-06 16:15:48 : INFO  : linear : Installomator did not close any apps, so no need to reopen any apps.
2026-05-06 16:15:48 : REQ   : linear : All done!
2026-05-06 16:15:48 : REQ   : linear : ################## End Installomator, exit code 0
``` 
