### PR TITLE
New label: emdash

### DIFF
--- a/fragments/labels/emdash.sh
+++ b/fragments/labels/emdash.sh
@@ -1,0 +1,11 @@
+emdash)
+    name="Emdash"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://github.com/generalaction/emdash/releases/latest/download/emdash-arm64.dmg"
+    else
+        downloadURL="https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.dmg"
+    fi
+    appNewVersion=$(versionFromGit generalaction emdash)
+    expectedTeamID="2AZ6648627"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

Adds a label for Emdash (https://github.com/generalaction/emdash), a macOS
desktop app for running multiple coding agents in parallel.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
DEBUG=1 LOGGING=INFO

2026-07-09 20:47:15 : INFO  : emdash : Label type: dmg
2026-07-09 20:47:15 : INFO  : emdash : archiveName: Emdash.dmg
2026-07-09 20:47:15 : INFO  : emdash : no blocking processes defined, using Emdash as default
2026-07-09 20:47:15 : INFO  : emdash : name: Emdash, appName: Emdash.app
2026-07-09 20:47:15 : INFO  : emdash : appversion:
2026-07-09 20:47:15 : INFO  : emdash : Latest version of Emdash is 1.1.37
2026-07-09 20:47:15 : REQ   : emdash : Downloading https://github.com/generalaction/emdash/releases/latest/download/emdash-arm64.dmg to Emdash.dmg
2026-07-09 20:47:23 : INFO  : emdash : Downloaded Emdash.dmg – Type is  zlib compressed data – SHA is c7cf975b01a502d7784613abebf102b80cab5c83 – Size is 213192 kB
2026-07-09 20:47:23 : REQ   : emdash : no more blocking processes, continue with update
2026-07-09 20:47:23 : REQ   : emdash : Installing Emdash
2026-07-09 20:47:25 : INFO  : emdash : Mounted: /Volumes/Emdash 1.1.37-arm64
2026-07-09 20:47:25 : INFO  : emdash : Verifying: /Volumes/Emdash 1.1.37-arm64/Emdash.app
2026-07-09 20:47:27 : INFO  : emdash : Team ID matching: 2AZ6648627 (expected: 2AZ6648627 )
2026-07-09 20:47:27 : INFO  : emdash : Installing Emdash version 1.1.37 on versionKey CFBundleShortVersionString.
2026-07-09 20:47:27 : INFO  : emdash : App has LSMinimumSystemVersion: 12.0
2026-07-09 20:47:27 : REQ   : emdash : ################## End Installomator, exit code 0
```