### PR TITLE
Create knime.sh

### DIFF
--- a/fragments/labels/knime.sh
+++ b/fragments/labels/knime.sh
@@ -1,0 +1,12 @@
+knime)
+    latestMinor=$(curl -fsL "https://docs.knime.com/latest/analytics_platform_release_notes/index.html" | grep -oE 'Version [0-9]+\.[0-9]+' | head -n 1 | awk '{print $2}')
+    appNewVersion=$(curl -fsL "https://docs.knime.com/ap/latest/changelogs/${latestMinor}/" | grep -oE 'KNIME Analytics Platform [0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | awk '{print $4}')
+    name="KNIME ${appNewVersion}"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="https://download.knime.com/analytics-platform/macosx/knime_${appNewVersion}.app.macosx.cocoa.aarch64.dmg"
+    elif [[ "$(arch)" == "i386" ]]; then
+        downloadURL="https://download.knime.com/analytics-platform/macosx/knime_${appNewVersion}.app.macosx.cocoa.x86_64.dmg"
+     fi
+    expectedTeamID="V7WZJX2HS9"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh knime DEBUG=1   
2026-06-12 16:36:54 : INFO  : knime : setting variable from argument DEBUG=1
2026-06-12 16:36:54 : INFO  : knime : Total items in argumentsArray: 1
2026-06-12 16:36:54 : INFO  : knime : argumentsArray: DEBUG=1
2026-06-12 16:36:54 : REQ   : knime : ################## Start Installomator v. 10.9beta, date 2026-06-12
2026-06-12 16:36:54 : INFO  : knime : ################## Version: 10.9beta
2026-06-12 16:36:54 : INFO  : knime : ################## Date: 2026-06-12
2026-06-12 16:36:54 : INFO  : knime : ################## knime
2026-06-12 16:36:54 : DEBUG : knime : DEBUG mode 1 enabled.
2026-06-12 16:36:55 : INFO  : knime : Reading arguments again: DEBUG=1
2026-06-12 16:36:55 : DEBUG : knime : argument: DEBUG=1
2026-06-12 16:36:55 : DEBUG : knime : name=KNIME 5.11.0
2026-06-12 16:36:56 : DEBUG : knime : appName=
2026-06-12 16:36:56 : DEBUG : knime : type=dmg
2026-06-12 16:36:56 : DEBUG : knime : archiveName=
2026-06-12 16:36:56 : DEBUG : knime : downloadURL=https://download.knime.com/analytics-platform/macosx/knime_5.11.0.app.macosx.cocoa.aarch64.dmg
2026-06-12 16:36:56 : DEBUG : knime : curlOptions=
2026-06-12 16:36:56 : DEBUG : knime : appNewVersion=5.11.0
2026-06-12 16:36:56 : DEBUG : knime : appCustomVersion function: Not defined
2026-06-12 16:36:56 : DEBUG : knime : versionKey=CFBundleShortVersionString
2026-06-12 16:36:56 : DEBUG : knime : packageID=
2026-06-12 16:36:56 : DEBUG : knime : pkgName=
2026-06-12 16:36:56 : DEBUG : knime : choiceChangesXML=
2026-06-12 16:36:56 : DEBUG : knime : expectedTeamID=V7WZJX2HS9
2026-06-12 16:36:56 : DEBUG : knime : blockingProcesses=
2026-06-12 16:36:56 : DEBUG : knime : installerTool=
2026-06-12 16:36:56 : DEBUG : knime : CLIInstaller=
2026-06-12 16:36:56 : DEBUG : knime : CLIArguments=
2026-06-12 16:36:56 : DEBUG : knime : updateTool=
2026-06-12 16:36:56 : DEBUG : knime : updateToolArguments=
2026-06-12 16:36:56 : DEBUG : knime : updateToolRunAsCurrentUser=
2026-06-12 16:36:56 : INFO  : knime : BLOCKING_PROCESS_ACTION=tell_user
2026-06-12 16:36:56 : INFO  : knime : NOTIFY=success
2026-06-12 16:36:56 : INFO  : knime : LOGGING=DEBUG
2026-06-12 16:36:56 : INFO  : knime : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-12 16:36:56 : INFO  : knime : Label type: dmg
2026-06-12 16:36:56 : INFO  : knime : archiveName: KNIME 5.11.0.dmg
2026-06-12 16:36:56 : INFO  : knime : no blocking processes defined, using KNIME 5.11.0 as default
2026-06-12 16:36:56 : DEBUG : knime : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-12 16:36:56 : INFO  : knime : name: KNIME 5.11.0, appName: KNIME 5.11.0.app
2026-06-12 16:36:56 : WARN  : knime : No previous app found
2026-06-12 16:36:56 : WARN  : knime : could not find KNIME 5.11.0.app
2026-06-12 16:36:56 : INFO  : knime : appversion: 
2026-06-12 16:36:57 : INFO  : knime : Latest version of KNIME 5.11.0 is 5.11.0
2026-06-12 16:36:57 : REQ   : knime : Downloading https://download.knime.com/analytics-platform/macosx/knime_5.11.0.app.macosx.cocoa.aarch64.dmg to KNIME 5.11.0.dmg
2026-06-12 16:36:57 : DEBUG : knime : No Dialog connection, just download
2026-06-12 16:37:20 : INFO  : knime : Downloaded KNIME 5.11.0.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 845d5469004574e37704739a5b1c153a76941add – Size is 786616 kB
2026-06-12 16:37:20 : DEBUG : knime : DEBUG mode 1, not checking for blocking processes
2026-06-12 16:37:20 : REQ   : knime : Installing KNIME 5.11.0
2026-06-12 16:37:20 : INFO  : knime : Mounting /Users/u0105821/git/github/Installomator/build/KNIME 5.11.0.dmg
2026-06-12 16:37:55 : DEBUG : knime : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D39DF90B
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $211D34CF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DF563A27
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $295FE1D8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DF563A27
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $75C491FB
verified   CRC32 $EE4169AA
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/KNIME 5.11.0 1

2026-06-12 16:37:55 : INFO  : knime : Mounted: /Volumes/KNIME 5.11.0 1
2026-06-12 16:37:55 : INFO  : knime : Verifying: /Volumes/KNIME 5.11.0 1/KNIME 5.11.0.app
2026-06-12 16:37:55 : DEBUG : knime : App size: 1.2G	/Volumes/KNIME 5.11.0 1/KNIME 5.11.0.app
2026-06-12 16:39:36 : DEBUG : knime : Debugging enabled, App Verification output was:
/Volumes/KNIME 5.11.0 1/KNIME 5.11.0.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: KNIME GmbH (V7WZJX2HS9)

2026-06-12 16:39:36 : INFO  : knime : Team ID matching: V7WZJX2HS9 (expected: V7WZJX2HS9 )
2026-06-12 16:39:36 : INFO  : knime : Installing KNIME 5.11.0 version 5.11.0 on versionKey CFBundleShortVersionString.
2026-06-12 16:39:36 : DEBUG : knime : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-12 16:39:36 : INFO  : knime : Finishing...
2026-06-12 16:39:39 : INFO  : knime : name: KNIME 5.11.0, appName: KNIME 5.11.0.app
2026-06-12 16:39:39 : WARN  : knime : No previous app found
2026-06-12 16:39:39 : WARN  : knime : could not find KNIME 5.11.0.app
2026-06-12 16:39:39 : REQ   : knime : Installed KNIME 5.11.0, version 5.11.0
2026-06-12 16:39:40 : INFO  : knime : notifying
2026-06-12 16:39:40 : DEBUG : knime : Unmounting /Volumes/KNIME 5.11.0 1
2026-06-12 16:39:41 : DEBUG : knime : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-12 16:39:41 : DEBUG : knime : DEBUG mode 1, not reopening anything
2026-06-12 16:39:41 : REQ   : knime : All done!
2026-06-12 16:39:41 : REQ   : knime : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
