### PR TITLE
New label: Markdown Preview

### DIFF
--- a/fragments/labels/markdown-preview.sh
+++ b/fragments/labels/markdown-preview.sh
@@ -1,8 +1,0 @@
-markdown-preview)
-    name="Markdown Preview"
-    type="dmg"
-    downloadURL=$(downloadURLFromGit "pluk-inc" "markdown-preview")
-    appNewVersion=$(versionFromGit "pluk-inc" "markdown-preview")
-    archiveName="Markdown-Preview.dmg"
-    expectedTeamID="5P3TSMNV42"
-    ;;

--- a/fragments/labels/markdown-preview.sh
+++ b/fragments/labels/markdown-preview.sh
@@ -3,5 +3,6 @@ markdown-preview)
     type="dmg"
     downloadURL=$(downloadURLFromGit "pluk-inc" "markdown-preview")
     appNewVersion=$(versionFromGit "pluk-inc" "markdown-preview")
+    archiveName="Markdown-Preview.dmg"
     expectedTeamID="5P3TSMNV42"
     ;;

--- a/fragments/labels/markdown-preview.sh
+++ b/fragments/labels/markdown-preview.sh
@@ -1,7 +1,7 @@
 markdown-preview)
     name="Markdown Preview"
     type="dmg"
-    downloadURL="https://github.com/pluk-inc/markdown-preview/releases/latest/download/Markdown-Preview.dmg"
+    downloadURL=$(downloadURLFromGit "pluk-inc" "markdown-preview")
     appNewVersion=$(versionFromGit "pluk-inc" "markdown-preview")
     expectedTeamID="5P3TSMNV42"
     ;;

--- a/fragments/labels/markdown-preview.sh
+++ b/fragments/labels/markdown-preview.sh
@@ -1,0 +1,7 @@
+markdown-preview)
+    name="Markdown Preview"
+    type="dmg"
+    downloadURL="https://github.com/pluk-inc/markdown-preview/releases/latest/download/Markdown-Preview.dmg"
+    appNewVersion=$(versionFromGit "pluk-inc" "markdown-preview")
+    expectedTeamID="5P3TSMNV42"
+    ;;

--- a/fragments/labels/markdownpreview.sh
+++ b/fragments/labels/markdownpreview.sh
@@ -1,0 +1,8 @@
+markdownpreview)
+    name="Markdown Preview"
+    type="dmg"
+    downloadURL=$(downloadURLFromGit "pluk-inc" "markdown-preview")
+    appNewVersion=$(versionFromGit "pluk-inc" "markdown-preview")
+    archiveName="Markdown-Preview.dmg"
+    expectedTeamID="5P3TSMNV42"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context**

