### PR TITLE
New Label: ThinLinc Client

### DIFF
--- a/fragments/labels/thinlincclient.sh
+++ b/fragments/labels/thinlincclient.sh
@@ -1,0 +1,8 @@
+thinlincclient)
+    name="ThinLinc Client"
+    type="dmg"
+    jsonFeed=$(curl -fsL "https://formulae.brew.sh/api/cask/thinlinc-client.json")
+    appNewVersion=$(getJSONValue "$jsonFeed" "version" | awk -F '_' '{ print $1 }')
+    downloadURL=$(getJSONValue "$jsonFeed" "url")
+    expectedTeamID="PHUT6TWL4H"
+    ;;

--- a/fragments/labels/thinlincclient.sh
+++ b/fragments/labels/thinlincclient.sh
@@ -1,8 +1,7 @@
 thinlincclient)
     name="ThinLinc Client"
     type="dmg"
-    jsonFeed=$(curl -fsL "https://formulae.brew.sh/api/cask/thinlinc-client.json")
-    appNewVersion=$(getJSONValue "$jsonFeed" "version" | awk -F '_' '{ print $1 }')
-    downloadURL=$(getJSONValue "$jsonFeed" "url")
+    downloadURL=$(curl -fsL "https://www.cendio.com/thinlinc/download/" | grep -Eo 'https://www\.cendio\.com/downloads/clients/tl-[0-9]+(\.[0-9]+)+_[0-9]+-client-macos\.dmg' | head -1)
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/tl-([0-9]+(\.[0-9]+)+)_[0-9]+-client-macos\.dmg$|\1|')
     expectedTeamID="PHUT6TWL4H"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")


