### PR TITLE
lastpassdesktop-new-label

### DIFF
--- a/fragments/labels/lastpassdesktop.sh
+++ b/fragments/labels/lastpassdesktop.sh
@@ -1,0 +1,8 @@
+lastpassdesktop)
+    name="LastPass for Desktop"
+    type="dmg"
+    downloadURL="https://download.cloud.lastpass.com/lastpass-for-desktop-macos/universal/LastPassForDesktopMac.dmg"
+    appNewVersion=$(curl -fsL "https://lastpass.com/misc_download2.php" | tr "<>" "\n\n" | awk '/id="macos-app"/{found=1} found && /Version [0-9]+\.[0-9]+\.[0-9]+/{print $2; exit}')
+    appCustomVersion() { /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "/Applications/LastPass for Desktop.app/Contents/Info.plist" | sed -E 's/-[0-9]+$//'; }
+    expectedTeamID="RNDLY9ZML8"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes


**Additional context** Add any other context about the label or fix here.

The current lastpass label should be updated because it still installs the deprecated legacy LastPass.app, while the vendor has replaced it with LastPass for Desktop.app. This is not just a download URL refresh: the app bundle name, download path, version format, and signing Team ID have all changed. The new vendor URL downloads LastPass for Desktop.app from the universal macOS DMG, and validation confirmed the binary is universal for both Intel and Apple Silicon. The vendor download page currently shows public version 2.1.0, while the app bundle reports CFBundleShortVersionString=2.1.0-0, so the label uses appCustomVersion to normalize the installed bundle version back to the vendor-facing version instead of relying on the deprecated appcast for LastPass.app. The old Team ID N24REP3BMN is also no longer correct for the replacement app; the new signed and notarized app verifies as LastPass US LP (RNDLY9ZML8).

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh lastpassdesktop DEBUG=1
2026-07-28 14:44:46 : INFO  : lastpassdesktop : setting variable from argument DEBUG=1
2026-07-28 14:44:46 : INFO  : lastpassdesktop : Total items in argumentsArray: 1
2026-07-28 14:44:46 : INFO  : lastpassdesktop : argumentsArray: DEBUG=1
2026-07-28 14:44:46 : REQ   : lastpassdesktop : ################## Start Installomator v. 10.10beta, date 2026-07-28
2026-07-28 14:44:47 : INFO  : lastpassdesktop : ################## Version: 10.10beta
2026-07-28 14:44:47 : INFO  : lastpassdesktop : ################## Date: 2026-07-28
2026-07-28 14:44:47 : INFO  : lastpassdesktop : ################## lastpassdesktop
2026-07-28 14:44:47 : DEBUG : lastpassdesktop : DEBUG mode 1 enabled.
2026-07-28 14:44:47 : INFO  : lastpassdesktop : Reading arguments again: DEBUG=1
2026-07-28 14:44:47 : DEBUG : lastpassdesktop : argument: DEBUG=1
2026-07-28 14:44:47 : DEBUG : lastpassdesktop : name=LastPass for Desktop
2026-07-28 14:44:47 : DEBUG : lastpassdesktop : appName=
2026-07-28 14:44:47 : DEBUG : lastpassdesktop : type=dmg
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : archiveName=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : downloadURL=https://download.cloud.lastpass.com/lastpass-for-desktop-macos/universal/LastPassForDesktopMac.dmg
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : curlOptions=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : appNewVersion=2.1.0
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : appCustomVersion function: Defined. 
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : versionKey=CFBundleShortVersionString
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : packageID=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : pkgName=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : choiceChangesXML=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : expectedTeamID=RNDLY9ZML8
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : blockingProcesses=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : installerTool=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : CLIInstaller=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : CLIArguments=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : updateTool=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : updateToolArguments=
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : updateToolRunAsCurrentUser=
2026-07-28 14:44:48 : INFO  : lastpassdesktop : BLOCKING_PROCESS_ACTION=tell_user
2026-07-28 14:44:48 : INFO  : lastpassdesktop : NOTIFY=success
2026-07-28 14:44:48 : INFO  : lastpassdesktop : LOGGING=DEBUG
2026-07-28 14:44:48 : INFO  : lastpassdesktop : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-28 14:44:48 : INFO  : lastpassdesktop : Label type: dmg
2026-07-28 14:44:48 : INFO  : lastpassdesktop : archiveName: LastPass for Desktop.dmg
2026-07-28 14:44:48 : INFO  : lastpassdesktop : no blocking processes defined, using LastPass for Desktop as default
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : Changing directory to /Users/u0105821/git/github/Installomator/build
Print: Entry, ":CFBundleShortVersionString", Does Not Exist
2026-07-28 14:44:48 : INFO  : lastpassdesktop : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/LastPass for Desktop.app/Contents/Info.plist
2026-07-28 14:44:48 : INFO  : lastpassdesktop : appversion: File Doesn't Exist, Will Create: /Applications/LastPass for Desktop.app/Contents/Info.plist
2026-07-28 14:44:48 : INFO  : lastpassdesktop : Latest version of LastPass for Desktop is 2.1.0
2026-07-28 14:44:48 : REQ   : lastpassdesktop : Downloading https://download.cloud.lastpass.com/lastpass-for-desktop-macos/universal/LastPassForDesktopMac.dmg to LastPass for Desktop.dmg
2026-07-28 14:44:48 : DEBUG : lastpassdesktop : No Dialog connection, just download
2026-07-28 14:44:55 : INFO  : lastpassdesktop : Downloaded LastPass for Desktop.dmg – Type is  zlib compressed data – SHA is 89e60cf90886bc771b4a6aecd33fc23ff20e6fb2 – Size is 213180 kB
2026-07-28 14:44:55 : DEBUG : lastpassdesktop : DEBUG mode 1, not checking for blocking processes
2026-07-28 14:44:55 : REQ   : lastpassdesktop : Installing LastPass for Desktop
2026-07-28 14:44:55 : INFO  : lastpassdesktop : Mounting /Users/u0105821/git/github/Installomator/build/LastPass for Desktop.dmg
2026-07-28 14:44:57 : DEBUG : lastpassdesktop : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $D82F11B9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0D017D25
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $2E2B2BC1
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $CD21EAA8
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $2E2B2BC1
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $4285490D
verified   CRC32 $99EF2CAE
/dev/disk5          	GUID_partition_scheme
/dev/disk5s1        	Apple_HFS                      	/Volumes/LastPass for Desktop 2.1.0-0-universal

