### PR TITLE
jamovi-update-label

### DIFF
--- a/fragments/labels/jamovi.sh
+++ b/fragments/labels/jamovi.sh
@@ -1,14 +1,13 @@
 jamovi)
     name="jamovi"
     type="dmg"
-    downloadURL="http://www.jamovi.org"
-    if [[ -n $jamoviLatest ]]; then
-        downloadURL="${downloadURL}$(curl -s "$downloadURL/download.html" | grep macos | grep "download-button" | head -1 | cut -d '"' -f 4)"
+    if [[ "$arch" == "arm64" ]]; then
+        archSuffix="arm64"
     else
-        downloadURL="${downloadURL}$(curl -s "$downloadURL/download.html" | grep macos | grep "download-button" | tail -1 | cut -d '"' -f 4)"
+        archSuffix="x64"
     fi
-    # The above is a cheat, they list both the "Latest" version and the "Solid" version twice on the page, but in opposing order.
-    #     I'm also assuming they mean Latest = beta, and Solid = Stable.
-    appNewVersion="$(echo $downloadPATH | cut -d '-' -f 2)"
+    downloadFile=$(curl -fsL "https://dl.jamovi.org/" | grep -o "jamovi-[0-9][^\"]*-macos-${archSuffix}\.dmg" | sort -Vu | tail -n 1)
+    downloadURL="https://dl.jamovi.org/${downloadFile}"
+    appNewVersion="$(echo "$downloadFile" | sed -E "s/^jamovi-([0-9.]+)-macos-${archSuffix}\.dmg$/\1/")"
     expectedTeamID="9NCBP559AB"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh jamovi DEBUG=1                                                                                             
2026-06-03 16:34:11 : INFO  : jamovi : setting variable from argument DEBUG=1
2026-06-03 16:34:11 : INFO  : jamovi : Total items in argumentsArray: 1
2026-06-03 16:34:11 : INFO  : jamovi : argumentsArray: DEBUG=1
2026-06-03 16:34:11 : REQ   : jamovi : ################## Start Installomator v. 10.9beta, date 2026-06-03
2026-06-03 16:34:11 : INFO  : jamovi : ################## Version: 10.9beta
2026-06-03 16:34:11 : INFO  : jamovi : ################## Date: 2026-06-03
2026-06-03 16:34:11 : INFO  : jamovi : ################## jamovi
2026-06-03 16:34:11 : DEBUG : jamovi : DEBUG mode 1 enabled.
2026-06-03 16:34:12 : INFO  : jamovi : Reading arguments again: DEBUG=1
2026-06-03 16:34:12 : DEBUG : jamovi : argument: DEBUG=1
2026-06-03 16:34:12 : DEBUG : jamovi : name=jamovi
2026-06-03 16:34:12 : DEBUG : jamovi : appName=
2026-06-03 16:34:12 : DEBUG : jamovi : type=dmg
2026-06-03 16:34:12 : DEBUG : jamovi : archiveName=
2026-06-03 16:34:12 : DEBUG : jamovi : downloadURL=https://dl.jamovi.org/jamovi-2.7.30.0-macos-x64.dmg
2026-06-03 16:34:12 : DEBUG : jamovi : curlOptions=
2026-06-03 16:34:12 : DEBUG : jamovi : appNewVersion=2.7.30.0
2026-06-03 16:34:12 : DEBUG : jamovi : appCustomVersion function: Not defined
2026-06-03 16:34:12 : DEBUG : jamovi : versionKey=CFBundleShortVersionString
2026-06-03 16:34:12 : DEBUG : jamovi : packageID=
2026-06-03 16:34:12 : DEBUG : jamovi : pkgName=
2026-06-03 16:34:12 : DEBUG : jamovi : choiceChangesXML=
2026-06-03 16:34:12 : DEBUG : jamovi : expectedTeamID=9NCBP559AB
2026-06-03 16:34:12 : DEBUG : jamovi : blockingProcesses=
2026-06-03 16:34:12 : DEBUG : jamovi : installerTool=
2026-06-03 16:34:12 : DEBUG : jamovi : CLIInstaller=
2026-06-03 16:34:12 : DEBUG : jamovi : CLIArguments=
2026-06-03 16:34:12 : DEBUG : jamovi : updateTool=
2026-06-03 16:34:12 : DEBUG : jamovi : updateToolArguments=
2026-06-03 16:34:12 : DEBUG : jamovi : updateToolRunAsCurrentUser=
2026-06-03 16:34:12 : INFO  : jamovi : BLOCKING_PROCESS_ACTION=tell_user
2026-06-03 16:34:12 : INFO  : jamovi : NOTIFY=success
2026-06-03 16:34:12 : INFO  : jamovi : LOGGING=DEBUG
2026-06-03 16:34:12 : INFO  : jamovi : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-03 16:34:12 : INFO  : jamovi : Label type: dmg
2026-06-03 16:34:12 : INFO  : jamovi : archiveName: jamovi.dmg
2026-06-03 16:34:12 : INFO  : jamovi : no blocking processes defined, using jamovi as default
2026-06-03 16:34:12 : DEBUG : jamovi : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-03 16:34:12 : INFO  : jamovi : name: jamovi, appName: jamovi.app
2026-06-03 16:34:13 : WARN  : jamovi : No previous app found
2026-06-03 16:34:13 : WARN  : jamovi : could not find jamovi.app
2026-06-03 16:34:13 : INFO  : jamovi : appversion: 
2026-06-03 16:34:13 : INFO  : jamovi : Latest version of jamovi is 2.7.30.0
2026-06-03 16:34:13 : REQ   : jamovi : Downloading https://dl.jamovi.org/jamovi-2.7.30.0-macos-x64.dmg to jamovi.dmg
2026-06-03 16:34:13 : DEBUG : jamovi : No Dialog connection, just download
2026-06-03 16:34:32 : INFO  : jamovi : Downloaded jamovi.dmg – Type is  zlib compressed data – SHA is 18557bb0e9b44882cccd8b1120c4ce8ecca66ff9 – Size is 443340 kB
2026-06-03 16:34:32 : DEBUG : jamovi : DEBUG mode 1, not checking for blocking processes
2026-06-03 16:34:32 : REQ   : jamovi : Installing jamovi
2026-06-03 16:34:32 : INFO  : jamovi : Mounting /Users/u0105821/git/github/Installomator/build/jamovi.dmg
2026-06-03 16:34:36 : DEBUG : jamovi : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $B7C90D9B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0ED1E5F0
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7EB2CE8A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $6ECD4A66
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7EB2CE8A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $4A6D0DB2
verified   CRC32 $843D1385
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/jamovi

