### PR TITLE
zulujdk18-label-update

### DIFF
--- a/Installomator.sh
+++ b/Installomator.sh
@@ -12405,14 +12405,14 @@ zulujdk18)
     name="Zulu JDK 18"
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.18"
-    if [[ $(arch) == i386 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
-    elif [[ $(arch) == arm64 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*aarch64[.]dmg' | sort -Vu | tail -n 1)"
+    else
+        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*x64[.]dmg' | sort -Vu | tail -n 1)"
     fi
-    expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
     appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    expectedTeamID="TDTHCUPYFR"
     ;;
 zulujdk21)
     name="Zulu JDK 21"

--- a/Installomator.sh
+++ b/Installomator.sh
@@ -12405,14 +12405,14 @@ zulujdk18)
     name="Zulu JDK 18"
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.18"
-    if [[ $(arch) == arm64 ]]; then
-        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*aarch64[.]dmg' | sort -Vu | tail -n 1)"
-    else
-        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*x64[.]dmg' | sort -Vu | tail -n 1)"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    elif [[ $(arch) == arm64 ]]; then
+        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
     fi
+    expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
     appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
-    expectedTeamID="TDTHCUPYFR"
     ;;
 zulujdk21)
     name="Zulu JDK 21"

--- a/fragments/labels/zulujdk18.sh
+++ b/fragments/labels/zulujdk18.sh
@@ -8,6 +8,6 @@ zulujdk18)
         downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*x64[.]dmg' | sort -Vu | tail -n 1)"
     fi
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
-    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//")
     expectedTeamID="TDTHCUPYFR"
     ;;

