### PR TITLE
Replace hdiutil with diskutil #3059

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -4,7 +4,7 @@ cleanupAndExit() { # $1 = exit code, $2 message, $3 level
     if [ -n "$dmgmount" ]; then
         # unmount disk image
         printlog "Unmounting $dmgmount" DEBUG
-        unmountingOut=$(hdiutil detach "$dmgmount" 2>&1)
+        unmountingOut=$(diskutil eject "$dmgmount" 2>&1)
         printlog "Debugging enabled, Unmounting output was:\n$unmountingOut" DEBUG
     fi
     if [ "$DEBUG" -ne 1 ]; then
@@ -596,9 +596,11 @@ mountDMG() {
     # mount the dmg
     printlog "Mounting $tmpDir/$archiveName"
     # always pipe 'Y\n' in case the dmg requires an agreement
-    dmgmountOut=$(echo 'Y'$'\n' | hdiutil attach "$tmpDir/$archiveName" -nobrowse -readonly )
+    dmgmountOut=$(echo 'Y'$'\n' | diskutil image attach --mountOptions nobrowse --readOnly --plist "$tmpDir/$archiveName" )
     dmgmountStatus=$(echo $?)
-    dmgmount=$(echo $dmgmountOut | tail -n 1 | cut -c 54- )
+    dmgmount=$(echo "$dmgmountOut" \
+    | awk '/<key>mount-point<\/key>/ {getline; print; exit}' \
+    | sed -E 's|.*<string>(.*)</string>.*|\1|')
     deduplicatelogs "$dmgmountOut"
 
     if [[ $dmgmountStatus -ne 0 ]] ; then


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Editing the `function.sh`

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Replacing the `hdiutil` with `diskutil` to resolve deprecation warning present in MacOS 27.

**Installomator log** 
```
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : Total items in argumentsArray: 0
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : argumentsArray: 
2026-07-01 15:09:16 : REQ   : adobeacrobatprodc : ################## Start Installomator v. 10.9beta, date 2026-07-01
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : ################## Version: 10.9beta
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : ################## Date: 2026-07-01
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : ################## adobeacrobatprodc
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : DEBUG mode 1 enabled.
2026-07-01 15:09:16 : INFO  : adobeacrobatprodc : Reading arguments again: 
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : name=Adobe Acrobat Pro DC
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : appName=Acrobat Distiller.app
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : type=pkgInDmg
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : archiveName=
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : downloadURL=https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : curlOptions=
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : appNewVersion=
2026-07-01 15:09:16 : DEBUG : adobeacrobatprodc : appCustomVersion function: Not defined
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : versionKey=CFBundleShortVersionString
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : packageID=com.adobe.acrobat.DC.viewer.app.pkg.MUI
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : pkgName=Acrobat/Acrobat DC Installer.pkg
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : choiceChangesXML=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : expectedTeamID=JQ525L2MZD
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : blockingProcesses=Acrobat Pro DC
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : installerTool=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : CLIInstaller=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : CLIArguments=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : updateTool=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : updateToolArguments=
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : updateToolRunAsCurrentUser=
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : BLOCKING_PROCESS_ACTION=tell_user
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : NOTIFY=success
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : LOGGING=DEBUG
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : Label type: pkgInDmg
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : archiveName: Adobe Acrobat Pro DC.dmg
2026-07-01 15:09:17 : DEBUG : adobeacrobatprodc : Changing directory to .
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : No version found using packageID com.adobe.acrobat.DC.viewer.app.pkg.MUI
2026-07-01 15:09:17 : INFO  : adobeacrobatprodc : name: Adobe Acrobat Pro DC, appName: Acrobat Distiller.app
2026-07-01 15:09:18 : WARN  : adobeacrobatprodc : No previous app found
2026-07-01 15:09:18 : WARN  : adobeacrobatprodc : could not find Acrobat Distiller.app
2026-07-01 15:09:18 : INFO  : adobeacrobatprodc : appversion: 
2026-07-01 15:09:18 : INFO  : adobeacrobatprodc : Latest version not specified.
2026-07-01 15:09:18 : REQ   : adobeacrobatprodc : Downloading https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg to Adobe Acrobat Pro DC.dmg
2026-07-01 15:09:18 : DEBUG : adobeacrobatprodc : No Dialog connection, just download
2026-07-01 15:09:55 : INFO  : adobeacrobatprodc : Downloaded Adobe Acrobat Pro DC.dmg – Type is  ISO 9660 CD-ROM filesystem data 'ACROBAT' – SHA is b597a3d27014c59792f54aaea4570f79a325c485 – Size is 1655636 kB
2026-07-01 15:09:55 : DEBUG : adobeacrobatprodc : DEBUG mode 1, not checking for blocking processes
2026-07-01 15:09:55 : REQ   : adobeacrobatprodc : Installing Adobe Acrobat Pro DC
2026-07-01 15:09:55 : INFO  : adobeacrobatprodc : Mounting ./Adobe Acrobat Pro DC.dmg
2026-07-01 15:09:56 : DEBUG : adobeacrobatprodc : Debugging enabled, dmgmount output was:
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
<key>system-entities</key>
<array>
<dict>
<key>content-hint</key>
<string>Apple_partition_scheme</string>
<key>dev-entry</key>
<string>disk17</string>
<key>size</key>
<integer>1681072128</integer>
</dict>
<dict>
<key>content-hint</key>
<string>Apple_partition_map</string>
<key>dev-entry</key>
<string>disk17s1</string>
<key>size</key>
<integer>32256</integer>
</dict>
<dict>
<key>content-hint</key>
<string>Apple_HFS</string>
<key>dev-entry</key>
<string>disk17s2</string>
<key>filesystem-name</key>
<string>HFS+</string>
<key>filesystem-type</key>
<string>hfs</string>
<key>mount-point</key>
<string>/Volumes/Acrobat</string>
<key>size</key>
<integer>1679886336</integer>
<key>volume-name</key>
<string>Acrobat</string>
</dict>
</array>
</dict>
</plist>

2026-07-01 15:09:56 : INFO  : adobeacrobatprodc : Mounted: /Volumes/Acrobat
2026-07-01 15:09:56 : INFO  : adobeacrobatprodc : found pkg: /Volumes/Acrobat/Acrobat/Acrobat DC Installer.pkg
2026-07-01 15:09:56 : INFO  : adobeacrobatprodc : Verifying: /Volumes/Acrobat/Acrobat/Acrobat DC Installer.pkg
2026-07-01 15:09:56 : DEBUG : adobeacrobatprodc : File list: -rw-r--r--@ 1 nlahaye  staff   1.6G Jun  9 02:28 /Volumes/Acrobat/Acrobat/Acrobat DC Installer.pkg
2026-07-01 15:09:56 : DEBUG : adobeacrobatprodc : File type: /Volumes/Acrobat/Acrobat/Acrobat DC Installer.pkg: xar archive compressed TOC: 15175, SHA-1 checksum
2026-07-01 15:09:57 : DEBUG : adobeacrobatprodc : spctlOut is /Volumes/Acrobat/Acrobat/Acrobat DC Installer.pkg: accepted
2026-07-01 15:09:57 : DEBUG : adobeacrobatprodc : source=Notarized Developer ID
2026-07-01 15:09:57 : DEBUG : adobeacrobatprodc : origin=Developer ID Installer: Adobe Inc. (JQ525L2MZD)
2026-07-01 15:09:57 : INFO  : adobeacrobatprodc : Team ID: JQ525L2MZD (expected: JQ525L2MZD )
2026-07-01 15:09:57 : DEBUG : adobeacrobatprodc : DEBUG enabled, skipping installation
2026-07-01 15:09:57 : INFO  : adobeacrobatprodc : Finishing...
2026-07-01 15:10:00 : INFO  : adobeacrobatprodc : No version found using packageID com.adobe.acrobat.DC.viewer.app.pkg.MUI
2026-07-01 15:10:00 : INFO  : adobeacrobatprodc : name: Adobe Acrobat Pro DC, appName: Acrobat Distiller.app
2026-07-01 15:10:01 : WARN  : adobeacrobatprodc : No previous app found
2026-07-01 15:10:01 : WARN  : adobeacrobatprodc : could not find Acrobat Distiller.app
2026-07-01 15:10:01 : REQ   : adobeacrobatprodc : Installed Adobe Acrobat Pro DC
2026-07-01 15:10:01 : INFO  : adobeacrobatprodc : notifying
2026-07-01 15:10:01 : DEBUG : adobeacrobatprodc : Unmounting /Volumes/Acrobat
2026-07-01 15:10:03 : DEBUG : adobeacrobatprodc : Debugging enabled, Unmounting output was:
Disk /Volumes/Acrobat ejected
2026-07-01 15:10:03 : DEBUG : adobeacrobatprodc : DEBUG mode 1, not reopening anything
2026-07-01 15:10:03 : REQ   : adobeacrobatprodc : All done!
2026-07-01 15:10:03 : REQ   : adobeacrobatprodc : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Resolving #3059 