### PR TITLE
Update joplin.sh

### DIFF
--- a/fragments/labels/joplin.sh
+++ b/fragments/labels/joplin.sh
@@ -1,12 +1,12 @@
 joplin)
     name="Joplin"
     type="dmg"
-	if [[ $(arch) == “arm64” ]]; then
-        archiveName="Joplin-[0-9.]*-arm64.DMG"
-    elif [[ $(arch) == “i386” ]]; then
-        archiveName="Joplin-[0-9.]*.dmg"
+    if [[ "$arch" == "arm64" ]]; then
+        archiveName="arm64.DMG"
+    elif [[ "$arch" == "i386" ]]; then
+        archiveName=".dmg"
     fi
-    downloadURL="$(downloadURLFromGit laurent22 joplin)"
-    appNewVersion="$(versionFromGit laurent22 joplin)"
+    downloadURL=$(downloadURLFromGit laurent22 joplin)
+    appNewVersion=$(versionFromGit laurent22 joplin)
     expectedTeamID="A9BXAFS6CT"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is an improvement because it replaces fragile and error-prone logic with a clean, native Installomator pattern that is easier to maintain and less likely to break across releases: it fixes shell parsing risk by using standard ASCII quoting and the normalized arch variable, uses architecture-specific asset filtering that matches Joplin’s actual GitHub release naming without overfitting to a full filename regex, keeps version and download resolution tied to Installomator’s GitHub helper functions, and retains the verified Team ID for signature enforcement; combined with the live validation you ran (non-empty version and URL, successful redirect resolution, mountable DMG payload, and matching Team ID), the result is more reliable for automated deployment and safer for long-term PR review.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh joplin DEBUG=1
2026-07-16 15:32:16 : INFO  : joplin : setting variable from argument DEBUG=1
2026-07-16 15:32:16 : INFO  : joplin : Total items in argumentsArray: 1
2026-07-16 15:32:16 : INFO  : joplin : argumentsArray: DEBUG=1
2026-07-16 15:32:16 : REQ   : joplin : ################## Start Installomator v. 10.10beta, date 2026-07-16
2026-07-16 15:32:16 : INFO  : joplin : ################## Version: 10.10beta
2026-07-16 15:32:16 : INFO  : joplin : ################## Date: 2026-07-16
2026-07-16 15:32:16 : INFO  : joplin : ################## joplin
2026-07-16 15:32:16 : DEBUG : joplin : DEBUG mode 1 enabled.
2026-07-16 15:32:18 : INFO  : joplin : Reading arguments again: DEBUG=1
2026-07-16 15:32:18 : DEBUG : joplin : argument: DEBUG=1
2026-07-16 15:32:18 : DEBUG : joplin : name=Joplin
2026-07-16 15:32:18 : DEBUG : joplin : appName=
2026-07-16 15:32:18 : DEBUG : joplin : type=dmg
2026-07-16 15:32:18 : DEBUG : joplin : archiveName=
2026-07-16 15:32:18 : DEBUG : joplin : downloadURL=https://github.com/laurent22/joplin/releases/download/v3.6.15/Joplin-3.6.15.dmg
2026-07-16 15:32:18 : DEBUG : joplin : curlOptions=
2026-07-16 15:32:18 : DEBUG : joplin : appNewVersion=3.6.15
2026-07-16 15:32:18 : DEBUG : joplin : appCustomVersion function: Not defined
2026-07-16 15:32:18 : DEBUG : joplin : versionKey=CFBundleShortVersionString
2026-07-16 15:32:18 : DEBUG : joplin : packageID=
2026-07-16 15:32:18 : DEBUG : joplin : pkgName=
2026-07-16 15:32:18 : DEBUG : joplin : choiceChangesXML=
2026-07-16 15:32:18 : DEBUG : joplin : expectedTeamID=A9BXAFS6CT
2026-07-16 15:32:18 : DEBUG : joplin : blockingProcesses=
2026-07-16 15:32:19 : DEBUG : joplin : installerTool=
2026-07-16 15:32:19 : DEBUG : joplin : CLIInstaller=
2026-07-16 15:32:19 : DEBUG : joplin : CLIArguments=
2026-07-16 15:32:19 : DEBUG : joplin : updateTool=
2026-07-16 15:32:19 : DEBUG : joplin : updateToolArguments=
2026-07-16 15:32:19 : DEBUG : joplin : updateToolRunAsCurrentUser=
2026-07-16 15:32:19 : INFO  : joplin : BLOCKING_PROCESS_ACTION=tell_user
2026-07-16 15:32:19 : INFO  : joplin : NOTIFY=success
2026-07-16 15:32:19 : INFO  : joplin : LOGGING=DEBUG
2026-07-16 15:32:19 : INFO  : joplin : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-16 15:32:19 : INFO  : joplin : Label type: dmg
2026-07-16 15:32:19 : INFO  : joplin : archiveName: Joplin.dmg
2026-07-16 15:32:19 : INFO  : joplin : no blocking processes defined, using Joplin as default
2026-07-16 15:32:19 : DEBUG : joplin : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-16 15:32:19 : INFO  : joplin : name: Joplin, appName: Joplin.app
2026-07-16 15:32:19 : WARN  : joplin : No previous app found
2026-07-16 15:32:19 : WARN  : joplin : could not find Joplin.app
2026-07-16 15:32:19 : INFO  : joplin : appversion: 
2026-07-16 15:32:19 : INFO  : joplin : Latest version of Joplin is 3.6.15
2026-07-16 15:32:19 : REQ   : joplin : Downloading https://github.com/laurent22/joplin/releases/download/v3.6.15/Joplin-3.6.15.dmg to Joplin.dmg
2026-07-16 15:32:19 : DEBUG : joplin : No Dialog connection, just download
2026-07-16 15:32:25 : INFO  : joplin : Downloaded Joplin.dmg – Type is  zlib compressed data – SHA is b302130c0d9e4a8db47f537ae5fb7ba48022091d – Size is 164524 kB
2026-07-16 15:32:25 : DEBUG : joplin : DEBUG mode 1, not checking for blocking processes
2026-07-16 15:32:25 : REQ   : joplin : Installing Joplin
2026-07-16 15:32:25 : INFO  : joplin : Mounting /Users/u0105821/git/github/Installomator/build/Joplin.dmg
2026-07-16 15:32:29 : DEBUG : joplin : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F797478D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1817FDCC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $47F72754
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $6342244E
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $47F72754
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $ADB011A8
verified   CRC32 $02A6C299
/dev/disk9          	GUID_partition_scheme
/dev/disk9s1        	Apple_HFS                      	/Volumes/Joplin 3.6.15

