### PR TITLE
Fix: podman label for 6.0+ changes

### DIFF
--- a/fragments/labels/podman.sh
+++ b/fragments/labels/podman.sh
@@ -1,8 +1,14 @@
 podman)
     name="Podman"
     type="pkg"
-    archiveName="podman-installer-macos-universal.pkg"
-    downloadURL=$(downloadURLFromGit containers podman)
-    appNewVersion=$(versionFromGit containers podman)
+    packageID="com.redhat.podman"
     expectedTeamID="HYSCB8KRL2"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="podman-installer-macos-arm64.pkg"
+        downloadURL=$(downloadURLFromGit podman-container-tools podman)
+        appNewVersion=$(versionFromGit podman-container-tools podman)
+    elif [[ $(arch) == "i386" ]]; then
+        printlog "Podman 6.0+ requires Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Podman 6.0+ requires Apple Silicon (arm64) Macs." ERROR
+    fi
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context**

This PR fixes the `podman` label, which was failing to download and reporting the wrong installed version. Primary due to breaking changes with Podman 6.0 release artifacts. 

Problems:

- **Repo renamed:** upstream moved from `containers/podman` to `podman-container-tools/podman`.
- **Asset dropped:** `podman-installer-macos-universal.pkg` no longer exists, as was the `*amd64.pkg` builds. Only `*arm64.pkg` builds remain after 6.0. As a result `downloadURL` resolved to a bare `https://github.com` and verification failed with "no usable signature".
- **Wrong version source:** with `name="Podman"`, `mdfind` matched `/Applications/Podman Desktop.app`, so the installed version was read from Podman Desktop (e.g. 1.28.2) instead of the podman CLI.

Changes:

