### PR TITLE
yubikeymanagerqt: match installed app name (fixes #3064)

### DIFF
--- a/fragments/labels/yubikeymanagerqt.sh
+++ b/fragments/labels/yubikeymanagerqt.sh
@@ -1,7 +1,9 @@
 yubikeymanagerqt)
     name="YubiKey Manager GUI"
+    appName="YubiKey Manager.app"
     type="pkg"
-    downloadURL="https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-latest-mac.pkg"
-    appNewVersion=$(curl -fsIL "${downloadURL}" | grep -i "^location" | grep -Eo "[1-9][0-9\.]*" )
+    downloadURL=$(curl -fsL "https://developers.yubico.com/yubikey-manager-qt/Releases/" | grep -oE "yubikey-manager-qt-[0-9][^\"]*-mac\.pkg" | head -1 | sed 's|^|https://developers.yubico.com/yubikey-manager-qt/Releases/|')
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/yubikey-manager-qt-([^-]+)-mac\.pkg$|\1|')
     expectedTeamID="LQA3CS5MM7"
+    blockingProcesses=( "YubiKey Manager" )
     ;;

--- a/fragments/labels/yubikeymanagerqt.sh
+++ b/fragments/labels/yubikeymanagerqt.sh
@@ -1,9 +1,9 @@
 yubikeymanagerqt)
-    name="YubiKey Manager GUI"
-    appName="YubiKey Manager.app"
+    name="YubiKey Manager"
     type="pkg"
-    downloadURL=$(curl -fsL "https://developers.yubico.com/yubikey-manager-qt/Releases/" | grep -oE "yubikey-manager-qt-[0-9][^\"]*-mac\.pkg" | head -1 | sed 's|^|https://developers.yubico.com/yubikey-manager-qt/Releases/|')
+    releaseData=$(curl -fsL "https://developers.yubico.com/yubikey-manager-qt/Releases/atom.xml")
+    downloadURL=$(echo "$releaseData" | grep -oE 'https://developers\.yubico\.com/yubikey-manager-qt/Releases/yubikey-manager-qt-[0-9][^"]*-mac\.pkg' | head -1)
     appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/yubikey-manager-qt-([^-]+)-mac\.pkg$|\1|')
     expectedTeamID="LQA3CS5MM7"
-    blockingProcesses=( "YubiKey Manager" )
+    blockingProcesses=( "ykman-gui" )
     ;;


### PR DESCRIPTION
Fixes #3064.

The `yubikeymanagerqt` label searched for `YubiKey Manager GUI.app`, but the pkg
installs `/Applications/YubiKey Manager.app` — so Installomator never found the
installed app, and it collided with the separate `yubikeymanager` (CLI) label
(1.2.x vs 5.x false mismatches).

Changes:
- add `appName="YubiKey Manager.app"` so the correct bundle is detected
- derive `downloadURL` from the Yubico Releases listing (newest `yubikey-manager-qt-*-mac.pkg`)
- derive `appNewVersion` from that URL
- add `blockingProcesses`
- keep `expectedTeamID=LQA3CS5MM7`

Tested with DEBUG=1:
- downloadURL → yubikey-manager-qt-1.2.5-mac.pkg
- appNewVersion → 1.2.5
- Team ID: LQA3CS5MM7 (expected: LQA3CS5MM7) ✓
- payload installs /Applications/YubiKey Manager.app, CFBundleShortVersionString 1.2.5, bundle id com.yubico.ykman
- End Installomator, exit code 0

Note: the YubiKey Manager (Qt GUI) is EOL per Yubico (Yubico Authenticator is the
successor); the 5.x releases on the Yubico page are the ykman CLI, not the GUI.
This keeps `yubikeymanager` = supported CLI package and `yubikeymanagerqt` = legacy
GUI cleanly separated.

Tested locally with `DEBUG=1`:

```
: yubikeymanagerqt : ################## Start Installomator v. 10.9
: yubikeymanagerqt : name=YubiKey Manager GUI
: yubikeymanagerqt : appName=YubiKey Manager.app
: yubikeymanagerqt : type=pkg
: yubikeymanagerqt : downloadURL=https://developers.yubico.com/yubikey-manager-qt/Releases/yubikey-manager-qt-1.2.5-mac.pkg
: yubikeymanagerqt : appNewVersion=1.2.5
: yubikeymanagerqt : expectedTeamID=LQA3CS5MM7
: yubikeymanagerqt : blockingProcesses=YubiKey Manager
: yubikeymanagerqt : Latest version of YubiKey Manager GUI is 1.2.5
: yubikeymanagerqt : Downloading …/yubikey-manager-qt-1.2.5-mac.pkg to YubiKey Manager GUI.pkg
: yubikeymanagerqt : Verifying: YubiKey Manager GUI.pkg
: yubikeymanagerqt : Team ID: LQA3CS5MM7 (expected: LQA3CS5MM7 )
: yubikeymanagerqt : ################## End Installomator, exit code 0
```
(GitHub tag is 1.2.6, but the newest macOS package on the release page is 1.2.5.)