Output:
```
./utils/assemble.sh thinlincclient DEBUG=1
2026-07-09 11:53:34 : INFO  : thinlincclient : setting variable from argument DEBUG=1
2026-07-09 11:53:34 : INFO  : thinlincclient : Total items in argumentsArray: 1
2026-07-09 11:53:34 : INFO  : thinlincclient : argumentsArray: DEBUG=1
2026-07-09 11:53:34 : REQ   : thinlincclient : ################## Start Installomator v. 10.9beta, date 2026-07-09
2026-07-09 11:53:34 : INFO  : thinlincclient : ################## Version: 10.9beta
2026-07-09 11:53:34 : INFO  : thinlincclient : ################## Date: 2026-07-09
2026-07-09 11:53:34 : INFO  : thinlincclient : ################## thinlincclient
2026-07-09 11:53:34 : DEBUG : thinlincclient : DEBUG mode 1 enabled.
2026-07-09 11:53:35 : INFO  : thinlincclient : Reading arguments again: DEBUG=1
2026-07-09 11:53:35 : DEBUG : thinlincclient : argument: DEBUG=1
2026-07-09 11:53:35 : DEBUG : thinlincclient : name=ThinLinc Client
2026-07-09 11:53:35 : DEBUG : thinlincclient : appName=
2026-07-09 11:53:35 : DEBUG : thinlincclient : type=dmg
2026-07-09 11:53:35 : DEBUG : thinlincclient : archiveName=
2026-07-09 11:53:35 : DEBUG : thinlincclient : downloadURL=https://www.cendio.com/downloads/clients/tl-4.20.0_4284-client-macos.dmg
2026-07-09 11:53:35 : DEBUG : thinlincclient : curlOptions=
2026-07-09 11:53:35 : DEBUG : thinlincclient : appNewVersion=4.20.0
2026-07-09 11:53:35 : DEBUG : thinlincclient : appCustomVersion function: Not defined
2026-07-09 11:53:35 : DEBUG : thinlincclient : versionKey=CFBundleShortVersionString
2026-07-09 11:53:35 : DEBUG : thinlincclient : packageID=
2026-07-09 11:53:35 : DEBUG : thinlincclient : pkgName=
2026-07-09 11:53:35 : DEBUG : thinlincclient : choiceChangesXML=
2026-07-09 11:53:35 : DEBUG : thinlincclient : expectedTeamID=PHUT6TWL4H
2026-07-09 11:53:35 : DEBUG : thinlincclient : blockingProcesses=
2026-07-09 11:53:35 : DEBUG : thinlincclient : installerTool=
2026-07-09 11:53:35 : DEBUG : thinlincclient : CLIInstaller=
2026-07-09 11:53:35 : DEBUG : thinlincclient : CLIArguments=
2026-07-09 11:53:35 : DEBUG : thinlincclient : updateTool=
2026-07-09 11:53:35 : DEBUG : thinlincclient : updateToolArguments=
2026-07-09 11:53:35 : DEBUG : thinlincclient : updateToolRunAsCurrentUser=
2026-07-09 11:53:35 : INFO  : thinlincclient : BLOCKING_PROCESS_ACTION=tell_user
2026-07-09 11:53:35 : INFO  : thinlincclient : NOTIFY=success
2026-07-09 11:53:35 : INFO  : thinlincclient : LOGGING=DEBUG
2026-07-09 11:53:35 : INFO  : thinlincclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-09 11:53:35 : INFO  : thinlincclient : Label type: dmg
2026-07-09 11:53:35 : INFO  : thinlincclient : archiveName: ThinLinc Client.dmg
2026-07-09 11:53:35 : INFO  : thinlincclient : no blocking processes defined, using ThinLinc Client as default
2026-07-09 11:53:35 : DEBUG : thinlincclient : Changing directory to /Library/Management/AppAutoPatch/Installomator/build
2026-07-09 11:53:35 : INFO  : thinlincclient : name: ThinLinc Client, appName: ThinLinc Client.app
2026-07-09 11:53:36 : WARN  : thinlincclient : No previous app found
2026-07-09 11:53:36 : WARN  : thinlincclient : could not find ThinLinc Client.app
2026-07-09 11:53:36 : INFO  : thinlincclient : appversion: 
2026-07-09 11:53:36 : INFO  : thinlincclient : Latest version of ThinLinc Client is 4.20.0
2026-07-09 11:53:36 : REQ   : thinlincclient : Downloading https://www.cendio.com/downloads/clients/tl-4.20.0_4284-client-macos.dmg to ThinLinc Client.dmg
2026-07-09 11:53:36 : DEBUG : thinlincclient : No Dialog connection, just download
2026-07-09 11:53:44 : INFO  : thinlincclient : Downloaded ThinLinc Client.dmg – Type is  bzip2 compressed data, block size = 900k – SHA is 6bffcdd98ff9de86dbdd3cad7437e6a4c2a0fa81 – Size is 9244 kB
2026-07-09 11:53:44 : DEBUG : thinlincclient : DEBUG mode 1, not checking for blocking processes
2026-07-09 11:53:44 : REQ   : thinlincclient : Installing ThinLinc Client
2026-07-09 11:53:44 : INFO  : thinlincclient : Mounting /Library/Management/AppAutoPatch/Installomator/build/ThinLinc Client.dmg
hdiutil: WARNING: 'hdiutil attach -nobrowse -readonly ...' is deprecated. Please use 'diskutil image attach --mountOptions nobrowse --readOnly ...' instead.
2026-07-09 11:53:46 : DEBUG : thinlincclient : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $0A85C063
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $A4059737
Checksumming Macintosh (Apple_Driver_ATAPI : 2)…
Macintosh (Apple_Driver_ATAPI : 2): verified   CRC32 $C71C0011
Checksumming Mac_OS_X (Apple_HFSX : 3)…
Mac_OS_X (Apple_HFSX : 3): verified   CRC32 $6BA64CC7
Checksumming  (Apple_Free : 4)…
(Apple_Free : 4): verified   CRC32 $00000000
verified   CRC32 $2F8E974A
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_Driver_ATAPI
/dev/disk6s3        	Apple_HFSX                     	/Volumes/ThinLinc Client

2026-07-09 11:53:46 : INFO  : thinlincclient : Mounted: /Volumes/ThinLinc Client
2026-07-09 11:53:46 : INFO  : thinlincclient : Verifying: /Volumes/ThinLinc Client/ThinLinc Client.app
2026-07-09 11:53:46 : DEBUG : thinlincclient : App size:  24M	/Volumes/ThinLinc Client/ThinLinc Client.app
2026-07-09 11:53:47 : DEBUG : thinlincclient : Debugging enabled, App Verification output was:
/Volumes/ThinLinc Client/ThinLinc Client.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Cendio AB (PHUT6TWL4H)

2026-07-09 11:53:47 : INFO  : thinlincclient : Team ID matching: PHUT6TWL4H (expected: PHUT6TWL4H )
2026-07-09 11:53:47 : INFO  : thinlincclient : Installing ThinLinc Client version 4.20.0 on versionKey CFBundleShortVersionString.
2026-07-09 11:53:47 : DEBUG : thinlincclient : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-09 11:53:47 : INFO  : thinlincclient : Finishing...
2026-07-09 11:53:50 : INFO  : thinlincclient : name: ThinLinc Client, appName: ThinLinc Client.app
2026-07-09 11:53:50 : WARN  : thinlincclient : No previous app found
2026-07-09 11:53:50 : WARN  : thinlincclient : could not find ThinLinc Client.app
2026-07-09 11:53:50 : REQ   : thinlincclient : Installed ThinLinc Client, version 4.20.0
2026-07-09 11:53:50 : INFO  : thinlincclient : notifying
2026-07-09 11:53:50 : DEBUG : thinlincclient : Unmounting /Volumes/ThinLinc Client
2026-07-09 11:53:50 : DEBUG : thinlincclient : Debugging enabled, Unmounting output was:
hdiutil: WARNING: 'hdiutil detach ...' is deprecated. Please use 'diskutil eject ...' instead.
2026-07-09 11:53:50 : DEBUG : thinlincclient : "disk6" ejected.
2026-07-09 11:53:51 : DEBUG : thinlincclient : DEBUG mode 1, not reopening anything
2026-07-09 11:53:51 : REQ   : thinlincclient : All done!
2026-07-09 11:53:51 : REQ   : thinlincclient : ################## End Installomator, exit code 0 
```