- Point `downloadURLFromGit`/`versionFromGit` at the renamed org `podman-container-tools`.
- Download the arch-specific `podman-installer-macos-arm64.pkg`.
- Detect the installed version from the pkg receipt via `packageID="com.redhat.podman"` (and not `expectedTeamID` which also matches Podman Desktop)
- Exit `95` on Intel Macs — podman 6.x no longer ships a macOS `amd64` installer (same pattern as the `codex`/`googlegemini` labels). Although there are still patches for 5.x, finding the latest download link via html scrape fallback on rate limit seems overly complicated to support / maintain.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-07-09 10:53:35 : INFO  : podman : Total items in argumentsArray: 0
2026-07-09 10:53:35 : INFO  : podman : argumentsArray: 
2026-07-09 10:53:35 : REQ   : podman : ################## Start Installomator v. 10.10beta, date 2026-07-09
2026-07-09 10:53:35 : INFO  : podman : ################## Version: 10.10beta
2026-07-09 10:53:35 : INFO  : podman : ################## Date: 2026-07-09
2026-07-09 10:53:35 : INFO  : podman : ################## podman
2026-07-09 10:53:35 : DEBUG : podman : DEBUG mode 1 enabled.
2026-07-09 10:53:37 : INFO  : podman : Reading arguments again: 
2026-07-09 10:53:37 : DEBUG : podman : name=Podman
2026-07-09 10:53:37 : DEBUG : podman : appName=
2026-07-09 10:53:37 : DEBUG : podman : type=pkg
2026-07-09 10:53:37 : DEBUG : podman : archiveName=podman-installer-macos-arm64.pkg
2026-07-09 10:53:37 : DEBUG : podman : downloadURL=https://github.com/podman-container-tools/podman/releases/download/v6.0.1/podman-installer-macos-arm64.pkg
2026-07-09 10:53:37 : DEBUG : podman : curlOptions=
2026-07-09 10:53:37 : DEBUG : podman : appNewVersion=6.0.1
2026-07-09 10:53:37 : DEBUG : podman : appCustomVersion function: Not defined
2026-07-09 10:53:37 : DEBUG : podman : versionKey=CFBundleShortVersionString
2026-07-09 10:53:37 : DEBUG : podman : packageID=com.redhat.podman
2026-07-09 10:53:37 : DEBUG : podman : pkgName=
2026-07-09 10:53:37 : DEBUG : podman : choiceChangesXML=
2026-07-09 10:53:37 : DEBUG : podman : expectedTeamID=HYSCB8KRL2
2026-07-09 10:53:37 : DEBUG : podman : blockingProcesses=
2026-07-09 10:53:37 : DEBUG : podman : installerTool=
2026-07-09 10:53:37 : DEBUG : podman : CLIInstaller=
2026-07-09 10:53:37 : DEBUG : podman : CLIArguments=
2026-07-09 10:53:37 : DEBUG : podman : updateTool=
2026-07-09 10:53:37 : DEBUG : podman : updateToolArguments=
2026-07-09 10:53:37 : DEBUG : podman : updateToolRunAsCurrentUser=
2026-07-09 10:53:37 : INFO  : podman : BLOCKING_PROCESS_ACTION=tell_user
2026-07-09 10:53:37 : INFO  : podman : NOTIFY=success
2026-07-09 10:53:37 : INFO  : podman : LOGGING=DEBUG
2026-07-09 10:53:37 : INFO  : podman : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-09 10:53:37 : INFO  : podman : Label type: pkg
2026-07-09 10:53:38 : INFO  : podman : archiveName: podman-installer-macos-arm64.pkg
2026-07-09 10:53:38 : INFO  : podman : no blocking processes defined, using Podman as default
2026-07-09 10:53:38 : DEBUG : podman : Changing directory to /Users/<user>/git/github/Installomator/Installomator/build
2026-07-09 10:53:38 : INFO  : podman : found packageID com.redhat.podman installed, version 6.0.0
2026-07-09 10:53:38 : INFO  : podman : appversion: 6.0.0
2026-07-09 10:53:38 : INFO  : podman : Latest version of Podman is 6.0.1
2026-07-09 10:53:38 : INFO  : podman : podman-installer-macos-arm64.pkg exists and DEBUG mode 1 enabled, skipping download
2026-07-09 10:53:38 : DEBUG : podman : DEBUG mode 1, not checking for blocking processes
2026-07-09 10:53:38 : REQ   : podman : Installing Podman
2026-07-09 10:53:38 : INFO  : podman : Verifying: podman-installer-macos-arm64.pkg
2026-07-09 10:53:38 : DEBUG : podman : File list: -rw-r--r--@ 1 <user>  staff    71M  9 Jul 10:47 podman-installer-macos-arm64.pkg
2026-07-09 10:53:38 : DEBUG : podman : File type: podman-installer-macos-arm64.pkg: xar archive compressed TOC: 4945, SHA-1 checksum
2026-07-09 10:53:38 : DEBUG : podman : spctlOut is podman-installer-macos-arm64.pkg: accepted
2026-07-09 10:53:38 : DEBUG : podman : source=Notarized Developer ID
2026-07-09 10:53:38 : DEBUG : podman : origin=Developer ID Installer: Red Hat, Inc. (HYSCB8KRL2)
2026-07-09 10:53:38 : INFO  : podman : Team ID: HYSCB8KRL2 (expected: HYSCB8KRL2 )
2026-07-09 10:53:38 : INFO  : podman : Checking package version.
2026-07-09 10:53:38 : INFO  : podman : Downloaded package com.redhat.podman version 
2026-07-09 10:53:38 : DEBUG : podman : DEBUG enabled, skipping installation
2026-07-09 10:53:38 : INFO  : podman : Finishing...
2026-07-09 10:53:42 : INFO  : podman : found packageID com.redhat.podman installed, version 6.0.0
2026-07-09 10:53:42 : REQ   : podman : Installed Podman
2026-07-09 10:53:42 : INFO  : podman : notifying
2026-07-09 10:53:42 : DEBUG : podman : DEBUG mode 1, not reopening anything
2026-07-09 10:53:42 : REQ   : podman : All done!
2026-07-09 10:53:42 : REQ   : podman : ################## End Installomator, exit code 0 
```
