### PR TITLE
Fixed sqldeveloper.sh

### DIFF
--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -1,7 +1,4 @@
-sqldeveloper|\
-oraclesqldeveloper)
-    # This label does not support killing blocking processes
-    # The name of the process that needs to be killed is 'java'. Killing that may have unintended consequences.
+sqldeveloper|oraclesqldeveloper)
     name="SQLDeveloper"
     type="zip"
     if [[ "$(arch)" == "arm64" ]]; then
@@ -10,9 +7,7 @@ oraclesqldeveloper)
         printlog "Oracle SQL Developer is only available for Apple Silicon (arm64) Macs." ERROR
         cleanupAndExit 95 "Oracle SQL Developer requires Apple Silicon" ERROR
     fi
-    # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The 5 dot-separated version number form the downloadURL is truncated to be comparable with CFBundleVersion.
     versionKey="CFBundleVersion"
     appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}' | cut -d . -f 1-4)
     expectedTeamID="VB5E2TV963"
-    blockingProcesses=( NONE )
     ;;

--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -4,16 +4,15 @@ oraclesqldeveloper)
     # The name of the process that needs to be killed is 'java'. Killing that may have unintended consequences.
     name="SQLDeveloper"
     type="zip"
-    if [[ "$(arch)" == "i386" ]]; then
-        cleanupAndExit 33 "Oracle SQL Developer is not longer available for x64 architecture" ERROR
+    if [[ "$(arch)" == "arm64" ]]; then
+        downloadURL=$(curl -fsL https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -Eo 'https://download\.oracle\.com/otn_software/java/sqldeveloper/sqldeveloper-[0-9\.]*-macos-aarch64\.app\.zip' | head -1)
+    else
+        printlog "Oracle SQL Developer is only available for Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Oracle SQL Developer requires Apple Silicon" ERROR
     fi
-    downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -o 'https://download\.oracle\.com/otn_software/java/sqldeveloper/sqldeveloper-[0-9\.]*-macos-aarch64\.app\.zip')
-    # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The custom version gives 5 numbers and matches the version in downloadURL.
-    appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}')
+    # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The 5 dot-separated version number form the downloadURL is truncated to be comparable with CFBundleVersion.
     versionKey="CFBundleVersion"
-    appCustomVersion() {
-        sql_version_file="/Applications/SQLDeveloper.app/Contents/Resources/sqldeveloper/sqldeveloper/bin/version.properties"
-        [[ -f "${sql_version_file}" ]] && /usr/bin/grep VER_FULL "${sql_version_file}" | /usr/bin/cut -d = -f 2
-    }
+    appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}' | cut -d . -f 1-4)
     expectedTeamID="VB5E2TV963"
+    blockingProcesses=( NONE )
     ;;

--- a/fragments/labels/sqldeveloper.sh
+++ b/fragments/labels/sqldeveloper.sh
@@ -4,10 +4,10 @@ oraclesqldeveloper)
     # The name of the process that needs to be killed is 'java'. Killing that may have unintended consequences.
     name="SQLDeveloper"
     type="zip"
-    downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -o 'https://download\.oracle\.com[^"]*macos-x64\.app\.zip')
-    if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL=$(echo "$downloadURL" | sed 's/x64/aarch64/')
+    if [[ "$(arch)" == "i386" ]]; then
+        cleanupAndExit 33 "Oracle SQL Developer is not longer available for x64 architecture" ERROR
     fi
