### PR TITLE
bitfocuscompanion-new-label

### DIFF
--- a/fragments/labels/bitfocuscompanion.sh
+++ b/fragments/labels/bitfocuscompanion.sh
@@ -1,0 +1,12 @@
+bitfocuscompanion)
+    name="Companion"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(curl -fsL "https://api.bitfocus.io/v1/product/companion/packages?branch=stable&limit=5" | grep -o 'https://cf-pub.bitfocus.io/[^"]*' | grep 'mac-arm64' | head -1)
+        appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*-mac-arm64-([0-9.]+)-.*/\1/')
+    elif [[ $(arch) == "i386" ]]; then
+        downloadURL=$(curl -fsL "https://api.bitfocus.io/v1/product/companion/packages?branch=stable&limit=5" | grep -o 'https://cf-pub.bitfocus.io/[^"]*' | grep 'mac-x64' | head -1)
+        appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*-mac-x64-([0-9.]+)-.*/\1/')
+    fi
+    expectedTeamID="FGQ2G3HYBT"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Added a new label for [Bitfocus Companion](https://bitfocus.io/companion) (bitfocuscompanion).

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
```
026-07-20 17:21:52 : INFO  : bitfocuscompanion : setting variable from argument DEBUG=1
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : Total items in argumentsArray: 1
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : argumentsArray: DEBUG=1
2026-07-20 17:21:52 : REQ   : bitfocuscompanion : ################## Start Installomator v. 10.10beta, date 2026-07-20
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : ################## Version: 10.10beta
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : ################## Date: 2026-07-20
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : ################## bitfocuscompanion
2026-07-20 17:21:52 : DEBUG : bitfocuscompanion : DEBUG mode 1 enabled.
2026-07-20 17:21:52 : INFO  : bitfocuscompanion : SwiftDialog is not installed, clear cmd file var
2026-07-20 17:21:53 : INFO  : bitfocuscompanion : Reading arguments again: DEBUG=1
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : argument: DEBUG=1
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : name=Companion
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : appName=
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : type=dmg
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : archiveName=
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : downloadURL=https://cf-pub.bitfocus.io/companion/companion/companion-mac-arm64-5.0.2-9665-stable-5eb89669c6.dmg
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : curlOptions=
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : appNewVersion=5.0.2
2026-07-20 17:21:53 : DEBUG : bitfocuscompanion : appCustomVersion function: Not defined
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : versionKey=CFBundleShortVersionString
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : packageID=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : pkgName=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : choiceChangesXML=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : expectedTeamID=FGQ2G3HYBT
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : blockingProcesses=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : installerTool=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : CLIInstaller=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : CLIArguments=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : updateTool=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : updateToolArguments=
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : updateToolRunAsCurrentUser=
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : BLOCKING_PROCESS_ACTION=tell_user
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : NOTIFY=success
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : LOGGING=DEBUG
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : Label type: dmg
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : archiveName: Companion.dmg
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : no blocking processes defined, using Companion as default
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : Changing directory to /Users/theo/Downloads/Installomator/build
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : name: Companion, appName: Companion.app
2026-07-20 17:21:54 : WARN  : bitfocuscompanion : No previous app found
2026-07-20 17:21:54 : WARN  : bitfocuscompanion : could not find Companion.app
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : appversion: 
2026-07-20 17:21:54 : INFO  : bitfocuscompanion : Latest version of Companion is 5.0.2
2026-07-20 17:21:54 : REQ   : bitfocuscompanion : Downloading https://cf-pub.bitfocus.io/companion/companion/companion-mac-arm64-5.0.2-9665-stable-5eb89669c6.dmg to Companion.dmg
2026-07-20 17:21:54 : DEBUG : bitfocuscompanion : No Dialog connection, just download
2026-07-20 17:22:11 : INFO  : bitfocuscompanion : Downloaded Companion.dmg – Type is  zlib compressed data – SHA is 1cb8604d7b7eae26b9c544d723f6c1c09e6c210d – Size is 360552 kB
2026-07-20 17:22:11 : DEBUG : bitfocuscompanion : DEBUG mode 1, not checking for blocking processes
2026-07-20 17:22:11 : REQ   : bitfocuscompanion : Installing Companion
2026-07-20 17:22:11 : INFO  : bitfocuscompanion : Mounting /Users/theo/Downloads/Installomator/build/Companion.dmg
2026-07-20 17:22:14 : DEBUG : bitfocuscompanion : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A0BDFF98
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9B768561
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $EFA83396
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $AB095E16
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $EFA83396
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $55BE6A83
verified   CRC32 $AF0619F6
/dev/disk5              GUID_partition_scheme
/dev/disk5s1            Apple_HFS                       /Volumes/Companion 5.0.2-arm64 1

2026-07-20 17:22:14 : INFO  : bitfocuscompanion : Mounted: /Volumes/Companion 5.0.2-arm64 1
2026-07-20 17:22:14 : INFO  : bitfocuscompanion : Verifying: /Volumes/Companion 5.0.2-arm64 1/Companion.app
2026-07-20 17:22:14 : DEBUG : bitfocuscompanion : App size: 838M        /Volumes/Companion 5.0.2-arm64 1/Companion.app
2026-07-20 17:22:16 : DEBUG : bitfocuscompanion : Debugging enabled, App Verification output was:
/Volumes/Companion 5.0.2-arm64 1/Companion.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bitfocus AS (FGQ2G3HYBT)

2026-07-20 17:22:16 : INFO  : bitfocuscompanion : Team ID matching: FGQ2G3HYBT (expected: FGQ2G3HYBT )
2026-07-20 17:22:16 : INFO  : bitfocuscompanion : Installing Companion version 5.0.2 on versionKey CFBundleShortVersionString.
2026-07-20 17:22:16 : INFO  : bitfocuscompanion : App has LSMinimumSystemVersion: 12.0
2026-07-20 17:22:16 : DEBUG : bitfocuscompanion : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-20 17:22:16 : INFO  : bitfocuscompanion : Finishing...
2026-07-20 17:22:19 : INFO  : bitfocuscompanion : name: Companion, appName: Companion.app
2026-07-20 17:22:20 : WARN  : bitfocuscompanion : No previous app found
2026-07-20 17:22:20 : WARN  : bitfocuscompanion : could not find Companion.app
2026-07-20 17:22:20 : REQ   : bitfocuscompanion : Installed Companion, version 5.0.2
2026-07-20 17:22:20 : INFO  : bitfocuscompanion : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-07-20 17:22:20 : DEBUG : bitfocuscompanion : Unmounting /Volumes/Companion 5.0.2-arm64 1
2026-07-20 17:22:21 : DEBUG : bitfocuscompanion : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-07-20 17:22:21 : DEBUG : bitfocuscompanion : DEBUG mode 1, not reopening anything
2026-07-20 17:22:21 : REQ   : bitfocuscompanion : All done!
2026-07-20 17:22:21 : REQ   : bitfocuscompanion : ################## End Installomator, exit code 0
```