### PR TITLE
Update flstudiomac.sh

### DIFF
--- a/fragments/labels/flstudiomac.sh
+++ b/fragments/labels/flstudiomac.sh
@@ -1,15 +1,9 @@
 flstudiomac)
-    name="flstudiomac"
+    name="FL Studio"
+    appName="FL Studio 2025.app"
     type="pkgInDmg"
-    packageID="com.Image-Line.pkg.flcloud.plugins
-com.Image-Line.pkg.24ONLINE"
     downloadURL="https://support.image-line.com/redirect/flstudio_mac_installer"
     curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15" )
-    appNewVersion=$(curl -fsL "https://support.image-line.com/api.php?call=get_version_info&callback=il_get_version_info_cb&prod_type=undefined" | \
-        sed 's/var get_version_info_res;get_version_info_res = il_get_version_info_cb(//;s/);$//' | \
-        sed 's/\\//g' | \
-        grep -o '"os":"mac","version":"[0-9.]*"' | \
-        sed 's/.*"version":"\([0-9.]*\)".*/\1/')
+    appNewVersion=$(curl -fsIL "https://support.image-line.com/redirect/flstudio_mac_installer" | grep -i ^location | tail -1 | sed 's/.*flstudio_mac_\([0-9]*\.[0-9]*\.[0-9]*\.[0-9]*\)\.dmg.*/\1/')
     expectedTeamID="N68WEP5ZZZ"
     ;;
-    


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Label was broken and not resolving the appNewVersion
App name changed.
Removed the packageID and let the version check use the installed app.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