+    downloadURL=$(curl -fs https://www.oracle.com/database/sqldeveloper/technologies/download/ | grep -o 'https://download\.oracle\.com/otn_software/java/sqldeveloper/sqldeveloper-[0-9\.]*-macos-aarch64\.app\.zip')
     # CFBundleShortVersionString does not exist. CFBundleVersion gives 4 dot-separated numbers. The custom version gives 5 numbers and matches the version in downloadURL.
     appNewVersion=$(echo "$downloadURL" | awk -F - '{print $2}')
     versionKey="CFBundleVersion"


### PR DESCRIPTION
1. Updated the downloadURL to match the new URL pattern.
2. Added cleanupAndExit for Intel, since it is no longer supported and there is no download available

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context**
I'm not sure how to handle missing x64 support. My guess was to '''cleanupAndExit''' Intel arch is detected.

**Installomator log** 
```2026-07-20 17:59:26 : INFO  : oraclesqldeveloper : Total items in argumentsArray: 0
2026-07-20 17:59:26 : INFO  : oraclesqldeveloper : argumentsArray: 
2026-07-20 17:59:26 : REQ   : oraclesqldeveloper : ################## Start Installomator v. 10.10beta, date 2026-07-20
2026-07-20 17:59:26 : INFO  : oraclesqldeveloper : ################## Version: 10.10beta
2026-07-20 17:59:26 : INFO  : oraclesqldeveloper : ################## Date: 2026-07-20
2026-07-20 17:59:26 : INFO  : oraclesqldeveloper : ################## oraclesqldeveloper
2026-07-20 17:59:26 : DEBUG : oraclesqldeveloper : DEBUG mode 1 enabled.
2026-07-20 17:59:27 : INFO  : oraclesqldeveloper : Reading arguments again: 
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : name=SQLDeveloper
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : appName=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : type=zip
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : archiveName=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : downloadURL=https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-26.2.0.186.2220-macos-aarch64.app.zip
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : curlOptions=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : appNewVersion=26.2.0.186.2220
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : appCustomVersion function: Defined. 
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : versionKey=CFBundleVersion
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : packageID=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : pkgName=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : choiceChangesXML=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : expectedTeamID=VB5E2TV963
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : blockingProcesses=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : installerTool=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : CLIInstaller=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : CLIArguments=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : updateTool=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : updateToolArguments=
2026-07-20 17:59:27 : DEBUG : oraclesqldeveloper : updateToolRunAsCurrentUser=
2026-07-20 17:59:27 : INFO  : oraclesqldeveloper : BLOCKING_PROCESS_ACTION=tell_user
2026-07-20 17:59:27 : INFO  : oraclesqldeveloper : NOTIFY=success
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : LOGGING=DEBUG
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : Label type: zip
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : archiveName: SQLDeveloper.zip
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : no blocking processes defined, using SQLDeveloper as default
2026-07-20 17:59:28 : DEBUG : oraclesqldeveloper : Changing directory to .
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : Custom App Version detection is used, found 26.2.0.186.2220
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : appversion: 26.2.0.186.2220
2026-07-20 17:59:28 : INFO  : oraclesqldeveloper : Latest version of SQLDeveloper is 26.2.0.186.2220
2026-07-20 17:59:28 : WARN  : oraclesqldeveloper : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-20 17:59:28 : REQ   : oraclesqldeveloper : Downloading https://download.oracle.com/otn_software/java/sqldeveloper/sqldeveloper-26.2.0.186.2220-macos-aarch64.app.zip to SQLDeveloper.zip
2026-07-20 17:59:28 : DEBUG : oraclesqldeveloper : No Dialog connection, just download
2026-07-20 17:59:48 : INFO  : oraclesqldeveloper : Downloaded SQLDeveloper.zip – Type is  Zip archive data, at least v1.0 to extract, compression method=store – SHA is 12c2fc29eb6fe44c5567a183001d7d8fafdd5f42 – Size is 442888 kB
2026-07-20 17:59:48 : DEBUG : oraclesqldeveloper : DEBUG mode 1, not checking for blocking processes
2026-07-20 17:59:48 : REQ   : oraclesqldeveloper : Installing SQLDeveloper
2026-07-20 17:59:48 : INFO  : oraclesqldeveloper : Unzipping SQLDeveloper.zip
2026-07-20 17:59:51 : INFO  : oraclesqldeveloper : Verifying: ./SQLDeveloper.app
2026-07-20 17:59:51 : DEBUG : oraclesqldeveloper : App size: 658M	./SQLDeveloper.app
2026-07-20 17:59:52 : DEBUG : oraclesqldeveloper : Debugging enabled, App Verification output was:
./SQLDeveloper.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Oracle America, Inc. (VB5E2TV963)

2026-07-20 17:59:52 : INFO  : oraclesqldeveloper : Team ID matching: VB5E2TV963 (expected: VB5E2TV963 )
2026-07-20 17:59:52 : INFO  : oraclesqldeveloper : Downloaded version of SQLDeveloper is  on versionKey CFBundleVersion (replacing version 26.2.0.186.2220).
2026-07-20 17:59:52 : DEBUG : oraclesqldeveloper : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-20 17:59:52 : INFO  : oraclesqldeveloper : Finishing...
2026-07-20 17:59:55 : INFO  : oraclesqldeveloper : Custom App Version detection is used, found 26.2.0.186.2220
2026-07-20 17:59:55 : REQ   : oraclesqldeveloper : Installed SQLDeveloper
2026-07-20 17:59:55 : INFO  : oraclesqldeveloper : notifying
2026-07-20 17:59:55 : DEBUG : oraclesqldeveloper : DEBUG mode 1, not reopening anything
2026-07-20 17:59:56 : REQ   : oraclesqldeveloper : All done!
2026-07-20 17:59:56 : REQ   : oraclesqldeveloper : ################## End Installomator, exit code 0 
```

Fixes #3114
