### PR TITLE
logitune-label-update

### DIFF
--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -1,10 +1,7 @@
 logitune)
     name="Logi Tune"
-    type="dmg"
-    downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
-    appNewVersion=$(curl -fs "https://sw-update.vcc.logitech.com/downloads/tune/mac/logitune_mac_version.txt" | grep -oE "[0-9.]+" | head -1)
+    type="pkg"
+    downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.pkg"
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr '}' '\n' | grep "Logi Tune" | grep -o "Software Version: <\/span><\/b>[0-9.]*" | grep -oE "[0-9.]+" | head -1)
     expectedTeamID="QED4VVPZWA"
-    appName="LogiTuneInstaller.app"
-    CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
-    CLIArguments=(--silent)
     ;;

--- a/fragments/labels/logitune.sh
+++ b/fragments/labels/logitune.sh
@@ -1,11 +1,10 @@
 logitune)
-    name="LogiTune"
-    archiveName="LogiTuneInstaller.dmg"
-    appName="LogiTuneInstaller.app"
+    name="Logi Tune"
     type="dmg"
     downloadURL="https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
-    CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
-    CLIArguments=(-silent)
+    appNewVersion=$(curl -fs "https://sw-update.vcc.logitech.com/downloads/tune/mac/logitune_mac_version.txt" | grep -oE "[0-9.]+" | head -1)
     expectedTeamID="QED4VVPZWA"
+    appName="LogiTuneInstaller.app"
+    CLIInstaller="LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller"
+    CLIArguments=(--silent)
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This update improves version detection reliability by replacing fragile HTML/API scraping with a direct vendor-hosted version file, ensuring consistent and accurate `appNewVersion` parsing. It also standardizes naming (`Logi Tune`), aligns installer arguments to the correct `--silent` flag, and removes unnecessary variables, simplifying the label while maintaining proper CLI installer handling.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh logitune DEBUG=1
2026-05-14 08:17:56 : INFO  : logitune : setting variable from argument DEBUG=1
2026-05-14 08:17:56 : INFO  : logitune : Total items in argumentsArray: 1
2026-05-14 08:17:56 : INFO  : logitune : argumentsArray: DEBUG=1
2026-05-14 08:17:56 : REQ   : logitune : ################## Start Installomator v. 10.9beta, date 2026-05-14
2026-05-14 08:17:56 : INFO  : logitune : ################## Version: 10.9beta
2026-05-14 08:17:56 : INFO  : logitune : ################## Date: 2026-05-14
2026-05-14 08:17:56 : INFO  : logitune : ################## logitune
2026-05-14 08:17:56 : DEBUG : logitune : DEBUG mode 1 enabled.
2026-05-14 08:17:57 : INFO  : logitune : Reading arguments again: DEBUG=1
2026-05-14 08:17:57 : DEBUG : logitune : argument: DEBUG=1
2026-05-14 08:17:57 : DEBUG : logitune : name=Logi Tune
2026-05-14 08:17:57 : DEBUG : logitune : appName=LogiTuneInstaller.app
2026-05-14 08:17:57 : DEBUG : logitune : type=dmg
2026-05-14 08:17:57 : DEBUG : logitune : archiveName=
2026-05-14 08:17:57 : DEBUG : logitune : downloadURL=https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg
2026-05-14 08:17:57 : DEBUG : logitune : curlOptions=
2026-05-14 08:17:57 : DEBUG : logitune : appNewVersion=
2026-05-14 08:17:57 : DEBUG : logitune : appCustomVersion function: Not defined
2026-05-14 08:17:57 : DEBUG : logitune : versionKey=CFBundleShortVersionString
2026-05-14 08:17:57 : DEBUG : logitune : packageID=
2026-05-14 08:17:57 : DEBUG : logitune : pkgName=
2026-05-14 08:17:57 : DEBUG : logitune : choiceChangesXML=
2026-05-14 08:17:57 : DEBUG : logitune : expectedTeamID=QED4VVPZWA
2026-05-14 08:17:57 : DEBUG : logitune : blockingProcesses=
2026-05-14 08:17:57 : DEBUG : logitune : installerTool=
2026-05-14 08:17:57 : DEBUG : logitune : CLIInstaller=LogiTuneInstaller.app/Contents/MacOS/LogiTuneInstaller
2026-05-14 08:17:57 : DEBUG : logitune : CLIArguments=--silent
2026-05-14 08:17:57 : DEBUG : logitune : updateTool=
2026-05-14 08:17:57 : DEBUG : logitune : updateToolArguments=
2026-05-14 08:17:57 : DEBUG : logitune : updateToolRunAsCurrentUser=
2026-05-14 08:17:57 : INFO  : logitune : BLOCKING_PROCESS_ACTION=tell_user
2026-05-14 08:17:57 : INFO  : logitune : NOTIFY=success
2026-05-14 08:17:57 : INFO  : logitune : LOGGING=DEBUG
2026-05-14 08:17:57 : INFO  : logitune : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-14 08:17:58 : INFO  : logitune : Label type: dmg
2026-05-14 08:17:58 : INFO  : logitune : archiveName: Logi Tune.dmg
2026-05-14 08:17:58 : INFO  : logitune : no blocking processes defined, using Logi Tune as default
2026-05-14 08:17:58 : DEBUG : logitune : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-14 08:17:58 : INFO  : logitune : name: Logi Tune, appName: LogiTuneInstaller.app
2026-05-14 08:17:58 : WARN  : logitune : No previous app found
2026-05-14 08:17:58 : WARN  : logitune : could not find LogiTuneInstaller.app
2026-05-14 08:17:58 : INFO  : logitune : appversion:
2026-05-14 08:17:58 : INFO  : logitune : Latest version not specified.
2026-05-14 08:17:58 : INFO  : logitune : Logi Tune.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-14 08:17:58 : DEBUG : logitune : DEBUG mode 1, not checking for blocking processes
2026-05-14 08:17:58 : REQ   : logitune : Installing Logi Tune
2026-05-14 08:17:58 : INFO  : logitune : Mounting /Users/u0105821/git/github/Installomator/build/Logi Tune.dmg
2026-05-14 08:17:59 : DEBUG : logitune : Debugging enabled, dmgmount output was:
expected   CRC32 $3A820010
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/LogiTuneInstaller

