### PR TITLE
New dmg URLs for dialpad

### DIFF
--- a/fragments/labels/dialpad.sh
+++ b/fragments/labels/dialpad.sh
@@ -1,11 +1,10 @@
 dialpad)
-    # credit: @ehosaka
     name="Dialpad"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://storage.googleapis.com/dialpad_native/osx/arm64/Dialpad.dmg"
+        downloadURL="https://download.dialpad.com/osx/arm64/Dialpad.dmg"
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://storage.googleapis.com/dialpad_native/osx/x64/Dialpad.dmg"
+        downloadURL="https://download.dialpad.com/osx/x64/Dialpad.dmg"
     fi
     expectedTeamID="9V29MQSZ9M"
     ;;

--- a/fragments/labels/dialpad.sh
+++ b/fragments/labels/dialpad.sh
@@ -3,8 +3,11 @@ dialpad)
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://download.dialpad.com/osx/arm64/Dialpad.dmg"
+        dialpadVersionURL="https://dialpad.com/native/minsupportedversion/darwin/arm64/?channel=stable"
     elif [[ $(arch) == "i386" ]]; then
         downloadURL="https://download.dialpad.com/osx/x64/Dialpad.dmg"
+        dialpadVersionURL="https://dialpad.com/native/minsupportedversion/darwin/x64/?channel=stable"
     fi
+    appNewVersion=$(getJSONValue "$(curl -fsL "$dialpadVersionURL")" latest_version)
     expectedTeamID="9V29MQSZ9M"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** 

Dialpad's documentation lists updated URLs for macOS dmgs. The images at the old URLs are no longer being updated. The images at the new URLs have the current version of the app.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
% utils/assemble.sh dialpad
2026-07-08 15:02:31 : INFO  : dialpad : Total items in argumentsArray: 0
2026-07-08 15:02:31 : INFO  : dialpad : argumentsArray:
2026-07-08 15:02:32 : REQ   : dialpad : ################## Start Installomator v. 10.10beta, date 2026-07-08
2026-07-08 15:02:32 : INFO  : dialpad : ################## Version: 10.10beta
2026-07-08 15:02:32 : INFO  : dialpad : ################## Date: 2026-07-08
2026-07-08 15:02:32 : INFO  : dialpad : ################## dialpad
2026-07-08 15:02:32 : DEBUG : dialpad : DEBUG mode 1 enabled.
2026-07-08 15:02:32 : INFO  : dialpad : Reading arguments again:
2026-07-08 15:02:32 : DEBUG : dialpad : name=Dialpad
2026-07-08 15:02:32 : DEBUG : dialpad : appName=
2026-07-08 15:02:32 : DEBUG : dialpad : type=dmg
2026-07-08 15:02:32 : DEBUG : dialpad : archiveName=
2026-07-08 15:02:32 : DEBUG : dialpad : downloadURL=https://download.dialpad.com/osx/arm64/Dialpad.dmg
2026-07-08 15:02:32 : DEBUG : dialpad : curlOptions=
2026-07-08 15:02:32 : DEBUG : dialpad : appNewVersion=
2026-07-08 15:02:32 : DEBUG : dialpad : appCustomVersion function: Not defined
2026-07-08 15:02:32 : DEBUG : dialpad : versionKey=CFBundleShortVersionString
2026-07-08 15:02:32 : DEBUG : dialpad : packageID=
2026-07-08 15:02:32 : DEBUG : dialpad : pkgName=
2026-07-08 15:02:32 : DEBUG : dialpad : choiceChangesXML=
2026-07-08 15:02:32 : DEBUG : dialpad : expectedTeamID=9V29MQSZ9M
2026-07-08 15:02:32 : DEBUG : dialpad : blockingProcesses=
2026-07-08 15:02:32 : DEBUG : dialpad : installerTool=
2026-07-08 15:02:32 : DEBUG : dialpad : CLIInstaller=
2026-07-08 15:02:32 : DEBUG : dialpad : CLIArguments=
2026-07-08 15:02:32 : DEBUG : dialpad : updateTool=
2026-07-08 15:02:32 : DEBUG : dialpad : updateToolArguments=
2026-07-08 15:02:32 : DEBUG : dialpad : updateToolRunAsCurrentUser=
2026-07-08 15:02:32 : INFO  : dialpad : BLOCKING_PROCESS_ACTION=tell_user
2026-07-08 15:02:32 : INFO  : dialpad : NOTIFY=success
2026-07-08 15:02:32 : INFO  : dialpad : LOGGING=DEBUG
2026-07-08 15:02:32 : INFO  : dialpad : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-08 15:02:32 : INFO  : dialpad : Label type: dmg
2026-07-08 15:02:32 : INFO  : dialpad : archiveName: Dialpad.dmg
2026-07-08 15:02:32 : INFO  : dialpad : no blocking processes defined, using Dialpad as default
2026-07-08 15:02:32 : DEBUG : dialpad : Changing directory to /Users/hessf/Git/Installomator/build
2026-07-08 15:02:32 : INFO  : dialpad : App(s) found: /Applications/Dialpad.app
2026-07-08 15:02:32 : INFO  : dialpad : found app at /Applications/Dialpad.app, version 2605.1.0, on versionKey CFBundleShortVersionString
2026-07-08 15:02:32 : INFO  : dialpad : appversion: 2605.1.0
2026-07-08 15:02:33 : INFO  : dialpad : Latest version not specified.
2026-07-08 15:02:33 : REQ   : dialpad : Downloading https://download.dialpad.com/osx/arm64/Dialpad.dmg to Dialpad.dmg
2026-07-08 15:02:33 : DEBUG : dialpad : No Dialog connection, just download
2026-07-08 15:03:01 : INFO  : dialpad : Downloaded Dialpad.dmg – Type is  zlib compressed data – SHA is 627a3c9f46a9e4ddf9dcfb16a04a2c74293d5e25 – Size is 147724 kB
2026-07-08 15:03:01 : DEBUG : dialpad : DEBUG mode 1, not checking for blocking processes
2026-07-08 15:03:01 : REQ   : dialpad : Installing Dialpad
2026-07-08 15:03:01 : INFO  : dialpad : Mounting /Users/hessf/Git/Installomator/build/Dialpad.dmg
2026-07-08 15:03:04 : DEBUG : dialpad : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $385EC0A8
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D41088B8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $75FB0148
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $F243AB17
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $75FB0148
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $25A69869
verified   CRC32 $489A0F99
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Dialpad

