### PR TITLE
Fix codex.sh

### DIFF
--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -1,18 +1,19 @@
 codex)
     name="Codex"
-    type="dmg"
+    type="zip"
     appName="ChatGPT.app"
     targetDir="/Applications/ChatGPT.localized"
     appCustomVersion() {
         /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$targetDir/$appName/Contents/Info.plist" 2>/dev/null
     }
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+        sparkleData=$(curl -fsL "https://persistent.oaistatic.com/codex-app-prod/appcast.xml")
+        appNewVersion=$(echo "$sparkleData" | awk -F "[<>]" '/<sparkle:shortVersionString>/{print $3; exit}')
+        downloadURL=$(echo "$sparkleData" | awk -F 'url="' '/<enclosure url=/{split($2,a,"\""); print a[1]; exit}')
     else
         printlog "Codex is only compatible with Apple Silicon (arm64) Macs." ERROR
         cleanupAndExit 95 "Codex requires Apple Silicon" ERROR
     fi
-    appNewVersion="$(curl -fs "https://persistent.oaistatic.com/codex-app-prod/appcast.xml" | grep -o '<sparkle:shortVersionString>[^<]*' | head -1 | cut -d '>' -f 2)"
     expectedTeamID="2DC432GLL2"
     blockingProcesses=( "ChatGPT" )
     ;;

--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -3,9 +3,6 @@ codex)
     type="zip"
     appName="ChatGPT.app"
     targetDir="/Applications/ChatGPT.localized"
-    appCustomVersion() {
-        /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$targetDir/$appName/Contents/Info.plist" 2>/dev/null
-    }
     if [[ $(arch) == "arm64" ]]; then
         sparkleData=$(curl -fsL "https://persistent.oaistatic.com/codex-app-prod/appcast.xml")
         appNewVersion=$(echo "$sparkleData" | awk -F "[<>]" '/<sparkle:shortVersionString>/{print $3; exit}')

--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -1,6 +1,11 @@
 codex)
     name="Codex"
     type="dmg"
+    appName="ChatGPT.app"
+    targetDir="/Applications/ChatGPT.localized"
+    appCustomVersion() {
+        /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$targetDir/$appName/Contents/Info.plist" 2>/dev/null
+    }
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
     else
@@ -9,4 +14,5 @@ codex)
     fi
     appNewVersion="$(curl -fs "https://persistent.oaistatic.com/codex-app-prod/appcast.xml" | grep -o '<sparkle:shortVersionString>[^<]*' | head -1 | cut -d '>' -f 2)"
     expectedTeamID="2DC432GLL2"
+    blockingProcesses=( "ChatGPT" )
     ;;

--- a/fragments/labels/codex.sh
+++ b/fragments/labels/codex.sh
@@ -1,16 +1,14 @@
-codex)
-    name="Codex"
+chatgpt|codex)
+    name="ChatGPT"
     type="zip"
-    appName="ChatGPT.app"
-    targetDir="/Applications/ChatGPT.localized"
     if [[ $(arch) == "arm64" ]]; then
         sparkleData=$(curl -fsL "https://persistent.oaistatic.com/codex-app-prod/appcast.xml")
-        appNewVersion=$(echo "$sparkleData" | awk -F "[<>]" '/<sparkle:shortVersionString>/{print $3; exit}')
-        downloadURL=$(echo "$sparkleData" | awk -F 'url="' '/<enclosure url=/{split($2,a,"\""); print a[1]; exit}')
+        appNewVersion=$(echo "$sparkleData" | xpath 'string(//rss/channel/item[1]/sparkle:shortVersionString)')
+        downloadURL=$(echo "$sparkleData" | xpath 'string(//rss/channel/item[1]/enclosure/@url)')
     else
-        printlog "Codex is only compatible with Apple Silicon (arm64) Macs." ERROR
-        cleanupAndExit 95 "Codex requires Apple Silicon" ERROR
+        printlog "ChatGPT is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "ChatGPT requires Apple Silicon" ERROR
     fi
-    expectedTeamID="2DC432GLL2"
     blockingProcesses=( "ChatGPT" )
+    expectedTeamID="2DC432GLL2"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

The Codex release channel packages `ChatGPT.app` with bundle ID `com.openai.codex`, while public ChatGPT uses the same app name with bundle ID `com.openai.chat`. This change keeps Codex in `/Applications/ChatGPT.localized`, reads the version and matching ZIP URL from the same Sparkle feed, and relies on Installomator's built-in `targetDir`-aware version lookup.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

No linked issue.

```text
2026-07-23 13:54:22 : INFO  : codex : setting variable from argument DEBUG=1
2026-07-23 13:54:22 : REQ   : codex : ################## Start Installomator v. 10.10beta, date 2026-07-23
2026-07-23 13:54:22 : INFO  : codex : ################## codex
2026-07-23 13:54:22 : DEBUG : codex : DEBUG mode 1 enabled.
2026-07-23 13:54:22 : DEBUG : codex : name=Codex
2026-07-23 13:54:22 : DEBUG : codex : appName=ChatGPT.app
2026-07-23 13:54:22 : DEBUG : codex : type=zip
2026-07-23 13:54:23 : DEBUG : codex : downloadURL=https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.715.72359.zip
2026-07-23 13:54:23 : DEBUG : codex : appNewVersion=26.715.72359
2026-07-23 13:54:23 : DEBUG : codex : appCustomVersion function: Not defined
2026-07-23 13:54:23 : DEBUG : codex : versionKey=CFBundleShortVersionString
2026-07-23 13:54:23 : DEBUG : codex : expectedTeamID=2DC432GLL2
2026-07-23 13:54:23 : DEBUG : codex : blockingProcesses=ChatGPT
2026-07-23 13:54:23 : INFO  : codex : Label type: zip
2026-07-23 13:54:23 : INFO  : codex : archiveName: Codex.zip
2026-07-23 13:54:23 : INFO  : codex : App(s) found: /Applications/ChatGPT.localized/ChatGPT.app
2026-07-23 13:54:23 : INFO  : codex : found app at /Applications/ChatGPT.localized/ChatGPT.app, version 26.715.72359, on versionKey CFBundleShortVersionString
2026-07-23 13:54:23 : INFO  : codex : appversion: 26.715.72359
2026-07-23 13:54:23 : INFO  : codex : Latest version of Codex is 26.715.72359
2026-07-23 13:54:23 : WARN  : codex : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-23 13:54:23 : REQ   : codex : Downloading https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.715.72359.zip to Codex.zip
2026-07-23 13:54:38 : INFO  : codex : Downloaded Codex.zip – Type is Zip archive data, at least v1.0 to extract, compression method=store – SHA is 67d918762284f602b884568534c754d0522b7456 – Size is 557708 kB
2026-07-23 13:54:38 : REQ   : codex : Installing Codex
2026-07-23 13:54:38 : INFO  : codex : Unzipping Codex.zip
2026-07-23 13:54:43 : INFO  : codex : Verifying: ChatGPT.app
ChatGPT.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)
2026-07-23 13:54:44 : INFO  : codex : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2026-07-23 13:54:44 : INFO  : codex : Downloaded version of Codex is 26.715.72359 on versionKey CFBundleShortVersionString, same as installed.
2026-07-23 13:54:45 : REG   : codex : No new version to install
2026-07-23 13:54:45 : REQ   : codex : ################## End Installomator, exit code 0
```
