### PR TITLE
quickbooksonline-new-label

### DIFF
--- a/fragments/labels/quickbooksonline.sh
+++ b/fragments/labels/quickbooksonline.sh
@@ -2,7 +2,6 @@ quickbooksonline)
     name="QuickBooks Online"
     type="dmg"
     downloadURL="https://http-download.intuit.com/http.intuit/CMO/tango/static/latest/QuickBooks%20Online.dmg"
-    appNewVersion="99.99.99"
     versionKey="CFBundleShortVersionString"
     expectedTeamID="G4SSPX3CBL"
     ;;

--- a/fragments/labels/quickbooksonline.sh
+++ b/fragments/labels/quickbooksonline.sh
@@ -1,0 +1,8 @@
+quickbooksonline)
+    name="QuickBooks Online"
+    type="dmg"
+    downloadURL="https://http-download.intuit.com/http.intuit/CMO/tango/static/latest/QuickBooks%20Online.dmg"
+    appNewVersion="99.99.99"
+    versionKey="CFBundleShortVersionString"
+    expectedTeamID="G4SSPX3CBL"
+    ;;

--- a/fragments/labels/quickbooksonline.sh
+++ b/fragments/labels/quickbooksonline.sh
@@ -2,6 +2,5 @@ quickbooksonline)
     name="QuickBooks Online"
     type="dmg"
     downloadURL="https://http-download.intuit.com/http.intuit/CMO/tango/static/latest/QuickBooks%20Online.dmg"
-    versionKey="CFBundleShortVersionString"
     expectedTeamID="G4SSPX3CBL"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

pull request creating or modifying a label in the fragments/labels folder,

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This pull request introduces a new label for QuickBooks Online to the Installomator framework. It configures the application to download directly as a DMG file, utilizes CFBundleShortVersionString for version detection, and enforces security by verifying the expected Team ID (G4SSPX3CBL). This addition bypasses recent scraping complications on the vendor's download page by targeting a direct, reliable download URL.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh quickbooksonline DEBUG=1
2026-05-28 14:56:41 : INFO  : quickbooksonline : setting variable from argument DEBUG=1
2026-05-28 14:56:41 : INFO  : quickbooksonline : Total items in argumentsArray: 1
2026-05-28 14:56:41 : INFO  : quickbooksonline : argumentsArray: DEBUG=1
2026-05-28 14:56:41 : REQ   : quickbooksonline : ################## Start Installomator v. 10.9beta, date 2026-05-28
2026-05-28 14:56:41 : INFO  : quickbooksonline : ################## Version: 10.9beta
2026-05-28 14:56:41 : INFO  : quickbooksonline : ################## Date: 2026-05-28
2026-05-28 14:56:41 : INFO  : quickbooksonline : ################## quickbooksonline
2026-05-28 14:56:41 : DEBUG : quickbooksonline : DEBUG mode 1 enabled.
2026-05-28 14:56:42 : INFO  : quickbooksonline : Reading arguments again: DEBUG=1
2026-05-28 14:56:42 : DEBUG : quickbooksonline : argument: DEBUG=1
2026-05-28 14:56:42 : DEBUG : quickbooksonline : name=QuickBooks Online
2026-05-28 14:56:42 : DEBUG : quickbooksonline : appName=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : type=dmg
2026-05-28 14:56:42 : DEBUG : quickbooksonline : archiveName=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : downloadURL=https://http-download.intuit.com/http.intuit/CMO/tango/static/latest/QuickBooks%20Online.dmg
2026-05-28 14:56:42 : DEBUG : quickbooksonline : curlOptions=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : appNewVersion=99.99.99
2026-05-28 14:56:42 : DEBUG : quickbooksonline : appCustomVersion function: Not defined
2026-05-28 14:56:42 : DEBUG : quickbooksonline : versionKey=CFBundleShortVersionString
2026-05-28 14:56:42 : DEBUG : quickbooksonline : packageID=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : pkgName=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : choiceChangesXML=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : expectedTeamID=G4SSPX3CBL
2026-05-28 14:56:42 : DEBUG : quickbooksonline : blockingProcesses=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : installerTool=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : CLIInstaller=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : CLIArguments=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : updateTool=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : updateToolArguments=
2026-05-28 14:56:42 : DEBUG : quickbooksonline : updateToolRunAsCurrentUser=
2026-05-28 14:56:42 : INFO  : quickbooksonline : BLOCKING_PROCESS_ACTION=tell_user
2026-05-28 14:56:42 : INFO  : quickbooksonline : NOTIFY=success
2026-05-28 14:56:42 : INFO  : quickbooksonline : LOGGING=DEBUG
2026-05-28 14:56:42 : INFO  : quickbooksonline : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-28 14:56:42 : INFO  : quickbooksonline : Label type: dmg
2026-05-28 14:56:42 : INFO  : quickbooksonline : archiveName: QuickBooks Online.dmg
2026-05-28 14:56:42 : INFO  : quickbooksonline : no blocking processes defined, using QuickBooks Online as default
2026-05-28 14:56:42 : DEBUG : quickbooksonline : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-28 14:56:42 : INFO  : quickbooksonline : name: QuickBooks Online, appName: QuickBooks Online.app
2026-05-28 14:56:43 : WARN  : quickbooksonline : No previous app found
2026-05-28 14:56:43 : WARN  : quickbooksonline : could not find QuickBooks Online.app
2026-05-28 14:56:43 : INFO  : quickbooksonline : appversion:
2026-05-28 14:56:43 : INFO  : quickbooksonline : Latest version of QuickBooks Online is 99.99.99
2026-05-28 14:56:43 : REQ   : quickbooksonline : Downloading https://http-download.intuit.com/http.intuit/CMO/tango/static/latest/QuickBooks%20Online.dmg to QuickBooks Online.dmg
2026-05-28 14:56:43 : DEBUG : quickbooksonline : No Dialog connection, just download
2026-05-28 14:56:48 : INFO  : quickbooksonline : Downloaded QuickBooks Online.dmg – Type is  zlib compressed data – SHA is 542837e536966d0ba7a4e99273d6304599377a43 – Size is 163964 kB
2026-05-28 14:56:48 : DEBUG : quickbooksonline : DEBUG mode 1, not checking for blocking processes
2026-05-28 14:56:49 : REQ   : quickbooksonline : Installing QuickBooks Online
2026-05-28 14:56:49 : INFO  : quickbooksonline : Mounting /Users/u0105821/git/github/Installomator/build/QuickBooks Online.dmg
2026-05-28 14:56:53 : DEBUG : quickbooksonline : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $5FB8CAB6
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3AB70BB8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $6E71A975
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A0A3BCEE
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $6E71A975
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $57E85C50
verified   CRC32 $818849E7
/dev/disk15         	GUID_partition_scheme
/dev/disk15s1       	Apple_HFS                      	/Volumes/QuickBooks Online 2

