### PR TITLE
zulujdk17-label-update

### DIFF
--- a/fragments/labels/zulujdk17.sh
+++ b/fragments/labels/zulujdk17.sh
@@ -2,12 +2,13 @@ zulujdk17)
     name="Zulu JDK 17"
     type="pkgInDmg"
     packageID="com.azulsystems.zulu.17"
-    if [[ $(arch) == i386 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*x64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
-    elif [[ $(arch) == arm64 ]]; then
-        downloadURL=https://cdn.azul.com/zulu/bin/$(curl -fs "https://cdn.azul.com/zulu/bin/" | grep -Eio '">zulu17.*ca-jdk17.*aarch64.dmg(.*)' | cut -c3- | sed 's/<\/a>//' | sed -E 's/([0-9.]*)M//' | awk '{print $2 $1}' | sort | cut -c11- | tail -1)
+    curlOptions=( -H "Referer: https://www.azul.com/downloads/" )
+    if [[ "$arch" == "arm64" ]]; then
+        downloadURL=$(curl -fsL "https://api.azul.com/metadata/v1/zulu/packages/?java_version=17&os=macos&arch=arm&java_package_type=jdk&archive_type=dmg&javafx_bundled=false&release_status=ga&availability_types=CA&latest=true" | grep -oE '"download_url":"[^"]*"' | head -1 | sed 's/"download_url":"//' | tr -d '"')
+    else
+        downloadURL=$(curl -fsL "https://api.azul.com/metadata/v1/zulu/packages/?java_version=17&os=macos&arch=x64&java_package_type=jdk&archive_type=dmg&javafx_bundled=false&release_status=ga&availability_types=CA&latest=true" | grep -oE '"download_url":"[^"]*"' | head -1 | sed 's/"download_url":"//' | tr -d '"')
     fi
+    appNewVersion=$(echo "$downloadURL" | grep -oE 'jdk17\.[0-9]+\.[0-9]+' | sed 's/jdk//')
+    appCustomVersion() { [ -f "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" ] && /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Info.plist" "CFBundleName" | sed 's/Zulu //'; }
     expectedTeamID="TDTHCUPYFR"
-    appCustomVersion(){ java -version 2>&1 | grep Runtime | awk '{print $4}' | sed -e "s/.*Zulu//" | cut -d '-' -f 1 | sed -e "s/+/\./" }
-    appNewVersion=$(echo "$downloadURL" | cut -d "-" -f 1 | sed -e "s/.*zulu//") # Cannot be compared to anything
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

This update significantly improves the reliability and speed of the Zulu JDK 17 deployment by migrating away from fragile HTML scraping of the vendor's download directory in favor of structured queries via Azul's official metadata API. Additionally, it transitions the architecture check to standard variable syntax, introduces curlOptions with proper referer headers to prevent potential blocking, and replaces the live java execution in appCustomVersion() with a safer, static plist reading method from the installed directory, allowing for accurate version comparison.

```
Installomator/utils/assemble.sh zulujdk17 DEBUG=1
2026-05-29 14:04:02 : INFO  : zulujdk17 : setting variable from argument DEBUG=1
2026-05-29 14:04:02 : INFO  : zulujdk17 : Total items in argumentsArray: 1
2026-05-29 14:04:02 : INFO  : zulujdk17 : argumentsArray: DEBUG=1
2026-05-29 14:04:02 : REQ   : zulujdk17 : ################## Start Installomator v. 10.9beta, date 2026-05-29
2026-05-29 14:04:02 : INFO  : zulujdk17 : ################## Version: 10.9beta
2026-05-29 14:04:02 : INFO  : zulujdk17 : ################## Date: 2026-05-29
2026-05-29 14:04:02 : INFO  : zulujdk17 : ################## zulujdk17
2026-05-29 14:04:02 : DEBUG : zulujdk17 : DEBUG mode 1 enabled.
2026-05-29 14:04:03 : INFO  : zulujdk17 : Reading arguments again: DEBUG=1
2026-05-29 14:04:03 : DEBUG : zulujdk17 : argument: DEBUG=1
2026-05-29 14:04:03 : DEBUG : zulujdk17 : name=Zulu JDK 17
2026-05-29 14:04:03 : DEBUG : zulujdk17 : appName=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : type=pkgInDmg
2026-05-29 14:04:03 : DEBUG : zulujdk17 : archiveName=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : downloadURL=https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jdk17.0.19-macosx_x64.dmg
2026-05-29 14:04:03 : DEBUG : zulujdk17 : curlOptions=-H Referer: https://www.azul.com/downloads/
2026-05-29 14:04:03 : DEBUG : zulujdk17 : appNewVersion=17.0.19
2026-05-29 14:04:03 : DEBUG : zulujdk17 : appCustomVersion function: Defined. 
2026-05-29 14:04:03 : DEBUG : zulujdk17 : versionKey=CFBundleShortVersionString
2026-05-29 14:04:03 : DEBUG : zulujdk17 : packageID=com.azulsystems.zulu.17
2026-05-29 14:04:03 : DEBUG : zulujdk17 : pkgName=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : choiceChangesXML=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : expectedTeamID=TDTHCUPYFR
2026-05-29 14:04:03 : DEBUG : zulujdk17 : blockingProcesses=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : installerTool=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : CLIInstaller=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : CLIArguments=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : updateTool=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : updateToolArguments=
2026-05-29 14:04:03 : DEBUG : zulujdk17 : updateToolRunAsCurrentUser=
2026-05-29 14:04:03 : INFO  : zulujdk17 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-29 14:04:03 : INFO  : zulujdk17 : NOTIFY=success
2026-05-29 14:04:03 : INFO  : zulujdk17 : LOGGING=DEBUG
2026-05-29 14:04:03 : INFO  : zulujdk17 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-29 14:04:04 : INFO  : zulujdk17 : Label type: pkgInDmg
2026-05-29 14:04:04 : INFO  : zulujdk17 : archiveName: Zulu JDK 17.dmg
2026-05-29 14:04:04 : INFO  : zulujdk17 : no blocking processes defined, using Zulu JDK 17 as default
2026-05-29 14:04:04 : DEBUG : zulujdk17 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-29 14:04:04 : INFO  : zulujdk17 : Custom App Version detection is used, found 
2026-05-29 14:04:04 : INFO  : zulujdk17 : appversion: 
2026-05-29 14:04:04 : INFO  : zulujdk17 : Latest version of Zulu JDK 17 is 17.0.19
2026-05-29 14:04:04 : REQ   : zulujdk17 : Downloading https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jdk17.0.19-macosx_x64.dmg to Zulu JDK 17.dmg
2026-05-29 14:04:04 : DEBUG : zulujdk17 : No Dialog connection, just download
2026-05-29 14:04:11 : INFO  : zulujdk17 : Downloaded Zulu JDK 17.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is e3f55e701a39303100bf823e0a42a594a4c33d82 – Size is 197432 kB
2026-05-29 14:04:11 : DEBUG : zulujdk17 : DEBUG mode 1, not checking for blocking processes
2026-05-29 14:04:11 : REQ   : zulujdk17 : Installing Zulu JDK 17
2026-05-29 14:04:11 : INFO  : zulujdk17 : Mounting /Users/u0105821/git/github/Installomator/build/Zulu JDK 17.dmg
2026-05-29 14:04:19 : DEBUG : zulujdk17 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0628D780
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E7EC98CA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $E783DD6C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $020A7FA2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $E783DD6C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $92ECBF5F
verified   CRC32 $118FA0A1
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/Azul Zulu JDK 17.66+19

2026-05-29 14:04:19 : INFO  : zulujdk17 : Mounted: /Volumes/Azul Zulu JDK 17.66+19
2026-05-29 14:04:19 : DEBUG : zulujdk17 : Found pkg(s):
/Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg
2026-05-29 14:04:19 : INFO  : zulujdk17 : found pkg: /Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg
2026-05-29 14:04:19 : INFO  : zulujdk17 : Verifying: /Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg
2026-05-29 14:04:19 : DEBUG : zulujdk17 : File list: -rw-r--r--@ 1 u0105821  staff   186M Apr 18 03:57 /Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg
2026-05-29 14:04:19 : DEBUG : zulujdk17 : File type: /Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg: xar archive compressed TOC: 4963, SHA-1 checksum
2026-05-29 14:04:20 : DEBUG : zulujdk17 : spctlOut is /Volumes/Azul Zulu JDK 17.66+19/Double-Click to Install Azul Zulu JDK 17.pkg: accepted
2026-05-29 14:04:20 : DEBUG : zulujdk17 : source=Notarized Developer ID
2026-05-29 14:04:20 : DEBUG : zulujdk17 : origin=Developer ID Installer: Azul Systems, Inc. (TDTHCUPYFR)
2026-05-29 14:04:20 : INFO  : zulujdk17 : Team ID: TDTHCUPYFR (expected: TDTHCUPYFR )
2026-05-29 14:04:20 : DEBUG : zulujdk17 : DEBUG enabled, skipping installation
2026-05-29 14:04:20 : INFO  : zulujdk17 : Finishing...
2026-05-29 14:04:23 : INFO  : zulujdk17 : Custom App Version detection is used, found 
2026-05-29 14:04:23 : REQ   : zulujdk17 : Installed Zulu JDK 17, version 17.0.19
2026-05-29 14:04:23 : INFO  : zulujdk17 : notifying
2026-05-29 14:04:23 : DEBUG : zulujdk17 : Unmounting /Volumes/Azul Zulu JDK 17.66+19
2026-05-29 14:04:24 : DEBUG : zulujdk17 : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-29 14:04:24 : DEBUG : zulujdk17 : DEBUG mode 1, not reopening anything
2026-05-29 14:04:24 : REQ   : zulujdk17 : All done!
2026-05-29 14:04:24 : REQ   : zulujdk17 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
