### PR TITLE
druvainsyncgov-new-label

### DIFF
--- a/fragments/labels/druvainsyncgov.sh
+++ b/fragments/labels/druvainsyncgov.sh
@@ -1,0 +1,8 @@
+druvainsyncgov)
+    name="Druva inSync"
+    type="pkgInDmg"
+    druvaFeed=$(curl -fsL "https://downloads.druva.com/insync/js/data.json")
+    appNewVersion=$(getJSONValue "$druvaFeed" "find(item => item.title === 'macOS' && item.installerDetails[0].downloadURL.includes('_Gov/')).installerDetails[0].version")
+    downloadURL=$(getJSONValue "$druvaFeed" "find(item => item.title === 'macOS' && item.installerDetails[0].downloadURL.includes('_Gov/')).installerDetails[0].downloadURL")
+    expectedTeamID="JN6HK3RMAP"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh druvainsyncgov DEBUG=1
2026-07-15 09:09:48 : INFO  : druvainsyncgov : setting variable from argument DEBUG=1
2026-07-15 09:09:48 : INFO  : druvainsyncgov : Total items in argumentsArray: 1
2026-07-15 09:09:48 : INFO  : druvainsyncgov : argumentsArray: DEBUG=1
2026-07-15 09:09:48 : REQ   : druvainsyncgov : ################## Start Installomator v. 10.10beta, date 2026-07-15
2026-07-15 09:09:48 : INFO  : druvainsyncgov : ################## Version: 10.10beta
2026-07-15 09:09:48 : INFO  : druvainsyncgov : ################## Date: 2026-07-15
2026-07-15 09:09:48 : INFO  : druvainsyncgov : ################## druvainsyncgov
2026-07-15 09:09:49 : DEBUG : druvainsyncgov : DEBUG mode 1 enabled.
2026-07-15 09:09:49 : INFO  : druvainsyncgov : Reading arguments again: DEBUG=1
2026-07-15 09:09:49 : DEBUG : druvainsyncgov : argument: DEBUG=1
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : name=Druva inSync
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : appName=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : type=pkgInDmg
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : archiveName=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : downloadURL=https://downloads.druva.com/downloads/inSync/MAC/7.6.1_Gov/inSync-7.6.1-r110931.dmg
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : curlOptions=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : appNewVersion=7.6.1
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : appCustomVersion function: Not defined
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : versionKey=CFBundleShortVersionString
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : packageID=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : pkgName=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : choiceChangesXML=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : expectedTeamID=JN6HK3RMAP
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : blockingProcesses=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : installerTool=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : CLIInstaller=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : CLIArguments=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : updateTool=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : updateToolArguments=
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : updateToolRunAsCurrentUser=
2026-07-15 09:09:50 : INFO  : druvainsyncgov : BLOCKING_PROCESS_ACTION=tell_user
2026-07-15 09:09:50 : INFO  : druvainsyncgov : NOTIFY=success
2026-07-15 09:09:50 : INFO  : druvainsyncgov : LOGGING=DEBUG
2026-07-15 09:09:50 : INFO  : druvainsyncgov : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-15 09:09:50 : INFO  : druvainsyncgov : Label type: pkgInDmg
2026-07-15 09:09:50 : INFO  : druvainsyncgov : archiveName: Druva inSync.dmg
2026-07-15 09:09:50 : INFO  : druvainsyncgov : no blocking processes defined, using Druva inSync as default
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-15 09:09:50 : INFO  : druvainsyncgov : name: Druva inSync, appName: Druva inSync.app
2026-07-15 09:09:50 : WARN  : druvainsyncgov : No previous app found
2026-07-15 09:09:50 : WARN  : druvainsyncgov : could not find Druva inSync.app
2026-07-15 09:09:50 : INFO  : druvainsyncgov : appversion: 
2026-07-15 09:09:50 : INFO  : druvainsyncgov : Latest version of Druva inSync is 7.6.1
2026-07-15 09:09:50 : REQ   : druvainsyncgov : Downloading https://downloads.druva.com/downloads/inSync/MAC/7.6.1_Gov/inSync-7.6.1-r110931.dmg to Druva inSync.dmg
2026-07-15 09:09:50 : DEBUG : druvainsyncgov : No Dialog connection, just download
2026-07-15 09:10:00 : INFO  : druvainsyncgov : Downloaded Druva inSync.dmg – Type is  zlib compressed data – SHA is 654f7c97070a03332820f1acd7dda21b32eeea1b – Size is 262796 kB
2026-07-15 09:10:00 : DEBUG : druvainsyncgov : DEBUG mode 1, not checking for blocking processes
2026-07-15 09:10:00 : REQ   : druvainsyncgov : Installing Druva inSync
2026-07-15 09:10:00 : INFO  : druvainsyncgov : Mounting /Users/u0105821/git/github/Installomator/build/Druva inSync.dmg
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $64A08DBF
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $07D6E8FF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $ABAB81B1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $5F532998
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $ABAB81B1
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $DE65FD0C
verified   CRC32 $60133742
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/inSync

2026-07-15 09:10:04 : INFO  : druvainsyncgov : Mounted: /Volumes/inSync
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : Found pkg(s):
/Volumes/inSync/Install inSync.pkg
2026-07-15 09:10:04 : INFO  : druvainsyncgov : found pkg: /Volumes/inSync/Install inSync.pkg
2026-07-15 09:10:04 : INFO  : druvainsyncgov : Verifying: /Volumes/inSync/Install inSync.pkg
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : File list: -rw-r--r--  1 mac  staff   251M Aug 28  2025 /Volumes/inSync/Install inSync.pkg
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : File type: /Volumes/inSync/Install inSync.pkg: xar archive compressed TOC: 4751, SHA-1 checksum
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : spctlOut is /Volumes/inSync/Install inSync.pkg: accepted
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : source=Notarized Developer ID
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : origin=Developer ID Installer: Druva Technologies PTE LTD (JN6HK3RMAP)
2026-07-15 09:10:04 : INFO  : druvainsyncgov : Team ID: JN6HK3RMAP (expected: JN6HK3RMAP )
2026-07-15 09:10:04 : DEBUG : druvainsyncgov : DEBUG enabled, skipping installation
2026-07-15 09:10:04 : INFO  : druvainsyncgov : Finishing...
2026-07-15 09:10:07 : INFO  : druvainsyncgov : name: Druva inSync, appName: Druva inSync.app
2026-07-15 09:10:08 : WARN  : druvainsyncgov : No previous app found
2026-07-15 09:10:08 : WARN  : druvainsyncgov : could not find Druva inSync.app
2026-07-15 09:10:08 : REQ   : druvainsyncgov : Installed Druva inSync, version 7.6.1
2026-07-15 09:10:08 : INFO  : druvainsyncgov : notifying
2026-07-15 09:10:09 : DEBUG : druvainsyncgov : Unmounting /Volumes/inSync
2026-07-15 09:10:09 : DEBUG : druvainsyncgov : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-07-15 09:10:09 : DEBUG : druvainsyncgov : DEBUG mode 1, not reopening anything
2026-07-15 09:10:09 : REQ   : druvainsyncgov : All done!
2026-07-15 09:10:09 : REQ   : druvainsyncgov : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