2026-06-03 16:34:36 : INFO  : jamovi : Mounted: /Volumes/jamovi
2026-06-03 16:34:36 : INFO  : jamovi : Verifying: /Volumes/jamovi/jamovi.app
2026-06-03 16:34:37 : DEBUG : jamovi : App size: 997M	/Volumes/jamovi/jamovi.app
2026-06-03 16:34:46 : DEBUG : jamovi : Debugging enabled, App Verification output was:
/Volumes/jamovi/jamovi.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The jamovi project Pty Ltd (9NCBP559AB)

2026-06-03 16:34:46 : INFO  : jamovi : Team ID matching: 9NCBP559AB (expected: 9NCBP559AB )
2026-06-03 16:34:46 : INFO  : jamovi : Installing jamovi version 2.7.30.0 on versionKey CFBundleShortVersionString.
2026-06-03 16:34:46 : INFO  : jamovi : App has LSMinimumSystemVersion: 10.13
2026-06-03 16:34:46 : DEBUG : jamovi : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-03 16:34:46 : INFO  : jamovi : Finishing...
2026-06-03 16:34:49 : INFO  : jamovi : name: jamovi, appName: jamovi.app
2026-06-03 16:34:49 : WARN  : jamovi : No previous app found
2026-06-03 16:34:49 : WARN  : jamovi : could not find jamovi.app
2026-06-03 16:34:49 : REQ   : jamovi : Installed jamovi, version 2.7.30.0
2026-06-03 16:34:49 : INFO  : jamovi : notifying
2026-06-03 16:34:50 : DEBUG : jamovi : Unmounting /Volumes/jamovi
2026-06-03 16:34:50 : DEBUG : jamovi : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-03 16:34:50 : DEBUG : jamovi : DEBUG mode 1, not reopening anything
2026-06-03 16:34:50 : REQ   : jamovi : All done!
2026-06-03 16:34:50 : REQ   : jamovi : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