[](./utils/assemble.sh flstudiomac            
2026-05-25 18:59:32 : INFO  : flstudiomac : Total items in argumentsArray: 0
2026-05-25 18:59:33 : INFO  : flstudiomac : argumentsArray: 
2026-05-25 18:59:33 : REQ   : flstudiomac : ################## Start Installomator v. 10.9beta, date 2026-05-25
2026-05-25 18:59:33 : INFO  : flstudiomac : ################## Version: 10.9beta
2026-05-25 18:59:33 : INFO  : flstudiomac : ################## Date: 2026-05-25
2026-05-25 18:59:33 : INFO  : flstudiomac : ################## flstudiomac
2026-05-25 18:59:33 : DEBUG : flstudiomac : DEBUG mode 1 enabled.
2026-05-25 18:59:34 : INFO  : flstudiomac : Reading arguments again: 
2026-05-25 18:59:34 : DEBUG : flstudiomac : name=FL Studio 2025
2026-05-25 18:59:34 : DEBUG : flstudiomac : appName=
2026-05-25 18:59:34 : DEBUG : flstudiomac : type=pkgInDmg
2026-05-25 18:59:34 : DEBUG : flstudiomac : archiveName=
2026-05-25 18:59:34 : DEBUG : flstudiomac : downloadURL=https://support.image-line.com/redirect/flstudio_mac_installer
2026-05-25 18:59:34 : DEBUG : flstudiomac : curlOptions=-H User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Safari/605.1.15
2026-05-25 18:59:34 : DEBUG : flstudiomac : appNewVersion=25.2.5.5055
2026-05-25 18:59:34 : DEBUG : flstudiomac : appCustomVersion function: Not defined
2026-05-25 18:59:34 : DEBUG : flstudiomac : versionKey=CFBundleShortVersionString
2026-05-25 18:59:34 : DEBUG : flstudiomac : packageID=
2026-05-25 18:59:34 : DEBUG : flstudiomac : pkgName=
2026-05-25 18:59:34 : DEBUG : flstudiomac : choiceChangesXML=
2026-05-25 18:59:34 : DEBUG : flstudiomac : expectedTeamID=N68WEP5ZZZ
2026-05-25 18:59:34 : DEBUG : flstudiomac : blockingProcesses=
2026-05-25 18:59:34 : DEBUG : flstudiomac : installerTool=
2026-05-25 18:59:34 : DEBUG : flstudiomac : CLIInstaller=
2026-05-25 18:59:34 : DEBUG : flstudiomac : CLIArguments=
2026-05-25 18:59:34 : DEBUG : flstudiomac : updateTool=
2026-05-25 18:59:34 : DEBUG : flstudiomac : updateToolArguments=
2026-05-25 18:59:34 : DEBUG : flstudiomac : updateToolRunAsCurrentUser=
2026-05-25 18:59:34 : INFO  : flstudiomac : BLOCKING_PROCESS_ACTION=tell_user
2026-05-25 18:59:34 : INFO  : flstudiomac : NOTIFY=success
2026-05-25 18:59:34 : INFO  : flstudiomac : LOGGING=DEBUG
2026-05-25 18:59:34 : INFO  : flstudiomac : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-25 18:59:34 : INFO  : flstudiomac : Label type: pkgInDmg
2026-05-25 18:59:34 : INFO  : flstudiomac : archiveName: FL Studio 2025.dmg
2026-05-25 18:59:34 : INFO  : flstudiomac : no blocking processes defined, using FL Studio 2025 as default
2026-05-25 18:59:34 : DEBUG : flstudiomac : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-25 18:59:34 : INFO  : flstudiomac : App(s) found: /Applications/FL Studio 2025.app
2026-05-25 18:59:34 : INFO  : flstudiomac : found app at /Applications/FL Studio 2025.app, version 25.2.5.5055, on versionKey CFBundleShortVersionString
2026-05-25 18:59:34 : INFO  : flstudiomac : appversion: 25.2.5.5055
2026-05-25 18:59:34 : INFO  : flstudiomac : Latest version of FL Studio 2025 is 25.2.5.5055
2026-05-25 18:59:34 : WARN  : flstudiomac : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-25 18:59:34 : REQ   : flstudiomac : Downloading https://support.image-line.com/redirect/flstudio_mac_installer to FL Studio 2025.dmg
2026-05-25 18:59:34 : DEBUG : flstudiomac : No Dialog connection, just download
2026-05-25 19:47:40 : INFO  : flstudiomac : Downloaded FL Studio 2025.dmg – Type is  zlib compressed data – SHA is cfd20ee6a6f5b21ed1d36caaf17267d91034cbcf – Size is 1114132 kB
2026-05-25 19:47:40 : DEBUG : flstudiomac : DEBUG mode 1, not checking for blocking processes
2026-05-25 19:47:40 : REQ   : flstudiomac : Installing FL Studio 2025
2026-05-25 19:47:40 : INFO  : flstudiomac : Mounting /Users/gilburns/GitHub/Installomator/build/FL Studio 2025.dmg
2026-05-25 19:47:45 : DEBUG : flstudiomac : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D7B75018
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $A5715F73
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $51FA9240
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $4EEBADB6
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $51FA9240
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $1BCC187A
verified   CRC32 $A6E2214F
/dev/disk79         	GUID_partition_scheme
/dev/disk79s1       	Apple_HFS                      	/Volumes/FL Studio

2026-05-25 19:47:45 : INFO  : flstudiomac : Mounted: /Volumes/FL Studio
2026-05-25 19:47:45 : DEBUG : flstudiomac : Found pkg(s):
/Volumes/FL Studio/Install FL Studio.pkg
2026-05-25 19:47:45 : INFO  : flstudiomac : found pkg: /Volumes/FL Studio/Install FL Studio.pkg
2026-05-25 19:47:45 : INFO  : flstudiomac : Verifying: /Volumes/FL Studio/Install FL Studio.pkg
2026-05-25 19:47:45 : DEBUG : flstudiomac : File list: -rw-r--r--  1 gilburns  staff   1.1G Mar  6 06:34 /Volumes/FL Studio/Install FL Studio.pkg
2026-05-25 19:47:45 : DEBUG : flstudiomac : File type: /Volumes/FL Studio/Install FL Studio.pkg: xar archive compressed TOC: 7475, SHA-1 checksum
2026-05-25 19:47:46 : DEBUG : flstudiomac : spctlOut is /Volumes/FL Studio/Install FL Studio.pkg: accepted
2026-05-25 19:47:46 : DEBUG : flstudiomac : source=Notarized Developer ID
2026-05-25 19:47:46 : DEBUG : flstudiomac : origin=Developer ID Installer: image-line (N68WEP5ZZZ)
2026-05-25 19:47:46 : INFO  : flstudiomac : Team ID: N68WEP5ZZZ (expected: N68WEP5ZZZ )
2026-05-25 19:47:46 : DEBUG : flstudiomac : DEBUG enabled, skipping installation
2026-05-25 19:47:46 : INFO  : flstudiomac : Finishing...
2026-05-25 19:47:49 : INFO  : flstudiomac : App(s) found: /Applications/FL Studio 2025.app
2026-05-25 19:47:49 : INFO  : flstudiomac : found app at /Applications/FL Studio 2025.app, version 25.2.5.5055, on versionKey CFBundleShortVersionString
2026-05-25 19:47:49 : REQ   : flstudiomac : Installed FL Studio 2025, version 25.2.5.5055
2026-05-25 19:47:49 : INFO  : flstudiomac : notifying
2026-05-25 19:47:50 : DEBUG : flstudiomac : Unmounting /Volumes/FL Studio
2026-05-25 19:48:00 : DEBUG : flstudiomac : Debugging enabled, Unmounting output was:
"disk79" ejected.
2026-05-25 19:48:00 : DEBUG : flstudiomac : DEBUG mode 1, not reopening anything
2026-05-25 19:48:00 : REQ   : flstudiomac : All done!
2026-05-25 19:48:00 : REQ   : flstudiomac : ################## End Installomator, exit code 0 )
