### PR TITLE
opencodedesktop-new-label

### DIFF
--- a/fragments/labels/opencodedesktop.sh
+++ b/fragments/labels/opencodedesktop.sh
@@ -1,0 +1,12 @@
+opencodedesktop)
+    name="OpenCode"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="mac-arm64\.dmg$"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="mac-x64\.dmg$"
+    fi
+    downloadURL=$(downloadURLFromGit "anomalyco" "opencode")
+    appNewVersion=$(versionFromGit "anomalyco" "opencode")
+    expectedTeamID="5NZ4Q7NXJ4"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh opencodedesktop DEBUG=1
2026-07-22 10:21:20 : INFO  : opencodedesktop : setting variable from argument DEBUG=1
2026-07-22 10:21:20 : INFO  : opencodedesktop : Total items in argumentsArray: 1
2026-07-22 10:21:20 : INFO  : opencodedesktop : argumentsArray: DEBUG=1
2026-07-22 10:21:20 : REQ   : opencodedesktop : ################## Start Installomator v. 10.10beta, date 2026-07-22
2026-07-22 10:21:20 : INFO  : opencodedesktop : ################## Version: 10.10beta
2026-07-22 10:21:20 : INFO  : opencodedesktop : ################## Date: 2026-07-22
2026-07-22 10:21:20 : INFO  : opencodedesktop : ################## opencodedesktop
2026-07-22 10:21:20 : DEBUG : opencodedesktop : DEBUG mode 1 enabled.
2026-07-22 10:21:23 : INFO  : opencodedesktop : Reading arguments again: DEBUG=1
2026-07-22 10:21:23 : DEBUG : opencodedesktop : argument: DEBUG=1
2026-07-22 10:21:23 : DEBUG : opencodedesktop : name=OpenCode
2026-07-22 10:21:23 : DEBUG : opencodedesktop : appName=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : type=dmg
2026-07-22 10:21:23 : DEBUG : opencodedesktop : archiveName=mac-arm64\.dmg$
2026-07-22 10:21:23 : DEBUG : opencodedesktop : downloadURL=https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-desktop-mac-arm64.dmg
2026-07-22 10:21:23 : DEBUG : opencodedesktop : curlOptions=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : appNewVersion=1.18.4
2026-07-22 10:21:23 : DEBUG : opencodedesktop : appCustomVersion function: Not defined
2026-07-22 10:21:23 : DEBUG : opencodedesktop : versionKey=CFBundleShortVersionString
2026-07-22 10:21:23 : DEBUG : opencodedesktop : packageID=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : pkgName=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : choiceChangesXML=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : expectedTeamID=5NZ4Q7NXJ4
2026-07-22 10:21:23 : DEBUG : opencodedesktop : blockingProcesses=
2026-07-22 10:21:23 : DEBUG : opencodedesktop : installerTool=
2026-07-22 10:21:24 : DEBUG : opencodedesktop : CLIInstaller=
2026-07-22 10:21:24 : DEBUG : opencodedesktop : CLIArguments=
2026-07-22 10:21:24 : DEBUG : opencodedesktop : updateTool=
2026-07-22 10:21:24 : DEBUG : opencodedesktop : updateToolArguments=
2026-07-22 10:21:24 : DEBUG : opencodedesktop : updateToolRunAsCurrentUser=
2026-07-22 10:21:24 : INFO  : opencodedesktop : BLOCKING_PROCESS_ACTION=tell_user
2026-07-22 10:21:24 : INFO  : opencodedesktop : NOTIFY=success
2026-07-22 10:21:24 : INFO  : opencodedesktop : LOGGING=DEBUG
2026-07-22 10:21:24 : INFO  : opencodedesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-22 10:21:24 : INFO  : opencodedesktop : Label type: dmg
2026-07-22 10:21:24 : INFO  : opencodedesktop : archiveName: mac-arm64\.dmg$
2026-07-22 10:21:24 : INFO  : opencodedesktop : no blocking processes defined, using OpenCode as default
2026-07-22 10:21:24 : DEBUG : opencodedesktop : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-22 10:21:24 : INFO  : opencodedesktop : name: OpenCode, appName: OpenCode.app
2026-07-22 10:21:24 : INFO  : opencodedesktop : App(s) found: /Applications/Utilities/Admin/OpenCode.app
2026-07-22 10:21:24 : INFO  : opencodedesktop : found app at /Applications/Utilities/Admin/OpenCode.app, version 1.18.3, on versionKey CFBundleShortVersionString
2026-07-22 10:21:24 : INFO  : opencodedesktop : appversion: 1.18.3
2026-07-22 10:21:24 : INFO  : opencodedesktop : Latest version of OpenCode is 1.18.4
2026-07-22 10:21:24 : REQ   : opencodedesktop : Downloading https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-desktop-mac-arm64.dmg to mac-arm64\.dmg$
2026-07-22 10:21:24 : DEBUG : opencodedesktop : No Dialog connection, just download
2026-07-22 10:21:29 : INFO  : opencodedesktop : Downloaded mac-arm64\.dmg$ – Type is  zlib compressed data – SHA is \d9d48f3ebca1c5016ee8c4fdf5bcee59f81c51dd – Size is 148476 kB
2026-07-22 10:21:29 : DEBUG : opencodedesktop : DEBUG mode 1, not checking for blocking processes
2026-07-22 10:21:29 : REQ   : opencodedesktop : Installing OpenCode
2026-07-22 10:21:29 : INFO  : opencodedesktop : Mounting /Users/u0105821/git/github/Installomator/build/mac-arm64\.dmg$
2026-07-22 10:21:32 : DEBUG : opencodedesktop : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $AB0CF9C4
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7F3FAFAD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F1D7DB14
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $84DF4EE2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F1D7DB14
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $2679FE84
verified   CRC32 $EA3DD6D4
/dev/disk9          	GUID_partition_scheme
/dev/disk9s1        	Apple_HFS                      	/Volumes/OpenCode 1.18.4-arm64

