### PR TITLE
Update microsoftonedrivesuprod.sh

### DIFF
--- a/fragments/labels/microsoftonedrivesuprod.sh
+++ b/fragments/labels/microsoftonedrivesuprod.sh
@@ -3,8 +3,8 @@ microsoftonedrivesuprod)
     # Microsoft OneDrive StandaloneUpdater Production
     name="OneDrive"
     type="pkg"
-    onedriveFeed="https://g.live.com/0USSDMC_W5T/MacODSUProduction"
-    downloadURL="$(curl -fsL "${onedriveFeed}" | grep -A1 "UniversalPkgBinaryURL" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
-    appNewVersion="$(curl -fsL "${onedriveFeed}" | grep -A1 "CFBundleShortVersionString" | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)"
+    onedriveFeedData=$(curl -fsL "https://g.live.com/0USSDMC_W5T/StandaloneProductManifest" )
+    downloadURL=$(echo "$onedriveFeedData" | xmllint --xpath "string(/plist/dict/key[.='ManifestArray']/following-sibling::array[1]/dict[1]//string[contains(text(),'universal/OneDrive.pkg')])" -)
+    appNewVersion=$(echo "$onedriveFeedData" | xmllint --xpath "string(/plist/dict/key[.='ManifestArray']/following-sibling::array[1]/dict[1]/key[.='CFBundleShortVersionString']/following-sibling::string[1])" -)
     expectedTeamID="UBF8T346G9"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
The prod URL changed yet again. 

Yes, there are comments in the label. But since we have 6 different OneDrive labels, it feels like there needs to be something to differentiate them.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Fixes https://github.com/Installomator/Installomator/issues/3091



```
./utils/assemble.sh microsoftonedrivesuprod
2026-07-16 20:59:55 : INFO  : microsoftonedrivesuprod : Total items in argumentsArray: 0
2026-07-16 20:59:55 : INFO  : microsoftonedrivesuprod : argumentsArray: 
2026-07-16 20:59:55 : REQ   : microsoftonedrivesuprod : ################## Start Installomator v. 10.10beta, date 2026-07-16
2026-07-16 20:59:55 : INFO  : microsoftonedrivesuprod : ################## Version: 10.10beta
2026-07-16 20:59:55 : INFO  : microsoftonedrivesuprod : ################## Date: 2026-07-16
2026-07-16 20:59:55 : INFO  : microsoftonedrivesuprod : ################## microsoftonedrivesuprod
2026-07-16 20:59:55 : DEBUG : microsoftonedrivesuprod : DEBUG mode 1 enabled.
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : Reading arguments again: 
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : name=OneDrive
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : appName=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : type=pkg
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : archiveName=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : downloadURL=https://oneclient.sfx.ms/Mac/Installers/26.119.0622.0003/universal/OneDrive.pkg
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : curlOptions=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : appNewVersion=26.119.0622
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : appCustomVersion function: Not defined
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : versionKey=CFBundleShortVersionString
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : packageID=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : pkgName=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : choiceChangesXML=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : expectedTeamID=UBF8T346G9
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : blockingProcesses=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : installerTool=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : CLIInstaller=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : CLIArguments=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : updateTool=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : updateToolArguments=
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : updateToolRunAsCurrentUser=
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : BLOCKING_PROCESS_ACTION=tell_user
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : NOTIFY=success
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : LOGGING=DEBUG
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : Label type: pkg
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : archiveName: OneDrive.pkg
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : no blocking processes defined, using OneDrive as default
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : App(s) found: /Applications/OneDrive.app
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : found app at /Applications/OneDrive.app, version 26.119.0622, on versionKey CFBundleShortVersionString
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : appversion: 26.119.0622
2026-07-16 20:59:56 : INFO  : microsoftonedrivesuprod : Latest version of OneDrive is 26.119.0622
2026-07-16 20:59:56 : WARN  : microsoftonedrivesuprod : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-16 20:59:56 : REQ   : microsoftonedrivesuprod : Downloading https://oneclient.sfx.ms/Mac/Installers/26.119.0622.0003/universal/OneDrive.pkg to OneDrive.pkg
2026-07-16 20:59:56 : DEBUG : microsoftonedrivesuprod : No Dialog connection, just download
2026-07-16 21:00:44 : INFO  : microsoftonedrivesuprod : Downloaded OneDrive.pkg – Type is  xar archive compressed TOC – SHA is 3fe15d2e90479b9cf4c6b70ce0346092a5ac2201 – Size is 377004 kB
2026-07-16 21:00:44 : DEBUG : microsoftonedrivesuprod : DEBUG mode 1, not checking for blocking processes
2026-07-16 21:00:44 : REQ   : microsoftonedrivesuprod : Installing OneDrive
2026-07-16 21:00:44 : INFO  : microsoftonedrivesuprod : Verifying: OneDrive.pkg
2026-07-16 21:00:44 : DEBUG : microsoftonedrivesuprod : File list: -rw-r--r--  1 gilburns  staff   353M Jul 16 21:00 OneDrive.pkg
2026-07-16 21:00:44 : DEBUG : microsoftonedrivesuprod : File type: OneDrive.pkg: xar archive compressed TOC: 7239, SHA-1 checksum
2026-07-16 21:00:45 : DEBUG : microsoftonedrivesuprod : spctlOut is OneDrive.pkg: accepted
2026-07-16 21:00:45 : DEBUG : microsoftonedrivesuprod : source=Notarized Developer ID
2026-07-16 21:00:45 : DEBUG : microsoftonedrivesuprod : origin=Developer ID Installer: Microsoft Corporation (UBF8T346G9)
2026-07-16 21:00:45 : INFO  : microsoftonedrivesuprod : Team ID: UBF8T346G9 (expected: UBF8T346G9 )
2026-07-16 21:00:45 : DEBUG : microsoftonedrivesuprod : DEBUG enabled, skipping installation
2026-07-16 21:00:45 : INFO  : microsoftonedrivesuprod : Finishing...
2026-07-16 21:00:48 : INFO  : microsoftonedrivesuprod : App(s) found: /Applications/OneDrive.app
2026-07-16 21:00:48 : INFO  : microsoftonedrivesuprod : found app at /Applications/OneDrive.app, version 26.119.0622, on versionKey CFBundleShortVersionString
2026-07-16 21:00:48 : REQ   : microsoftonedrivesuprod : Installed OneDrive, version 26.119.0622
2026-07-16 21:00:48 : INFO  : microsoftonedrivesuprod : notifying
2026-07-16 21:00:48 : DEBUG : microsoftonedrivesuprod : DEBUG mode 1, not reopening anything
2026-07-16 21:00:48 : REQ   : microsoftonedrivesuprod : All done!
2026-07-16 21:00:48 : REQ   : microsoftonedrivesuprod : ################## End Installomator, exit code 0 

```