### PR TITLE
Create jamf-cli.sh

### DIFF
--- a/fragments/labels/jamf-cli.sh
+++ b/fragments/labels/jamf-cli.sh
@@ -1,0 +1,9 @@
+jamf-cli)
+    name="jamf-cli"
+    type="pkg"
+    downloadURL="$( downloadURLFromGit Jamf-Concepts jamf-cli )"
+    appNewVersion="$( versionFromGit Jamf-Concept jamf-cli )"
+    expectedTeamID="483DWKW443"
+    appName="jamf-cli"
+    appCustomVersion() { /usr/local/bin/jamf-cli --version | head -n1 | awk '{ print \$2 }' }
+    ;;

--- a/fragments/labels/jamfcli.sh
+++ b/fragments/labels/jamfcli.sh
@@ -1,3 +1,4 @@
+jamfcli|\
 jamf-cli)
     name="jamf-cli"
     type="pkg"


### PR DESCRIPTION
Add new label for jamf-cli

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
No, but I do know the format, and have contributed regularly.

**Additional context** Add any other context about the label or fix here.
jamf-cli is a new command line tool for accessing the Jamf Pro API

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-05-28 15:41:48 : REQ   : valuesfromarguments : ################## Start Installomator v. 10.9, date 2025-08-25
2026-05-28 15:41:48 : INFO  : valuesfromarguments : ################## Version: 10.9
2026-05-28 15:41:48 : INFO  : valuesfromarguments : ################## Date: 2025-08-25
2026-05-28 15:41:48 : INFO  : valuesfromarguments : ################## valuesfromarguments
2026-05-28 15:41:48 : INFO  : valuesfromarguments : setting variable from argument name=jamf-cli
2026-05-28 15:41:48 : INFO  : valuesfromarguments : setting variable from argument type=pkg
2026-05-28 15:41:48 : INFO  : valuesfromarguments : setting variable from argument downloadURL=$( downloadURLFromGit "Jamf-Concepts" "jamf-cli" )
2026-05-28 15:41:48 : INFO  : valuesfromarguments : setting variable from argument appNewVersion=$( versionFromGit "Jamf-Concepts" "jamf-cli" )
2026-05-28 15:41:49 : INFO  : valuesfromarguments : setting variable from argument expectedTeamID=483DWKW443
2026-05-28 15:41:49 : INFO  : valuesfromarguments : setting variable from argument appName=jamf-cli
2026-05-28 15:41:49 : INFO  : valuesfromarguments : setting variable from argument appCustomVersion() { /usr/local/bin/jamf-cli --version | head -n1 | awk '{ print $2 }' }
2026-05-28 15:41:49 : INFO  : valuesfromarguments : setting variable from argument DEBUG=1
2026-05-28 15:41:49 : INFO  : valuesfromarguments : Total items in argumentsArray: 8
2026-05-28 15:41:49 : INFO  : valuesfromarguments : argumentsArray: name=jamf-cli type=pkg downloadURL=$( downloadURLFromGit "Jamf-Concepts" "jamf-cli" ) appNewVersion=$( versionFromGit "Jamf-Concepts" "jamf-cli" ) expectedTeamID=483DWKW443 appName=jamf-cli appCustomVersion() { /usr/local/bin/jamf-cli --version | head -n1 | awk '{ print $2 }' } DEBUG=1
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : DEBUG mode 1 enabled.
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : name=jamf-cli
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : appName=jamf-cli
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : type=pkg
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : archiveName=
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : downloadURL=https://github.com/Jamf-Concepts/jamf-cli/releases/download/v1.17.0/jamf-cli-1.17.0.pkg
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : curlOptions=
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : appNewVersion=1.17.0
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : appCustomVersion function: Defined. 
2026-05-28 15:41:49 : DEBUG : valuesfromarguments : versionKey=CFBundleShortVersionString
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : packageID=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : pkgName=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : choiceChangesXML=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : expectedTeamID=483DWKW443
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : blockingProcesses=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : installerTool=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : CLIInstaller=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : CLIArguments=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : updateTool=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : updateToolArguments=
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : updateToolRunAsCurrentUser=
2026-05-28 15:41:50 : INFO  : valuesfromarguments : BLOCKING_PROCESS_ACTION=tell_user
2026-05-28 15:41:50 : INFO  : valuesfromarguments : NOTIFY=success
2026-05-28 15:41:50 : INFO  : valuesfromarguments : LOGGING=DEBUG
2026-05-28 15:41:50 : INFO  : valuesfromarguments : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-28 15:41:50 : INFO  : valuesfromarguments : Label type: pkg
2026-05-28 15:41:50 : INFO  : valuesfromarguments : archiveName: jamf-cli.pkg
2026-05-28 15:41:50 : INFO  : valuesfromarguments : no blocking processes defined, using jamf-cli as default
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : Changing directory to /usr/local/Installomator
2026-05-28 15:41:50 : INFO  : valuesfromarguments : Custom App Version detection is used, found 1.17.0
2026-05-28 15:41:50 : INFO  : valuesfromarguments : appversion: 1.17.0
2026-05-28 15:41:50 : INFO  : valuesfromarguments : Latest version of jamf-cli is 1.17.0
2026-05-28 15:41:50 : WARN  : valuesfromarguments : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-28 15:41:50 : REQ   : valuesfromarguments : Downloading https://github.com/Jamf-Concepts/jamf-cli/releases/download/v1.17.0/jamf-cli-1.17.0.pkg to jamf-cli.pkg
2026-05-28 15:41:50 : DEBUG : valuesfromarguments : No Dialog connection, just download
2026-05-28 15:41:51 : INFO  : valuesfromarguments : Downloaded jamf-cli.pkg – Type is  xar archive compressed TOC – SHA is 94f26c63ab392f4f49e267c1028d681e61ce8df1 – Size is 11648 kB
2026-05-28 15:41:51 : DEBUG : valuesfromarguments : DEBUG mode 1, not checking for blocking processes
2026-05-28 15:41:51 : REQ   : valuesfromarguments : Installing jamf-cli
2026-05-28 15:41:51 : INFO  : valuesfromarguments : Verifying: jamf-cli.pkg
2026-05-28 15:41:51 : DEBUG : valuesfromarguments : File list: -rw-r--r--  1 root  wheel    11M May 28 15:41 jamf-cli.pkg
2026-05-28 15:41:51 : DEBUG : valuesfromarguments : File type: jamf-cli.pkg: xar archive compressed TOC: 4337, SHA-1 checksum
2026-05-28 15:41:52 : DEBUG : valuesfromarguments : spctlOut is jamf-cli.pkg: accepted
2026-05-28 15:41:52 : DEBUG : valuesfromarguments : source=Notarized Developer ID
2026-05-28 15:41:52 : DEBUG : valuesfromarguments : origin=Developer ID Installer: JAMF Software (483DWKW443)
2026-05-28 15:41:52 : INFO  : valuesfromarguments : Team ID: 483DWKW443 (expected: 483DWKW443 )
2026-05-28 15:41:52 : DEBUG : valuesfromarguments : DEBUG enabled, skipping installation
2026-05-28 15:41:52 : INFO  : valuesfromarguments : Finishing...
2026-05-28 15:41:55 : INFO  : valuesfromarguments : Custom App Version detection is used, found 1.17.0
2026-05-28 15:41:55 : REQ   : valuesfromarguments : Installed jamf-cli, version 1.17.0
2026-05-28 15:41:55 : INFO  : valuesfromarguments : notifying
2026-05-28 15:41:55 : DEBUG : valuesfromarguments : DEBUG mode 1, not reopening anything
2026-05-28 15:41:55 : REQ   : valuesfromarguments : All done!
2026-05-28 15:41:55 : REQ   : valuesfromarguments : ################## End Installomator, exit code 0 

```