### PR TITLE
expressvpn-label-update

### DIFF
--- a/fragments/labels/expressvpn.sh
+++ b/fragments/labels/expressvpn.sh
@@ -1,8 +1,7 @@
 expressvpn)
     name="ExpressVPN"
     type="pkg"
-    packageID="com.expressvpn.ExpressVPN"
     downloadURL="https://www.expressvpn.com/clients/latest/mac"
-    appNewVersion="$(curl -fsIL https://www.expressvpn.com/clients/latest/mac | grep -i ^location | sed -n -e 's/^\(.*\)\(_release\)\(.*\)$/\3\2\1/p' | sed -n -e 's/^.*mac_//p')"
-    expectedTeamID="VMES9GFUQJ"
+    appNewVersion="$(curl -fsIL "https://www.expressvpn.com/clients/latest/mac" | grep -i "^location:" | sed 's/.*expressvpn_mac_//i; s/_release\.pkg.*//; s/\.[0-9]*$//')"
+    expectedTeamID="TC292Y5427"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** Add any other context about the label or fix here.

This update improves version detection reliability and corrects the Developer Team ID to match the currently signed ExpressVPN installer package. The label also removes the unnecessary packageID variable for a standard /Applications install and simplifies the version parsing logic while still resolving the latest release dynamically from the vendor redirect URL. All four required variables (name, type, downloadURL, and expectedTeamID) are present, and the updated appNewVersion parsing appears aligned with the installer naming format.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh expressvpn DEBUG=0
2026-05-13 12:31:09 : INFO  : expressvpn : setting variable from argument DEBUG=0
2026-05-13 12:31:09 : INFO  : expressvpn : Total items in argumentsArray: 1
2026-05-13 12:31:09 : INFO  : expressvpn : argumentsArray: DEBUG=0
2026-05-13 12:31:09 : REQ   : expressvpn : ################## Start Installomator v. 10.9beta, date 2026-05-13
2026-05-13 12:31:09 : INFO  : expressvpn : ################## Version: 10.9beta
2026-05-13 12:31:09 : INFO  : expressvpn : ################## Date: 2026-05-13
2026-05-13 12:31:09 : INFO  : expressvpn : ################## expressvpn
2026-05-13 12:31:10 : INFO  : expressvpn : Reading arguments again: DEBUG=0
2026-05-13 12:31:10 : INFO  : expressvpn : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 12:31:10 : INFO  : expressvpn : NOTIFY=success
2026-05-13 12:31:10 : INFO  : expressvpn : LOGGING=INFO
2026-05-13 12:31:10 : INFO  : expressvpn : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 12:31:10 : INFO  : expressvpn : Label type: pkg
2026-05-13 12:31:10 : INFO  : expressvpn : archiveName: ExpressVPN.pkg
2026-05-13 12:31:10 : INFO  : expressvpn : no blocking processes defined, using ExpressVPN as default
2026-05-13 12:31:11 : INFO  : expressvpn : name: ExpressVPN, appName: ExpressVPN.app
2026-05-13 12:31:11 : WARN  : expressvpn : No previous app found
2026-05-13 12:31:11 : WARN  : expressvpn : could not find ExpressVPN.app
2026-05-13 12:31:11 : INFO  : expressvpn : appversion:
2026-05-13 12:31:11 : INFO  : expressvpn : Latest version of ExpressVPN is 11.71.0
2026-05-13 12:31:11 : REQ   : expressvpn : Downloading https://www.expressvpn.com/clients/latest/mac to ExpressVPN.pkg
2026-05-13 12:31:14 : INFO  : expressvpn : Downloaded ExpressVPN.pkg – Type is  xar archive compressed TOC – SHA is 973be53285cf4bb2858e0ef6ac557fb1b1ba0f4b – Size is 99104 kB
2026-05-13 12:31:14 : REQ   : expressvpn : no more blocking processes, continue with update
2026-05-13 12:31:14 : REQ   : expressvpn : Installing ExpressVPN
2026-05-13 12:31:14 : INFO  : expressvpn : Verifying: ExpressVPN.pkg
2026-05-13 12:31:15 : INFO  : expressvpn : Team ID: TC292Y5427 (expected: TC292Y5427 )
2026-05-13 12:31:15 : INFO  : expressvpn : Installing ExpressVPN.pkg to /
2026-05-13 12:31:29 : INFO  : expressvpn : Finishing...
2026-05-13 12:31:32 : INFO  : expressvpn : App(s) found: /Applications/ExpressVPN.app
2026-05-13 12:31:32 : INFO  : expressvpn : found app at /Applications/ExpressVPN.app, version 11.71.0, on versionKey CFBundleShortVersionString
2026-05-13 12:31:32 : REQ   : expressvpn : Installed ExpressVPN, version 11.71.0
2026-05-13 12:31:32 : INFO  : expressvpn : notifying
2026-05-13 12:31:32 : INFO  : expressvpn : Installomator did not close any apps, so no need to reopen any apps.
2026-05-13 12:31:32 : REQ   : expressvpn : All done!
2026-05-13 12:31:32 : REQ   : expressvpn : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
