### PR TITLE
Add label notioncalendar

### DIFF
--- a/fragments/labels/notioncalendar.sh
+++ b/fragments/labels/notioncalendar.sh
@@ -1,0 +1,11 @@
+notioncalendar)
+    name="Notion Calendar"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="https://www.notion.so/calendar/desktop/mac-apple-silicon/download"
+    else
+        downloadURL="https://www.notion.so/calendar/desktop/mac-intel/download"
+    fi
+    appNewVersion="$(curl -fsIL "$downloadURL" | grep -i "^location" | grep -i "dmg" | awk '{print $2}' | sed -e 's/.*Notion%20Calendar-\(.*\).dmg.*/\1/' | cut -d '-' -f 1)"
+    expectedTeamID="LBQJ96FQ8D"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes
**Additional context** Add any other context about the label or fix here.
There's a closed PR at #1899 but I think Notion may have changed their site so that the direct download links work now. There's also a "https://www.notion.so/calendar/desktop/mac/download" link that goes to the universal version, but I prefer architecture-specific builds to cut down on the bloat.
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
```
robot@macos ~ % sudo /Users/robot/Documents/GitHub/Installomator/utils/assemble.sh notioncalendar DEBUG=0
Password:
2026-06-24 23:36:23 : INFO  : notioncalendar : setting variable from argument DEBUG=0
2026-06-24 23:36:23 : INFO  : notioncalendar : Total items in argumentsArray: 1
2026-06-24 23:36:23 : INFO  : notioncalendar : argumentsArray: DEBUG=0
2026-06-24 23:36:23 : REQ   : notioncalendar : ################## Start Installomator v. 10.9beta, date 2026-06-24
2026-06-24 23:36:23 : INFO  : notioncalendar : ################## Version: 10.9beta
2026-06-24 23:36:23 : INFO  : notioncalendar : ################## Date: 2026-06-24
2026-06-24 23:36:23 : INFO  : notioncalendar : ################## notioncalendar
2026-06-24 23:36:23 : INFO  : notioncalendar : SwiftDialog is not installed, clear cmd file var
2026-06-24 23:36:24 : INFO  : notioncalendar : Reading arguments again: DEBUG=0
2026-06-24 23:36:24 : INFO  : notioncalendar : BLOCKING_PROCESS_ACTION=tell_user
2026-06-24 23:36:24 : INFO  : notioncalendar : NOTIFY=success
2026-06-24 23:36:24 : INFO  : notioncalendar : LOGGING=INFO
2026-06-24 23:36:24 : INFO  : notioncalendar : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-24 23:36:24 : INFO  : notioncalendar : Label type: dmg
2026-06-24 23:36:24 : INFO  : notioncalendar : archiveName: Notion Calendar.dmg
2026-06-24 23:36:24 : INFO  : notioncalendar : no blocking processes defined, using Notion Calendar as default
2026-06-24 23:36:24 : INFO  : notioncalendar : name: Notion Calendar, appName: Notion Calendar.app
2026-06-24 23:36:24 : WARN  : notioncalendar : No previous app found
2026-06-24 23:36:24 : WARN  : notioncalendar : could not find Notion Calendar.app
2026-06-24 23:36:24 : INFO  : notioncalendar : appversion: 
2026-06-24 23:36:24 : INFO  : notioncalendar : Latest version of Notion Calendar is 1.137.0
2026-06-24 23:36:24 : REQ   : notioncalendar : Downloading https://www.notion.so/calendar/desktop/mac-apple-silicon/download to Notion Calendar.dmg
2026-06-24 23:36:51 : INFO  : notioncalendar : Downloaded Notion Calendar.dmg – Type is  lzfse encoded, lzvn compressed – SHA is e9e041a7b1b98d13dcd81f2df3d900c448cc4105 – Size is 131420 kB
2026-06-24 23:36:51 : REQ   : notioncalendar : no more blocking processes, continue with update
2026-06-24 23:36:51 : REQ   : notioncalendar : Installing Notion Calendar
2026-06-24 23:36:51 : INFO  : notioncalendar : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7dwe1UQuZK/Notion Calendar.dmg
2026-06-24 23:36:55 : INFO  : notioncalendar : Mounted: /Volumes/Notion Calendar Installer
2026-06-24 23:36:55 : INFO  : notioncalendar : Verifying: /Volumes/Notion Calendar Installer/Notion Calendar.app
2026-06-24 23:36:57 : INFO  : notioncalendar : Team ID matching: LBQJ96FQ8D (expected: LBQJ96FQ8D )
2026-06-24 23:36:57 : INFO  : notioncalendar : Installing Notion Calendar version 1.137.0 on versionKey CFBundleShortVersionString.
2026-06-24 23:36:57 : INFO  : notioncalendar : App has LSMinimumSystemVersion: 12.0
2026-06-24 23:36:57 : INFO  : notioncalendar : Copy /Volumes/Notion Calendar Installer/Notion Calendar.app to /Applications
2026-06-24 23:36:57 : WARN  : notioncalendar : Changing owner to robot
2026-06-24 23:36:57 : INFO  : notioncalendar : Finishing...
2026-06-24 23:37:00 : INFO  : notioncalendar : App(s) found: /Applications/Notion Calendar.app
2026-06-24 23:37:00 : INFO  : notioncalendar : found app at /Applications/Notion Calendar.app, version 1.137.0, on versionKey CFBundleShortVersionString
2026-06-24 23:37:00 : REQ   : notioncalendar : Installed Notion Calendar, version 1.137.0
2026-06-24 23:37:00 : INFO  : notioncalendar : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-06-24 23:37:01 : INFO  : notioncalendar : Installomator did not close any apps, so no need to reopen any apps.
2026-06-24 23:37:01 : REQ   : notioncalendar : All done!
2026-06-24 23:37:01 : REQ   : notioncalendar : ################## End Installomator, exit code 0
```