### PR TITLE
dbeaverteam-new-label

### DIFF
--- a/fragments/labels/dbeaverteam.sh
+++ b/fragments/labels/dbeaverteam.sh
@@ -1,0 +1,12 @@
+dbeaverteam)
+    name="DBeaverTeam"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg"
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL="https://dbeaver.com/files/dbeaver-te-latest-macos-x86_64.dmg"
+    fi
+    appNewVersion=$(curl -fsI -o /dev/null -w '%{redirect_url}' "$downloadURL" | sed -E 's|.*/dbeaver-te-([0-9]+(\.[0-9]+)+)-macos-(aarch64|x86_64)\.dmg|\1|')
+    expectedTeamID="42B6MDKMW8"
+    blockingProcesses=( dbeaver )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh dbeaverteam DEBUG=1
2026-06-05 17:15:13 : INFO  : dbeaverteam : setting variable from argument DEBUG=1
2026-06-05 17:15:13 : INFO  : dbeaverteam : Total items in argumentsArray: 1
2026-06-05 17:15:13 : INFO  : dbeaverteam : argumentsArray: DEBUG=1
2026-06-05 17:15:13 : REQ   : dbeaverteam : ################## Start Installomator v. 10.9beta, date 2026-06-05
2026-06-05 17:15:13 : INFO  : dbeaverteam : ################## Version: 10.9beta
2026-06-05 17:15:13 : INFO  : dbeaverteam : ################## Date: 2026-06-05
2026-06-05 17:15:13 : INFO  : dbeaverteam : ################## dbeaverteam
2026-06-05 17:15:13 : DEBUG : dbeaverteam : DEBUG mode 1 enabled.
sed: 1: "s|.*/dbeaver-te-([0-9]+ ...": RE error: parentheses not balanced
2026-06-05 17:15:14 : INFO  : dbeaverteam : Reading arguments again: DEBUG=1
2026-06-05 17:15:14 : DEBUG : dbeaverteam : argument: DEBUG=1
2026-06-05 17:15:14 : DEBUG : dbeaverteam : name=DBeaverTeam
2026-06-05 17:15:14 : DEBUG : dbeaverteam : appName=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : type=dmg
2026-06-05 17:15:14 : DEBUG : dbeaverteam : archiveName=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : downloadURL=https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg
2026-06-05 17:15:14 : DEBUG : dbeaverteam : curlOptions=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : appNewVersion=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : appCustomVersion function: Not defined
2026-06-05 17:15:14 : DEBUG : dbeaverteam : versionKey=CFBundleShortVersionString
2026-06-05 17:15:14 : DEBUG : dbeaverteam : packageID=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : pkgName=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : choiceChangesXML=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : expectedTeamID=42B6MDKMW8
2026-06-05 17:15:14 : DEBUG : dbeaverteam : blockingProcesses=dbeaver
2026-06-05 17:15:14 : DEBUG : dbeaverteam : installerTool=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : CLIInstaller=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : CLIArguments=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : updateTool=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : updateToolArguments=
2026-06-05 17:15:14 : DEBUG : dbeaverteam : updateToolRunAsCurrentUser=
2026-06-05 17:15:14 : INFO  : dbeaverteam : BLOCKING_PROCESS_ACTION=tell_user
2026-06-05 17:15:14 : INFO  : dbeaverteam : NOTIFY=success
2026-06-05 17:15:14 : INFO  : dbeaverteam : LOGGING=DEBUG
2026-06-05 17:15:14 : INFO  : dbeaverteam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-05 17:15:14 : INFO  : dbeaverteam : Label type: dmg
2026-06-05 17:15:14 : INFO  : dbeaverteam : archiveName: DBeaverTeam.dmg
2026-06-05 17:15:14 : DEBUG : dbeaverteam : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-05 17:15:14 : INFO  : dbeaverteam : name: DBeaverTeam, appName: DBeaverTeam.app
2026-06-05 17:15:14 : WARN  : dbeaverteam : No previous app found
2026-06-05 17:15:14 : WARN  : dbeaverteam : could not find DBeaverTeam.app
2026-06-05 17:15:14 : INFO  : dbeaverteam : appversion: 
2026-06-05 17:15:14 : INFO  : dbeaverteam : Latest version not specified.
2026-06-05 17:15:14 : REQ   : dbeaverteam : Downloading https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg to DBeaverTeam.dmg
2026-06-05 17:15:14 : DEBUG : dbeaverteam : No Dialog connection, just download
2026-06-05 17:15:26 : INFO  : dbeaverteam : Downloaded DBeaverTeam.dmg – Type is  zlib compressed data – SHA is 134c13d8e68d1ba2068b329e5a97ff3e84d77c4e – Size is 360608 kB
2026-06-05 17:15:26 : DEBUG : dbeaverteam : DEBUG mode 1, not checking for blocking processes
2026-06-05 17:15:26 : REQ   : dbeaverteam : Installing DBeaverTeam
2026-06-05 17:15:26 : INFO  : dbeaverteam : Mounting /Users/u0105821/git/github/Installomator/build/DBeaverTeam.dmg
2026-06-05 17:15:29 : DEBUG : dbeaverteam : Debugging enabled, dmgmount output was:
End-User License Agreement

