### PR TITLE
sequelace-new-label

### DIFF
--- a/fragments/labels/sequelace.sh
+++ b/fragments/labels/sequelace.sh
@@ -2,6 +2,6 @@ sequelace)
     name="Sequel Ace"
     type="zip"
     downloadURL="$(downloadURLFromGit sequel-ace sequel-ace)"
-    appNewVersion="$(versionFromGit sequel-ace sequel-ace)"
+    appNewVersion="$(curl -fsL "https://api.github.com/repos/sequel-ace/sequel-ace/releases/latest" | awk -F '"' '/"tag_name"/{print $4; exit}' | sed -E 's|^production/||; s|-[0-9]+$||')"
     expectedTeamID="NKQ4HJ66PX"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This fixes appNewVersion mis-extraction in the sequelace label. The label currently relies on versionFromGit, which derives the version by stripping non-numeric characters from the GitHub release tag_name. Sequel Ace tags releases as production/<version>-<build> (e.g. production/5.2.1-20100), and that format includes a channel prefix (production/) and a build-number suffix (-20100) on either side of the real version. versionFromGit's generic stripping logic removes the punctuation but not the extra digit groups, so the prefix and suffix collapse into the version string, producing 5.2.120100 instead of 5.2.1. Since Installomator only checks for inequality rather than ordering, this mismatch causes the app to be flagged as outdated and reinstalled on every single run even though the installed version is current — confirmed in a v10.9beta log where appNewVersion reported 5.2.120100 against an installed version of 5.2.1.

