### PR TITLE
focusritecontrol2-new-label

### DIFF
--- a/fragments/labels/focusritecontrol2.sh
+++ b/fragments/labels/focusritecontrol2.sh
@@ -1,0 +1,7 @@
+focusritecontrol2)
+    name="Focusrite Control 2"
+    type="dmg"
+    appNewVersion=$(curl -fsL "https://releases.focusrite.com/com.focusrite.focusrite-control/release/focusrite-control.release.mac.xml" | xmllint --xpath 'string((//*[local-name()="enclosure"]/@*[local-name()="version"])[1])' -)
+    downloadURL=$(curl -fsL "https://releases.focusrite.com/com.focusrite.focusrite-control/release/focusrite-control.release.mac.xml" | xmllint --xpath 'string((//*[local-name()="enclosure"]/@url)[1])' -)
+    expectedTeamID="7VYBQV3T2Q"
+;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh focusritecontrol2 DEBUG=1
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : setting variable from argument DEBUG=1
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : Total items in argumentsArray: 1
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : argumentsArray: DEBUG=1
2026-06-02 12:02:17 : REQ   : focusritecontrol2 : ################## Start Installomator v. 10.9beta, date 2026-06-02
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : ################## Version: 10.9beta
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : ################## Date: 2026-06-02
2026-06-02 12:02:17 : INFO  : focusritecontrol2 : ################## focusritecontrol2
2026-06-02 12:02:17 : DEBUG : focusritecontrol2 : DEBUG mode 1 enabled.
2026-06-02 12:02:18 : INFO  : focusritecontrol2 : Reading arguments again: DEBUG=1
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : argument: DEBUG=1
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : name=Focusrite Control 2
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : appName=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : type=dmg
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : archiveName=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : downloadURL=https://releases.focusrite.com/com.focusrite.focusrite-control/release/Focusrite-Control-2-1.1014.0.0.dmg
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : curlOptions=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : appNewVersion=1.1014.0.0
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : appCustomVersion function: Not defined
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : versionKey=CFBundleShortVersionString
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : packageID=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : pkgName=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : choiceChangesXML=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : expectedTeamID=7VYBQV3T2Q
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : blockingProcesses=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : installerTool=
2026-06-02 12:02:18 : DEBUG : focusritecontrol2 : CLIInstaller=
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : CLIArguments=
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : updateTool=
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : updateToolArguments=
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : updateToolRunAsCurrentUser=
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : BLOCKING_PROCESS_ACTION=tell_user
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : NOTIFY=success
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : LOGGING=DEBUG
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : Label type: dmg
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : archiveName: Focusrite Control 2.dmg
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : no blocking processes defined, using Focusrite Control 2 as default
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : name: Focusrite Control 2, appName: Focusrite Control 2.app
2026-06-02 12:02:19 : WARN  : focusritecontrol2 : No previous app found
2026-06-02 12:02:19 : WARN  : focusritecontrol2 : could not find Focusrite Control 2.app
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : appversion: 
2026-06-02 12:02:19 : INFO  : focusritecontrol2 : Latest version of Focusrite Control 2 is 1.1014.0.0
2026-06-02 12:02:19 : REQ   : focusritecontrol2 : Downloading https://releases.focusrite.com/com.focusrite.focusrite-control/release/Focusrite-Control-2-1.1014.0.0.dmg to Focusrite Control 2.dmg
2026-06-02 12:02:19 : DEBUG : focusritecontrol2 : No Dialog connection, just download
2026-06-02 12:02:23 : INFO  : focusritecontrol2 : Downloaded Focusrite Control 2.dmg – Type is  zlib compressed data – SHA is f193350d616e9b4ffdcb492a30333b1042d8f055 – Size is 115500 kB
2026-06-02 12:02:23 : DEBUG : focusritecontrol2 : DEBUG mode 1, not checking for blocking processes
2026-06-02 12:02:23 : REQ   : focusritecontrol2 : Installing Focusrite Control 2
2026-06-02 12:02:23 : INFO  : focusritecontrol2 : Mounting /Users/u0105821/git/github/Installomator/build/Focusrite Control 2.dmg
2026-06-02 12:02:27 : DEBUG : focusritecontrol2 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $922DA511
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $783DBF44
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $91D70321
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $1D3B1926
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $91D70321
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $3EB650FC
verified   CRC32 $469E33C0
/dev/disk13         	GUID_partition_scheme
/dev/disk13s1       	Apple_HFS                      	/Volumes/Focusrite Control 2 1

2026-06-02 12:02:27 : INFO  : focusritecontrol2 : Mounted: /Volumes/Focusrite Control 2 1
2026-06-02 12:02:27 : INFO  : focusritecontrol2 : Verifying: /Volumes/Focusrite Control 2 1/Focusrite Control 2.app
2026-06-02 12:02:27 : DEBUG : focusritecontrol2 : App size: 186M	/Volumes/Focusrite Control 2 1/Focusrite Control 2.app
2026-06-02 12:02:28 : DEBUG : focusritecontrol2 : Debugging enabled, App Verification output was:
/Volumes/Focusrite Control 2 1/Focusrite Control 2.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Focusrite Audio Engineering Ltd. (7VYBQV3T2Q)

2026-06-02 12:02:28 : INFO  : focusritecontrol2 : Team ID matching: 7VYBQV3T2Q (expected: 7VYBQV3T2Q )
2026-06-02 12:02:28 : INFO  : focusritecontrol2 : Installing Focusrite Control 2 version 1.1014.0.0 on versionKey CFBundleShortVersionString.
2026-06-02 12:02:28 : DEBUG : focusritecontrol2 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-02 12:02:28 : INFO  : focusritecontrol2 : Finishing...
2026-06-02 12:02:31 : INFO  : focusritecontrol2 : name: Focusrite Control 2, appName: Focusrite Control 2.app
2026-06-02 12:02:32 : WARN  : focusritecontrol2 : No previous app found
2026-06-02 12:02:32 : WARN  : focusritecontrol2 : could not find Focusrite Control 2.app
2026-06-02 12:02:32 : REQ   : focusritecontrol2 : Installed Focusrite Control 2, version 1.1014.0.0
2026-06-02 12:02:32 : INFO  : focusritecontrol2 : notifying
2026-06-02 12:02:32 : DEBUG : focusritecontrol2 : Unmounting /Volumes/Focusrite Control 2 1
2026-06-02 12:02:32 : DEBUG : focusritecontrol2 : Debugging enabled, Unmounting output was:
"disk13" ejected.
2026-06-02 12:02:32 : DEBUG : focusritecontrol2 : DEBUG mode 1, not reopening anything
2026-06-02 12:02:32 : REQ   : focusritecontrol2 : All done!
2026-06-02 12:02:32 : REQ   : focusritecontrol2 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
