### PR TITLE
Create druvainsyncgov.sh

### DIFF
--- a/fragments/labels/druvainsyncgov.sh
+++ b/fragments/labels/druvainsyncgov.sh
@@ -1,0 +1,8 @@
+druvainsyncgov)
+    name="Druva inSync"
+    type="pkgInDmg"
+    druvaFeed=$(curl -fsL "https://downloads.druva.com/insync/js/data.json")
+    appNewVersion=$(echo "$druvaFeed" | jq -r '.[] | select(.title=="macOS" and (.cloudopsNotes | test("GOVcloud"; "i"))) | .supportedVersions[0]')
+    downloadURL=$(echo "$druvaFeed" | jq -r '.[] | select(.title=="macOS" and (.cloudopsNotes | test("GOVcloud"; "i"))) | .installerDetails[0].downloadURL')
+    expectedTeamID="JN6HK3RMAP"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
_YES_

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
_YES_

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
_YES_

**Additional context** Add any other context about the label or fix here.
_The Druva inSync client has a commercial and a gov version. The app is named the same when installed, but the versioning is different depending on the client enrollment method. This label searches the data.json for the Govcloud version and uses the URL listed there._

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-07-14 11:02:01 : INFO  : druvainsyncgov : setting variable from argument DEBUG=1
2026-07-14 11:02:01 : INFO  : druvainsyncgov : Total items in argumentsArray: 1
2026-07-14 11:02:01 : INFO  : druvainsyncgov : argumentsArray: DEBUG=1
2026-07-14 11:02:01 : REQ   : druvainsyncgov : ################## Start Installomator v. 10.9beta, date 2025-11-12
2026-07-14 11:02:01 : INFO  : druvainsyncgov : ################## Version: 10.9beta
2026-07-14 11:02:01 : INFO  : druvainsyncgov : ################## Date: 2025-11-12
2026-07-14 11:02:01 : INFO  : druvainsyncgov : ################## druvainsyncgov
2026-07-14 11:02:01 : DEBUG : druvainsyncgov : DEBUG mode 1 enabled.
2026-07-14 11:02:02 : INFO  : druvainsyncgov : Reading arguments again: DEBUG=1
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : argument: DEBUG=1
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : name=Druva inSync
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : appName=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : type=pkgInDmg
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : archiveName=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : downloadURL=https://downloads.druva.com/downloads/inSync/MAC/7.6.1_Gov/inSync-7.6.1-r110931.dmg
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : curlOptions=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : appNewVersion=7.6.1
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : appCustomVersion function: Not defined
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : versionKey=CFBundleShortVersionString
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : packageID=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : pkgName=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : choiceChangesXML=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : expectedTeamID=JN6HK3RMAP
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : blockingProcesses=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : installerTool=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : CLIInstaller=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : CLIArguments=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : updateTool=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : updateToolArguments=
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : updateToolRunAsCurrentUser=
2026-07-14 11:02:02 : INFO  : druvainsyncgov : BLOCKING_PROCESS_ACTION=tell_user
2026-07-14 11:02:02 : INFO  : druvainsyncgov : NOTIFY=success
2026-07-14 11:02:02 : INFO  : druvainsyncgov : LOGGING=DEBUG
2026-07-14 11:02:02 : INFO  : druvainsyncgov : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-14 11:02:02 : INFO  : druvainsyncgov : Label type: pkgInDmg
2026-07-14 11:02:02 : INFO  : druvainsyncgov : archiveName: Druva inSync.dmg
2026-07-14 11:02:02 : INFO  : druvainsyncgov : no blocking processes defined, using Druva inSync as default
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : Changing directory to .
2026-07-14 11:02:02 : INFO  : druvainsyncgov : App(s) found: /Applications/Druva inSync.app
2026-07-14 11:02:02 : INFO  : druvainsyncgov : found app at /Applications/Druva inSync.app, version 7.6.1, on versionKey CFBundleShortVersionString
2026-07-14 11:02:02 : INFO  : druvainsyncgov : appversion: 7.6.1
2026-07-14 11:02:02 : INFO  : druvainsyncgov : Latest version of Druva inSync is 7.6.1
2026-07-14 11:02:02 : WARN  : druvainsyncgov : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-14 11:02:02 : REQ   : druvainsyncgov : Downloading https://downloads.druva.com/downloads/inSync/MAC/7.6.1_Gov/inSync-7.6.1-r110931.dmg to Druva inSync.dmg
2026-07-14 11:02:02 : DEBUG : druvainsyncgov : No Dialog connection, just download
2026-07-14 11:02:53 : INFO  : druvainsyncgov : Downloaded Druva inSync.dmg – Type is  zlib compressed data – SHA is 654f7c97070a03332820f1acd7dda21b32eeea1b – Size is 262508 kB
2026-07-14 11:02:53 : DEBUG : druvainsyncgov : DEBUG mode 1, not checking for blocking processes
2026-07-14 11:02:53 : REQ   : druvainsyncgov : Installing Druva inSync
2026-07-14 11:02:53 : INFO  : druvainsyncgov : Mounting ./Druva inSync.dmg
2026-07-14 11:02:57 : DEBUG : druvainsyncgov : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $64A08DBF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $07D6E8FF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $ABAB81B1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $5F532998
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $ABAB81B1
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $DE65FD0C
verified   CRC32 $60133742
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_APFS
/dev/disk9          	EF57347C-0000-11AA-AA11-0030654
/dev/disk9s1        	41504653-0000-11AA-AA11-0030654	/Volumes/inSync