This will add [Markdown Preview](http://markdownpreview.app/), a simple Markdown viewer for reading .md files.

Installs a universal binary:

```
❯ file /Applications/Markdown\ Preview.app/Contents/MacOS/Markdown\ Preview
/Applications/Markdown Preview.app/Contents/MacOS/Markdown Preview: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/Applications/Markdown Preview.app/Contents/MacOS/Markdown Preview (for architecture x86_64):	Mach-O 64-bit executable x86_64
/Applications/Markdown Preview.app/Contents/MacOS/Markdown Preview (for architecture arm64):	Mach-O 64-bit executable arm64
```

**Installomator log** 

```
❯ sudo utils/assemble.sh markdown-preview DEBUG=1
2026-07-22 08:54:20 : INFO  : markdown-preview : setting variable from argument DEBUG=1
2026-07-22 08:54:20 : INFO  : markdown-preview : Total items in argumentsArray: 1
2026-07-22 08:54:20 : INFO  : markdown-preview : argumentsArray: DEBUG=1
2026-07-22 08:54:20 : REQ   : markdown-preview : ################## Start Installomator v. 10.10beta, date 2026-07-22
2026-07-22 08:54:20 : INFO  : markdown-preview : ################## Version: 10.10beta
2026-07-22 08:54:20 : INFO  : markdown-preview : ################## Date: 2026-07-22
2026-07-22 08:54:20 : INFO  : markdown-preview : ################## markdown-preview
2026-07-22 08:54:20 : DEBUG : markdown-preview : DEBUG mode 1 enabled.
2026-07-22 08:54:21 : INFO  : markdown-preview : Reading arguments again: DEBUG=1
2026-07-22 08:54:21 : DEBUG : markdown-preview : argument: DEBUG=1
2026-07-22 08:54:21 : DEBUG : markdown-preview : name=Markdown Preview
2026-07-22 08:54:21 : DEBUG : markdown-preview : appName=
2026-07-22 08:54:21 : DEBUG : markdown-preview : type=dmg
2026-07-22 08:54:21 : DEBUG : markdown-preview : archiveName=Markdown-Preview.dmg
2026-07-22 08:54:21 : DEBUG : markdown-preview : downloadURL=https://github.com/pluk-inc/markdown-preview/releases/download/v0.0.39/Markdown-Preview.dmg
2026-07-22 08:54:21 : DEBUG : markdown-preview : curlOptions=
2026-07-22 08:54:21 : DEBUG : markdown-preview : appNewVersion=0.0.39
2026-07-22 08:54:21 : DEBUG : markdown-preview : appCustomVersion function: Not defined
2026-07-22 08:54:21 : DEBUG : markdown-preview : versionKey=CFBundleShortVersionString
2026-07-22 08:54:21 : DEBUG : markdown-preview : packageID=
2026-07-22 08:54:22 : DEBUG : markdown-preview : pkgName=
2026-07-22 08:54:22 : DEBUG : markdown-preview : choiceChangesXML=
2026-07-22 08:54:22 : DEBUG : markdown-preview : expectedTeamID=5P3TSMNV42
2026-07-22 08:54:22 : DEBUG : markdown-preview : blockingProcesses=
2026-07-22 08:54:22 : DEBUG : markdown-preview : installerTool=
2026-07-22 08:54:22 : DEBUG : markdown-preview : CLIInstaller=
2026-07-22 08:54:22 : DEBUG : markdown-preview : CLIArguments=
2026-07-22 08:54:22 : DEBUG : markdown-preview : updateTool=
2026-07-22 08:54:22 : DEBUG : markdown-preview : updateToolArguments=
2026-07-22 08:54:22 : DEBUG : markdown-preview : updateToolRunAsCurrentUser=
2026-07-22 08:54:22 : INFO  : markdown-preview : BLOCKING_PROCESS_ACTION=tell_user
2026-07-22 08:54:22 : INFO  : markdown-preview : NOTIFY=success
2026-07-22 08:54:22 : INFO  : markdown-preview : LOGGING=DEBUG
2026-07-22 08:54:22 : INFO  : markdown-preview : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-22 08:54:22 : INFO  : markdown-preview : Label type: dmg
2026-07-22 08:54:22 : INFO  : markdown-preview : archiveName: Markdown-Preview.dmg
2026-07-22 08:54:22 : INFO  : markdown-preview : no blocking processes defined, using Markdown Preview as default
2026-07-22 08:54:22 : DEBUG : markdown-preview : Changing directory to /Users/hbokh/Projects/Apple/Github/Installomator/build
2026-07-22 08:54:22 : INFO  : markdown-preview : App(s) found: /Applications/Markdown Preview.app
2026-07-22 08:54:22 : INFO  : markdown-preview : found app at /Applications/Markdown Preview.app, version 0.0.39, on versionKey CFBundleShortVersionString
2026-07-22 08:54:22 : INFO  : markdown-preview : appversion: 0.0.39
2026-07-22 08:54:22 : INFO  : markdown-preview : Latest version of Markdown Preview is 0.0.39
2026-07-22 08:54:22 : WARN  : markdown-preview : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-07-22 08:54:22 : REQ   : markdown-preview : Downloading https://github.com/pluk-inc/markdown-preview/releases/download/v0.0.39/Markdown-Preview.dmg to Markdown-Preview.dmg
2026-07-22 08:54:22 : DEBUG : markdown-preview : No Dialog connection, just download
2026-07-22 08:54:24 : INFO  : markdown-preview : Downloaded Markdown-Preview.dmg – Type is  XZ compressed data, checksum NONE – SHA is 8c3b54f827bb9600791286ce6df50750b8130eea – Size is 8844 kB
2026-07-22 08:54:24 : DEBUG : markdown-preview : DEBUG mode 1, not checking for blocking processes
2026-07-22 08:54:24 : REQ   : markdown-preview : Installing Markdown Preview
2026-07-22 08:54:24 : INFO  : markdown-preview : Mounting /Users/hbokh/Projects/Apple/Github/Installomator/build/Markdown-Preview.dmg
2026-07-22 08:54:25 : DEBUG : markdown-preview : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $1A9C7719
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified CRC32 $1551F357
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $EDC95FED
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified CRC32 $9EDAC034
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $EDC95FED
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified CRC32 $86A2B3DD
verified CRC32 $FBC1B64E
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_APFS
/dev/disk7          	EF57347C-0000-11AA-AA11-0030654
/dev/disk7s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Markdown Preview

2026-07-22 08:54:25 : INFO  : markdown-preview : Mounted: /Volumes/Markdown Preview
2026-07-22 08:54:25 : INFO  : markdown-preview : Verifying: /Volumes/Markdown Preview/Markdown Preview.app
2026-07-22 08:54:25 : DEBUG : markdown-preview : App size:  23M	/Volumes/Markdown Preview/Markdown Preview.app
2026-07-22 08:54:26 : DEBUG : markdown-preview : Debugging enabled, App Verification output was:
/Volumes/Markdown Preview/Markdown Preview.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mohamed Fauzaan (5P3TSMNV42)

2026-07-22 08:54:26 : INFO  : markdown-preview : Team ID matching: 5P3TSMNV42 (expected: 5P3TSMNV42 )
2026-07-22 08:54:26 : INFO  : markdown-preview : Downloaded version of Markdown Preview is 0.0.39 on versionKey CFBundleShortVersionString, same as installed.
2026-07-22 08:54:26 : DEBUG : markdown-preview : Unmounting /Volumes/Markdown Preview
2026-07-22 08:54:26 : DEBUG : markdown-preview : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-07-22 08:54:26 : DEBUG : markdown-preview : DEBUG mode 1, not reopening anything
2026-07-22 08:54:26 : REG   : markdown-preview : No new version to install
2026-07-22 08:54:26 : REQ   : markdown-preview : ################## End Installomator, exit code 0
```