### PR TITLE
Update airserver.sh

### DIFF
--- a/fragments/labels/airserver.sh
+++ b/fragments/labels/airserver.sh
@@ -1,8 +1,7 @@
 airserver)
-    # credit: AP Orlebeke (@apizz)
     name="AirServer"
     type="dmg"
     downloadURL="https://www.airserver.com/download/mac/latest"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "location" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g')
+    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "location" | sed -E 's/.*\/[a-zA-Z]*-([0-9.]*)\..*/\1/g' | head -1)
     expectedTeamID="6C755KS5W3"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Fix failing `appNewVersion` that was getting 2 lines by adding `head -1`.
Removed unnecessary comments from the label.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./utils/assemble.sh airserver                              
2026-05-25 16:39:16 : INFO  : airserver : Total items in argumentsArray: 0
2026-05-25 16:39:16 : INFO  : airserver : argumentsArray: 
2026-05-25 16:39:16 : REQ   : airserver : ################## Start Installomator v. 10.9beta, date 2026-05-25
2026-05-25 16:39:16 : INFO  : airserver : ################## Version: 10.9beta
2026-05-25 16:39:16 : INFO  : airserver : ################## Date: 2026-05-25
2026-05-25 16:39:16 : INFO  : airserver : ################## airserver
2026-05-25 16:39:16 : DEBUG : airserver : DEBUG mode 1 enabled.
2026-05-25 16:39:18 : INFO  : airserver : Reading arguments again: 
2026-05-25 16:39:18 : DEBUG : airserver : name=AirServer
2026-05-25 16:39:18 : DEBUG : airserver : appName=
2026-05-25 16:39:18 : DEBUG : airserver : type=dmg
2026-05-25 16:39:18 : DEBUG : airserver : archiveName=
2026-05-25 16:39:18 : DEBUG : airserver : downloadURL=https://www.airserver.com/download/mac/latest
2026-05-25 16:39:18 : DEBUG : airserver : curlOptions=
2026-05-25 16:39:18 : DEBUG : airserver : appNewVersion=7.3.1
2026-05-25 16:39:18 : DEBUG : airserver : appCustomVersion function: Not defined
2026-05-25 16:39:18 : DEBUG : airserver : versionKey=CFBundleShortVersionString
2026-05-25 16:39:18 : DEBUG : airserver : packageID=
2026-05-25 16:39:18 : DEBUG : airserver : pkgName=
2026-05-25 16:39:18 : DEBUG : airserver : choiceChangesXML=
2026-05-25 16:39:18 : DEBUG : airserver : expectedTeamID=6C755KS5W3
2026-05-25 16:39:18 : DEBUG : airserver : blockingProcesses=
2026-05-25 16:39:18 : DEBUG : airserver : installerTool=
2026-05-25 16:39:18 : DEBUG : airserver : CLIInstaller=
2026-05-25 16:39:18 : DEBUG : airserver : CLIArguments=
2026-05-25 16:39:18 : DEBUG : airserver : updateTool=
2026-05-25 16:39:18 : DEBUG : airserver : updateToolArguments=
2026-05-25 16:39:18 : DEBUG : airserver : updateToolRunAsCurrentUser=
2026-05-25 16:39:18 : INFO  : airserver : BLOCKING_PROCESS_ACTION=tell_user
2026-05-25 16:39:18 : INFO  : airserver : NOTIFY=success
2026-05-25 16:39:18 : INFO  : airserver : LOGGING=DEBUG
2026-05-25 16:39:18 : INFO  : airserver : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-25 16:39:18 : INFO  : airserver : Label type: dmg
2026-05-25 16:39:18 : INFO  : airserver : archiveName: AirServer.dmg
2026-05-25 16:39:18 : INFO  : airserver : no blocking processes defined, using AirServer as default
2026-05-25 16:39:18 : DEBUG : airserver : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-25 16:39:18 : INFO  : airserver : name: AirServer, appName: AirServer.app
2026-05-25 16:39:18 : WARN  : airserver : No previous app found
2026-05-25 16:39:18 : WARN  : airserver : could not find AirServer.app
2026-05-25 16:39:18 : INFO  : airserver : appversion: 
2026-05-25 16:39:18 : INFO  : airserver : Latest version of AirServer is 7.3.1
2026-05-25 16:39:18 : REQ   : airserver : Downloading https://www.airserver.com/download/mac/latest to AirServer.dmg
2026-05-25 16:39:18 : DEBUG : airserver : No Dialog connection, just download
2026-05-25 16:40:00 : INFO  : airserver : Downloaded AirServer.dmg – Type is  zlib compressed data – SHA is 0160cc710d690797d0180ac4331097a560531e6b – Size is 33808 kB
2026-05-25 16:40:00 : DEBUG : airserver : DEBUG mode 1, not checking for blocking processes
2026-05-25 16:40:00 : REQ   : airserver : Installing AirServer
2026-05-25 16:40:00 : INFO  : airserver : Mounting /Users/gilburns/GitHub/Installomator/build/AirServer.dmg
2026-05-25 16:40:04 : DEBUG : airserver : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $252B40D3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $69D56621
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F6B8CFF1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $11A47DDE
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F6B8CFF1
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $69C18043
verified   CRC32 $02624785
/dev/disk79         	GUID_partition_scheme
/dev/disk79s1       	Apple_HFS                      	/Volumes/AirServer 7.3.1

2026-05-25 16:40:04 : INFO  : airserver : Mounted: /Volumes/AirServer 7.3.1
2026-05-25 16:40:04 : INFO  : airserver : Verifying: /Volumes/AirServer 7.3.1/AirServer.app
2026-05-25 16:40:04 : DEBUG : airserver : App size:  59M	/Volumes/AirServer 7.3.1/AirServer.app
2026-05-25 16:40:05 : DEBUG : airserver : Debugging enabled, App Verification output was:
/Volumes/AirServer 7.3.1/AirServer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: App Dynamic (6C755KS5W3)

2026-05-25 16:40:05 : INFO  : airserver : Team ID matching: 6C755KS5W3 (expected: 6C755KS5W3 )
2026-05-25 16:40:05 : INFO  : airserver : Installing AirServer version 7.3.1 on versionKey CFBundleShortVersionString.
2026-05-25 16:40:05 : INFO  : airserver : App has LSMinimumSystemVersion: 10.13
2026-05-25 16:40:05 : DEBUG : airserver : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-25 16:40:05 : INFO  : airserver : Finishing...
2026-05-25 16:40:08 : INFO  : airserver : name: AirServer, appName: AirServer.app
2026-05-25 16:40:08 : WARN  : airserver : No previous app found
2026-05-25 16:40:08 : WARN  : airserver : could not find AirServer.app
2026-05-25 16:40:08 : REQ   : airserver : Installed AirServer, version 7.3.1
2026-05-25 16:40:08 : INFO  : airserver : notifying
2026-05-25 16:40:09 : DEBUG : airserver : Unmounting /Volumes/AirServer 7.3.1
2026-05-25 16:40:20 : DEBUG : airserver : Debugging enabled, Unmounting output was:
"disk79" ejected.
2026-05-25 16:40:20 : DEBUG : airserver : DEBUG mode 1, not reopening anything
2026-05-25 16:40:20 : REQ   : airserver : All done!
2026-05-25 16:40:20 : REQ   : airserver : ################## End Installomator, exit code 0 

```