### PR TITLE
vcvrack2free-new-label

### DIFF
--- a/fragments/labels/vcvrack2free.sh
+++ b/fragments/labels/vcvrack2free.sh
@@ -1,0 +1,8 @@
+vcvrack2free)
+    name="VCV Rack 2 Free"
+    type="pkg"
+    downloadFile=$(curl -fsL "https://vcvrack.com/downloads/" | grep -Eo 'RackFree-[0-9]+(\.[0-9]+)+-mac-x64\+arm64\.pkg' | head -n 1)
+    appNewVersion=$(echo "$downloadFile" | sed -E 's/^RackFree-([0-9]+(\.[0-9]+)+)-mac-x64\+arm64\.pkg$/\1/')
+    downloadURL="https://vcvrack.com/downloads/${downloadFile}"
+    expectedTeamID="V8SW9J626X"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh vcvrack2free DEBUG=1
2026-06-18 15:57:39 : INFO  : vcvrack2free : setting variable from argument DEBUG=1
2026-06-18 15:57:39 : INFO  : vcvrack2free : Total items in argumentsArray: 1
2026-06-18 15:57:39 : INFO  : vcvrack2free : argumentsArray: DEBUG=1
2026-06-18 15:57:39 : REQ   : vcvrack2free : ################## Start Installomator v. 10.9beta, date 2026-06-18
2026-06-18 15:57:39 : INFO  : vcvrack2free : ################## Version: 10.9beta
2026-06-18 15:57:39 : INFO  : vcvrack2free : ################## Date: 2026-06-18
2026-06-18 15:57:39 : INFO  : vcvrack2free : ################## vcvrack2free
2026-06-18 15:57:39 : DEBUG : vcvrack2free : DEBUG mode 1 enabled.
2026-06-18 15:57:40 : INFO  : vcvrack2free : Reading arguments again: DEBUG=1
2026-06-18 15:57:40 : DEBUG : vcvrack2free : argument: DEBUG=1
2026-06-18 15:57:40 : DEBUG : vcvrack2free : name=VCV Rack 2 Free
2026-06-18 15:57:40 : DEBUG : vcvrack2free : appName=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : type=pkg
2026-06-18 15:57:40 : DEBUG : vcvrack2free : archiveName=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : downloadURL=https://vcvrack.com/downloads/RackFree-2.6.6-mac-x64+arm64.pkg
2026-06-18 15:57:40 : DEBUG : vcvrack2free : curlOptions=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : appNewVersion=2.6.6
2026-06-18 15:57:40 : DEBUG : vcvrack2free : appCustomVersion function: Not defined
2026-06-18 15:57:40 : DEBUG : vcvrack2free : versionKey=CFBundleShortVersionString
2026-06-18 15:57:40 : DEBUG : vcvrack2free : packageID=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : pkgName=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : choiceChangesXML=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : expectedTeamID=V8SW9J626X
2026-06-18 15:57:40 : DEBUG : vcvrack2free : blockingProcesses=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : installerTool=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : CLIInstaller=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : CLIArguments=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : updateTool=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : updateToolArguments=
2026-06-18 15:57:40 : DEBUG : vcvrack2free : updateToolRunAsCurrentUser=
2026-06-18 15:57:40 : INFO  : vcvrack2free : BLOCKING_PROCESS_ACTION=tell_user
2026-06-18 15:57:40 : INFO  : vcvrack2free : NOTIFY=success
2026-06-18 15:57:40 : INFO  : vcvrack2free : LOGGING=DEBUG
2026-06-18 15:57:40 : INFO  : vcvrack2free : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-18 15:57:40 : INFO  : vcvrack2free : Label type: pkg
2026-06-18 15:57:40 : INFO  : vcvrack2free : archiveName: VCV Rack 2 Free.pkg
2026-06-18 15:57:40 : INFO  : vcvrack2free : no blocking processes defined, using VCV Rack 2 Free as default
2026-06-18 15:57:40 : DEBUG : vcvrack2free : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-06-18 15:57:40 : INFO  : vcvrack2free : name: VCV Rack 2 Free, appName: VCV Rack 2 Free.app
2026-06-18 15:57:40 : WARN  : vcvrack2free : No previous app found
2026-06-18 15:57:40 : WARN  : vcvrack2free : could not find VCV Rack 2 Free.app
2026-06-18 15:57:40 : INFO  : vcvrack2free : appversion: 
2026-06-18 15:57:40 : INFO  : vcvrack2free : Latest version of VCV Rack 2 Free is 2.6.6
2026-06-18 15:57:40 : REQ   : vcvrack2free : Downloading https://vcvrack.com/downloads/RackFree-2.6.6-mac-x64+arm64.pkg to VCV Rack 2 Free.pkg
2026-06-18 15:57:40 : DEBUG : vcvrack2free : No Dialog connection, just download
2026-06-18 15:57:44 : INFO  : vcvrack2free : Downloaded VCV Rack 2 Free.pkg – Type is  xar archive compressed TOC – SHA is 5f4c1a23f801240f1e95bd0a7884b70b9812ee1c – Size is 25960 kB
2026-06-18 15:57:44 : DEBUG : vcvrack2free : DEBUG mode 1, not checking for blocking processes
2026-06-18 15:57:44 : REQ   : vcvrack2free : Installing VCV Rack 2 Free
2026-06-18 15:57:44 : INFO  : vcvrack2free : Verifying: VCV Rack 2 Free.pkg
2026-06-18 15:57:44 : DEBUG : vcvrack2free : File list: -rw-r--r--  1 root  staff    25M Jun 18 15:57 VCV Rack 2 Free.pkg
2026-06-18 15:57:44 : DEBUG : vcvrack2free : File type: VCV Rack 2 Free.pkg: xar archive compressed TOC: 4478, SHA-1 checksum
2026-06-18 15:57:45 : DEBUG : vcvrack2free : spctlOut is VCV Rack 2 Free.pkg: accepted
2026-06-18 15:57:45 : DEBUG : vcvrack2free : source=Notarized Developer ID
2026-06-18 15:57:45 : DEBUG : vcvrack2free : origin=Developer ID Installer: Andrew Belt (V8SW9J626X)
2026-06-18 15:57:45 : INFO  : vcvrack2free : Team ID: V8SW9J626X (expected: V8SW9J626X )
2026-06-18 15:57:45 : DEBUG : vcvrack2free : DEBUG enabled, skipping installation
2026-06-18 15:57:45 : INFO  : vcvrack2free : Finishing...
2026-06-18 15:57:48 : INFO  : vcvrack2free : name: VCV Rack 2 Free, appName: VCV Rack 2 Free.app
2026-06-18 15:57:48 : WARN  : vcvrack2free : No previous app found
2026-06-18 15:57:48 : WARN  : vcvrack2free : could not find VCV Rack 2 Free.app
2026-06-18 15:57:48 : REQ   : vcvrack2free : Installed VCV Rack 2 Free, version 2.6.6
2026-06-18 15:57:48 : INFO  : vcvrack2free : notifying
2026-06-18 15:57:48 : DEBUG : vcvrack2free : DEBUG mode 1, not reopening anything
2026-06-18 15:57:48 : REQ   : vcvrack2free : All done!
2026-06-18 15:57:48 : REQ   : vcvrack2free : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
