### PR TITLE
magnolia-new-label

### DIFF
--- a/fragments/labels/magnolia.sh
+++ b/fragments/labels/magnolia.sh
@@ -1,0 +1,12 @@
+magnolia)
+    name="Magnolia"
+    type="dmg"
+    if [[ "$arch" == "arm64" ]]; then
+        archiveName="Magnolia-mac-arm64\\.dmg"
+    elif [[ "$arch" == "i386" ]]; then
+        archiveName="Magnolia-mac-x64\\.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit caledavis Magnolia)
+    appNewVersion=$(versionFromGit caledavis Magnolia)
+    expectedTeamID="DTRLLXT8T7"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh magnolia DEBUG=1   
2026-06-12 11:55:35 : INFO  : magnolia : setting variable from argument DEBUG=1
2026-06-12 11:55:35 : INFO  : magnolia : Total items in argumentsArray: 1
2026-06-12 11:55:35 : INFO  : magnolia : argumentsArray: DEBUG=1
2026-06-12 11:55:35 : REQ   : magnolia : ################## Start Installomator v. 10.9beta, date 2026-06-12
2026-06-12 11:55:35 : INFO  : magnolia : ################## Version: 10.9beta
2026-06-12 11:55:35 : INFO  : magnolia : ################## Date: 2026-06-12
2026-06-12 11:55:35 : INFO  : magnolia : ################## magnolia
2026-06-12 11:55:35 : DEBUG : magnolia : DEBUG mode 1 enabled.
2026-06-12 11:55:37 : INFO  : magnolia : Reading arguments again: DEBUG=1
2026-06-12 11:55:37 : DEBUG : magnolia : argument: DEBUG=1
2026-06-12 11:55:37 : DEBUG : magnolia : name=Magnolia
2026-06-12 11:55:37 : DEBUG : magnolia : appName=
2026-06-12 11:55:37 : DEBUG : magnolia : type=dmg
2026-06-12 11:55:37 : DEBUG : magnolia : archiveName=
2026-06-12 11:55:37 : DEBUG : magnolia : downloadURL=https://github.com/caledavis/Magnolia/releases/download/v1.4.0/Magnolia-mac-arm64.dmg
2026-06-12 11:55:37 : DEBUG : magnolia : curlOptions=
2026-06-12 11:55:37 : DEBUG : magnolia : appNewVersion=1.4.0
2026-06-12 11:55:37 : DEBUG : magnolia : appCustomVersion function: Not defined
2026-06-12 11:55:37 : DEBUG : magnolia : versionKey=CFBundleShortVersionString
2026-06-12 11:55:37 : DEBUG : magnolia : packageID=
2026-06-12 11:55:37 : DEBUG : magnolia : pkgName=
2026-06-12 11:55:37 : DEBUG : magnolia : choiceChangesXML=
2026-06-12 11:55:37 : DEBUG : magnolia : expectedTeamID=DTRLLXT8T7
2026-06-12 11:55:37 : DEBUG : magnolia : blockingProcesses=
2026-06-12 11:55:37 : DEBUG : magnolia : installerTool=
2026-06-12 11:55:37 : DEBUG : magnolia : CLIInstaller=
2026-06-12 11:55:37 : DEBUG : magnolia : CLIArguments=
2026-06-12 11:55:37 : DEBUG : magnolia : updateTool=
2026-06-12 11:55:37 : DEBUG : magnolia : updateToolArguments=
2026-06-12 11:55:37 : DEBUG : magnolia : updateToolRunAsCurrentUser=
2026-06-12 11:55:37 : INFO  : magnolia : BLOCKING_PROCESS_ACTION=tell_user
2026-06-12 11:55:37 : INFO  : magnolia : NOTIFY=success
2026-06-12 11:55:37 : INFO  : magnolia : LOGGING=DEBUG
2026-06-12 11:55:37 : INFO  : magnolia : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-12 11:55:37 : INFO  : magnolia : Label type: dmg
2026-06-12 11:55:37 : INFO  : magnolia : archiveName: Magnolia.dmg
2026-06-12 11:55:37 : INFO  : magnolia : no blocking processes defined, using Magnolia as default
2026-06-12 11:55:37 : DEBUG : magnolia : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-12 11:55:37 : INFO  : magnolia : name: Magnolia, appName: Magnolia.app
2026-06-12 11:55:38 : WARN  : magnolia : No previous app found
2026-06-12 11:55:38 : WARN  : magnolia : could not find Magnolia.app
2026-06-12 11:55:38 : INFO  : magnolia : appversion: 
2026-06-12 11:55:38 : INFO  : magnolia : Latest version of Magnolia is 1.4.0
2026-06-12 11:55:38 : REQ   : magnolia : Downloading https://github.com/caledavis/Magnolia/releases/download/v1.4.0/Magnolia-mac-arm64.dmg to Magnolia.dmg
2026-06-12 11:55:38 : DEBUG : magnolia : No Dialog connection, just download
2026-06-12 11:55:43 : INFO  : magnolia : Downloaded Magnolia.dmg – Type is  zlib compressed data – SHA is 5587051c8cc38fa514b14dff9b84e4e07a5dba10 – Size is 147852 kB
2026-06-12 11:55:43 : DEBUG : magnolia : DEBUG mode 1, not checking for blocking processes
2026-06-12 11:55:43 : REQ   : magnolia : Installing Magnolia
2026-06-12 11:55:43 : INFO  : magnolia : Mounting /Users/u0105821/git/github/Installomator/build/Magnolia.dmg
2026-06-12 11:55:46 : DEBUG : magnolia : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $1F1748A9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $35CE619D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DBD0031A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $D9BCD91A
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DBD0031A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $678559FF
verified   CRC32 $7FC80636
/dev/disk15         	GUID_partition_scheme
/dev/disk15s1       	Apple_HFS                      	/Volumes/Magnolia 1.4.0

