### PR TITLE
omnigraffle6-label-update

### DIFF
--- a/fragments/labels/omnigraffle6.sh
+++ b/fragments/labels/omnigraffle6.sh
@@ -1,7 +1,8 @@
 omnigraffle6)
     name="OmniGraffle"
     type="dmg"
-    downloadURL=$(curl -fs "https://update.omnigroup.com/appcast/com.omnigroup.OmniGraffle6" | xpath '(//rss/channel/item/enclosure/@url)[1]' 2>/dev/null | cut -d '"' -f 2)
-    appNewVersion=$( echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' )
-    expectedTeamID="34YW5XSRB7"
+    downloadURL=$(curl -fs "https://update.omnigroup.com/appcast/com.omnigroup.OmniGraffle6" | xmllint --xpath '(//rss/channel/item/enclosure/@url)[1]' --nowarning - 2>/dev/null | cut -d '"' -f 2)
+    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[a-zA-Z]+-([0-9.]+)\..*/\1/')
+    expectedTeamID="Group"
+    acceptEULA="yes"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

This update replaces the deprecated `xpath` parsing with `xmllint` for improved compatibility and reliability when extracting the download URL from the Omni Group appcast. The version parsing regex has also been tightened to better match expected version formats. The `expectedTeamID="Group"` value is a workaround for a known Installomator issue: the app is signed with a 2017-era Developer ID certificate that predates Apple’s requirement to include the Team ID in the OU field. As a result, the certificate uses `OU=The Omni Group` instead of the Team ID (`34YW5XSRB7`), and Installomator incorrectly extracts the human-readable name rather than the actual Team ID.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh omnigraffle6 DEBUG=0
2026-05-13 16:16:48 : INFO  : omnigraffle6 : setting variable from argument DEBUG=0
2026-05-13 16:16:48 : INFO  : omnigraffle6 : Total items in argumentsArray: 1
2026-05-13 16:16:48 : INFO  : omnigraffle6 : argumentsArray: DEBUG=0
2026-05-13 16:16:48 : REQ   : omnigraffle6 : ################## Start Installomator v. 10.9beta, date 2026-05-13
2026-05-13 16:16:48 : INFO  : omnigraffle6 : ################## Version: 10.9beta
2026-05-13 16:16:48 : INFO  : omnigraffle6 : ################## Date: 2026-05-13
2026-05-13 16:16:48 : INFO  : omnigraffle6 : ################## omnigraffle6
2026-05-13 16:16:49 : INFO  : omnigraffle6 : Reading arguments again: DEBUG=0
2026-05-13 16:16:49 : INFO  : omnigraffle6 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-13 16:16:49 : INFO  : omnigraffle6 : NOTIFY=success
2026-05-13 16:16:49 : INFO  : omnigraffle6 : LOGGING=INFO
2026-05-13 16:16:49 : INFO  : omnigraffle6 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-13 16:16:49 : INFO  : omnigraffle6 : Label type: dmg
2026-05-13 16:16:49 : INFO  : omnigraffle6 : archiveName: OmniGraffle.dmg
2026-05-13 16:16:49 : INFO  : omnigraffle6 : no blocking processes defined, using OmniGraffle as default
2026-05-13 16:16:49 : INFO  : omnigraffle6 : name: OmniGraffle, appName: OmniGraffle.app
2026-05-13 16:16:49 : WARN  : omnigraffle6 : No previous app found
2026-05-13 16:16:49 : WARN  : omnigraffle6 : could not find OmniGraffle.app
2026-05-13 16:16:49 : INFO  : omnigraffle6 : appversion: 
2026-05-13 16:16:49 : INFO  : omnigraffle6 : Latest version of OmniGraffle is 6.6.2
2026-05-13 16:16:49 : REQ   : omnigraffle6 : Downloading https://downloads.omnigroup.com/software/MacOSX/10.10/OmniGraffle-6.6.2.dmg to OmniGraffle.dmg
2026-05-13 16:16:57 : INFO  : omnigraffle6 : Downloaded OmniGraffle.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is 8ec42619d9e3df190678508ac5037d8aef55000c – Size is 294964 kB
2026-05-13 16:16:57 : REQ   : omnigraffle6 : no more blocking processes, continue with update
2026-05-13 16:16:57 : REQ   : omnigraffle6 : Installing OmniGraffle
2026-05-13 16:16:57 : INFO  : omnigraffle6 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.b4LAaRwgB7/OmniGraffle.dmg
2026-05-13 16:17:09 : INFO  : omnigraffle6 : Mounted: /Volumes/OmniGraffle 1
2026-05-13 16:17:09 : INFO  : omnigraffle6 : Verifying: /Volumes/OmniGraffle 1/OmniGraffle.app
2026-05-13 16:17:26 : INFO  : omnigraffle6 : Team ID matching: Group (expected: Group )
2026-05-13 16:17:26 : INFO  : omnigraffle6 : Installing OmniGraffle version 6.6.2 on versionKey CFBundleShortVersionString.
2026-05-13 16:17:26 : INFO  : omnigraffle6 : App has LSMinimumSystemVersion: 10.10
2026-05-13 16:17:26 : INFO  : omnigraffle6 : Copy /Volumes/OmniGraffle 1/OmniGraffle.app to /Applications
2026-05-13 16:17:49 : WARN  : omnigraffle6 : Changing owner to u0105821
2026-05-13 16:17:50 : INFO  : omnigraffle6 : Finishing...
2026-05-13 16:17:53 : INFO  : omnigraffle6 : App(s) found: /Applications/OmniGraffle.app
2026-05-13 16:17:53 : INFO  : omnigraffle6 : found app at /Applications/OmniGraffle.app, version 6.6.2, on versionKey CFBundleShortVersionString
2026-05-13 16:17:53 : REQ   : omnigraffle6 : Installed OmniGraffle, version 6.6.2
2026-05-13 16:17:53 : INFO  : omnigraffle6 : notifying
2026-05-13 16:17:54 : INFO  : omnigraffle6 : Installomator did not close any apps, so no need to reopen any apps.
2026-05-13 16:17:54 : REQ   : omnigraffle6 : All done!
2026-05-13 16:17:54 : REQ   : omnigraffle6 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
