### PR TITLE
fix: bruno.sh

### DIFF
--- a/fragments/labels/bruno.sh
+++ b/fragments/labels/bruno.sh
@@ -1,5 +1,4 @@
 bruno)
-    # https://github.com/usebruno/bruno; https://www.usebruno.com/
     name="Bruno"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then

--- a/fragments/labels/bruno.sh
+++ b/fragments/labels/bruno.sh
@@ -9,5 +9,5 @@ bruno)
     fi
     downloadURL="$(downloadURLFromGit usebruno bruno)"
     appNewVersion="$(versionFromGit usebruno bruno)"
-    expectedTeamID="W7LPPWA48L"
+    expectedTeamID="P3WTZH48ZB"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** 

Fixes #3068 , change of signing cert ([confirmed by repo maintainer](https://github.com/usebruno/bruno/issues/8481#issuecomment-4881351832))

**Installomator log** 

```
./utils/assemble.sh bruno
2026-07-06 17:34:12 : INFO  : bruno : Total items in argumentsArray: 0
2026-07-06 17:34:12 : INFO  : bruno : argumentsArray: 
2026-07-06 17:34:12 : REQ   : bruno : ################## Start Installomator v. 10.10beta, date 2026-07-06
2026-07-06 17:34:12 : INFO  : bruno : ################## Version: 10.10beta
2026-07-06 17:34:12 : INFO  : bruno : ################## Date: 2026-07-06
2026-07-06 17:34:12 : INFO  : bruno : ################## bruno
2026-07-06 17:34:12 : DEBUG : bruno : DEBUG mode 1 enabled.
2026-07-06 17:34:13 : INFO  : bruno : Reading arguments again: 
2026-07-06 17:34:13 : DEBUG : bruno : name=Bruno
2026-07-06 17:34:13 : DEBUG : bruno : appName=
2026-07-06 17:34:13 : DEBUG : bruno : type=dmg
2026-07-06 17:34:13 : DEBUG : bruno : archiveName=bruno_[0-9.]*_arm64_mac.dmg
2026-07-06 17:34:13 : DEBUG : bruno : downloadURL=https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_arm64_mac.dmg
2026-07-06 17:34:13 : DEBUG : bruno : curlOptions=
2026-07-06 17:34:13 : DEBUG : bruno : appNewVersion=3.5.1
2026-07-06 17:34:13 : DEBUG : bruno : appCustomVersion function: Not defined
2026-07-06 17:34:13 : DEBUG : bruno : versionKey=CFBundleShortVersionString
2026-07-06 17:34:13 : DEBUG : bruno : packageID=
2026-07-06 17:34:13 : DEBUG : bruno : pkgName=
2026-07-06 17:34:13 : DEBUG : bruno : choiceChangesXML=
2026-07-06 17:34:14 : DEBUG : bruno : expectedTeamID=P3WTZH48ZB
2026-07-06 17:34:14 : DEBUG : bruno : blockingProcesses=
2026-07-06 17:34:14 : DEBUG : bruno : installerTool=
2026-07-06 17:34:14 : DEBUG : bruno : CLIInstaller=
2026-07-06 17:34:14 : DEBUG : bruno : CLIArguments=
2026-07-06 17:34:14 : DEBUG : bruno : updateTool=
2026-07-06 17:34:14 : DEBUG : bruno : updateToolArguments=
2026-07-06 17:34:14 : DEBUG : bruno : updateToolRunAsCurrentUser=
2026-07-06 17:34:14 : INFO  : bruno : BLOCKING_PROCESS_ACTION=tell_user
2026-07-06 17:34:14 : INFO  : bruno : NOTIFY=success
2026-07-06 17:34:14 : INFO  : bruno : LOGGING=DEBUG
2026-07-06 17:34:14 : INFO  : bruno : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-06 17:34:14 : INFO  : bruno : Label type: dmg
2026-07-06 17:34:14 : INFO  : bruno : archiveName: bruno_[0-9.]*_arm64_mac.dmg
2026-07-06 17:34:14 : INFO  : bruno : no blocking processes defined, using Bruno as default
2026-07-06 17:34:14 : DEBUG : bruno : Changing directory to /Users/phildye/Projects/Installomator/build
2026-07-06 17:34:14 : INFO  : bruno : App(s) found: /Applications/Bruno.app
2026-07-06 17:34:14 : INFO  : bruno : found app at /Applications/Bruno.app, version 3.5.1, on versionKey CFBundleShortVersionString
2026-07-06 17:34:14 : INFO  : bruno : appversion: 3.5.1
2026-07-06 17:34:14 : INFO  : bruno : Latest version of Bruno is 3.5.1
2026-07-06 17:34:14 : WARN  : bruno : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-06 17:34:14 : REQ   : bruno : Downloading https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_arm64_mac.dmg to bruno_[0-9.]*_arm64_mac.dmg
2026-07-06 17:34:14 : DEBUG : bruno : No Dialog connection, just download
2026-07-06 17:34:40 : INFO  : bruno : Downloaded bruno_[0-9.]*_arm64_mac.dmg – Type is  zlib compressed data – SHA is e3b7b4243caa1dfbe962b0354d701c18b276b690 – Size is 164684 kB
2026-07-06 17:34:40 : DEBUG : bruno : DEBUG mode 1, not checking for blocking processes
2026-07-06 17:34:40 : REQ   : bruno : Installing Bruno
2026-07-06 17:34:40 : INFO  : bruno : Mounting /Users/phildye/Projects/Installomator/build/bruno_[0-9.]*_arm64_mac.dmg
2026-07-06 17:34:44 : DEBUG : bruno : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $22C0CB57
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $21EC005A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $99A571C2
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $B6FB7EA2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $99A571C2
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $3F7769C8
verified CRC32 $AF67B275
/dev/disk4              GUID_partition_scheme
/dev/disk4s1            Apple_APFS
/dev/disk5              EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1            41504653-0000-11AA-AA11-0030654 /Volumes/Bruno 3.5.1-arm64

2026-07-06 17:34:44 : INFO  : bruno : Mounted: /Volumes/Bruno 3.5.1-arm64
2026-07-06 17:34:44 : INFO  : bruno : Verifying: /Volumes/Bruno 3.5.1-arm64/Bruno.app
2026-07-06 17:34:44 : DEBUG : bruno : App size: 450M    /Volumes/Bruno 3.5.1-arm64/Bruno.app
2026-07-06 17:34:46 : DEBUG : bruno : Debugging enabled, App Verification output was:
/Volumes/Bruno 3.5.1-arm64/Bruno.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bruno Software, Inc. (P3WTZH48ZB)

2026-07-06 17:34:46 : INFO  : bruno : Team ID matching: P3WTZH48ZB (expected: P3WTZH48ZB )
2026-07-06 17:34:46 : INFO  : bruno : Downloaded version of Bruno is 3.5.1 on versionKey CFBundleShortVersionString, same as installed.
2026-07-06 17:34:46 : DEBUG : bruno : Unmounting /Volumes/Bruno 3.5.1-arm64
2026-07-06 17:34:46 : DEBUG : bruno : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-07-06 17:34:46 : DEBUG : bruno : DEBUG mode 1, not reopening anything
2026-07-06 17:34:46 : REG   : bruno : No new version to install
2026-07-06 17:34:46 : REQ   : bruno : ################## End Installomator, exit code 0 

```

