### PR TITLE
dbvisualizer-update-label

### DIFF
--- a/fragments/labels/dbvisualizer.sh
+++ b/fragments/labels/dbvisualizer.sh
@@ -2,10 +2,7 @@ dbvisualizer)
     name="DbVisualizer"
     type="dmg"
     dbvisVersion=$(curl -fsL "https://www.dbvis.com/download/" | grep -oE 'Latest version [0-9]+(\.[0-9]+)+' | head -n 1 | awk '{print $3}')
-    appNewVersion="$dbvisVersion"
-    if [[ "$appNewVersion" =~ ^[0-9]+\.[0-9]+$ ]]; then
-        appNewVersion="${appNewVersion}.0"
-    fi
+    appNewVersion=$(echo "$dbvisVersion" | awk -F. '{for (i = NF+1; i <= 3; i++) $i = 0; print $1"."$2"."$3}')
     downloadVersion="${dbvisVersion//./_}"
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://www.dbvis.com/product_download/dbvis-${dbvisVersion}/media/dbvis_macos-aarch64_${downloadVersion}.dmg"

--- a/fragments/labels/dbvisualizer.sh
+++ b/fragments/labels/dbvisualizer.sh
@@ -1,9 +1,16 @@
 dbvisualizer)
     name="DbVisualizer"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://www.dbvis.com/download/" | sed -n 's/.*Latest version \([0-9.]*\).*/\1/p' | head -n1)
