### PR TITLE
Fiddlereverywhere new label

### DIFF
--- a/fragments/labels/fiddlereverywhere.sh
+++ b/fragments/labels/fiddlereverywhere.sh
@@ -1,7 +1,11 @@
 fiddlereverywhere)
     name="Fiddler Everywhere"
     type="dmg"
-    downloadURL="https://api.getfiddler.com/mac/latest-mac"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="https://api.getfiddler.com/mac-arm64/latest-mac"
+    else
+        downloadURL="https://api.getfiddler.com/mac/latest-mac"
+    fi
     appNewVersion=$(curl -fsL -w "%{url_effective}" -o /dev/null "$downloadURL" | sed -E 's|.*Fiddler%20Everywhere%20([0-9.]+)\.dmg|\1|')
     expectedTeamID="CHSQ3M3P37"
     ;;

--- a/fragments/labels/fiddlereverywhere.sh
+++ b/fragments/labels/fiddlereverywhere.sh
@@ -1,0 +1,7 @@
+fiddlereverywhere)
+    name="Fiddler Everywhere"
+    type="dmg"
+    downloadURL="https://api.getfiddler.com/mac/latest-mac"
+    appNewVersion=$(curl -fsL -w "%{url_effective}" -o /dev/null "$downloadURL" | sed -E 's|.*Fiddler%20Everywhere%20([0-9.]+)\.dmg|\1|')
+    expectedTeamID="CHSQ3M3P37"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The label is simplified to use Fiddler’s latest macOS redirect endpoint instead of scraping Telerik release-history HTML and manually constructing a fallback URL. During review, the updated PR version had the required name, type, downloadURL, and expectedTeamID variables, plus appNewVersion, but it should preserve architecture-specific handling because Fiddler publishes separate Intel and Apple Silicon macOS DMGs; the reviewed version below branches on $(arch) and keeps version parsing tied to the final redirected DMG URL.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh fiddlereverywhere DEBUG=1
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : setting variable from argument DEBUG=1
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : Total items in argumentsArray: 1
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : argumentsArray: DEBUG=1
2026-06-03 14:29:58 : REQ   : fiddlereverywhere : ################## Start Installomator v. 10.9beta, date 2026-06-03
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : ################## Version: 10.9beta
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : ################## Date: 2026-06-03
2026-06-03 14:29:58 : INFO  : fiddlereverywhere : ################## fiddlereverywhere
2026-06-03 14:29:58 : DEBUG : fiddlereverywhere : DEBUG mode 1 enabled.
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : Reading arguments again: DEBUG=1
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : argument: DEBUG=1
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : name=Fiddler Everywhere
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : appName=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : type=dmg
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : archiveName=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : downloadURL=https://api.getfiddler.com/mac/latest-mac
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : curlOptions=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : appNewVersion=7.8.0
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : appCustomVersion function: Not defined
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : versionKey=CFBundleShortVersionString
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : packageID=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : pkgName=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : choiceChangesXML=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : expectedTeamID=CHSQ3M3P37
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : blockingProcesses=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : installerTool=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : CLIInstaller=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : CLIArguments=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : updateTool=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : updateToolArguments=
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : updateToolRunAsCurrentUser=
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : BLOCKING_PROCESS_ACTION=tell_user
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : NOTIFY=success
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : LOGGING=DEBUG
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : Label type: dmg
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : archiveName: Fiddler Everywhere.dmg
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : no blocking processes defined, using Fiddler Everywhere as default
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : name: Fiddler Everywhere, appName: Fiddler Everywhere.app
2026-06-03 14:30:04 : WARN  : fiddlereverywhere : No previous app found
2026-06-03 14:30:04 : WARN  : fiddlereverywhere : could not find Fiddler Everywhere.app
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : appversion: 
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : Latest version of Fiddler Everywhere is 7.8.0
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : Fiddler Everywhere.dmg exists and DEBUG mode 1 enabled, skipping download
2026-06-03 14:30:04 : DEBUG : fiddlereverywhere : DEBUG mode 1, not checking for blocking processes
2026-06-03 14:30:04 : REQ   : fiddlereverywhere : Installing Fiddler Everywhere
2026-06-03 14:30:04 : INFO  : fiddlereverywhere : Mounting /Users/u0105821/git/github/Installomator/build/Fiddler Everywhere.dmg
2026-06-03 14:30:05 : DEBUG : fiddlereverywhere : Debugging enabled, dmgmount output was:
End User License Agreement

.
.
.

Last Log repeated 2 times
Rev. TMPLT14SEPT2023-FIDDLER-EVERYWHERE-22APRIL2024

expected   CRC32 $A12BAA1D
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/Fiddler Everywhere 7.8.0

2026-06-03 14:30:05 : INFO  : fiddlereverywhere : Mounted: /Volumes/Fiddler Everywhere 7.8.0
2026-06-03 14:30:05 : INFO  : fiddlereverywhere : Verifying: /Volumes/Fiddler Everywhere 7.8.0/Fiddler Everywhere.app
2026-06-03 14:30:05 : DEBUG : fiddlereverywhere : App size: 481M	/Volumes/Fiddler Everywhere 7.8.0/Fiddler Everywhere.app
2026-06-03 14:30:09 : DEBUG : fiddlereverywhere : Debugging enabled, App Verification output was:
/Volumes/Fiddler Everywhere 7.8.0/Fiddler Everywhere.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Telerik A D (CHSQ3M3P37)

2026-06-03 14:30:09 : INFO  : fiddlereverywhere : Team ID matching: CHSQ3M3P37 (expected: CHSQ3M3P37 )
2026-06-03 14:30:09 : INFO  : fiddlereverywhere : Installing Fiddler Everywhere version 7.8.0 on versionKey CFBundleShortVersionString.
2026-06-03 14:30:09 : INFO  : fiddlereverywhere : App has LSMinimumSystemVersion: 12.0
2026-06-03 14:30:09 : DEBUG : fiddlereverywhere : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-03 14:30:09 : INFO  : fiddlereverywhere : Finishing...
2026-06-03 14:30:12 : INFO  : fiddlereverywhere : name: Fiddler Everywhere, appName: Fiddler Everywhere.app
2026-06-03 14:30:12 : WARN  : fiddlereverywhere : No previous app found
2026-06-03 14:30:12 : WARN  : fiddlereverywhere : could not find Fiddler Everywhere.app
2026-06-03 14:30:12 : REQ   : fiddlereverywhere : Installed Fiddler Everywhere, version 7.8.0
2026-06-03 14:30:12 : INFO  : fiddlereverywhere : notifying
2026-06-03 14:30:12 : DEBUG : fiddlereverywhere : Unmounting /Volumes/Fiddler Everywhere 7.8.0
2026-06-03 14:30:13 : DEBUG : fiddlereverywhere : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-03 14:30:13 : DEBUG : fiddlereverywhere : DEBUG mode 1, not reopening anything
2026-06-03 14:30:13 : REQ   : fiddlereverywhere : All done!
2026-06-03 14:30:13 : REQ   : fiddlereverywhere : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
