### PR TITLE
Fix appNewVersion for Packages.app

### DIFF
--- a/fragments/labels/packages.sh
+++ b/fragments/labels/packages.sh
@@ -2,8 +2,7 @@ packages)
     name="Packages"
     type="pkgInDmg"
     pkgName="Install Packages.pkg"
-    pkgsDetails="$(curl -fs "http://s.sudre.free.fr/Software/documentation/RemoteVersion.plist")"
-    appNewVersion=$(echo "${pkgsDetails}"| xpath 'string(//dict/string[1])' 2>/dev/null)
-    downloadURL=$(echo "${pkgsDetails}"| xpath 'string(//dict/string[2])' 2>/dev/null)
+    appNewVersion=$(curl -fsL http://s.sudre.free.fr/Software/Packages/release_notes.html | grep "<b>Version</b>" | grep -oE "[0-9].*[0-9]")
+    downloadURL="http://s.sudre.free.fr/Software/files/Packages.dmg"
     expectedTeamID="NL5M9E394P"
    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
RemoteVersion.plist isn't updated. But release_notes.html is.

**Installomator log**
With latest version installed:
```
➜  Installomator git:(fix_packages_appNewVersion) sudo ./assemble.sh packages NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0
2026-06-04 14:49:11 : INFO  : packages : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-06-04 14:49:11 : INFO  : packages : setting variable from argument NOTIFY=success
2026-06-04 14:49:11 : INFO  : packages : setting variable from argument NOTIFY_DIALOG=1
2026-06-04 14:49:11 : INFO  : packages : setting variable from argument DEBUG=0
2026-06-04 14:49:11 : INFO  : packages : Total items in argumentsArray: 4
2026-06-04 14:49:11 : INFO  : packages : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 14:49:11 : REQ   : packages : ################## Start Installomator v. 10.9beta, date 2026-06-04
2026-06-04 14:49:11 : INFO  : packages : ################## Version: 10.9beta
2026-06-04 14:49:11 : INFO  : packages : ################## Date: 2026-06-04
2026-06-04 14:49:11 : INFO  : packages : ################## packages
2026-06-04 14:49:12 : INFO  : packages : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0
2026-06-04 14:49:12 : INFO  : packages : BLOCKING_PROCESS_ACTION=tell_user
2026-06-04 14:49:12 : INFO  : packages : NOTIFY=success
2026-06-04 14:49:12 : INFO  : packages : LOGGING=INFO
2026-06-04 14:49:12 : INFO  : packages : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-04 14:49:12 : INFO  : packages : Label type: pkgInDmg
2026-06-04 14:49:13 : INFO  : packages : archiveName: Packages.dmg
2026-06-04 14:49:13 : INFO  : packages : no blocking processes defined, using Packages as default
2026-06-04 14:49:13 : INFO  : packages : App(s) found: /Applications/Packages.app
2026-06-04 14:49:13 : INFO  : packages : found app at /Applications/Packages.app, version 1.2.11, on versionKey CFBundleShortVersionString
2026-06-04 14:49:13 : INFO  : packages : appversion: 1.2.11
2026-06-04 14:49:13 : INFO  : packages : Latest version of Packages is 1.2.11
2026-06-04 14:49:13 : INFO  : packages : There is no newer version available.
2026-06-04 14:49:13 : INFO  : packages : Installomator did not close any apps, so no need to reopen any apps.
2026-06-04 14:49:13 : REQ   : packages : No newer version.
2026-06-04 14:49:13 : REQ   : packages : ################## End Installomator, exit code 0 
```