### PR TITLE
jre8-label-update

### DIFF
--- a/fragments/labels/jre8.sh
+++ b/fragments/labels/jre8.sh
@@ -2,11 +2,12 @@ jre8)
     name="Java Runtime Environment 8"
     type="pkgInDmg"
     versionKey="CFBundleVersion"
-    versionURL=$(curl -fs "https://javadl-esd-secure.oracle.com/update/mac/map-mac-1.8.0.xml" | xpath '( //java-update-map/mapping/url)[last()]' 2>/dev/null | cut -d\> -f2 | cut -d\< -f1)
-    appNewVersion=$(curl -fs "${versionURL}" | xpath '(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null | cut -d '"' -f 2)
-    appBuildVersion=$(echo $appNewVersion | cut -d. -f3)
-    downloadURL="$(curl -fs "${versionURL}" | xpath '(//rss/channel/item/enclosure/@url)[last()]' 2>/dev/null | cut -d '"' -f 2)"
+    sparkleData=$(curl -fs "$(curl -fs "https://javadl-esd-secure.oracle.com/update/mac/map-mac-1.8.0.xml" | xmllint --xpath 'string((//java-update-map/mapping/url[not(contains(., "-cb.xml"))])[last()])' -)")
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure"]/@*[local-name()="version"])[last()])' -)
+    appBuildVersion=$(echo "$appNewVersion" | cut -d. -f3)
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure"]/@url)[last()])' -)
     pkgName="Java 8 Update ${appBuildVersion}.app/Contents/Resources/JavaAppletPlugin.pkg"
     appCustomVersion(){ defaults read "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Info.plist" "${versionKey}" 2>/dev/null }
     expectedTeamID="VB5E2TV963"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh jre8 DEBUG=0
2026-07-16 14:28:38 : INFO  : jre8 : setting variable from argument DEBUG=0
2026-07-16 14:28:38 : INFO  : jre8 : Total items in argumentsArray: 1
2026-07-16 14:28:38 : INFO  : jre8 : argumentsArray: DEBUG=0
2026-07-16 14:28:38 : REQ   : jre8 : ################## Start Installomator v. 10.10beta, date 2026-07-16
2026-07-16 14:28:38 : INFO  : jre8 : ################## Version: 10.10beta
2026-07-16 14:28:38 : INFO  : jre8 : ################## Date: 2026-07-16
2026-07-16 14:28:38 : INFO  : jre8 : ################## jre8
2026-07-16 14:28:39 : INFO  : jre8 : Reading arguments again: DEBUG=0
2026-07-16 14:28:39 : INFO  : jre8 : BLOCKING_PROCESS_ACTION=tell_user
2026-07-16 14:28:39 : INFO  : jre8 : NOTIFY=success
2026-07-16 14:28:39 : INFO  : jre8 : LOGGING=INFO
2026-07-16 14:28:39 : INFO  : jre8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-16 14:28:39 : INFO  : jre8 : Label type: pkgInDmg
2026-07-16 14:28:39 : INFO  : jre8 : archiveName: Java Runtime Environment 8.dmg
2026-07-16 14:28:39 : INFO  : jre8 : Custom App Version detection is used, found 
2026-07-16 14:28:39 : INFO  : jre8 : appversion: 
2026-07-16 14:28:39 : INFO  : jre8 : Latest version of Java Runtime Environment 8 is 1.8.491.10
2026-07-16 14:28:39 : REQ   : jre8 : Downloading https://javadl.oracle.com/webapps/download/GetFile/1.8.0_491-b10/f7fe8e644f724108bdb54139381e29a7/unix-i586/jre-8u491-fcs-bin-b10-macosx-x64-30_mar_2026_au.dmg to Java Runtime Environment 8.dmg
2026-07-16 14:28:43 : INFO  : jre8 : Downloaded Java Runtime Environment 8.dmg – Type is  zlib compressed data – SHA is 59e3bad79845ae5928bdd28ff9f0d912916093b4 – Size is 99140 kB
2026-07-16 14:28:43 : REQ   : jre8 : Installing Java Runtime Environment 8
2026-07-16 14:28:43 : INFO  : jre8 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JhKSn6EjGi/Java Runtime Environment 8.dmg
2026-07-16 14:28:47 : INFO  : jre8 : Mounted: /Volumes/Oracle Java 1.8.0_491
2026-07-16 14:28:47 : INFO  : jre8 : found pkg: /Volumes/Oracle Java 1.8.0_491/Java 8 Update 491.app/Contents/Resources/JavaAppletPlugin.pkg
2026-07-16 14:28:47 : INFO  : jre8 : Verifying: /Volumes/Oracle Java 1.8.0_491/Java 8 Update 491.app/Contents/Resources/JavaAppletPlugin.pkg
2026-07-16 14:28:47 : INFO  : jre8 : Team ID: VB5E2TV963 (expected: VB5E2TV963 )
2026-07-16 14:28:47 : INFO  : jre8 : Installing /Volumes/Oracle Java 1.8.0_491/Java 8 Update 491.app/Contents/Resources/JavaAppletPlugin.pkg to /
2026-07-16 14:30:43 : INFO  : jre8 : Finishing...
2026-07-16 14:30:46 : INFO  : jre8 : Custom App Version detection is used, found 1.8.491.10
2026-07-16 14:30:47 : REQ   : jre8 : Installed Java Runtime Environment 8, version 1.8.491.10
2026-07-16 14:30:47 : INFO  : jre8 : notifying
2026-07-16 14:30:47 : INFO  : jre8 : Installomator did not close any apps, so no need to reopen any apps.
2026-07-16 14:30:47 : REQ   : jre8 : All done!
2026-07-16 14:30:47 : REQ   : jre8 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
