### PR TITLE
lucidlink-label-update

### DIFF
--- a/fragments/labels/lucidlink.sh
+++ b/fragments/labels/lucidlink.sh
@@ -1,8 +1,7 @@
 lucidlink)
     name="Lucid"
-    # https://www.lucidlink.com/download
     type="pkg"
-    downloadURL="https://www.lucidlink.com/download/latest/osx/stable/"
-    appNewVersion=$( curl -fsIL "${downloadURL}" | grep -i "^location" | awk '{print $2}' | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' )
+    downloadURL="https://www.lucidlink.com/download/latest/osx/stable"
+    appNewVersion=$(curl -fsIL -H "Referer: https://www.lucidlink.com/download/latest/osx/stable" "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/lucid-([0-9]+(\.[0-9]+)+)\.pkg$|\1|')
     expectedTeamID="Y4KMJPU2B4"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

This pull request creates or modifies a label in the fragments/labels folder.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This update improves the reliability of the LucidLink package version detection by correcting the download URL format and adding an explicit Referer header required by the vendor’s redirect flow. The updated appNewVersion logic now follows redirects more consistently, captures the final package URL safely, and uses stricter regex matching to extract the version number from the redirected .pkg filename. The label continues to meet Installomator standards with all required variables present, uses a stable vendor-hosted download endpoint, and avoids unnecessary complexity or unsupported helper functions since LucidLink is not GitHub-hosted.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
$ Installomator/utils/assemble.sh lucidlink DEBUG=1
2026-05-18 15:02:09 : INFO  : lucidlink : setting variable from argument DEBUG=1
2026-05-18 15:02:09 : INFO  : lucidlink : Total items in argumentsArray: 1
2026-05-18 15:02:09 : INFO  : lucidlink : argumentsArray: DEBUG=1
2026-05-18 15:02:10 : REQ   : lucidlink : ################## Start Installomator v. 10.9beta, date 2026-05-18
2026-05-18 15:02:10 : INFO  : lucidlink : ################## Version: 10.9beta
2026-05-18 15:02:10 : INFO  : lucidlink : ################## Date: 2026-05-18
2026-05-18 15:02:10 : INFO  : lucidlink : ################## lucidlink
2026-05-18 15:02:10 : DEBUG : lucidlink : DEBUG mode 1 enabled.
2026-05-18 15:02:11 : INFO  : lucidlink : Reading arguments again: DEBUG=1
2026-05-18 15:02:11 : DEBUG : lucidlink : argument: DEBUG=1
2026-05-18 15:02:11 : DEBUG : lucidlink : name=Lucid
2026-05-18 15:02:11 : DEBUG : lucidlink : appName=
2026-05-18 15:02:11 : DEBUG : lucidlink : type=pkg
2026-05-18 15:02:11 : DEBUG : lucidlink : archiveName=
2026-05-18 15:02:11 : DEBUG : lucidlink : downloadURL=https://www.lucidlink.com/download/latest/osx/stable
2026-05-18 15:02:11 : DEBUG : lucidlink : curlOptions=
2026-05-18 15:02:11 : DEBUG : lucidlink : appNewVersion=2.9.8131
2026-05-18 15:02:11 : DEBUG : lucidlink : appCustomVersion function: Not defined
2026-05-18 15:02:11 : DEBUG : lucidlink : versionKey=CFBundleShortVersionString
2026-05-18 15:02:11 : DEBUG : lucidlink : packageID=
2026-05-18 15:02:11 : DEBUG : lucidlink : pkgName=
2026-05-18 15:02:11 : DEBUG : lucidlink : choiceChangesXML=
2026-05-18 15:02:11 : DEBUG : lucidlink : expectedTeamID=Y4KMJPU2B4
2026-05-18 15:02:11 : DEBUG : lucidlink : blockingProcesses=
2026-05-18 15:02:11 : DEBUG : lucidlink : installerTool=
2026-05-18 15:02:11 : DEBUG : lucidlink : CLIInstaller=
2026-05-18 15:02:11 : DEBUG : lucidlink : CLIArguments=
2026-05-18 15:02:11 : DEBUG : lucidlink : updateTool=
2026-05-18 15:02:11 : DEBUG : lucidlink : updateToolArguments=
2026-05-18 15:02:11 : DEBUG : lucidlink : updateToolRunAsCurrentUser=
2026-05-18 15:02:11 : INFO  : lucidlink : BLOCKING_PROCESS_ACTION=tell_user
2026-05-18 15:02:11 : INFO  : lucidlink : NOTIFY=success
2026-05-18 15:02:11 : INFO  : lucidlink : LOGGING=DEBUG
2026-05-18 15:02:11 : INFO  : lucidlink : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-18 15:02:11 : INFO  : lucidlink : Label type: pkg
2026-05-18 15:02:11 : INFO  : lucidlink : archiveName: Lucid.pkg
2026-05-18 15:02:11 : INFO  : lucidlink : no blocking processes defined, using Lucid as default
2026-05-18 15:02:11 : DEBUG : lucidlink : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-18 15:02:11 : INFO  : lucidlink : name: Lucid, appName: Lucid.app
2026-05-18 15:02:12 : WARN  : lucidlink : No previous app found
2026-05-18 15:02:12 : WARN  : lucidlink : could not find Lucid.app
2026-05-18 15:02:12 : INFO  : lucidlink : appversion:
2026-05-18 15:02:12 : INFO  : lucidlink : Latest version of Lucid is 2.9.8131
2026-05-18 15:02:12 : REQ   : lucidlink : Downloading https://www.lucidlink.com/download/latest/osx/stable to Lucid.pkg
2026-05-18 15:02:12 : DEBUG : lucidlink : No Dialog connection, just download
2026-05-18 15:02:22 : INFO  : lucidlink : Downloaded Lucid.pkg – Type is  xar archive compressed TOC – SHA is 542b820c97b64eeda87be37ddd0546beeee60798 – Size is 376932 kB
2026-05-18 15:02:22 : DEBUG : lucidlink : DEBUG mode 1, not checking for blocking processes
2026-05-18 15:02:22 : REQ   : lucidlink : Installing Lucid
2026-05-18 15:02:22 : INFO  : lucidlink : Verifying: Lucid.pkg
2026-05-18 15:02:22 : DEBUG : lucidlink : File list: -rw-r--r--  1 u0105821  staff   355M May 18 15:02 Lucid.pkg
2026-05-18 15:02:22 : DEBUG : lucidlink : File type: Lucid.pkg: xar archive compressed TOC: 4919, SHA-1 checksum
2026-05-18 15:02:22 : DEBUG : lucidlink : spctlOut is Lucid.pkg: accepted
2026-05-18 15:02:22 : DEBUG : lucidlink : source=Notarized Developer ID
2026-05-18 15:02:22 : DEBUG : lucidlink : origin=Developer ID Installer: LucidLink Corp. (Y4KMJPU2B4)
2026-05-18 15:02:22 : INFO  : lucidlink : Team ID: Y4KMJPU2B4 (expected: Y4KMJPU2B4 )
2026-05-18 15:02:22 : DEBUG : lucidlink : DEBUG enabled, skipping installation
2026-05-18 15:02:22 : INFO  : lucidlink : Finishing...
2026-05-18 15:02:26 : INFO  : lucidlink : name: Lucid, appName: Lucid.app
2026-05-18 15:02:26 : WARN  : lucidlink : No previous app found
2026-05-18 15:02:26 : WARN  : lucidlink : could not find Lucid.app
2026-05-18 15:02:26 : REQ   : lucidlink : Installed Lucid, version 2.9.8131
2026-05-18 15:02:26 : INFO  : lucidlink : notifying
2026-05-18 15:02:26 : DEBUG : lucidlink : DEBUG mode 1, not reopening anything
2026-05-18 15:02:26 : REQ   : lucidlink : All done!
2026-05-18 15:02:26 : REQ   : lucidlink : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
