### PR TITLE
Create new label TechSmith Audiate

### DIFF
--- a/fragments/labels/techsmithaudiate.sh
+++ b/fragments/labels/techsmithaudiate.sh
@@ -1,10 +1,10 @@
 techsmithaudiate)
 	name="TechSmith Audiate"
-	type="zip"
+	type="dmg"
 	feedURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest-mac.yml"
 	baseURL="https://cdn-audiate.cloud.techsmith.com/audiate/"
 	appNewVersion="$(curl -fsL "$feedURL" | awk -F': ' '/^version: /{print $2}')"
-	downloadURL="${baseURL}$(curl -fsL "$feedURL" | awk -F': ' '/^path: /{print $2}')"
+	downloadURL="${baseURL}$(curl -fsL "$feedURL" | awk '/universal.*\.dmg/{print $3}')"
 	appName="Audiate.app"
 	expectedTeamID="7TQL462TU8"
 	;;

--- a/fragments/labels/techsmithaudiate.sh
+++ b/fragments/labels/techsmithaudiate.sh
@@ -1,5 +1,4 @@
 techsmithaudiate)
-    #
     name="TechSmith Audiate"
     type="dmg"
     downloadURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest/Audiate.dmg"

--- a/fragments/labels/techsmithaudiate.sh
+++ b/fragments/labels/techsmithaudiate.sh
@@ -1,10 +1,10 @@
 techsmithaudiate)
 	name="TechSmith Audiate"
 	type="dmg"
-	feedURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest-mac.yml"
-	baseURL="https://cdn-audiate.cloud.techsmith.com/audiate/"
-	appNewVersion="$(curl -fsL "$feedURL" | awk -F': ' '/^version: /{print $2}')"
-	downloadURL="${baseURL}$(curl -fsL "$feedURL" | awk '/universal.*\.dmg/{print $3}')"
+	baseURL="https://cdn-audiate.cloud.techsmith.com/audiate"
+	feedURL="$(curl -fsL "$baseURL/latest-mac.yml")"
+	appNewVersion="$(echo "$feedURL" | awk -F': ' '/^version: /{print $2}')"
+	downloadURL="${baseURL}/$(echo "$feedURL" | awk '/universal.*\.dmg/{print $3}')"
 	appName="Audiate.app"
 	expectedTeamID="7TQL462TU8"
 	;;

--- a/fragments/labels/techsmithaudiate.sh
+++ b/fragments/labels/techsmithaudiate.sh
@@ -1,0 +1,8 @@
+techsmithaudiate)
+    #
+    name="TechSmith Audiate"
+    type="dmg"
+    downloadURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest/Audiate.dmg"
+    expectedTeamID="7TQL462TU8"
+    appName="Audiate.app"
+    ;;

--- a/fragments/labels/techsmithaudiate.sh
+++ b/fragments/labels/techsmithaudiate.sh
@@ -1,7 +1,10 @@
 techsmithaudiate)
