### PR TITLE
Update bitwigstudio.sh

### DIFF
--- a/fragments/labels/bitwigstudio.sh
+++ b/fragments/labels/bitwigstudio.sh
@@ -1,7 +1,8 @@
 bitwigstudio)
     name="Bitwig Studio"
     type="dmg"
-    appNewVersion="$(curl -fs "https://www.bitwig.com/download/" | grep 'changelog' | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/')"
-    downloadURL="https://www.bitwig.com/dl/Bitwig%20Studio/${appNewVersion}/installer_mac/"
+    bitwigDetails=$(curl -sfL "https://www.bitwig.com/previous_releases/" | grep -o 'href="https://www\.bitwig\.com/dl/Bitwig%20Studio/[^/]*/installer_mac/"' | head -1 )
+    appNewVersion=$(echo $bitwigDetails | grep -o 'Studio/[^/]*/installer' | awk -F'/' '{print $2}')
+    downloadURL=$(echo $bitwigDetails | grep -o 'https://[^"]*')
     expectedTeamID="2B6K987585"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Fixed broken `appNewVersion` and `downloadURL` variables.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./utils/assemble.sh bitwigstudio
2026-05-25 20:25:29 : INFO  : bitwigstudio : Total items in argumentsArray: 0
2026-05-25 20:25:29 : INFO  : bitwigstudio : argumentsArray: 
2026-05-25 20:25:29 : REQ   : bitwigstudio : ################## Start Installomator v. 10.9beta, date 2026-05-25
2026-05-25 20:25:29 : INFO  : bitwigstudio : ################## Version: 10.9beta
2026-05-25 20:25:29 : INFO  : bitwigstudio : ################## Date: 2026-05-25
2026-05-25 20:25:29 : INFO  : bitwigstudio : ################## bitwigstudio
2026-05-25 20:25:29 : DEBUG : bitwigstudio : DEBUG mode 1 enabled.
2026-05-25 20:25:32 : INFO  : bitwigstudio : Reading arguments again: 
2026-05-25 20:25:32 : DEBUG : bitwigstudio : name=Bitwig Studio
2026-05-25 20:25:32 : DEBUG : bitwigstudio : appName=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : type=dmg
2026-05-25 20:25:32 : DEBUG : bitwigstudio : archiveName=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : downloadURL=https://www.bitwig.com/dl/Bitwig%20Studio/6.0.6/installer_mac/
2026-05-25 20:25:32 : DEBUG : bitwigstudio : curlOptions=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : appNewVersion=6.0.6
2026-05-25 20:25:32 : DEBUG : bitwigstudio : appCustomVersion function: Not defined
2026-05-25 20:25:32 : DEBUG : bitwigstudio : versionKey=CFBundleShortVersionString
2026-05-25 20:25:32 : DEBUG : bitwigstudio : packageID=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : pkgName=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : choiceChangesXML=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : expectedTeamID=2B6K987585
2026-05-25 20:25:32 : DEBUG : bitwigstudio : blockingProcesses=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : installerTool=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : CLIInstaller=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : CLIArguments=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : updateTool=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : updateToolArguments=
2026-05-25 20:25:32 : DEBUG : bitwigstudio : updateToolRunAsCurrentUser=
2026-05-25 20:25:32 : INFO  : bitwigstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-05-25 20:25:32 : INFO  : bitwigstudio : NOTIFY=success
2026-05-25 20:25:32 : INFO  : bitwigstudio : LOGGING=DEBUG
2026-05-25 20:25:32 : INFO  : bitwigstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-25 20:25:32 : INFO  : bitwigstudio : Label type: dmg
2026-05-25 20:25:32 : INFO  : bitwigstudio : archiveName: Bitwig Studio.dmg
2026-05-25 20:25:32 : INFO  : bitwigstudio : no blocking processes defined, using Bitwig Studio as default
2026-05-25 20:25:32 : DEBUG : bitwigstudio : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-25 20:25:32 : INFO  : bitwigstudio : name: Bitwig Studio, appName: Bitwig Studio.app
2026-05-25 20:25:33 : WARN  : bitwigstudio : No previous app found
2026-05-25 20:25:33 : WARN  : bitwigstudio : could not find Bitwig Studio.app
2026-05-25 20:25:33 : INFO  : bitwigstudio : appversion: 
2026-05-25 20:25:33 : INFO  : bitwigstudio : Latest version of Bitwig Studio is 6.0.6
2026-05-25 20:25:33 : REQ   : bitwigstudio : Downloading https://www.bitwig.com/dl/Bitwig%20Studio/6.0.6/installer_mac/ to Bitwig Studio.dmg
2026-05-25 20:25:33 : DEBUG : bitwigstudio : No Dialog connection, just download
2026-05-25 20:47:50 : INFO  : bitwigstudio : Downloaded Bitwig Studio.dmg – Type is  zlib compressed data – SHA is 0beb1814f3f30b55579bb8a7a57705fc798c0d12 – Size is 540736 kB
2026-05-25 20:47:50 : DEBUG : bitwigstudio : DEBUG mode 1, not checking for blocking processes
2026-05-25 20:47:50 : REQ   : bitwigstudio : Installing Bitwig Studio
2026-05-25 20:47:50 : INFO  : bitwigstudio : Mounting /Users/gilburns/GitHub/Installomator/build/Bitwig Studio.dmg
2026-05-25 20:47:51 : DEBUG : bitwigstudio : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $AD71C74C
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $E7E6381B
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $A648A58A
verified   CRC32 $DE0D3F54
/dev/disk79         	Apple_partition_scheme
/dev/disk79s1       	Apple_partition_map
/dev/disk79s2       	Apple_HFS                      	/Volumes/Bitwig Studio 6.0.6

