### PR TITLE
opencode-new-label

### DIFF
--- a/fragments/labels/opencode.sh
+++ b/fragments/labels/opencode.sh
@@ -1,0 +1,12 @@
+opencode)
+    name="OpenCode"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        archiveName="opencode-desktop-mac-arm64.dmg"
+    else
+        archiveName="opencode-desktop-mac-x64.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit anomalyco opencode)
+    appNewVersion=$(versionFromGit anomalyco opencode)
+    expectedTeamID="5NZ4Q7NXJ4"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh opencode DEBUG=1
2026-06-03 17:18:15 : INFO  : opencode : setting variable from argument DEBUG=1
2026-06-03 17:18:15 : INFO  : opencode : Total items in argumentsArray: 1
2026-06-03 17:18:15 : INFO  : opencode : argumentsArray: DEBUG=1
2026-06-03 17:18:15 : REQ   : opencode : ################## Start Installomator v. 10.9beta, date 2026-06-03
2026-06-03 17:18:15 : INFO  : opencode : ################## Version: 10.9beta
2026-06-03 17:18:15 : INFO  : opencode : ################## Date: 2026-06-03
2026-06-03 17:18:16 : INFO  : opencode : ################## opencode
2026-06-03 17:18:16 : DEBUG : opencode : DEBUG mode 1 enabled.
2026-06-03 17:18:17 : INFO  : opencode : Reading arguments again: DEBUG=1
2026-06-03 17:18:17 : DEBUG : opencode : argument: DEBUG=1
2026-06-03 17:18:17 : DEBUG : opencode : name=OpenCode
2026-06-03 17:18:17 : DEBUG : opencode : appName=
2026-06-03 17:18:17 : DEBUG : opencode : type=dmg
2026-06-03 17:18:17 : DEBUG : opencode : archiveName=opencode-desktop-mac-arm64.dmg
2026-06-03 17:18:17 : DEBUG : opencode : downloadURL=https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-desktop-mac-arm64.dmg
2026-06-03 17:18:17 : DEBUG : opencode : curlOptions=
2026-06-03 17:18:17 : DEBUG : opencode : appNewVersion=1.15.13
2026-06-03 17:18:17 : DEBUG : opencode : appCustomVersion function: Not defined
2026-06-03 17:18:17 : DEBUG : opencode : versionKey=CFBundleShortVersionString
2026-06-03 17:18:17 : DEBUG : opencode : packageID=
2026-06-03 17:18:17 : DEBUG : opencode : pkgName=
2026-06-03 17:18:17 : DEBUG : opencode : choiceChangesXML=
2026-06-03 17:18:17 : DEBUG : opencode : expectedTeamID=5NZ4Q7NXJ4
2026-06-03 17:18:17 : DEBUG : opencode : blockingProcesses=
2026-06-03 17:18:17 : DEBUG : opencode : installerTool=
2026-06-03 17:18:18 : DEBUG : opencode : CLIInstaller=
2026-06-03 17:18:18 : DEBUG : opencode : CLIArguments=
2026-06-03 17:18:18 : DEBUG : opencode : updateTool=
2026-06-03 17:18:18 : DEBUG : opencode : updateToolArguments=
2026-06-03 17:18:18 : DEBUG : opencode : updateToolRunAsCurrentUser=
2026-06-03 17:18:18 : INFO  : opencode : BLOCKING_PROCESS_ACTION=tell_user
2026-06-03 17:18:18 : INFO  : opencode : NOTIFY=success
2026-06-03 17:18:18 : INFO  : opencode : LOGGING=DEBUG
2026-06-03 17:18:18 : INFO  : opencode : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-03 17:18:18 : INFO  : opencode : Label type: dmg
2026-06-03 17:18:18 : INFO  : opencode : archiveName: opencode-desktop-mac-arm64.dmg
2026-06-03 17:18:18 : INFO  : opencode : no blocking processes defined, using OpenCode as default
2026-06-03 17:18:18 : DEBUG : opencode : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-03 17:18:18 : INFO  : opencode : name: OpenCode, appName: OpenCode.app
2026-06-03 17:18:18 : WARN  : opencode : No previous app found
2026-06-03 17:18:18 : WARN  : opencode : could not find OpenCode.app
2026-06-03 17:18:18 : INFO  : opencode : appversion: 
2026-06-03 17:18:18 : INFO  : opencode : Latest version of OpenCode is 1.15.13
2026-06-03 17:18:18 : INFO  : opencode : opencode-desktop-mac-arm64.dmg exists and DEBUG mode 1 enabled, skipping download
2026-06-03 17:18:18 : DEBUG : opencode : DEBUG mode 1, not checking for blocking processes
2026-06-03 17:18:18 : REQ   : opencode : Installing OpenCode
2026-06-03 17:18:18 : INFO  : opencode : Mounting /Users/u0105821/git/github/Installomator/build/opencode-desktop-mac-arm64.dmg
2026-06-03 17:18:18 : DEBUG : opencode : Debugging enabled, dmgmount output was:
expected   CRC32 $0E334F23
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/OpenCode 1.15.13-arm64

2026-06-03 17:18:18 : INFO  : opencode : Mounted: /Volumes/OpenCode 1.15.13-arm64
2026-06-03 17:18:18 : INFO  : opencode : Verifying: /Volumes/OpenCode 1.15.13-arm64/OpenCode.app
2026-06-03 17:18:18 : DEBUG : opencode : App size: 366M	/Volumes/OpenCode 1.15.13-arm64/OpenCode.app
2026-06-03 17:18:20 : DEBUG : opencode : Debugging enabled, App Verification output was:
/Volumes/OpenCode 1.15.13-arm64/OpenCode.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Anomaly Innovations, Inc. (5NZ4Q7NXJ4)

2026-06-03 17:18:20 : INFO  : opencode : Team ID matching: 5NZ4Q7NXJ4 (expected: 5NZ4Q7NXJ4 )
2026-06-03 17:18:20 : INFO  : opencode : Installing OpenCode version 1.15.13 on versionKey CFBundleShortVersionString.
2026-06-03 17:18:20 : INFO  : opencode : App has LSMinimumSystemVersion: 12.0
2026-06-03 17:18:20 : DEBUG : opencode : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-03 17:18:20 : INFO  : opencode : Finishing...
2026-06-03 17:18:23 : INFO  : opencode : name: OpenCode, appName: OpenCode.app
2026-06-03 17:18:23 : WARN  : opencode : No previous app found
2026-06-03 17:18:23 : WARN  : opencode : could not find OpenCode.app
2026-06-03 17:18:23 : REQ   : opencode : Installed OpenCode, version 1.15.13
2026-06-03 17:18:23 : INFO  : opencode : notifying
2026-06-03 17:18:24 : DEBUG : opencode : Unmounting /Volumes/OpenCode 1.15.13-arm64
2026-06-03 17:18:24 : DEBUG : opencode : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-03 17:18:24 : DEBUG : opencode : DEBUG mode 1, not reopening anything
2026-06-03 17:18:24 : REQ   : opencode : All done!
2026-06-03 17:18:24 : REQ   : opencode : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
