### PR TITLE
Update sonoss2.sh

### DIFF
--- a/fragments/labels/sonoss2.sh
+++ b/fragments/labels/sonoss2.sh
@@ -2,5 +2,7 @@ sonoss2)
     name="Sonos"
     type="dmg"
     downloadURL="https://www.sonos.com/redir/controller_software_mac2"
+    appNewVersion=$(curl -LIs -o /dev/null -w "%{url_effective}\n" "$downloadURL" | grep -oE '[0-9]+\.[0-9]+-[0-9]+' | tr '-' '.')
+    versionKey="CFBundleVersion"
     expectedTeamID="2G4LW83Q3E"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Add the `appNewVersion` variable to the label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


```
./utils/assemble.sh sonoss2
2026-05-30 21:24:51 : INFO  : sonoss2 : Total items in argumentsArray: 0
2026-05-30 21:24:51 : INFO  : sonoss2 : argumentsArray: 
2026-05-30 21:24:51 : REQ   : sonoss2 : ################## Start Installomator v. 10.9beta, date 2026-05-30
2026-05-30 21:24:51 : INFO  : sonoss2 : ################## Version: 10.9beta
2026-05-30 21:24:51 : INFO  : sonoss2 : ################## Date: 2026-05-30
2026-05-30 21:24:51 : INFO  : sonoss2 : ################## sonoss2
2026-05-30 21:24:51 : DEBUG : sonoss2 : DEBUG mode 1 enabled.
2026-05-30 21:24:52 : INFO  : sonoss2 : Reading arguments again: 
2026-05-30 21:24:52 : DEBUG : sonoss2 : name=Sonos
2026-05-30 21:24:52 : DEBUG : sonoss2 : appName=
2026-05-30 21:24:52 : DEBUG : sonoss2 : type=dmg
2026-05-30 21:24:52 : DEBUG : sonoss2 : archiveName=
2026-05-30 21:24:52 : DEBUG : sonoss2 : downloadURL=https://www.sonos.com/redir/controller_software_mac2
2026-05-30 21:24:52 : DEBUG : sonoss2 : curlOptions=
2026-05-30 21:24:52 : DEBUG : sonoss2 : appNewVersion=90.0.77070
2026-05-30 21:24:52 : DEBUG : sonoss2 : appCustomVersion function: Not defined
2026-05-30 21:24:52 : DEBUG : sonoss2 : versionKey=CFBundleVersion
2026-05-30 21:24:52 : DEBUG : sonoss2 : packageID=
2026-05-30 21:24:52 : DEBUG : sonoss2 : pkgName=
2026-05-30 21:24:52 : DEBUG : sonoss2 : choiceChangesXML=
2026-05-30 21:24:52 : DEBUG : sonoss2 : expectedTeamID=2G4LW83Q3E
2026-05-30 21:24:52 : DEBUG : sonoss2 : blockingProcesses=
2026-05-30 21:24:52 : DEBUG : sonoss2 : installerTool=
2026-05-30 21:24:52 : DEBUG : sonoss2 : CLIInstaller=
2026-05-30 21:24:52 : DEBUG : sonoss2 : CLIArguments=
2026-05-30 21:24:52 : DEBUG : sonoss2 : updateTool=
2026-05-30 21:24:52 : DEBUG : sonoss2 : updateToolArguments=
2026-05-30 21:24:52 : DEBUG : sonoss2 : updateToolRunAsCurrentUser=
2026-05-30 21:24:52 : INFO  : sonoss2 : BLOCKING_PROCESS_ACTION=tell_user
2026-05-30 21:24:52 : INFO  : sonoss2 : NOTIFY=success
2026-05-30 21:24:52 : INFO  : sonoss2 : LOGGING=DEBUG
2026-05-30 21:24:52 : INFO  : sonoss2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-30 21:24:52 : INFO  : sonoss2 : Label type: dmg
2026-05-30 21:24:52 : INFO  : sonoss2 : archiveName: Sonos.dmg
2026-05-30 21:24:52 : INFO  : sonoss2 : no blocking processes defined, using Sonos as default
2026-05-30 21:24:52 : DEBUG : sonoss2 : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-30 21:24:52 : INFO  : sonoss2 : App(s) found: /Applications/Sonos.app
2026-05-30 21:24:52 : INFO  : sonoss2 : found app at /Applications/Sonos.app, version 90.0.77070, on versionKey CFBundleVersion
2026-05-30 21:24:52 : INFO  : sonoss2 : appversion: 90.0.77070
2026-05-30 21:24:52 : INFO  : sonoss2 : Latest version of Sonos is 90.0.77070
2026-05-30 21:24:52 : WARN  : sonoss2 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-30 21:24:52 : REQ   : sonoss2 : Downloading https://www.sonos.com/redir/controller_software_mac2 to Sonos.dmg
2026-05-30 21:24:52 : DEBUG : sonoss2 : No Dialog connection, just download
2026-05-30 21:25:01 : INFO  : sonoss2 : Downloaded Sonos.dmg – Type is  zlib compressed data – SHA is 5b9f85c9452dde026bb71a4cdefb46535c2fa96f – Size is 62424 kB
2026-05-30 21:25:01 : DEBUG : sonoss2 : DEBUG mode 1, not checking for blocking processes
2026-05-30 21:25:01 : REQ   : sonoss2 : Installing Sonos
2026-05-30 21:25:01 : INFO  : sonoss2 : Mounting /Users/gilburns/GitHub/Installomator/build/Sonos.dmg
2026-05-30 21:25:05 : DEBUG : sonoss2 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $2ACB1D27
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ABE5ED4D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $8657F903
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $BCB7FA40
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $8657F903
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CB9DECF6
verified   CRC32 $17A038CB
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/Sonos

2026-05-30 21:25:05 : INFO  : sonoss2 : Mounted: /Volumes/Sonos
2026-05-30 21:25:05 : INFO  : sonoss2 : Verifying: /Volumes/Sonos/Sonos.app
2026-05-30 21:25:05 : DEBUG : sonoss2 : App size: 107M	/Volumes/Sonos/Sonos.app
2026-05-30 21:25:06 : DEBUG : sonoss2 : Debugging enabled, App Verification output was:
/Volumes/Sonos/Sonos.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Sonos, Inc. (2G4LW83Q3E)

2026-05-30 21:25:06 : INFO  : sonoss2 : Team ID matching: 2G4LW83Q3E (expected: 2G4LW83Q3E )
2026-05-30 21:25:06 : INFO  : sonoss2 : Downloaded version of Sonos is 90.0.77070 on versionKey CFBundleVersion, same as installed.
2026-05-30 21:25:06 : DEBUG : sonoss2 : Unmounting /Volumes/Sonos
2026-05-30 21:25:06 : DEBUG : sonoss2 : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-05-30 21:25:06 : DEBUG : sonoss2 : DEBUG mode 1, not reopening anything
2026-05-30 21:25:06 : REG   : sonoss2 : No new version to install
2026-05-30 21:25:06 : REQ   : sonoss2 : ################## End Installomator, exit code 0 

```