### PR TITLE
Update hudlsportscode.sh

### DIFF
--- a/fragments/labels/hudlsportscode.sh
+++ b/fragments/labels/hudlsportscode.sh
@@ -3,6 +3,5 @@ hudlsportscode)
     type="appInDmgInZip"
     appNewVersion=$(curl -fs https://www.hudl.com/downloads/elite | grep -A 1 "Download Hudl Sportscode" | grep -o -e "[0-9.]*")
     downloadURL="https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-$appNewVersion.dmg.zip"
-	versionKey="CFBundleVersion"
     expectedTeamID="4M6T2C723P"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Fix the case for the label file and removed the versionKey since the standard `CFBundleShortVersionString` key held the correct version info.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./utils/assemble.sh hudlsportscode
2026-05-16 08:52:02 : INFO  : hudlsportscode : Total items in argumentsArray: 0
2026-05-16 08:52:02 : INFO  : hudlsportscode : argumentsArray: 
2026-05-16 08:52:02 : REQ   : hudlsportscode : ################## Start Installomator v. 10.9beta, date 2026-05-16
2026-05-16 08:52:02 : INFO  : hudlsportscode : ################## Version: 10.9beta
2026-05-16 08:52:02 : INFO  : hudlsportscode : ################## Date: 2026-05-16
2026-05-16 08:52:02 : INFO  : hudlsportscode : ################## hudlsportscode
2026-05-16 08:52:02 : DEBUG : hudlsportscode : DEBUG mode 1 enabled.
2026-05-16 08:52:04 : INFO  : hudlsportscode : Reading arguments again: 
2026-05-16 08:52:04 : DEBUG : hudlsportscode : name=Hudl Sportscode
2026-05-16 08:52:04 : DEBUG : hudlsportscode : appName=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : type=appInDmgInZip
2026-05-16 08:52:04 : DEBUG : hudlsportscode : archiveName=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : downloadURL=https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-12.79.0.dmg.zip
2026-05-16 08:52:04 : DEBUG : hudlsportscode : curlOptions=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : appNewVersion=12.79.0
2026-05-16 08:52:04 : DEBUG : hudlsportscode : appCustomVersion function: Not defined
2026-05-16 08:52:04 : DEBUG : hudlsportscode : versionKey=CFBundleShortVersionString
2026-05-16 08:52:04 : DEBUG : hudlsportscode : packageID=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : pkgName=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : choiceChangesXML=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : expectedTeamID=4M6T2C723P
2026-05-16 08:52:04 : DEBUG : hudlsportscode : blockingProcesses=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : installerTool=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : CLIInstaller=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : CLIArguments=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : updateTool=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : updateToolArguments=
2026-05-16 08:52:04 : DEBUG : hudlsportscode : updateToolRunAsCurrentUser=
2026-05-16 08:52:04 : INFO  : hudlsportscode : BLOCKING_PROCESS_ACTION=tell_user
2026-05-16 08:52:04 : INFO  : hudlsportscode : NOTIFY=success
2026-05-16 08:52:04 : INFO  : hudlsportscode : LOGGING=DEBUG
2026-05-16 08:52:04 : INFO  : hudlsportscode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-16 08:52:04 : INFO  : hudlsportscode : Label type: appInDmgInZip
2026-05-16 08:52:04 : INFO  : hudlsportscode : archiveName: Hudl Sportscode.zip
2026-05-16 08:52:04 : INFO  : hudlsportscode : no blocking processes defined, using Hudl Sportscode as default
2026-05-16 08:52:04 : DEBUG : hudlsportscode : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-16 08:52:04 : INFO  : hudlsportscode : name: Hudl Sportscode, appName: Hudl Sportscode.app
2026-05-16 08:52:04 : WARN  : hudlsportscode : No previous app found
2026-05-16 08:52:04 : WARN  : hudlsportscode : could not find Hudl Sportscode.app
2026-05-16 08:52:04 : INFO  : hudlsportscode : appversion: 
2026-05-16 08:52:04 : INFO  : hudlsportscode : Latest version of Hudl Sportscode is 12.79.0
2026-05-16 08:52:04 : REQ   : hudlsportscode : Downloading https://sportscode64-updates.s3.amazonaws.com/PublicReleaseDmgs/HudlSportscode-12.79.0.dmg.zip to Hudl Sportscode.zip
2026-05-16 08:52:04 : DEBUG : hudlsportscode : No Dialog connection, just download
2026-05-16 08:56:42 : INFO  : hudlsportscode : Downloaded Hudl Sportscode.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is b7388ffa1b7f8774a7356a8d5f62605dcc126bde – Size is 131132 kB
2026-05-16 08:56:42 : DEBUG : hudlsportscode : DEBUG mode 1, not checking for blocking processes
2026-05-16 08:56:42 : REQ   : hudlsportscode : Installing Hudl Sportscode
2026-05-16 08:56:42 : INFO  : hudlsportscode : Unzipping Hudl Sportscode.zip
2026-05-16 08:56:43 : INFO  : hudlsportscode : found dmg: /Users/gilburns/GitHub/Installomator/build/HudlSportscode.dmg
2026-05-16 08:56:43 : INFO  : hudlsportscode : Mounting /Users/gilburns/GitHub/Installomator/build/HudlSportscode.dmg
2026-05-16 08:56:46 : DEBUG : hudlsportscode : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D2E71997
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1AE4D80E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2065878D
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $2062C10A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2065878D
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $37056EEB
verified   CRC32 $2D38DC09
/dev/disk40         	GUID_partition_scheme
/dev/disk40s1       	Apple_APFS
/dev/disk41         	EF57347C-0000-11AA-AA11-0030654
/dev/disk41s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Hudl Sportscode

2026-05-16 08:56:46 : INFO  : hudlsportscode : Mounted: /Volumes/Hudl Sportscode
2026-05-16 08:56:46 : INFO  : hudlsportscode : Verifying: /Volumes/Hudl Sportscode/Hudl Sportscode.app
2026-05-16 08:56:46 : DEBUG : hudlsportscode : App size: 307M	/Volumes/Hudl Sportscode/Hudl Sportscode.app
2026-05-16 08:56:53 : DEBUG : hudlsportscode : Debugging enabled, App Verification output was:
/Volumes/Hudl Sportscode/Hudl Sportscode.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Agile Sports Technologies (4M6T2C723P)

2026-05-16 08:56:53 : INFO  : hudlsportscode : Team ID matching: 4M6T2C723P (expected: 4M6T2C723P )
2026-05-16 08:56:53 : INFO  : hudlsportscode : Installing Hudl Sportscode version 12.79.0 on versionKey CFBundleShortVersionString.
2026-05-16 08:56:53 : INFO  : hudlsportscode : App has LSMinimumSystemVersion: 15.0
2026-05-16 08:56:53 : DEBUG : hudlsportscode : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-16 08:56:53 : INFO  : hudlsportscode : Finishing...
2026-05-16 08:56:56 : INFO  : hudlsportscode : name: Hudl Sportscode, appName: Hudl Sportscode.app
2026-05-16 08:56:56 : WARN  : hudlsportscode : No previous app found
2026-05-16 08:56:56 : WARN  : hudlsportscode : could not find Hudl Sportscode.app
2026-05-16 08:56:56 : REQ   : hudlsportscode : Installed Hudl Sportscode, version 12.79.0
2026-05-16 08:56:56 : INFO  : hudlsportscode : notifying
2026-05-16 08:56:56 : DEBUG : hudlsportscode : Unmounting /Volumes/Hudl Sportscode
2026-05-16 08:56:57 : DEBUG : hudlsportscode : Debugging enabled, Unmounting output was:
"disk40" ejected.
2026-05-16 08:56:57 : DEBUG : hudlsportscode : DEBUG mode 1, not reopening anything
2026-05-16 08:56:57 : REQ   : hudlsportscode : All done!
2026-05-16 08:56:57 : REQ   : hudlsportscode : ################## End Installomator, exit code 0 

```