### PR TITLE
kiro-label-update

### DIFF
--- a/fragments/labels/kiro.sh
+++ b/fragments/labels/kiro.sh
@@ -1,11 +1,11 @@
 kiro)
     name="Kiro"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://kiro.dev/changelog/ide/" | grep -oE '0\.[0-9]+\.[0-9]+' | head -1)
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/${appNewVersion}/kiro-ide-${appNewVersion}-stable-darwin-arm64.dmg"
+        downloadURL=$(curl -fsL "https://kiro.dev/downloads" | grep -Eo 'https://prod\.download\.desktop\.kiro\.dev/releases/stable/darwin-arm64/signed/[0-9]+\.[0-9]+\.[0-9]+/kiro-ide-[0-9]+\.[0-9]+\.[0-9]+-stable-darwin-arm64\.dmg' | head -1)
     elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://prod.download.desktop.kiro.dev/releases/stable/darwin-x64/signed/${appNewVersion}/kiro-ide-${appNewVersion}-stable-darwin-x64.dmg"
+        downloadURL=$(curl -fsL "https://kiro.dev/downloads" | grep -Eo 'https://prod\.download\.desktop\.kiro\.dev/releases/stable/darwin-x64/signed/[0-9]+\.[0-9]+\.[0-9]+/kiro-ide-[0-9]+\.[0-9]+\.[0-9]+-stable-darwin-x64\.dmg' | head -1)
     fi
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/signed/([0-9]+\.[0-9]+\.[0-9]+)/.*|\1|')
     expectedTeamID="94KV3E626L"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The Kiro label was improved by deriving the actual download URL from Kiro’s downloads page instead of guessing it from the changelog version. Previously, it scraped appNewVersion from https://kiro.dev/changelog/ide/, assumed the download URL followed a matching path, and only matched versions beginning with 0.

Now, the label scrapes the real architecture-specific .dmg URL from https://kiro.dev/downloads, supports both Apple Silicon and Intel download links directly, and then extracts appNewVersion from the signed download URL afterward. This avoids breakage when the changelog version and the available download version drift apart, and it also supports future 1.x.x style versions because the version-matching regex now allows any x.x.x format.

