### PR TITLE
Fix redshift label: switch from pkg to dmg with BitRock CLIInstaller

### DIFF
--- a/fragments/labels/redshift.sh
+++ b/fragments/labels/redshift.sh
@@ -1,9 +1,14 @@
 redshift)
     name="redshift"
+    appName="Maxon Redshift Installer.app"
     blockingProcesses=( "Cinema 4D" )
-    type="pkg"
+    type="dmg"
     packageID="com.redshift3d.redshift"
     expectedTeamID="4ZY22YGXQG"
-    downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redshift[^"]*\.pkg' | head -1)
+    downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redshift[^"]*macos\.dmg' | head -1)
     appNewVersion=$(sed -n 's/.*redshift_\([^_]*\).*/\1/p' <<< "${downloadURL}")
+    installerTool="Maxon Redshift Installer.app"
+    CLIInstaller="Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh"
+    # Customize --enable-components for other DCC integrations (Maya, Vectorworks, ZBrush)
+    CLIArguments=( --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026 )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES
**Additional context** Add any other context about the label or fix here.
The installer supports optional plugin collections and default ones. I was not sure how to account for this in the fragment so i just set a baseline and added a single line comment. If there is a better way happy to adapt. 
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
[STEP 1 of 7]
Executing Policy INSTALOMOTOR: redshift
[STEP 2 of 7]
Running script -0_Install swiftDialog direct - 2026.sh...
Script exit code: 0
Script result: /Library/Application Support/Dialog: directory
icon not defined.
INSTALL=
Dialog check for installation
Dialog version installed: 3.0.1
Dialog version 3.0.1 already found. Perfect!
[STEP 3 of 7]
Running script 00_Prepare_SwiftDialog - 2026.sh...
Script exit code: 0
Script result: 2026-05-14 16:12:35 : Installomator starting up SwiftDialog
overlayicon used from Dialog.png
dialog_command_file: /var/tmp/dialog.log
message: Installing RedShift
icon: https://[REDACTED]/icon/hash_[REDACTED]
overlayicon: /Library/Application Support/Dialog/Dialog.png
dialogCMD: /usr/local/bin/dialog --title none --icon https://[REDACTED]/icon/hash_[REDACTED]
--overlayicon /Library/Application Support/Dialog/Dialog.png --message Installing RedShift --mini --progress 100 --position bottomright --moveable --commandfile /var/tmp/dialog.log
2026-05-14 16:12:35 : SwiftDialog started!
[STEP 4 of 7]
Running script Installomator.sh 2026 beta...
Script exit code: 0
Script result: 2026-05-14 16:12:36 : REQ   :  : shifting arguments for Jamf
2026-05-14 16:12:36 : INFO  : redshift : setting variable from argument DIALOG_CMD_FILE=/var/tmp/dialog.log
2026-05-14 16:12:36 : INFO  : redshift : setting variable from argument DEBUG=0
2026-05-14 16:12:36 : INFO  : redshift : Total items in argumentsArray: 2
2026-05-14 16:12:36 : INFO  : redshift : argumentsArray: DIALOG_CMD_FILE=/var/tmp/dialog.log DEBUG=0
2026-05-14 16:12:36 : REQ   : redshift : ################## Start Installomator v. 10.9beta, date 2025-12-23
2026-05-14 16:12:36 : INFO  : redshift : ################## Version: 10.9beta
2026-05-14 16:12:36 : INFO  : redshift : ################## Date: 2025-12-23
2026-05-14 16:12:36 : INFO  : redshift : ################## redshift
2026-05-14 16:12:37 : INFO  : redshift : Reading arguments again: DIALOG_CMD_FILE=/var/tmp/dialog.log DEBUG=0
2026-05-14 16:12:37 : INFO  : redshift : BLOCKING_PROCESS_ACTION=tell_user
2026-05-14 16:12:37 : INFO  : redshift : NOTIFY=success
2026-05-14 16:12:37 : INFO  : redshift : LOGGING=INFO
2026-05-14 16:12:37 : INFO  : redshift : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-14 16:12:37 : INFO  : redshift : Label type: dmg
2026-05-14 16:12:37 : INFO  : redshift : archiveName: redshift.dmg
2026-05-14 16:12:37 : INFO  : redshift : No version found using packageID com.redshift3d.redshift
2026-05-14 16:12:37 : INFO  : redshift : name: redshift, appName: Maxon Redshift Installer.app
2026-05-14 16:12:38 : WARN  : redshift : No previous app found
2026-05-14 16:12:38 : WARN  : redshift : could not find Maxon Redshift Installer.app
2026-05-14 16:12:38 : INFO  : redshift : appversion: 
2026-05-14 16:12:38 : INFO  : redshift : Latest version of redshift is 2026.6.2
2026-05-14 16:12:38 : REQ   : redshift : Downloading https://installer.maxon.net/installer/rs/redshift_2026.6.2_2518604743_macos.dmg to redshift.dmg
2026-05-14 16:15:49 : INFO  : redshift : Downloaded redshift.dmg – Type is  zlib compressed data – SHA is 89834ba7de2d3e8d1553e351b459c41992e31205 – Size is 11829540 kB
2026-05-14 16:15:49 : REQ   : redshift : no more blocking processes, continue with update
2026-05-14 16:15:49 : REQ   : redshift : Installing redshift
2026-05-14 16:15:49 : REQ   : redshift : installerTool used: Maxon Redshift Installer.app
2026-05-14 16:15:49 : INFO  : redshift : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.afZF18kbLG/redshift.dmg
2026-05-14 16:16:03 : INFO  : redshift : Mounted: /Volumes/Maxon Redshift
2026-05-14 16:16:03 : INFO  : redshift : Verifying: /Volumes/Maxon Redshift/Maxon Redshift Installer.app
2026-05-14 16:16:15 : INFO  : redshift : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2026-05-14 16:16:15 : INFO  : redshift : Installing redshift version 2026.6.2 on versionKey CFBundleShortVersionString.
2026-05-14 16:16:15 : INFO  : redshift : CLIInstaller exists, running installer command /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2025,PluginC4D2026,ZBrushGroup,ZBrush2026
2026-05-14 16:18:45 : INFO  : redshift : Succesfully ran /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2025,PluginC4D2026,ZBrushGroup,ZBrush2026
2026-05-14 16:18:45 : INFO  : redshift : Finishing...
2026-05-14 16:18:48 : INFO  : redshift : No version found using packageID com.redshift3d.redshift
2026-05-14 16:18:48 : INFO  : redshift : name: redshift, appName: Maxon Redshift Installer.app
2026-05-14 16:18:49 : INFO  : redshift : App(s) found: /Applications/Maxon Redshift 2026/bin/redshiftDownloadTool.app
[STEP 5 of 7]
Running script zz_Quit_SwiftDialog - 2026.sh...
Script exit code: 0
Script result: 2026-05-14 16:18:51 : Installomator finishing off SwiftDialog
2026-05-14 16:18:51 : Ending SwiftDialog
Dialog: progress: complete
Dialog: progresstext: Done
Dialog: quit:
No matching processes were found
2026-05-14 16:18:52 : SwiftDialog stopped!
[STEP 6 of 7]
[STEP 7 of 7]
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
