### PR TITLE
Fixed redshiftlite appVersion (switched from pkg to dmg installation)

### DIFF
--- a/fragments/labels/redshiftlite.sh
+++ b/fragments/labels/redshiftlite.sh
@@ -1,9 +1,12 @@
 redshiftlite)
     name="redshift"
     blockingProcesses=( "Cinema 4D" )
-    type="pkg"
-    packageID="com.redshift3d.redshift"
+    type="dmg"
     expectedTeamID="4ZY22YGXQG"
-    downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redshift[^"]*min\.pkg' | head -1)
+    downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*redshift[^"]*min\.dmg' | head -1)
     appNewVersion=$(sed -n 's/.*redshift_\([^_]*\).*/\1/p' <<< "${downloadURL}")
+    appCustomVersion() {/usr/bin/defaults read "/Applications/Maxon Redshift 2026/uninstall.app/Contents/Info.plist" CFBundleVersion }
+    installerTool="Maxon Redshift Installer.app"
+    CLIInstaller="Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=( --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026 )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
CLI part is copied from the `redshift` label. I can't see any issues, but have limited ability to test the lite installation for any possible authentication requirements when the renderer is used.

**Installomator log**
Without any installation:
```
➜  Installomator git:(fix_redshift_AppVersion) ✗ sudo ./assemble.sh redshiftlite NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-06-04 10:36:15 : INFO  : redshiftlite : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-06-04 10:36:15 : INFO  : redshiftlite : setting variable from argument NOTIFY=success
2026-06-04 10:36:15 : INFO  : redshiftlite : setting variable from argument NOTIFY_DIALOG=1
2026-06-04 10:36:15 : INFO  : redshiftlite : setting variable from argument DEBUG=0
2026-06-04 10:36:15 : INFO  : redshiftlite : Total items in argumentsArray: 4
2026-06-04 10:36:15 : INFO  : redshiftlite : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:36:15 : REQ   : redshiftlite : ################## Start Installomator v. 10.9beta, date 2026-06-04
2026-06-04 10:36:15 : INFO  : redshiftlite : ################## Version: 10.9beta
2026-06-04 10:36:15 : INFO  : redshiftlite : ################## Date: 2026-06-04
2026-06-04 10:36:15 : INFO  : redshiftlite : ################## redshiftlite
2026-06-04 10:36:16 : INFO  : redshiftlite : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:36:16 : INFO  : redshiftlite : BLOCKING_PROCESS_ACTION=tell_user
2026-06-04 10:36:16 : INFO  : redshiftlite : NOTIFY=success
2026-06-04 10:36:16 : INFO  : redshiftlite : LOGGING=INFO
2026-06-04 10:36:16 : INFO  : redshiftlite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-04 10:36:16 : INFO  : redshiftlite : Label type: dmg
2026-06-04 10:36:16 : INFO  : redshiftlite : archiveName: redshift.dmg
2026-06-04 10:36:16.824 defaults[63930:3906955] 
The domain/default pair of (/Applications/Maxon Redshift 2026/uninstall.app/Contents/Info.plist, CFBundleVersion) does not exist
2026-06-04 10:36:16 : INFO  : redshiftlite : Custom App Version detection is used, found 
2026-06-04 10:36:16 : INFO  : redshiftlite : appversion: 
2026-06-04 10:36:16 : INFO  : redshiftlite : Latest version of redshift is 2026.6.2
2026-06-04 10:36:16 : REQ   : redshiftlite : Downloading https://installer.maxon.net/installer/rs/redshift_2026.6.2_2518604743_macos_min.dmg to redshift.dmg
2026-06-04 10:37:03 : INFO  : redshiftlite : Downloaded redshift.dmg – Type is  zlib compressed data – SHA is f8dd84df07a2e9d997b7816a22b0c67aeeba425b – Size is 1540528 kB
2026-06-04 10:37:04 : REQ   : redshiftlite : no more blocking processes, continue with update
2026-06-04 10:37:04 : REQ   : redshiftlite : Installing redshift
2026-06-04 10:37:04 : REQ   : redshiftlite : installerTool used: Maxon Redshift Installer.app
2026-06-04 10:37:04 : INFO  : redshiftlite : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1OP9EDMYHl/redshift.dmg
2026-06-04 10:37:07 : INFO  : redshiftlite : Mounted: /Volumes/Maxon Redshift
2026-06-04 10:37:07 : INFO  : redshiftlite : Verifying: /Volumes/Maxon Redshift/Maxon Redshift Installer.app
2026-06-04 10:37:08 : INFO  : redshiftlite : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2026-06-04 10:37:08 : INFO  : redshiftlite : Installing redshift version 2026.6.2 on versionKey CFBundleShortVersionString.
2026-06-04 10:37:08 : INFO  : redshiftlite : CLIInstaller exists, running installer command /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026
2026-06-04 10:38:17 : INFO  : redshiftlite : Succesfully ran /Volumes/Maxon Redshift/Maxon Redshift Installer.app/Contents/MacOS/installbuilder.sh --mode unattended --enable-components Cinema4DGroup,PluginC4D2023,PluginC4D2024,PluginC4D2025,PluginC4D2026
2026-06-04 10:38:17 : INFO  : redshiftlite : Finishing...
2026-06-04 10:38:20 : INFO  : redshiftlite : Custom App Version detection is used, found 2026.6.2
2026-06-04 10:38:20 : REQ   : redshiftlite : Installed redshift, version 2026.6.2
2026-06-04 10:38:20 : INFO  : redshiftlite : notifying
2026-06-04 10:38:28 : INFO  : redshiftlite : Installomator did not close any apps, so no need to reopen any apps.
2026-06-04 10:38:28 : REQ   : redshiftlite : All done!
2026-06-04 10:38:28 : REQ   : redshiftlite : ################## End Installomator, exit code 0 
```


With latest redshift installed:
```
➜  Installomator git:(fix_redshift_AppVersion) ✗ sudo ./assemble.sh redshiftlite NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-06-04 10:38:50 : INFO  : redshiftlite : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-06-04 10:38:50 : INFO  : redshiftlite : setting variable from argument NOTIFY=success
2026-06-04 10:38:50 : INFO  : redshiftlite : setting variable from argument NOTIFY_DIALOG=1
2026-06-04 10:38:50 : INFO  : redshiftlite : setting variable from argument DEBUG=0
2026-06-04 10:38:50 : INFO  : redshiftlite : Total items in argumentsArray: 4
2026-06-04 10:38:50 : INFO  : redshiftlite : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:38:50 : REQ   : redshiftlite : ################## Start Installomator v. 10.9beta, date 2026-06-04
2026-06-04 10:38:50 : INFO  : redshiftlite : ################## Version: 10.9beta
2026-06-04 10:38:50 : INFO  : redshiftlite : ################## Date: 2026-06-04
2026-06-04 10:38:50 : INFO  : redshiftlite : ################## redshiftlite
2026-06-04 10:38:51 : INFO  : redshiftlite : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 10:38:51 : INFO  : redshiftlite : BLOCKING_PROCESS_ACTION=tell_user
2026-06-04 10:38:51 : INFO  : redshiftlite : NOTIFY=success
2026-06-04 10:38:51 : INFO  : redshiftlite : LOGGING=INFO
2026-06-04 10:38:51 : INFO  : redshiftlite : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-04 10:38:51 : INFO  : redshiftlite : Label type: dmg
2026-06-04 10:38:51 : INFO  : redshiftlite : archiveName: redshift.dmg
2026-06-04 10:38:51 : INFO  : redshiftlite : Custom App Version detection is used, found 2026.6.2
2026-06-04 10:38:51 : INFO  : redshiftlite : appversion: 2026.6.2
2026-06-04 10:38:51 : INFO  : redshiftlite : Latest version of redshift is 2026.6.2
2026-06-04 10:38:51 : INFO  : redshiftlite : There is no newer version available.
2026-06-04 10:38:51 : INFO  : redshiftlite : Installomator did not close any apps, so no need to reopen any apps.
2026-06-04 10:38:51 : REQ   : redshiftlite : No newer version.
2026-06-04 10:38:51 : REQ   : redshiftlite : ################## End Installomator, exit code 0
```