### PR TITLE
Rstudio label update

### DIFF
--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -2,6 +2,7 @@ rstudio)
     name="RStudio"
     type="dmg"
     downloadURL="https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg"
-    appNewVersion=$(curl -sfI "$downloadURL" | grep -i "^location" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\-[0-9]+' | sed 's/-/+/')
+     finalURL=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL")
+    appNewVersion=$(echo "$finalURL" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\-[0-9]+' | sed 's/-/+/')
     expectedTeamID="FYF2F5GFX4"
     ;;

--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -2,7 +2,7 @@ rstudio)
     name="RStudio"
     type="dmg"
     downloadURL="https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg"
-     finalURL=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL")
+    finalURL=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL")
     appNewVersion=$(echo "$finalURL" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\-[0-9]+' | sed 's/-/+/')
     expectedTeamID="FYF2F5GFX4"
     ;;

--- a/fragments/labels/rstudio.sh
+++ b/fragments/labels/rstudio.sh
@@ -2,7 +2,7 @@ rstudio)
     name="RStudio"
     type="dmg"
     downloadURL="https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg"
-    finalURL=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL")
+    finalURL=$(curl -fsLI -o /dev/null -w "%{url_effective}" "$downloadURL")
     appNewVersion=$(echo "$finalURL" | grep -oE '[0-9]{4}\.[0-9]{2}\.[0-9]{1,2}\-[0-9]+' | sed 's/-/+/')
     expectedTeamID="FYF2F5GFX4"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Pull request creating or modifying a label in the fragments/labels folder

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** Add any other context about the label or fix here.

The updated label improves the reliability of the version detection logic by modernizing how download redirects are handled. Instead of scraping raw HTTP response headers for the location field, the update utilizes curl's native %{url_effective} write-out variable to cleanly capture the final destination URL after following redirects. This provides a more robust and less error-prone method for extracting the version string from the filename, ensuring the label handles unexpected header formatting changes or multi-hop redirects gracefully.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh rstudio DEBUG=1
2026-05-28 12:49:28 : INFO  : rstudio : setting variable from argument DEBUG=1
2026-05-28 12:49:28 : INFO  : rstudio : Total items in argumentsArray: 1
2026-05-28 12:49:28 : INFO  : rstudio : argumentsArray: DEBUG=1
2026-05-28 12:49:28 : REQ   : rstudio : ################## Start Installomator v. 10.9beta, date 2026-05-28
2026-05-28 12:49:28 : INFO  : rstudio : ################## Version: 10.9beta
2026-05-28 12:49:28 : INFO  : rstudio : ################## Date: 2026-05-28
2026-05-28 12:49:28 : INFO  : rstudio : ################## rstudio
2026-05-28 12:49:28 : DEBUG : rstudio : DEBUG mode 1 enabled.
2026-05-28 12:49:54 : INFO  : rstudio : Reading arguments again: DEBUG=1
2026-05-28 12:49:54 : DEBUG : rstudio : argument: DEBUG=1
2026-05-28 12:49:54 : DEBUG : rstudio : name=RStudio
2026-05-28 12:49:54 : DEBUG : rstudio : appName=
2026-05-28 12:49:54 : DEBUG : rstudio : type=dmg
2026-05-28 12:49:54 : DEBUG : rstudio : archiveName=
2026-05-28 12:49:54 : DEBUG : rstudio : downloadURL=https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg
2026-05-28 12:49:54 : DEBUG : rstudio : curlOptions=
2026-05-28 12:49:54 : DEBUG : rstudio : appNewVersion=2026.05.0+218
2026-05-28 12:49:54 : DEBUG : rstudio : appCustomVersion function: Not defined
2026-05-28 12:49:54 : DEBUG : rstudio : versionKey=CFBundleShortVersionString
2026-05-28 12:49:54 : DEBUG : rstudio : packageID=
2026-05-28 12:49:54 : DEBUG : rstudio : pkgName=
2026-05-28 12:49:54 : DEBUG : rstudio : choiceChangesXML=
2026-05-28 12:49:54 : DEBUG : rstudio : expectedTeamID=FYF2F5GFX4
2026-05-28 12:49:54 : DEBUG : rstudio : blockingProcesses=
2026-05-28 12:49:54 : DEBUG : rstudio : installerTool=
2026-05-28 12:49:54 : DEBUG : rstudio : CLIInstaller=
2026-05-28 12:49:54 : DEBUG : rstudio : CLIArguments=
2026-05-28 12:49:54 : DEBUG : rstudio : updateTool=
2026-05-28 12:49:54 : DEBUG : rstudio : updateToolArguments=
2026-05-28 12:49:54 : DEBUG : rstudio : updateToolRunAsCurrentUser=
2026-05-28 12:49:54 : INFO  : rstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-05-28 12:49:54 : INFO  : rstudio : NOTIFY=success
2026-05-28 12:49:54 : INFO  : rstudio : LOGGING=DEBUG
2026-05-28 12:49:54 : INFO  : rstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-28 12:49:54 : INFO  : rstudio : Label type: dmg
2026-05-28 12:49:54 : INFO  : rstudio : archiveName: RStudio.dmg
2026-05-28 12:49:54 : INFO  : rstudio : no blocking processes defined, using RStudio as default
2026-05-28 12:49:55 : DEBUG : rstudio : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-28 12:49:55 : INFO  : rstudio : name: RStudio, appName: RStudio.app
2026-05-28 12:49:55 : WARN  : rstudio : No previous app found
2026-05-28 12:49:55 : WARN  : rstudio : could not find RStudio.app
2026-05-28 12:49:55 : INFO  : rstudio : appversion:
2026-05-28 12:49:55 : INFO  : rstudio : Latest version of RStudio is 2026.05.0+218
2026-05-28 12:49:55 : REQ   : rstudio : Downloading https://rstudio.org/download/latest/stable/desktop/mac/RStudio-latest.dmg to RStudio.dmg
2026-05-28 12:49:55 : DEBUG : rstudio : No Dialog connection, just download
2026-05-28 12:50:24 : INFO  : rstudio : Downloaded RStudio.dmg – Type is  zlib compressed data – SHA is 0acafbced53fc65f9ddde28de852adfccf1eae84 – Size is 721324 kB
2026-05-28 12:50:24 : DEBUG : rstudio : DEBUG mode 1, not checking for blocking processes
2026-05-28 12:50:24 : REQ   : rstudio : Installing RStudio
2026-05-28 12:50:24 : INFO  : rstudio : Mounting /Users/u0105821/git/github/Installomator/build/RStudio.dmg
2026-05-28 12:50:29 : DEBUG : rstudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $6FF13BD8
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $58A8020F
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $D97A1756
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $2CD9CAFD
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $D97A1756
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $A90C5555
verified   CRC32 $B684C659
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_APFS
/dev/disk14         	EF57347C-0000-11AA-AA11-0030654
/dev/disk14s1       	41504653-0000-11AA-AA11-0030654	/Volumes/RStudio-2026.05.0-218 1

2026-05-28 12:50:29 : INFO  : rstudio : Mounted: /Volumes/RStudio-2026.05.0-218 1
2026-05-28 12:50:29 : INFO  : rstudio : Verifying: /Volumes/RStudio-2026.05.0-218 1/RStudio.app
2026-05-28 12:50:29 : DEBUG : rstudio : App size: 1.6G	/Volumes/RStudio-2026.05.0-218 1/RStudio.app
2026-05-28 12:50:35 : DEBUG : rstudio : Debugging enabled, App Verification output was:
/Volumes/RStudio-2026.05.0-218 1/RStudio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: RStudio Inc. (FYF2F5GFX4)

2026-05-28 12:50:35 : INFO  : rstudio : Team ID matching: FYF2F5GFX4 (expected: FYF2F5GFX4 )
2026-05-28 12:50:35 : INFO  : rstudio : Installing RStudio version 2026.05.0+218 on versionKey CFBundleShortVersionString.
2026-05-28 12:50:35 : INFO  : rstudio : App has LSMinimumSystemVersion: 12.0
2026-05-28 12:50:35 : DEBUG : rstudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-28 12:50:35 : INFO  : rstudio : Finishing...
2026-05-28 12:50:39 : INFO  : rstudio : name: RStudio, appName: RStudio.app
2026-05-28 12:50:39 : WARN  : rstudio : No previous app found
2026-05-28 12:50:39 : WARN  : rstudio : could not find RStudio.app
2026-05-28 12:50:39 : REQ   : rstudio : Installed RStudio, version 2026.05.0+218
2026-05-28 12:50:39 : INFO  : rstudio : notifying
2026-05-28 12:50:39 : DEBUG : rstudio : Unmounting /Volumes/RStudio-2026.05.0-218 1
2026-05-28 12:50:39 : DEBUG : rstudio : Debugging enabled, Unmounting output was:
"disk13" ejected.
2026-05-28 12:50:39 : DEBUG : rstudio : DEBUG mode 1, not reopening anything
2026-05-28 12:50:40 : REQ   : rstudio : All done!
2026-05-28 12:50:40 : REQ   : rstudio : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
