### PR TITLE
Update boxdrive.sh

### DIFF
--- a/fragments/labels/boxdrive.sh
+++ b/fragments/labels/boxdrive.sh
@@ -1,8 +1,9 @@
 boxdrive)
     name="Box"
     type="pkg"
-    packageID="com.box.desktop.installer.desktop"
-    appNewVersion=$(curl -fsL "https://formulae.brew.sh/api/cask/box-drive.json" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 | cut -d',' -f1)
-    downloadURL="https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-${appNewVersion}.pkg"
+    jsonFeed=$(curl -fsL "https://cdn07.boxcdn.net/Autoupdate6.json")
+    macDetails=$(getJSONValue "$jsonFeed" "mac.enterprise")
+    appNewVersion=$(getJSONValue "$macDetails" "version")
+    downloadURL=$(getJSONValue "$macDetails" '["download-url"]')
     expectedTeamID="M683GB7CPW"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
This removes the `packageID` variable and lets the version check happen on the app. Also switches the feed for `appNewVersion` and `downloadURL` to the official box json feed instead of using the brew feed.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./utils/assemble.sh boxdrive
2026-05-24 14:56:15 : INFO  : boxdrive : Total items in argumentsArray: 0
2026-05-24 14:56:15 : INFO  : boxdrive : argumentsArray: 
2026-05-24 14:56:15 : REQ   : boxdrive : ################## Start Installomator v. 10.9beta, date 2026-05-24
2026-05-24 14:56:15 : INFO  : boxdrive : ################## Version: 10.9beta
2026-05-24 14:56:15 : INFO  : boxdrive : ################## Date: 2026-05-24
2026-05-24 14:56:15 : INFO  : boxdrive : ################## boxdrive
2026-05-24 14:56:15 : DEBUG : boxdrive : DEBUG mode 1 enabled.
2026-05-24 14:56:16 : INFO  : boxdrive : Reading arguments again: 
2026-05-24 14:56:16 : DEBUG : boxdrive : name=Box
2026-05-24 14:56:16 : DEBUG : boxdrive : appName=
2026-05-24 14:56:16 : DEBUG : boxdrive : type=pkg
2026-05-24 14:56:16 : DEBUG : boxdrive : archiveName=
2026-05-24 14:56:16 : DEBUG : boxdrive : downloadURL=https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-2.51.233.pkg
2026-05-24 14:56:16 : DEBUG : boxdrive : curlOptions=
2026-05-24 14:56:16 : DEBUG : boxdrive : appNewVersion=2.51.233
2026-05-24 14:56:16 : DEBUG : boxdrive : appCustomVersion function: Not defined
2026-05-24 14:56:16 : DEBUG : boxdrive : versionKey=CFBundleShortVersionString
2026-05-24 14:56:16 : DEBUG : boxdrive : packageID=
2026-05-24 14:56:16 : DEBUG : boxdrive : pkgName=
2026-05-24 14:56:16 : DEBUG : boxdrive : choiceChangesXML=
2026-05-24 14:56:16 : DEBUG : boxdrive : expectedTeamID=M683GB7CPW
2026-05-24 14:56:16 : DEBUG : boxdrive : blockingProcesses=
2026-05-24 14:56:16 : DEBUG : boxdrive : installerTool=
2026-05-24 14:56:16 : DEBUG : boxdrive : CLIInstaller=
2026-05-24 14:56:16 : DEBUG : boxdrive : CLIArguments=
2026-05-24 14:56:16 : DEBUG : boxdrive : updateTool=
2026-05-24 14:56:16 : DEBUG : boxdrive : updateToolArguments=
2026-05-24 14:56:16 : DEBUG : boxdrive : updateToolRunAsCurrentUser=
2026-05-24 14:56:16 : INFO  : boxdrive : BLOCKING_PROCESS_ACTION=tell_user
2026-05-24 14:56:16 : INFO  : boxdrive : NOTIFY=success
2026-05-24 14:56:16 : INFO  : boxdrive : LOGGING=DEBUG
2026-05-24 14:56:16 : INFO  : boxdrive : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-24 14:56:16 : INFO  : boxdrive : Label type: pkg
2026-05-24 14:56:16 : INFO  : boxdrive : archiveName: Box.pkg
2026-05-24 14:56:16 : INFO  : boxdrive : no blocking processes defined, using Box as default
2026-05-24 14:56:16 : DEBUG : boxdrive : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-24 14:56:16 : INFO  : boxdrive : App(s) found: /Applications/Box.app
2026-05-24 14:56:16 : INFO  : boxdrive : found app at /Applications/Box.app, version 2.51.233, on versionKey CFBundleShortVersionString
2026-05-24 14:56:16 : INFO  : boxdrive : appversion: 2.51.233
2026-05-24 14:56:16 : INFO  : boxdrive : Latest version of Box is 2.51.233
2026-05-24 14:56:16 : WARN  : boxdrive : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-24 14:56:16 : REQ   : boxdrive : Downloading https://e3.boxcdn.net/desktop/releases/mac/BoxDrive-2.51.233.pkg to Box.pkg
2026-05-24 14:56:16 : DEBUG : boxdrive : No Dialog connection, just download
2026-05-24 14:57:54 : INFO  : boxdrive : Downloaded Box.pkg – Type is  xar archive compressed TOC – SHA is 3335d295b27ae0b4bc3fc8a7783377870b41ab03 – Size is 60444 kB
2026-05-24 14:57:54 : DEBUG : boxdrive : DEBUG mode 1, not checking for blocking processes
2026-05-24 14:57:54 : REQ   : boxdrive : Installing Box
2026-05-24 14:57:54 : INFO  : boxdrive : Verifying: Box.pkg
2026-05-24 14:57:54 : DEBUG : boxdrive : File list: -rw-r--r--  1 gilburns  staff    58M May 24 14:57 Box.pkg
2026-05-24 14:57:54 : DEBUG : boxdrive : File type: Box.pkg: xar archive compressed TOC: 5357, SHA-1 checksum
2026-05-24 14:57:54 : DEBUG : boxdrive : spctlOut is Box.pkg: accepted
2026-05-24 14:57:54 : DEBUG : boxdrive : source=Notarized Developer ID
2026-05-24 14:57:54 : DEBUG : boxdrive : origin=Developer ID Installer: Box, Inc. (M683GB7CPW)
2026-05-24 14:57:54 : INFO  : boxdrive : Team ID: M683GB7CPW (expected: M683GB7CPW )
2026-05-24 14:57:54 : DEBUG : boxdrive : DEBUG enabled, skipping installation
2026-05-24 14:57:54 : INFO  : boxdrive : Finishing...
2026-05-24 14:57:57 : INFO  : boxdrive : App(s) found: /Applications/Box.app
2026-05-24 14:57:58 : INFO  : boxdrive : found app at /Applications/Box.app, version 2.51.233, on versionKey CFBundleShortVersionString
2026-05-24 14:57:58 : REQ   : boxdrive : Installed Box, version 2.51.233
2026-05-24 14:57:58 : INFO  : boxdrive : notifying
2026-05-24 14:57:58 : DEBUG : boxdrive : DEBUG mode 1, not reopening anything
2026-05-24 14:57:58 : REQ   : boxdrive : All done!
2026-05-24 14:57:58 : REQ   : boxdrive : ################## End Installomator, exit code 0 
```
