### PR TITLE
Add appCustomVersion to strip last digit from app version

### DIFF
--- a/fragments/labels/displaylinkmanager.sh
+++ b/fragments/labels/displaylinkmanager.sh
@@ -4,5 +4,6 @@ displaylinkmanager)
     appNewVersion=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'DisplayLink%20Manager%20Graphics%20Connectivity[0-9.]*-Release' | head -1 | sed 's/DisplayLink%20Manager%20Graphics%20Connectivity//' | sed 's/-Release//')
     productPage=$(curl -sfL https://www.synaptics.com/products/displaylink-graphics/downloads/macos | grep -o 'href="/products/displaylink-manager-graphics-connectivity-[^"]*?filetype=exe"' | head -1 | sed 's/href="//' | sed 's/"$//' | sed 's/?filetype=exe/?filetype=pkg/')
     downloadURL="https://www.synaptics.com$(curl -sfL "https://www.synaptics.com${productPage}" | grep -o '/sites/default/files/exe_files/[^"]*\.pkg' | head -1)"
+    appCustomVersion(){defaults read /Applications/DisplayLink\ Manager.app/Contents/Info.plist CFBundleShortVersionString | awk -F "." '{print$1"."$2}'}
     expectedTeamID="73YQY62QM3"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
This is to strip the last digit from the app bundle version, since the website only shows the first two digits.
Currently 16.0.16 -> 16.0

**Installomator log** 
With latest version installed:
```
➜  Installomator git:(fix_for_displaylinkmanager_appVersion) sudo ./assemble.sh displaylinkmanager NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-05-19 15:09:42 : INFO  : displaylinkmanager : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-05-19 15:09:43 : INFO  : displaylinkmanager : setting variable from argument NOTIFY=success
2026-05-19 15:09:43 : INFO  : displaylinkmanager : setting variable from argument NOTIFY_DIALOG=1
2026-05-19 15:09:43 : INFO  : displaylinkmanager : setting variable from argument DEBUG=0
2026-05-19 15:09:43 : INFO  : displaylinkmanager : Total items in argumentsArray: 4
2026-05-19 15:09:43 : INFO  : displaylinkmanager : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-05-19 15:09:43 : REQ   : displaylinkmanager : ################## Start Installomator v. 10.9beta, date 2026-05-19
2026-05-19 15:09:43 : INFO  : displaylinkmanager : ################## Version: 10.9beta
2026-05-19 15:09:43 : INFO  : displaylinkmanager : ################## Date: 2026-05-19
2026-05-19 15:09:43 : INFO  : displaylinkmanager : ################## displaylinkmanager
2026-05-19 15:09:44 : INFO  : displaylinkmanager : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-05-19 15:09:44 : INFO  : displaylinkmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-05-19 15:09:44 : INFO  : displaylinkmanager : NOTIFY=success
2026-05-19 15:09:44 : INFO  : displaylinkmanager : LOGGING=INFO
2026-05-19 15:09:44 : INFO  : displaylinkmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-19 15:09:44 : INFO  : displaylinkmanager : Label type: pkg
2026-05-19 15:09:44 : INFO  : displaylinkmanager : archiveName: DisplayLink Manager.pkg
2026-05-19 15:09:44 : INFO  : displaylinkmanager : no blocking processes defined, using DisplayLink Manager as default
2026-05-19 15:09:44 : INFO  : displaylinkmanager : Custom App Version detection is used, found 16.0
2026-05-19 15:09:44 : INFO  : displaylinkmanager : appversion: 16.0
2026-05-19 15:09:44 : INFO  : displaylinkmanager : Latest version of DisplayLink Manager is 16.0
2026-05-19 15:09:44 : INFO  : displaylinkmanager : There is no newer version available.
2026-05-19 15:09:44 : INFO  : displaylinkmanager : Installomator did not close any apps, so no need to reopen any apps.
2026-05-19 15:09:44 : REQ   : displaylinkmanager : No newer version.
2026-05-19 15:09:44 : REQ   : displaylinkmanager : ################## End Installomator, exit code 0 
```