### PR TITLE
Create cleanshotx.sh

### DIFF
--- a/fragments/labels/cleanshotx.sh
+++ b/fragments/labels/cleanshotx.sh
@@ -1,0 +1,8 @@
+cleanshotx)
+    name="CleanShot X"
+    type="dmg"
+    pageContent=$(curl -fsL "https://cleanshot.com/changelog")
+    appNewVersion=$(echo "$pageContent" | perl -0ne 'print $1 if /class="number"[^>]*>(\d+(?:\.\d+)+)</i' | head -n 1)
+    downloadURL="https://updates.getcleanshot.com/v3/CleanShot-X-${appNewVersion}.dmg"
+    expectedTeamID="AFJU4P8ZV4"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh cleanshotx DEBUG=1
2026-05-29 14:34:50 : INFO  : cleanshotx : setting variable from argument DEBUG=1
2026-05-29 14:34:50 : INFO  : cleanshotx : Total items in argumentsArray: 1
2026-05-29 14:34:50 : INFO  : cleanshotx : argumentsArray: DEBUG=1
2026-05-29 14:34:50 : REQ   : cleanshotx : ################## Start Installomator v. 10.9beta, date 2026-05-29
2026-05-29 14:34:50 : INFO  : cleanshotx : ################## Version: 10.9beta
2026-05-29 14:34:50 : INFO  : cleanshotx : ################## Date: 2026-05-29
2026-05-29 14:34:50 : INFO  : cleanshotx : ################## cleanshotx
2026-05-29 14:34:50 : DEBUG : cleanshotx : DEBUG mode 1 enabled.
2026-05-29 14:34:51 : INFO  : cleanshotx : Reading arguments again: DEBUG=1
2026-05-29 14:34:51 : DEBUG : cleanshotx : argument: DEBUG=1
2026-05-29 14:34:51 : DEBUG : cleanshotx : name=CleanShot X
2026-05-29 14:34:51 : DEBUG : cleanshotx : appName=
2026-05-29 14:34:51 : DEBUG : cleanshotx : type=dmg
2026-05-29 14:34:51 : DEBUG : cleanshotx : archiveName=
2026-05-29 14:34:51 : DEBUG : cleanshotx : downloadURL=https://updates.getcleanshot.com/v3/CleanShot-X-4.8.8.dmg
2026-05-29 14:34:51 : DEBUG : cleanshotx : curlOptions=
2026-05-29 14:34:51 : DEBUG : cleanshotx : appNewVersion=4.8.8
2026-05-29 14:34:51 : DEBUG : cleanshotx : appCustomVersion function: Not defined
2026-05-29 14:34:51 : DEBUG : cleanshotx : versionKey=CFBundleShortVersionString
2026-05-29 14:34:51 : DEBUG : cleanshotx : packageID=
2026-05-29 14:34:51 : DEBUG : cleanshotx : pkgName=
2026-05-29 14:34:51 : DEBUG : cleanshotx : choiceChangesXML=
2026-05-29 14:34:51 : DEBUG : cleanshotx : expectedTeamID=AFJU4P8ZV4
2026-05-29 14:34:51 : DEBUG : cleanshotx : blockingProcesses=
2026-05-29 14:34:51 : DEBUG : cleanshotx : installerTool=
2026-05-29 14:34:51 : DEBUG : cleanshotx : CLIInstaller=
2026-05-29 14:34:51 : DEBUG : cleanshotx : CLIArguments=
2026-05-29 14:34:51 : DEBUG : cleanshotx : updateTool=
2026-05-29 14:34:51 : DEBUG : cleanshotx : updateToolArguments=
2026-05-29 14:34:51 : DEBUG : cleanshotx : updateToolRunAsCurrentUser=
2026-05-29 14:34:51 : INFO  : cleanshotx : BLOCKING_PROCESS_ACTION=tell_user
2026-05-29 14:34:51 : INFO  : cleanshotx : NOTIFY=success
2026-05-29 14:34:51 : INFO  : cleanshotx : LOGGING=DEBUG
2026-05-29 14:34:51 : INFO  : cleanshotx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-29 14:34:51 : INFO  : cleanshotx : Label type: dmg
2026-05-29 14:34:51 : INFO  : cleanshotx : archiveName: CleanShot X.dmg
2026-05-29 14:34:51 : INFO  : cleanshotx : no blocking processes defined, using CleanShot X as default
2026-05-29 14:34:51 : DEBUG : cleanshotx : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-05-29 14:34:51 : INFO  : cleanshotx : name: CleanShot X, appName: CleanShot X.app
2026-05-29 14:34:52 : WARN  : cleanshotx : No previous app found
2026-05-29 14:34:52 : WARN  : cleanshotx : could not find CleanShot X.app
2026-05-29 14:34:52 : INFO  : cleanshotx : appversion: 
2026-05-29 14:34:52 : INFO  : cleanshotx : Latest version of CleanShot X is 4.8.8
2026-05-29 14:34:52 : REQ   : cleanshotx : Downloading https://updates.getcleanshot.com/v3/CleanShot-X-4.8.8.dmg to CleanShot X.dmg
2026-05-29 14:34:52 : DEBUG : cleanshotx : No Dialog connection, just download
2026-05-29 14:34:53 : INFO  : cleanshotx : Downloaded CleanShot X.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 23fb4a6ca541e261a996980eb079939e6bc5b11d – Size is 48416 kB
2026-05-29 14:34:53 : DEBUG : cleanshotx : DEBUG mode 1, not checking for blocking processes
2026-05-29 14:34:53 : REQ   : cleanshotx : Installing CleanShot X
2026-05-29 14:34:53 : INFO  : cleanshotx : Mounting /Users/u0105821/git/github/Installomator/build/CleanShot X.dmg
2026-05-29 14:34:57 : DEBUG : cleanshotx : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $312B3B1A
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $A1E464F6
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F73747A7
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $838A068B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F73747A7
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $7F6BEBEA
verified   CRC32 $BB6D3AE7
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_APFS
/dev/disk19         	EF57347C-0000-11AA-AA11-0030654
/dev/disk19s1       	41504653-0000-11AA-AA11-0030654	/Volumes/CleanShot X

