### PR TITLE
ChatGPT: Point label at unified ChatGPT app

### DIFF
--- a/fragments/labels/chatgpt.sh
+++ b/fragments/labels/chatgpt.sh
@@ -2,10 +2,10 @@ chatgpt)
     name="ChatGPT"
     type="dmg"
     if [[ $(arch) == arm64 ]]; then
-        downloadURL="https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_latest.dmg"
+        downloadURL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
     else
         cleanupandexit 2 "No Intel-compatible download URL found. $appLabel is not Intel-compatible. Could not install app." ERROR
     fi
-    appNewVersion="$(curl -fs "https://persistent.oaistatic.com/sidekick/public/sparkle_public_appcast.xml" | xpath '(//rss/channel/item/title)[1]/text()' 2>/dev/null)"
+    appNewVersion="$(curl -fs "https://persistent.oaistatic.com/codex-app-prod/appcast.xml" | xpath '(//rss/channel/item/title)[1]/text()' 2>/dev/null)"
     expectedTeamID="2DC432GLL2"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Label - It modifies `fragments/labels/chatgpt.sh` only.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes. Only the two URL string values changed; no reformatting.

**Additional context**

OpenAI merged Codex, ChatGPT, and ChatGPT Work into a single `ChatGPT.app`. The `sidekick` endpoints this label used now serve **"ChatGPT Classic"** - the appcast channel title is literally `ChatGPT Classic` and its enclosure is `ChatGPT_Classic.pkg` - so `downloadURL` and `appNewVersion` were pointing at the wrong app.

This points them at the unified app, which OpenAI now distributes from the `codex-app-prod` bucket:

- `downloadURL`: `https://persistent.oaistatic.com/codex-app-prod/Codex.dmg`
- `appNewVersion`: `https://persistent.oaistatic.com/codex-app-prod/appcast.xml`

`Codex.dmg` now contains `ChatGPT.app`, and `appNewVersion` parses to the same version reported for the installed app. `expectedTeamID` `2DC432GLL2` is unchanged and the app is still arm64-only, so the existing Intel guard is kept.

I would like to suggest the old `codex` label be removed entirely, but did not stage that in this PR.

**Installomator log**

```
2026-07-17 14:04:52 : INFO  : chatgpt : ################## chatgpt
2026-07-17 14:04:52 : DEBUG : chatgpt : DEBUG mode 1 enabled.
2026-07-17 14:04:52 : DEBUG : chatgpt : name=ChatGPT
2026-07-17 14:04:52 : DEBUG : chatgpt : type=dmg
2026-07-17 14:04:52 : DEBUG : chatgpt : downloadURL=https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
2026-07-17 14:04:52 : DEBUG : chatgpt : appNewVersion=26.715.21425
2026-07-17 14:04:52 : DEBUG : chatgpt : versionKey=CFBundleShortVersionString
2026-07-17 14:04:52 : DEBUG : chatgpt : expectedTeamID=2DC432GLL2
2026-07-17 14:04:53 : INFO  : chatgpt : Label type: dmg
2026-07-17 14:04:53 : INFO  : chatgpt : name: ChatGPT, appName: ChatGPT.app
2026-07-17 14:04:53 : INFO  : chatgpt : Latest version of ChatGPT is 26.715.21425
2026-07-17 14:04:53 : REQ   : chatgpt : Downloading https://persistent.oaistatic.com/codex-app-prod/Codex.dmg to ChatGPT.dmg
2026-07-17 14:04:59 : INFO  : chatgpt : Downloaded ChatGPT.dmg – Type is  zlib compressed data – SHA is 1ec701aaccaf4b4e348aaf5d9242179c46d950b1 – Size is 604740 kB
2026-07-17 14:04:59 : REQ   : chatgpt : Installing ChatGPT
2026-07-17 14:04:59 : INFO  : chatgpt : Mounting /Users/dustin/code/Installomator/build/ChatGPT.dmg
2026-07-17 14:05:04 : INFO  : chatgpt : Mounted: /Volumes/ChatGPT Installer
2026-07-17 14:05:04 : INFO  : chatgpt : Verifying: /Volumes/ChatGPT Installer/ChatGPT.app
2026-07-17 14:05:08 : DEBUG : chatgpt : Debugging enabled, App Verification output was:
/Volumes/ChatGPT Installer/ChatGPT.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)
2026-07-17 14:05:08 : INFO  : chatgpt : Team ID matching: 2DC432GLL2 (expected: 2DC432GLL2 )
2026-07-17 14:05:08 : INFO  : chatgpt : Installing ChatGPT version 26.715.21425 on versionKey CFBundleShortVersionString.
2026-07-17 14:05:08 : INFO  : chatgpt : App has LSMinimumSystemVersion: 12.0
2026-07-17 14:05:08 : DEBUG : chatgpt : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-17 14:05:11 : REQ   : chatgpt : Installed ChatGPT, version 26.715.21425
2026-07-17 14:05:12 : REQ   : chatgpt : All done!
2026-07-17 14:05:12 : REQ   : chatgpt : ################## End Installomator, exit code 0
```
