### PR TITLE
Create monotypeconnect.sh

### DIFF
--- a/fragments/labels/monotypeconnect.sh
+++ b/fragments/labels/monotypeconnect.sh
@@ -1,0 +1,7 @@
+monotypeconnect)
+    name="Monotype Connect"
+    type="dmg"
+    downloadURL="https://links.extensis.com/extensis_connect/ec_latest?language=en&platform=mac"
+    appNewVersion=$( curl -is "$downloadURL" | grep "location:" | grep -o "[[:digit:]]\+-[[:digit:]]\+-[[:digit:]]\+" | sed -e 's/-/./g' )
+    expectedTeamID="J6MMHGD9D6"
+    ;;

--- a/fragments/labels/monotypeconnect.sh
+++ b/fragments/labels/monotypeconnect.sh
@@ -2,6 +2,6 @@ monotypeconnect)
     name="Monotype Connect"
     type="dmg"
     downloadURL="https://links.extensis.com/extensis_connect/ec_latest?language=en&platform=mac"
-    appNewVersion=$( curl -is "$downloadURL" | grep "location:" | grep -o "[[:digit:]]\+-[[:digit:]]\+-[[:digit:]]\+" | sed -e 's/-/./g' )
+    appNewVersion=$(curl -fsS -D - -o /dev/null "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's|.*/ExtensisConnect-M-([0-9]+)-([0-9]+)-([0-9]+)\.dmg$|\1.\2.\3|')
     expectedTeamID="J6MMHGD9D6"
     ;;


### PR DESCRIPTION
2026-07-14 11:07:35 : INFO  : monotypeconnect : setting variable from argument DEBUG=0
2026-07-14 11:07:35 : INFO  : monotypeconnect : Total items in argumentsArray: 1
2026-07-14 11:07:35 : INFO  : monotypeconnect : argumentsArray: DEBUG=0
2026-07-14 11:07:35 : REQ   : monotypeconnect : ################## Start Installomator v. 10.10beta, date 2026-07-14
2026-07-14 11:07:35 : INFO  : monotypeconnect : ################## Version: 10.10beta
2026-07-14 11:07:35 : INFO  : monotypeconnect : ################## Date: 2026-07-14
2026-07-14 11:07:35 : INFO  : monotypeconnect : ################## monotypeconnect
2026-07-14 11:07:36 : INFO  : monotypeconnect : Reading arguments again: DEBUG=0
2026-07-14 11:07:36 : INFO  : monotypeconnect : BLOCKING_PROCESS_ACTION=tell_user
2026-07-14 11:07:36 : INFO  : monotypeconnect : NOTIFY=success
2026-07-14 11:07:36 : INFO  : monotypeconnect : LOGGING=INFO
2026-07-14 11:07:36 : INFO  : monotypeconnect : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-14 11:07:36 : INFO  : monotypeconnect : Label type: dmg
2026-07-14 11:07:36 : INFO  : monotypeconnect : archiveName: Monotype Connect.dmg
2026-07-14 11:07:36 : INFO  : monotypeconnect : no blocking processes defined, using Monotype Connect as default
2026-07-14 11:07:36 : INFO  : monotypeconnect : name: Monotype Connect, appName: Monotype Connect.app
2026-07-14 11:07:36 : WARN  : monotypeconnect : No previous app found
2026-07-14 11:07:36 : WARN  : monotypeconnect : could not find Monotype Connect.app
2026-07-14 11:07:36 : INFO  : monotypeconnect : appversion:
2026-07-14 11:07:36 : INFO  : monotypeconnect : Latest version of Monotype Connect is 28.1.6
2026-07-14 11:07:36 : REQ   : monotypeconnect : Downloading https://links.extensis.com/extensis_connect/ec_latest?language=en&platform=mac to Monotype Connect.dmg
2026-07-14 11:08:11 : INFO  : monotypeconnect : Downloaded Monotype Connect.dmg – Type is  zlib compressed data – SHA is 99198c6d0bd7b06e62859637a631fd9ec5dea6ba – Size is 279344 kB
2026-07-14 11:08:11 : REQ   : monotypeconnect : no more blocking processes, continue with update
2026-07-14 11:08:11 : REQ   : monotypeconnect : Installing Monotype Connect
2026-07-14 11:08:11 : INFO  : monotypeconnect : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.mxwKPYeKUA/Monotype Connect.dmg
2026-07-14 11:08:15 : INFO  : monotypeconnect : Mounted: /Volumes/Extensis Connect
2026-07-14 11:08:15 : INFO  : monotypeconnect : Verifying: /Volumes/Extensis Connect/Monotype Connect.app
2026-07-14 11:08:18 : INFO  : monotypeconnect : Team ID matching: J6MMHGD9D6 (expected: J6MMHGD9D6 )
2026-07-14 11:08:18 : INFO  : monotypeconnect : Installing Monotype Connect version 28.1.6 on versionKey CFBundleShortVersionString.
2026-07-14 11:08:18 : INFO  : monotypeconnect : App has LSMinimumSystemVersion: 12.0
2026-07-14 11:08:18 : INFO  : monotypeconnect : Copy /Volumes/Extensis Connect/Monotype Connect.app to /Applications
2026-07-14 11:08:20 : WARN  : monotypeconnect : Changing owner to testuser
2026-07-14 11:08:20 : INFO  : monotypeconnect : Finishing...
2026-07-14 11:08:23 : INFO  : monotypeconnect : App(s) found: /Applications/Monotype Connect.app
2026-07-14 11:08:23 : INFO  : monotypeconnect : found app at /Applications/Monotype Connect.app, version 28.1.6, on versionKey CFBundleShortVersionString
2026-07-14 11:08:23 : REQ   : monotypeconnect : Installed Monotype Connect, version 28.1.6
2026-07-14 11:08:23 : INFO  : monotypeconnect : notifying
2026-07-14 11:08:24 : INFO  : monotypeconnect : Installomator did not close any apps, so no need to reopen any apps.
2026-07-14 11:08:24 : REQ   : monotypeconnect : All done!
2026-07-14 11:08:24 : REQ   : monotypeconnect : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.
Extensis Connect is 'rebranded' to Monotype Connect
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
