### PR TITLE
Update adobecreativeclouddesktop.sh

### DIFF
--- a/fragments/labels/adobecreativeclouddesktop.sh
+++ b/fragments/labels/adobecreativeclouddesktop.sh
@@ -12,13 +12,12 @@ adobecreativeclouddesktop)
     else
         downloadURL=$(curl -fs "https://helpx.adobe.com/in/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html" | grep -o 'https.*osx10.*dmg' | head -1 | cut -d '"' -f1)
     fi
-    #appNewVersion=$(curl -fs "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html" | grep "mandatory" | head -1 | grep -o "Version *.* released" | cut -d " " -f2)
     appNewVersion=$(echo $downloadURL | grep -o '[^x]*$' | cut -d '.' -f 1 | sed 's/_/\./g')
+    appCustomVersion() { defaults read "/Library/Application Support/Adobe/Adobe Desktop Common/ADS/Adobe Desktop Service.app/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null }
     targetDir="/Applications/Utilities/Adobe Creative Cloud/ACC/"
     installerTool="Install.app"
     CLIInstaller="Install.app/Contents/MacOS/Install"
     CLIArguments=(--mode=silent)
     expectedTeamID="JQ525L2MZD"
     blockingProcesses=( "Creative Cloud" )
-    Company="Adobe"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Removed old commented out line for `appNewVersion`
Remove unnecessary `Company` variable
Added `appCustomVersion` to detect installed version correctly

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./assemble.sh adobecreativeclouddesktop
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : Total items in argumentsArray: 0
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : argumentsArray: 
2026-05-30 09:59:06 : REQ   : adobecreativeclouddesktop : ################## Start Installomator v. 10.9beta, date 2026-05-30
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : ################## Version: 10.9beta
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : ################## Date: 2026-05-30
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : ################## adobecreativeclouddesktop
2026-05-30 09:59:06 : DEBUG : adobecreativeclouddesktop : DEBUG mode 1 enabled.
2026-05-30 09:59:06 : INFO  : adobecreativeclouddesktop : Reading arguments again: 
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : name=Adobe Creative Cloud
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : appName=Creative Cloud.app
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : type=dmg
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : archiveName=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : downloadURL=https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.9.1/1/macarm64/ACCCx6_9_1_1.dmg
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : curlOptions=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : appNewVersion=6.9.1.1
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : appCustomVersion function: Defined. 
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : versionKey=CFBundleShortVersionString
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : packageID=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : pkgName=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : choiceChangesXML=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : expectedTeamID=JQ525L2MZD
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : blockingProcesses=Creative Cloud
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : installerTool=Install.app
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : CLIInstaller=Install.app/Contents/MacOS/Install
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : CLIArguments=--mode=silent
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : updateTool=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : updateToolArguments=
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : updateToolRunAsCurrentUser=
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : BLOCKING_PROCESS_ACTION=tell_user
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : NOTIFY=success
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : LOGGING=DEBUG
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : Label type: dmg
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : archiveName: Adobe Creative Cloud.dmg
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : Custom App Version detection is used, found 6.9.1.1
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : appversion: 6.9.1.1
2026-05-30 09:59:07 : INFO  : adobecreativeclouddesktop : Latest version of Adobe Creative Cloud is 6.9.1.1
2026-05-30 09:59:07 : WARN  : adobecreativeclouddesktop : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-30 09:59:07 : REQ   : adobecreativeclouddesktop : Downloading https://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/6.9.1/1/macarm64/ACCCx6_9_1_1.dmg to Adobe Creative Cloud.dmg
2026-05-30 09:59:07 : DEBUG : adobecreativeclouddesktop : No Dialog connection, just download
2026-05-30 09:59:46 : INFO  : adobecreativeclouddesktop : Downloaded Adobe Creative Cloud.dmg – Type is  zlib compressed data – SHA is 80250a49d35d43249a8f9a6474d69bc4989e0575 – Size is 311664 kB
2026-05-30 09:59:46 : DEBUG : adobecreativeclouddesktop : DEBUG mode 1, not checking for blocking processes
2026-05-30 09:59:46 : REQ   : adobecreativeclouddesktop : Installing Adobe Creative Cloud
2026-05-30 09:59:46 : REQ   : adobecreativeclouddesktop : installerTool used: Install.app
2026-05-30 09:59:46 : INFO  : adobecreativeclouddesktop : Mounting /Users/gilburns/GitHub/Installomator/build/Adobe Creative Cloud.dmg
2026-05-30 09:59:48 : DEBUG : adobecreativeclouddesktop : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $5966D477
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $EC0266ED
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $3AF8ED5D
verified   CRC32 $371C2FCD
/dev/disk18         	Apple_partition_scheme
/dev/disk18s1       	Apple_partition_map
/dev/disk18s2       	Apple_HFS                      	/Volumes/Creative Cloud

2026-05-30 09:59:48 : INFO  : adobecreativeclouddesktop : Mounted: /Volumes/Creative Cloud
2026-05-30 09:59:48 : INFO  : adobecreativeclouddesktop : Verifying: /Volumes/Creative Cloud/Install.app
2026-05-30 09:59:48 : DEBUG : adobecreativeclouddesktop : App size:  17M	/Volumes/Creative Cloud/Install.app
2026-05-30 09:59:49 : DEBUG : adobecreativeclouddesktop : Debugging enabled, App Verification output was:
/Volumes/Creative Cloud/Install.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Adobe Inc. (JQ525L2MZD)

2026-05-30 09:59:49 : INFO  : adobecreativeclouddesktop : Team ID matching: JQ525L2MZD (expected: JQ525L2MZD )
2026-05-30 09:59:49 : INFO  : adobecreativeclouddesktop : Downloaded version of Adobe Creative Cloud is 2.14.0.71 on versionKey CFBundleShortVersionString (replacing version 6.9.1.1).
2026-05-30 09:59:49 : INFO  : adobecreativeclouddesktop : App has LSMinimumSystemVersion: 10.13
2026-05-30 09:59:49 : DEBUG : adobecreativeclouddesktop : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-05-30 09:59:49 : INFO  : adobecreativeclouddesktop : Finishing...
2026-05-30 09:59:52 : INFO  : adobecreativeclouddesktop : Custom App Version detection is used, found 6.9.1.1
2026-05-30 09:59:52 : REQ   : adobecreativeclouddesktop : Installed Adobe Creative Cloud, version 2.14.0.71
2026-05-30 09:59:52 : INFO  : adobecreativeclouddesktop : notifying
2026-05-30 09:59:52 : DEBUG : adobecreativeclouddesktop : Unmounting /Volumes/Creative Cloud
2026-05-30 10:00:03 : DEBUG : adobecreativeclouddesktop : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-30 10:00:03 : DEBUG : adobecreativeclouddesktop : DEBUG mode 1, not reopening anything
2026-05-30 10:00:03 : REQ   : adobecreativeclouddesktop : All done!
2026-05-30 10:00:03 : REQ   : adobecreativeclouddesktop : ################## End Installomator, exit code 0 

```