### PR TITLE
prusaslicer-label-update

### DIFF
--- a/fragments/labels/prusaslicer.sh
+++ b/fragments/labels/prusaslicer.sh
@@ -1,8 +1,9 @@
 prusaslicer)
     name="PrusaSlicer"
     type="dmg"
-    archiveName="PrusaSlicer-[0-9.]*+MacOS-universal-[0-9.]*.dmg"
-    downloadURL="$(downloadURLFromGit prusa3d PrusaSlicer)"
-    appNewVersion="$(versionFromGit prusa3d PrusaSlicer)"
+    downloadURL="$(curl -sfL "https://api.github.com/repos/prusa3d/PrusaSlicer/releases" | grep "browser_download_url" | grep -i "macos-universal.dmg" | grep -v -- "-rc\|-beta\|-alpha" | head -1 | tr -d ' "' | sed 's/browser_download_url://')"
+    appNewVersion="$(echo "$downloadURL" | sed 's/.*PrusaSlicer-//;s/-macos.*//')"
+    folderName="Original Prusa Drivers"
+    appName="${folderName}/PrusaSlicer.app"
     expectedTeamID="DKPB65N43Z"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes, wating on reply to suggested fixes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
 Pull request creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This update replaces the generic downloadURLFromGit and versionFromGit helpers with explicit GitHub API parsing to reliably select the latest non-prerelease macOS universal DMG, avoiding accidental installs of alpha, beta, or release candidate builds. It also derives appNewVersion directly from the resolved download URL to ensure version consistency, and corrects the app path by accounting for the nested Original Prusa Drivers folder inside the DMG, improving install detection and reliability.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh prusaslicer DEBUG=0
2026-05-13 10:51:45 : INFO  : prusaslicer : setting variable from argument DEBUG=0
2026-05-13 10:51:45 : INFO  : prusaslicer : Total items in argumentsArray: 1
2026-05-13 10:51:45 : INFO  : prusaslicer : argumentsArray: DEBUG=0
2026-05-13 10:51:45 : REQ   : prusaslicer : ################## Start Installomator v. 10.9beta, date 2026-05-13
2026-05-13 10:51:45 : INFO  : prusaslicer : ################## Version: 10.9beta
2026-05-13 10:51:45 : INFO  : prusaslicer : ################## Date: 2026-05-13
2026-05-13 10:51:45 : INFO  : prusaslicer : ################## prusaslicer
2026-05-13 10:51:46 : INFO  : prusaslicer : Reading arguments again: DEBUG=0
2026-05-13 10:51:47 : INFO  : prusaslicer : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 10:51:47 : INFO  : prusaslicer : NOTIFY=success
2026-05-13 10:51:47 : INFO  : prusaslicer : LOGGING=INFO
2026-05-13 10:51:47 : INFO  : prusaslicer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 10:51:47 : INFO  : prusaslicer : Label type: dmg
2026-05-13 10:51:47 : INFO  : prusaslicer : archiveName: PrusaSlicer.dmg
2026-05-13 10:51:47 : INFO  : prusaslicer : no blocking processes defined, using PrusaSlicer as default
2026-05-13 10:51:47 : INFO  : prusaslicer : name: PrusaSlicer, appName: Original Prusa Drivers/PrusaSlicer.app
2026-05-13 10:51:47 : WARN  : prusaslicer : No previous app found
2026-05-13 10:51:47 : WARN  : prusaslicer : could not find Original Prusa Drivers/PrusaSlicer.app
2026-05-13 10:51:47 : INFO  : prusaslicer : appversion:
2026-05-13 10:51:47 : INFO  : prusaslicer : Latest version of PrusaSlicer is 2.9.2
2026-05-13 10:51:47 : REQ   : prusaslicer : Downloading https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.9.2/PrusaSlicer-2.9.2-macos-universal.dmg to PrusaSlicer.dmg
2026-05-13 10:51:51 : INFO  : prusaslicer : Downloaded PrusaSlicer.dmg – Type is  zlib compressed data – SHA is 3e29d15a31839b31ddb0e03327c84044222934da – Size is 148092 kB
2026-05-13 10:51:51 : REQ   : prusaslicer : no more blocking processes, continue with update
2026-05-13 10:51:51 : REQ   : prusaslicer : Installing PrusaSlicer
2026-05-13 10:51:51 : INFO  : prusaslicer : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.KChGFTeL78/PrusaSlicer.dmg
2026-05-13 10:51:54 : INFO  : prusaslicer : Mounted: /Volumes/Original Prusa Drivers 1
2026-05-13 10:51:54 : INFO  : prusaslicer : Verifying: /Volumes/Original Prusa Drivers 1/Original Prusa Drivers/PrusaSlicer.app
2026-05-13 10:51:56 : INFO  : prusaslicer : Team ID matching: DKPB65N43Z (expected: DKPB65N43Z )
2026-05-13 10:51:56 : INFO  : prusaslicer : Installing PrusaSlicer version PrusaSlicer PrusaSlicer-2.9.2 on versionKey CFBundleShortVersionString.
2026-05-13 10:51:56 : INFO  : prusaslicer : App has LSMinimumSystemVersion: 10.13
2026-05-13 10:51:56 : INFO  : prusaslicer : Copy /Volumes/Original Prusa Drivers 1/Original Prusa Drivers/PrusaSlicer.app to /Applications
2026-05-13 10:51:58 : WARN  : prusaslicer : Changing owner to u0105821
2026-05-13 10:51:58 : INFO  : prusaslicer : Finishing...
2026-05-13 10:52:01 : INFO  : prusaslicer : App(s) found: /Applications/Original Prusa Drivers/PrusaSlicer.app
2026-05-13 10:52:01 : INFO  : prusaslicer : found app at /Applications/Original Prusa Drivers/PrusaSlicer.app, version PrusaSlicer PrusaSlicer-2.9.2, on versionKey CFBundleShortVersionString
2026-05-13 10:52:01 : REQ   : prusaslicer : Installed PrusaSlicer, version PrusaSlicer PrusaSlicer-2.9.2
2026-05-13 10:52:02 : INFO  : prusaslicer : notifying
2026-05-13 10:52:02 : INFO  : prusaslicer : Installomator did not close any apps, so no need to reopen any apps.
2026-05-13 10:52:02 : REQ   : prusaslicer : All done!
2026-05-13 10:52:02 : REQ   : prusaslicer : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes unreliable version and download detection by selecting the latest stable macOS DMG (excluding prereleases) via the GitHub API, and corrects the app path inside the DMG so Installomator can properly locate and install PrusaSlicer.