### PR TITLE
maxqda26-new-label

### DIFF
--- a/fragments/labels/maxqda26.sh
+++ b/fragments/labels/maxqda26.sh
@@ -1,0 +1,7 @@
+maxqda26)
+    name="MAXQDA"
+    type="dmg"
+    downloadURL="https://updates.maxqda.de/MAXQDA/MAXQDA.dmg"
+    appNewVersion=$(curl -fsL "https://updates.maxqda.de/MAXQDA/MaxCastMac.xml" | grep -o 'sparkle:shortVersionString="[^"]*"' | head -1 | sed 's/sparkle:shortVersionString="//;s/"//')
+    expectedTeamID="7ME932KUT6"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh maxqda26 DEBUG=1      
2026-06-02 08:35:25 : INFO  : maxqda26 : setting variable from argument DEBUG=1
2026-06-02 08:35:25 : INFO  : maxqda26 : Total items in argumentsArray: 1
2026-06-02 08:35:25 : INFO  : maxqda26 : argumentsArray: DEBUG=1
2026-06-02 08:35:26 : REQ   : maxqda26 : ################## Start Installomator v. 10.9beta, date 2026-06-02
2026-06-02 08:35:26 : INFO  : maxqda26 : ################## Version: 10.9beta
2026-06-02 08:35:26 : INFO  : maxqda26 : ################## Date: 2026-06-02
2026-06-02 08:35:26 : INFO  : maxqda26 : ################## maxqda26
2026-06-02 08:35:26 : DEBUG : maxqda26 : DEBUG mode 1 enabled.
2026-06-02 08:35:27 : INFO  : maxqda26 : Reading arguments again: DEBUG=1
2026-06-02 08:35:27 : DEBUG : maxqda26 : argument: DEBUG=1
2026-06-02 08:35:27 : DEBUG : maxqda26 : name=MAXQDA
2026-06-02 08:35:27 : DEBUG : maxqda26 : appName=
2026-06-02 08:35:27 : DEBUG : maxqda26 : type=dmg
2026-06-02 08:35:27 : DEBUG : maxqda26 : archiveName=
2026-06-02 08:35:27 : DEBUG : maxqda26 : downloadURL=https://updates.maxqda.de/MAXQDA/MAXQDA.dmg
2026-06-02 08:35:27 : DEBUG : maxqda26 : curlOptions=
2026-06-02 08:35:27 : DEBUG : maxqda26 : appNewVersion=26.2.1
2026-06-02 08:35:27 : DEBUG : maxqda26 : appCustomVersion function: Not defined
2026-06-02 08:35:27 : DEBUG : maxqda26 : versionKey=CFBundleShortVersionString
2026-06-02 08:35:27 : DEBUG : maxqda26 : packageID=
2026-06-02 08:35:27 : DEBUG : maxqda26 : pkgName=
2026-06-02 08:35:27 : DEBUG : maxqda26 : choiceChangesXML=
2026-06-02 08:35:27 : DEBUG : maxqda26 : expectedTeamID=7ME932KUT6
2026-06-02 08:35:27 : DEBUG : maxqda26 : blockingProcesses=
2026-06-02 08:35:27 : DEBUG : maxqda26 : installerTool=
2026-06-02 08:35:27 : DEBUG : maxqda26 : CLIInstaller=
2026-06-02 08:35:27 : DEBUG : maxqda26 : CLIArguments=
2026-06-02 08:35:27 : DEBUG : maxqda26 : updateTool=
2026-06-02 08:35:27 : DEBUG : maxqda26 : updateToolArguments=
2026-06-02 08:35:27 : DEBUG : maxqda26 : updateToolRunAsCurrentUser=
2026-06-02 08:35:27 : INFO  : maxqda26 : BLOCKING_PROCESS_ACTION=tell_user
2026-06-02 08:35:27 : INFO  : maxqda26 : NOTIFY=success
2026-06-02 08:35:27 : INFO  : maxqda26 : LOGGING=DEBUG
2026-06-02 08:35:27 : INFO  : maxqda26 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-02 08:35:27 : INFO  : maxqda26 : Label type: dmg
2026-06-02 08:35:27 : INFO  : maxqda26 : archiveName: MAXQDA.dmg
2026-06-02 08:35:27 : INFO  : maxqda26 : no blocking processes defined, using MAXQDA as default
2026-06-02 08:35:27 : DEBUG : maxqda26 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-02 08:35:27 : INFO  : maxqda26 : name: MAXQDA, appName: MAXQDA.app
2026-06-02 08:35:28 : WARN  : maxqda26 : No previous app found
2026-06-02 08:35:28 : WARN  : maxqda26 : could not find MAXQDA.app
2026-06-02 08:35:28 : INFO  : maxqda26 : appversion: 
2026-06-02 08:35:28 : INFO  : maxqda26 : Latest version of MAXQDA is 26.2.1
2026-06-02 08:35:28 : REQ   : maxqda26 : Downloading https://updates.maxqda.de/MAXQDA/MAXQDA.dmg to MAXQDA.dmg
2026-06-02 08:35:28 : DEBUG : maxqda26 : No Dialog connection, just download
2026-06-02 08:36:09 : INFO  : maxqda26 : Downloaded MAXQDA.dmg – Type is  zlib compressed data – SHA is dd5ceb3b802e939436ff34bc3680c0d27823084e – Size is 672204 kB
2026-06-02 08:36:09 : DEBUG : maxqda26 : DEBUG mode 1, not checking for blocking processes
2026-06-02 08:36:09 : REQ   : maxqda26 : Installing MAXQDA
2026-06-02 08:36:09 : INFO  : maxqda26 : Mounting /Users/u0105821/git/github/Installomator/build/MAXQDA.dmg
2026-06-02 08:36:12 : DEBUG : maxqda26 : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $68382A70
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $08266F6B
Checksumming disk image (Apple_HFS : 2)…
disk image (Apple_HFS : 2): verified   CRC32 $62D316E9
verified   CRC32 $DC989126
/dev/disk7          	Apple_partition_scheme
/dev/disk7s1        	Apple_partition_map
/dev/disk7s2        	Apple_HFS                      	/Volumes/MAXQDA

