### PR TITLE
Update 1password8.sh

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -2,7 +2,7 @@
     name="1Password"
     type="pkg"
     downloadURL="https://downloads.1password.com/mac/1Password.pkg"
-    appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
+    appNewVersion=$(curl -s https://releases.1password.com/mac/stable/index.xml | grep "<title>" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
     expectedTeamID="2BUA8C4S2C"
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     ;;


### PR DESCRIPTION
Fix to search for version numbers in title fields only to avoid errant matches elsewhere (e.g. description which currently mentions 10.1.2 and is getting mis-reported as the current version by the label)

Fix to search for version numbers in title fields only to avoid errant matches elsewhere (e.g. description which currently mentions 10.1.2 and is getting mis-reported as the current version by the label)

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes*

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

*there is also #3016 but that also modifies what URL is being checked. I reached out to 1Password support for guidance about the difference in the 2 URLs and they advised the following about the app-update.agilebits.com URL:

> It's an older service that is due for a rewrite at some point. That rewrite hasn't been prioritised yet, so it should be fine for a while, but backwards compatibility isn't fully guaranteed (though it's expected, since all 1Password apps use it to check for updates).

> In the URL you referenced, the final N is currently interpreted as "production" for backwards compatibility

Based on the above and the fact the existing URL @ releases.1password.com can still be used by only searching values found in the  <title> tag I think opting for this PR over the other makes sense.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-07-16 08:53:42 : INFO  : 1password8 : Total items in argumentsArray: 0
2026-07-16 08:53:42 : INFO  : 1password8 : argumentsArray:
2026-07-16 08:53:42 : REQ   : 1password8 : ################## Start Installomator v. 10.9+1pasword8-fix, date 2026-07-03+2026-07-14
2026-07-16 08:53:42 : INFO  : 1password8 : ################## Version: 10.9+1pasword8-fix
2026-07-16 08:53:42 : INFO  : 1password8 : ################## Date: 2026-07-03+2026-07-14
2026-07-16 08:53:42 : INFO  : 1password8 : ################## 1password8
2026-07-16 08:53:42 : DEBUG : 1password8 : DEBUG mode 1 enabled.
2026-07-16 08:53:43 : INFO  : 1password8 : Reading arguments again:
2026-07-16 08:53:43 : DEBUG : 1password8 : name=1Password
2026-07-16 08:53:43 : DEBUG : 1password8 : appName=
2026-07-16 08:53:43 : DEBUG : 1password8 : type=pkg
2026-07-16 08:53:43 : DEBUG : 1password8 : archiveName=
2026-07-16 08:53:43 : DEBUG : 1password8 : downloadURL=https://downloads.1password.com/mac/1Password.pkg
2026-07-16 08:53:43 : DEBUG : 1password8 : curlOptions=
2026-07-16 08:53:43 : DEBUG : 1password8 : appNewVersion=8.12.28
2026-07-16 08:53:43 : DEBUG : 1password8 : appCustomVersion function: Not defined
2026-07-16 08:53:43 : DEBUG : 1password8 : versionKey=CFBundleShortVersionString
2026-07-16 08:53:43 : DEBUG : 1password8 : packageID=
2026-07-16 08:53:43 : DEBUG : 1password8 : pkgName=
2026-07-16 08:53:43 : DEBUG : 1password8 : choiceChangesXML=
2026-07-16 08:53:43 : DEBUG : 1password8 : expectedTeamID=2BUA8C4S2C
2026-07-16 08:53:43 : DEBUG : 1password8 : blockingProcesses=1Password Extension Helper 1Password 7 1Password 8 1Password 1PasswordNativeMessageHost 1PasswordSafariAppExtension
2026-07-16 08:53:43 : DEBUG : 1password8 : installerTool=
2026-07-16 08:53:43 : DEBUG : 1password8 : CLIInstaller=
2026-07-16 08:53:43 : DEBUG : 1password8 : CLIArguments=
2026-07-16 08:53:43 : DEBUG : 1password8 : updateTool=
2026-07-16 08:53:43 : DEBUG : 1password8 : updateToolArguments=
2026-07-16 08:53:43 : DEBUG : 1password8 : updateToolRunAsCurrentUser=
2026-07-16 08:53:43 : INFO  : 1password8 : BLOCKING_PROCESS_ACTION=tell_user
2026-07-16 08:53:43 : INFO  : 1password8 : NOTIFY=success
2026-07-16 08:53:43 : INFO  : 1password8 : LOGGING=DEBUG
2026-07-16 08:53:43 : INFO  : 1password8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-16 08:53:43 : INFO  : 1password8 : Label type: pkg
2026-07-16 08:53:43 : INFO  : 1password8 : archiveName: 1Password.pkg
2026-07-16 08:53:43 : DEBUG : 1password8 : Changing directory to .
2026-07-16 08:53:43 : INFO  : 1password8 : name: 1Password, appName: 1Password.app
2026-07-16 08:53:43 : WARN  : 1password8 : No previous app found
2026-07-16 08:53:43 : WARN  : 1password8 : could not find 1Password.app
2026-07-16 08:53:43 : INFO  : 1password8 : appversion:
2026-07-16 08:53:43 : INFO  : 1password8 : Latest version of 1Password is 8.12.28
2026-07-16 08:53:43 : REQ   : 1password8 : Downloading https://downloads.1password.com/mac/1Password.pkg to 1Password.pkg
2026-07-16 08:53:43 : DEBUG : 1password8 : No Dialog connection, just download
2026-07-16 08:54:00 : INFO  : 1password8 : Downloaded 1Password.pkg – Type is  xar archive compressed TOC – SHA is ededfa0dd862d66b1f2f5174f55dddc52a15f251 – Size is 377632 kB
2026-07-16 08:54:00 : DEBUG : 1password8 : DEBUG mode 1, not checking for blocking processes
2026-07-16 08:54:00 : REQ   : 1password8 : Installing 1Password
2026-07-16 08:54:00 : INFO  : 1password8 : Verifying: 1Password.pkg
2026-07-16 08:54:00 : DEBUG : 1password8 : File list: -rw-r--r--@ 1 root  staff   364M Jul 16 08:53 1Password.pkg
2026-07-16 08:54:00 : DEBUG : 1password8 : File type: 1Password.pkg: xar archive compressed TOC: 4645, SHA-1 checksum
2026-07-16 08:54:00 : DEBUG : 1password8 : spctlOut is 1Password.pkg: accepted
2026-07-16 08:54:00 : DEBUG : 1password8 : source=Notarized Developer ID
2026-07-16 08:54:00 : DEBUG : 1password8 : origin=Developer ID Installer: AgileBits Inc. (2BUA8C4S2C)
2026-07-16 08:54:00 : INFO  : 1password8 : Team ID: 2BUA8C4S2C (expected: 2BUA8C4S2C )
2026-07-16 08:54:00 : DEBUG : 1password8 : DEBUG enabled, skipping installation
2026-07-16 08:54:00 : INFO  : 1password8 : Finishing...
2026-07-16 08:54:04 : INFO  : 1password8 : name: 1Password, appName: 1Password.app
2026-07-16 08:54:04 : WARN  : 1password8 : No previous app found
2026-07-16 08:54:04 : WARN  : 1password8 : could not find 1Password.app
2026-07-16 08:54:04 : REQ   : 1password8 : Installed 1Password, version 8.12.28
2026-07-16 08:54:04 : INFO  : 1password8 : notifying
2026-07-16 08:54:04 : DEBUG : 1password8 : DEBUG mode 1, not reopening anything
2026-07-16 08:54:04 : REQ   : 1password8 : All done!
2026-07-16 08:54:04 : REQ   : 1password8 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

I don't see any issues logged for this, but this PR fixes the label so Installomator correctly identifies the updated app version by only checking the <title> tag.