### PR TITLE
New Label: coteditor

### DIFF
--- a/fragments/labels/coteditor.sh
+++ b/fragments/labels/coteditor.sh
@@ -1,0 +1,7 @@
+coteditor)
+    name="CotEditor"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit coteditor CotEditor)"
+    appNewVersion="$(versionFromGit coteditor CotEditor)"
+    expectedTeamID="HT3Z3A72WZ"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

n/a

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```sh
./utils/assemble.sh coteditor
2026-06-26 10:14:25 : REQ   : coteditor : ################## Start Installomator v. 10.9beta, date 2026-06-26
2026-06-26 10:14:25 : INFO  : coteditor : ################## Version: 10.9beta
2026-06-26 10:14:25 : INFO  : coteditor : ################## Date: 2026-06-26
2026-06-26 10:14:25 : INFO  : coteditor : ################## coteditor
2026-06-26 10:14:25 : DEBUG : coteditor : DEBUG mode 1 enabled.
2026-06-26 10:14:25 : INFO  : coteditor : SwiftDialog is not installed, clear cmd file var
2026-06-26 10:14:26 : DEBUG : coteditor : name=CotEditor
2026-06-26 10:14:26 : DEBUG : coteditor : appName=
2026-06-26 10:14:26 : DEBUG : coteditor : type=dmg
2026-06-26 10:14:26 : DEBUG : coteditor : archiveName=
2026-06-26 10:14:27 : DEBUG : coteditor : downloadURL=https://github.com/coteditor/CotEditor/releases/download/7.0.5/CotEditor_7.0.5.dmg
2026-06-26 10:14:27 : DEBUG : coteditor : curlOptions=
2026-06-26 10:14:27 : DEBUG : coteditor : appNewVersion=7.0.5
2026-06-26 10:14:27 : DEBUG : coteditor : appCustomVersion function: Not defined
2026-06-26 10:14:27 : DEBUG : coteditor : versionKey=CFBundleShortVersionString
2026-06-26 10:14:27 : DEBUG : coteditor : packageID=
2026-06-26 10:14:27 : DEBUG : coteditor : pkgName=
2026-06-26 10:14:27 : DEBUG : coteditor : choiceChangesXML=
2026-06-26 10:14:27 : DEBUG : coteditor : expectedTeamID=HT3Z3A72WZ
2026-06-26 10:14:27 : DEBUG : coteditor : blockingProcesses=
2026-06-26 10:14:27 : DEBUG : coteditor : installerTool=
2026-06-26 10:14:27 : DEBUG : coteditor : CLIInstaller=
2026-06-26 10:14:27 : DEBUG : coteditor : CLIArguments=
2026-06-26 10:14:27 : DEBUG : coteditor : updateTool=
2026-06-26 10:14:27 : DEBUG : coteditor : updateToolArguments=
2026-06-26 10:14:27 : DEBUG : coteditor : updateToolRunAsCurrentUser=
2026-06-26 10:14:27 : INFO  : coteditor : BLOCKING_PROCESS_ACTION=tell_user
2026-06-26 10:14:27 : INFO  : coteditor : NOTIFY=success
2026-06-26 10:14:27 : INFO  : coteditor : LOGGING=DEBUG
2026-06-26 10:14:27 : INFO  : coteditor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-26 10:14:27 : INFO  : coteditor : Label type: dmg
2026-06-26 10:14:27 : INFO  : coteditor : archiveName: CotEditor.dmg
2026-06-26 10:14:27 : INFO  : coteditor : no blocking processes defined, using CotEditor as default
2026-06-26 10:14:27 : DEBUG : coteditor : Changing directory to /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build
2026-06-26 10:14:27 : INFO  : coteditor : App(s) found: /Applications/CotEditor.app
2026-06-26 10:14:27 : INFO  : coteditor : found app at /Applications/CotEditor.app, version 5.1.2, on versionKey CFBundleShortVersionString
2026-06-26 10:14:27 : INFO  : coteditor : appversion: 0
2026-06-26 10:14:27 : INFO  : coteditor : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-06-26 10:14:27 : INFO  : coteditor : Latest version of CotEditor is 7.0.5
2026-06-26 10:14:27 : REQ   : coteditor : Downloading https://github.com/coteditor/CotEditor/releases/download/7.0.5/CotEditor_7.0.5.dmg to CotEditor.dmg
2026-06-26 10:14:27 : DEBUG : coteditor : No Dialog connection, just download
2026-06-26 10:14:29 : INFO  : coteditor : Downloaded CotEditor.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is faff0d7da6c6fe7c5fc186363b64116638478058 – Size is 30040 kB
2026-06-26 10:14:29 : DEBUG : coteditor : DEBUG mode 1, not checking for blocking processes
2026-06-26 10:14:29 : REQ   : coteditor : Installing CotEditor
2026-06-26 10:14:29 : INFO  : coteditor : Mounting /Users/kenchan0130/ghq/github.com/Installomator/Installomator/build/CotEditor.dmg
2026-06-26 10:14:32 : DEBUG : coteditor : Debugging enabled, dmgmount output was:
Protective Master Boot Record (MBR : 0)のチェックサムを計算中…
Protective Master Boot Record (MBR :: 検証済み CRC32 $B96D70AF
GPT Header (Primary GPT Header : 1)のチェックサムを計算中…
GPT Header (Primary GPT Header : 1): 検証済み CRC32 $8110C361
GPT Partition Data (Primary GPT Table : 2)のチェックサムを計算中…
GPT Partition Data (Primary GPT Tabl: 検証済み CRC32 $18D3A3A6
(Apple_Free : 3)のチェックサムを計算中…
(Apple_Free : 3): 検証済み CRC32 $00000000
disk image (Apple_APFS : 4)のチェックサムを計算中…
disk image (Apple_APFS : 4): 検証済み CRC32 $A401DB1E
(Apple_Free : 5)のチェックサムを計算中…
(Apple_Free : 5): 検証済み CRC32 $00000000
GPT Partition Data (Backup GPT Table : 6)のチェックサムを計算中…
GPT Partition Data (Backup GPT Table: 検証済み CRC32 $18D3A3A6
GPT Header (Backup GPT Header : 7)のチェックサムを計算中…
GPT Header (Backup GPT Header : 7): 検証済み CRC32 $B9881BAE
検証済み CRC32 $95D1DD34
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/CotEditor

2026-06-26 10:14:32 : INFO  : coteditor : Mounted: /Volumes/CotEditor
2026-06-26 10:14:32 : INFO  : coteditor : Verifying: /Volumes/CotEditor/CotEditor.app
2026-06-26 10:14:33 : DEBUG : coteditor : App size: 126M	/Volumes/CotEditor/CotEditor.app
2026-06-26 10:14:36 : DEBUG : coteditor : Debugging enabled, App Verification output was:
/Volumes/CotEditor/CotEditor.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mineko IMANISHI (HT3Z3A72WZ)

2026-06-26 10:14:36 : INFO  : coteditor : Team ID matching: HT3Z3A72WZ (expected: HT3Z3A72WZ )
2026-06-26 10:14:36 : INFO  : coteditor : Downloaded version of CotEditor is 7.0.5 on versionKey CFBundleShortVersionString (replacing version 0).
2026-06-26 10:14:36 : INFO  : coteditor : App has LSMinimumSystemVersion: 15.0
2026-06-26 10:14:36 : DEBUG : coteditor : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-26 10:14:36 : INFO  : coteditor : Finishing...
2026-06-26 10:14:39 : INFO  : coteditor : App(s) found: /Applications/CotEditor.app
2026-06-26 10:14:39 : INFO  : coteditor : found app at /Applications/CotEditor.app, version 5.1.2, on versionKey CFBundleShortVersionString
2026-06-26 10:14:39 : WARN  : coteditor : Replacing App Store apps, no matter the version
2026-06-26 10:14:39 : REQ   : coteditor : Installed CotEditor, version 7.0.5
2026-06-26 10:14:39 : INFO  : coteditor : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-06-26 10:14:39 : DEBUG : coteditor : Unmounting /Volumes/CotEditor
2026-06-26 10:14:39 : DEBUG : coteditor : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-06-26 10:14:39 : DEBUG : coteditor : DEBUG mode 1, not reopening anything
2026-06-26 10:14:39 : REQ   : coteditor : All done!
2026-06-26 10:14:39 : REQ   : coteditor : ################## End Installomator, exit code 0
```