--- a/fragments/labels/zulujdk18.sh
+++ b/fragments/labels/zulujdk18.sh
@@ -2,12 +2,12 @@ zulujdk18)
     name="Zulu JDK 18"
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.18"
-    if [[ $(arch) == i386 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
-    elif [[ $(arch) == arm64 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu18.*ca-jdk18.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    if [[ $(arch) == arm64 ]]; then
+        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*aarch64[.]dmg' | sort -Vu | tail -n 1)"
+    else
+        downloadURL="https://cdn.azul.com/zulu/bin/$(curl -fsL 'https://cdn.azul.com/zulu/bin/' | grep -Eo 'zulu18[^"<]*ca-jdk18[^"<]*x64[.]dmg' | sort -Vu | tail -n 1)"
     fi
-    expectedTeamID="TDTHCUPYFR"
     appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
     appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
+    expectedTeamID="TDTHCUPYFR"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The updated label improves download reliability and architecture handling for Zulu JDK 18 by validating separate dynamically resolved download URLs for both Apple Silicon and Intel Macs. The label continues to pull the latest available vendor-hosted DMG directly from Azul’s CDN while preserving compatibility with Installomator’s package-based installation workflow. The review also confirmed that the `appCustomVersion` function correctly normalizes the installed Java runtime version format, and that the `expectedTeamID` remains valid for signature verification. Additionally, the label maintains proper use of `pkgInDmg`, preserves the required `packageID` for non-application installs, and avoids unnecessary blocking process logic for a package-based installer.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh zulujdk18 DEBUG=1
2026-05-19 09:46:29 : INFO  : zulujdk18 : setting variable from argument DEBUG=1
2026-05-19 09:46:29 : INFO  : zulujdk18 : Total items in argumentsArray: 1
2026-05-19 09:46:29 : INFO  : zulujdk18 : argumentsArray: DEBUG=1
2026-05-19 09:46:29 : REQ   : zulujdk18 : ################## Start Installomator v. 10.9beta, date 2026-05-19
2026-05-19 09:46:30 : INFO  : zulujdk18 : ################## Version: 10.9beta
2026-05-19 09:46:30 : INFO  : zulujdk18 : ################## Date: 2026-05-19
2026-05-19 09:46:30 : INFO  : zulujdk18 : ################## zulujdk18
2026-05-19 09:46:30 : DEBUG : zulujdk18 : DEBUG mode 1 enabled.
2026-05-19 09:46:30 : INFO  : zulujdk18 : Reading arguments again: DEBUG=1
2026-05-19 09:46:30 : DEBUG : zulujdk18 : argument: DEBUG=1
2026-05-19 09:46:30 : DEBUG : zulujdk18 : name=Zulu JDK 18
2026-05-19 09:46:30 : DEBUG : zulujdk18 : appName=
2026-05-19 09:46:30 : DEBUG : zulujdk18 : type=pkgInDmg
2026-05-19 09:46:30 : DEBUG : zulujdk18 : archiveName=
2026-05-19 09:46:30 : DEBUG : zulujdk18 : downloadURL=https://cdn.azul.com/zulu/bin/zulu18.32.13-ca-jdk18.0.2.1-macosx_aarch64.dmg
2026-05-19 09:46:30 : DEBUG : zulujdk18 : curlOptions=
2026-05-19 09:46:30 : DEBUG : zulujdk18 : appNewVersion=18.32.13
2026-05-19 09:46:30 : DEBUG : zulujdk18 : appCustomVersion function: Defined.
2026-05-19 09:46:30 : DEBUG : zulujdk18 : versionKey=CFBundleShortVersionString
2026-05-19 09:46:31 : DEBUG : zulujdk18 : packageID=com.azulsystems.zulu.18
2026-05-19 09:46:31 : DEBUG : zulujdk18 : pkgName=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : choiceChangesXML=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : expectedTeamID=TDTHCUPYFR
2026-05-19 09:46:31 : DEBUG : zulujdk18 : blockingProcesses=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : installerTool=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : CLIInstaller=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : CLIArguments=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : updateTool=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : updateToolArguments=
2026-05-19 09:46:31 : DEBUG : zulujdk18 : updateToolRunAsCurrentUser=
2026-05-19 09:46:31 : INFO  : zulujdk18 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-19 09:46:31 : INFO  : zulujdk18 : NOTIFY=success
2026-05-19 09:46:31 : INFO  : zulujdk18 : LOGGING=DEBUG
2026-05-19 09:46:31 : INFO  : zulujdk18 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-19 09:46:31 : INFO  : zulujdk18 : Label type: pkgInDmg
2026-05-19 09:46:31 : INFO  : zulujdk18 : archiveName: Zulu JDK 18.dmg
2026-05-19 09:46:31 : INFO  : zulujdk18 : no blocking processes defined, using Zulu JDK 18 as default
2026-05-19 09:46:31 : DEBUG : zulujdk18 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-19 09:46:31 : INFO  : zulujdk18 : Custom App Version detection is used, found be
2026-05-19 09:46:31 : INFO  : zulujdk18 : appversion: be
2026-05-19 09:46:31 : INFO  : zulujdk18 : Latest version of Zulu JDK 18 is 18.32.13
2026-05-19 09:46:31 : INFO  : zulujdk18 : Zulu JDK 18.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-19 09:46:31 : DEBUG : zulujdk18 : DEBUG mode 1, not checking for blocking processes
2026-05-19 09:46:31 : REQ   : zulujdk18 : Installing Zulu JDK 18
2026-05-19 09:46:31 : INFO  : zulujdk18 : Mounting /Users/u0105821/git/github/Installomator/build/Zulu JDK 18.dmg
2026-05-19 09:46:31 : DEBUG : zulujdk18 : Debugging enabled, dmgmount output was:
expected   CRC32 $F2D91D7E
/dev/disk15         	GUID_partition_scheme
/dev/disk15s1       	Apple_HFS                      	/Volumes/Azul Zulu JDK 18.32+13

2026-05-19 09:46:31 : INFO  : zulujdk18 : Mounted: /Volumes/Azul Zulu JDK 18.32+13
2026-05-19 09:46:31 : DEBUG : zulujdk18 : Found pkg(s):
/Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg
2026-05-19 09:46:31 : INFO  : zulujdk18 : found pkg: /Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg
2026-05-19 09:46:31 : INFO  : zulujdk18 : Verifying: /Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg
2026-05-19 09:46:31 : DEBUG : zulujdk18 : File list: -rw-r--r--  1 u0105821  staff   183M Aug 29  2022 /Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg
2026-05-19 09:46:32 : DEBUG : zulujdk18 : File type: /Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg: xar archive compressed TOC: 4891, SHA-1 checksum
2026-05-19 09:46:32 : DEBUG : zulujdk18 : spctlOut is /Volumes/Azul Zulu JDK 18.32+13/Double-Click to Install Azul Zulu JDK 18.pkg: accepted
2026-05-19 09:46:32 : DEBUG : zulujdk18 : source=Notarized Developer ID
2026-05-19 09:46:32 : DEBUG : zulujdk18 : origin=Developer ID Installer: Azul Systems, Inc. (TDTHCUPYFR)
2026-05-19 09:46:32 : INFO  : zulujdk18 : Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2026-05-19 09:46:32 : INFO  : zulujdk18 : Checking package version.
2026-05-19 09:46:39 : INFO  : zulujdk18 : Downloaded package com.azulsystems.zulu.18 version
2026-05-19 09:46:39 : DEBUG : zulujdk18 : DEBUG enabled, skipping installation
2026-05-19 09:46:39 : INFO  : zulujdk18 : Finishing...
2026-05-19 09:46:43 : INFO  : zulujdk18 : Custom App Version detection is used, found be
2026-05-19 09:46:43 : REQ   : zulujdk18 : Installed Zulu JDK 18
2026-05-19 09:46:43 : INFO  : zulujdk18 : notifying
2026-05-19 09:46:43 : DEBUG : zulujdk18 : Unmounting /Volumes/Azul Zulu JDK 18.32+13
2026-05-19 09:46:43 : DEBUG : zulujdk18 : Debugging enabled, Unmounting output was:
"disk15" ejected.
2026-05-19 09:46:43 : DEBUG : zulujdk18 : DEBUG mode 1, not reopening anything
2026-05-19 09:46:43 : REQ   : zulujdk18 : All done!
2026-05-19 09:46:43 : REQ   : zulujdk18 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
