### PR TITLE
New label: Radix

### DIFF
--- a/fragments/labels/radix.sh
+++ b/fragments/labels/radix.sh
@@ -1,7 +1,6 @@
 radix)
     name="Radix"
     type="zip"
-    packageID="com.colinkim.Radix"
     versionKey="CFBundleShortVersionString"
     appNewVersion=$(versionFromGit colinvkim Radix)
     downloadURL=$(downloadURLFromGit colinvkim Radix)

--- a/fragments/labels/radix.sh
+++ b/fragments/labels/radix.sh
@@ -1,0 +1,9 @@
+radix)
+    name="Radix"
+    type="zip"
+    packageID="com.colinkim.Radix"
+    versionKey="CFBundleShortVersionString"
+    appNewVersion=$(versionFromGit colinvkim Radix)
+    downloadURL=$(downloadURLFromGit colinvkim Radix)
+    expectedTeamID="42MBX5D86L"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context**
Radix: A fast, native macOS disk space analyzer that makes crowded drives easy to understand.
[github.com/colinvkim/Radix](https://github.com/colinvkim/Radix)

**Installomator log** 
``` bash
2026-07-17 14:07:38 : INFO  : radix : Total items in argumentsArray: 0
2026-07-17 14:07:38 : INFO  : radix : argumentsArray:
2026-07-17 14:07:38 : REQ   : radix : ################## Start Installomator v. 10.10beta, date 2026-07-17
2026-07-17 14:07:38 : INFO  : radix : ################## Version: 10.10beta
2026-07-17 14:07:38 : INFO  : radix : ################## Date: 2026-07-17
2026-07-17 14:07:38 : INFO  : radix : ################## radix
2026-07-17 14:07:38 : DEBUG : radix : DEBUG mode 1 enabled.
2026-07-17 14:07:40 : INFO  : radix : Reading arguments again:
2026-07-17 14:07:40 : DEBUG : radix : name=Radix
2026-07-17 14:07:40 : DEBUG : radix : appName=
2026-07-17 14:07:40 : DEBUG : radix : type=zip
2026-07-17 14:07:40 : DEBUG : radix : archiveName=
2026-07-17 14:07:40 : DEBUG : radix : downloadURL=https://github.com/colinvkim/Radix/releases/download/v1.5.1/Radix.zip
2026-07-17 14:07:40 : DEBUG : radix : curlOptions=
2026-07-17 14:07:40 : DEBUG : radix : appNewVersion=1.5.1
2026-07-17 14:07:40 : DEBUG : radix : appCustomVersion function: Not defined
2026-07-17 14:07:40 : DEBUG : radix : versionKey=CFBundleShortVersionString
2026-07-17 14:07:40 : DEBUG : radix : packageID=com.colinkim.Radix
2026-07-17 14:07:40 : DEBUG : radix : pkgName=
2026-07-17 14:07:40 : DEBUG : radix : choiceChangesXML=
2026-07-17 14:07:40 : DEBUG : radix : expectedTeamID=42MBX5D86L
2026-07-17 14:07:40 : DEBUG : radix : blockingProcesses=
2026-07-17 14:07:40 : DEBUG : radix : installerTool=
2026-07-17 14:07:40 : DEBUG : radix : CLIInstaller=
2026-07-17 14:07:40 : DEBUG : radix : CLIArguments=
2026-07-17 14:07:40 : DEBUG : radix : updateTool=
2026-07-17 14:07:40 : DEBUG : radix : updateToolArguments=
2026-07-17 14:07:40 : DEBUG : radix : updateToolRunAsCurrentUser=
2026-07-17 14:07:40 : INFO  : radix : BLOCKING_PROCESS_ACTION=tell_user
2026-07-17 14:07:40 : INFO  : radix : NOTIFY=success
2026-07-17 14:07:40 : INFO  : radix : LOGGING=DEBUG
2026-07-17 14:07:40 : INFO  : radix : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-17 14:07:40 : INFO  : radix : Label type: zip
2026-07-17 14:07:40 : INFO  : radix : archiveName: Radix.zip
2026-07-17 14:07:40 : INFO  : radix : no blocking processes defined, using Radix as default
2026-07-17 14:07:40 : DEBUG : radix : Changing directory to Build
2026-07-17 14:07:40 : INFO  : radix : No version found using packageID com.colinkim.Radix
2026-07-17 14:07:40 : INFO  : radix : App(s) found: /Applications/Radix.app
2026-07-17 14:07:40 : INFO  : radix : found app at /Applications/Radix.app, version 1.5.1, on versionKey CFBundleShortVersionString
2026-07-17 14:07:40 : INFO  : radix : appversion: 1.5.1
2026-07-17 14:07:40 : INFO  : radix : Latest version of Radix is 1.5.1
2026-07-17 14:07:40 : WARN  : radix : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-17 14:07:40 : REQ   : radix : Downloading https://github.com/colinvkim/Radix/releases/download/v1.5.1/Radix.zip to Radix.zip
2026-07-17 14:07:40 : DEBUG : radix : No Dialog connection, just download
2026-07-17 14:07:40 : INFO  : radix : Downloaded Radix.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 84eafa0b16a5a778d8930a766b754ad358fcbf78 – Size is 6460 kB
2026-07-17 14:07:40 : DEBUG : radix : DEBUG mode 1, not checking for blocking processes
2026-07-17 14:07:40 : REQ   : radix : Installing Radix
2026-07-17 14:07:40 : INFO  : radix : Unzipping Radix.zip
2026-07-17 14:07:40 : INFO  : radix : Verifying: Build/Radix.app
2026-07-17 14:07:40 : DEBUG : radix : App size:  13M    Build/Radix.app
2026-07-17 14:07:41 : DEBUG : radix : Debugging enabled, App Verification output was:
Build/Radix.app: accepted
source=Notarized Developer ID
override=security disabled
origin=Developer ID Application: BONNIE MAURENE WONGTRAKOOL (42MBX5D86L)

2026-07-17 14:07:41 : INFO  : radix : Team ID matching: 42MBX5D86L (expected: 42MBX5D86L )
Error: Domain 'Build/Radix.app/Contents/Info.plist' not found.
2026-07-17 14:07:41 : INFO  : radix : Downloaded version of Radix is  on versionKey CFBundleShortVersionString (replacing version 1.5.1).
2026-07-17 14:07:41 : DEBUG : radix : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-17 14:07:41 : INFO  : radix : Finishing...
2026-07-17 14:07:44 : INFO  : radix : No version found using packageID com.colinkim.Radix
2026-07-17 14:07:44 : INFO  : radix : App(s) found: /Applications/Radix.app
2026-07-17 14:07:44 : INFO  : radix : found app at /Applications/Radix.app, version 1.5.1, on versionKey CFBundleShortVersionString
2026-07-17 14:07:44 : REQ   : radix : Installed Radix
2026-07-17 14:07:44 : INFO  : radix : notifying
2026-07-17 14:07:44 : DEBUG : radix : DEBUG mode 1, not reopening anything
2026-07-17 14:07:44 : REQ   : radix : All done!
2026-07-17 14:07:44 : REQ   : radix : ################## End Installomator, exit code 0
```