### PR TITLE
Update firefoxesr_intl.sh to use PKG

### DIFF
--- a/fragments/labels/firefoxesr_intl.sh
+++ b/fragments/labels/firefoxesr_intl.sh
@@ -1,8 +1,9 @@
-firefoxesr_intl)
+firefoxesr_intl|\
+firefoxesrpkg_intl)
     # This label will try to figure out the selected language of the user,
     # and install corrosponding version of Firefox ESR
     name="Firefox"
-    type="dmg"
+    type="pkg"
     userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-')
     printlog "Found language $userLanguage to be used for $name."
     releaseURL="https://ftp.mozilla.org/pub/firefox/releases/latest-esr/README.txt"
@@ -14,14 +15,14 @@ firefoxesr_intl)
         userLanguage=${userLanguage:0:2}
     done
     printlog "Using language '$userLanguage' for download."
-    downloadURL="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=$userLanguage"
+    downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx&lang=$userLanguage"
     if ! curl -sfL --output /dev/null -r 0-0 $downloadURL; then
         printlog "Download not found for '$userLanguage', using default ('en-US')."
-        downloadURL="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx"
+        downloadURL="https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx"
     fi
     firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
-    appNewVersion=$(getJSONValue "$firefoxVersions" "LATEST_FIREFOX_VERSION")
+    appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
+    appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
     blockingProcesses=( firefox )
-    printlog "WARNING for ERROR: Label firefox and firefox_intl should not be used. Instead use firefoxpkg and firefoxpkg_intl as per recommendations from Firefox. It's not fully certain that the app actually gets updated here. firefoxpkg and firefoxpkg_intl will have built in updates and make sure the client is updated in the future." REQ
     ;;

--- a/fragments/labels/firefoxesrintl.sh
+++ b/fragments/labels/firefoxesrintl.sh
@@ -1,5 +1,5 @@
-firefoxesr_intl|\
-firefoxesrpkg_intl)
+firefoxesrintl|\
+firefoxesrpkgintl)
     # This label will try to figure out the selected language of the user,
     # and install corrosponding version of Firefox ESR
     name="Firefox"
@@ -24,5 +24,4 @@ firefoxesrpkg_intl)
     appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR")
     appNewVersion=${appNewVersion:0:-3}
     expectedTeamID="43AQ936H96"
-    blockingProcesses=( firefox )
     ;;


### PR DESCRIPTION
Updated firefoxesr_intl to download PKG instead of DMG and also get the version for ESR instead of the normal release.

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
I also added a second label to be consistent with the label for firefoxesr. Also the warning is not needed anymore as the label now uses the pkg file instead of the dmg file.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : setting variable from argument DEBUG=1
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : Total items in argumentsArray: 1
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : argumentsArray: DEBUG=1
2026-05-08 13:53:39 : REQ   : firefoxesr_intl : ################## Start Installomator v. 10.9beta, date 2026-05-07
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : ################## Version: 10.9beta
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : ################## Date: 2026-05-07
2026-05-08 13:53:39 : INFO  : firefoxesr_intl : ################## firefoxesr_intl
2026-05-08 13:53:39 : DEBUG : firefoxesr_intl : DEBUG mode 1 enabled.
2026-05-08 13:53:40 : INFO  : firefoxesr_intl : Found language de-DE to be used for Firefox.
2026-05-08 13:53:40 : INFO  : firefoxesr_intl : No locale matching 'de-DE', trying 'de'
2026-05-08 13:53:40 : INFO  : firefoxesr_intl : Using language 'de' for download.
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : Reading arguments again: DEBUG=1
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : argument: DEBUG=1
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : name=Firefox
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : appName=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : type=pkg
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : archiveName=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : downloadURL=https://download.mozilla.org/?product=firefox-esr-pkg-latest-ssl&os=osx&lang=de
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : curlOptions=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : appNewVersion=140.10.2
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : appCustomVersion function: Not defined
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : versionKey=CFBundleShortVersionString
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : packageID=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : pkgName=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : choiceChangesXML=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : expectedTeamID=43AQ936H96
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : blockingProcesses=firefox
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : installerTool=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : CLIInstaller=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : CLIArguments=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : updateTool=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : updateToolArguments=
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : updateToolRunAsCurrentUser=
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : BLOCKING_PROCESS_ACTION=tell_user
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : NOTIFY=success
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : LOGGING=DEBUG
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : Label type: pkg
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : archiveName: Firefox.pkg
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : Changing directory to .
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : App(s) found: /Applications/Firefox.app
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : found app at /Applications/Firefox.app, version 140.10.2, on versionKey CFBundleShortVersionString
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : appversion: 140.10.2
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : Latest version of Firefox is 140.10.2
2026-05-08 13:53:41 : WARN  : firefoxesr_intl : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : Firefox.pkg exists and DEBUG mode 1 enabled, skipping download
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : DEBUG mode 1, not checking for blocking processes
2026-05-08 13:53:41 : REQ   : firefoxesr_intl : Installing Firefox
2026-05-08 13:53:41 : INFO  : firefoxesr_intl : Verifying: Firefox.pkg
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : File list: -rw-r--r--  1 u093222  staff   163M  8 Mai  13:34 Firefox.pkg
2026-05-08 13:53:41 : DEBUG : firefoxesr_intl : File type: Firefox.pkg: xar archive compressed TOC: 4444, SHA-1 checksum
2026-05-08 13:53:42 : DEBUG : firefoxesr_intl : spctlOut is Firefox.pkg: accepted
2026-05-08 13:53:42 : DEBUG : firefoxesr_intl : source=Notarized Developer ID
2026-05-08 13:53:42 : DEBUG : firefoxesr_intl : origin=Developer ID Installer: Mozilla Corporation (43AQ936H96)
2026-05-08 13:53:42 : INFO  : firefoxesr_intl : Team ID: 43AQ936H96 (expected: 43AQ936H96 )
2026-05-08 13:53:42 : DEBUG : firefoxesr_intl : DEBUG enabled, skipping installation
2026-05-08 13:53:42 : INFO  : firefoxesr_intl : Finishing...
2026-05-08 13:53:45 : INFO  : firefoxesr_intl : App(s) found: /Applications/Firefox.app
2026-05-08 13:53:45 : INFO  : firefoxesr_intl : found app at /Applications/Firefox.app, version 140.10.2, on versionKey CFBundleShortVersionString
2026-05-08 13:53:45 : REQ   : firefoxesr_intl : Installed Firefox, version 140.10.2
2026-05-08 13:53:45 : INFO  : firefoxesr_intl : notifying
2026-05-08 13:53:45 : DEBUG : firefoxesr_intl : DEBUG mode 1, not reopening anything
2026-05-08 13:53:45 : REQ   : firefoxesr_intl : All done!
2026-05-08 13:53:45 : REQ   : firefoxesr_intl : ################## End Installomator, exit code 0 

```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