2026-07-28 14:44:58 : INFO  : lastpassdesktop : Mounted: /Volumes/LastPass for Desktop 2.1.0-0-universal
2026-07-28 14:44:58 : INFO  : lastpassdesktop : Verifying: /Volumes/LastPass for Desktop 2.1.0-0-universal/LastPass for Desktop.app
2026-07-28 14:44:58 : DEBUG : lastpassdesktop : App size: 436M	/Volumes/LastPass for Desktop 2.1.0-0-universal/LastPass for Desktop.app
2026-07-28 14:45:00 : DEBUG : lastpassdesktop : Debugging enabled, App Verification output was:
/Volumes/LastPass for Desktop 2.1.0-0-universal/LastPass for Desktop.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: LastPass US LP (RNDLY9ZML8)

2026-07-28 14:45:00 : INFO  : lastpassdesktop : Team ID matching: RNDLY9ZML8 (expected: RNDLY9ZML8 )
2026-07-28 14:45:00 : INFO  : lastpassdesktop : Downloaded version of LastPass for Desktop is 2.1.0-0 on versionKey CFBundleShortVersionString (replacing version File Doesn't Exist, Will Create: /Applications/LastPass for Desktop.app/Contents/Info.plist).
2026-07-28 14:45:00 : INFO  : lastpassdesktop : App has LSMinimumSystemVersion: 12
2026-07-28 14:45:00 : DEBUG : lastpassdesktop : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-28 14:45:00 : INFO  : lastpassdesktop : Finishing...
Print: Entry, ":CFBundleShortVersionString", Does Not Exist
2026-07-28 14:45:03 : INFO  : lastpassdesktop : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/LastPass for Desktop.app/Contents/Info.plist
2026-07-28 14:45:04 : REQ   : lastpassdesktop : Installed LastPass for Desktop, version 2.1.0-0
2026-07-28 14:45:04 : INFO  : lastpassdesktop : notifying
2026-07-28 14:45:04 : DEBUG : lastpassdesktop : Unmounting /Volumes/LastPass for Desktop 2.1.0-0-universal
2026-07-28 14:45:04 : DEBUG : lastpassdesktop : Debugging enabled, Unmounting output was:
"disk5" ejected.
2026-07-28 14:45:04 : DEBUG : lastpassdesktop : DEBUG mode 1, not reopening anything
2026-07-28 14:45:04 : REQ   : lastpassdesktop : All done!
2026-07-28 14:45:04 : REQ   : lastpassdesktop : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