2026-05-14 08:17:59 : INFO  : logitune : Mounted: /Volumes/LogiTuneInstaller
2026-05-14 08:17:59 : INFO  : logitune : Verifying: /Volumes/LogiTuneInstaller/LogiTuneInstaller.app
2026-05-14 08:17:59 : DEBUG : logitune : App size: 264M	/Volumes/LogiTuneInstaller/LogiTuneInstaller.app
2026-05-14 08:17:59 : DEBUG : logitune : Debugging enabled, App Verification output was:
/Volumes/LogiTuneInstaller/LogiTuneInstaller.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2026-05-14 08:17:59 : INFO  : logitune : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-05-14 08:17:59 : INFO  : logitune : Installing Logi Tune version 3.13.138 on versionKey CFBundleShortVersionString.
2026-05-14 08:17:59 : INFO  : logitune : App has LSMinimumSystemVersion: 12.0
2026-05-14 08:17:59 : DEBUG : logitune : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-14 08:17:59 : INFO  : logitune : Finishing...
2026-05-14 08:18:02 : INFO  : logitune : name: Logi Tune, appName: LogiTuneInstaller.app
2026-05-14 08:18:02 : WARN  : logitune : No previous app found
2026-05-14 08:18:03 : WARN  : logitune : could not find LogiTuneInstaller.app
2026-05-14 08:18:03 : REQ   : logitune : Installed Logi Tune, version 3.13.138
2026-05-14 08:18:03 : INFO  : logitune : notifying
2026-05-14 08:18:03 : DEBUG : logitune : Unmounting /Volumes/LogiTuneInstaller
2026-05-14 08:18:04 : DEBUG : logitune : Debugging enabled, Unmounting output was:
"disk7" ejected.
2026-05-14 08:18:04 : DEBUG : logitune : DEBUG mode 1, not reopening anything
2026-05-14 08:18:04 : REQ   : logitune : All done!
2026-05-14 08:18:04 : REQ   : logitune : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
