### PR TITLE
New label: Exocharts

### DIFF
--- a/fragments/labels/exocharts.sh
+++ b/fragments/labels/exocharts.sh
@@ -1,0 +1,7 @@
+exocharts)
+    name="Exocharts"
+    type="dmg"
+    appNewVersion=$(curl -fs "https://help.exocharts.com/hc/en-us/articles/5466518923281-Exocharts-downloads" | grep -o "Exocharts_[0-9.]*_M1_ARM.dmg" | head -1 | sed -E 's/Exocharts_([0-9.]+)_M1_ARM.dmg/\1/')
+    downloadURL="https://exocharts.com/downloads/Exocharts_${appNewVersion}_M1_ARM.dmg"
+    expectedTeamID="7HSW4JKZM2"
+    ;;

--- a/fragments/labels/exocharts.sh
+++ b/fragments/labels/exocharts.sh
@@ -1,7 +1,13 @@
 exocharts)
     name="Exocharts"
     type="dmg"
-    appNewVersion=$(curl -fs "https://help.exocharts.com/hc/en-us/articles/5466518923281-Exocharts-downloads" | grep -o "Exocharts_[0-9.]*_M1_ARM.dmg" | head -1 | sed -E 's/Exocharts_([0-9.]+)_M1_ARM.dmg/\1/')
-    downloadURL="https://exocharts.com/downloads/Exocharts_${appNewVersion}_M1_ARM.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fsL "https://help.exocharts.com/api/v2/help_center/en-us/articles/5466518923281.json" | plutil -extract article.body raw -o - - | grep -o 'https://exocharts.com/downloads/Exocharts_[0-9.]*_M1_ARM\.dmg' | head -1)
+    else
+        printlog "Exocharts is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Exocharts requires Apple Silicon" ERROR
+    fi
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/Exocharts_([0-9.]+)_M1_ARM\.dmg|\1|')
+    versionKey="CFBundleVersion"
     expectedTeamID="7HSW4JKZM2"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** 
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** 
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** 
Yes

**Additional context** Add any other context about the label or fix here.
As the download link contains the version number, it is necessary to scrap the page to retrieve that version number and build a "dynamic" downloadURL

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-07-09 11:16:40 : INFO  : exocharts : setting variable from argument DEBUG=0
2026-07-09 11:16:40 : INFO  : exocharts : Total items in argumentsArray: 1
2026-07-09 11:16:40 : INFO  : exocharts : argumentsArray: DEBUG=0
2026-07-09 11:16:40 : REQ   : exocharts : ################## Start Installomator v. 10.10beta, date 2026-07-09
2026-07-09 11:16:40 : INFO  : exocharts : ################## Version: 10.10beta
2026-07-09 11:16:40 : INFO  : exocharts : ################## Date: 2026-07-09
2026-07-09 11:16:40 : INFO  : exocharts : ################## exocharts
2026-07-09 11:16:41 : INFO  : exocharts : Reading arguments again: DEBUG=0
2026-07-09 11:16:41 : INFO  : exocharts : BLOCKING_PROCESS_ACTION=tell_user
2026-07-09 11:16:41 : INFO  : exocharts : NOTIFY=success
2026-07-09 11:16:41 : INFO  : exocharts : LOGGING=INFO
2026-07-09 11:16:41 : INFO  : exocharts : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-09 11:16:41 : INFO  : exocharts : Label type: dmg
2026-07-09 11:16:41 : INFO  : exocharts : archiveName: Exocharts.dmg
2026-07-09 11:16:41 : INFO  : exocharts : no blocking processes defined, using Exocharts as default
2026-07-09 11:16:41 : INFO  : exocharts : App(s) found: /Applications/Exocharts.app
2026-07-09 11:16:42.009 defaults[20908:272656]
The domain/default pair of (/Applications/Exocharts.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-07-09 11:16:42 : INFO  : exocharts : found app at /Applications/Exocharts.app, version , on versionKey CFBundleShortVersionString
2026-07-09 11:16:42 : INFO  : exocharts : appversion:
2026-07-09 11:16:42 : INFO  : exocharts : Latest version of Exocharts is 3.7.0
2026-07-09 11:16:42 : REQ   : exocharts : Downloading https://exocharts.com/downloads/Exocharts_3.7.0_M1_ARM.dmg to Exocharts.dmg
2026-07-09 11:16:49 : INFO  : exocharts : Downloaded Exocharts.dmg – Type is  XZ compressed data, checksum NONE – SHA is b48269e219eed2ff7428ee9c2a5b197cdce0c18e – Size is 197264 kB
2026-07-09 11:16:49 : REQ   : exocharts : no more blocking processes, continue with update
2026-07-09 11:16:49 : REQ   : exocharts : Installing Exocharts
2026-07-09 11:16:49 : INFO  : exocharts : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.1fLpiBxEH2/Exocharts.dmg
2026-07-09 11:16:58 : INFO  : exocharts : Mounted: /Volumes/Exocharts_3.7.0
2026-07-09 11:16:58 : INFO  : exocharts : Verifying: /Volumes/Exocharts_3.7.0/Exocharts.app
2026-07-09 11:17:04 : INFO  : exocharts : Team ID matching: 7HSW4JKZM2 (expected: 7HSW4JKZM2 )
2026-07-09 11:17:04.421 defaults[21068:273583]
The domain/default pair of (/Volumes/Exocharts_3.7.0/Exocharts.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-07-09 11:17:04 : INFO  : exocharts : Installing Exocharts version  on versionKey CFBundleShortVersionString.
2026-07-09 11:17:04 : INFO  : exocharts : App has LSMinimumSystemVersion: 11.0
2026-07-09 11:17:04 : WARN  : exocharts : Removing existing /Applications/Exocharts.app
2026-07-09 11:17:04 : INFO  : exocharts : Copy /Volumes/Exocharts_3.7.0/Exocharts.app to /Applications
2026-07-09 11:17:06 : WARN  : exocharts : Changing owner to michael.debona
2026-07-09 11:17:07 : INFO  : exocharts : Finishing...
2026-07-09 11:17:10 : INFO  : exocharts : App(s) found: /Applications/Exocharts.app
2026-07-09 11:17:10.141 defaults[21122:274027]
The domain/default pair of (/Applications/Exocharts.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-07-09 11:17:10 : INFO  : exocharts : found app at /Applications/Exocharts.app, version , on versionKey CFBundleShortVersionString
2026-07-09 11:17:10 : REQ   : exocharts : Installed Exocharts
2026-07-09 11:17:10 : INFO  : exocharts : notifying
2026-07-09 11:17:10 : INFO  : exocharts : Installomator did not close any apps, so no need to reopen any apps.
2026-07-09 11:17:10 : REQ   : exocharts : All done!
2026-07-09 11:17:10 : REQ   : exocharts : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
