### PR TITLE
aftermath-label-update

### DIFF
--- a/fragments/labels/aftermath.sh
+++ b/fragments/labels/aftermath.sh
@@ -4,5 +4,5 @@ aftermath)
     packageID="com.jamf.aftermath"
     downloadURL="$(downloadURLFromGit jamf aftermath)"
     appNewVersion="$(versionFromGit jamf aftermath)"
-    expectedTeamID="C793NB2B2B"
+    expectedTeamID="483DWKW443"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Pull request creating or modifying a label in the fragments/labels folder.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

This update corrects the expectedTeamID from C793NB2B2B to 483DWKW443, aligning the label with the current signing identity used by Jamf for the official Aftermath package. The label already follows current Installomator best practices by using downloadURLFromGit and versionFromGit for reliable GitHub release handling, includes all required variables, and properly defines appNewVersion for version-aware installs. No unnecessary variables, process overrides, or custom logic were introduced, keeping the label simple and maintainable while improving package verification reliability and reducing the risk of Team ID validation failures during deployment.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh aftermath DEBUG=1
2026-05-13 12:45:36 : INFO  : aftermath : setting variable from argument DEBUG=1
2026-05-13 12:45:36 : INFO  : aftermath : Total items in argumentsArray: 1
2026-05-13 12:45:36 : INFO  : aftermath : argumentsArray: DEBUG=1
2026-05-13 12:45:36 : REQ   : aftermath : ################## Start Installomator v. 10.9beta, date 2026-05-13
2026-05-13 12:45:36 : INFO  : aftermath : ################## Version: 10.9beta
2026-05-13 12:45:36 : INFO  : aftermath : ################## Date: 2026-05-13
2026-05-13 12:45:36 : INFO  : aftermath : ################## aftermath
2026-05-13 12:45:36 : DEBUG : aftermath : DEBUG mode 1 enabled.
2026-05-13 12:45:37 : INFO  : aftermath : Reading arguments again: DEBUG=1
2026-05-13 12:45:37 : DEBUG : aftermath : argument: DEBUG=1
2026-05-13 12:45:37 : DEBUG : aftermath : name=Aftermath
2026-05-13 12:45:37 : DEBUG : aftermath : appName=
2026-05-13 12:45:37 : DEBUG : aftermath : type=pkg
2026-05-13 12:45:37 : DEBUG : aftermath : archiveName=
2026-05-13 12:45:38 : DEBUG : aftermath : downloadURL=https://github.com/jamf/aftermath/releases/download/v2.3.0/aftermath-2.3.0.pkg
2026-05-13 12:45:38 : DEBUG : aftermath : curlOptions=
2026-05-13 12:45:38 : DEBUG : aftermath : appNewVersion=2.3.0
2026-05-13 12:45:38 : DEBUG : aftermath : appCustomVersion function: Not defined
2026-05-13 12:45:38 : DEBUG : aftermath : versionKey=CFBundleShortVersionString
2026-05-13 12:45:38 : DEBUG : aftermath : packageID=com.jamf.aftermath
2026-05-13 12:45:38 : DEBUG : aftermath : pkgName=
2026-05-13 12:45:38 : DEBUG : aftermath : choiceChangesXML=
2026-05-13 12:45:38 : DEBUG : aftermath : expectedTeamID=483DWKW443
2026-05-13 12:45:38 : DEBUG : aftermath : blockingProcesses=
2026-05-13 12:45:38 : DEBUG : aftermath : installerTool=
2026-05-13 12:45:38 : DEBUG : aftermath : CLIInstaller=
2026-05-13 12:45:38 : DEBUG : aftermath : CLIArguments=
2026-05-13 12:45:38 : DEBUG : aftermath : updateTool=
2026-05-13 12:45:38 : DEBUG : aftermath : updateToolArguments=
2026-05-13 12:45:38 : DEBUG : aftermath : updateToolRunAsCurrentUser=
2026-05-13 12:45:38 : INFO  : aftermath : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 12:45:38 : INFO  : aftermath : NOTIFY=success
2026-05-13 12:45:38 : INFO  : aftermath : LOGGING=DEBUG
2026-05-13 12:45:38 : INFO  : aftermath : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 12:45:38 : INFO  : aftermath : Label type: pkg
2026-05-13 12:45:38 : INFO  : aftermath : archiveName: Aftermath.pkg
2026-05-13 12:45:38 : INFO  : aftermath : no blocking processes defined, using Aftermath as default
2026-05-13 12:45:38 : DEBUG : aftermath : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-13 12:45:38 : INFO  : aftermath : No version found using packageID com.jamf.aftermath
2026-05-13 12:45:38 : INFO  : aftermath : name: Aftermath, appName: Aftermath.app
2026-05-13 12:45:38 : WARN  : aftermath : No previous app found
2026-05-13 12:45:38 : WARN  : aftermath : could not find Aftermath.app
2026-05-13 12:45:38 : INFO  : aftermath : appversion:
2026-05-13 12:45:38 : INFO  : aftermath : Latest version of Aftermath is 2.3.0
2026-05-13 12:45:38 : REQ   : aftermath : Downloading https://github.com/jamf/aftermath/releases/download/v2.3.0/aftermath-2.3.0.pkg to Aftermath.pkg
2026-05-13 12:45:38 : DEBUG : aftermath : No Dialog connection, just download
2026-05-13 12:45:39 : INFO  : aftermath : Downloaded Aftermath.pkg – Type is  xar archive compressed TOC
2026-05-13 12:45:39 : INFO  : aftermath : - OpenPGP Secret Key – SHA is b2b809e6d64a992b4d2ee651fb2fd6b7f47f6605 – Size is 564 kB
2026-05-13 12:45:39 : DEBUG : aftermath : DEBUG mode 1, not checking for blocking processes
2026-05-13 12:45:39 : REQ   : aftermath : Installing Aftermath
2026-05-13 12:45:39 : INFO  : aftermath : Verifying: Aftermath.pkg
2026-05-13 12:45:39 : DEBUG : aftermath : File list: -rw-r--r--  1 root  staff   563K May 13 12:45 Aftermath.pkg
2026-05-13 12:45:39 : DEBUG : aftermath : File type: Aftermath.pkg: xar archive compressed TOC: 4576, SHA-1 checksum, contains
2026-05-13 12:45:39 : DEBUG : aftermath : - OpenPGP Secret Key
2026-05-13 12:45:39 : DEBUG : aftermath : spctlOut is Aftermath.pkg: accepted
2026-05-13 12:45:39 : DEBUG : aftermath : source=Notarized Developer ID
2026-05-13 12:45:39 : DEBUG : aftermath : origin=Developer ID Installer: JAMF Software (483DWKW443)
2026-05-13 12:45:39 : INFO  : aftermath : Team ID: 483DWKW443 (expected: 483DWKW443 )
2026-05-13 12:45:39 : DEBUG : aftermath : DEBUG enabled, skipping installation
2026-05-13 12:45:39 : INFO  : aftermath : Finishing...
2026-05-13 12:45:42 : INFO  : aftermath : No version found using packageID com.jamf.aftermath
2026-05-13 12:45:42 : INFO  : aftermath : name: Aftermath, appName: Aftermath.app
2026-05-13 12:45:43 : WARN  : aftermath : No previous app found
2026-05-13 12:45:43 : WARN  : aftermath : could not find Aftermath.app
2026-05-13 12:45:43 : REQ   : aftermath : Installed Aftermath, version 2.3.0
2026-05-13 12:45:43 : INFO  : aftermath : notifying
2026-05-13 12:45:43 : DEBUG : aftermath : DEBUG mode 1, not reopening anything
2026-05-13 12:45:43 : REQ   : aftermath : All done!
2026-05-13 12:45:43 : REQ   : aftermath : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