2026-06-12 11:55:46 : INFO  : magnolia : Mounted: /Volumes/Magnolia 1.4.0
2026-06-12 11:55:46 : INFO  : magnolia : Verifying: /Volumes/Magnolia 1.4.0/Magnolia.app
2026-06-12 11:55:46 : DEBUG : magnolia : App size: 357M	/Volumes/Magnolia 1.4.0/Magnolia.app
2026-06-12 11:55:48 : DEBUG : magnolia : Debugging enabled, App Verification output was:
/Volumes/Magnolia 1.4.0/Magnolia.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Cale Davis (DTRLLXT8T7)

2026-06-12 11:55:48 : INFO  : magnolia : Team ID matching: DTRLLXT8T7 (expected: DTRLLXT8T7 )
2026-06-12 11:55:48 : INFO  : magnolia : Installing Magnolia version 1.4.0 on versionKey CFBundleShortVersionString.
2026-06-12 11:55:48 : INFO  : magnolia : App has LSMinimumSystemVersion: 10.15
2026-06-12 11:55:48 : DEBUG : magnolia : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-12 11:55:48 : INFO  : magnolia : Finishing...
2026-06-12 11:55:51 : INFO  : magnolia : name: Magnolia, appName: Magnolia.app
2026-06-12 11:55:51 : WARN  : magnolia : No previous app found
2026-06-12 11:55:51 : WARN  : magnolia : could not find Magnolia.app
2026-06-12 11:55:51 : REQ   : magnolia : Installed Magnolia, version 1.4.0
2026-06-12 11:55:51 : INFO  : magnolia : notifying
2026-06-12 11:55:51 : DEBUG : magnolia : Unmounting /Volumes/Magnolia 1.4.0
2026-06-12 11:55:52 : DEBUG : magnolia : Debugging enabled, Unmounting output was:
"disk15" ejected.
2026-06-12 11:55:52 : DEBUG : magnolia : DEBUG mode 1, not reopening anything
2026-06-12 11:55:52 : REQ   : magnolia : All done!
2026-06-12 11:55:52 : REQ   : magnolia : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
