### PR TITLE
Update firefoxesr.sh to get correct version

### DIFF
--- a/fragments/labels/firefoxesr.sh
+++ b/fragments/labels/firefoxesr.sh
@@ -5,6 +5,7 @@ firefoxesrpkg)
     downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx"
     firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
     appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
+    appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
     blockingProcesses=( firefox )
     ;;

--- a/fragments/labels/firefoxesr.sh
+++ b/fragments/labels/firefoxesr.sh
@@ -7,5 +7,4 @@ firefoxesrpkg)
     appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
     appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
-    blockingProcesses=( firefox )
     ;;


### PR DESCRIPTION
Remove esr suffix from the website version because Firefox.app does not have it in its version string.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-05-08 13:34:13 : INFO  : firefoxesr : setting variable from argument DEBUG=1
2026-05-08 13:34:13 : INFO  : firefoxesr : Total items in argumentsArray: 1
2026-05-08 13:34:13 : INFO  : firefoxesr : argumentsArray: DEBUG=1
2026-05-08 13:34:13 : REQ   : firefoxesr : ################## Start Installomator v. 10.9beta, date 2026-05-07
2026-05-08 13:34:13 : INFO  : firefoxesr : ################## Version: 10.9beta
2026-05-08 13:34:13 : INFO  : firefoxesr : ################## Date: 2026-05-07
2026-05-08 13:34:13 : INFO  : firefoxesr : ################## firefoxesr
2026-05-08 13:34:13 : DEBUG : firefoxesr : DEBUG mode 1 enabled.
2026-05-08 13:34:13 : INFO  : firefoxesr : Reading arguments again: DEBUG=1
2026-05-08 13:34:13 : DEBUG : firefoxesr : argument: DEBUG=1
2026-05-08 13:34:13 : DEBUG : firefoxesr : name=Firefox
2026-05-08 13:34:13 : DEBUG : firefoxesr : appName=
2026-05-08 13:34:13 : DEBUG : firefoxesr : type=pkg
2026-05-08 13:34:13 : DEBUG : firefoxesr : archiveName=
2026-05-08 13:34:13 : DEBUG : firefoxesr : downloadURL=https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx
2026-05-08 13:34:13 : DEBUG : firefoxesr : curlOptions=
2026-05-08 13:34:13 : DEBUG : firefoxesr : appNewVersion=140.10.2
2026-05-08 13:34:13 : DEBUG : firefoxesr : appCustomVersion function: Not defined
2026-05-08 13:34:13 : DEBUG : firefoxesr : versionKey=CFBundleShortVersionString
2026-05-08 13:34:13 : DEBUG : firefoxesr : packageID=
2026-05-08 13:34:13 : DEBUG : firefoxesr : pkgName=
2026-05-08 13:34:13 : DEBUG : firefoxesr : choiceChangesXML=
2026-05-08 13:34:13 : DEBUG : firefoxesr : expectedTeamID=43AQ936H96
2026-05-08 13:34:13 : DEBUG : firefoxesr : blockingProcesses=firefox
2026-05-08 13:34:13 : DEBUG : firefoxesr : installerTool=
2026-05-08 13:34:13 : DEBUG : firefoxesr : CLIInstaller=
2026-05-08 13:34:13 : DEBUG : firefoxesr : CLIArguments=
2026-05-08 13:34:13 : DEBUG : firefoxesr : updateTool=
2026-05-08 13:34:13 : DEBUG : firefoxesr : updateToolArguments=
2026-05-08 13:34:13 : DEBUG : firefoxesr : updateToolRunAsCurrentUser=
2026-05-08 13:34:13 : INFO  : firefoxesr : BLOCKING_PROCESS_ACTION=tell_user
2026-05-08 13:34:13 : INFO  : firefoxesr : NOTIFY=success
2026-05-08 13:34:13 : INFO  : firefoxesr : LOGGING=DEBUG
2026-05-08 13:34:13 : INFO  : firefoxesr : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-08 13:34:13 : INFO  : firefoxesr : Label type: pkg
2026-05-08 13:34:13 : INFO  : firefoxesr : archiveName: Firefox.pkg
2026-05-08 13:34:13 : DEBUG : firefoxesr : Changing directory to .
2026-05-08 13:34:13 : INFO  : firefoxesr : App(s) found: /Applications/Firefox.app
2026-05-08 13:34:13 : INFO  : firefoxesr : found app at /Applications/Firefox.app, version 140.10.2, on versionKey CFBundleShortVersionString
2026-05-08 13:34:13 : INFO  : firefoxesr : appversion: 140.10.2
2026-05-08 13:34:14 : INFO  : firefoxesr : Latest version of Firefox is 140.10.2
2026-05-08 13:34:14 : WARN  : firefoxesr : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-08 13:34:14 : REQ   : firefoxesr : Downloading https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx to Firefox.pkg
2026-05-08 13:34:14 : DEBUG : firefoxesr : No Dialog connection, just download
2026-05-08 13:34:23 : INFO  : firefoxesr : Downloaded Firefox.pkg – Type is  xar archive compressed TOC – SHA is fd8803e3cfedff9a7d5b4626df7dbf53d09ba481 – Size is 180844 kB
2026-05-08 13:34:23 : DEBUG : firefoxesr : DEBUG mode 1, not checking for blocking processes
2026-05-08 13:34:23 : REQ   : firefoxesr : Installing Firefox
2026-05-08 13:34:23 : INFO  : firefoxesr : Verifying: Firefox.pkg
2026-05-08 13:34:23 : DEBUG : firefoxesr : File list: -rw-r--r--  1 u093222  staff   163M  8 Mai  13:34 Firefox.pkg
2026-05-08 13:34:23 : DEBUG : firefoxesr : File type: Firefox.pkg: xar archive compressed TOC: 4444, SHA-1 checksum
2026-05-08 13:34:23 : DEBUG : firefoxesr : spctlOut is Firefox.pkg: accepted
2026-05-08 13:34:23 : DEBUG : firefoxesr : source=Notarized Developer ID
2026-05-08 13:34:23 : DEBUG : firefoxesr : origin=Developer ID Installer: Mozilla Corporation (43AQ936H96)
2026-05-08 13:34:23 : INFO  : firefoxesr : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2026-05-08 13:34:23 : DEBUG : firefoxesr : DEBUG enabled, skipping installation
2026-05-08 13:34:23 : INFO  : firefoxesr : Finishing...
2026-05-08 13:34:26 : INFO  : firefoxesr : App(s) found: /Applications/Firefox.app
2026-05-08 13:34:26 : INFO  : firefoxesr : found app at /Applications/Firefox.app, version 140.10.2, on versionKey CFBundleShortVersionString
2026-05-08 13:34:26 : REQ   : firefoxesr : Installed Firefox, version 140.10.2
2026-05-08 13:34:26 : INFO  : firefoxesr : notifying
2026-05-08 13:34:27 : DEBUG : firefoxesr : DEBUG mode 1, not reopening anything
2026-05-08 13:34:27 : REQ   : firefoxesr : All done!
2026-05-08 13:34:27 : REQ   : firefoxesr : ################## End Installomator, exit code 0 
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
