### PR TITLE
Add appCustomVersion to redshift

### DIFF
--- a/fragments/labels/redshift.sh
+++ b/fragments/labels/redshift.sh
@@ -3,10 +3,10 @@ redshift)
     appName="Maxon Redshift Installer.app"
     blockingProcesses=( "Cinema 4D" )
     type="dmg"
-    packageID="com.redshift3d.redshift"
     expectedTeamID="4ZY22YGXQG"
     downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redshift[^"]*macos\.dmg' | head -1)
     appNewVersion=$(sed -n 's/.*redshift_\([^_]*\).*/\1/p' <<< "${downloadURL}")
+    appCustomVersion() {/usr/bin/defaults read "/Applications/Maxon Redshift 2026/uninstall.app/Contents/Info.plist" CFBundleVersion }
     installerTool="Maxon Redshift Installer.app"
     CLIInstaller="Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh"
     # Customize --enable-components for other DCC integrations (Maya, Vectorworks, ZBrush)

--- a/fragments/labels/redshift.sh
+++ b/fragments/labels/redshift.sh
@@ -1,6 +1,5 @@
 redshift)
     name="redshift"
-    appName="Maxon Redshift Installer.app"
     blockingProcesses=( "Cinema 4D" )
     type="dmg"
     expectedTeamID="4ZY22YGXQG"

--- a/fragments/labels/redshift.sh
+++ b/fragments/labels/redshift.sh
@@ -9,6 +9,5 @@ redshift)
     appCustomVersion() {/usr/bin/defaults read "/Applications/Maxon Redshift 2026/uninstall.app/Contents/Info.plist" CFBundleVersion }
     installerTool="Maxon Redshift Installer.app"
     CLIInstaller="Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh"
-    # Customize --enable-components for other DCC integrations (Maya, Vectorworks, ZBrush)
     CLIArguments=( --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026 )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
Previous version of the app was pkg installed, but since the move to dmg install the receipt isn't updated during installation.
Since there's no unique app bundle to be used for reading appVersion, I've added a customAppVersion routine instead.

Good to know for the future is that this will possibly break later this year when the install path will be renamed to 2027.

**Installomator log** 
Without any previous installation:
```
➜  Installomator git:(fix_redshift_AppVersion) ✗ sudo ./assemble.sh redshift NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-06-04 10:14:34 : INFO  : redshift : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-06-04 10:14:35 : INFO  : redshift : setting variable from argument NOTIFY=success
2026-06-04 10:14:35 : INFO  : redshift : setting variable from argument NOTIFY_DIALOG=1
2026-06-04 10:14:35 : INFO  : redshift : setting variable from argument DEBUG=0
2026-06-04 10:14:35 : INFO  : redshift : Total items in argumentsArray: 4
2026-06-04 10:14:35 : INFO  : redshift : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:14:35 : REQ   : redshift : ################## Start Installomator v. 10.9beta, date 2026-06-04
2026-06-04 10:14:35 : INFO  : redshift : ################## Version: 10.9beta
2026-06-04 10:14:35 : INFO  : redshift : ################## Date: 2026-06-04
2026-06-04 10:14:35 : INFO  : redshift : ################## redshift
2026-06-04 10:14:36 : INFO  : redshift : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:14:36 : INFO  : redshift : BLOCKING_PROCESS_ACTION=tell_user
2026-06-04 10:14:36 : INFO  : redshift : NOTIFY=success
2026-06-04 10:14:36 : INFO  : redshift : LOGGING=INFO
2026-06-04 10:14:36 : INFO  : redshift : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-04 10:14:36 : INFO  : redshift : Label type: dmg
2026-06-04 10:14:36 : INFO  : redshift : archiveName: redshift.dmg
2026-06-04 10:14:36.738 defaults[55264:3824019] 
The domain/default pair of (/Applications/Maxon Redshift 2026/uninstall.app/Contents/Info.plist, CFBundleVersion) does not exist
2026-06-04 10:14:36 : INFO  : redshift : Custom App Version detection is used, found 
2026-06-04 10:14:36 : INFO  : redshift : appversion: 
2026-06-04 10:14:36 : INFO  : redshift : Latest version of redshift is 2026.6.2
2026-06-04 10:14:36 : REQ   : redshift : Downloading https://installer.maxon.net/installer/rs/redshift_2026.6.2_2518604743_macos.dmg to redshift.dmg
2026-06-04 10:21:29 : INFO  : redshift : Downloaded redshift.dmg – Type is  zlib compressed data – SHA is 89834ba7de2d3e8d1553e351b459c41992e31205 – Size is 11829536 kB
2026-06-04 10:21:29 : REQ   : redshift : no more blocking processes, continue with update
2026-06-04 10:21:29 : REQ   : redshift : Installing redshift
2026-06-04 10:21:29 : REQ   : redshift : installerTool used: Maxon Redshift Installer.app
2026-06-04 10:21:29 : INFO  : redshift : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JbE6uL2OXB/redshift.dmg
2026-06-04 10:21:31 : INFO  : redshift : Mounted: /Volumes/Maxon Redshift
2026-06-04 10:21:31 : INFO  : redshift : Verifying: /Volumes/Maxon Redshift/Maxon Redshift Installer.app
2026-06-04 10:21:40 : INFO  : redshift : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2026-06-04 10:21:40 : INFO  : redshift : Installing redshift version 2026.6.2 on versionKey CFBundleShortVersionString.
2026-06-04 10:21:40 : INFO  : redshift : CLIInstaller exists, running installer command /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026
2026-06-04 10:23:23 : INFO  : redshift : Succesfully ran /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026
2026-06-04 10:23:23 : INFO  : redshift : Finishing...
2026-06-04 10:23:26 : INFO  : redshift : Custom App Version detection is used, found 2026.6.2
2026-06-04 10:23:26 : REQ   : redshift : Installed redshift, version 2026.6.2
2026-06-04 10:23:26 : INFO  : redshift : notifying
2026-06-04 10:23:34 : INFO  : redshift : Installomator did not close any apps, so no need to reopen any apps.
2026-06-04 10:23:34 : REQ   : redshift : All done!
2026-06-04 10:23:34 : REQ   : redshift : ################## End Installomator, exit code 0 
```

