### PR TITLE
soapuiopensource-label-update

### DIFF
--- a/fragments/labels/soapuiopensource.sh
+++ b/fragments/labels/soapuiopensource.sh
@@ -1,11 +1,13 @@
 soapuiopensource)
-    appNewVersion="$(versionFromGit SmartBear soapui)"
+    soapuiJSON=$(curl -fsL "https://api.github.com/repos/SmartBear/soapui/releases/latest")
+    appNewVersion=$(getJSONValue "$soapuiJSON" "tag_name" | sed 's/^v//')
     name="SoapUI-$appNewVersion"
     type="dmg"
     if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL="$(curl -fsL "https://github.com/SmartBear/soapui/releases/latest" | grep -m 1 -o 'href=".*arm64.*\.dmg".*' | cut -d '"' -f 2)"
+        platformName="arm64"
     else
-        downloadURL="$(curl -fsL "https://github.com/SmartBear/soapui/releases/latest" | grep -m 1 -o 'href=".*\.dmg".*' | cut -d '"' -f 2)"
+        platformName="x64"
     fi
+    downloadURL=$(getJSONValue "$soapuiJSON" "body" | grep -o "https://dl.eviware.com/soapuios/${appNewVersion}/SoapUI-${platformName}-${appNewVersion}.dmg" | head -n 1)
     expectedTeamID="HVA5GNL2LF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it avoids scraping the GitHub release HTML page, which is brittle and can break whenever GitHub changes its markup. The latest SmartBear SoapUI release does not publish attached GitHub release assets, so downloadURLFromGit is not a safe option here; however, the GitHub Releases API does expose the latest tag and the release body, and that body contains the official SmartBear CDN links for both Mac DMGs. Using getJSONValue against the GitHub API response is more Installomator-native and reviewable, while the $(arch) check selects the correct arm64 or x64 DMG. It also keeps name="SoapUI-$appNewVersion", which matches the actual mounted app bundle name, for example SoapUI-5.10.0.app. Validation confirmed both architecture-specific DMGs return successfully, contain the expected app version, and are notarized with Team ID HVA5GNL2LF.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh soapuiopensource DEBUG=1
2026-07-28 14:02:46 : INFO  : soapuiopensource : setting variable from argument DEBUG=1
2026-07-28 14:02:46 : INFO  : soapuiopensource : Total items in argumentsArray: 1
2026-07-28 14:02:46 : INFO  : soapuiopensource : argumentsArray: DEBUG=1
2026-07-28 14:02:46 : REQ   : soapuiopensource : ################## Start Installomator v. 10.10beta, date 2026-07-28
2026-07-28 14:02:47 : INFO  : soapuiopensource : ################## Version: 10.10beta
2026-07-28 14:02:47 : INFO  : soapuiopensource : ################## Date: 2026-07-28
2026-07-28 14:02:47 : INFO  : soapuiopensource : ################## soapuiopensource
2026-07-28 14:02:47 : DEBUG : soapuiopensource : DEBUG mode 1 enabled.
2026-07-28 14:02:47 : INFO  : soapuiopensource : Reading arguments again: DEBUG=1
2026-07-28 14:02:47 : DEBUG : soapuiopensource : argument: DEBUG=1
2026-07-28 14:02:48 : DEBUG : soapuiopensource : name=SoapUI-5.10.0
2026-07-28 14:02:48 : DEBUG : soapuiopensource : appName=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : type=dmg
2026-07-28 14:02:48 : DEBUG : soapuiopensource : archiveName=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : downloadURL=https://dl.eviware.com/soapuios/5.10.0/SoapUI-arm64-5.10.0.dmg
2026-07-28 14:02:48 : DEBUG : soapuiopensource : curlOptions=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : appNewVersion=5.10.0
2026-07-28 14:02:48 : DEBUG : soapuiopensource : appCustomVersion function: Not defined
2026-07-28 14:02:48 : DEBUG : soapuiopensource : versionKey=CFBundleShortVersionString
2026-07-28 14:02:48 : DEBUG : soapuiopensource : packageID=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : pkgName=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : choiceChangesXML=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : expectedTeamID=HVA5GNL2LF
2026-07-28 14:02:48 : DEBUG : soapuiopensource : blockingProcesses=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : installerTool=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : CLIInstaller=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : CLIArguments=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : updateTool=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : updateToolArguments=
2026-07-28 14:02:48 : DEBUG : soapuiopensource : updateToolRunAsCurrentUser=
2026-07-28 14:02:48 : INFO  : soapuiopensource : BLOCKING_PROCESS_ACTION=tell_user
2026-07-28 14:02:48 : INFO  : soapuiopensource : NOTIFY=success
2026-07-28 14:02:48 : INFO  : soapuiopensource : LOGGING=DEBUG
2026-07-28 14:02:48 : INFO  : soapuiopensource : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-28 14:02:48 : INFO  : soapuiopensource : Label type: dmg
2026-07-28 14:02:48 : INFO  : soapuiopensource : archiveName: SoapUI-5.10.0.dmg
2026-07-28 14:02:48 : INFO  : soapuiopensource : no blocking processes defined, using SoapUI-5.10.0 as default
2026-07-28 14:02:48 : DEBUG : soapuiopensource : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-28 14:02:48 : INFO  : soapuiopensource : name: SoapUI-5.10.0, appName: SoapUI-5.10.0.app
2026-07-28 14:02:48 : WARN  : soapuiopensource : No previous app found
2026-07-28 14:02:48 : WARN  : soapuiopensource : could not find SoapUI-5.10.0.app
2026-07-28 14:02:48 : INFO  : soapuiopensource : appversion: 
2026-07-28 14:02:48 : INFO  : soapuiopensource : Latest version of SoapUI-5.10.0 is 5.10.0
2026-07-28 14:02:48 : REQ   : soapuiopensource : Downloading https://dl.eviware.com/soapuios/5.10.0/SoapUI-arm64-5.10.0.dmg to SoapUI-5.10.0.dmg
2026-07-28 14:02:48 : DEBUG : soapuiopensource : No Dialog connection, just download
2026-07-28 14:02:55 : INFO  : soapuiopensource : Downloaded SoapUI-5.10.0.dmg – Type is  zlib compressed data – SHA is 27b582f4862f5db4f71981fbf6569027a298421e – Size is 196828 kB
2026-07-28 14:02:55 : DEBUG : soapuiopensource : DEBUG mode 1, not checking for blocking processes
2026-07-28 14:02:55 : REQ   : soapuiopensource : Installing SoapUI-5.10.0
2026-07-28 14:02:55 : INFO  : soapuiopensource : Mounting /Users/u0105821/git/github/Installomator/build/SoapUI-5.10.0.dmg
2026-07-28 14:02:56 : DEBUG : soapuiopensource : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $2F44FCBD
verified   CRC32 $A35F24E8
/dev/disk5          	Apple_partition_scheme
/dev/disk5s1        	Apple_partition_map
/dev/disk5s2        	Apple_HFS                      	/Volumes/SoapUI-arm64-5.10.0