2026-07-22 10:21:32 : INFO  : opencodedesktop : Mounted: /Volumes/OpenCode 1.18.4-arm64
2026-07-22 10:21:32 : INFO  : opencodedesktop : Verifying: /Volumes/OpenCode 1.18.4-arm64/OpenCode.app
2026-07-22 10:21:32 : DEBUG : opencodedesktop : App size: 390M	/Volumes/OpenCode 1.18.4-arm64/OpenCode.app
2026-07-22 10:21:34 : DEBUG : opencodedesktop : Debugging enabled, App Verification output was:
/Volumes/OpenCode 1.18.4-arm64/OpenCode.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Anomaly Innovations, Inc. (5NZ4Q7NXJ4)

2026-07-22 10:21:34 : INFO  : opencodedesktop : Team ID matching: 5NZ4Q7NXJ4 (expected: 5NZ4Q7NXJ4 )
2026-07-22 10:21:34 : INFO  : opencodedesktop : Downloaded version of OpenCode is 1.18.4 on versionKey CFBundleShortVersionString (replacing version 1.18.3).
2026-07-22 10:21:34 : INFO  : opencodedesktop : App has LSMinimumSystemVersion: 12.0
2026-07-22 10:21:34 : DEBUG : opencodedesktop : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-22 10:21:34 : INFO  : opencodedesktop : Finishing...
2026-07-22 10:21:37 : INFO  : opencodedesktop : name: OpenCode, appName: OpenCode.app
2026-07-22 10:21:37 : INFO  : opencodedesktop : App(s) found: /Applications/Utilities/Admin/OpenCode.app
2026-07-22 10:21:37 : INFO  : opencodedesktop : found app at /Applications/Utilities/Admin/OpenCode.app, version 1.18.3, on versionKey CFBundleShortVersionString
2026-07-22 10:21:37 : REQ   : opencodedesktop : Installed OpenCode, version 1.18.4
2026-07-22 10:21:37 : INFO  : opencodedesktop : notifying
2026-07-22 10:21:38 : DEBUG : opencodedesktop : Unmounting /Volumes/OpenCode 1.18.4-arm64
2026-07-22 10:21:38 : DEBUG : opencodedesktop : Debugging enabled, Unmounting output was:
"disk9" ejected.
2026-07-22 10:21:38 : DEBUG : opencodedesktop : DEBUG mode 1, not reopening anything
2026-07-22 10:21:38 : REQ   : opencodedesktop : All done!
2026-07-22 10:21:38 : REQ   : opencodedesktop : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