IMPORTANT - READ CAREFULLY: This End-User License Agreement ("EULA")
is a legal agreement between you and DBeaver Corporation to regulate
your use of the DBeaver software and its related components.

If you do not agree to all of the terms of this EULA, you should
not download, install or use the DBeaver software and its related
components.  If you have already downloaded or installed the DBeaver
Software, you should remove it from your system and destroy all
copies thereof.

1. Definitions in this EULA

"Licensor" means DBeaver Corp.

"Licensee" means an individual or a legal entity exercising rights
under, and complying with all of the terms and conditions of this
EULA or future versions of this EULA.

"Software" means the software program known as DBeaver Enterprise
edition in binary form, including its documentation, any third party
software programs that are owned and licensed by parties other than
Licensor and that are either integrated with or made part of Software
(collectively, "Third Party Software").

"License Certificate" means evidence of a license provided by
Licensor to Licensee in electronic or printed form and defining the
optional rights related to the Software.

"License Key" means a unique key-code file, provided by Licensor
or its authorized representatives, that enables the Licensee to use
the Software.

"Group License Key" means a unique key-code file, provided by
Licensor or its authorized representatives, that enables the Licensee
to use the Software by the determined number of users.

"Subscription License Key" means a unique key-code file, provided
by Licensor or its authorized representatives, that enables the
Licensee to use the Software during the subscription period.

2. Ownership

The Software is the property of Licensor or its suppliers. The
Software is licensed, not sold. Title and copyrights to the Software,
in whole and in part, all copies thereof and all modifications,
enhancements, derivatives and other alterations of the Software
regardless of who made any modifications, if any, are, and will
remain, the sole and exclusive property of Licensor.

3. Third Party JDBC database drivers

The Software may contain third party JDBC database drivers which
requires notices and/or additional terms and conditions. You have
to read and accept a driver EULA in the driver settings dialog
appearing before the first usage.

4. Purchased Licenses

According to the License Certificate, Licensor grants Licensee a
non-exclusive, non-transferable rights to use the Software, and
sub-sequent versions thereof, under certain obligations and limited
rights as set forth in this EULA.  Licensee may: -  Use each License
Key or Subscription License Key on more than one computer system,
as long as it is always used by the same user. Each new user of the
Software requires an additional License Key.  -  Use the Group
License Key on the number of computer systems determined in the
Group License, as long as it is always used by the same number of
users.  Each new user of the Software requires an additional License
Key.  -  Use the Group License Key on the computer system that
provides access for the number of users determined in the Group
License, as long as it is always used by the same number of users.
Each new user of the Software requires an additional License Key.
-  Make copies of the Software and the License Key as reasonably
necessary for the use authorized by this EULA, including backup
and/or archival purposes. No other copies may be made. Each copy
must reproduce all copyright and other proprietary rights notices
on or in the Software Product.  -  Notwithstanding the non-transferability,
Licensee may transfer a license to another user in the same
organization, when, and only when, the designated Licensee (user)
moves to non-database tasks or leaves the organization.

5. Trial License

A time limited version of the Software, Trial License, is provided
for a period of fourteen (14) days ("Trial Period") from the date
of issuing a temporary evaluation License Key. The time limited
version is subject to all terms set forth in this EULA with the
exception that the Trial License is not for general commercial use.
The Software contains a feature that will automatically disable the
Software after the Trial Period has expired. Licensee may not
disable, destroy, or remove this feature of the Software, and any
attempt to do so will be in violation of this EULA and immediately
terminate this agreement.

6. Early Access Program license

Not applicable to DBeaver Team Edition.

7. License Restrictions

Licensee may not: -  Reverse engineer, decompile, disassemble,
modify, translate, attempt to discover the source code of the
Software in whole or in part.  -  Distribute, copy, publish, assign,
sell, bargain, convey, transfer, pledge, lease or grant any further
rights to use the Software.  -  Modify or create derivative work
based Software in whole or in part -  Tamper with, alter, disable
or circumvent the Software's built-in license verification and
enforcement capabilities.  -  Remove of alter any trademark,
copyright, logo or other proprietary notices in the Software.  -
Disclose the License Key, Group License Key, Subscription License
Key in any way.

8. Disclaimer of Warranty

Unless specified in this EULA, all express or implied conditions,
representations and warranties, including any implied warranty of
fitness for a particular purpose are disclaimed, except to the
extent that these disclaimers are held to be legally invalid.

9. Limitation of Liability

