### PR TITLE
Create termius.sh

### DIFF
--- a/fragments/labels/termius.sh
+++ b/fragments/labels/termius.sh
@@ -1,0 +1,7 @@
+termius)
+    name="Termius"
+    type="dmg"
+    downloadURL="https://termi.us/mac-download"
+    appNewVersion=$(curl -fsL "https://autoupdate.termius.com/mac-universal/latest-mac.yml" | awk '/^version:/{print $2; exit}')
+    expectedTeamID="6KN952WR85"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh termius DEBUG=1                
2026-06-05 17:05:51 : INFO  : termius : setting variable from argument DEBUG=1
2026-06-05 17:05:51 : INFO  : termius : Total items in argumentsArray: 1
2026-06-05 17:05:51 : INFO  : termius : argumentsArray: DEBUG=1
2026-06-05 17:05:51 : REQ   : termius : ################## Start Installomator v. 10.9beta, date 2026-06-05
2026-06-05 17:05:51 : INFO  : termius : ################## Version: 10.9beta
2026-06-05 17:05:51 : INFO  : termius : ################## Date: 2026-06-05
2026-06-05 17:05:51 : INFO  : termius : ################## termius
2026-06-05 17:05:51 : DEBUG : termius : DEBUG mode 1 enabled.
2026-06-05 17:05:52 : INFO  : termius : Reading arguments again: DEBUG=1
2026-06-05 17:05:52 : DEBUG : termius : argument: DEBUG=1
2026-06-05 17:05:52 : DEBUG : termius : name=Termius
2026-06-05 17:05:52 : DEBUG : termius : appName=
2026-06-05 17:05:52 : DEBUG : termius : type=dmg
2026-06-05 17:05:52 : DEBUG : termius : archiveName=
2026-06-05 17:05:52 : DEBUG : termius : downloadURL=https://termi.us/mac-download
2026-06-05 17:05:52 : DEBUG : termius : curlOptions=
2026-06-05 17:05:52 : DEBUG : termius : appNewVersion=9.39.0
2026-06-05 17:05:52 : DEBUG : termius : appCustomVersion function: Not defined
2026-06-05 17:05:52 : DEBUG : termius : versionKey=CFBundleShortVersionString
2026-06-05 17:05:52 : DEBUG : termius : packageID=
2026-06-05 17:05:52 : DEBUG : termius : pkgName=
2026-06-05 17:05:52 : DEBUG : termius : choiceChangesXML=
2026-06-05 17:05:52 : DEBUG : termius : expectedTeamID=6KN952WR85
2026-06-05 17:05:52 : DEBUG : termius : blockingProcesses=
2026-06-05 17:05:52 : DEBUG : termius : installerTool=
2026-06-05 17:05:52 : DEBUG : termius : CLIInstaller=
2026-06-05 17:05:52 : DEBUG : termius : CLIArguments=
2026-06-05 17:05:52 : DEBUG : termius : updateTool=
2026-06-05 17:05:52 : DEBUG : termius : updateToolArguments=
2026-06-05 17:05:52 : DEBUG : termius : updateToolRunAsCurrentUser=
2026-06-05 17:05:52 : INFO  : termius : BLOCKING_PROCESS_ACTION=tell_user
2026-06-05 17:05:52 : INFO  : termius : NOTIFY=success
2026-06-05 17:05:52 : INFO  : termius : LOGGING=DEBUG
2026-06-05 17:05:52 : INFO  : termius : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-05 17:05:52 : INFO  : termius : Label type: dmg
2026-06-05 17:05:52 : INFO  : termius : archiveName: Termius.dmg
2026-06-05 17:05:52 : INFO  : termius : no blocking processes defined, using Termius as default
2026-06-05 17:05:52 : DEBUG : termius : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-05 17:05:52 : INFO  : termius : name: Termius, appName: Termius.app
2026-06-05 17:05:52 : WARN  : termius : No previous app found
2026-06-05 17:05:52 : WARN  : termius : could not find Termius.app
2026-06-05 17:05:52 : INFO  : termius : appversion: 
2026-06-05 17:05:52 : INFO  : termius : Latest version of Termius is 9.39.0
2026-06-05 17:05:52 : REQ   : termius : Downloading https://termi.us/mac-download to Termius.dmg
2026-06-05 17:05:52 : DEBUG : termius : No Dialog connection, just download
2026-06-05 17:05:59 : INFO  : termius : Downloaded Termius.dmg – Type is  zlib compressed data – SHA is 055cbdc213201a0545b4b322875ccc2255c193c6 – Size is 245864 kB
2026-06-05 17:05:59 : DEBUG : termius : DEBUG mode 1, not checking for blocking processes
2026-06-05 17:06:00 : REQ   : termius : Installing Termius
2026-06-05 17:06:00 : INFO  : termius : Mounting /Users/u0105821/git/github/Installomator/build/Termius.dmg
2026-06-05 17:06:01 : DEBUG : termius : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $2395152B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E1975F39
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F8CABA36
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $A38AD00C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F8CABA36
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $B6FB7ECC
verified   CRC32 $513B662E
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_APFS
/dev/disk19         	EF57347C-0000-11AA-AA11-0030654
/dev/disk19s1       	41504653-0000-11AA-AA11-0030654	/Volumes/Termius 9.39.0 1

2026-06-05 17:06:01 : INFO  : termius : Mounted: /Volumes/Termius 9.39.0 1
2026-06-05 17:06:01 : INFO  : termius : Verifying: /Volumes/Termius 9.39.0 1/Termius.app
2026-06-05 17:06:01 : DEBUG : termius : App size: 530M	/Volumes/Termius 9.39.0 1/Termius.app
2026-06-05 17:06:03 : DEBUG : termius : Debugging enabled, App Verification output was:
/Volumes/Termius 9.39.0 1/Termius.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Termius Corporation (6KN952WR85)

2026-06-05 17:06:03 : INFO  : termius : Team ID matching: 6KN952WR85 (expected: 6KN952WR85 )
2026-06-05 17:06:04 : INFO  : termius : Installing Termius version 9.39.0 on versionKey CFBundleShortVersionString.
2026-06-05 17:06:04 : INFO  : termius : App has LSMinimumSystemVersion: 10.13
2026-06-05 17:06:04 : DEBUG : termius : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-05 17:06:04 : INFO  : termius : Finishing...
2026-06-05 17:06:07 : INFO  : termius : name: Termius, appName: Termius.app
2026-06-05 17:06:07 : WARN  : termius : No previous app found
2026-06-05 17:06:07 : WARN  : termius : could not find Termius.app
2026-06-05 17:06:07 : REQ   : termius : Installed Termius, version 9.39.0
2026-06-05 17:06:07 : INFO  : termius : notifying
2026-06-05 17:06:07 : DEBUG : termius : Unmounting /Volumes/Termius 9.39.0 1
2026-06-05 17:06:08 : DEBUG : termius : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-05 17:06:08 : DEBUG : termius : DEBUG mode 1, not reopening anything
2026-06-05 17:06:08 : REQ   : termius : All done!
2026-06-05 17:06:08 : REQ   : termius : ################## End Installomator, exit code 0
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
