### PR TITLE
sonoss2-label-update

### DIFF
--- a/fragments/labels/sonoss2.sh
+++ b/fragments/labels/sonoss2.sh
@@ -1,8 +1,8 @@
 sonoss2)
     name="Sonos"
     type="dmg"
-    downloadURL="https://www.sonos.com/redir/controller_software_mac2"
-    appNewVersion=$(curl -LIs -o /dev/null -w "%{url_effective}\n" "$downloadURL" | grep -oE '[0-9]+\.[0-9]+-[0-9]+' | tr '-' '.')
+    downloadURL="https://update-software.sonos.com/software/rT0797IawE/Sonos_90.0-77070.dmg"
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/Sonos_([0-9]+)\.([0-9]+)-([0-9]+)\.dmg|\1.\2.\3|')
     versionKey="CFBundleVersion"
     expectedTeamID="2G4LW83Q3E"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

This label improves reliability by avoiding the Sonos redirect URL for runtime version detection, since https://www.sonos.com/redir/controller_software_mac2 currently returns HTTP 403 to command-line curl requests and can leave appNewVersion empty. Using the resolved Sonos CDN URL makes the download deterministic, and deriving appNewVersion from that URL produces 90.0.77070, which matches the app’s CFBundleVersion; keeping versionKey="CFBundleVersion" is therefore correct. The label also avoids depending on a blocked redirect chain or fragile header behavior during every Installomator run. Validation confirmed the DMG mounts cleanly, contains Sonos.app, and is notarized with Team ID 2G4LW83Q3E. One operational note is that the current Sonos S2 Mac app is Intel-only, so Apple Silicon deployments need Rosetta available before launch.

