### PR TITLE
Updated microsoftteamsnew.sh

### DIFF
--- a/fragments/labels/microsoftteamsnew.sh
+++ b/fragments/labels/microsoftteamsnew.sh
@@ -2,7 +2,7 @@ microsoftteamsnew)
     name="Microsoft Teams"
     type="pkg"
     MAUSource="https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409TEAMS21.xml"
-    downloadURL=$(curl -fsL $MAUSource | xmllint --xpath '//array/dict[1]/key[text()="Location"]/following-sibling::string[1]/text()' - 2>/dev/null )
+    downloadURL=$(curl -fsL $MAUSource | xmllint --xpath '//array/dict[1]/key[text()="FullUpdaterLocation"]/following-sibling::string[1]/text()' - 2>/dev/null )
     appNewVersion=$(curl -fsL $MAUSource | xmllint --xpath '//array/dict[1]/key[text()="Update Version"]/following-sibling::string[1]/text()' - 2>/dev/null)
     expectedTeamID="UBF8T346G9"
     blockingProcesses=( MSTeams "Microsoft Teams" "Microsoft Teams WebView" "Microsoft Teams Launcher" "Microsoft Teams (work preview)")


### PR DESCRIPTION
Changed the key that fetches the URL from the MAUSource XML to fetch the full installer instead of the delta update.
Fixes  #3007 

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** 
```
2026-06-01 20:35:32 : INFO  : microsoftteamsnew : Total items in argumentsArray: 0
2026-06-01 20:35:32 : INFO  : microsoftteamsnew : argumentsArray:
2026-06-01 20:35:32 : REQ   : microsoftteamsnew : ################## Start Installomator v. 10.9beta, date 2026-06-01
2026-06-01 20:35:32 : INFO  : microsoftteamsnew : ################## Version: 10.9beta
2026-06-01 20:35:32 : INFO  : microsoftteamsnew : ################## Date: 2026-06-01
2026-06-01 20:35:32 : INFO  : microsoftteamsnew : ################## microsoftteamsnew
2026-06-01 20:35:32 : DEBUG : microsoftteamsnew : DEBUG mode 1 enabled.
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : Reading arguments again:
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : name=Microsoft Teams
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : appName=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : type=pkg
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : archiveName=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : downloadURL=https://teamsinstaller.public.onecdn.static.microsoft/production-osx/26120.3106.4725.800/MicrosoftTeams.pkg
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : curlOptions=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : appNewVersion=26120.3106.4725.800
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : appCustomVersion function: Not defined
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : versionKey=CFBundleShortVersionString
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : packageID=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : pkgName=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : choiceChangesXML=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : expectedTeamID=UBF8T346G9
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : blockingProcesses=MSTeams Microsoft Teams Microsoft Teams WebView Microsoft Teams Launcher Microsoft Teams (work preview)
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : installerTool=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : CLIInstaller=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : CLIArguments=
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : updateTool=/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/MacOS/msupdate
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : updateToolArguments=--install --apps TEAMS21
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : updateToolRunAsCurrentUser=
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : BLOCKING_PROCESS_ACTION=tell_user
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : NOTIFY=success
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : LOGGING=DEBUG
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : Label type: pkg
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : archiveName: Microsoft Teams.pkg
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : Changing directory to .
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : name: Microsoft Teams, appName: Microsoft Teams.app
2026-06-01 20:35:33 : WARN  : microsoftteamsnew : No previous app found
2026-06-01 20:35:33 : WARN  : microsoftteamsnew : could not find Microsoft Teams.app
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : appversion:
2026-06-01 20:35:33 : INFO  : microsoftteamsnew : Latest version of Microsoft Teams is 26120.3106.4725.800
2026-06-01 20:35:33 : REQ   : microsoftteamsnew : Downloading https://teamsinstaller.public.onecdn.static.microsoft/production-osx/26120.3106.4725.800/MicrosoftTeams.pkg to Microsoft Teams.pkg
2026-06-01 20:35:33 : DEBUG : microsoftteamsnew : No Dialog connection, just download
2026-06-01 20:35:47 : INFO  : microsoftteamsnew : Downloaded Microsoft Teams.pkg – Type is  xar archive compressed TOC – SHA is 53b2d7dcd2f040fdc9faa398d6bb605f2894964c – Size is 327696 kB
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : DEBUG mode 1, not checking for blocking processes
2026-06-01 20:35:47 : REQ   : microsoftteamsnew : Installing Microsoft Teams
2026-06-01 20:35:47 : INFO  : microsoftteamsnew : Verifying: Microsoft Teams.pkg
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : File list: -rw-r--r--  1 l9065  staff   318M Jun  1 20:35 Microsoft Teams.pkg
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : File type: Microsoft Teams.pkg: xar archive compressed TOC: 5378, SHA-1 checksum
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : spctlOut is Microsoft Teams.pkg: accepted
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : source=Notarized Developer ID
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2026-06-01 20:35:47 : INFO  : microsoftteamsnew : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2026-06-01 20:35:47 : DEBUG : microsoftteamsnew : DEBUG enabled, skipping installation
2026-06-01 20:35:47 : INFO  : microsoftteamsnew : Finishing...
2026-06-01 20:35:50 : INFO  : microsoftteamsnew : name: Microsoft Teams, appName: Microsoft Teams.app
2026-06-01 20:35:50 : WARN  : microsoftteamsnew : No previous app found
2026-06-01 20:35:50 : WARN  : microsoftteamsnew : could not find Microsoft Teams.app
2026-06-01 20:35:50 : REQ   : microsoftteamsnew : Installed Microsoft Teams, version 26120.3106.4725.800
2026-06-01 20:35:50 : INFO  : microsoftteamsnew : notifying
2026-06-01 20:35:51 : DEBUG : microsoftteamsnew : DEBUG mode 1, not reopening anything
2026-06-01 20:35:51 : REQ   : microsoftteamsnew : All done!
2026-06-01 20:35:51 : REQ   : microsoftteamsnew : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. 
Fixes  #3007
