### PR TITLE
Add googleearth appNewVersion

### DIFF
--- a/fragments/labels/googleearth.sh
+++ b/fragments/labels/googleearth.sh
@@ -1,6 +1,7 @@
 googleearth)
     name="Google Earth Pro"
     type="pkgInDmg"
+    appNewVersion=$(curl -fsL "https://www.google.com/earth/about/versions/\#download-pro" | grep -oi "<strong>version [0-9\.]*" | grep -o "[0-9\.]*")
     downloadURL="https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg"
     expectedTeamID="EQHXZ8M8AV"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Adds the appNewVersion check to the Google Earth label.

**Installomator log**
```
2026-05-20 09:39:10 : INFO  : googleearth : setting variable from argument DEBUG=0
2026-05-20 09:39:10 : INFO  : googleearth : Total items in argumentsArray: 1
2026-05-20 09:39:10 : INFO  : googleearth : argumentsArray: DEBUG=0
2026-05-20 09:39:10 : REQ   : googleearth : ################## Start Installomator v. 10.9, date 2026-05-20
2026-05-20 09:39:10 : INFO  : googleearth : ################## Version: 10.9
2026-05-20 09:39:10 : INFO  : googleearth : ################## Date: 2026-05-20
2026-05-20 09:39:10 : INFO  : googleearth : ################## googleearth
2026-05-20 09:39:11 : INFO  : googleearth : Reading arguments again: DEBUG=0
2026-05-20 09:39:11 : INFO  : googleearth : BLOCKING_PROCESS_ACTION=tell_user
2026-05-20 09:39:11 : INFO  : googleearth : NOTIFY=success
2026-05-20 09:39:11 : INFO  : googleearth : LOGGING=INFO
2026-05-20 09:39:11 : INFO  : googleearth : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-20 09:39:11 : INFO  : googleearth : Label type: pkgInDmg
2026-05-20 09:39:11 : INFO  : googleearth : archiveName: Google Earth Pro.dmg
2026-05-20 09:39:11 : INFO  : googleearth : no blocking processes defined, using Google Earth Pro as default
2026-05-20 09:39:11 : INFO  : googleearth : App(s) found: /Applications/Google Earth Pro.app
2026-05-20 09:39:11 : INFO  : googleearth : found app at /Applications/Google Earth Pro.app, version 7.3, on versionKey CFBundleShortVersionString
2026-05-20 09:39:11 : INFO  : googleearth : appversion: 7.3
2026-05-20 09:39:11 : INFO  : googleearth : Latest version of Google Earth Pro is 7.3
2026-05-20 09:39:11 : INFO  : googleearth : There is no newer version available.
2026-05-20 09:39:11 : INFO  : googleearth : Installomator did not close any apps, so no need to reopen any apps.
2026-05-20 09:39:11 : REQ   : googleearth : No newer version.
2026-05-20 09:39:11 : REQ   : googleearth : ################## End Installomator, exit code 0 
```