To the extent not prohibited by law, in no event will Licensor (or
any third-party-developer) be liable for any lost revenue, profit
or data, or for special, indirect, consequential, incidental or
punitive damages, however caused regardless of the theory of
liability, arising out of or related to the use of or inability to
use Software, even if Licensor has been advised of the possibility
of such damages.

In no event will Licensor's liability to Licensee, whether in
contract, tort (including negligence), or otherwise, exceed the
amount paid by Licensee for Software under this EULA. The foregoing
limitations will apply even if the above stated warranty fails of
its essential purpose. Some states do not allow the exclusion of
incidental or consequential damages, so some of the terms above may
not be applicable to Licensee.

10. Termination

This EULA is effective until terminated. Licensee may terminate
this EULA at any time by destroying all copies of Software.  This
agreement may be terminated by either party if the other party
commits a material breach. Either party will have thirty (30)
calendar days following the receipt of written notice to remedy any
material breaches. Immediately upon termination, any Accessible
Code in possession, custody or control of Licensee must be destroyed
and written confirmation of such destruction provided to Licensor.

Licensee agrees that upon termination of this EULA for any reason,
Licensor may take actions so that Software no longer operates.

11. Severability

If any provision of this EULA is held to be unenforceable, this
EULA will remain in effect with the provision omitted, unless
omission would frustrate the intent of the parties, in which case
this EULA will immediately terminate.

12. Integration

This EULA is the entire agreement between Licensee and Licensor
relating to its subject matter. It supersedes all prior or
contemporaneous oral or written communications, proposals,
representations and warranties and prevails over any conflicting
or additional terms of any quote, order, acknowledgment, or other
communication between the parties relating to its subject matter
during the term of this EULA. No modification of this EULA will be
binding, unless in writing and signed by an authorized representative
of each party.

13. Reservation of rights

All rights not expressly granted in this EULA are reserved by
Licensor.  Licensor reserves the right at any time to cease the
support of the Software and to alter prices, features, specifications,
capabilities, functions, licensing terms, release dates, general
availability or other characteristics of the Software.

14. Licensor Representations

Licensor represents, warrants, and covenants that it and each of
its affiliates and their respective agents and subcontractors (i)
use and will continue to use commercially reasonable efforts to
ensure that there is no slavery, human trafficking, and/or child
or forced labor in any part of their respective businesses or supply
chain; (ii) have not, and their respective directors, officers, and
employees have not, been convicted of any offense involving slavery,
human trafficking, and/or child or forced labor; and (iii) are not
currently and have not in the past been the subject of any
investigation, inquiry, or enforcement proceedings in relation to
an alleged offense in connection with slavery, human trafficking,
and/or child or forced labor.
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $10189002
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $4A01C829
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $203DA0FD
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $129C2D41
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $203DA0FD
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $D85C585F
verified   CRC32 $5C4FB6C1
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/DBeaver Team

2026-06-05 17:15:29 : INFO  : dbeaverteam : Mounted: /Volumes/DBeaver Team
2026-06-05 17:15:29 : INFO  : dbeaverteam : Verifying: /Volumes/DBeaver Team/DBeaverTeam.app
2026-06-05 17:15:29 : DEBUG : dbeaverteam : App size: 448M	/Volumes/DBeaver Team/DBeaverTeam.app
2026-06-05 17:15:33 : DEBUG : dbeaverteam : Debugging enabled, App Verification output was:
/Volumes/DBeaver Team/DBeaverTeam.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DBeaver Corporation (42B6MDKMW8)

2026-06-05 17:15:33 : INFO  : dbeaverteam : Team ID matching: 42B6MDKMW8 (expected: 42B6MDKMW8 )
2026-06-05 17:15:33 : INFO  : dbeaverteam : Installing DBeaverTeam version 26.0.0 on versionKey CFBundleShortVersionString.
2026-06-05 17:15:33 : DEBUG : dbeaverteam : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-05 17:15:33 : INFO  : dbeaverteam : Finishing...
2026-06-05 17:15:36 : INFO  : dbeaverteam : name: DBeaverTeam, appName: DBeaverTeam.app
2026-06-05 17:15:36 : WARN  : dbeaverteam : No previous app found
2026-06-05 17:15:36 : WARN  : dbeaverteam : could not find DBeaverTeam.app
2026-06-05 17:15:36 : REQ   : dbeaverteam : Installed DBeaverTeam, version 26.0.0
2026-06-05 17:15:36 : INFO  : dbeaverteam : notifying
2026-06-05 17:15:36 : DEBUG : dbeaverteam : Unmounting /Volumes/DBeaver Team
2026-06-05 17:15:37 : DEBUG : dbeaverteam : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-05 17:15:37 : DEBUG : dbeaverteam : DEBUG mode 1, not reopening anything
2026-06-05 17:15:37 : REQ   : dbeaverteam : All done!
2026-06-05 17:15:37 : REQ   : dbeaverteam : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
