### PR TITLE
Create zoapiclient.sh

### DIFF
--- a/fragments/labels/zoapi.sh
+++ b/fragments/labels/zoapi.sh
@@ -2,9 +2,12 @@ zoapiclient)
 	name="Zoapi Client"
 	type="dmg"
 	appName="Zoapi.app"
-	ymlContent=$(curl -fsL "https://share.zoapi.com/zoapi/v0/api/fetch/client/mac/latest-mac.yml")
-	appNewVersion=$(echo "$ymlContent" | grep "^version:" | sed 's/^version:[[:space:]]*\([0-9.]*\).*/\1/')
-	sha512=$(echo "$ymlContent" | grep -A2 "url: ZoapiClient-Setup.dmg" | grep "sha512:" | sed 's/^[[:space:]]*sha512:[[:space:]]*//')
-	downloadURL="https://share.zoapi.com/zoapi/client/ZoapiClient-Setup.dmg"
+	if [[ $(arch) == "arm64" ]]; then
+		downloadURL="https://share.zoapi.com/zoapi/client/ZoapiClient-Setup.dmg"
+	else
+		printlog "Zoapi Client is only compatible with Apple Silicon (arm64) Macs." ERROR
+		cleanupAndExit 95 "Zoapi Client requires Apple Silicon" ERROR
+	fi
+	appNewVersion=$(curl -fsL "https://share.zoapi.com/zoapi/v0/api/fetch/client/mac/latest-mac.yml" | grep "^version:" | sed 's/^version:[[:space:]]*\([0-9.]*\).*/\1/')
 	expectedTeamID="WFY2HJH6B3"
 	;;

--- a/fragments/labels/zoapi.sh
+++ b/fragments/labels/zoapi.sh
@@ -1,0 +1,10 @@
+zoapiclient)
+	name="Zoapi Client"
+	type="dmg"
+	appName="Zoapi.app"
+	ymlContent=$(curl -fsL "https://share.zoapi.com/zoapi/v0/api/fetch/client/mac/latest-mac.yml")
+	appNewVersion=$(echo "$ymlContent" | grep "^version:" | sed 's/^version:[[:space:]]*\([0-9.]*\).*/\1/')
+	sha512=$(echo "$ymlContent" | grep -A2 "url: ZoapiClient-Setup.dmg" | grep "sha512:" | sed 's/^[[:space:]]*sha512:[[:space:]]*//')
+	downloadURL="https://share.zoapi.com/zoapi/client/ZoapiClient-Setup.dmg"
+	expectedTeamID="WFY2HJH6B3"
+	;;