-    name="TechSmith Audiate"
-    type="dmg"
-    downloadURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest/Audiate.dmg"
-    expectedTeamID="7TQL462TU8"
-    appName="Audiate.app"
-    ;;
+	name="TechSmith Audiate"
+	type="zip"
+	feedURL="https://cdn-audiate.cloud.techsmith.com/audiate/latest-mac.yml"
+	baseURL="https://cdn-audiate.cloud.techsmith.com/audiate/"
+	appNewVersion="$(curl -fsL "$feedURL" | awk -F': ' '/^version: /{print $2}')"
+	downloadURL="${baseURL}$(curl -fsL "$feedURL" | awk -F': ' '/^path: /{print $2}')"
+	appName="Audiate.app"
+	expectedTeamID="7TQL462TU8"
+	;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Script result: 2026-06-01 16:53:42 : REQ   :  : shifting arguments for Jamf
2026-06-01 16:53:42 : INFO  : techsmithaudiate : setting variable from argument NOTIFY=silent
2026-06-01 16:53:42 : INFO  : techsmithaudiate : Total items in argumentsArray: 1
2026-06-01 16:53:42 : INFO  : techsmithaudiate : argumentsArray: NOTIFY=silent
2026-06-01 16:53:42 : REQ   : techsmithaudiate : ################## Start Installomator v. 10.8beta, date 2025-03-28
2026-06-01 16:53:42 : INFO  : techsmithaudiate : ################## Version: 10.8beta
2026-06-01 16:53:42 : INFO  : techsmithaudiate : ################## Date: 2025-03-28
2026-06-01 16:53:42 : INFO  : techsmithaudiate : ################## techsmithaudiate
2026-06-01 16:53:42 : INFO  : techsmithaudiate : Reading arguments again: NOTIFY=silent
2026-06-01 16:53:42 : INFO  : techsmithaudiate : BLOCKING_PROCESS_ACTION=tell_user
2026-06-01 16:53:42 : INFO  : techsmithaudiate : NOTIFY=silent
2026-06-01 16:53:42 : INFO  : techsmithaudiate : LOGGING=INFO
2026-06-01 16:53:42 : INFO  : techsmithaudiate : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-01 16:53:42 : INFO  : techsmithaudiate : Label type: dmg
2026-06-01 16:53:42 : INFO  : techsmithaudiate : archiveName: TechSmith Audiate.dmg
2026-06-01 16:53:42 : INFO  : techsmithaudiate : no blocking processes defined, using TechSmith Audiate as default
2026-06-01 16:53:42 : INFO  : techsmithaudiate : name: TechSmith Audiate, appName: Audiate.app
2026-06-01 16:53:42 : WARN  : techsmithaudiate : No previous app found
2026-06-01 16:53:42 : WARN  : techsmithaudiate : could not find Audiate.app
2026-06-01 16:53:42 : INFO  : techsmithaudiate : appversion: 
2026-06-01 16:53:42 : INFO  : techsmithaudiate : Latest version not specified.
2026-06-01 16:53:42 : REQ   : techsmithaudiate : Downloading https://cdn-audiate.cloud.techsmith.com/audiate/latest/Audiate.dmg to TechSmith Audiate.dmg
2026-06-01 16:54:48 : INFO  : techsmithaudiate : Downloaded TechSmith Audiate.dmg – Type is  zlib compressed data – SHA is 66d423843b14ed6b77ea83ad3fcea1e49e048d0b – Size is 426468 kB
2026-06-01 16:54:48 : REQ   : techsmithaudiate : no more blocking processes, continue with update
2026-06-01 16:54:48 : REQ   : techsmithaudiate : Installing TechSmith Audiate
2026-06-01 16:54:48 : INFO  : techsmithaudiate : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.VkE84KGuPh/TechSmith Audiate.dmg
2026-06-01 16:54:52 : INFO  : techsmithaudiate : Mounted: /Volumes/Audiate
2026-06-01 16:54:52 : INFO  : techsmithaudiate : Verifying: /Volumes/Audiate/Audiate.app
2026-06-01 16:54:56 : INFO  : techsmithaudiate : Team ID matching: 7TQL462TU8 (expected: 7TQL462TU8 )
2026-06-01 16:54:56 : INFO  : techsmithaudiate : Installing TechSmith Audiate version 2026.2.3 on versionKey CFBundleShortVersionString.
2026-06-01 16:54:56 : INFO  : techsmithaudiate : App has LSMinimumSystemVersion: 12.0
2026-06-01 16:54:56 : INFO  : techsmithaudiate : Copy /Volumes/Audiate/Audiate.app to /Applications
2026-06-01 16:54:59 : WARN  : techsmithaudiate : Changing owner to mirko.steinbrecher
2026-06-01 16:54:59 : INFO  : techsmithaudiate : Finishing...
2026-06-01 16:55:02 : INFO  : techsmithaudiate : App(s) found: /Applications/Audiate.app
2026-06-01 16:55:02 : INFO  : techsmithaudiate : found app at /Applications/Audiate.app, version 2026.2.3, on versionKey CFBundleShortVersionString
2026-06-01 16:55:02 : REQ   : techsmithaudiate : Installed TechSmith Audiate, version 2026.2.3
2026-06-01 16:55:02 : INFO  : techsmithaudiate : Installomator did not close any apps, so no need to reopen any apps.
2026-06-01 16:55:02 : REQ   : techsmithaudiate : All done!
2026-06-01 16:55:02 : REQ   : techsmithaudiate : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
