### PR TITLE
New label: Slido

### DIFF
--- a/fragments/labels/slido.sh
+++ b/fragments/labels/slido.sh
@@ -1,0 +1,8 @@
+slido)
+    name="Slido"
+    type="dmg"
+    downloadURL=$(curl -fsIL "https://www.slido.com/api/download?application=powerpoint-mac" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1)
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*_r([0-9]+)\.dmg$|\1|')
+    versionKey="CFBundleVersion"
+    expectedTeamID="44X73QA89R"
+    ;;


### PR DESCRIPTION
Have you confirmed this pull request is not a duplicate?
Yes — there is no slido label on Installomator/Installomator:main (neither fragments/labels/slido.sh nor a slido) case in Installomator.sh).

Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?
Yes — it adds a single new file, fragments/labels/slido.sh. Installomator.sh is untouched.

Did you use our editorconfig file?
Yes — 4-space indentation, spaces only (no tabs), trailing whitespace trimmed, final newline present.

Additional context
Slido for Mac (the PowerPoint add-in companion app), vendor sli.do s.r.o. The app doesn't expose a stable remote version string, so the label sets no appNewVersion — Installomator downloads the dmg and compares its version against the installed app. downloadURL is Slido's official API endpoint (https://www.slido.com/api/download?application=powerpoint-mac), which 302-redirects to download.slido.com/.../SlidoForMac_rXXXX.dmg. Notarized Developer ID, Team ID 44X73QA89R.

Fixes: N/A (new label, no associated issue).

Installomator log (DEBUG=1 LOGGING=INFO):

2026-07-07 13:03:51 : REQ   : slido : ################## Start Installomator v. 10.9, date 2026-07-03
2026-07-07 13:03:52 : INFO  : slido : ################## slido
2026-07-07 13:03:52 : INFO  : slido : Label type: dmg
2026-07-07 13:03:52 : INFO  : slido : archiveName: Slido.dmg
2026-07-07 13:03:52 : INFO  : slido : no blocking processes defined, using Slido as default
2026-07-07 13:03:52 : INFO  : slido : name: Slido, appName: Slido.app
2026-07-07 13:03:52 : WARN  : slido : No previous app found
2026-07-07 13:03:52 : WARN  : slido : could not find Slido.app
2026-07-07 13:03:52 : INFO  : slido : appversion:
2026-07-07 13:03:52 : INFO  : slido : Latest version not specified.
2026-07-07 13:03:52 : REQ   : slido : Downloading https://www.slido.com/api/download?application=powerpoint-mac to Slido.dmg
2026-07-07 13:03:54 : INFO  : slido : Downloaded Slido.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 67be0cbfb611eb5c087951f731bba907e90e452f – Size is 10872 kB
2026-07-07 13:03:54 : REQ   : slido : Installing Slido
2026-07-07 13:03:54 : INFO  : slido : Mounting Slido.dmg
2026-07-07 13:03:57 : INFO  : slido : Mounted: /Volumes/Slido
2026-07-07 13:03:57 : INFO  : slido : Verifying: /Volumes/Slido/Slido.app
2026-07-07 13:03:58 : INFO  : slido : Team ID matching: 44X73QA89R (expected: 44X73QA89R )
2026-07-07 13:03:58 : INFO  : slido : Installing Slido version 1.12.0 on versionKey CFBundleShortVersionString.
2026-07-07 13:03:58 : INFO  : slido : App has LSMinimumSystemVersion: 12.4
2026-07-07 13:03:58 : INFO  : slido : Finishing...
2026-07-07 13:04:01 : REQ   : slido : Installed Slido, version 1.12.0
2026-07-07 13:04:01 : INFO  : slido : notifying
2026-07-07 13:04:02 : REQ   : slido : All done!
2026-07-07 13:04:02 : REQ   : slido : ################## End Installomator, exit code 0