### PR TITLE
Update workbrew.sh

### DIFF
--- a/fragments/labels/workbrew.sh
+++ b/fragments/labels/workbrew.sh
@@ -1,9 +1,8 @@
 workbrew)
     name="Workbrew"
     type="pkg"
-    packageID="com.workbrew.Workbrew"
     downloadURL="https://console.workbrew.com/downloads/macos"
-    appNewVersion="$(curl -ifs "https://console.workbrew.com/downloads/macos" | grep -o "Workbrew-[0-9].[0.9].[0-9][0-9].pkg" | grep -o "[0-9].[0.9].[0-9][0-9]")"
+    appNewVersion="$(curl -sIL https://console.workbrew.com/downloads/macos | grep -i "^content-disposition:" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')"
     appCustomVersion(){ /opt/workbrew/bin/brew --version | grep "Workbrew " | awk '{ print $2 }' | cut -d'-' -f1 }
     expectedTeamID="676JW3JDLF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Current label file is no longer correctly detecting the appNewVersion variable.
Additionally, it had both a `packageID` and a `appCustomVersion` for detecting the installed version. I thought the appCustomVersion made more sense to keep. Someone could remove the binary and not forget the pkg.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./utils/assemble.sh workbrew
2026-05-12 19:53:03 : INFO  : workbrew : Total items in argumentsArray: 0
2026-05-12 19:53:03 : INFO  : workbrew : argumentsArray: 
2026-05-12 19:53:03 : REQ   : workbrew : ################## Start Installomator v. 10.9beta, date 2026-05-12
2026-05-12 19:53:03 : INFO  : workbrew : ################## Version: 10.9beta
2026-05-12 19:53:03 : INFO  : workbrew : ################## Date: 2026-05-12
2026-05-12 19:53:03 : INFO  : workbrew : ################## workbrew
2026-05-12 19:53:03 : DEBUG : workbrew : DEBUG mode 1 enabled.
2026-05-12 19:53:05 : INFO  : workbrew : Reading arguments again: 
2026-05-12 19:53:05 : DEBUG : workbrew : name=Workbrew
2026-05-12 19:53:05 : DEBUG : workbrew : appName=
2026-05-12 19:53:05 : DEBUG : workbrew : type=pkg
2026-05-12 19:53:05 : DEBUG : workbrew : archiveName=
2026-05-12 19:53:05 : DEBUG : workbrew : downloadURL=https://console.workbrew.com/downloads/macos
2026-05-12 19:53:05 : DEBUG : workbrew : curlOptions=
2026-05-12 19:53:05 : DEBUG : workbrew : appNewVersion=1.8.4
2026-05-12 19:53:05 : DEBUG : workbrew : appCustomVersion function: Defined. 
2026-05-12 19:53:05 : DEBUG : workbrew : versionKey=CFBundleShortVersionString
2026-05-12 19:53:05 : DEBUG : workbrew : packageID=
2026-05-12 19:53:05 : DEBUG : workbrew : pkgName=
2026-05-12 19:53:05 : DEBUG : workbrew : choiceChangesXML=
2026-05-12 19:53:05 : DEBUG : workbrew : expectedTeamID=676JW3JDLF
2026-05-12 19:53:05 : DEBUG : workbrew : blockingProcesses=
2026-05-12 19:53:05 : DEBUG : workbrew : installerTool=
2026-05-12 19:53:05 : DEBUG : workbrew : CLIInstaller=
2026-05-12 19:53:05 : DEBUG : workbrew : CLIArguments=
2026-05-12 19:53:05 : DEBUG : workbrew : updateTool=
2026-05-12 19:53:05 : DEBUG : workbrew : updateToolArguments=
2026-05-12 19:53:05 : DEBUG : workbrew : updateToolRunAsCurrentUser=
2026-05-12 19:53:05 : INFO  : workbrew : BLOCKING_PROCESS_ACTION=tell_user
2026-05-12 19:53:05 : INFO  : workbrew : NOTIFY=success
2026-05-12 19:53:05 : INFO  : workbrew : LOGGING=DEBUG
2026-05-12 19:53:05 : INFO  : workbrew : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-12 19:53:05 : INFO  : workbrew : Label type: pkg
2026-05-12 19:53:05 : INFO  : workbrew : archiveName: Workbrew.pkg
2026-05-12 19:53:05 : INFO  : workbrew : no blocking processes defined, using Workbrew as default
2026-05-12 19:53:05 : DEBUG : workbrew : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-12 19:53:05 : INFO  : workbrew : Custom App Version detection is used, found 1.8.3
2026-05-12 19:53:05 : INFO  : workbrew : appversion: 1.8.3
2026-05-12 19:53:05 : INFO  : workbrew : Latest version of Workbrew is 1.8.4
2026-05-12 19:53:05 : REQ   : workbrew : Downloading https://console.workbrew.com/downloads/macos to Workbrew.pkg
2026-05-12 19:53:05 : DEBUG : workbrew : No Dialog connection, just download
2026-05-12 20:01:08 : INFO  : workbrew : Downloaded Workbrew.pkg – Type is  xar archive compressed TOC – SHA is 9f076aae844aa5709f2a059e602a5716eefd755f – Size is 196620 kB
2026-05-12 20:01:08 : DEBUG : workbrew : DEBUG mode 1, not checking for blocking processes
2026-05-12 20:01:08 : REQ   : workbrew : Installing Workbrew
2026-05-12 20:01:08 : INFO  : workbrew : Verifying: Workbrew.pkg
2026-05-12 20:01:08 : DEBUG : workbrew : File list: -rw-r--r--  1 gilburns  staff   184M May 12 20:01 Workbrew.pkg
2026-05-12 20:01:08 : DEBUG : workbrew : File type: Workbrew.pkg: xar archive compressed TOC: 4904, SHA-1 checksum
2026-05-12 20:01:09 : DEBUG : workbrew : spctlOut is Workbrew.pkg: accepted
2026-05-12 20:01:09 : DEBUG : workbrew : source=Notarized Developer ID
2026-05-12 20:01:09 : DEBUG : workbrew : origin=Developer ID Installer: Workbrew Inc. (676JW3JDLF)
2026-05-12 20:01:09 : INFO  : workbrew : Team ID: 676JW3JDLF (expected: 676JW3JDLF )
2026-05-12 20:01:09 : DEBUG : workbrew : DEBUG enabled, skipping installation
2026-05-12 20:01:09 : INFO  : workbrew : Finishing...
2026-05-12 20:01:12 : INFO  : workbrew : Custom App Version detection is used, found 1.8.3
2026-05-12 20:01:12 : REQ   : workbrew : Installed Workbrew, version 1.8.4
2026-05-12 20:01:12 : INFO  : workbrew : notifying
2026-05-12 20:01:13 : DEBUG : workbrew : DEBUG mode 1, not reopening anything
2026-05-12 20:01:13 : REQ   : workbrew : All done!
2026-05-12 20:01:13 : REQ   : workbrew : ################## End Installomator, exit code 0 

```