### PR TITLE
Update soapuiopensource.sh

### DIFF
--- a/fragments/labels/soapuiopensource.sh
+++ b/fragments/labels/soapuiopensource.sh
@@ -1,19 +1,11 @@
 soapuiopensource)
-    name="SoapUI"
-    type="dmg"
-    downloadURL="$(curl -fsL "https://github.com/SmartBear/soapui/releases/latest" | grep -m 1 -o 'href=".*\.dmg".*' | cut -d '"' -f 2)"
     appNewVersion="$(versionFromGit SmartBear soapui)"
-    appCustomVersion() {
-        while IFS= read -r line; do
-            soapUIApps+=("$line")
-        done < <(ls -d ${targetDir}/* | grep -E "SoapUI-.*\.app")
-
-        if [ -e "${soapUIApps[-1]}" ]; then
-            defaults read "${soapUIApps[-1]}/Contents/Info.plist" CFBundleShortVersionString
-        fi
-    }
-    installerTool="SoapUI ${appNewVersion} Installer.app"
-    CLIInstaller="${installerTool}/Contents/MacOS/JavaApplicationStub"
-    CLIArguments=(-q)
+    name="SoapUI-$appNewVersion"
+    type="dmg"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL="$(curl -fsL "https://github.com/SmartBear/soapui/releases/latest" | grep -m 1 -o 'href=".*arm64.*\.dmg".*' | cut -d '"' -f 2)"
+    else
+        downloadURL="$(curl -fsL "https://github.com/SmartBear/soapui/releases/latest" | grep -m 1 -o 'href=".*\.dmg".*' | cut -d '"' -f 2)"
+    fi
     expectedTeamID="HVA5GNL2LF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
App is no longer a CLI install app. It is now the real app on a DMG.
Also added support for arm64 to the label

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes #3048 

https://github.com/Installomator/Installomator/issues/3048

```
./utils/assemble.sh soapuiopensource
2026-06-27 13:30:01 : INFO  : soapuiopensource : Total items in argumentsArray: 0
2026-06-27 13:30:01 : INFO  : soapuiopensource : argumentsArray: 
2026-06-27 13:30:01 : REQ   : soapuiopensource : ################## Start Installomator v. 10.9beta, date 2026-06-27
2026-06-27 13:30:01 : INFO  : soapuiopensource : ################## Version: 10.9beta
2026-06-27 13:30:01 : INFO  : soapuiopensource : ################## Date: 2026-06-27
2026-06-27 13:30:01 : INFO  : soapuiopensource : ################## soapuiopensource
2026-06-27 13:30:01 : DEBUG : soapuiopensource : DEBUG mode 1 enabled.
2026-06-27 13:30:03 : INFO  : soapuiopensource : Reading arguments again: 
2026-06-27 13:30:03 : DEBUG : soapuiopensource : name=SoapUI-5.10.0
2026-06-27 13:30:03 : DEBUG : soapuiopensource : appName=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : type=dmg
2026-06-27 13:30:03 : DEBUG : soapuiopensource : archiveName=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : downloadURL=https://dl.eviware.com/soapuios/5.10.0/SoapUI-arm64-5.10.0.dmg
2026-06-27 13:30:03 : DEBUG : soapuiopensource : curlOptions=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : appNewVersion=5.10.0
2026-06-27 13:30:03 : DEBUG : soapuiopensource : appCustomVersion function: Not defined
2026-06-27 13:30:03 : DEBUG : soapuiopensource : versionKey=CFBundleShortVersionString
2026-06-27 13:30:03 : DEBUG : soapuiopensource : packageID=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : pkgName=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : choiceChangesXML=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : expectedTeamID=HVA5GNL2LF
2026-06-27 13:30:03 : DEBUG : soapuiopensource : blockingProcesses=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : installerTool=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : CLIInstaller=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : CLIArguments=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : updateTool=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : updateToolArguments=
2026-06-27 13:30:03 : DEBUG : soapuiopensource : updateToolRunAsCurrentUser=
2026-06-27 13:30:03 : INFO  : soapuiopensource : BLOCKING_PROCESS_ACTION=tell_user
2026-06-27 13:30:03 : INFO  : soapuiopensource : NOTIFY=success
2026-06-27 13:30:03 : INFO  : soapuiopensource : LOGGING=DEBUG
2026-06-27 13:30:03 : INFO  : soapuiopensource : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-06-27 13:30:03 : INFO  : soapuiopensource : Label type: dmg
2026-06-27 13:30:03 : INFO  : soapuiopensource : archiveName: SoapUI-5.10.0.dmg
2026-06-27 13:30:03 : INFO  : soapuiopensource : no blocking processes defined, using SoapUI-5.10.0 as default
2026-06-27 13:30:03 : DEBUG : soapuiopensource : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-06-27 13:30:03 : INFO  : soapuiopensource : name: SoapUI-5.10.0, appName: SoapUI-5.10.0.app
2026-06-27 13:30:03 : WARN  : soapuiopensource : No previous app found
2026-06-27 13:30:03 : WARN  : soapuiopensource : could not find SoapUI-5.10.0.app
2026-06-27 13:30:03 : INFO  : soapuiopensource : appversion: 
2026-06-27 13:30:04 : INFO  : soapuiopensource : Latest version of SoapUI-5.10.0 is 5.10.0
2026-06-27 13:30:04 : REQ   : soapuiopensource : Downloading https://dl.eviware.com/soapuios/5.10.0/SoapUI-arm64-5.10.0.dmg to SoapUI-5.10.0.dmg
2026-06-27 13:30:04 : DEBUG : soapuiopensource : No Dialog connection, just download
2026-06-27 13:30:27 : INFO  : soapuiopensource : Downloaded SoapUI-5.10.0.dmg – Type is  zlib compressed data – SHA is 27b582f4862f5db4f71981fbf6569027a298421e – Size is 197092 kB
2026-06-27 13:30:27 : DEBUG : soapuiopensource : DEBUG mode 1, not checking for blocking processes
2026-06-27 13:30:27 : REQ   : soapuiopensource : Installing SoapUI-5.10.0
2026-06-27 13:30:27 : INFO  : soapuiopensource : Mounting /Users/gilburns/GitHub/Installomator/build/SoapUI-5.10.0.dmg
2026-06-27 13:30:28 : DEBUG : soapuiopensource : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $2F44FCBD
verified   CRC32 $A35F24E8
/dev/disk18         	Apple_partition_scheme
/dev/disk18s1       	Apple_partition_map
/dev/disk18s2       	Apple_HFS                      	/Volumes/SoapUI-arm64-5.10.0

2026-06-27 13:30:28 : INFO  : soapuiopensource : Mounted: /Volumes/SoapUI-arm64-5.10.0
2026-06-27 13:30:28 : INFO  : soapuiopensource : Verifying: /Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app
2026-06-27 13:30:29 : DEBUG : soapuiopensource : App size: 311M	/Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app
2026-06-27 13:30:30 : DEBUG : soapuiopensource : Debugging enabled, App Verification output was:
/Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Smart Bear Software, Inc. (HVA5GNL2LF)

2026-06-27 13:30:30 : INFO  : soapuiopensource : Team ID matching: HVA5GNL2LF (expected: HVA5GNL2LF )
2026-06-27 13:30:30 : INFO  : soapuiopensource : Installing SoapUI-5.10.0 version 5.10.0 on versionKey CFBundleShortVersionString.
2026-06-27 13:30:30 : INFO  : soapuiopensource : App has LSMinimumSystemVersion: 10.11
2026-06-27 13:30:30 : DEBUG : soapuiopensource : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-06-27 13:30:30 : INFO  : soapuiopensource : Finishing...
2026-06-27 13:30:33 : INFO  : soapuiopensource : name: SoapUI-5.10.0, appName: SoapUI-5.10.0.app
2026-06-27 13:30:33 : WARN  : soapuiopensource : No previous app found
2026-06-27 13:30:33 : WARN  : soapuiopensource : could not find SoapUI-5.10.0.app
2026-06-27 13:30:33 : REQ   : soapuiopensource : Installed SoapUI-5.10.0, version 5.10.0
2026-06-27 13:30:33 : INFO  : soapuiopensource : notifying
2026-06-27 13:30:34 : DEBUG : soapuiopensource : Unmounting /Volumes/SoapUI-arm64-5.10.0
2026-06-27 13:30:44 : DEBUG : soapuiopensource : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-06-27 13:30:44 : DEBUG : soapuiopensource : DEBUG mode 1, not reopening anything
2026-06-27 13:30:44 : REQ   : soapuiopensource : All done!
2026-06-27 13:30:44 : REQ   : soapuiopensource : ################## End Installomator, exit code 0 

```