### PR TITLE
digiexam-update-label

### DIFF
--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -1,7 +1,7 @@
 digiexam)
-	name="Digiexam"
-	type="dmg"
-	downloadURL="https://www.digiexam.com/hubfs/client/Digiexam_Mac.dmg"
-    appNewVersion=$( curl -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" -fs https://support.digiexam.se/hc/en-us/articles/7119593625628-Client-updates | perl -ne 'print if /Version(?!.*Only(?!.*Mac))(?=.*Mac)?/' | head -1 | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
-	expectedTeamID="73T9H7VE4P"
-	;;
+    name="Digiexam"
+    type="tbz"
+    downloadURL="https://cdn.crabnebula.app/download/digiexam/digiexam/latest/platform/dmg-universal"
+    appNewVersion=$( curl -sL "https://www.digiexam.com/platform/release-notes" | perl -0777 -ne 'print $1 if /isLatest\W+true\W+platform\W+mac[^}]*version\W+([\d.]+)/' )
+    expectedTeamID="73T9H7VE4P"
+    ;;

--- a/fragments/labels/digiexam.sh
+++ b/fragments/labels/digiexam.sh
@@ -1,7 +1,10 @@
 digiexam)
     name="Digiexam"
     type="tbz"
-    downloadURL="https://cdn.crabnebula.app/download/digiexam/digiexam/latest/platform/dmg-universal"
-    appNewVersion=$( curl -sL "https://www.digiexam.com/platform/release-notes" | perl -0777 -ne 'print $1 if /isLatest\W+true\W+platform\W+mac[^}]*version\W+([\d.]+)/' )
+    archiveName="Digiexam.app.tar.gz"
+    crabNebulaData=$(curl -fsL "https://cdn.crabnebula.app/update/digiexam/digiexam/macos-universal/0.0.0")
+    appNewVersion=$(printf "%s" "$crabNebulaData" | plutil -extract version raw -o - -)
+    downloadURL=$(printf "%s" "$crabNebulaData" | plutil -extract url raw -o - -)
     expectedTeamID="73T9H7VE4P"
+    blockingProcesses=( "digiexam" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes

**Additional context** Add any other context about the label or fix here.

Digiexam released an overhaul of their app in Spring 2025.  The updated label download url points to the new version of the app, since the old app is deprecated.  I also updated the appNewVersion to pull from the new release notes site.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-07-24 10:19:29 : REQ   : digiexam : ################## Start Installomator v. 10.9, date 2026-07-03
2026-07-24 10:19:29 : INFO  : digiexam : ################## Version: 10.9
2026-07-24 10:19:29 : INFO  : digiexam : ################## Date: 2026-07-03
2026-07-24 10:19:29 : INFO  : digiexam : ################## digiexam
2026-07-24 10:19:29 : INFO  : digiexam : SwiftDialog is not installed, clear cmd file var
2026-07-24 10:19:31 : INFO  : digiexam : Reading arguments again: 
2026-07-24 10:19:31 : INFO  : digiexam : BLOCKING_PROCESS_ACTION=tell_user
2026-07-24 10:19:31 : INFO  : digiexam : NOTIFY=silent
2026-07-24 10:19:31 : INFO  : digiexam : LOGGING=INFO
2026-07-24 10:19:31 : INFO  : digiexam : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2026-07-24 10:19:32 : INFO  : digiexam : Label type: tbz
2026-07-24 10:19:32 : INFO  : digiexam : archiveName: Digiexam.tbz
2026-07-24 10:19:32 : INFO  : digiexam : no blocking processes defined, using Digiexam as default
2026-07-24 10:19:32 : INFO  : digiexam : name: Digiexam, appName: Digiexam.app
2026-07-24 10:19:33 : WARN  : digiexam : No previous app found
2026-07-24 10:19:33 : WARN  : digiexam : could not find Digiexam.app
2026-07-24 10:19:33 : INFO  : digiexam : appversion: 
2026-07-24 10:19:33 : INFO  : digiexam : Latest version of Digiexam is 26.1.24
2026-07-24 10:19:34 : REQ   : digiexam : Downloading https://cdn.crabnebula.app/download/digiexam/digiexam/latest/platform/dmg-universal to Digiexam.tbz
2026-07-24 10:19:35 : INFO  : digiexam : Downloaded Digiexam.tbz – Type is  gzip compressed data, original size modulo 2^32 85072896 – SHA is 94a2c2e41a67f7644bf9b97a1d4e3024bacd1988 – Size is 36316 kB
2026-07-24 10:19:35 : REQ   : digiexam : no more blocking processes, continue with update
2026-07-24 10:19:35 : REQ   : digiexam : Installing Digiexam
2026-07-24 10:19:35 : INFO  : digiexam : Unzipping Digiexam.tbz
2026-07-24 10:19:35 : INFO  : digiexam : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.yVzLDshv7I/Digiexam.app
2026-07-24 10:19:35 : INFO  : digiexam : Team ID matching: 73T9H7VE4P (expected: 73T9H7VE4P )
2026-07-24 10:19:35 : INFO  : digiexam : Installing Digiexam version 26.1.24 on versionKey CFBundleShortVersionString.
2026-07-24 10:19:35 : INFO  : digiexam : App has LSMinimumSystemVersion: 12
2026-07-24 10:19:35 : INFO  : digiexam : Copy /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.yVzLDshv7I/Digiexam.app to /Applications
2026-07-24 10:19:36 : WARN  : digiexam : Changing owner to USERNAME
2026-07-24 10:19:36 : INFO  : digiexam : Finishing...
2026-07-24 10:19:39 : INFO  : digiexam : App(s) found: /Applications/Digiexam.app
2026-07-24 10:19:39 : INFO  : digiexam : found app at /Applications/Digiexam.app, version 26.1.24, on versionKey CFBundleShortVersionString
2026-07-24 10:19:39 : REQ   : digiexam : Installed Digiexam, version 26.1.24
2026-07-24 10:19:39 : INFO  : digiexam : Installomator did not close any apps, so no need to reopen any apps.
2026-07-24 10:19:39 : REQ   : digiexam : All done!
2026-07-24 10:19:40 : REQ   : digiexam : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
