### PR TITLE
Label for Gram editor

### DIFF
--- a/fragments/labels/gram.sh
+++ b/fragments/labels/gram.sh
@@ -1,0 +1,10 @@
+gram)
+     name="Gram Editor"
+     type="dmg"
+     packageID="app.liten.Gram"
+     appNewVersion="$(curl "https://codeberg.org/GramEditor/gram/releases.rss" | xmllint --xpath 'string(//item/title)' -)"
+     downloadURL="$([[ $(/usr/bin/arch) == "arm64" ]] && echo "https://codeberg.org/GramEditor/gram/releases/download/${appNewVersion}/Gram-aarch64-${appNewVersion}.dmg" || echo "https://ziranpub.b-cdn.net/Gram-x86_64-${appNewVersion}.dmg")"
+     expectedTeamID="TQ3LTB39SU"
+     appName="Gram.app"
+     blockingProcesses=( "gram" "Gram" )
+;;

--- a/fragments/labels/gram.sh
+++ b/fragments/labels/gram.sh
@@ -1,10 +1,9 @@
 gram)
      name="Gram Editor"
      type="dmg"
-     packageID="app.liten.Gram"
+     appName="Gram.app"
      appNewVersion="$(curl "https://codeberg.org/GramEditor/gram/releases.rss" | xmllint --xpath 'string(//item/title)' -)"
      downloadURL="$([[ $(/usr/bin/arch) == "arm64" ]] && echo "https://codeberg.org/GramEditor/gram/releases/download/${appNewVersion}/Gram-aarch64-${appNewVersion}.dmg" || echo "https://ziranpub.b-cdn.net/Gram-x86_64-${appNewVersion}.dmg")"
      expectedTeamID="TQ3LTB39SU"
-     appName="Gram.app"
      blockingProcesses=( "gram" "Gram" )
 ;;

--- a/fragments/labels/gram.sh
+++ b/fragments/labels/gram.sh
@@ -2,7 +2,7 @@ gram)
      name="Gram Editor"
      type="dmg"
      appName="Gram.app"
-     appNewVersion="$(curl "https://codeberg.org/GramEditor/gram/releases.rss" | xmllint --xpath 'string(//item/title)' -)"
+     appNewVersion="$(curl -fsL "https://codeberg.org/GramEditor/gram/releases.rss" | xmllint --xpath 'string(//item/title)' -)"
      downloadURL="$([[ $(/usr/bin/arch) == "arm64" ]] && echo "https://codeberg.org/GramEditor/gram/releases/download/${appNewVersion}/Gram-aarch64-${appNewVersion}.dmg" || echo "https://ziranpub.b-cdn.net/Gram-x86_64-${appNewVersion}.dmg")"
      expectedTeamID="TQ3LTB39SU"
      blockingProcesses=( "gram" "Gram" )


### PR DESCRIPTION
https://gram.liten.app

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
None

