### PR TITLE
Update dedoose.sh'

### DIFF
--- a/fragments/labels/dedoose.sh
+++ b/fragments/labels/dedoose.sh
@@ -1,7 +1,7 @@
 dedoose)
     name="Dedoose"
     type="dmg"
-    downloadURL=$(curl -fsL "https://www.dedoose.com/download-the-app" | grep -oE 'https://[^"]+\.dmg' | head -1)
-    appNewVersion=$(echo "$downloadURL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+    appNewVersion=$(curl -I https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg | grep -o "Dedoose-Mac-v[0-9.].*[0-9.].*[0-9.].dmg" | sed -e 's/Dedoose-Mac-v//g' -e 's/.dmg//g')
+    downloadURL="https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg"
     expectedTeamID="9U74Q6K62X"
     ;;

--- a/fragments/labels/dedoose.sh
+++ b/fragments/labels/dedoose.sh
@@ -1,7 +1,7 @@
 dedoose)
     name="Dedoose"
     type="dmg"
-    appNewVersion=$(curl -I https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg | grep -o "Dedoose-Mac-v[0-9.].*[0-9.].*[0-9.].dmg" | sed -e 's/Dedoose-Mac-v//g' -e 's/.dmg//g')
     downloadURL="https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg"
+    appNewVersion=$(curl -fsI https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg | grep -i "^content-disposition:" | grep -o "v[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}" | sed 's/^v//')
     expectedTeamID="9U74Q6K62X"
     ;;


### PR DESCRIPTION
Updated AppNewVersion and downloadURL to match vendor changes

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Modifying a label

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Direct edit of the label file to update the URLs

**Additional context** Add any other context about the label or fix here.
Vendor redid their download site and broke the label.  This fix just updates the downloadURL and appnewversion detection

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
```
[REDACTED] Installomator-10.8 % sudo sh ./assemble.sh dedoose DEBUG=0
Password:
./assemble.sh: line 16: zparseopts: command not found
./assemble.sh: line 18: (I)(-h|--help): syntax error in expression (error token is "(-h|--help)")
./assemble.sh: line 23: (I)(-s|--script): syntax error in expression (error token is "(-s|--script)")
./assemble.sh: line 25: (I)(-p|--pkg): syntax error in expression (error token is "(-p|--pkg)")
./assemble.sh: line 27: (I)(-n|--notarize): syntax error in expression (error token is "(-n|--notarize)")
./assemble.sh: line 30: (I)(-r|--run): syntax error in expression (error token is "(-r|--run)")
2026-05-08 14:16:38 : INFO  : dedoose : setting variable from argument DEBUG=0
2026-05-08 14:16:38 : INFO  : dedoose : Total items in argumentsArray: 1
2026-05-08 14:16:38 : INFO  : dedoose : argumentsArray: DEBUG=0
2026-05-08 14:16:38 : REQ   : dedoose : ################## Start Installomator v. 10.8, date 2026-05-08
2026-05-08 14:16:38 : INFO  : dedoose : ################## Version: 10.8
2026-05-08 14:16:38 : INFO  : dedoose : ################## Date: 2026-05-08
2026-05-08 14:16:38 : INFO  : dedoose : ################## dedoose
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
2026-05-08 14:16:38 : INFO  : dedoose : Reading arguments again: DEBUG=0
2026-05-08 14:16:38 : INFO  : dedoose : BLOCKING_PROCESS_ACTION=tell_user
2026-05-08 14:16:38 : INFO  : dedoose : NOTIFY=success
2026-05-08 14:16:39 : INFO  : dedoose : LOGGING=INFO
2026-05-08 14:16:39 : INFO  : dedoose : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-08 14:16:39 : INFO  : dedoose : Label type: dmg
2026-05-08 14:16:39 : INFO  : dedoose : archiveName: Dedoose.dmg
2026-05-08 14:16:39 : INFO  : dedoose : no blocking processes defined, using Dedoose as default
2026-05-08 14:16:39 : INFO  : dedoose : name: Dedoose, appName: Dedoose.app
2026-05-08 14:16:39 : WARN  : dedoose : No previous app found
2026-05-08 14:16:39 : WARN  : dedoose : could not find Dedoose.app
2026-05-08 14:16:39 : INFO  : dedoose : appversion: 
2026-05-08 14:16:39 : INFO  : dedoose : Latest version of Dedoose is 10.1.5
2026-05-08 14:16:39 : REQ   : dedoose : Downloading https://downloads.dedoose.com/dedoose-app-releases/Dedoose-Mac.dmg to Dedoose.dmg
2026-05-08 14:16:40 : INFO  : dedoose : Downloaded Dedoose.dmg – Type is  zlib compressed data – SHA is 5aa9661554b259f95e05becaa17ec93d76babf0f – Size is 35648 kB
2026-05-08 14:16:40 : REQ   : dedoose : no more blocking processes, continue with update
2026-05-08 14:16:40 : REQ   : dedoose : Installing Dedoose
2026-05-08 14:16:40 : INFO  : dedoose : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.fZ67eSAIwI/Dedoose.dmg
2026-05-08 14:16:42 : INFO  : dedoose : Mounted: /Volumes/Dedoose
2026-05-08 14:16:42 : INFO  : dedoose : Verifying: /Volumes/Dedoose/Dedoose.app
2026-05-08 14:16:43 : INFO  : dedoose : Team ID matching: 9U74Q6K62X (expected: 9U74Q6K62X )
2026-05-08 14:16:43 : INFO  : dedoose : Installing Dedoose version 10.1.5 on versionKey CFBundleShortVersionString.
2026-05-08 14:16:43 : INFO  : dedoose : App has LSMinimumSystemVersion: 10.6
2026-05-08 14:16:43 : INFO  : dedoose : Copy /Volumes/Dedoose/Dedoose.app to /Applications
2026-05-08 14:16:43 : WARN  : dedoose : Changing owner to [REDACTED]
2026-05-08 14:16:43 : INFO  : dedoose : Finishing...
2026-05-08 14:16:46 : INFO  : dedoose : App(s) found: /Applications/Dedoose.app
2026-05-08 14:16:46 : INFO  : dedoose : found app at /Applications/Dedoose.app, version 10.1.5, on versionKey CFBundleShortVersionString
2026-05-08 14:16:46 : REQ   : dedoose : Installed Dedoose, version 10.1.5
2026-05-08 14:16:46 : INFO  : dedoose : notifying
2026-05-08 14:16:47 : INFO  : dedoose : Installomator did not close any apps, so no need to reopen any apps.
2026-05-08 14:16:47 : REQ   : dedoose : All done!
2026-05-08 14:16:47 : REQ   : dedoose : ################## End Installomator, exit code 0 
```