### PR TITLE
label beekeeperstudio refactor

### DIFF
--- a/fragments/labels/beekeeperstudio.sh
+++ b/fragments/labels/beekeeperstudio.sh
@@ -1,0 +1,12 @@
+beekeeperstudio)
+    name="Beekeeper Studio"
+    type="dmg"
+    appNewVersion="$(versionFromGit beekeeper-studio beekeeper-studio)"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="Beekeeper-Studio-${appNewVersion}-arm64.dmg"
+    else
+        archiveName="Beekeeper-Studio-${appNewVersion}.dmg"
+    fi
+    downloadURL="$(downloadURLFromGit beekeeper-studio beekeeper-studio)"
+    expectedTeamID="7KK583U8H2"
+    ;;


### PR DESCRIPTION


All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes (there is a duplicate submitted by myself here: https://github.com/Installomator/Installomator/pull/2888 I am not sure what happened with that as it ended up containing commits for another label I submitted, so I have created a fresh new request.)

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
No

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
This is a new label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Output:
```
./utils/assemble.sh beekeeperstudio DEBUG=0 INSTALL=force
2026-05-08 16:37:01 : INFO  : beekeeperstudio : setting variable from argument DEBUG=0
2026-05-08 16:37:01 : INFO  : beekeeperstudio : setting variable from argument INSTALL=force
2026-05-08 16:37:01 : INFO  : beekeeperstudio : Total items in argumentsArray: 2
2026-05-08 16:37:01 : INFO  : beekeeperstudio : argumentsArray: DEBUG=0 INSTALL=force
2026-05-08 16:37:01 : REQ   : beekeeperstudio : ################## Start Installomator v. 10.9beta, date 2026-05-08
2026-05-08 16:37:01 : INFO  : beekeeperstudio : ################## Version: 10.9beta
2026-05-08 16:37:01 : INFO  : beekeeperstudio : ################## Date: 2026-05-08
2026-05-08 16:37:01 : INFO  : beekeeperstudio : ################## beekeeperstudio
2026-05-08 16:37:03 : INFO  : beekeeperstudio : Reading arguments again: DEBUG=0 INSTALL=force
2026-05-08 16:37:03 : INFO  : beekeeperstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-05-08 16:37:03 : INFO  : beekeeperstudio : NOTIFY=success
2026-05-08 16:37:04 : INFO  : beekeeperstudio : LOGGING=INFO
2026-05-08 16:37:04 : INFO  : beekeeperstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-08 16:37:04 : INFO  : beekeeperstudio : Label type: dmg
2026-05-08 16:37:04 : INFO  : beekeeperstudio : archiveName: Beekeeper-Studio-5.7.2-arm64.dmg
2026-05-08 16:37:04 : INFO  : beekeeperstudio : no blocking processes defined, using Beekeeper Studio as default
2026-05-08 16:37:04 : INFO  : beekeeperstudio : App(s) found: /Applications/Beekeeper Studio.app
2026-05-08 16:37:04 : INFO  : beekeeperstudio : found app at /Applications/Beekeeper Studio.app, version 5.7.2, on versionKey CFBundleShortVersionString
2026-05-08 16:37:04 : INFO  : beekeeperstudio : appversion: 5.7.2
2026-05-08 16:37:04 : INFO  : beekeeperstudio : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-05-08 16:37:04 : INFO  : beekeeperstudio : Latest version of Beekeeper Studio is 5.7.2
2026-05-08 16:37:04 : INFO  : beekeeperstudio : There is no newer version available.
2026-05-08 16:37:04 : REQ   : beekeeperstudio : Downloading https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.7.2/Beekeeper-Studio-5.7.2-arm64.dmg to Beekeeper-Studio-5.7.2-arm64.dmg
2026-05-08 16:37:41 : INFO  : beekeeperstudio : Downloaded Beekeeper-Studio-5.7.2-arm64.dmg – Type is  zlib compressed data – SHA is 1381a992922b5d445c17235e0ceb5cdd209f68ca – Size is 344128 kB
2026-05-08 16:37:41 : REQ   : beekeeperstudio : no more blocking processes, continue with update
2026-05-08 16:37:41 : REQ   : beekeeperstudio : Installing Beekeeper Studio
2026-05-08 16:37:41 : INFO  : beekeeperstudio : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.MLGHCSTsC1/Beekeeper-Studio-5.7.2-arm64.dmg
2026-05-08 16:37:47 : INFO  : beekeeperstudio : Mounted: /Volumes/Beekeeper Studio 5.7.2-arm64
2026-05-08 16:37:47 : INFO  : beekeeperstudio : Verifying: /Volumes/Beekeeper Studio 5.7.2-arm64/Beekeeper Studio.app
2026-05-08 16:37:50 : INFO  : beekeeperstudio : Team ID matching: 7KK583U8H2 (expected: 7KK583U8H2 )
2026-05-08 16:37:50 : INFO  : beekeeperstudio : Downloaded version of Beekeeper Studio is 5.7.2 on versionKey CFBundleShortVersionString, same as installed.
2026-05-08 16:37:50 : INFO  : beekeeperstudio : Using force to install anyway.
2026-05-08 16:37:51 : INFO  : beekeeperstudio : App has LSMinimumSystemVersion: 12.0
2026-05-08 16:37:51 : WARN  : beekeeperstudio : Removing existing /Applications/Beekeeper Studio.app
2026-05-08 16:37:52 : INFO  : beekeeperstudio : Copy /Volumes/Beekeeper Studio 5.7.2-arm64/Beekeeper Studio.app to /Applications
2026-05-08 16:37:54 : WARN  : beekeeperstudio : Changing owner to brendon.m
2026-05-08 16:37:54 : INFO  : beekeeperstudio : Finishing...
2026-05-08 16:37:57 : INFO  : beekeeperstudio : App(s) found: /Applications/Beekeeper Studio.app
2026-05-08 16:37:57 : INFO  : beekeeperstudio : found app at /Applications/Beekeeper Studio.app, version 5.7.2, on versionKey CFBundleShortVersionString
2026-05-08 16:37:58 : REQ   : beekeeperstudio : Installed Beekeeper Studio, version 5.7.2
2026-05-08 16:37:58 : INFO  : beekeeperstudio : notifying
2026-05-08 16:37:58 : INFO  : beekeeperstudio : Installomator did not close any apps, so no need to reopen any apps.
2026-05-08 16:37:58 : REQ   : beekeeperstudio : All done!
2026-05-08 16:37:58 : REQ   : beekeeperstudio : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
