### PR TITLE
Create dia.sh

### DIFF
--- a/fragments/labels/dia.sh
+++ b/fragments/labels/dia.sh
@@ -1,7 +1,12 @@
 dia)
     name="Dia"
     type="dmg"
-    downloadURL="https://releases.diabrowser.com/release/Dia-latest.dmg"
-    appNewVersion=$(curl -sIL "$downloadURL" | grep -i "^content-disposition:" | sed 's/.*Dia-\([0-9.]*\)-.*\.dmg.*/\1/')
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://releases.diabrowser.com/release/Dia-latest.dmg"
+    else
+        printlog "Dia is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Dia requires Apple Silicon" ERROR
+    fi
+    appNewVersion=$(curl -sIL "$downloadURL" | sed -nE 's/.*Dia-([0-9]+([.][0-9]+)+)-[0-9]+[.]dmg.*/\1/p')
     expectedTeamID="S6N382Y83G"
     ;;

--- a/fragments/labels/dia.sh
+++ b/fragments/labels/dia.sh
@@ -1,0 +1,7 @@
+dia)
+    name="Dia"
+    type="dmg"
+    downloadURL="https://releases.diabrowser.com/release/Dia-latest.dmg"
+    appNewVersion=$(curl -sIL "$downloadURL" | grep -i "^content-disposition:" | sed 's/.*Dia-\([0-9.]*\)-.*\.dmg.*/\1/')
+    expectedTeamID="S6N382Y83G"
+    ;;

--- a/fragments/labels/dia.sh
+++ b/fragments/labels/dia.sh
@@ -8,6 +8,5 @@ dia)
         cleanupAndExit 95 "Dia requires Apple Silicon" ERROR
     fi
     appNewVersion=$(curl -sIL "$downloadURL" | sed -nE 's/.*Dia-([0-9]+([.][0-9]+)+)-[0-9]+[.]dmg.*/\1/p')
-    blockingProcesses=( "Dia" )
     expectedTeamID="S6N382Y83G"
     ;;

--- a/fragments/labels/dia.sh
+++ b/fragments/labels/dia.sh
@@ -8,5 +8,6 @@ dia)
         cleanupAndExit 95 "Dia requires Apple Silicon" ERROR
     fi
     appNewVersion=$(curl -sIL "$downloadURL" | sed -nE 's/.*Dia-([0-9]+([.][0-9]+)+)-[0-9]+[.]dmg.*/\1/p')
+    blockingProcesses=( "Dia" )
     expectedTeamID="S6N382Y83G"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
