### PR TITLE
Update korgsoftwarepass.sh

### DIFF
--- a/fragments/labels/korgsoftwarepass.sh
+++ b/fragments/labels/korgsoftwarepass.sh
@@ -1,9 +1,7 @@
 korgsoftwarepass)
     name="Korg Software Pass"
     type="pkgInDmg"
-    packageID="jp.co.korg.pkg.korgsoftwarepass"
-    downloadVersion="$(curl -fs "https://id.korg.com/static_pages/3" | grep -E ".KORG_Software_Pass_([0-9]+(_[0-9]+)+)\.dmg" | cut -d\" -f4 | cut -d_ -f5-7 | cut -d. -f1 | xargs)"
-    appNewVersion="$(echo "$downloadVersion" | tr '_' '.')"
-    downloadURL="https://storage.korg.com/korgms/korg_collection/mac/KORG_Software_Pass_${downloadVersion}.dmg"
+    downloadURL="https://id.korg.com/redirect/korg-software-pass/mac"
+    appNewVersion="$(curl -LIs -o /dev/null -w "%{url_effective}\n" "$downloadURL" | grep -oE '[0-9]+_[0-9]+_[0-9]+' | tr '_' '.')"
     expectedTeamID="9H3HFX7NG2"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
The existing label was no longer working the webpage scraping to find the version no longer worked. Switched to the download itself to get the current version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


[](./utils/assemble.sh korgsoftwarepass             
2026-05-31 10:32:30 : INFO  : korgsoftwarepass : Total items in argumentsArray: 0
2026-05-31 10:32:30 : INFO  : korgsoftwarepass : argumentsArray: 
2026-05-31 10:32:30 : REQ   : korgsoftwarepass : ################## Start Installomator v. 10.9beta, date 2026-05-31
2026-05-31 10:32:30 : INFO  : korgsoftwarepass : ################## Version: 10.9beta
2026-05-31 10:32:30 : INFO  : korgsoftwarepass : ################## Date: 2026-05-31
2026-05-31 10:32:30 : INFO  : korgsoftwarepass : ################## korgsoftwarepass
2026-05-31 10:32:30 : DEBUG : korgsoftwarepass : DEBUG mode 1 enabled.
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : Reading arguments again: 
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : name=Korg Software Pass
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : appName=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : type=pkgInDmg
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : archiveName=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : downloadURL=https://id.korg.com/redirect/korg-software-pass/mac
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : curlOptions=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : appNewVersion=1.3.16
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : appCustomVersion function: Not defined
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : versionKey=CFBundleShortVersionString
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : packageID=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : pkgName=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : choiceChangesXML=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : expectedTeamID=9H3HFX7NG2
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : blockingProcesses=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : installerTool=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : CLIInstaller=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : CLIArguments=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : updateTool=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : updateToolArguments=
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : updateToolRunAsCurrentUser=
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : BLOCKING_PROCESS_ACTION=tell_user
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : NOTIFY=success
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : LOGGING=DEBUG
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : Label type: pkgInDmg
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : archiveName: Korg Software Pass.dmg
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : no blocking processes defined, using Korg Software Pass as default
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : name: Korg Software Pass, appName: Korg Software Pass.app
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : App(s) found: /Applications/KORG/KORG Software Pass.app
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : found app at /Applications/KORG/KORG Software Pass.app, version 1.3.16, on versionKey CFBundleShortVersionString
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : appversion: 1.3.16
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : Latest version of Korg Software Pass is 1.3.16
2026-05-31 10:32:31 : WARN  : korgsoftwarepass : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : Korg Software Pass.dmg exists and DEBUG mode 1 enabled, skipping download
2026-05-31 10:32:31 : DEBUG : korgsoftwarepass : DEBUG mode 1, not checking for blocking processes
2026-05-31 10:32:31 : REQ   : korgsoftwarepass : Installing Korg Software Pass
2026-05-31 10:32:31 : INFO  : korgsoftwarepass : Mounting /Users/gilburns/GitHub/Installomator/build/Korg Software Pass.dmg
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : Debugging enabled, dmgmount output was:
expected   CRC32 $76265E0E
/dev/disk20         	GUID_partition_scheme
/dev/disk20s1       	Apple_HFS                      	/Volumes/KORG_Software_Pass

2026-05-31 10:32:32 : INFO  : korgsoftwarepass : Mounted: /Volumes/KORG_Software_Pass
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : Found pkg(s):
/Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2026-05-31 10:32:32 : INFO  : korgsoftwarepass : found pkg: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2026-05-31 10:32:32 : INFO  : korgsoftwarepass : Verifying: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : File list: -rw-r--r--@ 1 gilburns  staff    23M Feb 19 18:51 /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : File type: /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg: xar archive compressed TOC: 5103, SHA-1 checksum, contains 
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : - OpenPGP Secret Key
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : spctlOut is /Volumes/KORG_Software_Pass/KORG_Software_Pass Installer.pkg: accepted
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : source=Notarized Developer ID
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : origin=Developer ID Installer: KORG INC. (9H3HFX7NG2)
2026-05-31 10:32:32 : INFO  : korgsoftwarepass : Team ID: 9H3HFX7NG2 (expected: 9H3HFX7NG2 )
2026-05-31 10:32:32 : DEBUG : korgsoftwarepass : DEBUG enabled, skipping installation
2026-05-31 10:32:32 : INFO  : korgsoftwarepass : Finishing...
2026-05-31 10:32:35 : INFO  : korgsoftwarepass : name: Korg Software Pass, appName: Korg Software Pass.app
2026-05-31 10:32:35 : INFO  : korgsoftwarepass : App(s) found: /Applications/KORG/KORG Software Pass.app
2026-05-31 10:32:35 : INFO  : korgsoftwarepass : found app at /Applications/KORG/KORG Software Pass.app, version 1.3.16, on versionKey CFBundleShortVersionString
2026-05-31 10:32:35 : REQ   : korgsoftwarepass : Installed Korg Software Pass, version 1.3.16
2026-05-31 10:32:35 : INFO  : korgsoftwarepass : notifying
2026-05-31 10:32:35 : DEBUG : korgsoftwarepass : Unmounting /Volumes/KORG_Software_Pass
2026-05-31 10:32:35 : DEBUG : korgsoftwarepass : Debugging enabled, Unmounting output was:
"disk20" ejected.
2026-05-31 10:32:35 : DEBUG : korgsoftwarepass : DEBUG mode 1, not reopening anything
2026-05-31 10:32:35 : REQ   : korgsoftwarepass : All done!
2026-05-31 10:32:35 : REQ   : korgsoftwarepass : ################## End Installomator, exit code 0 
)