2026-05-29 14:34:57 : INFO  : cleanshotx : Mounted: /Volumes/CleanShot X
2026-05-29 14:34:57 : INFO  : cleanshotx : Verifying: /Volumes/CleanShot X/CleanShot X.app
2026-05-29 14:34:57 : DEBUG : cleanshotx : App size:  70M	/Volumes/CleanShot X/CleanShot X.app
2026-05-29 14:34:58 : DEBUG : cleanshotx : Debugging enabled, App Verification output was:
/Volumes/CleanShot X/CleanShot X.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Make The Web Oślizło & Magiera s.c. (AFJU4P8ZV4)

2026-05-29 14:34:58 : INFO  : cleanshotx : Team ID matching: AFJU4P8ZV4 (expected: AFJU4P8ZV4 )
2026-05-29 14:34:58 : INFO  : cleanshotx : Installing CleanShot X version 4.8.8 on versionKey CFBundleShortVersionString.
2026-05-29 14:34:58 : INFO  : cleanshotx : App has LSMinimumSystemVersion: 10.15
2026-05-29 14:34:58 : DEBUG : cleanshotx : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-29 14:34:58 : INFO  : cleanshotx : Finishing...
2026-05-29 14:35:01 : INFO  : cleanshotx : name: CleanShot X, appName: CleanShot X.app
2026-05-29 14:35:01 : WARN  : cleanshotx : No previous app found
2026-05-29 14:35:01 : WARN  : cleanshotx : could not find CleanShot X.app
2026-05-29 14:35:01 : REQ   : cleanshotx : Installed CleanShot X, version 4.8.8
2026-05-29 14:35:01 : INFO  : cleanshotx : notifying
2026-05-29 14:35:01 : DEBUG : cleanshotx : Unmounting /Volumes/CleanShot X
2026-05-29 14:35:02 : DEBUG : cleanshotx : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-29 14:35:02 : DEBUG : cleanshotx : DEBUG mode 1, not reopening anything
2026-05-29 14:35:02 : REQ   : cleanshotx : All done!
2026-05-29 14:35:02 : REQ   : cleanshotx : ################## End Installomator, exit code 0
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
