### PR TITLE
Create gitcredentialmanager.sh

### DIFF
--- a/fragments/labels/gitcredentialmanager.sh
+++ b/fragments/labels/gitcredentialmanager.sh
@@ -3,7 +3,7 @@ gitcredentialmanager)
     type="pkg"
     packageID="com.microsoft.gitcredentialmanager"
     appNewVersion=$(versionFromGit git-ecosystem git-credential-manager)
-    if [[ "$arch" == "arm64" ]]; then
+    if [[ "$(arch)" == "arm64" ]]; then
         downloadURL="https://github.com/git-ecosystem/git-credential-manager/releases/download/v${appNewVersion}/gcm-osx-arm64-${appNewVersion}.pkg"
     else
         downloadURL="https://github.com/git-ecosystem/git-credential-manager/releases/download/v${appNewVersion}/gcm-osx-x64-${appNewVersion}.pkg"

--- a/fragments/labels/gitcredentialmanager.sh
+++ b/fragments/labels/gitcredentialmanager.sh
@@ -1,0 +1,12 @@
+gitcredentialmanager)
+    name="Git Credential Manager"
+    type="pkg"
+    packageID="com.microsoft.gitcredentialmanager"
+    appNewVersion=$(versionFromGit git-ecosystem git-credential-manager)
+    if [[ "$arch" == "arm64" ]]; then
+        downloadURL="https://github.com/git-ecosystem/git-credential-manager/releases/download/v${appNewVersion}/gcm-osx-arm64-${appNewVersion}.pkg"
+    else
+        downloadURL="https://github.com/git-ecosystem/git-credential-manager/releases/download/v${appNewVersion}/gcm-osx-x64-${appNewVersion}.pkg"
+    fi
+    expectedTeamID="UBF8T346G9"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : setting variable from argument DEBUG=0
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : Total items in argumentsArray: 1
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : argumentsArray: DEBUG=0
2026-06-25 11:57:58 : REQ   : gitcredentialmanager : ################## Start Installomator v. 10.9beta, date 2026-06-25
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : ################## Version: 10.9beta
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : ################## Date: 2026-06-25
2026-06-25 11:57:58 : INFO  : gitcredentialmanager : ################## gitcredentialmanager
2026-06-25 11:57:59 : INFO  : gitcredentialmanager : Reading arguments again: DEBUG=0
2026-06-25 11:57:59 : INFO  : gitcredentialmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : NOTIFY=success
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : LOGGING=INFO
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : Label type: pkg
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : archiveName: Git Credential Manager.pkg
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : no blocking processes defined, using Git Credential Manager as default
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : No version found using packageID com.microsoft.gitcredentialmanager
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : name: Git Credential Manager, appName: Git Credential Manager.app
2026-06-25 11:58:00 : WARN  : gitcredentialmanager : No previous app found
2026-06-25 11:58:00 : WARN  : gitcredentialmanager : could not find Git Credential Manager.app
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : appversion: 
2026-06-25 11:58:00 : INFO  : gitcredentialmanager : Latest version of Git Credential Manager is 2.8.0
2026-06-25 11:58:00 : REQ   : gitcredentialmanager : Downloading https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.8.0/gcm-osx-x64-2.8.0.pkg to Git Credential Manager.pkg
2026-06-25 11:58:06 : INFO  : gitcredentialmanager : Downloaded Git Credential Manager.pkg – Type is  xar archive compressed TOC – SHA is 76c9dea0d9758acfb8288fb66eaf710aceb4986d – Size is 45356 kB
2026-06-25 11:58:06 : REQ   : gitcredentialmanager : no more blocking processes, continue with update
2026-06-25 11:58:06 : REQ   : gitcredentialmanager : Installing Git Credential Manager
2026-06-25 11:58:06 : INFO  : gitcredentialmanager : Verifying: Git Credential Manager.pkg
2026-06-25 11:58:06 : INFO  : gitcredentialmanager : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2026-06-25 11:58:06 : INFO  : gitcredentialmanager : Installing Git Credential Manager.pkg to /
2026-06-25 11:58:10 : INFO  : gitcredentialmanager : Finishing...
2026-06-25 11:58:13 : INFO  : gitcredentialmanager : No version found using packageID com.microsoft.gitcredentialmanager
2026-06-25 11:58:13 : INFO  : gitcredentialmanager : name: Git Credential Manager, appName: Git Credential Manager.app
2026-06-25 11:58:13 : WARN  : gitcredentialmanager : No previous app found
2026-06-25 11:58:13 : WARN  : gitcredentialmanager : could not find Git Credential Manager.app
2026-06-25 11:58:13 : REQ   : gitcredentialmanager : Installed Git Credential Manager, version 2.8.0
2026-06-25 11:58:13 : INFO  : gitcredentialmanager : notifying
2026-06-25 11:58:13 : INFO  : gitcredentialmanager : Installomator did not close any apps, so no need to reopen any apps.
2026-06-25 11:58:13 : REQ   : gitcredentialmanager : All done!
2026-06-25 11:58:13 : REQ   : gitcredentialmanager : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