2026-07-16 15:32:29 : INFO  : joplin : Mounted: /Volumes/Joplin 3.6.15
2026-07-16 15:32:29 : INFO  : joplin : Verifying: /Volumes/Joplin 3.6.15/Joplin.app
2026-07-16 15:32:29 : DEBUG : joplin : App size: 386M	/Volumes/Joplin 3.6.15/Joplin.app
2026-07-16 15:32:31 : DEBUG : joplin : Debugging enabled, App Verification output was:
/Volumes/Joplin 3.6.15/Joplin.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Laurent Cozic (A9BXAFS6CT)

2026-07-16 15:32:31 : INFO  : joplin : Team ID matching: A9BXAFS6CT (expected: A9BXAFS6CT )
2026-07-16 15:32:31 : INFO  : joplin : Installing Joplin version 3.6.15 on versionKey CFBundleShortVersionString.
2026-07-16 15:32:31 : INFO  : joplin : App has LSMinimumSystemVersion: 12.0
2026-07-16 15:32:31 : DEBUG : joplin : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-16 15:32:31 : INFO  : joplin : Finishing...
2026-07-16 15:32:34 : INFO  : joplin : name: Joplin, appName: Joplin.app
2026-07-16 15:32:35 : WARN  : joplin : No previous app found
2026-07-16 15:32:35 : WARN  : joplin : could not find Joplin.app
2026-07-16 15:32:35 : REQ   : joplin : Installed Joplin, version 3.6.15
2026-07-16 15:32:35 : INFO  : joplin : notifying
2026-07-16 15:32:35 : DEBUG : joplin : Unmounting /Volumes/Joplin 3.6.15
2026-07-16 15:32:35 : DEBUG : joplin : Debugging enabled, Unmounting output was:
"disk9" ejected.
2026-07-16 15:32:35 : DEBUG : joplin : DEBUG mode 1, not reopening anything
2026-07-16 15:32:35 : REQ   : joplin : All done!
2026-07-16 15:32:35 : REQ   : joplin : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
