### PR TITLE
Add nps-santa-full label for full Santa package

### DIFF
--- a/fragments/labels/nps-santa-full.sh
+++ b/fragments/labels/nps-santa-full.sh
@@ -1,0 +1,9 @@
+nps-santa-full)
+    name="Santa"
+    type="pkg"
+    packageID="com.northpolesec.santa"
+    archiveName="[0-9]\\.pkg"
+    downloadURL=$(downloadURLFromGit northpolesec santa)
+    appNewVersion=$(versionFromGit northpolesec santa)
+    expectedTeamID="ZMCG7MLDV9"
+    ;;

--- a/fragments/labels/npssantafull.sh
+++ b/fragments/labels/npssantafull.sh
@@ -1,4 +1,4 @@
-nps-santa-full)
+npssantafull)
     name="Santa"
     type="pkg"
     packageID="com.northpolesec.santa"


### PR DESCRIPTION
- Adds nps-santa-full.sh for installing the full Santa package
- Uses archiveName pattern to match santa-VERSION.pkg (excludes lite variant)
- Santa now releases both full and lite packages; this ensures the full version is downloaded

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES
**Additional context** Add any other context about the label or fix here.
Santa now releases both a full package and a lite package (as of 2025.x). The nps-santa label defaults to the lite version because the downloadURLFromGit function picks the first .pkg file, which is santa-VERSION-lite.pkg.

This label explicitly downloads the full Santa package by using an archiveName pattern that matches files ending with a digit followed by .pkg (e.g., santa-2026.3.pkg), excluding the lite variant.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
2026-05-08 23:00:51 : REQ   : nps-santa-full : ################## Start Installomator v. 10.9beta, date 2026-05-08
2026-05-08 23:00:51 : INFO  : nps-santa-full : ################## Version: 10.9beta
2026-05-08 23:00:51 : INFO  : nps-santa-full : ################## Date: 2026-05-08
2026-05-08 23:00:51 : INFO  : nps-santa-full : ################## nps-santa-full
2026-05-08 23:00:52 : INFO  : nps-santa-full : Reading arguments again: LOGGING=INFO NOTIFY=silent DEBUG=0 INSTALL=force
2026-05-08 23:00:52 : INFO  : nps-santa-full : BLOCKING_PROCESS_ACTION=tell_user
2026-05-08 23:00:52 : INFO  : nps-santa-full : NOTIFY=silent
2026-05-08 23:00:52 : INFO  : nps-santa-full : LOGGING=INFO
2026-05-08 23:00:52 : INFO  : nps-santa-full : Label type: pkg
2026-05-08 23:00:52 : INFO  : nps-santa-full : archiveName: [0-9]\.pkg
2026-05-08 23:00:52 : INFO  : nps-santa-full : no blocking processes defined, using Santa as default
2026-05-08 23:00:52 : INFO  : nps-santa-full : Latest version of Santa is 2026.3
2026-05-08 23:00:52 : REQ   : nps-santa-full : Downloading https://github.com/northpolesec/santa/releases/download/2026.3/santa-2026.3.pkg to [0-9]\.pkg
2026-05-08 23:00:54 : INFO  : nps-santa-full : Downloaded [0-9]\.pkg – Type is  xar archive compressed TOC – Size is 35116 kB
2026-05-08 23:00:54 : REQ   : nps-santa-full : Installing Santa
2026-05-08 23:00:54 : INFO  : nps-santa-full : Team ID: ZMCG7MLDV9 (expected: ZMCG7MLDV9 )
2026-05-08 23:00:54 : REQ   : nps-santa-full : Installed Santa, version 2026.3
2026-05-08 23:00:54 : REQ   : nps-santa-full : All done!
2026-05-08 23:00:54 : REQ   : nps-santa-full : ################## End Installomator, exit code 0
```

The log confirms the label successfully downloads the full Santa package (`santa-2026.3.pkg`) rather than the lite version.
