### PR TITLE
fix(nodejslts): use JSON API for version detection instead of HTML parsing

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -8337,7 +8337,7 @@ nodejs)
 nodejslts)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(curl -fs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts)][0].version')
+    appNewVersion=$(getJSONValue "$(curl -fsL https://nodejs.org/dist/index.json)" "filter(x => x.lts)[0].version")
     downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -8337,7 +8337,7 @@ nodejs)
 nodejslts)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(curl -fsL https://nodejs.org/en | xmllint --html --xpath '//a[contains(text(),"LTS")]/@href' - 2>/dev/null | grep -oE 'v[0-9]+(\.[0-9]+)*' | head -1)
+    appNewVersion=$(curl -fs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts)][0].version')
     downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -8337,7 +8337,7 @@ nodejs)
 nodejslts)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(getJSONValue "$(curl -fsL https://nodejs.org/dist/index.json)" "filter(x => x.lts)[0].version")
+    appNewVersion=$(curl -fsL https://nodejs.org/en | xmllint --html --xpath '//a[contains(text(),"LTS")]/@href' - 2>/dev/null | grep -oE 'v[0-9]+(\.[0-9]+)*' | head -1)
     downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"

--- a/fragments/labels/nodejslts.sh
+++ b/fragments/labels/nodejslts.sh
@@ -1,7 +1,7 @@
 nodejslts)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(curl -fs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts)][0].version')
+    appNewVersion=$(getJSONValue "$(curl -fsL https://nodejs.org/dist/index.json)" "filter(x => x.lts)[0].version")
     downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"

--- a/fragments/labels/nodejslts.sh
+++ b/fragments/labels/nodejslts.sh
@@ -1,7 +1,7 @@
 nodejslts)
     name="nodejs"
     type="pkg"
-    appNewVersion=$(curl -fsL https://nodejs.org/en | xmllint --html --xpath '//a[contains(text(),"LTS")]/@href' - 2>/dev/null | grep -oE 'v[0-9]+(\.[0-9]+)*' | head -1)
+    appNewVersion=$(curl -fs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts)][0].version')
     downloadURL="https://nodejs.org/dist/$appNewVersion/node-$appNewVersion.pkg"
     appCustomVersion(){/usr/local/bin/node -v}
     expectedTeamID="HX7739G8FX"


### PR DESCRIPTION
## Summary

The `nodejslts` label's `appNewVersion` was using `xmllint` to parse the `nodejs.org/en` HTML page, which broke when the site structure changed. This resulted in an empty version string and a malformed download URL like `https://nodejs.org/dist//node-.pkg`.

Switch to the stable JSON API at `nodejs.org/dist/index.json` and extract the latest LTS version using the built-in `getJSONValue` helper.

### Files changed
- `Installomator.sh` — main script
- `fragments/labels/nodejslts.sh` — label fragment

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

Closes #2835

---

**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

The fix is in `fragments/labels/nodejslts.sh`. `Installomator.sh` is updated to keep the in-script copy of the label in sync.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context**

Initial commit used `jq` for parsing, but per review feedback `jq` is only bundled with recent macOS versions. Updated to use the built-in `getJSONValue` JXA helper for backwards compatibility. The lookup uses `Array.prototype.filter` to pick the first LTS entry from the `nodejs.org/dist/index.json` array (entries are returned newest-first, so `[0]` after filtering is the current LTS).

**Installomator log**

```
2026-05-08 11:38:34 : INFO  : nodejslts : argumentsArray: DEBUG=2
2026-05-08 11:38:34 : REQ   : nodejslts : ################## Start Installomator v. 10.9beta, date 2026-05-06
2026-05-08 11:38:34 : INFO  : nodejslts : ################## Version: 10.9beta
2026-05-08 11:38:34 : INFO  : nodejslts : ################## Date: 2026-05-06
2026-05-08 11:38:34 : INFO  : nodejslts : ################## nodejslts
2026-05-08 11:38:34 : DEBUG : nodejslts : DEBUG mode 2 enabled.
2026-05-08 11:38:35 : DEBUG : nodejslts : name=nodejs
2026-05-08 11:38:35 : DEBUG : nodejslts : type=pkg
2026-05-08 11:38:35 : DEBUG : nodejslts : downloadURL=https://nodejs.org/dist/v24.15.0/node-v24.15.0.pkg
2026-05-08 11:38:35 : DEBUG : nodejslts : appNewVersion=v24.15.0
2026-05-08 11:38:35 : DEBUG : nodejslts : appCustomVersion function: Defined.
2026-05-08 11:38:35 : DEBUG : nodejslts : expectedTeamID=HX7739G8FX
2026-05-08 11:38:35 : INFO  : nodejslts : Label type: pkg
2026-05-08 11:38:35 : INFO  : nodejslts : archiveName: nodejs.pkg
2026-05-08 11:38:36 : INFO  : nodejslts : Custom App Version detection is used, found v20.13.1
2026-05-08 11:38:36 : INFO  : nodejslts : appversion: v20.13.1
2026-05-08 11:38:36 : INFO  : nodejslts : Latest version of nodejs is v24.15.0
2026-05-08 11:38:36 : REQ   : nodejslts : Downloading https://nodejs.org/dist/v24.15.0/node-v24.15.0.pkg to nodejs.pkg
2026-05-08 11:38:41 : INFO  : nodejslts : Downloaded nodejs.pkg – Type is  xar archive compressed TOC – SHA is b546b25c12b5625b28ef83775336ad675f1dd23b – Size is 98960 kB
2026-05-08 11:38:41 : REQ   : nodejslts : Installing nodejs
2026-05-08 11:38:41 : INFO  : nodejslts : Verifying: nodejs.pkg
2026-05-08 11:38:42 : DEBUG : nodejslts : spctlOut is nodejs.pkg: accepted
2026-05-08 11:38:42 : DEBUG : nodejslts : source=Notarized Developer ID
2026-05-08 11:38:42 : DEBUG : nodejslts : origin=Developer ID Installer: Node.js Foundation (HX7739G8FX)
2026-05-08 11:38:42 : INFO  : nodejslts : Team ID: HX7739G8FX (expected: HX7739G8FX )
2026-05-08 11:38:42 : DEBUG : nodejslts : DEBUG mode 2 enabled, exiting
2026-05-08 11:38:42 : REQ   : nodejslts : ################## End Installomator, exit code 0
```