```shell
2026-07-14 15:30:36 : INFO  : dia : setting variable from argument DEBUG=1
2026-07-14 15:30:36 : INFO  : dia : Total items in argumentsArray: 1
2026-07-14 15:30:36 : INFO  : dia : argumentsArray: DEBUG=1
2026-07-14 15:30:36 : REQ   : dia : ################## Start Installomator v. 10.9, date 2026-07-03
2026-07-14 15:30:36 : INFO  : dia : ################## Version: 10.9
2026-07-14 15:30:36 : INFO  : dia : ################## Date: 2026-07-03
2026-07-14 15:30:36 : INFO  : dia : ################## dia
2026-07-14 15:30:36 : DEBUG : dia : DEBUG mode 1 enabled.
2026-07-14 15:30:37 : INFO  : dia : Reading arguments again: DEBUG=1
2026-07-14 15:30:37 : DEBUG : dia : argument: DEBUG=1
2026-07-14 15:30:37 : DEBUG : dia : name=Dia
2026-07-14 15:30:37 : DEBUG : dia : appName=
2026-07-14 15:30:37 : DEBUG : dia : type=dmg
2026-07-14 15:30:37 : DEBUG : dia : archiveName=
2026-07-14 15:30:37 : DEBUG : dia : downloadURL=https://releases.diabrowser.com/release/Dia-latest.dmg
2026-07-14 15:30:37 : DEBUG : dia : curlOptions=
2026-07-14 15:30:37 : DEBUG : dia : appNewVersion=1.39.2
2026-07-14 15:30:37 : DEBUG : dia : appCustomVersion function: Not defined
2026-07-14 15:30:37 : DEBUG : dia : versionKey=CFBundleShortVersionString
2026-07-14 15:30:37 : DEBUG : dia : packageID=
2026-07-14 15:30:37 : DEBUG : dia : pkgName=
2026-07-14 15:30:37 : DEBUG : dia : choiceChangesXML=
2026-07-14 15:30:37 : DEBUG : dia : expectedTeamID=S6N382Y83G
2026-07-14 15:30:37 : DEBUG : dia : blockingProcesses=
2026-07-14 15:30:37 : DEBUG : dia : installerTool=
2026-07-14 15:30:37 : DEBUG : dia : CLIInstaller=
2026-07-14 15:30:37 : DEBUG : dia : CLIArguments=
2026-07-14 15:30:37 : DEBUG : dia : updateTool=
2026-07-14 15:30:37 : DEBUG : dia : updateToolArguments=
2026-07-14 15:30:37 : DEBUG : dia : updateToolRunAsCurrentUser=
2026-07-14 15:30:37 : INFO  : dia : BLOCKING_PROCESS_ACTION=tell_user
2026-07-14 15:30:37 : INFO  : dia : NOTIFY=success
2026-07-14 15:30:37 : INFO  : dia : LOGGING=DEBUG
2026-07-14 15:30:37 : INFO  : dia : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-14 15:30:37 : INFO  : dia : Label type: dmg
2026-07-14 15:30:37 : INFO  : dia : archiveName: Dia.dmg
2026-07-14 15:30:37 : INFO  : dia : no blocking processes defined, using Dia as default
2026-07-14 15:30:37 : DEBUG : dia : Changing directory to /usr/local/Installomator
2026-07-14 15:30:37 : INFO  : dia : name: Dia, appName: Dia.app
2026-07-14 15:30:37 : WARN  : dia : No previous app found
2026-07-14 15:30:37 : WARN  : dia : could not find Dia.app
2026-07-14 15:30:37 : INFO  : dia : appversion: 
2026-07-14 15:30:37 : INFO  : dia : Latest version of Dia is 1.39.2
2026-07-14 15:30:37 : REQ   : dia : Downloading https://releases.diabrowser.com/release/Dia-latest.dmg to Dia.dmg
2026-07-14 15:30:37 : DEBUG : dia : No Dialog connection, just download
2026-07-14 15:30:52 : INFO  : dia : Downloaded Dia.dmg – Type is  zlib compressed data – SHA is 14e4d2a69adaf30a195697a062eb1622c940f031 – Size is 754648 kB
2026-07-14 15:30:52 : DEBUG : dia : DEBUG mode 1, not checking for blocking processes
2026-07-14 15:30:52 : REQ   : dia : Installing Dia
2026-07-14 15:30:52 : INFO  : dia : Mounting /usr/local/Installomator/Dia.dmg
2026-07-14 15:30:57 : DEBUG : dia : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A8D9F5B1
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $CC74EE37
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $0B38B8A4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $7D5DD425
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $0B38B8A4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E2B03B93
verified   CRC32 $C8E05971
/dev/disk52         	GUID_partition_scheme
/dev/disk52s1       	Apple_HFS                      	/Volumes/Dia

2026-07-14 15:30:57 : INFO  : dia : Mounted: /Volumes/Dia
2026-07-14 15:30:57 : INFO  : dia : Verifying: /Volumes/Dia/Dia.app
2026-07-14 15:30:57 : DEBUG : dia : App size: 1.4G	/Volumes/Dia/Dia.app
2026-07-14 15:31:01 : DEBUG : dia : Debugging enabled, App Verification output was:
/Volumes/Dia/Dia.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Browser Company of New York Inc. (S6N382Y83G)

2026-07-14 15:31:01 : INFO  : dia : Team ID matching: S6N382Y83G (expected: S6N382Y83G )
2026-07-14 15:31:01 : INFO  : dia : Installing Dia version 1.39.2 on versionKey CFBundleShortVersionString.
2026-07-14 15:31:01 : INFO  : dia : App has LSMinimumSystemVersion: 14.0
2026-07-14 15:31:01 : DEBUG : dia : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-14 15:31:01 : INFO  : dia : Finishing...
2026-07-14 15:31:04 : INFO  : dia : name: Dia, appName: Dia.app
2026-07-14 15:31:04 : WARN  : dia : No previous app found
2026-07-14 15:31:04 : WARN  : dia : could not find Dia.app
2026-07-14 15:31:04 : REQ   : dia : Installed Dia, version 1.39.2
2026-07-14 15:31:04 : INFO  : dia : notifying
2026-07-14 15:31:05 : DEBUG : dia : Unmounting /Volumes/Dia
2026-07-14 15:31:15 : DEBUG : dia : Debugging enabled, Unmounting output was:
"disk52" ejected.
2026-07-14 15:31:15 : DEBUG : dia : DEBUG mode 1, not reopening anything
2026-07-14 15:31:15 : REQ   : dia : All done!
2026-07-14 15:31:15 : REQ   : dia : ################## End Installomator, exit code 0 

```