The fix replaces the versionFromGit call with a direct extraction from the same GitHub API tag_name field, explicitly stripping the known production/ prefix and trailing -<build> suffix via sed, while leaving downloadURLFromGit untouched since asset resolution was never affected. This was validated end-to-end against the live release feed: the corrected pipeline was run against multiple real tags (production/5.2.1-20100 → 5.2.1, production/5.3.0-20102 → 5.3.0, production/5.0.9-20095 → 5.0.9, and the current live release production/5.3.1-20104 → 5.3.1), and in each case the derived version matched the installed app's CFBundleShortVersionString exactly. downloadURL and expectedTeamID (NKQ4HJ66PX, confirmed against the shipped binary's embedded Developer ID certificate) are unchanged and continue to verify correctly.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh sequelace DEBUG=1
2026-07-28 16:20:41 : INFO  : sequelace : setting variable from argument DEBUG=1
2026-07-28 16:20:41 : INFO  : sequelace : Total items in argumentsArray: 1
2026-07-28 16:20:42 : INFO  : sequelace : argumentsArray: DEBUG=1
2026-07-28 16:20:42 : REQ   : sequelace : ################## Start Installomator v. 10.10beta, date 2026-07-28
2026-07-28 16:20:42 : INFO  : sequelace : ################## Version: 10.10beta
2026-07-28 16:20:42 : INFO  : sequelace : ################## Date: 2026-07-28
2026-07-28 16:20:42 : INFO  : sequelace : ################## sequelace
2026-07-28 16:20:42 : DEBUG : sequelace : DEBUG mode 1 enabled.
2026-07-28 16:20:43 : INFO  : sequelace : Reading arguments again: DEBUG=1
2026-07-28 16:20:43 : DEBUG : sequelace : argument: DEBUG=1
2026-07-28 16:20:43 : DEBUG : sequelace : name=Sequel Ace
2026-07-28 16:20:43 : DEBUG : sequelace : appName=
2026-07-28 16:20:43 : DEBUG : sequelace : type=zip
2026-07-28 16:20:43 : DEBUG : sequelace : archiveName=
2026-07-28 16:20:43 : DEBUG : sequelace : downloadURL=https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/5.3.1-20104/Sequel-Ace-5.3.1.zip
2026-07-28 16:20:43 : DEBUG : sequelace : curlOptions=
2026-07-28 16:20:43 : DEBUG : sequelace : appNewVersion=5.3.1
2026-07-28 16:20:43 : DEBUG : sequelace : appCustomVersion function: Not defined
2026-07-28 16:20:43 : DEBUG : sequelace : versionKey=CFBundleShortVersionString
2026-07-28 16:20:43 : DEBUG : sequelace : packageID=
2026-07-28 16:20:43 : DEBUG : sequelace : pkgName=
2026-07-28 16:20:43 : DEBUG : sequelace : choiceChangesXML=
2026-07-28 16:20:43 : DEBUG : sequelace : expectedTeamID=NKQ4HJ66PX
2026-07-28 16:20:43 : DEBUG : sequelace : blockingProcesses=
2026-07-28 16:20:43 : DEBUG : sequelace : installerTool=
2026-07-28 16:20:43 : DEBUG : sequelace : CLIInstaller=
2026-07-28 16:20:43 : DEBUG : sequelace : CLIArguments=
2026-07-28 16:20:43 : DEBUG : sequelace : updateTool=
2026-07-28 16:20:43 : DEBUG : sequelace : updateToolArguments=
2026-07-28 16:20:43 : DEBUG : sequelace : updateToolRunAsCurrentUser=
2026-07-28 16:20:43 : INFO  : sequelace : BLOCKING_PROCESS_ACTION=tell_user
2026-07-28 16:20:43 : INFO  : sequelace : NOTIFY=success
2026-07-28 16:20:43 : INFO  : sequelace : LOGGING=DEBUG
2026-07-28 16:20:43 : INFO  : sequelace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-28 16:20:43 : INFO  : sequelace : Label type: zip
2026-07-28 16:20:43 : INFO  : sequelace : archiveName: Sequel Ace.zip
2026-07-28 16:20:43 : INFO  : sequelace : no blocking processes defined, using Sequel Ace as default
2026-07-28 16:20:43 : DEBUG : sequelace : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-07-28 16:20:43 : INFO  : sequelace : name: Sequel Ace, appName: Sequel Ace.app
2026-07-28 16:20:44 : WARN  : sequelace : No previous app found
2026-07-28 16:20:44 : WARN  : sequelace : could not find Sequel Ace.app
2026-07-28 16:20:44 : INFO  : sequelace : appversion: 
2026-07-28 16:20:44 : INFO  : sequelace : Latest version of Sequel Ace is 5.3.1
2026-07-28 16:20:44 : REQ   : sequelace : Downloading https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/5.3.1-20104/Sequel-Ace-5.3.1.zip to Sequel Ace.zip
2026-07-28 16:20:44 : DEBUG : sequelace : No Dialog connection, just download
2026-07-28 16:20:45 : INFO  : sequelace : Downloaded Sequel Ace.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=store – SHA is e34819a9b421f6bbb62d618f54c66ba06cefc33c – Size is 20116 kB
2026-07-28 16:20:45 : DEBUG : sequelace : DEBUG mode 1, not checking for blocking processes
2026-07-28 16:20:45 : REQ   : sequelace : Installing Sequel Ace
2026-07-28 16:20:45 : INFO  : sequelace : Unzipping Sequel Ace.zip
2026-07-28 16:20:47 : INFO  : sequelace : Verifying: /Users/u0105821/git/github/Installomator/build/Sequel Ace.app
2026-07-28 16:20:47 : DEBUG : sequelace : App size:  55M	/Users/u0105821/git/github/Installomator/build/Sequel Ace.app
2026-07-28 16:20:47 : DEBUG : sequelace : Debugging enabled, App Verification output was:
/Users/u0105821/git/github/Installomator/build/Sequel Ace.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Moballo, LLC (NKQ4HJ66PX)

2026-07-28 16:20:47 : INFO  : sequelace : Team ID matching: NKQ4HJ66PX (expected: NKQ4HJ66PX )
2026-07-28 16:20:47 : INFO  : sequelace : Installing Sequel Ace version 5.3.1 on versionKey CFBundleShortVersionString.
2026-07-28 16:20:47 : INFO  : sequelace : App has LSMinimumSystemVersion: 12.0
2026-07-28 16:20:47 : DEBUG : sequelace : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-07-28 16:20:47 : INFO  : sequelace : Finishing...
2026-07-28 16:20:50 : INFO  : sequelace : name: Sequel Ace, appName: Sequel Ace.app
2026-07-28 16:20:51 : INFO  : sequelace : App(s) found: /Users/u0105821/git/github/Installomator/build/Sequel Ace.app
2026-07-28 16:20:51 : WARN  : sequelace : could not determine location of Sequel Ace.app
2026-07-28 16:20:51 : REQ   : sequelace : Installed Sequel Ace, version 5.3.1
2026-07-28 16:20:51 : INFO  : sequelace : notifying
2026-07-28 16:20:51 : DEBUG : sequelace : DEBUG mode 1, not reopening anything
2026-07-28 16:20:51 : REQ   : sequelace : All done!
2026-07-28 16:20:51 : REQ   : sequelace : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
