### PR TITLE
Fix logitechoptionsplus app new version

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -4,8 +4,8 @@ logitechoptionsplus)
     archiveName="logioptionsplus_installer.zip"
     installerTool="logioptionsplus_installer.app"
     type="zip"
-    downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
     osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print$1}')
+    downloadURL="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n"  | grep  -o "https://.*logioptionsplus.*zip" | head -1)"
     appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)

--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -5,9 +5,8 @@ logitechoptionsplus)
     installerTool="logioptionsplus_installer.app"
     type="zip"
     downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
-    # Latest version of Logi Options+ requires macOS 13+
-    # If older macOS is specified in the url for appNewVersion, it will never correspond to the installed version
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-13.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print$1}')
+    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
I've added the major os version as a variable to the url for getting both downloadURL and appNewVersion to support all OS versions. Hopefully that makes this last a little longer than before.

**Installomator log** 
```
➜  Installomator git:(fix_logitechoptionsplus_appNewVersion) ✗ sudo ./assemble.sh logitechoptionsplus NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0 
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : setting variable from argument NOTIFY=success
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : setting variable from argument NOTIFY_DIALOG=1
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=0
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : Total items in argumentsArray: 4
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-05-19 16:52:30 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.9beta, date 2026-05-19
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : ################## Version: 10.9beta
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : ################## Date: 2026-05-19
2026-05-19 16:52:30 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : NOTIFY=success
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : LOGGING=INFO
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : Label type: zip
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : archiveName: logioptionsplus_installer.zip
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : App(s) found: /Applications/logioptionsplus.app
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : found app at /Applications/logioptionsplus.app, version 2.3.879545, on versionKey CFBundleShortVersionString
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : appversion: 2.3.879545
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 2.3.879545
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : There is no newer version available.
2026-05-19 16:52:31 : INFO  : logitechoptionsplus : Installomator did not close any apps, so no need to reopen any apps.
2026-05-19 16:52:31 : REQ   : logitechoptionsplus : No newer version.
2026-05-19 16:52:31 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0 
```