### PR TITLE
Update spotify.sh

### DIFF
--- a/fragments/labels/spotify.sh
+++ b/fragments/labels/spotify.sh
@@ -1,6 +1,12 @@
 spotify)
     name="Spotify"
     type="dmg"
+    tmpSpotifyDir=$(mktemp -d)
+    zipSpotifyPath="$tmpSpotifyDir/SpotifyInstaller.zip"
+    curl -fsSL "https://download.scdn.co/SpotifyInstaller.zip" -o "$zipSpotifyPath"
+    unzip -q "$zipSpotifyPath" -d "$tmpSpotifyDir"
+    appNewVersion=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$tmpSpotifyDir/Install Spotify.app/Contents/Info.plist")
+    rm -rf "$tmpSpotifyDir"
     if [[ $(arch) == arm64 ]]; then
         downloadURL="https://download.scdn.co/SpotifyARM64.dmg"
     elif [[ $(arch) == i386 ]]; then


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Slightly hackish way to get `appNewVersion` defined. 

It is downloading the small **Install Spotify.app** stub installer zip file, expanding it, reading the version from it and then deleting it. It's a much smaller download to get the `appNewVersion` than a full download of the actual DMG file. (<2 MB) The alternative is no value for `appNewVersion`, then the larger 160 MB would need to be downloaded to determine if an upgrade were required.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
./utils/assemble.sh spotify
2026-05-30 21:04:46 : INFO  : spotify : Total items in argumentsArray: 0
2026-05-30 21:04:46 : INFO  : spotify : argumentsArray: 
2026-05-30 21:04:46 : REQ   : spotify : ################## Start Installomator v. 10.9beta, date 2026-05-30
2026-05-30 21:04:46 : INFO  : spotify : ################## Version: 10.9beta
2026-05-30 21:04:46 : INFO  : spotify : ################## Date: 2026-05-30
2026-05-30 21:04:46 : INFO  : spotify : ################## spotify
2026-05-30 21:04:46 : DEBUG : spotify : DEBUG mode 1 enabled.
2026-05-30 21:04:47 : INFO  : spotify : Reading arguments again: 
2026-05-30 21:04:47 : DEBUG : spotify : name=Spotify
2026-05-30 21:04:47 : DEBUG : spotify : appName=
2026-05-30 21:04:47 : DEBUG : spotify : type=dmg
2026-05-30 21:04:47 : DEBUG : spotify : archiveName=
2026-05-30 21:04:47 : DEBUG : spotify : downloadURL=https://download.scdn.co/SpotifyARM64.dmg
2026-05-30 21:04:47 : DEBUG : spotify : curlOptions=
2026-05-30 21:04:47 : DEBUG : spotify : appNewVersion=1.2.90.451
2026-05-30 21:04:47 : DEBUG : spotify : appCustomVersion function: Not defined
2026-05-30 21:04:47 : DEBUG : spotify : versionKey=CFBundleShortVersionString
2026-05-30 21:04:47 : DEBUG : spotify : packageID=
2026-05-30 21:04:47 : DEBUG : spotify : pkgName=
2026-05-30 21:04:47 : DEBUG : spotify : choiceChangesXML=
2026-05-30 21:04:47 : DEBUG : spotify : expectedTeamID=2FNC3A47ZF
2026-05-30 21:04:47 : DEBUG : spotify : blockingProcesses=
2026-05-30 21:04:47 : DEBUG : spotify : installerTool=
2026-05-30 21:04:47 : DEBUG : spotify : CLIInstaller=
2026-05-30 21:04:47 : DEBUG : spotify : CLIArguments=
2026-05-30 21:04:47 : DEBUG : spotify : updateTool=
2026-05-30 21:04:47 : DEBUG : spotify : updateToolArguments=
2026-05-30 21:04:47 : DEBUG : spotify : updateToolRunAsCurrentUser=
2026-05-30 21:04:47 : INFO  : spotify : BLOCKING_PROCESS_ACTION=tell_user
2026-05-30 21:04:47 : INFO  : spotify : NOTIFY=success
2026-05-30 21:04:47 : INFO  : spotify : LOGGING=DEBUG
2026-05-30 21:04:47 : INFO  : spotify : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-30 21:04:47 : INFO  : spotify : Label type: dmg
2026-05-30 21:04:47 : INFO  : spotify : archiveName: Spotify.dmg
2026-05-30 21:04:47 : INFO  : spotify : no blocking processes defined, using Spotify as default
2026-05-30 21:04:47 : DEBUG : spotify : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-30 21:04:47 : INFO  : spotify : App(s) found: /Applications/Spotify.app
2026-05-30 21:04:47 : INFO  : spotify : found app at /Applications/Spotify.app, version 1.2.90.451, on versionKey CFBundleShortVersionString
2026-05-30 21:04:47 : INFO  : spotify : appversion: 1.2.90.451
2026-05-30 21:04:47 : INFO  : spotify : Latest version of Spotify is 1.2.90.451
2026-05-30 21:04:47 : WARN  : spotify : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-30 21:04:47 : REQ   : spotify : Downloading https://download.scdn.co/SpotifyARM64.dmg to Spotify.dmg
2026-05-30 21:04:47 : DEBUG : spotify : No Dialog connection, just download
2026-05-30 21:05:12 : INFO  : spotify : Downloaded Spotify.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 5d2d0068e6ea1f5544a98d2227b8cba4449e9be4 – Size is 164568 kB
2026-05-30 21:05:12 : DEBUG : spotify : DEBUG mode 1, not checking for blocking processes
2026-05-30 21:05:12 : REQ   : spotify : Installing Spotify
2026-05-30 21:05:12 : INFO  : spotify : Mounting /Users/gilburns/GitHub/Installomator/build/Spotify.dmg
2026-05-30 21:05:20 : DEBUG : spotify : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $3952083E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ADD4B67C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $8AD9BCC4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFSX : 4)…
disk image (Apple_HFSX : 4): verified   CRC32 $B1C72FD5
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $8AD9BCC4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $5DB15261
verified   CRC32 $D2E34D9A
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/Spotify

2026-05-30 21:05:20 : INFO  : spotify : Mounted: /Volumes/Spotify
2026-05-30 21:05:20 : INFO  : spotify : Verifying: /Volumes/Spotify/Spotify.app
2026-05-30 21:05:20 : DEBUG : spotify : App size: 377M	/Volumes/Spotify/Spotify.app
2026-05-30 21:05:31 : DEBUG : spotify : Debugging enabled, App Verification output was:
/Volumes/Spotify/Spotify.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Spotify (2FNC3A47ZF)

2026-05-30 21:05:31 : INFO  : spotify : Team ID matching: 2FNC3A47ZF (expected: 2FNC3A47ZF )
2026-05-30 21:05:31 : INFO  : spotify : Downloaded version of Spotify is 1.2.90.451 on versionKey CFBundleShortVersionString, same as installed.
2026-05-30 21:05:31 : DEBUG : spotify : Unmounting /Volumes/Spotify
2026-05-30 21:05:31 : DEBUG : spotify : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-30 21:05:31 : DEBUG : spotify : DEBUG mode 1, not reopening anything
2026-05-30 21:05:31 : REG   : spotify : No new version to install
2026-05-30 21:05:31 : REQ   : spotify : ################## End Installomator, exit code 0 

```