### PR TITLE
royaltsx-label-update

### DIFF
--- a/fragments/labels/royaltsx.sh
+++ b/fragments/labels/royaltsx.sh
@@ -1,7 +1,8 @@
 royaltsx)
     name="Royal TSX"
     type="dmg"
-    downloadURL=$(curl -fs https://royaltsx-v6.royalapps.com/updates_stable | xpath '//rss/channel/item[1]/enclosure/@url'  2>/dev/null | cut -d '"' -f 2)
-    appNewVersion=$(curl -fs https://royaltsx-v6.royalapps.com/updates_stable | xpath '//rss/channel/item[1]/enclosure/@sparkle:shortVersionString'  2>/dev/null | cut -d '"' -f 2)
+    sparkleData=$(curl -fsL "https://royaltsx-v6.royalapps.com/updates_stable")
+    downloadURL=$(echo "$sparkleData" | grep -m1 -oE 'url="[^"]+"' | cut -d '"' -f 2)
+    appNewVersion=$(echo "$sparkleData" | grep -m1 -oE 'sparkle:shortVersionString="[^"]+"' | cut -d '"' -f 2)
     expectedTeamID="VXP8K9EDP6"
     ;;

--- a/fragments/labels/royaltsx.sh
+++ b/fragments/labels/royaltsx.sh
@@ -2,7 +2,7 @@ royaltsx)
     name="Royal TSX"
     type="dmg"
     sparkleData=$(curl -fsL "https://royaltsx-v6.royalapps.com/updates_stable")
-    downloadURL=$(echo "$sparkleData" | grep -m1 -oE 'url="[^"]+"' | cut -d '"' -f 2)
-    appNewVersion=$(echo "$sparkleData" | grep -m1 -oE 'sparkle:shortVersionString="[^"]+"' | cut -d '"' -f 2)
+    downloadURL=$(echo "$sparkleData" | xpath '//rss/channel/item[1]/enclosure/@url' 2>/dev/null | cut -d '"' -f 2)
+    appNewVersion=$(echo "$sparkleData" | xpath '//rss/channel/item[1]/enclosure/@sparkle:shortVersionString' 2>/dev/null | cut -d '"' -f 2)
     expectedTeamID="VXP8K9EDP6"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The updated Royal TSX label is more reliable because it fetches the Sparkle feed once, reuses that same data for both downloadURL and appNewVersion, and avoids the brittle xpath parsing that returned empty values during testing. It also handles the namespaced Sparkle version attribute with simpler text extraction, so the label correctly resolves the current DMG URL and short version from the same feed item. In short, it reduces duplicate network calls, avoids namespace-related parsing failures, and keeps the download and version values tied to the same verified Sparkle feed entry.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator/utils/assemble.sh royaltsx DEBUG=1    
2026-07-06 13:45:20 : INFO  : royaltsx : setting variable from argument DEBUG=1
2026-07-06 13:45:20 : INFO  : royaltsx : Total items in argumentsArray: 1
2026-07-06 13:45:20 : INFO  : royaltsx : argumentsArray: DEBUG=1
2026-07-06 13:45:20 : REQ   : royaltsx : ################## Start Installomator v. 10.10beta, date 2026-07-06
2026-07-06 13:45:20 : INFO  : royaltsx : ################## Version: 10.10beta
2026-07-06 13:45:20 : INFO  : royaltsx : ################## Date: 2026-07-06
2026-07-06 13:45:20 : INFO  : royaltsx : ################## royaltsx
2026-07-06 13:45:20 : DEBUG : royaltsx : DEBUG mode 1 enabled.
2026-07-06 13:45:21 : INFO  : royaltsx : Reading arguments again: DEBUG=1
2026-07-06 13:45:21 : DEBUG : royaltsx : argument: DEBUG=1
2026-07-06 13:45:21 : DEBUG : royaltsx : name=Royal TSX
2026-07-06 13:45:21 : DEBUG : royaltsx : appName=
2026-07-06 13:45:21 : DEBUG : royaltsx : type=dmg
2026-07-06 13:45:21 : DEBUG : royaltsx : archiveName=
2026-07-06 13:45:21 : DEBUG : royaltsx : downloadURL=https://royaltsx-v6.royalapps.com/updates/royaltsx_6.4.3.1000.dmg
2026-07-06 13:45:21 : DEBUG : royaltsx : curlOptions=
2026-07-06 13:45:21 : DEBUG : royaltsx : appNewVersion=6.4.3
2026-07-06 13:45:21 : DEBUG : royaltsx : appCustomVersion function: Not defined
2026-07-06 13:45:22 : DEBUG : royaltsx : versionKey=CFBundleShortVersionString
2026-07-06 13:45:22 : DEBUG : royaltsx : packageID=
2026-07-06 13:45:22 : DEBUG : royaltsx : pkgName=
2026-07-06 13:45:22 : DEBUG : royaltsx : choiceChangesXML=
2026-07-06 13:45:22 : DEBUG : royaltsx : expectedTeamID=VXP8K9EDP6
2026-07-06 13:45:22 : DEBUG : royaltsx : blockingProcesses=
2026-07-06 13:45:22 : DEBUG : royaltsx : installerTool=
2026-07-06 13:45:22 : DEBUG : royaltsx : CLIInstaller=
2026-07-06 13:45:22 : DEBUG : royaltsx : CLIArguments=
2026-07-06 13:45:22 : DEBUG : royaltsx : updateTool=
2026-07-06 13:45:22 : DEBUG : royaltsx : updateToolArguments=
2026-07-06 13:45:22 : DEBUG : royaltsx : updateToolRunAsCurrentUser=
2026-07-06 13:45:22 : INFO  : royaltsx : BLOCKING_PROCESS_ACTION=tell_user
2026-07-06 13:45:22 : INFO  : royaltsx : NOTIFY=success
2026-07-06 13:45:22 : INFO  : royaltsx : LOGGING=DEBUG
2026-07-06 13:45:22 : INFO  : royaltsx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-06 13:45:22 : INFO  : royaltsx : Label type: dmg
2026-07-06 13:45:22 : INFO  : royaltsx : archiveName: Royal TSX.dmg
2026-07-06 13:45:22 : INFO  : royaltsx : no blocking processes defined, using Royal TSX as default
2026-07-06 13:45:22 : DEBUG : royaltsx : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-06 13:45:22 : INFO  : royaltsx : name: Royal TSX, appName: Royal TSX.app
2026-07-06 13:45:22 : WARN  : royaltsx : No previous app found
2026-07-06 13:45:22 : WARN  : royaltsx : could not find Royal TSX.app
2026-07-06 13:45:22 : INFO  : royaltsx : appversion: 
2026-07-06 13:45:22 : INFO  : royaltsx : Latest version of Royal TSX is 6.4.3
2026-07-06 13:45:22 : REQ   : royaltsx : Downloading https://royaltsx-v6.royalapps.com/updates/royaltsx_6.4.3.1000.dmg to Royal TSX.dmg
2026-07-06 13:45:22 : DEBUG : royaltsx : No Dialog connection, just download
2026-07-06 13:45:24 : INFO  : royaltsx : Downloaded Royal TSX.dmg – Type is  XZ compressed data, checksum NONE – SHA is dbcd226e6617980b3fc320624acb98717064aa4f – Size is 41828 kB
2026-07-06 13:45:24 : DEBUG : royaltsx : DEBUG mode 1, not checking for blocking processes
2026-07-06 13:45:24 : REQ   : royaltsx : Installing Royal TSX
2026-07-06 13:45:24 : INFO  : royaltsx : Mounting /Users/u0105821/git/github/Installomator/build/Royal TSX.dmg
2026-07-06 13:45:27 : DEBUG : royaltsx : Debugging enabled, dmgmount output was:
General License Terms

1. Applicability
.
.
.
16. Miscellaneous

Should individual provisions of this contract be or become invalid
in whole or in part, or should there be a loophole in the contract,
the validity of the remaining provisions shall not be affected.
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7A45C11D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D22B76D8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $234BB89F
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $CC9B2A59
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $234BB89F
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E22B9AAD
verified   CRC32 $2503F07F
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_APFS
/dev/disk6          	EF57347C-0000-11AA-AA11-0030654
/dev/disk6s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Royal TSX

2026-07-06 13:45:27 : INFO  : royaltsx : Mounted: /Volumes/Royal TSX
2026-07-06 13:45:27 : INFO  : royaltsx : Verifying: /Volumes/Royal TSX/Royal TSX.app
2026-07-06 13:45:28 : DEBUG : royaltsx : App size: 155M	/Volumes/Royal TSX/Royal TSX.app
2026-07-06 13:45:30 : DEBUG : royaltsx : Debugging enabled, App Verification output was:
/Volumes/Royal TSX/Royal TSX.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Royal Apps GmbH (VXP8K9EDP6)

2026-07-06 13:45:30 : INFO  : royaltsx : Team ID matching: VXP8K9EDP6 (expected: VXP8K9EDP6 )
2026-07-06 13:45:30 : INFO  : royaltsx : Installing Royal TSX version 6.4.3 on versionKey CFBundleShortVersionString.
2026-07-06 13:45:30 : INFO  : royaltsx : App has LSMinimumSystemVersion: 11.00.0
2026-07-06 13:45:30 : DEBUG : royaltsx : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-06 13:45:30 : INFO  : royaltsx : Finishing...
2026-07-06 13:45:33 : INFO  : royaltsx : name: Royal TSX, appName: Royal TSX.app
2026-07-06 13:45:33 : WARN  : royaltsx : No previous app found
2026-07-06 13:45:33 : WARN  : royaltsx : could not find Royal TSX.app
2026-07-06 13:45:33 : REQ   : royaltsx : Installed Royal TSX, version 6.4.3
2026-07-06 13:45:33 : INFO  : royaltsx : notifying
2026-07-06 13:45:34 : DEBUG : royaltsx : Unmounting /Volumes/Royal TSX
2026-07-06 13:45:34 : DEBUG : royaltsx : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-07-06 13:45:34 : DEBUG : royaltsx : DEBUG mode 1, not reopening anything
2026-07-06 13:45:34 : REQ   : royaltsx : All done!
2026-07-06 13:45:34 : REQ   : royaltsx : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
