### PR TITLE
arcbrowser-update-label

### DIFF
--- a/fragments/labels/arcbrowser.sh
+++ b/fragments/labels/arcbrowser.sh
@@ -1,7 +1,7 @@
 arcbrowser)
-name="Arc"
-type="dmg"
-downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
-appNewVersion="$(curl -fsIL https://releases.arc.net/release/Arc-latest.dmg | grep -i ^location | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+).*/\1/')"
-expectedTeamID="S6N382Y83G"
+    name="Arc"
+    type="dmg"
+    downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
+    appNewVersion=$(curl -fsIL "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/Arc-([0-9]+(\.[0-9]+)+)-[0-9]+\.dmg|\1|')
+    expectedTeamID="S6N382Y83G"
     ;;

--- a/fragments/labels/arcbrowser.sh
+++ b/fragments/labels/arcbrowser.sh
@@ -2,6 +2,6 @@ arcbrowser)
     name="Arc"
     type="dmg"
     downloadURL="https://releases.arc.net/release/Arc-latest.dmg"
-    appNewVersion=$(curl -fsIL "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/Arc-([0-9]+(\.[0-9]+)+)-[0-9]+\.dmg|\1|')
+    appNewVersion=$(curl -fsIL "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/Arc-([0-9]+(\.[0-9]+)+)-[0-9]+\.dmg$|\1|')
     expectedTeamID="S6N382Y83G"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh arcbrowser DEBUG=1  
2026-06-05 16:32:56 : INFO  : arcbrowser : setting variable from argument DEBUG=1
2026-06-05 16:32:56 : INFO  : arcbrowser : Total items in argumentsArray: 1
2026-06-05 16:32:56 : INFO  : arcbrowser : argumentsArray: DEBUG=1
2026-06-05 16:32:56 : REQ   : arcbrowser : ################## Start Installomator v. 10.9beta, date 2026-06-05
2026-06-05 16:32:56 : INFO  : arcbrowser : ################## Version: 10.9beta
2026-06-05 16:32:56 : INFO  : arcbrowser : ################## Date: 2026-06-05
2026-06-05 16:32:56 : INFO  : arcbrowser : ################## arcbrowser
2026-06-05 16:32:56 : DEBUG : arcbrowser : DEBUG mode 1 enabled.
2026-06-05 16:32:57 : INFO  : arcbrowser : Reading arguments again: DEBUG=1
2026-06-05 16:32:57 : DEBUG : arcbrowser : argument: DEBUG=1
2026-06-05 16:32:57 : DEBUG : arcbrowser : name=Arc
2026-06-05 16:32:57 : DEBUG : arcbrowser : appName=
2026-06-05 16:32:57 : DEBUG : arcbrowser : type=dmg
2026-06-05 16:32:57 : DEBUG : arcbrowser : archiveName=
2026-06-05 16:32:57 : DEBUG : arcbrowser : downloadURL=https://releases.arc.net/release/Arc-latest.dmg
2026-06-05 16:32:57 : DEBUG : arcbrowser : curlOptions=
2026-06-05 16:32:57 : DEBUG : arcbrowser : appNewVersion=1.149.0
2026-06-05 16:32:57 : DEBUG : arcbrowser : appCustomVersion function: Not defined
2026-06-05 16:32:57 : DEBUG : arcbrowser : versionKey=CFBundleShortVersionString
2026-06-05 16:32:57 : DEBUG : arcbrowser : packageID=
2026-06-05 16:32:58 : DEBUG : arcbrowser : pkgName=
2026-06-05 16:32:58 : DEBUG : arcbrowser : choiceChangesXML=
2026-06-05 16:32:58 : DEBUG : arcbrowser : expectedTeamID=S6N382Y83G
2026-06-05 16:32:58 : DEBUG : arcbrowser : blockingProcesses=
2026-06-05 16:32:58 : DEBUG : arcbrowser : installerTool=
2026-06-05 16:32:58 : DEBUG : arcbrowser : CLIInstaller=
2026-06-05 16:32:58 : DEBUG : arcbrowser : CLIArguments=
2026-06-05 16:32:58 : DEBUG : arcbrowser : updateTool=
2026-06-05 16:32:58 : DEBUG : arcbrowser : updateToolArguments=
2026-06-05 16:32:58 : DEBUG : arcbrowser : updateToolRunAsCurrentUser=
2026-06-05 16:32:58 : INFO  : arcbrowser : BLOCKING_PROCESS_ACTION=tell_user
2026-06-05 16:32:58 : INFO  : arcbrowser : NOTIFY=success
2026-06-05 16:32:58 : INFO  : arcbrowser : LOGGING=DEBUG
2026-06-05 16:32:58 : INFO  : arcbrowser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-05 16:32:58 : INFO  : arcbrowser : Label type: dmg
2026-06-05 16:32:58 : INFO  : arcbrowser : archiveName: Arc.dmg
2026-06-05 16:32:58 : INFO  : arcbrowser : no blocking processes defined, using Arc as default
2026-06-05 16:32:58 : DEBUG : arcbrowser : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-05 16:32:58 : INFO  : arcbrowser : name: Arc, appName: Arc.app
2026-06-05 16:32:58 : WARN  : arcbrowser : No previous app found
2026-06-05 16:32:58 : WARN  : arcbrowser : could not find Arc.app
2026-06-05 16:32:58 : INFO  : arcbrowser : appversion: 
2026-06-05 16:32:58 : INFO  : arcbrowser : Latest version of Arc is 1.149.0
2026-06-05 16:32:58 : REQ   : arcbrowser : Downloading https://releases.arc.net/release/Arc-latest.dmg to Arc.dmg
2026-06-05 16:32:58 : DEBUG : arcbrowser : No Dialog connection, just download
2026-06-05 16:33:11 : INFO  : arcbrowser : Downloaded Arc.dmg – Type is  zlib compressed data – SHA is ec70a5714f81fa7358b82952b325ac4095f3da3f – Size is 426476 kB
2026-06-05 16:33:11 : DEBUG : arcbrowser : DEBUG mode 1, not checking for blocking processes
2026-06-05 16:33:11 : REQ   : arcbrowser : Installing Arc
2026-06-05 16:33:11 : INFO  : arcbrowser : Mounting /Users/u0105821/git/github/Installomator/build/Arc.dmg
2026-06-05 16:33:15 : DEBUG : arcbrowser : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $44456370
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ACB310DD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2EF7ECBE
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $5E9B6892
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2EF7ECBE
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $1562A84A
verified   CRC32 $98AD8870
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_HFS                      	/Volumes/Arc

2026-06-05 16:33:15 : INFO  : arcbrowser : Mounted: /Volumes/Arc
2026-06-05 16:33:15 : INFO  : arcbrowser : Verifying: /Volumes/Arc/Arc.app
2026-06-05 16:33:15 : DEBUG : arcbrowser : App size: 822M	/Volumes/Arc/Arc.app
2026-06-05 16:33:20 : DEBUG : arcbrowser : Debugging enabled, App Verification output was:
/Volumes/Arc/Arc.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G)

2026-06-05 16:33:20 : INFO  : arcbrowser : Team ID matching: S6N382Y83G (expected: S6N382Y83G )
2026-06-05 16:33:20 : INFO  : arcbrowser : Installing Arc version 1.149.0 on versionKey CFBundleShortVersionString.
2026-06-05 16:33:20 : INFO  : arcbrowser : App has LSMinimumSystemVersion: 13.0.0
2026-06-05 16:33:20 : DEBUG : arcbrowser : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-05 16:33:20 : INFO  : arcbrowser : Finishing...
2026-06-05 16:33:23 : INFO  : arcbrowser : name: Arc, appName: Arc.app
2026-06-05 16:33:23 : WARN  : arcbrowser : No previous app found
2026-06-05 16:33:23 : WARN  : arcbrowser : could not find Arc.app
2026-06-05 16:33:23 : REQ   : arcbrowser : Installed Arc, version 1.149.0
2026-06-05 16:33:23 : INFO  : arcbrowser : notifying
2026-06-05 16:33:23 : DEBUG : arcbrowser : Unmounting /Volumes/Arc
2026-06-05 16:33:24 : DEBUG : arcbrowser : Debugging enabled, Unmounting output was:
"disk7" ejected.
2026-06-05 16:33:24 : DEBUG : arcbrowser : DEBUG mode 1, not reopening anything
2026-06-05 16:33:24 : REQ   : arcbrowser : All done!
2026-06-05 16:33:24 : REQ   : arcbrowser : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