-    versionUnderscore="${appNewVersion//./_}"
-    downloadURL="https://www.dbvis.com/product_download/dbvis-${appNewVersion}/media/dbvis_macos-aarch64_${versionUnderscore}.dmg"
+    dbvisVersion=$(curl -fsL "https://www.dbvis.com/download/" | grep -oE 'Latest version [0-9]+(\.[0-9]+)+' | head -n 1 | awk '{print $3}')
+    appNewVersion="$dbvisVersion"
+    if [[ "$appNewVersion" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        appNewVersion="${appNewVersion}.0"
+    fi
+    downloadVersion="${dbvisVersion//./_}"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://www.dbvis.com/product_download/dbvis-${dbvisVersion}/media/dbvis_macos-aarch64_${downloadVersion}.dmg"
+    else
+        downloadURL="https://www.dbvis.com/product_download/dbvis-${dbvisVersion}/media/dbvis_macos-x64_${downloadVersion}.dmg"
+    fi
     expectedTeamID="U9TP5KYV49"
-    blockingProcesses=( "DbVisualizer" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

Updated the dbvisualizer label to add Intel support—it now branches on $(arch) to pull the correct x64 or aarch64 DMG instead of hardcoding Apple Silicon only. Version detection is also more robust, using grep -oE to isolate the version string, and adds a check that pads two-component versions (e.g. 4.2) to three (4.2.0) so appNewVersion reliably matches the installed app's version format. blockingProcesses was dropped since it just duplicated name, which Installomator handles natively. Version parsing still relies on HTML scraping since no structured API/feed is available from the vendor.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh dbvisualizer DEBUG=1
2026-07-02 09:41:03 : INFO  : dbvisualizer : setting variable from argument DEBUG=1
2026-07-02 09:41:03 : INFO  : dbvisualizer : Total items in argumentsArray: 1
2026-07-02 09:41:03 : INFO  : dbvisualizer : argumentsArray: DEBUG=1
2026-07-02 09:41:03 : REQ   : dbvisualizer : ################## Start Installomator v. 10.9beta, date 2026-07-02
2026-07-02 09:41:03 : INFO  : dbvisualizer : ################## Version: 10.9beta
2026-07-02 09:41:03 : INFO  : dbvisualizer : ################## Date: 2026-07-02
2026-07-02 09:41:03 : INFO  : dbvisualizer : ################## dbvisualizer
2026-07-02 09:41:03 : DEBUG : dbvisualizer : DEBUG mode 1 enabled.
2026-07-02 09:41:04 : INFO  : dbvisualizer : Reading arguments again: DEBUG=1
2026-07-02 09:41:04 : DEBUG : dbvisualizer : argument: DEBUG=1
2026-07-02 09:41:04 : DEBUG : dbvisualizer : name=DbVisualizer
2026-07-02 09:41:04 : DEBUG : dbvisualizer : appName=
2026-07-02 09:41:04 : DEBUG : dbvisualizer : type=dmg
2026-07-02 09:41:04 : DEBUG : dbvisualizer : archiveName=
2026-07-02 09:41:04 : DEBUG : dbvisualizer : downloadURL=https://www.dbvis.com/product_download/dbvis-26.2/media/dbvis_macos-aarch64_26_2.dmg
2026-07-02 09:41:04 : DEBUG : dbvisualizer : curlOptions=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : appNewVersion=26.2.0
2026-07-02 09:41:05 : DEBUG : dbvisualizer : appCustomVersion function: Not defined
2026-07-02 09:41:05 : DEBUG : dbvisualizer : versionKey=CFBundleShortVersionString
2026-07-02 09:41:05 : DEBUG : dbvisualizer : packageID=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : pkgName=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : choiceChangesXML=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : expectedTeamID=U9TP5KYV49
2026-07-02 09:41:05 : DEBUG : dbvisualizer : blockingProcesses=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : installerTool=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : CLIInstaller=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : CLIArguments=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : updateTool=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : updateToolArguments=
2026-07-02 09:41:05 : DEBUG : dbvisualizer : updateToolRunAsCurrentUser=
2026-07-02 09:41:05 : INFO  : dbvisualizer : BLOCKING_PROCESS_ACTION=tell_user
2026-07-02 09:41:05 : INFO  : dbvisualizer : NOTIFY=success
2026-07-02 09:41:05 : INFO  : dbvisualizer : LOGGING=DEBUG
2026-07-02 09:41:05 : INFO  : dbvisualizer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-02 09:41:05 : INFO  : dbvisualizer : Label type: dmg
2026-07-02 09:41:05 : INFO  : dbvisualizer : archiveName: DbVisualizer.dmg
2026-07-02 09:41:05 : INFO  : dbvisualizer : no blocking processes defined, using DbVisualizer as default
2026-07-02 09:41:05 : DEBUG : dbvisualizer : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-02 09:41:05 : INFO  : dbvisualizer : name: DbVisualizer, appName: DbVisualizer.app
2026-07-02 09:41:05 : WARN  : dbvisualizer : No previous app found
2026-07-02 09:41:05 : WARN  : dbvisualizer : could not find DbVisualizer.app
2026-07-02 09:41:05 : INFO  : dbvisualizer : appversion: 
2026-07-02 09:41:05 : INFO  : dbvisualizer : Latest version of DbVisualizer is 26.2.0
2026-07-02 09:41:05 : REQ   : dbvisualizer : Downloading https://www.dbvis.com/product_download/dbvis-26.2/media/dbvis_macos-aarch64_26_2.dmg to DbVisualizer.dmg
2026-07-02 09:41:05 : DEBUG : dbvisualizer : No Dialog connection, just download
2026-07-02 09:41:15 : INFO  : dbvisualizer : Downloaded DbVisualizer.dmg – Type is  zlib compressed data – SHA is dd8122d0b45ce83633970d996943f72f5b3d1c7f – Size is 229460 kB
2026-07-02 09:41:15 : DEBUG : dbvisualizer : DEBUG mode 1, not checking for blocking processes
2026-07-02 09:41:16 : REQ   : dbvisualizer : Installing DbVisualizer
2026-07-02 09:41:16 : INFO  : dbvisualizer : Mounting /Users/u0105821/git/github/Installomator/build/DbVisualizer.dmg
2026-07-02 09:41:16 : DEBUG : dbvisualizer : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $263CB158
verified   CRC32 $11027535
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/DbVisualizer

2026-07-02 09:41:17 : INFO  : dbvisualizer : Mounted: /Volumes/DbVisualizer
2026-07-02 09:41:17 : INFO  : dbvisualizer : Verifying: /Volumes/DbVisualizer/DbVisualizer.app
2026-07-02 09:41:17 : DEBUG : dbvisualizer : App size: 328M	/Volumes/DbVisualizer/DbVisualizer.app
2026-07-02 09:41:18 : DEBUG : dbvisualizer : Debugging enabled, App Verification output was:
/Volumes/DbVisualizer/DbVisualizer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DbVis Software AB (U9TP5KYV49)

2026-07-02 09:41:18 : INFO  : dbvisualizer : Team ID matching: U9TP5KYV49 (expected: U9TP5KYV49 )
2026-07-02 09:41:18 : INFO  : dbvisualizer : Installing DbVisualizer version 26.2.0 on versionKey CFBundleShortVersionString.
2026-07-02 09:41:18 : INFO  : dbvisualizer : App has LSMinimumSystemVersion: 10.15
2026-07-02 09:41:18 : DEBUG : dbvisualizer : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-02 09:41:18 : INFO  : dbvisualizer : Finishing...
2026-07-02 09:41:21 : INFO  : dbvisualizer : name: DbVisualizer, appName: DbVisualizer.app
2026-07-02 09:41:21 : WARN  : dbvisualizer : No previous app found
2026-07-02 09:41:21 : WARN  : dbvisualizer : could not find DbVisualizer.app
2026-07-02 09:41:21 : REQ   : dbvisualizer : Installed DbVisualizer, version 26.2.0
2026-07-02 09:41:21 : INFO  : dbvisualizer : notifying
2026-07-02 09:41:22 : DEBUG : dbvisualizer : Unmounting /Volumes/DbVisualizer
2026-07-02 09:41:22 : DEBUG : dbvisualizer : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-07-02 09:41:22 : DEBUG : dbvisualizer : DEBUG mode 1, not reopening anything
2026-07-02 09:41:22 : REQ   : dbvisualizer : All done!
2026-07-02 09:41:22 : REQ   : dbvisualizer : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