```
2026-05-26 09:21:25 : INFO  : gram : Total items in argumentsArray: 0
2026-05-26 09:21:25 : INFO  : gram : argumentsArray: 
2026-05-26 09:21:25 : REQ   : gram : ################## Start Installomator v. 10.9beta, date 2026-05-22
2026-05-26 09:21:25 : INFO  : gram : ################## Version: 10.9beta
2026-05-26 09:21:25 : INFO  : gram : ################## Date: 2026-05-22
2026-05-26 09:21:25 : INFO  : gram : ################## gram
2026-05-26 09:21:25 : DEBUG : gram : DEBUG mode 1 enabled.
2026-05-26 09:21:26 : INFO  : gram : Reading arguments again: 
2026-05-26 09:21:26 : DEBUG : gram : name=Gram Editor
2026-05-26 09:21:26 : DEBUG : gram : appName=Gram.app
2026-05-26 09:21:26 : DEBUG : gram : type=dmg
2026-05-26 09:21:26 : DEBUG : gram : archiveName=
2026-05-26 09:21:26 : DEBUG : gram : downloadURL=https://codeberg.org/GramEditor/gram/releases/download/2.1.2/Gram-aarch64-2.1.2.dmg
2026-05-26 09:21:26 : DEBUG : gram : curlOptions=
2026-05-26 09:21:26 : DEBUG : gram : appNewVersion=2.1.2
2026-05-26 09:21:26 : DEBUG : gram : appCustomVersion function: Not defined
2026-05-26 09:21:26 : DEBUG : gram : versionKey=CFBundleShortVersionString
2026-05-26 09:21:26 : DEBUG : gram : packageID=app.liten.Gram
2026-05-26 09:21:26 : DEBUG : gram : pkgName=
2026-05-26 09:21:26 : DEBUG : gram : choiceChangesXML=
2026-05-26 09:21:26 : DEBUG : gram : expectedTeamID=TQ3LTB39SU
2026-05-26 09:21:26 : DEBUG : gram : blockingProcesses=gram Gram
2026-05-26 09:21:26 : DEBUG : gram : installerTool=
2026-05-26 09:21:26 : DEBUG : gram : CLIInstaller=
2026-05-26 09:21:26 : DEBUG : gram : CLIArguments=
2026-05-26 09:21:26 : DEBUG : gram : updateTool=
2026-05-26 09:21:26 : DEBUG : gram : updateToolArguments=
2026-05-26 09:21:26 : DEBUG : gram : updateToolRunAsCurrentUser=
2026-05-26 09:21:26 : INFO  : gram : BLOCKING_PROCESS_ACTION=tell_user
2026-05-26 09:21:26 : INFO  : gram : NOTIFY=success
2026-05-26 09:21:26 : INFO  : gram : LOGGING=DEBUG
2026-05-26 09:21:26 : INFO  : gram : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-26 09:21:26 : INFO  : gram : Label type: dmg
2026-05-26 09:21:26 : INFO  : gram : archiveName: Gram Editor.dmg
2026-05-26 09:21:27 : DEBUG : gram : Changing directory to .
2026-05-26 09:21:27 : INFO  : gram : No version found using packageID app.liten.Gram
2026-05-26 09:21:27 : INFO  : gram : App(s) found: /Applications/Gram.app
2026-05-26 09:21:27 : INFO  : gram : found app at /Applications/Gram.app, version 2.1.2, on versionKey CFBundleShortVersionString
2026-05-26 09:21:27 : INFO  : gram : appversion: 2.1.2
2026-05-26 09:21:27 : INFO  : gram : Latest version of Gram Editor is 2.1.2
2026-05-26 09:21:27 : WARN  : gram : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-26 09:21:27 : REQ   : gram : Downloading https://codeberg.org/GramEditor/gram/releases/download/2.1.2/Gram-aarch64-2.1.2.dmg to Gram Editor.dmg
2026-05-26 09:21:27 : DEBUG : gram : No Dialog connection, just download
2026-05-26 09:21:33 : INFO  : gram : Downloaded Gram Editor.dmg – Type is  zlib compressed data – SHA is 8a988813d5cd4a2eddfb98a7eccde50c85dd6b27 – Size is 99020 kB
2026-05-26 09:21:33 : DEBUG : gram : DEBUG mode 1, not checking for blocking processes
2026-05-26 09:21:33 : REQ   : gram : Installing Gram Editor
2026-05-26 09:21:33 : INFO  : gram : Mounting ./Gram Editor.dmg
2026-05-26 09:21:36 : DEBUG : gram : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F07D9DBA
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $2A0D5AEA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $25523D2E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $EAAF4C97
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $25523D2E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $083CEB05
verified   CRC32 $2A1F0E75
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Gram

2026-05-26 09:21:36 : INFO  : gram : Mounted: /Volumes/Gram
2026-05-26 09:21:36 : INFO  : gram : Verifying: /Volumes/Gram/Gram.app
2026-05-26 09:21:36 : DEBUG : gram : App size: 264M	/Volumes/Gram/Gram.app
2026-05-26 09:21:38 : DEBUG : gram : Debugging enabled, App Verification output was:
/Volumes/Gram/Gram.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Ziran AB (TQ3LTB39SU)

2026-05-26 09:21:38 : INFO  : gram : Team ID matching: TQ3LTB39SU (expected: TQ3LTB39SU )
2026-05-26 09:21:38 : INFO  : gram : Downloaded version of Gram Editor is 2.1.2 on versionKey CFBundleShortVersionString, same as installed.
2026-05-26 09:21:38 : DEBUG : gram : Unmounting /Volumes/Gram
2026-05-26 09:21:38 : DEBUG : gram : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-05-26 09:21:38 : DEBUG : gram : DEBUG mode 1, not reopening anything
2026-05-26 09:21:38 : REG   : gram : No new version to install
2026-05-26 09:21:38 : REQ   : gram : ################## End Installomator, exit code 0 
```