```
# sudo Installomator/utils/assemble.sh sonoss2 DEBUG=1
2026-07-28 12:25:35 : INFO  : sonoss2 : setting variable from argument DEBUG=1
2026-07-28 12:25:35 : INFO  : sonoss2 : Total items in argumentsArray: 1
2026-07-28 12:25:35 : INFO  : sonoss2 : argumentsArray: DEBUG=1
2026-07-28 12:25:36 : REQ   : sonoss2 : ################## Start Installomator v. 10.10beta, date 2026-07-28
2026-07-28 12:25:36 : INFO  : sonoss2 : ################## Version: 10.10beta
2026-07-28 12:25:36 : INFO  : sonoss2 : ################## Date: 2026-07-28
2026-07-28 12:25:36 : INFO  : sonoss2 : ################## sonoss2
2026-07-28 12:25:36 : DEBUG : sonoss2 : DEBUG mode 1 enabled.
2026-07-28 12:25:36 : INFO  : sonoss2 : Reading arguments again: DEBUG=1
2026-07-28 12:25:36 : DEBUG : sonoss2 : argument: DEBUG=1
2026-07-28 12:25:36 : DEBUG : sonoss2 : name=Sonos
2026-07-28 12:25:36 : DEBUG : sonoss2 : appName=
2026-07-28 12:25:36 : DEBUG : sonoss2 : type=dmg
2026-07-28 12:25:36 : DEBUG : sonoss2 : archiveName=
2026-07-28 12:25:36 : DEBUG : sonoss2 : downloadURL=https://update-software.sonos.com/software/rT0797IawE/Sonos_90.0-77070.dmg
2026-07-28 12:25:36 : DEBUG : sonoss2 : curlOptions=
2026-07-28 12:25:36 : DEBUG : sonoss2 : appNewVersion=90.0.77070
2026-07-28 12:25:36 : DEBUG : sonoss2 : appCustomVersion function: Not defined
2026-07-28 12:25:36 : DEBUG : sonoss2 : versionKey=CFBundleVersion
2026-07-28 12:25:36 : DEBUG : sonoss2 : packageID=
2026-07-28 12:25:36 : DEBUG : sonoss2 : pkgName=
2026-07-28 12:25:36 : DEBUG : sonoss2 : choiceChangesXML=
2026-07-28 12:25:36 : DEBUG : sonoss2 : expectedTeamID=2G4LW83Q3E
2026-07-28 12:25:36 : DEBUG : sonoss2 : blockingProcesses=
2026-07-28 12:25:36 : DEBUG : sonoss2 : installerTool=
2026-07-28 12:25:36 : DEBUG : sonoss2 : CLIInstaller=
2026-07-28 12:25:36 : DEBUG : sonoss2 : CLIArguments=
2026-07-28 12:25:36 : DEBUG : sonoss2 : updateTool=
2026-07-28 12:25:36 : DEBUG : sonoss2 : updateToolArguments=
2026-07-28 12:25:36 : DEBUG : sonoss2 : updateToolRunAsCurrentUser=
2026-07-28 12:25:37 : INFO  : sonoss2 : BLOCKING_PROCESS_ACTION=tell_user
2026-07-28 12:25:37 : INFO  : sonoss2 : NOTIFY=success
2026-07-28 12:25:37 : INFO  : sonoss2 : LOGGING=DEBUG
2026-07-28 12:25:37 : INFO  : sonoss2 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-28 12:25:37 : INFO  : sonoss2 : Label type: dmg
2026-07-28 12:25:37 : INFO  : sonoss2 : archiveName: Sonos.dmg
2026-07-28 12:25:37 : INFO  : sonoss2 : no blocking processes defined, using Sonos as default
2026-07-28 12:25:37 : DEBUG : sonoss2 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-28 12:25:37 : INFO  : sonoss2 : name: Sonos, appName: Sonos.app
2026-07-28 12:25:37 : WARN  : sonoss2 : No previous app found
2026-07-28 12:25:37 : WARN  : sonoss2 : could not find Sonos.app
2026-07-28 12:25:37 : INFO  : sonoss2 : appversion: 
2026-07-28 12:25:37 : INFO  : sonoss2 : Latest version of Sonos is 90.0.77070
2026-07-28 12:25:37 : REQ   : sonoss2 : Downloading https://update-software.sonos.com/software/rT0797IawE/Sonos_90.0-77070.dmg to Sonos.dmg
2026-07-28 12:25:37 : DEBUG : sonoss2 : No Dialog connection, just download
2026-07-28 12:25:40 : INFO  : sonoss2 : Downloaded Sonos.dmg – Type is  zlib compressed data – SHA is 5b9f85c9452dde026bb71a4cdefb46535c2fa96f – Size is 62200 kB
2026-07-28 12:25:40 : DEBUG : sonoss2 : DEBUG mode 1, not checking for blocking processes
2026-07-28 12:25:40 : REQ   : sonoss2 : Installing Sonos
2026-07-28 12:25:40 : INFO  : sonoss2 : Mounting /Users/u0105821/git/github/Installomator/build/Sonos.dmg
2026-07-28 12:25:44 : DEBUG : sonoss2 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $2ACB1D27
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $ABE5ED4D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $8657F903
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $BCB7FA40
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $8657F903
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CB9DECF6
verified   CRC32 $17A038CB
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/Sonos

2026-07-28 12:25:44 : INFO  : sonoss2 : Mounted: /Volumes/Sonos
2026-07-28 12:25:44 : INFO  : sonoss2 : Verifying: /Volumes/Sonos/Sonos.app
2026-07-28 12:25:44 : DEBUG : sonoss2 : App size: 107M	/Volumes/Sonos/Sonos.app
2026-07-28 12:25:45 : DEBUG : sonoss2 : Debugging enabled, App Verification output was:
/Volumes/Sonos/Sonos.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Sonos, Inc. (2G4LW83Q3E)

2026-07-28 12:25:45 : INFO  : sonoss2 : Team ID matching: 2G4LW83Q3E (expected: 2G4LW83Q3E )
2026-07-28 12:25:45 : INFO  : sonoss2 : Installing Sonos version 90.0.77070 on versionKey CFBundleVersion.
2026-07-28 12:25:45 : INFO  : sonoss2 : App has LSMinimumSystemVersion: 10.11
2026-07-28 12:25:45 : DEBUG : sonoss2 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-28 12:25:46 : INFO  : sonoss2 : Finishing...
2026-07-28 12:25:49 : INFO  : sonoss2 : name: Sonos, appName: Sonos.app
2026-07-28 12:25:49 : WARN  : sonoss2 : No previous app found
2026-07-28 12:25:49 : WARN  : sonoss2 : could not find Sonos.app
2026-07-28 12:25:49 : REQ   : sonoss2 : Installed Sonos, version 90.0.77070
2026-07-28 12:25:49 : INFO  : sonoss2 : notifying
2026-07-28 12:25:49 : DEBUG : sonoss2 : Unmounting /Volumes/Sonos
2026-07-28 12:25:50 : DEBUG : sonoss2 : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-07-28 12:25:50 : DEBUG : sonoss2 : DEBUG mode 1, not reopening anything
2026-07-28 12:25:50 : REQ   : sonoss2 : All done!
2026-07-28 12:25:50 : REQ   : sonoss2 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