2026-07-08 15:03:04 : INFO  : dialpad : Mounted: /Volumes/Dialpad
2026-07-08 15:03:04 : INFO  : dialpad : Verifying: /Volumes/Dialpad/Dialpad.app
2026-07-08 15:03:04 : DEBUG : dialpad : App size: 364M	/Volumes/Dialpad/Dialpad.app
2026-07-08 15:03:05 : DEBUG : dialpad : Debugging enabled, App Verification output was:
/Volumes/Dialpad/Dialpad.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Dialpad, Inc. (9V29MQSZ9M)

2026-07-08 15:03:05 : INFO  : dialpad : Team ID matching: 9V29MQSZ9M (expected: 9V29MQSZ9M )
2026-07-08 15:03:05 : INFO  : dialpad : Downloaded version of Dialpad is 2606.1.2 on versionKey CFBundleShortVersionString (replacing version 2605.1.0).
2026-07-08 15:03:05 : INFO  : dialpad : App has LSMinimumSystemVersion: 12.0
2026-07-08 15:03:05 : DEBUG : dialpad : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-08 15:03:05 : INFO  : dialpad : Finishing...
2026-07-08 15:03:08 : INFO  : dialpad : App(s) found: /Applications/Dialpad.app
2026-07-08 15:03:08 : INFO  : dialpad : found app at /Applications/Dialpad.app, version 2605.1.0, on versionKey CFBundleShortVersionString
2026-07-08 15:03:08 : REQ   : dialpad : Installed Dialpad, version 2606.1.2
2026-07-08 15:03:08 : INFO  : dialpad : notifying
2026-07-08 15:03:08 : DEBUG : dialpad : Unmounting /Volumes/Dialpad
2026-07-08 15:03:08 : DEBUG : dialpad : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-07-08 15:03:09 : DEBUG : dialpad : DEBUG mode 1, not reopening anything
2026-07-08 15:03:09 : REQ   : dialpad : All done!
2026-07-08 15:03:09 : REQ   : dialpad : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
