### PR TITLE
updated packageID for macadminspython

### DIFF
--- a/fragments/labels/macadminspython.sh
+++ b/fragments/labels/macadminspython.sh
@@ -1,7 +1,7 @@
 macadminspython)
     name="MacAdmins Python"
     type="pkg"
-    packageID="org.macadmins.python.recommended"
+    packageID="io.macadmins.python.recommended"
     downloadURL=$(curl --silent --fail "https://api.github.com/repos/macadmins/python/releases/latest" | awk -F '"' "/browser_download_url/ && /python_recommended_signed/ { print \$4; exit }")
     appNewVersion=$(grep -o -E '\d+\.\d+\.\d+\.\d+' <<< $downloadURL | head -n 1)
     expectedTeamID="T4SK8ZXCXG"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — this modifies fragments/labels/macadminspython.sh only.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes.  The repo's .editorconfig is already in the directory and most editors pick it up automatically. Since you're editing in Cursor/VSCode, it's being respected.

**Additional context** Add any other context about the label or fix here.
Fixed incorrect packageID for the macadminspython label. The package ID was `org.macadmins.python.recommended` but the actual bundle identifier used by the MacAdmins Python installer is `io.macadmins.python.recommended`. This caused Installomator to fail the package receipt check after installation.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

I already had macadamias python installed, but because of the incorrect packageID, running the current version gave me this output:
```sudo ./Installomator.sh macadminspython DEBUG=0
Password:
2026-05-13 10:50:22 : INFO  : macadminspython : setting variable from argument DEBUG=0
2026-05-13 10:50:22 : INFO  : macadminspython : Total items in argumentsArray: 1
2026-05-13 10:50:22 : INFO  : macadminspython : argumentsArray: DEBUG=0
2026-05-13 10:50:22 : REQ   : macadminspython : ################## Start Installomator v. 10.9beta, date 2026-05-12
2026-05-13 10:50:22 : INFO  : macadminspython : ################## Version: 10.9beta
2026-05-13 10:50:22 : INFO  : macadminspython : ################## Date: 2026-05-12
2026-05-13 10:50:22 : INFO  : macadminspython : ################## macadminspython
2026-05-13 10:50:23 : INFO  : macadminspython : Reading arguments again: DEBUG=0
2026-05-13 10:50:23 : INFO  : macadminspython : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 10:50:23 : INFO  : macadminspython : NOTIFY=success
2026-05-13 10:50:23 : INFO  : macadminspython : LOGGING=INFO
2026-05-13 10:50:23 : INFO  : macadminspython : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 10:50:23 : INFO  : macadminspython : Label type: pkg
2026-05-13 10:50:23 : INFO  : macadminspython : archiveName: MacAdmins Python.pkg
2026-05-13 10:50:23 : INFO  : macadminspython : No version found using packageID org.macadmins.python.recommended
2026-05-13 10:50:23 : INFO  : macadminspython : name: MacAdmins Python, appName: MacAdmins Python.app
2026-05-13 10:50:23 : WARN  : macadminspython : No previous app found
2026-05-13 10:50:23 : WARN  : macadminspython : could not find MacAdmins Python.app
2026-05-13 10:50:23 : INFO  : macadminspython : appversion: 
2026-05-13 10:50:23 : INFO  : macadminspython : Latest version of MacAdmins Python is 3.14.5.80756
2026-05-13 10:50:23 : REQ   : macadminspython : Downloading https://github.com/macadmins/python/releases/download/v3.14.5.80756/python_recommended_signed-3.14.5.80756.pkg to MacAdmins Python.pkg
2026-05-13 10:50:25 : INFO  : macadminspython : Downloaded MacAdmins Python.pkg – Type is  xar archive compressed TOC – SHA is a99c44f1b7377c51e0454cc5a03ffa33f64ea769 – Size is 60080 kB
2026-05-13 10:50:25 : REQ   : macadminspython : Installing MacAdmins Python
2026-05-13 10:50:25 : INFO  : macadminspython : Verifying: MacAdmins Python.pkg
2026-05-13 10:50:25 : INFO  : macadminspython : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2026-05-13 10:50:26 : INFO  : macadminspython : Installing MacAdmins Python.pkg to /
2026-05-13 10:50:35 : INFO  : macadminspython : Finishing...
2026-05-13 10:50:38 : INFO  : macadminspython : No version found using packageID org.macadmins.python.recommended
2026-05-13 10:50:38 : INFO  : macadminspython : name: MacAdmins Python, appName: MacAdmins Python.app
2026-05-13 10:50:38 : WARN  : macadminspython : No previous app found
2026-05-13 10:50:38 : WARN  : macadminspython : could not find MacAdmins Python.app
2026-05-13 10:50:38 : REQ   : macadminspython : Installed MacAdmins Python, version 3.14.5.80756
2026-05-13 10:50:38 : INFO  : macadminspython : notifying
2026-05-13 10:50:38 : INFO  : macadminspython : Installomator did not close any apps, so no need to reopen any apps.
2026-05-13 10:50:38 : REQ   : macadminspython : All done!
2026-05-13 10:50:38 : REQ   : macadminspython : ################## End Installomator, exit code 0 
```

With the updated change, it now correctly identifies the installed packageID:
```
sudo ./Installomator.sh macadminspython DEBUG=0
2026-05-13 10:51:04 : INFO  : macadminspython : setting variable from argument DEBUG=0
2026-05-13 10:51:04 : INFO  : macadminspython : Total items in argumentsArray: 1
2026-05-13 10:51:04 : INFO  : macadminspython : argumentsArray: DEBUG=0
2026-05-13 10:51:04 : REQ   : macadminspython : ################## Start Installomator v. 10.9beta, date 2026-05-12
2026-05-13 10:51:04 : INFO  : macadminspython : ################## Version: 10.9beta
2026-05-13 10:51:04 : INFO  : macadminspython : ################## Date: 2026-05-12
2026-05-13 10:51:04 : INFO  : macadminspython : ################## macadminspython
2026-05-13 10:51:05 : INFO  : macadminspython : Reading arguments again: DEBUG=0
2026-05-13 10:51:05 : INFO  : macadminspython : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 10:51:05 : INFO  : macadminspython : NOTIFY=success
2026-05-13 10:51:05 : INFO  : macadminspython : LOGGING=INFO
2026-05-13 10:51:05 : INFO  : macadminspython : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 10:51:05 : INFO  : macadminspython : Label type: pkg
2026-05-13 10:51:05 : INFO  : macadminspython : archiveName: MacAdmins Python.pkg
2026-05-13 10:51:05 : INFO  : macadminspython : found packageID io.macadmins.python.recommended installed, version 3.14.5.80756
2026-05-13 10:51:05 : INFO  : macadminspython : appversion: 3.14.5.80756
2026-05-13 10:51:05 : INFO  : macadminspython : Latest version of MacAdmins Python is 3.14.5.80756
2026-05-13 10:51:05 : INFO  : macadminspython : There is no newer version available.
2026-05-13 10:51:05 : INFO  : macadminspython : Installomator did not close any apps, so no need to reopen any apps.
2026-05-13 10:51:05 : REQ   : macadminspython : No newer version.
2026-05-13 10:51:05 : REQ   : macadminspython : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
