### PR TITLE
Create zulujdk25.sh

### DIFF
--- a/fragments/labels/zulujdk25.sh
+++ b/fragments/labels/zulujdk25.sh
@@ -1,0 +1,13 @@
+zulujdk25)
+    name="Zulu JDK 25"
+    type="pkgInDmg"
+    packageID="com.azulsystems.zulu.25"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu25.*ca-jdk25.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu25.*ca-jdk25.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+    fi
+    expectedTeamID="TDTHCUPYFR"
+    appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; fi }
+    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//" | sed 's/jdk//')
+    ;;

--- a/fragments/labels/zulujdk25.sh
+++ b/fragments/labels/zulujdk25.sh
@@ -3,11 +3,12 @@ zulujdk25)
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.25"
     if [[ $(arch) == i386 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu25.*ca-jdk25.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+        archFilter="x64"
     elif [[ $(arch) == arm64 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu25.*ca-jdk25.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a><\/td>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort -V | tail -1)
+        archFilter="aarch64"
     fi
+    downloadURL=$(curl -fs "https://api.azul.com/metadata/v1/zulu/packages/?java_version=25&os=macos&archive_type=dmg&latest=true&java_package_type=jdk&javafx=false&release_status=ga" | grep -Eo '"download_url":"[^"]+"' | grep "ca-jdk.*${archFilter}\.dmg" | sed -E 's/.*zulu([0-9\.]+)-.*/\1 &/' | sort -V | tail -1 | cut -d ' ' -f2 | cut -d '"' -f4)
+    appNewVersion=$(echo "$downloadURL" | sed -E 's#.*/zulu([0-9.]+)-.*#\1#')
     expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-25.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; fi }
-    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//" | sed 's/jdk//')
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
N/A

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-05-07 09:10:26 : INFO  : zulujdk25 : setting variable from argument DEBUG=0
2026-05-07 09:10:26 : INFO  : zulujdk25 : Total items in argumentsArray: 1
2026-05-07 09:10:26 : INFO  : zulujdk25 : argumentsArray: DEBUG=0
2026-05-07 09:10:26 : REQ   : zulujdk25 : ################## Start Installomator v. 10.9beta, date 2026-05-07
2026-05-07 09:10:26 : INFO  : zulujdk25 : ################## Version: 10.9beta
2026-05-07 09:10:26 : INFO  : zulujdk25 : ################## Date: 2026-05-07
2026-05-07 09:10:26 : INFO  : zulujdk25 : ################## zulujdk25
2026-05-07 09:10:26 : INFO  : zulujdk25 : SwiftDialog is not installed, clear cmd file var
2026-05-07 09:10:27 : INFO  : zulujdk25 : Reading arguments again: DEBUG=0
2026-05-07 09:10:27 : INFO  : zulujdk25 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-07 09:10:27 : INFO  : zulujdk25 : NOTIFY=success
2026-05-07 09:10:27 : INFO  : zulujdk25 : LOGGING=INFO
2026-05-07 09:10:27 : INFO  : zulujdk25 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-07 09:10:27 : INFO  : zulujdk25 : Label type: pkgInDmg
2026-05-07 09:10:27 : INFO  : zulujdk25 : archiveName: Zulu JDK 25.dmg
2026-05-07 09:10:27 : INFO  : zulujdk25 : no blocking processes defined, using Zulu JDK 25 as default
2026-05-07 09:10:27 : INFO  : zulujdk25 : Custom App Version detection is used, found 
2026-05-07 09:10:27 : INFO  : zulujdk25 : appversion: 
2026-05-07 09:10:27 : INFO  : zulujdk25 : Latest version of Zulu JDK 25 is 25.34.17
2026-05-07 09:10:27 : REQ   : zulujdk25 : Downloading https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-macosx_aarch64.dmg to Zulu JDK 25.dmg
2026-05-07 09:10:32 : INFO  : zulujdk25 : Downloaded Zulu JDK 25.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 95be22d27aad39adf212e9d9c08a48ae3e85532c – Size is 230396 kB
2026-05-07 09:10:32 : REQ   : zulujdk25 : no more blocking processes, continue with update
2026-05-07 09:10:32 : REQ   : zulujdk25 : Installing Zulu JDK 25
2026-05-07 09:10:32 : INFO  : zulujdk25 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.p6RqK6GYjO/Zulu JDK 25.dmg
2026-05-07 09:10:44 : INFO  : zulujdk25 : Mounted: /Volumes/Azul Zulu JDK 25.34+17
2026-05-07 09:10:44 : INFO  : zulujdk25 : found pkg: /Volumes/Azul Zulu JDK 25.34+17/Double-Click to Install Azul Zulu JDK 25.pkg
2026-05-07 09:10:44 : INFO  : zulujdk25 : Verifying: /Volumes/Azul Zulu JDK 25.34+17/Double-Click to Install Azul Zulu JDK 25.pkg
2026-05-07 09:10:44 : INFO  : zulujdk25 : Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2026-05-07 09:10:44 : INFO  : zulujdk25 : Installing /Volumes/Azul Zulu JDK 25.34+17/Double-Click to Install Azul Zulu JDK 25.pkg to /
2026-05-07 09:11:00 : INFO  : zulujdk25 : Finishing...
2026-05-07 09:11:03 : INFO  : zulujdk25 : Custom App Version detection is used, found 
2026-05-07 09:11:03 : REQ   : zulujdk25 : Installed Zulu JDK 25, version 25.34.17
2026-05-07 09:11:03 : INFO  : zulujdk25 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-05-07 09:11:03 : INFO  : zulujdk25 : Installomator did not close any apps, so no need to reopen any apps.
2026-05-07 09:11:03 : REQ   : zulujdk25 : All done!
2026-05-07 09:11:03 : REQ   : zulujdk25 : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A