### PR DESCRIPTION
Add Zoapi Client for conference room screen sharing

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
➜  ~ /Users/amartin/Documents/GitHub/Installomator/assemble.sh zoapiclient  
2026-07-22 17:36:35 : INFO  : zoapiclient : Total items in argumentsArray: 0
2026-07-22 17:36:35 : INFO  : zoapiclient : argumentsArray: 
2026-07-22 17:36:35 : REQ   : zoapiclient : ################## Start Installomator v. 10.10beta, date 2026-07-22
2026-07-22 17:36:35 : INFO  : zoapiclient : ################## Version: 10.10beta
2026-07-22 17:36:35 : INFO  : zoapiclient : ################## Date: 2026-07-22
2026-07-22 17:36:35 : INFO  : zoapiclient : ################## zoapiclient
2026-07-22 17:36:35 : DEBUG : zoapiclient : DEBUG mode 1 enabled.
2026-07-22 17:36:37 : INFO  : zoapiclient : Reading arguments again: 
2026-07-22 17:36:37 : DEBUG : zoapiclient : name=Zoapi Client
2026-07-22 17:36:37 : DEBUG : zoapiclient : appName=Zoapi.app
2026-07-22 17:36:37 : DEBUG : zoapiclient : type=dmg
2026-07-22 17:36:37 : DEBUG : zoapiclient : archiveName=
2026-07-22 17:36:37 : DEBUG : zoapiclient : downloadURL=https://share.zoapi.com/zoapi/client/ZoapiClient-Setup.dmg
2026-07-22 17:36:37 : DEBUG : zoapiclient : curlOptions=
2026-07-22 17:36:37 : DEBUG : zoapiclient : appNewVersion=10.98.90
2026-07-22 17:36:37 : DEBUG : zoapiclient : appCustomVersion function: Not defined
2026-07-22 17:36:37 : DEBUG : zoapiclient : versionKey=CFBundleShortVersionString
2026-07-22 17:36:37 : DEBUG : zoapiclient : packageID=
2026-07-22 17:36:37 : DEBUG : zoapiclient : pkgName=
2026-07-22 17:36:37 : DEBUG : zoapiclient : choiceChangesXML=
2026-07-22 17:36:37 : DEBUG : zoapiclient : expectedTeamID=WFY2HJH6B3
2026-07-22 17:36:37 : DEBUG : zoapiclient : blockingProcesses=
2026-07-22 17:36:37 : DEBUG : zoapiclient : installerTool=
2026-07-22 17:36:37 : DEBUG : zoapiclient : CLIInstaller=
2026-07-22 17:36:37 : DEBUG : zoapiclient : CLIArguments=
2026-07-22 17:36:38 : DEBUG : zoapiclient : updateTool=
2026-07-22 17:36:38 : DEBUG : zoapiclient : updateToolArguments=
2026-07-22 17:36:38 : DEBUG : zoapiclient : updateToolRunAsCurrentUser=
2026-07-22 17:36:38 : INFO  : zoapiclient : BLOCKING_PROCESS_ACTION=tell_user
2026-07-22 17:36:38 : INFO  : zoapiclient : NOTIFY=success
2026-07-22 17:36:38 : INFO  : zoapiclient : LOGGING=DEBUG
2026-07-22 17:36:38 : INFO  : zoapiclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-22 17:36:38 : INFO  : zoapiclient : Label type: dmg
2026-07-22 17:36:38 : INFO  : zoapiclient : archiveName: Zoapi Client.dmg
2026-07-22 17:36:38 : INFO  : zoapiclient : no blocking processes defined, using Zoapi Client as default
2026-07-22 17:36:38 : DEBUG : zoapiclient : Changing directory to /Users/amartin/Documents/GitHub/Installomator/build
2026-07-22 17:36:38 : INFO  : zoapiclient : App(s) found: /Applications/Zoapi.app
2026-07-22 17:36:38 : INFO  : zoapiclient : found app at /Applications/Zoapi.app, version 10.97.80, on versionKey CFBundleShortVersionString
2026-07-22 17:36:38 : INFO  : zoapiclient : appversion: 10.97.80
2026-07-22 17:36:38 : INFO  : zoapiclient : Latest version of Zoapi Client is 10.98.90
2026-07-22 17:36:38 : REQ   : zoapiclient : Downloading https://share.zoapi.com/zoapi/client/ZoapiClient-Setup.dmg to Zoapi Client.dmg
2026-07-22 17:36:38 : DEBUG : zoapiclient : No Dialog connection, just download
2026-07-22 17:36:52 : INFO  : zoapiclient : Downloaded Zoapi Client.dmg – Type is  zlib compressed data – SHA is 876b9f4a868464422e0a5d134e1e299ddf8afdfc – Size is 114748 kB
2026-07-22 17:36:52 : DEBUG : zoapiclient : DEBUG mode 1, not checking for blocking processes
2026-07-22 17:36:52 : REQ   : zoapiclient : Installing Zoapi Client
2026-07-22 17:36:52 : INFO  : zoapiclient : Mounting /Users/amartin/Documents/GitHub/Installomator/build/Zoapi Client.dmg
2026-07-22 17:36:57 : DEBUG : zoapiclient : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $6D7466F3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $3B104F9E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $E691EBA2
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $09D18CF7
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $E691EBA2
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $9F9648E4
verified   CRC32 $9A34FE7F
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Zoapi

2026-07-22 17:36:57 : INFO  : zoapiclient : Mounted: /Volumes/Zoapi
2026-07-22 17:36:57 : INFO  : zoapiclient : Verifying: /Volumes/Zoapi/Zoapi.app
2026-07-22 17:36:57 : DEBUG : zoapiclient : App size: 269M	/Volumes/Zoapi/Zoapi.app
2026-07-22 17:36:59 : DEBUG : zoapiclient : Debugging enabled, App Verification output was:
/Volumes/Zoapi/Zoapi.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: ZOAPI INNOVATIONS PRIVATE LIMITED (WFY2HJH6B3)

2026-07-22 17:37:00 : INFO  : zoapiclient : Team ID matching: WFY2HJH6B3 (expected: WFY2HJH6B3 )
2026-07-22 17:37:00 : INFO  : zoapiclient : Downloaded version of Zoapi Client is 10.98.90 on versionKey CFBundleShortVersionString (replacing version 10.97.80).
2026-07-22 17:37:00 : INFO  : zoapiclient : App has LSMinimumSystemVersion: 12.0
2026-07-22 17:37:00 : DEBUG : zoapiclient : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-22 17:37:00 : INFO  : zoapiclient : Finishing...
2026-07-22 17:37:03 : INFO  : zoapiclient : App(s) found: /Applications/Zoapi.app
2026-07-22 17:37:03 : INFO  : zoapiclient : found app at /Applications/Zoapi.app, version 10.97.80, on versionKey CFBundleShortVersionString
2026-07-22 17:37:03 : REQ   : zoapiclient : Installed Zoapi Client, version 10.98.90
2026-07-22 17:37:03 : INFO  : zoapiclient : notifying
2026-07-22 17:37:03 : DEBUG : zoapiclient : Unmounting /Volumes/Zoapi
2026-07-22 17:37:04 : DEBUG : zoapiclient : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-07-22 17:37:04 : DEBUG : zoapiclient : DEBUG mode 1, not reopening anything
2026-07-22 17:37:04 : REQ   : zoapiclient : All done!
2026-07-22 17:37:04 : REQ   : zoapiclient : ################## End Installomator, exit code 0 
```