2026-05-28 14:56:53 : INFO  : quickbooksonline : Mounted: /Volumes/QuickBooks Online 2
2026-05-28 14:56:53 : INFO  : quickbooksonline : Verifying: /Volumes/QuickBooks Online 2/QuickBooks Online.app
2026-05-28 14:56:53 : DEBUG : quickbooksonline : App size: 391M	/Volumes/QuickBooks Online 2/QuickBooks Online.app
2026-05-28 14:56:57 : DEBUG : quickbooksonline : Debugging enabled, App Verification output was:
/Volumes/QuickBooks Online 2/QuickBooks Online.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Intuit Inc. (G4SSPX3CBL)

2026-05-28 14:56:57 : INFO  : quickbooksonline : Team ID matching: G4SSPX3CBL (expected: G4SSPX3CBL )
2026-05-28 14:56:57 : INFO  : quickbooksonline : Installing QuickBooks Online version 3.10.0 on versionKey CFBundleShortVersionString.
2026-05-28 14:56:57 : INFO  : quickbooksonline : App has LSMinimumSystemVersion: 11.0
2026-05-28 14:56:57 : DEBUG : quickbooksonline : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-28 14:56:57 : INFO  : quickbooksonline : Finishing...
2026-05-28 14:57:00 : INFO  : quickbooksonline : name: QuickBooks Online, appName: QuickBooks Online.app
2026-05-28 14:57:00 : WARN  : quickbooksonline : No previous app found
2026-05-28 14:57:00 : WARN  : quickbooksonline : could not find QuickBooks Online.app
2026-05-28 14:57:00 : REQ   : quickbooksonline : Installed QuickBooks Online, version 3.10.0
2026-05-28 14:57:00 : INFO  : quickbooksonline : notifying
2026-05-28 14:57:01 : DEBUG : quickbooksonline : Unmounting /Volumes/QuickBooks Online 2
2026-05-28 14:57:01 : DEBUG : quickbooksonline : Debugging enabled, Unmounting output was:
"disk15" ejected.
2026-05-28 14:57:01 : DEBUG : quickbooksonline : DEBUG mode 1, not reopening anything
2026-05-28 14:57:01 : REQ   : quickbooksonline : All done!
2026-05-28 14:57:01 : REQ   : quickbooksonline : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
