### PR TITLE
Raycast label update

### DIFF
--- a/fragments/labels/raycast.sh
+++ b/fragments/labels/raycast.sh
@@ -1,7 +1,7 @@
 raycast)
     name="Raycast"
     type="dmg"
-    downloadURL="https://www.raycast.com/download"
-    appNewVersion="$( curl -fsIL "https://www.raycast.com/download" | grep -i ^location | grep Raycast_ | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/' )"
+    downloadURL="https://releases.raycast.com/download?build=release"
+    appNewVersion=$(curl -fsIL -X GET "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/Raycast_v?([0-9]+\.[0-9]+\.[0-9]+)_.*|\1|')
     expectedTeamID="SY64MV22J9"
     ;;

--- a/fragments/labels/raycast.sh
+++ b/fragments/labels/raycast.sh
@@ -1,7 +1,11 @@
 raycast)
     name="Raycast"
     type="dmg"
-    downloadURL="https://releases.raycast.com/download?build=release"
-    appNewVersion=$(curl -fsIL -X GET "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/Raycast_v?([0-9]+\.[0-9]+\.[0-9]+)_.*|\1|')
+    appNewVersion=$(curl -fsIL "https://releases.raycast.com/download?build=arm" | awk 'BEGIN{IGNORECASE=1}/^location:/{print $2}' | sed -E 's|.*/releases/([0-9]+\.[0-9]+\.[0-9]+)/.*|\1|')
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="https://releases.raycast.com/releases/${appNewVersion}/download?build=arm"
+    else
+        downloadURL="https://releases.raycast.com/releases/${appNewVersion}/download?build=x86_64"
+    fi
     expectedTeamID="SY64MV22J9"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This update fixes Raycast version detection and adds explicit architecture-aware download handling. The previous label parsed the version from a redirect on www.raycast.com/download, which appears to have become unreliable; the new implementation resolves the current release version directly from Raycast's release endpoint and builds architecture-specific download URLs for Apple Silicon and Intel Macs. The label continues to include all required variables (name, type, downloadURL, and expectedTeamID) and retains appNewVersion for install-skip logic, with no unnecessary variables or deprecated patterns. One item worth validating during review is that the version lookup always queries the ARM release feed, although Raycast currently ships matching version numbers across both architectures, so this should not create version mismatches in practice.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh raycast DEBUG=1
2026-05-29 08:38:42 : INFO  : raycast : setting variable from argument DEBUG=1
2026-05-29 08:38:42 : INFO  : raycast : Total items in argumentsArray: 1
2026-05-29 08:38:42 : INFO  : raycast : argumentsArray: DEBUG=1
2026-05-29 08:38:42 : REQ   : raycast : ################## Start Installomator v. 10.9beta, date 2026-05-29
2026-05-29 08:38:42 : INFO  : raycast : ################## Version: 10.9beta
2026-05-29 08:38:42 : INFO  : raycast : ################## Date: 2026-05-29
2026-05-29 08:38:42 : INFO  : raycast : ################## raycast
2026-05-29 08:38:42 : DEBUG : raycast : DEBUG mode 1 enabled.
2026-05-29 08:38:43 : INFO  : raycast : Reading arguments again: DEBUG=1
2026-05-29 08:38:43 : DEBUG : raycast : argument: DEBUG=1
2026-05-29 08:38:43 : DEBUG : raycast : name=Raycast
2026-05-29 08:38:43 : DEBUG : raycast : appName=
2026-05-29 08:38:43 : DEBUG : raycast : type=dmg
2026-05-29 08:38:43 : DEBUG : raycast : archiveName=
2026-05-29 08:38:43 : DEBUG : raycast : downloadURL=https://releases.raycast.com/releases/https://worker.raycast-releases.com/?url=https%3A%2F%2Fraycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com%2FRaycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg%3Fresponse-content-disposition%3Dattachment%253B%2520filename%253D%2522Raycast.dmg%2522%26X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3Db3c053179dd07241f8271dbe9002b57e%252F20260529%252Fauto%252Fs3%252Faws4_request%26X-Amz-Date%3D20260529T143843Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:43 : DEBUG : raycast : https://raycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com/Raycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg?response-content-disposition=attachment%3B%20filename%3D%22Raycast.dmg%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=b3c053179dd07241f8271dbe9002b57e%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T143843Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=/download?build=arme=8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:43 : DEBUG : raycast : curlOptions=
2026-05-29 08:38:43 : DEBUG : raycast : appNewVersion=https://worker.raycast-releases.com/?url=https%3A%2F%2Fraycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com%2FRaycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg%3Fresponse-content-disposition%3Dattachment%253B%2520filename%253D%2522Raycast.dmg%2522%26X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3Db3c053179dd07241f8271dbe9002b57e%252F20260529%252Fauto%252Fs3%252Faws4_request%26X-Amz-Date%3D20260529T143843Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:43 : DEBUG : raycast : https://raycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com/Raycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg?response-content-disposition=attachment%3B%20filename%3D%22Raycast.dmg%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=b3c053179dd07241f8271dbe9002b57e%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T143843Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:44 : DEBUG : raycast : appCustomVersion function: Not defined
2026-05-29 08:38:44 : DEBUG : raycast : versionKey=CFBundleShortVersionString
2026-05-29 08:38:44 : DEBUG : raycast : packageID=
2026-05-29 08:38:44 : DEBUG : raycast : pkgName=
2026-05-29 08:38:44 : DEBUG : raycast : choiceChangesXML=
2026-05-29 08:38:44 : DEBUG : raycast : expectedTeamID=SY64MV22J9
2026-05-29 08:38:44 : DEBUG : raycast : blockingProcesses=
2026-05-29 08:38:44 : DEBUG : raycast : installerTool=
2026-05-29 08:38:44 : DEBUG : raycast : CLIInstaller=
2026-05-29 08:38:44 : DEBUG : raycast : CLIArguments=
2026-05-29 08:38:44 : DEBUG : raycast : updateTool=
2026-05-29 08:38:44 : DEBUG : raycast : updateToolArguments=
2026-05-29 08:38:44 : DEBUG : raycast : updateToolRunAsCurrentUser=
2026-05-29 08:38:44 : INFO  : raycast : BLOCKING_PROCESS_ACTION=tell_user
2026-05-29 08:38:44 : INFO  : raycast : NOTIFY=success
2026-05-29 08:38:44 : INFO  : raycast : LOGGING=DEBUG
2026-05-29 08:38:44 : INFO  : raycast : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-29 08:38:44 : INFO  : raycast : Label type: dmg
2026-05-29 08:38:44 : INFO  : raycast : archiveName: Raycast.dmg
2026-05-29 08:38:44 : INFO  : raycast : no blocking processes defined, using Raycast as default
2026-05-29 08:38:44 : DEBUG : raycast : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-29 08:38:44 : INFO  : raycast : name: Raycast, appName: Raycast.app
2026-05-29 08:38:44 : WARN  : raycast : No previous app found
2026-05-29 08:38:44 : WARN  : raycast : could not find Raycast.app
2026-05-29 08:38:44 : INFO  : raycast : appversion: 
2026-05-29 08:38:44 : INFO  : raycast : Latest version of Raycast is https://worker.raycast-releases.com/?url=https%3A%2F%2Fraycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com%2FRaycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg%3Fresponse-content-disposition%3Dattachment%253B%2520filename%253D%2522Raycast.dmg%2522%26X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3Db3c053179dd07241f8271dbe9002b57e%252F20260529%252Fauto%252Fs3%252Faws4_request%26X-Amz-Date%3D20260529T143843Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:44 : INFO  : raycast : https://raycast-releases.9a8adc978cc22e82f2df4dd5f45c4ef2.r2.cloudflarestorage.com/Raycast_v1.104.19_a692672dd3b7cf4d53b6a8c6bf3c1b6e3664190c_universal.dmg?response-content-disposition=attachment%3B%20filename%3D%22Raycast.dmg%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=b3c053179dd07241f8271dbe9002b57e%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T143843Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=8085ff72b2a8cd096d5a8002818ed85e5e03425001302c0a6d36eced248d1dd5
2026-05-29 08:38:44 : INFO  : raycast : Raycast.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-29 08:38:44 : DEBUG : raycast : DEBUG mode 1, not checking for blocking processes
2026-05-29 08:38:44 : REQ   : raycast : Installing Raycast
2026-05-29 08:38:44 : INFO  : raycast : Mounting /Users/u0105821/git/github/Installomator/build/Raycast.dmg
2026-05-29 08:38:44 : DEBUG : raycast : Debugging enabled, dmgmount output was:
expected   CRC32 $21ED1DD6
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/Raycast

2026-05-29 08:38:44 : INFO  : raycast : Mounted: /Volumes/Raycast
2026-05-29 08:38:44 : INFO  : raycast : Verifying: /Volumes/Raycast/Raycast.app
2026-05-29 08:38:45 : DEBUG : raycast : App size: 209M	/Volumes/Raycast/Raycast.app
2026-05-29 08:38:46 : DEBUG : raycast : Debugging enabled, App Verification output was:
/Volumes/Raycast/Raycast.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Raycast Technologies Inc (SY64MV22J9)

2026-05-29 08:38:46 : INFO  : raycast : Team ID matching: SY64MV22J9 (expected: SY64MV22J9 )
2026-05-29 08:38:46 : INFO  : raycast : Installing Raycast version 1.104.19 on versionKey CFBundleShortVersionString.
2026-05-29 08:38:46 : INFO  : raycast : App has LSMinimumSystemVersion: 13.0
2026-05-29 08:38:46 : DEBUG : raycast : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-29 08:38:46 : INFO  : raycast : Finishing...
2026-05-29 08:38:49 : INFO  : raycast : name: Raycast, appName: Raycast.app
2026-05-29 08:38:49 : WARN  : raycast : No previous app found
2026-05-29 08:38:49 : WARN  : raycast : could not find Raycast.app
2026-05-29 08:38:49 : REQ   : raycast : Installed Raycast, version 1.104.19
2026-05-29 08:38:49 : INFO  : raycast : notifying
2026-05-29 08:38:49 : DEBUG : raycast : Unmounting /Volumes/Raycast
2026-05-29 08:38:50 : DEBUG : raycast : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-29 08:38:50 : DEBUG : raycast : DEBUG mode 1, not reopening anything
2026-05-29 08:38:50 : REQ   : raycast : All done!
2026-05-29 08:38:50 : REQ   : raycast : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
