### PR TITLE
Fix logitechoptionsplus fallback for new macOS labels

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -6,13 +6,16 @@ logitechoptionsplus)
     type="zip"
     osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print$1}')
     logitechOptionsPlusJSON="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0")"
-    if ! printf "%s\n" "$logitechOptionsPlusJSON" | grep -q "https://.*logioptionsplus.*zip"; then
+    logitechOptionsPlusArticle="$(printf "%s\n" "$logitechOptionsPlusJSON" | sed $'s/},{"id"/}\\\n{"id"/g' | grep '"title":"Logi Options+"' | head -1)"
+    if [[ -z "$logitechOptionsPlusArticle" ]]; then
         # Logitech sometimes publishes app updates before adding labels for new macOS releases.
         logitechOptionsPlusJSON="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload")"
+        logitechOptionsPlusArticle="$(printf "%s\n" "$logitechOptionsPlusJSON" | sed $'s/},{"id"/}\\\n{"id"/g' | grep '"title":"Logi Options+"' | head -1)"
     fi
-    downloadURL="$(printf "%s\n" "$logitechOptionsPlusJSON" | tr "," "\n"  | grep  -o "https://.*logioptionsplus.*zip" | head -1)"
-    appNewVersion=$(printf "%s\n" "$logitechOptionsPlusJSON" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    downloadURL="$(printf "%s\n" "$logitechOptionsPlusArticle" | sed 's#\\/#/#g' | grep -o 'https://[^"]*logioptionsplus[^"]*\.zip' | head -1)"
+    appNewVersion=$(printf "%s\n" "$logitechOptionsPlusArticle" | sed 's/\\n/ /g;s/<[^>]*>//g' | grep -o 'Software Version: *[0-9][0-9.]*' | head -1 | grep -o '[0-9][0-9.]*')
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
+    versionKey="CFBundleVersion"
     expectedTeamID="QED4VVPZWA"
     ;;

--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -5,8 +5,13 @@ logitechoptionsplus)
     installerTool="logioptionsplus_installer.app"
     type="zip"
     osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print$1}')
-    downloadURL="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n"  | grep  -o "https://.*logioptionsplus.*zip" | head -1)"
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    logitechOptionsPlusJSON="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0")"
+    if ! printf "%s\n" "$logitechOptionsPlusJSON" | grep -q "https://.*logioptionsplus.*zip"; then
+        # Logitech sometimes publishes app updates before adding labels for new macOS releases.
+        logitechOptionsPlusJSON="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload")"
+    fi
+    downloadURL="$(printf "%s\n" "$logitechOptionsPlusJSON" | tr "," "\n"  | grep  -o "https://.*logioptionsplus.*zip" | head -1)"
+    appNewVersion=$(printf "%s\n" "$logitechOptionsPlusJSON" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes. I searched open PRs for `logitechoptionsplus`, `Logi Options+`, `mac-macos-x-27.0`, and related `downloadURL` terms and did not find an open duplicate.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes. This modifies only `fragments/labels/logitechoptionsplus.sh`.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes.

**Additional context**<br>
On macOS 27, Logitech’s OS-specific Zendesk API query for `webos=mac-macos-x-27.0` currently returns no Logi Options+ download article, leaving `downloadURL` empty. This change caches the OS-specific API response and falls back to Logitech’s general product-download feed only when that OS-specific response has no Logi Options+ ZIP. This preserves the existing older-OS behavior while handling newer macOS releases before Logitech adds a new `webos` label.

**Installomator log**<br>
`utils/assemble.sh logitechoptionsplus DEBUG=1`

```
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=1
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : Total items in argumentsArray: 1
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : argumentsArray: DEBUG=1
2026-07-04 15:46:40 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.10beta, date 2026-07-04
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : ################## Version: 10.10beta
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : ################## Date: 2026-07-04
2026-07-04 15:46:40 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2026-07-04 15:46:40 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled.
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : Reading arguments again: DEBUG=1
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : argument: DEBUG=1
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : name=Logi Options+
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : appName=logioptionsplus.app
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : type=zip
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : archiveName=logioptionsplus_installer.zip
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : curlOptions=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : appNewVersion=2.4.903778
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : appCustomVersion function: Not defined
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : versionKey=CFBundleShortVersionString
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : packageID=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : pkgName=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : choiceChangesXML=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : expectedTeamID=QED4VVPZWA
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : blockingProcesses=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : installerTool=logioptionsplus_installer.app
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : CLIInstaller=logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : CLIArguments=--quiet
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : updateTool=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : updateToolArguments=
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : updateToolRunAsCurrentUser=
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : NOTIFY=success
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : LOGGING=DEBUG
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : Label type: zip
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : archiveName: logioptionsplus_installer.zip
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : Changing directory to /private/tmp/Installomator/build
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : App(s) found: /Applications/logioptionsplus.app
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : found app at /Applications/logioptionsplus.app, version 2.4.903778, on versionKey CFBundleShortVersionString
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : appversion: 2.4.903778
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 2.4.903778
2026-07-04 15:46:41 : WARN  : logitechoptionsplus : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-04 15:46:41 : REQ   : logitechoptionsplus : Downloading https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip to logioptionsplus_installer.zip
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : No Dialog connection, just download
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : Downloaded logioptionsplus_installer.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=store – SHA is 87bde0216a7347136159a5b0c46454aca715ba6f – Size is 19912 kB
2026-07-04 15:46:41 : DEBUG : logitechoptionsplus : DEBUG mode 1, not checking for blocking processes
2026-07-04 15:46:41 : REQ   : logitechoptionsplus : Installing Logi Options+
2026-07-04 15:46:41 : REQ   : logitechoptionsplus : installerTool used: logioptionsplus_installer.app
2026-07-04 15:46:41 : INFO  : logitechoptionsplus : Unzipping logioptionsplus_installer.zip
2026-07-04 15:46:42 : INFO  : logitechoptionsplus : Verifying: /private/tmp/Installomator/build/logioptionsplus_installer.app
2026-07-04 15:46:42 : DEBUG : logitechoptionsplus : App size:  47M	/private/tmp/Installomator/build/logioptionsplus_installer.app
2026-07-04 15:46:42 : DEBUG : logitechoptionsplus : Debugging enabled, App Verification output was:
/private/tmp/Installomator/build/logioptionsplus_installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2026-07-04 15:46:42 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-07-04 15:46:42 : INFO  : logitechoptionsplus : Downloaded version of Logi Options+ is  on versionKey CFBundleShortVersionString (replacing version 2.4.903778).
2026-07-04 15:46:42 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 14.0
2026-07-04 15:46:42 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-04 15:46:42 : INFO  : logitechoptionsplus : Finishing...
2026-07-04 15:46:45 : INFO  : logitechoptionsplus : name: Logi Options+, appName: logioptionsplus_installer.app
2026-07-04 15:46:45 : WARN  : logitechoptionsplus : No previous app found
2026-07-04 15:46:45 : WARN  : logitechoptionsplus : could not find logioptionsplus_installer.app
2026-07-04 15:46:45 : REQ   : logitechoptionsplus : Installed Logi Options+
2026-07-04 15:46:45 : INFO  : logitechoptionsplus : notifying
2026-07-04 15:46:45 : DEBUG : logitechoptionsplus : DEBUG mode 1, not reopening anything
2026-07-04 15:46:45 : REQ   : logitechoptionsplus : All done!
2026-07-04 15:46:45 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0 

```