### PR TITLE
Fix teamviewer appNewVersion

### DIFF
--- a/fragments/labels/teamviewer.sh
+++ b/fragments/labels/teamviewer.sh
@@ -5,6 +5,6 @@ teamviewer)
     versionKey="CFBundleShortVersionString"
     pkgName="Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
     downloadURL="https://download.teamviewer.com/download/TeamViewer.dmg"
-    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/macos/" | grep 'data-json' | grep 'full' | awk -F '"' '{ print $4 }' | sed 's/&quot;/"/g' | plutil -extract "data.0.versionNumber" raw -o - -)
+    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/macos/" | grep 'data-json' | grep 'full' | grep -oE "versionNumber&quot;:&quot;[0-9\.]*" | grep -oE "[0-9\.]*")
     expectedTeamID="H7UGFBUGV6"
     ;;

--- a/fragments/labels/teamviewer.sh
+++ b/fragments/labels/teamviewer.sh
@@ -3,7 +3,8 @@ teamviewer)
     type="pkgInDmg"
     versionKey="CFBundleShortVersionString"
     pkgName="Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-    downloadURL="https://download.teamviewer.com/download/TeamViewer.dmg"
-    appNewVersion=$(curl -fs "https://www.teamviewer.com/en/download/macos/" | grep 'data-json' | grep 'full' | grep -oE "versionNumber&quot;:&quot;[0-9\.]*" | grep -oE "[0-9\.]*")
+    teamViewerDownloadData=$(curl -fsL "https://www.teamviewer.com/en/download/macos/" | tr "<" "\n<" | grep "cmp-smartdownloadbutton__wrapper" | grep "TeamViewer full client" | sed -E 's/.*data-json="([^"]*)".*/\1/;s/&quot;/"/g;s/&amp;/\&/g')
+    downloadURL=$(getJSONValue "$teamViewerDownloadData" "data[0].downloadLink")
+    appNewVersion=$(getJSONValue "$teamViewerDownloadData" "data[0].versionNumber")
     expectedTeamID="H7UGFBUGV6"
     ;;

--- a/fragments/labels/teamviewer.sh
+++ b/fragments/labels/teamviewer.sh
@@ -1,7 +1,6 @@
 teamviewer)
     name="TeamViewer"
     type="pkgInDmg"
-    # packageID="com.teamviewer.teamviewer"
     versionKey="CFBundleShortVersionString"
     pkgName="Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
     downloadURL="https://download.teamviewer.com/download/TeamViewer.dmg"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context**
appNewVersion for the teamviewer label was broken again.

**Installomator log**
```
sudo ./Installomator.sh teamviewer DEBUG=0
2026-07-10 09:15:48 : INFO  : teamviewer : setting variable from argument DEBUG=0
2026-07-10 09:15:48 : INFO  : teamviewer : Total items in argumentsArray: 1
2026-07-10 09:15:48 : INFO  : teamviewer : argumentsArray: DEBUG=0
2026-07-10 09:15:48 : REQ   : teamviewer : ################## Start Installomator v. 10.10beta, date 2026-07-10
2026-07-10 09:15:48 : INFO  : teamviewer : ################## Version: 10.10beta
2026-07-10 09:15:48 : INFO  : teamviewer : ################## Date: 2026-07-10
2026-07-10 09:15:48 : INFO  : teamviewer : ################## teamviewer
2026-07-10 09:15:49 : INFO  : teamviewer : Reading arguments again: DEBUG=0
2026-07-10 09:15:49 : INFO  : teamviewer : BLOCKING_PROCESS_ACTION=tell_user
2026-07-10 09:15:49 : INFO  : teamviewer : NOTIFY=success
2026-07-10 09:15:49 : INFO  : teamviewer : LOGGING=INFO
2026-07-10 09:15:49 : INFO  : teamviewer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-10 09:15:49 : INFO  : teamviewer : Label type: pkgInDmg
2026-07-10 09:15:49 : INFO  : teamviewer : archiveName: TeamViewer.dmg
2026-07-10 09:15:49 : INFO  : teamviewer : no blocking processes defined, using TeamViewer as default
2026-07-10 09:15:49 : INFO  : teamviewer : name: TeamViewer, appName: TeamViewer.app
2026-07-10 09:15:49 : WARN  : teamviewer : No previous app found
2026-07-10 09:15:49 : WARN  : teamviewer : could not find TeamViewer.app
2026-07-10 09:15:49 : INFO  : teamviewer : appversion: 
2026-07-10 09:15:49 : INFO  : teamviewer : Latest version of TeamViewer is 15.79.4
2026-07-10 09:15:50 : REQ   : teamviewer : Downloading https://download.teamviewer.com/download/TeamViewer.dmg to TeamViewer.dmg
2026-07-10 09:15:54 : INFO  : teamviewer : Downloaded TeamViewer.dmg – Type is  zlib compressed data – SHA is 862af70e20ddfab758caf6b1bf600c3e05ef54e6 – Size is 131140 kB
2026-07-10 09:15:54 : REQ   : teamviewer : no more blocking processes, continue with update
2026-07-10 09:15:54 : REQ   : teamviewer : Installing TeamViewer
2026-07-10 09:15:54 : INFO  : teamviewer : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.5LrHM6gkpS/TeamViewer.dmg
2026-07-10 09:15:56 : INFO  : teamviewer : Mounted: /Volumes/TeamViewer
2026-07-10 09:15:56 : INFO  : teamviewer : found pkg: /Volumes/TeamViewer/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg
2026-07-10 09:15:56 : INFO  : teamviewer : Verifying: /Volumes/TeamViewer/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg
2026-07-10 09:15:57 : INFO  : teamviewer : Team ID: H7UGFBUGV6 (expected: H7UGFBUGV6 )
2026-07-10 09:15:57 : INFO  : teamviewer : Installing /Volumes/TeamViewer/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg to /
2026-07-10 09:16:09 : INFO  : teamviewer : Finishing...
2026-07-10 09:16:12 : INFO  : teamviewer : App(s) found: /Applications/TeamViewer.app
2026-07-10 09:16:12 : INFO  : teamviewer : found app at /Applications/TeamViewer.app, version 15.79.4, on versionKey CFBundleShortVersionString
2026-07-10 09:16:12 : REQ   : teamviewer : Installed TeamViewer, version 15.79.4
2026-07-10 09:16:12 : INFO  : teamviewer : notifying
2026-07-10 09:16:13 : INFO  : teamviewer : Installomator did not close any apps, so no need to reopen any apps.
2026-07-10 09:16:13 : REQ   : teamviewer : All done!
2026-07-10 09:16:13 : REQ   : teamviewer : ################## End Installomator, exit code 0
```