### PR TITLE
Update synergybaseball.sh

### DIFF
--- a/fragments/labels/synergybaseball.sh
+++ b/fragments/labels/synergybaseball.sh
@@ -3,7 +3,5 @@ synergybaseball)
     type="dmg"
     downloadURL="$( echo https://www.synergysportstech.com/baseballclient/MacOS/$(curl -s https://www.synergysportstech.com/baseballclient/MacOS/default.htm | grep dmg | grep -o 'href="[^"]*' | head -1 | awk -F '="' '{print $NF}') )"
     appNewVersion=$(curl -fs https://www.synergysportstech.com/baseballclient/MacOS/default.htm | grep Version: | grep -o -e "[0-9.]*")
-	versionKey="CFBundleVersion"
     expectedTeamID="BATB6XS52B"
     ;;
-


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Fix case of the label.sh file and remove unnecessary versionKey

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./utils/assemble.sh synergybaseball                           
2026-05-16 09:47:48 : INFO  : synergybaseball : Total items in argumentsArray: 0
2026-05-16 09:47:48 : INFO  : synergybaseball : argumentsArray: 
2026-05-16 09:47:48 : REQ   : synergybaseball : ################## Start Installomator v. 10.9beta, date 2026-05-16
2026-05-16 09:47:48 : INFO  : synergybaseball : ################## Version: 10.9beta
2026-05-16 09:47:48 : INFO  : synergybaseball : ################## Date: 2026-05-16
2026-05-16 09:47:48 : INFO  : synergybaseball : ################## synergybaseball
2026-05-16 09:47:48 : DEBUG : synergybaseball : DEBUG mode 1 enabled.
2026-05-16 09:47:49 : INFO  : synergybaseball : Reading arguments again: 
2026-05-16 09:47:49 : DEBUG : synergybaseball : name=Synergy Baseball
2026-05-16 09:47:49 : DEBUG : synergybaseball : appName=
2026-05-16 09:47:49 : DEBUG : synergybaseball : type=dmg
2026-05-16 09:47:49 : DEBUG : synergybaseball : archiveName=
2026-05-16 09:47:49 : DEBUG : synergybaseball : downloadURL=https://www.synergysportstech.com/baseballclient/MacOS/Synergy_Baseball_2_0_9_449.dmg
2026-05-16 09:47:49 : DEBUG : synergybaseball : curlOptions=
2026-05-16 09:47:49 : DEBUG : synergybaseball : appNewVersion=2.0.9.449
2026-05-16 09:47:49 : DEBUG : synergybaseball : appCustomVersion function: Not defined
2026-05-16 09:47:49 : DEBUG : synergybaseball : versionKey=CFBundleShortVersionString
2026-05-16 09:47:49 : DEBUG : synergybaseball : packageID=
2026-05-16 09:47:49 : DEBUG : synergybaseball : pkgName=
2026-05-16 09:47:49 : DEBUG : synergybaseball : choiceChangesXML=
2026-05-16 09:47:49 : DEBUG : synergybaseball : expectedTeamID=BATB6XS52B
2026-05-16 09:47:49 : DEBUG : synergybaseball : blockingProcesses=
2026-05-16 09:47:49 : DEBUG : synergybaseball : installerTool=
2026-05-16 09:47:49 : DEBUG : synergybaseball : CLIInstaller=
2026-05-16 09:47:49 : DEBUG : synergybaseball : CLIArguments=
2026-05-16 09:47:49 : DEBUG : synergybaseball : updateTool=
2026-05-16 09:47:49 : DEBUG : synergybaseball : updateToolArguments=
2026-05-16 09:47:49 : DEBUG : synergybaseball : updateToolRunAsCurrentUser=
2026-05-16 09:47:49 : INFO  : synergybaseball : BLOCKING_PROCESS_ACTION=tell_user
2026-05-16 09:47:49 : INFO  : synergybaseball : NOTIFY=success
2026-05-16 09:47:49 : INFO  : synergybaseball : LOGGING=DEBUG
2026-05-16 09:47:49 : INFO  : synergybaseball : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-16 09:47:49 : INFO  : synergybaseball : Label type: dmg
2026-05-16 09:47:49 : INFO  : synergybaseball : archiveName: Synergy Baseball.dmg
2026-05-16 09:47:49 : INFO  : synergybaseball : no blocking processes defined, using Synergy Baseball as default
2026-05-16 09:47:49 : DEBUG : synergybaseball : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-16 09:47:49 : INFO  : synergybaseball : name: Synergy Baseball, appName: Synergy Baseball.app
2026-05-16 09:47:49 : WARN  : synergybaseball : No previous app found
2026-05-16 09:47:49 : WARN  : synergybaseball : could not find Synergy Baseball.app
2026-05-16 09:47:49 : INFO  : synergybaseball : appversion: 
2026-05-16 09:47:49 : INFO  : synergybaseball : Latest version of Synergy Baseball is 2.0.9.449
2026-05-16 09:47:49 : REQ   : synergybaseball : Downloading https://www.synergysportstech.com/baseballclient/MacOS/Synergy_Baseball_2_0_9_449.dmg to Synergy Baseball.dmg
2026-05-16 09:47:49 : DEBUG : synergybaseball : No Dialog connection, just download
2026-05-16 09:49:06 : INFO  : synergybaseball : Downloaded Synergy Baseball.dmg – Type is  lzfse encoded, lzvn compressed – SHA is c609af5ed8ec3aea4075362feac26bb40f4b0d61 – Size is 81936 kB
2026-05-16 09:49:06 : DEBUG : synergybaseball : DEBUG mode 1, not checking for blocking processes
2026-05-16 09:49:06 : REQ   : synergybaseball : Installing Synergy Baseball
2026-05-16 09:49:06 : INFO  : synergybaseball : Mounting /Users/gilburns/GitHub/Installomator/build/Synergy Baseball.dmg
2026-05-16 09:49:10 : DEBUG : synergybaseball : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $09E517F2
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9DDFB974
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5F1948B4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $A2990F1F
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5F1948B4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $EA012F5C
verified   CRC32 $5E8D1700
/dev/disk40         	GUID_partition_scheme
/dev/disk40s1       	Apple_APFS
/dev/disk41         	EF57347C-0000-11AA-AA11-0030654
/dev/disk41s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Synergy Baseball

2026-05-16 09:49:10 : INFO  : synergybaseball : Mounted: /Volumes/Synergy Baseball
2026-05-16 09:49:10 : INFO  : synergybaseball : Verifying: /Volumes/Synergy Baseball/Synergy Baseball.app
2026-05-16 09:49:10 : DEBUG : synergybaseball : App size: 183M	/Volumes/Synergy Baseball/Synergy Baseball.app
2026-05-16 09:49:14 : DEBUG : synergybaseball : Debugging enabled, App Verification output was:
/Volumes/Synergy Baseball/Synergy Baseball.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Synergy Sports Technology, LLC (BATB6XS52B)

2026-05-16 09:49:14 : INFO  : synergybaseball : Team ID matching: BATB6XS52B (expected: BATB6XS52B )
2026-05-16 09:49:14 : INFO  : synergybaseball : Installing Synergy Baseball version 2.0.9.449 on versionKey CFBundleShortVersionString.
2026-05-16 09:49:15 : INFO  : synergybaseball : App has LSMinimumSystemVersion: 10.13
2026-05-16 09:49:15 : DEBUG : synergybaseball : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-16 09:49:15 : INFO  : synergybaseball : Finishing...
2026-05-16 09:49:18 : INFO  : synergybaseball : name: Synergy Baseball, appName: Synergy Baseball.app
2026-05-16 09:49:18 : WARN  : synergybaseball : No previous app found
2026-05-16 09:49:18 : WARN  : synergybaseball : could not find Synergy Baseball.app
2026-05-16 09:49:18 : REQ   : synergybaseball : Installed Synergy Baseball, version 2.0.9.449
2026-05-16 09:49:18 : INFO  : synergybaseball : notifying
2026-05-16 09:49:18 : DEBUG : synergybaseball : Unmounting /Volumes/Synergy Baseball
2026-05-16 09:49:18 : DEBUG : synergybaseball : Debugging enabled, Unmounting output was:
"disk40" ejected.
2026-05-16 09:49:18 : DEBUG : synergybaseball : DEBUG mode 1, not reopening anything
2026-05-16 09:49:18 : REQ   : synergybaseball : All done!
2026-05-16 09:49:18 : REQ   : synergybaseball : ################## End Installomator, exit code 0 

```