With latest version installed:
```
➜  Installomator git:(fix_redshift_AppVersion) ✗ sudo ./assemble.sh redshift NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-06-04 10:24:02 : INFO  : redshift : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-06-04 10:24:02 : INFO  : redshift : setting variable from argument NOTIFY=success
2026-06-04 10:24:02 : INFO  : redshift : setting variable from argument NOTIFY_DIALOG=1
2026-06-04 10:24:02 : INFO  : redshift : setting variable from argument DEBUG=0
2026-06-04 10:24:02 : INFO  : redshift : Total items in argumentsArray: 4
2026-06-04 10:24:02 : INFO  : redshift : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:24:02 : REQ   : redshift : ################## Start Installomator v. 10.9beta, date 2026-06-04
2026-06-04 10:24:02 : INFO  : redshift : ################## Version: 10.9beta
2026-06-04 10:24:02 : INFO  : redshift : ################## Date: 2026-06-04
2026-06-04 10:24:02 : INFO  : redshift : ################## redshift
2026-06-04 10:24:03 : INFO  : redshift : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:24:03 : INFO  : redshift : BLOCKING_PROCESS_ACTION=tell_user
2026-06-04 10:24:03 : INFO  : redshift : NOTIFY=success
2026-06-04 10:24:03 : INFO  : redshift : LOGGING=INFO
2026-06-04 10:24:03 : INFO  : redshift : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-04 10:24:03 : INFO  : redshift : Label type: dmg
2026-06-04 10:24:03 : INFO  : redshift : archiveName: redshift.dmg
2026-06-04 10:24:03 : INFO  : redshift : Custom App Version detection is used, found 2026.6.2
2026-06-04 10:24:03 : INFO  : redshift : appversion: 2026.6.2
2026-06-04 10:24:03 : INFO  : redshift : Latest version of redshift is 2026.6.2
2026-06-04 10:24:03 : INFO  : redshift : There is no newer version available.
2026-06-04 10:24:03 : INFO  : redshift : Installomator did not close any apps, so no need to reopen any apps.
2026-06-04 10:24:03 : REQ   : redshift : No newer version.
2026-06-04 10:24:03 : REQ   : redshift : ################## End Installomator, exit code 0
```