2026-07-14 11:02:57 : INFO  : druvainsyncgov : Mounted: /Volumes/inSync
2026-07-14 11:02:57 : DEBUG : druvainsyncgov : Found pkg(s):
/Volumes/inSync/Install inSync.pkg
2026-07-14 11:02:57 : INFO  : druvainsyncgov : found pkg: /Volumes/inSync/Install inSync.pkg
2026-07-14 11:02:57 : INFO  : druvainsyncgov : Verifying: /Volumes/inSync/Install inSync.pkg
2026-07-14 11:02:57 : DEBUG : druvainsyncgov : File list: -rw-r--r--  1 jareyoun  staff   251M Aug 28  2025 /Volumes/inSync/Install inSync.pkg
2026-07-14 11:02:57 : DEBUG : druvainsyncgov : File type: /Volumes/inSync/Install inSync.pkg: xar archive compressed TOC: 4751, SHA-1 checksum
2026-07-14 11:02:58 : DEBUG : druvainsyncgov : spctlOut is /Volumes/inSync/Install inSync.pkg: accepted
2026-07-14 11:02:58 : DEBUG : druvainsyncgov : source=Notarized Developer ID
2026-07-14 11:02:58 : DEBUG : druvainsyncgov : origin=Developer ID Installer: Druva Technologies PTE LTD (JN6HK3RMAP)
2026-07-14 11:02:58 : INFO  : druvainsyncgov : Team ID: JN6HK3RMAP (expected: JN6HK3RMAP )
2026-07-14 11:02:58 : DEBUG : druvainsyncgov : DEBUG enabled, skipping installation
2026-07-14 11:02:58 : INFO  : druvainsyncgov : Finishing...
2026-07-14 11:03:01 : INFO  : druvainsyncgov : App(s) found: /Applications/Druva inSync.app
2026-07-14 11:03:01 : INFO  : druvainsyncgov : found app at /Applications/Druva inSync.app, version 7.6.1, on versionKey CFBundleShortVersionString
2026-07-14 11:03:01 : REQ   : druvainsyncgov : Installed Druva inSync, version 7.6.1
2026-07-14 11:03:01 : INFO  : druvainsyncgov : notifying
2026-07-14 11:03:01 : DEBUG : druvainsyncgov : Unmounting /Volumes/inSync
2026-07-14 11:03:11 : DEBUG : druvainsyncgov : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-07-14 11:03:11 : DEBUG : druvainsyncgov : DEBUG mode 1, not reopening anything
2026-07-14 11:03:11 : REQ   : druvainsyncgov : All done!
2026-07-14 11:03:11 : REQ   : druvainsyncgov : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
