### PR TITLE
Update aircall.sh

### DIFF
--- a/fragments/labels/aircall.sh
+++ b/fragments/labels/aircall.sh
@@ -7,9 +7,6 @@ aircall)
     elif [[ $(arch) == "i386" ]]; then
         cpu_arch="x64"
     fi
-    # The download endpoint redirects to the versioned file, so the redirect is
-    # resolved here to get both the URL and the version, for example:
-    # https://download-electron.aircall.io/aircall-workspace/Aircall-Workspace-1.15.20-arm64.pkg
     downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=${cpu_arch}&platform=macPkg")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*-([0-9.]*)-.*/\1/')
     expectedTeamID="3ML357Q795"

--- a/fragments/labels/aircall.sh
+++ b/fragments/labels/aircall.sh
@@ -2,12 +2,11 @@ aircall)
     name="Aircall Workspace"
     type="pkg"
     packageID="io.aircall.workspace"
-    if [[ $(arch) == "arm64" ]]; then
-        cpu_arch="arm64"
-    elif [[ $(arch) == "i386" ]]; then
-        cpu_arch="x64"
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=arm64&platform=macPkg")
+    else
+        downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=x64&platform=macPkg")
     fi
-    downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=${cpu_arch}&platform=macPkg")
     appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*-([0-9.]*)-.*/\1/')
     expectedTeamID="3ML357Q795"
     ;;

--- a/fragments/labels/aircall.sh
+++ b/fragments/labels/aircall.sh
@@ -1,8 +1,16 @@
 aircall)
-    name="Aircall"
-    type="zip"
-    aircallUpdate=$(curl -fsL "https://electron.aircall.io/update/osx/1.0.0?channel=stable")
-    downloadURL=$(echo "${aircallUpdate}" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
-    appNewVersion=$(echo "${aircallUpdate}" | sed -n 's/.*"name":"\([^"]*\)".*/\1/p')
+    name="Aircall Workspace"
+    type="pkg"
+    packageID="io.aircall.workspace"
+    if [[ $(arch) == "arm64" ]]; then
+        cpu_arch="arm64"
+    elif [[ $(arch) == "i386" ]]; then
+        cpu_arch="x64"
+    fi
+    # The download endpoint redirects to the versioned file, so the redirect is
+    # resolved here to get both the URL and the version, for example:
+    # https://download-electron.aircall.io/aircall-workspace/Aircall-Workspace-1.15.20-arm64.pkg
+    downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=${cpu_arch}&platform=macPkg")
+    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*-([0-9.]*)-.*/\1/')
     expectedTeamID="3ML357Q795"
     ;;

--- a/fragments/labels/aircall.sh
+++ b/fragments/labels/aircall.sh
@@ -1,7 +1,6 @@
 aircall)
     name="Aircall Workspace"
     type="pkg"
-    packageID="io.aircall.workspace"
     if [[ "$(arch)" == "arm64" ]]; then
         downloadURL=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "https://electron.aircall.io/download/osx?appType=aircall-workspace&arch=arm64&platform=macPkg")
     else


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
Aircall has renamed their stable desktop client to Aircall Workspace for desktop. aircall.io/download now offers only this new client, and its download buttons point at new electron.aircall.io endpoints. The same build is published on the stable update feed, but only when the new appType=aircall-workspace parameter is passed:
* new (Aircall Workspace)
https://electron.aircall.io/update/osx/1.0.0?channel=stable&appType=aircall-workspace&arch=arm64
{"name":"1.15.20","url":"https://download-electron.aircall.io/aircall-workspace/Aircall-Workspace-1.15.20-arm64.zip"}

* what the old label used still serves the superseded client
https://electron.aircall.io/update/osx/1.0.0?channel=stable
{"name":"3.1.66","url":"https://download-electron.aircall.io/Aircall-3.1.66.zip"}

Because the old feed still answers, the existing label kept quietly installing the superseded 3.1.66 client rather than what Aircall now ships.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**