2026-05-25 20:47:51 : INFO  : bitwigstudio : Mounted: /Volumes/Bitwig Studio 6.0.6
2026-05-25 20:47:51 : INFO  : bitwigstudio : Verifying: /Volumes/Bitwig Studio 6.0.6/Bitwig Studio.app
2026-05-25 20:47:52 : DEBUG : bitwigstudio : App size: 874M	/Volumes/Bitwig Studio 6.0.6/Bitwig Studio.app
2026-05-25 20:47:59 : DEBUG : bitwigstudio : Debugging enabled, App Verification output was:
/Volumes/Bitwig Studio 6.0.6/Bitwig Studio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bitwig GmbH (2B6K987585)

2026-05-25 20:47:59 : INFO  : bitwigstudio : Team ID matching: 2B6K987585 (expected: 2B6K987585 )
2026-05-25 20:47:59 : INFO  : bitwigstudio : Installing Bitwig Studio version 6.0.6 on versionKey CFBundleShortVersionString.
2026-05-25 20:47:59 : INFO  : bitwigstudio : App has LSMinimumSystemVersion: 10.7
2026-05-25 20:47:59 : DEBUG : bitwigstudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-25 20:47:59 : INFO  : bitwigstudio : Finishing...
2026-05-25 20:48:02 : INFO  : bitwigstudio : name: Bitwig Studio, appName: Bitwig Studio.app
2026-05-25 20:48:03 : WARN  : bitwigstudio : No previous app found
2026-05-25 20:48:03 : WARN  : bitwigstudio : could not find Bitwig Studio.app
2026-05-25 20:48:03 : REQ   : bitwigstudio : Installed Bitwig Studio, version 6.0.6
2026-05-25 20:48:03 : INFO  : bitwigstudio : notifying
2026-05-25 20:48:03 : DEBUG : bitwigstudio : Unmounting /Volumes/Bitwig Studio 6.0.6
2026-05-25 20:48:14 : DEBUG : bitwigstudio : Debugging enabled, Unmounting output was:
"disk79" ejected.
2026-05-25 20:48:14 : DEBUG : bitwigstudio : DEBUG mode 1, not reopening anything
2026-05-25 20:48:14 : REQ   : bitwigstudio : All done!
2026-05-25 20:48:14 : REQ   : bitwigstudio : ################## End Installomator, exit code 0 

```