### PR TITLE
Add forcefulQuit label option; enable for 1password8

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -324,6 +324,31 @@ checkRunningProcesses() {
                 printlog "found blocking process $x"
                 appClosed=1
 
+                # forcefulQuit (label opt-in): some apps — notably
+                # menu-bar-resident Electron apps like 1Password 8 — trap
+                # both the AppleScript `quit` event and the SIGTERM that
+                # `pkill` sends, and keep running. A normal quit only
+                # closes their window; the background process survives, so
+                # the actions below can never clear it and we abort with
+                # exit 11. When the label sets forcefulQuit=YES, try a
+                # polite quit once, give it a short grace period, then
+                # escalate to an uncatchable SIGKILL. Only counts as still
+                # blocking if it survives even that.
+                if [[ "$forcefulQuit" == "YES" ]]; then
+                    printlog "forcefulQuit=YES: telling $x to quit, then SIGKILL if it survives"
+                    runAsUser osascript -e "tell app \"$x\" to quit"
+                    sleep 5
+                    if pgrep -xq "$x"; then
+                        printlog "$x still running after quit; sending SIGKILL"
+                        pkill -9 "$x"
+                        sleep 2
+                    fi
+                    if pgrep -xq "$x"; then
+                        countedProcesses=$((countedProcesses + 1))
+                    fi
+                    continue
+                fi
+
                 case $BLOCKING_PROCESS_ACTION in
                     quit|quit_kill)
                         printlog "telling app $x to quit"

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -276,6 +276,15 @@ NOTIFY_DIALOG=0
 #   When a workflow has no blocking processes, use
 #     blockingProcesses=( NONE )
 #
+# - forcefulQuit: (optional)
+#   Set to "YES" for apps that ignore a normal quit and keep running —
+#   typically menu-bar-resident Electron apps (e.g. 1Password 8) that
+#   trap both the AppleScript `quit` event and the SIGTERM that `pkill`
+#   sends, so the regular BLOCKING_PROCESS_ACTION handling can never
+#   clear them and Installomator aborts with exit 11. When set, each
+#   blocking process is told to quit, given a short grace period, then
+#   sent an uncatchable SIGKILL. Default is unset (normal behavior).
+#
 # - pkgName: (optional, only used for pkgInDmg, dmgInZip, and appInDmgInZip)
 #   File name or path to the pkg/dmg file _inside_ the dmg or zip.
 #   When not given the pkgName is derived from the $name

--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -5,4 +5,8 @@
     appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
+    # 1Password 8 is a menu-bar-resident Electron app that traps the
+    # AppleScript quit and SIGTERM and keeps running; force SIGKILL so the
+    # update isn't aborted by a process that won't close. See issue #2029.
+    forcefulQuit="YES"
     ;;


### PR DESCRIPTION
## Problem

`1password8` updates abort with `exit 11` ("could not quit all processes") whenever 1Password is running. 1Password 8 is a menu-bar-resident Electron app that traps **both** the AppleScript `quit` event **and** the SIGTERM that `pkill` sends, so it keeps running after a normal quit (only its window closes). `checkRunningProcesses` can therefore never clear it — even `BLOCKING_PROCESS_ACTION=kill` loops, because that path only sends a catchable SIGTERM. See #2029.

There is no launchd KeepAlive respawning it; the process simply survives every catchable signal Installomator currently sends. Nothing in the quit path ever sends an uncatchable SIGKILL.

## Fix

Add an opt-in label variable `forcefulQuit="YES"`. When set, `checkRunningProcesses` tells the app to quit, waits a short grace period, then escalates to `pkill -9` (SIGKILL). A process is only counted as still-blocking if it survives SIGKILL, so apps that honor the polite quit within the grace window are never force-killed and behavior for all existing labels is unchanged.

Enabled on the `1password8` label. Documented in `header.sh` alongside the other label variables.

## Notes

- Fragments only, per CONTRIBUTING — `Installomator.sh` not edited.
- The same SIGTERM-trap affects other menu-bar Electron apps; they can opt in the same way.
