### PR TITLE
chatgptatlas-new-label

### DIFF
--- a/fragments/labels/chatgptatlas.sh
+++ b/fragments/labels/chatgptatlas.sh
@@ -1,0 +1,12 @@
+chatgptatlas)
+    name="ChatGPT Atlas"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas.dmg"
+    else
+        printlog "ChatGPT Atlas is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "ChatGPT Atlas requires Apple Silicon" ERROR
+    fi
+    appNewVersion=$(curl -fs "https://persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml" | xmllint --xpath 'string((//*[local-name()="item"])[1]/*[local-name()="shortVersionString"]/text())' -)
+    expectedTeamID="2DC432GLL2"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh chatgptatlas DEBUG=1
2026-06-05 17:27:42 : INFO  : chatgptatlas : setting variable from argument DEBUG=1
2026-06-05 17:27:42 : INFO  : chatgptatlas : Total items in argumentsArray: 1
2026-06-05 17:27:42 : INFO  : chatgptatlas : argumentsArray: DEBUG=1
2026-06-05 17:27:42 : REQ   : chatgptatlas : ################## Start Installomator v. 10.9beta, date 2026-06-05
2026-06-05 17:27:42 : INFO  : chatgptatlas : ################## Version: 10.9beta
2026-06-05 17:27:43 : INFO  : chatgptatlas : ################## Date: 2026-06-05
2026-06-05 17:27:43 : INFO  : chatgptatlas : ################## chatgptatlas
2026-06-05 17:27:43 : DEBUG : chatgptatlas : DEBUG mode 1 enabled.
2026-06-05 17:27:43 : INFO  : chatgptatlas : Reading arguments again: DEBUG=1
2026-06-05 17:27:43 : DEBUG : chatgptatlas : argument: DEBUG=1
2026-06-05 17:27:43 : DEBUG : chatgptatlas : name=ChatGPT Atlas
2026-06-05 17:27:43 : DEBUG : chatgptatlas : appName=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : type=dmg
2026-06-05 17:27:43 : DEBUG : chatgptatlas : archiveName=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : downloadURL=https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas.dmg
2026-06-05 17:27:43 : DEBUG : chatgptatlas : curlOptions=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : appNewVersion=1.2026.126.0
2026-06-05 17:27:43 : DEBUG : chatgptatlas : appCustomVersion function: Not defined
2026-06-05 17:27:43 : DEBUG : chatgptatlas : versionKey=CFBundleShortVersionString
2026-06-05 17:27:43 : DEBUG : chatgptatlas : packageID=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : pkgName=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : choiceChangesXML=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : expectedTeamID=2DC432GLL2
2026-06-05 17:27:43 : DEBUG : chatgptatlas : blockingProcesses=
2026-06-05 17:27:43 : DEBUG : chatgptatlas : installerTool=
2026-06-05 17:27:44 : DEBUG : chatgptatlas : CLIInstaller=
2026-06-05 17:27:44 : DEBUG : chatgptatlas : CLIArguments=
2026-06-05 17:27:44 : DEBUG : chatgptatlas : updateTool=
2026-06-05 17:27:44 : DEBUG : chatgptatlas : updateToolArguments=
2026-06-05 17:27:44 : DEBUG : chatgptatlas : updateToolRunAsCurrentUser=
2026-06-05 17:27:44 : INFO  : chatgptatlas : BLOCKING_PROCESS_ACTION=tell_user
2026-06-05 17:27:44 : INFO  : chatgptatlas : NOTIFY=success
2026-06-05 17:27:44 : INFO  : chatgptatlas : LOGGING=DEBUG
2026-06-05 17:27:44 : INFO  : chatgptatlas : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-05 17:27:44 : INFO  : chatgptatlas : Label type: dmg
2026-06-05 17:27:44 : INFO  : chatgptatlas : archiveName: ChatGPT Atlas.dmg
2026-06-05 17:27:44 : INFO  : chatgptatlas : no blocking processes defined, using ChatGPT Atlas as default
2026-06-05 17:27:44 : DEBUG : chatgptatlas : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-05 17:27:44 : INFO  : chatgptatlas : name: ChatGPT Atlas, appName: ChatGPT Atlas.app
2026-06-05 17:27:44 : WARN  : chatgptatlas : No previous app found
2026-06-05 17:27:44 : WARN  : chatgptatlas : could not find ChatGPT Atlas.app
2026-06-05 17:27:44 : INFO  : chatgptatlas : appversion: 
2026-06-05 17:27:44 : INFO  : chatgptatlas : Latest version of ChatGPT Atlas is 1.2026.126.0
2026-06-05 17:27:44 : REQ   : chatgptatlas : Downloading https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas.dmg to ChatGPT Atlas.dmg
2026-06-05 17:27:44 : DEBUG : chatgptatlas : No Dialog connection, just download
2026-06-05 17:27:52 : INFO  : chatgptatlas : Downloaded ChatGPT Atlas.dmg – Type is  zlib compressed data – SHA is b922e70db188abc965475f42d9dbba9bafffa4eb – Size is 262912 kB
2026-06-05 17:27:52 : DEBUG : chatgptatlas : DEBUG mode 1, not checking for blocking processes
2026-06-05 17:27:52 : REQ   : chatgptatlas : Installing ChatGPT Atlas
2026-06-05 17:27:52 : INFO  : chatgptatlas : Mounting /Users/u0105821/git/github/Installomator/build/ChatGPT Atlas.dmg
2026-06-05 17:27:56 : DEBUG : chatgptatlas : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0C3DA759
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8417FE87
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5B6A2D69
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $5B44C201
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5B6A2D69
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $DB1FD401
verified   CRC32 $58464269
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/ChatGPT Atlas Installer

2026-06-05 17:27:56 : INFO  : chatgptatlas : Mounted: /Volumes/ChatGPT Atlas Installer
2026-06-05 17:27:56 : INFO  : chatgptatlas : Verifying: /Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app
2026-06-05 17:27:56 : DEBUG : chatgptatlas : App size: 558M	/Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app
2026-06-05 17:27:59 : DEBUG : chatgptatlas : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Atlas Installer/ChatGPT Atlas.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)

2026-06-05 17:27:59 : INFO  : chatgptatlas : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2026-06-05 17:27:59 : INFO  : chatgptatlas : Installing ChatGPT Atlas version 1.2026.126.0 on versionKey CFBundleShortVersionString.
2026-06-05 17:27:59 : INFO  : chatgptatlas : App has LSMinimumSystemVersion: 14.2
2026-06-05 17:27:59 : DEBUG : chatgptatlas : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-05 17:27:59 : INFO  : chatgptatlas : Finishing...
2026-06-05 17:28:02 : INFO  : chatgptatlas : name: ChatGPT Atlas, appName: ChatGPT Atlas.app
2026-06-05 17:28:02 : WARN  : chatgptatlas : No previous app found
2026-06-05 17:28:02 : WARN  : chatgptatlas : could not find ChatGPT Atlas.app
2026-06-05 17:28:02 : REQ   : chatgptatlas : Installed ChatGPT Atlas, version 1.2026.126.0
2026-06-05 17:28:02 : INFO  : chatgptatlas : notifying
2026-06-05 17:28:03 : DEBUG : chatgptatlas : Unmounting /Volumes/ChatGPT Atlas Installer
2026-06-05 17:28:03 : DEBUG : chatgptatlas : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-05 17:28:03 : DEBUG : chatgptatlas : DEBUG mode 1, not reopening anything
2026-06-05 17:28:03 : REQ   : chatgptatlas : All done!
2026-06-05 17:28:03 : REQ   : chatgptatlas : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