2026-07-28 14:02:56 : INFO  : soapuiopensource : Mounted: /Volumes/SoapUI-arm64-5.10.0
2026-07-28 14:02:56 : INFO  : soapuiopensource : Verifying: /Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app
2026-07-28 14:02:56 : DEBUG : soapuiopensource : App size: 311M	/Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app
2026-07-28 14:02:57 : DEBUG : soapuiopensource : Debugging enabled, App Verification output was:
/Volumes/SoapUI-arm64-5.10.0/SoapUI-5.10.0.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Smart Bear Software, Inc. (HVA5GNL2LF)

2026-07-28 14:02:57 : INFO  : soapuiopensource : Team ID matching: HVA5GNL2LF (expected: HVA5GNL2LF )
2026-07-28 14:02:57 : INFO  : soapuiopensource : Installing SoapUI-5.10.0 version 5.10.0 on versionKey CFBundleShortVersionString.
2026-07-28 14:02:57 : INFO  : soapuiopensource : App has LSMinimumSystemVersion: 10.11
2026-07-28 14:02:57 : DEBUG : soapuiopensource : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-28 14:02:57 : INFO  : soapuiopensource : Finishing...
2026-07-28 14:03:00 : INFO  : soapuiopensource : name: SoapUI-5.10.0, appName: SoapUI-5.10.0.app
2026-07-28 14:03:01 : WARN  : soapuiopensource : No previous app found
2026-07-28 14:03:01 : WARN  : soapuiopensource : could not find SoapUI-5.10.0.app
2026-07-28 14:03:01 : REQ   : soapuiopensource : Installed SoapUI-5.10.0, version 5.10.0
2026-07-28 14:03:01 : INFO  : soapuiopensource : notifying
2026-07-28 14:03:01 : DEBUG : soapuiopensource : Unmounting /Volumes/SoapUI-arm64-5.10.0
2026-07-28 14:03:01 : DEBUG : soapuiopensource : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-07-28 14:03:01 : DEBUG : soapuiopensource : DEBUG mode 1, not reopening anything
2026-07-28 14:03:01 : REQ   : soapuiopensource : All done!
2026-07-28 14:03:01 : REQ   : soapuiopensource : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