The main improvement is reliability: the label now follows the vendor’s published download links rather than constructing a URL from a separately scraped version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh kiro DEBUG=1
2026-07-16 15:06:23 : INFO  : kiro : setting variable from argument DEBUG=1
2026-07-16 15:06:23 : INFO  : kiro : Total items in argumentsArray: 1
2026-07-16 15:06:23 : INFO  : kiro : argumentsArray: DEBUG=1
2026-07-16 15:06:23 : REQ   : kiro : ################## Start Installomator v. 10.10beta, date 2026-07-16
2026-07-16 15:06:23 : INFO  : kiro : ################## Version: 10.10beta
2026-07-16 15:06:23 : INFO  : kiro : ################## Date: 2026-07-16
2026-07-16 15:06:23 : INFO  : kiro : ################## kiro
2026-07-16 15:06:23 : DEBUG : kiro : DEBUG mode 1 enabled.
2026-07-16 15:06:24 : INFO  : kiro : Reading arguments again: DEBUG=1
2026-07-16 15:06:24 : DEBUG : kiro : argument: DEBUG=1
2026-07-16 15:06:24 : DEBUG : kiro : name=Kiro
2026-07-16 15:06:24 : DEBUG : kiro : appName=
2026-07-16 15:06:24 : DEBUG : kiro : type=dmg
2026-07-16 15:06:24 : DEBUG : kiro : archiveName=
2026-07-16 15:06:24 : DEBUG : kiro : downloadURL=https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.138/kiro-ide-1.0.138-stable-darwin-arm64.dmg
2026-07-16 15:06:24 : DEBUG : kiro : curlOptions=
2026-07-16 15:06:24 : DEBUG : kiro : appNewVersion=1.0.138
2026-07-16 15:06:24 : DEBUG : kiro : appCustomVersion function: Not defined
2026-07-16 15:06:24 : DEBUG : kiro : versionKey=CFBundleShortVersionString
2026-07-16 15:06:24 : DEBUG : kiro : packageID=
2026-07-16 15:06:24 : DEBUG : kiro : pkgName=
2026-07-16 15:06:24 : DEBUG : kiro : choiceChangesXML=
2026-07-16 15:06:24 : DEBUG : kiro : expectedTeamID=94KV3E626L
2026-07-16 15:06:24 : DEBUG : kiro : blockingProcesses=
2026-07-16 15:06:24 : DEBUG : kiro : installerTool=
2026-07-16 15:06:24 : DEBUG : kiro : CLIInstaller=
2026-07-16 15:06:24 : DEBUG : kiro : CLIArguments=
2026-07-16 15:06:24 : DEBUG : kiro : updateTool=
2026-07-16 15:06:24 : DEBUG : kiro : updateToolArguments=
2026-07-16 15:06:25 : DEBUG : kiro : updateToolRunAsCurrentUser=
2026-07-16 15:06:25 : INFO  : kiro : BLOCKING_PROCESS_ACTION=tell_user
2026-07-16 15:06:25 : INFO  : kiro : NOTIFY=success
2026-07-16 15:06:25 : INFO  : kiro : LOGGING=DEBUG
2026-07-16 15:06:25 : INFO  : kiro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-16 15:06:25 : INFO  : kiro : Label type: dmg
2026-07-16 15:06:25 : INFO  : kiro : archiveName: Kiro.dmg
2026-07-16 15:06:25 : INFO  : kiro : no blocking processes defined, using Kiro as default
2026-07-16 15:06:25 : DEBUG : kiro : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-16 15:06:25 : INFO  : kiro : name: Kiro, appName: Kiro.app
2026-07-16 15:06:25 : WARN  : kiro : No previous app found
2026-07-16 15:06:25 : WARN  : kiro : could not find Kiro.app
2026-07-16 15:06:25 : INFO  : kiro : appversion: 
2026-07-16 15:06:25 : INFO  : kiro : Latest version of Kiro is 1.0.138
2026-07-16 15:06:25 : REQ   : kiro : Downloading https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.138/kiro-ide-1.0.138-stable-darwin-arm64.dmg to Kiro.dmg
2026-07-16 15:06:25 : DEBUG : kiro : No Dialog connection, just download
2026-07-16 15:06:33 : INFO  : kiro : Downloaded Kiro.dmg – Type is  zlib compressed data – SHA is be71d1a59fc38c9ac83789e155350d2889b99b0a – Size is 246028 kB
2026-07-16 15:06:33 : DEBUG : kiro : DEBUG mode 1, not checking for blocking processes
2026-07-16 15:06:33 : REQ   : kiro : Installing Kiro
2026-07-16 15:06:33 : INFO  : kiro : Mounting /Users/u0105821/git/github/Installomator/build/Kiro.dmg
2026-07-16 15:06:37 : DEBUG : kiro : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $65FDD7AC
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $DAA9A31C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $E427C87C
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $E3B001CE
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $E427C87C
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $864C9DEA
verified   CRC32 $288FD113
/dev/disk7          	GUID_partition_scheme
/dev/disk7s1        	Apple_APFS
/dev/disk8          	EF57347C-0000-11AA-AA11-0030654
/dev/disk8s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Kiro 1

2026-07-16 15:06:37 : INFO  : kiro : Mounted: /Volumes/Kiro 1
2026-07-16 15:06:37 : INFO  : kiro : Verifying: /Volumes/Kiro 1/Kiro.app
2026-07-16 15:06:38 : DEBUG : kiro : App size: 685M	/Volumes/Kiro 1/Kiro.app
2026-07-16 15:06:41 : DEBUG : kiro : Debugging enabled, App Verification output was:
/Volumes/Kiro 1/Kiro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: AMZN Mobile LLC (94KV3E626L)

2026-07-16 15:06:41 : INFO  : kiro : Team ID matching: 94KV3E626L (expected: 94KV3E626L )
2026-07-16 15:06:41 : INFO  : kiro : Installing Kiro version 1.0.138 on versionKey CFBundleShortVersionString.
2026-07-16 15:06:41 : INFO  : kiro : App has LSMinimumSystemVersion: 12.0
2026-07-16 15:06:41 : DEBUG : kiro : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-16 15:06:41 : INFO  : kiro : Finishing...
2026-07-16 15:06:44 : INFO  : kiro : name: Kiro, appName: Kiro.app
2026-07-16 15:06:44 : WARN  : kiro : No previous app found
2026-07-16 15:06:44 : WARN  : kiro : could not find Kiro.app
2026-07-16 15:06:44 : REQ   : kiro : Installed Kiro, version 1.0.138
2026-07-16 15:06:44 : INFO  : kiro : notifying
2026-07-16 15:06:45 : DEBUG : kiro : Unmounting /Volumes/Kiro 1
2026-07-16 15:06:45 : DEBUG : kiro : Debugging enabled, Unmounting output was:
"disk7" ejected.
2026-07-16 15:06:45 : DEBUG : kiro : DEBUG mode 1, not reopening anything
2026-07-16 15:06:45 : REQ   : kiro : All done!
2026-07-16 15:06:45 : REQ   : kiro : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
