### PR TITLE
Fix clickshare appNewVersion

### DIFF
--- a/fragments/labels/clickshare.sh
+++ b/fragments/labels/clickshare.sh
@@ -2,7 +2,7 @@ clickshare)
     name="ClickShare"
     type="zip"
     json_feed=$(curl -fsL "https://assets.cloud.barco.com/clickshare/release/release.mac")
-    appNewVersion=$(getJSONValue "${json_feed}" 'version')
+    appNewVersion=$(getJSONValue "${json_feed}" 'version' | tr -d 'b' | tr "-" ".")
     file_name=$(getJSONValue "${json_feed}" 'name')
     downloadURL="https://assets.cloud.barco.com/clickshare/release/${file_name}"
     expectedTeamID="P6CDJZR997"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
ClickShare uses a slightly different versioning system on their releases feed. (4.49.0-b11 vs 4.49.0.11)
This PR replaces the -b part with a . to make them match.

**Installomator log**
```
2026-05-20 07:56:58 : INFO  : clickshare : setting variable from argument DEBUG=0
2026-05-20 07:56:58 : INFO  : clickshare : Total items in argumentsArray: 1
2026-05-20 07:56:58 : INFO  : clickshare : argumentsArray: DEBUG=0
2026-05-20 07:56:58 : REQ   : clickshare : ################## Start Installomator v. 10.9, date 2026-05-20
2026-05-20 07:56:58 : INFO  : clickshare : ################## Version: 10.9
2026-05-20 07:56:58 : INFO  : clickshare : ################## Date: 2026-05-20
2026-05-20 07:56:58 : INFO  : clickshare : ################## clickshare
2026-05-20 07:56:58 : INFO  : clickshare : SwiftDialog is not installed, clear cmd file var
2026-05-20 07:56:59 : INFO  : clickshare : Reading arguments again: DEBUG=0
2026-05-20 07:56:59 : INFO  : clickshare : BLOCKING_PROCESS_ACTION=tell_user
2026-05-20 07:56:59 : INFO  : clickshare : NOTIFY=success
2026-05-20 07:57:00 : INFO  : clickshare : LOGGING=INFO
2026-05-20 07:57:00 : INFO  : clickshare : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-20 07:57:00 : INFO  : clickshare : Label type: zip
2026-05-20 07:57:00 : INFO  : clickshare : archiveName: ClickShare.zip
2026-05-20 07:57:00 : INFO  : clickshare : no blocking processes defined, using ClickShare as default
2026-05-20 07:57:00 : INFO  : clickshare : name: ClickShare, appName: ClickShare.app
2026-05-20 07:57:00 : WARN  : clickshare : No previous app found
2026-05-20 07:57:00 : WARN  : clickshare : could not find ClickShare.app
2026-05-20 07:57:00 : INFO  : clickshare : appversion:
2026-05-20 07:57:00 : INFO  : clickshare : Latest version of ClickShare is 4.49.0.11
2026-05-20 07:57:00 : REQ   : clickshare : Downloading https://assets.cloud.barco.com/clickshare/release/ClickShare-4.49.0-b11_mac.zip to ClickShare.zip
2026-05-20 07:57:20 : INFO  : clickshare : Downloaded ClickShare.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 98c8cfc71906bc192f35bd4d1be5638fd1dfc80a – Size is 164172 kB
2026-05-20 07:57:20 : REQ   : clickshare : no more blocking processes, continue with update
2026-05-20 07:57:20 : REQ   : clickshare : Installing ClickShare
2026-05-20 07:57:20 : INFO  : clickshare : Unzipping ClickShare.zip
2026-05-20 07:57:21 : INFO  : clickshare : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YC1cY5Nto3/ClickShare.app
2026-05-20 07:57:21 : INFO  : clickshare : Team ID matching: P6CDJZR997 (expected: P6CDJZR997 )
2026-05-20 07:57:21 : INFO  : clickshare : Installing ClickShare version 4.49.0.11 on versionKey CFBundleShortVersionString.
2026-05-20 07:57:21 : INFO  : clickshare : App has LSMinimumSystemVersion: 10.15
2026-05-20 07:57:22 : INFO  : clickshare : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.YC1cY5Nto3/ClickShare.app to /Applications
2026-05-20 07:57:22 : WARN  : clickshare : Changing owner to admin
2026-05-20 07:57:22 : INFO  : clickshare : Finishing...
2026-05-20 07:57:25 : INFO  : clickshare : App(s) found: /Applications/ClickShare.app
2026-05-20 07:57:25 : INFO  : clickshare : found app at /Applications/ClickShare.app, version 4.49.0.11, on versionKey CFBundleShortVersionString
2026-05-20 07:57:25 : REQ   : clickshare : Installed ClickShare, version 4.49.0.11
2026-05-20 07:57:25 : INFO  : clickshare : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-05-20 07:57:25 : INFO  : clickshare : Installomator did not close any apps, so no need to reopen any apps.
2026-05-20 07:57:25 : REQ   : clickshare : All done!
2026-05-20 07:57:25 : REQ   : clickshare : ################## End Installomator, exit code 0
```