2026-06-02 08:36:12 : INFO  : maxqda26 : Mounted: /Volumes/MAXQDA
2026-06-02 08:36:12 : INFO  : maxqda26 : Verifying: /Volumes/MAXQDA/MAXQDA.app
2026-06-02 08:36:12 : DEBUG : maxqda26 : App size: 1.6G	/Volumes/MAXQDA/MAXQDA.app
2026-06-02 08:36:19 : DEBUG : maxqda26 : Debugging enabled, App Verification output was:
/Volumes/MAXQDA/MAXQDA.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: VERBI Software Consult Sozialforschung GmbH (7ME932KUT6)

2026-06-02 08:36:19 : INFO  : maxqda26 : Team ID matching: 7ME932KUT6 (expected: 7ME932KUT6 )
2026-06-02 08:36:19 : INFO  : maxqda26 : Installing MAXQDA version 26.2.1 on versionKey CFBundleShortVersionString.
2026-06-02 08:36:19 : INFO  : maxqda26 : App has LSMinimumSystemVersion: 10.14.0
2026-06-02 08:36:19 : DEBUG : maxqda26 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-02 08:36:19 : INFO  : maxqda26 : Finishing...
2026-06-02 08:36:22 : INFO  : maxqda26 : name: MAXQDA, appName: MAXQDA.app
2026-06-02 08:36:23 : WARN  : maxqda26 : No previous app found
2026-06-02 08:36:23 : WARN  : maxqda26 : could not find MAXQDA.app
2026-06-02 08:36:23 : REQ   : maxqda26 : Installed MAXQDA, version 26.2.1
2026-06-02 08:36:23 : INFO  : maxqda26 : notifying
2026-06-02 08:36:23 : DEBUG : maxqda26 : Unmounting /Volumes/MAXQDA
2026-06-02 08:36:23 : DEBUG : maxqda26 : Debugging enabled, Unmounting output was:
"disk7" ejected.
2026-06-02 08:36:24 : DEBUG : maxqda26 : DEBUG mode 1, not reopening anything
2026-06-02 08:36:24 : REQ   : maxqda26 : All done!
2026-06-02 08:36:24 : REQ   : maxqda26 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
