### PR TITLE
Fix brave appNewVersion

### DIFF
--- a/fragments/labels/brave.sh
+++ b/fragments/labels/brave.sh
@@ -1,15 +1,13 @@
 brave)
     name="Brave Browser"
     type="dmg"
-    if [[ $(arch) != "i386" ]]; then
-        printlog "Architecture: arm64 (not i386)"
-        downloadURL=$(curl -fsIL https://laptop-updates.brave.com/latest/osxarm64/release | grep -i "^location" | sed -E 's/.*(https.*\.dmg).*/\1/g')
-        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="Brave-Browser-arm64.dmg"
     else
-        printlog "Architecture: i386"
-        downloadURL=$(curl -fsIL https://laptop-updates.brave.com/latest/osx/release | grep -i "^location" | sed -E 's/.*(https.*\.dmg).*/\1/g')
-        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
+        archiveName="Brave-Browser-x64.dmg"
     fi
+    downloadURL=$(downloadURLFromGit brave brave-browser)
+    appNewVersion=$(versionFromGit brave brave-browser | sed 's/\.//')
     versionKey="CFBundleVersion"
     expectedTeamID="KL8N8XSYF4"
     ;;

--- a/fragments/labels/brave.sh
+++ b/fragments/labels/brave.sh
@@ -8,7 +8,7 @@ brave)
     else
         printlog "Architecture: i386"
         downloadURL=$(curl -fsIL https://laptop-updates.brave.com/latest/osx/release | grep -i "^location" | sed -E 's/.*(https.*\.dmg).*/\1/g')
-        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
+        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
     fi
     versionKey="CFBundleVersion"
     expectedTeamID="KL8N8XSYF4"

--- a/fragments/labels/brave.sh
+++ b/fragments/labels/brave.sh
@@ -4,15 +4,12 @@ brave)
     if [[ $(arch) != "i386" ]]; then
         printlog "Architecture: arm64 (not i386)"
         downloadURL=$(curl -fsIL https://laptop-updates.brave.com/latest/osxarm64/release | grep -i "^location" | sed -E 's/.*(https.*\.dmg).*/\1/g')
-        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
-        #appNewVersion="96.$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:shortVersionString' 2>/dev/null  | cut -d '"' -f 2 | cut -d "." -f1-3)"
+        appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/appcast.xml" | xpath '//rss/channel/item[1]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
     else
         printlog "Architecture: i386"
         downloadURL=$(curl -fsIL https://laptop-updates.brave.com/latest/osx/release | grep -i "^location" | sed -E 's/.*(https.*\.dmg).*/\1/g')
         appNewVersion="$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:version' 2>/dev/null  | cut -d '"' -f 2)"
-        #appNewVersion="96.$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@sparkle:shortVersionString' 2>/dev/null  | cut -d '"' -f 2 | cut -d "." -f1-3)"
     fi
     versionKey="CFBundleVersion"
-#    downloadURL=$(curl -fsL "https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml" | xpath '//rss/channel/item[last()]/enclosure/@url' 2>/dev/null  | cut -d '"' -f 2)
     expectedTeamID="KL8N8XSYF4"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
appNewVersion returned an old version which caused unnecessary updates.

**Installomator log**
```
sudo ./Installomator.sh brave
Password:
2026-05-07 15:44:57 : INFO  : brave : Total items in argumentsArray: 0
2026-05-07 15:44:57 : INFO  : brave : argumentsArray: 
2026-05-07 15:44:57 : REQ   : brave : ################## Start Installomator v. 10.9beta, date 2026-05-07
2026-05-07 15:44:57 : INFO  : brave : ################## Version: 10.9beta
2026-05-07 15:44:57 : INFO  : brave : ################## Date: 2026-05-07
2026-05-07 15:44:57 : INFO  : brave : ################## brave
2026-05-07 15:44:57 : DEBUG : brave : DEBUG mode 1 enabled.
2026-05-07 15:44:57 : INFO  : brave : Architecture: arm64 (not i386)
2026-05-07 15:44:58 : INFO  : brave : Reading arguments again: 
2026-05-07 15:44:58 : DEBUG : brave : name=Brave Browser
2026-05-07 15:44:58 : DEBUG : brave : appName=
2026-05-07 15:44:58 : DEBUG : brave : type=dmg
2026-05-07 15:44:58 : DEBUG : brave : archiveName=
2026-05-07 15:44:58 : DEBUG : brave : downloadURL=https://referrals.brave.com/latest/Brave-Browser-arm64.dmg
2026-05-07 15:44:58 : DEBUG : brave : curlOptions=
2026-05-07 15:44:58 : DEBUG : brave : appNewVersion=189.145
2026-05-07 15:44:58 : DEBUG : brave : appCustomVersion function: Not defined
2026-05-07 15:44:58 : DEBUG : brave : versionKey=CFBundleVersion
2026-05-07 15:44:58 : DEBUG : brave : packageID=
2026-05-07 15:44:58 : DEBUG : brave : pkgName=
2026-05-07 15:44:58 : DEBUG : brave : choiceChangesXML=
2026-05-07 15:44:58 : DEBUG : brave : expectedTeamID=KL8N8XSYF4
2026-05-07 15:44:58 : DEBUG : brave : blockingProcesses=
2026-05-07 15:44:58 : DEBUG : brave : installerTool=
2026-05-07 15:44:58 : DEBUG : brave : CLIInstaller=
2026-05-07 15:44:58 : DEBUG : brave : CLIArguments=
2026-05-07 15:44:58 : DEBUG : brave : updateTool=
2026-05-07 15:44:58 : DEBUG : brave : updateToolArguments=
2026-05-07 15:44:58 : DEBUG : brave : updateToolRunAsCurrentUser=
2026-05-07 15:44:58 : INFO  : brave : BLOCKING_PROCESS_ACTION=tell_user
2026-05-07 15:44:58 : INFO  : brave : NOTIFY=success
2026-05-07 15:44:58 : INFO  : brave : LOGGING=DEBUG
2026-05-07 15:44:58 : INFO  : brave : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-07 15:44:58 : INFO  : brave : Label type: dmg
2026-05-07 15:44:58 : INFO  : brave : archiveName: Brave Browser.dmg
2026-05-07 15:44:58 : INFO  : brave : no blocking processes defined, using Brave Browser as default
2026-05-07 15:44:58 : DEBUG : brave : Changing directory to .
2026-05-07 15:44:58 : INFO  : brave : name: Brave Browser, appName: Brave Browser.app
2026-05-07 15:44:58 : WARN  : brave : No previous app found
2026-05-07 15:44:58 : WARN  : brave : could not find Brave Browser.app
2026-05-07 15:44:58 : INFO  : brave : appversion: 
2026-05-07 15:44:59 : INFO  : brave : Latest version of Brave Browser is 189.145
2026-05-07 15:44:59 : INFO  : brave : Brave Browser.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-07 15:44:59 : DEBUG : brave : DEBUG mode 1, not checking for blocking processes
2026-05-07 15:44:59 : REQ   : brave : Installing Brave Browser
2026-05-07 15:44:59 : INFO  : brave : Mounting ./Brave Browser.dmg
2026-05-07 15:44:59 : DEBUG : brave : Debugging enabled, dmgmount output was:
expected CRC32 $2C9F7712
/dev/disk5              Apple_partition_scheme
/dev/disk5s1            Apple_partition_map
/dev/disk5s2            Apple_HFS                       /Volumes/Brave Browser 1

2026-05-07 15:44:59 : INFO  : brave : Mounted: /Volumes/Brave Browser 1
2026-05-07 15:44:59 : INFO  : brave : Verifying: /Volumes/Brave Browser 1/Brave Browser.app
2026-05-07 15:44:59 : DEBUG : brave : App size: 411M    /Volumes/Brave Browser 1/Brave Browser.app
2026-05-07 15:45:10 : DEBUG : brave : Debugging enabled, App Verification output was:
/Volumes/Brave Browser 1/Brave Browser.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Brave Software, Inc. (KL8N8XSYF4)

2026-05-07 15:45:10 : INFO  : brave : Team ID matching: KL8N8XSYF4 (expected: KL8N8XSYF4 )
2026-05-07 15:45:10 : INFO  : brave : Installing Brave Browser version 189.145 on versionKey CFBundleVersion.
2026-05-07 15:45:10 : INFO  : brave : App has LSMinimumSystemVersion: 12.0
2026-05-07 15:45:10 : DEBUG : brave : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-07 15:45:10 : INFO  : brave : Finishing...
2026-05-07 15:45:13 : INFO  : brave : name: Brave Browser, appName: Brave Browser.app
2026-05-07 15:45:13 : WARN  : brave : No previous app found
2026-05-07 15:45:13 : WARN  : brave : could not find Brave Browser.app
2026-05-07 15:45:13 : REQ   : brave : Installed Brave Browser, version 189.145
2026-05-07 15:45:13 : INFO  : brave : notifying
2026-05-07 15:45:14 : DEBUG : brave : Unmounting /Volumes/Brave Browser 1
2026-05-07 15:45:14 : DEBUG : brave : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-05-07 15:45:14 : DEBUG : brave : DEBUG mode 1, not reopening anything
2026-05-07 15:45:14 : REQ   : brave : All done!
2026-05-07 15:45:14 : REQ   : brave : ################## End Installomator, exit code 0
```
