### PR TITLE
Update hudlstudio.sh

### DIFF
--- a/fragments/labels/hudlstudio.sh
+++ b/fragments/labels/hudlstudio.sh
@@ -3,6 +3,5 @@ hudlstudio)
     type="dmg"
     appNewVersion=$(curl -fs https://www.hudl.com/downloads/elite | grep -A 1 "Download Studio" | grep -o -e "[0-9.]*")
     downloadURL="https://studio-releases.s3.amazonaws.com/Studio-$appNewVersion.dmg"
-	versionKey="CFBundleVersion"
     expectedTeamID="2YLQ7PASUE"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Fixed case on the label.sh file and removed unnecessary versionKey from the label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./utils/assemble.sh hudlstudio   
2026-05-16 09:03:18 : INFO  : hudlstudio : Total items in argumentsArray: 0
2026-05-16 09:03:18 : INFO  : hudlstudio : argumentsArray: 
2026-05-16 09:03:18 : REQ   : hudlstudio : ################## Start Installomator v. 10.9beta, date 2026-05-16
2026-05-16 09:03:18 : INFO  : hudlstudio : ################## Version: 10.9beta
2026-05-16 09:03:18 : INFO  : hudlstudio : ################## Date: 2026-05-16
2026-05-16 09:03:18 : INFO  : hudlstudio : ################## hudlstudio
2026-05-16 09:03:18 : DEBUG : hudlstudio : DEBUG mode 1 enabled.
2026-05-16 09:03:20 : INFO  : hudlstudio : Reading arguments again: 
2026-05-16 09:03:20 : DEBUG : hudlstudio : name=Studio
2026-05-16 09:03:20 : DEBUG : hudlstudio : appName=
2026-05-16 09:03:20 : DEBUG : hudlstudio : type=dmg
2026-05-16 09:03:20 : DEBUG : hudlstudio : archiveName=
2026-05-16 09:03:20 : DEBUG : hudlstudio : downloadURL=https://studio-releases.s3.amazonaws.com/Studio-2.2.8.dmg
2026-05-16 09:03:20 : DEBUG : hudlstudio : curlOptions=
2026-05-16 09:03:20 : DEBUG : hudlstudio : appNewVersion=2.2.8
2026-05-16 09:03:20 : DEBUG : hudlstudio : appCustomVersion function: Not defined
2026-05-16 09:03:20 : DEBUG : hudlstudio : versionKey=CFBundleShortVersionString
2026-05-16 09:03:20 : DEBUG : hudlstudio : packageID=
2026-05-16 09:03:20 : DEBUG : hudlstudio : pkgName=
2026-05-16 09:03:20 : DEBUG : hudlstudio : choiceChangesXML=
2026-05-16 09:03:20 : DEBUG : hudlstudio : expectedTeamID=2YLQ7PASUE
2026-05-16 09:03:20 : DEBUG : hudlstudio : blockingProcesses=
2026-05-16 09:03:20 : DEBUG : hudlstudio : installerTool=
2026-05-16 09:03:20 : DEBUG : hudlstudio : CLIInstaller=
2026-05-16 09:03:20 : DEBUG : hudlstudio : CLIArguments=
2026-05-16 09:03:20 : DEBUG : hudlstudio : updateTool=
2026-05-16 09:03:20 : DEBUG : hudlstudio : updateToolArguments=
2026-05-16 09:03:20 : DEBUG : hudlstudio : updateToolRunAsCurrentUser=
2026-05-16 09:03:20 : INFO  : hudlstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-05-16 09:03:20 : INFO  : hudlstudio : NOTIFY=success
2026-05-16 09:03:20 : INFO  : hudlstudio : LOGGING=DEBUG
2026-05-16 09:03:20 : INFO  : hudlstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-16 09:03:20 : INFO  : hudlstudio : Label type: dmg
2026-05-16 09:03:20 : INFO  : hudlstudio : archiveName: Studio.dmg
2026-05-16 09:03:20 : INFO  : hudlstudio : no blocking processes defined, using Studio as default
2026-05-16 09:03:20 : DEBUG : hudlstudio : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-16 09:03:20 : INFO  : hudlstudio : name: Studio, appName: Studio.app
2026-05-16 09:03:20 : INFO  : hudlstudio : App(s) found: /Applications/Android Studio.app/Applications/Riverside Studio.app
2026-05-16 09:03:20 : WARN  : hudlstudio : could not determine location of Studio.app
2026-05-16 09:03:20 : INFO  : hudlstudio : appversion: 
2026-05-16 09:03:20 : INFO  : hudlstudio : Latest version of Studio is 2.2.8
2026-05-16 09:03:20 : REQ   : hudlstudio : Downloading https://studio-releases.s3.amazonaws.com/Studio-2.2.8.dmg to Studio.dmg
2026-05-16 09:03:20 : DEBUG : hudlstudio : No Dialog connection, just download
2026-05-16 09:16:38 : INFO  : hudlstudio : Downloaded Studio.dmg – Type is  zlib compressed data – SHA is ca5282fc948872db5b4e60b781e61e6a13c8c681 – Size is 262208 kB
2026-05-16 09:16:38 : DEBUG : hudlstudio : DEBUG mode 1, not checking for blocking processes
2026-05-16 09:16:38 : REQ   : hudlstudio : Installing Studio
2026-05-16 09:16:38 : INFO  : hudlstudio : Mounting /Users/gilburns/GitHub/Installomator/build/Studio.dmg
2026-05-16 09:16:42 : DEBUG : hudlstudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DE268647
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9DDA4450
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $34510924
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $4152301F
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $34510924
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E1D74BAE
verified   CRC32 $06001ED5
/dev/disk40         	GUID_partition_scheme
/dev/disk40s1       	Apple_HFS                      	/Volumes/Studio 2.2.8-universal

2026-05-16 09:16:42 : INFO  : hudlstudio : Mounted: /Volumes/Studio 2.2.8-universal
2026-05-16 09:16:42 : INFO  : hudlstudio : Verifying: /Volumes/Studio 2.2.8-universal/Studio.app
2026-05-16 09:16:43 : DEBUG : hudlstudio : App size: 664M	/Volumes/Studio 2.2.8-universal/Studio.app
2026-05-16 09:16:56 : DEBUG : hudlstudio : Debugging enabled, App Verification output was:
/Volumes/Studio 2.2.8-universal/Studio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: WY SRL (2YLQ7PASUE)

2026-05-16 09:16:56 : INFO  : hudlstudio : Team ID matching: 2YLQ7PASUE (expected: 2YLQ7PASUE )
2026-05-16 09:16:56 : INFO  : hudlstudio : Installing Studio version 2.2.8 on versionKey CFBundleShortVersionString.
2026-05-16 09:16:56 : INFO  : hudlstudio : App has LSMinimumSystemVersion: 10.13
2026-05-16 09:16:56 : DEBUG : hudlstudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-16 09:16:56 : INFO  : hudlstudio : Finishing...
2026-05-16 09:16:59 : INFO  : hudlstudio : name: Studio, appName: Studio.app
2026-05-16 09:16:59 : INFO  : hudlstudio : App(s) found: /Applications/Android Studio.app/Applications/Riverside Studio.app
2026-05-16 09:16:59 : WARN  : hudlstudio : could not determine location of Studio.app
2026-05-16 09:16:59 : REQ   : hudlstudio : Installed Studio, version 2.2.8
2026-05-16 09:16:59 : INFO  : hudlstudio : notifying
2026-05-16 09:17:00 : DEBUG : hudlstudio : Unmounting /Volumes/Studio 2.2.8-universal
2026-05-16 09:17:00 : DEBUG : hudlstudio : Debugging enabled, Unmounting output was:
"disk40" ejected.
2026-05-16 09:17:01 : DEBUG : hudlstudio : DEBUG mode 1, not reopening anything
2026-05-16 09:17:01 : REQ   : hudlstudio : All done!
2026-05-16 09:17:01 : REQ   : hudlstudio : ################## End Installomator, exit code 0 
```
