### PR TITLE
Update inkscape label

### DIFF
--- a/fragments/labels/inkscape.sh
+++ b/fragments/labels/inkscape.sh
@@ -3,10 +3,10 @@ inkscape)
     type="dmg"
     appCustomVersion() { /Applications/Inkscape.app/Contents/MacOS/inkscape --version | cut -d " " -f2 }
     inkscapeReleasesJSON=$(curl -fsL -A "Installomator/$VERSION (+https://github.com/Installomator/Installomator)" "https://media.inkscape.org/media/releases.json")
-    if ! printf '%s' "$inkscapeReleasesJSON" | jq -e . > /dev/null 2>&1; then
+    if ! getJSONValue "$inkscapeReleasesJSON" '' >/dev/null 2>&1; then
         cleanupAndExit 2 "Inkscape: could not fetch or parse releases JSON" ERROR
     fi
-    appNewVersion=$(jq -r '.[0].releases | map(select(.released != null)) | max_by(.released) | .version' <<< "$inkscapeReleasesJSON")
+    appNewVersion=$(getJSONValue "$inkscapeReleasesJSON" '[0].releases[0].version')
     if [[ -z "$appNewVersion" ]]; then
         cleanupAndExit 2 "Inkscape: could not determine version from releases JSON" ERROR
     fi
@@ -17,7 +17,7 @@ inkscape)
     else
         cleanupAndExit 99 "Inkscape: unsupported architecture $(arch)" ERROR
     fi
-    downloadURL=$(printf '%s' "$inkscapeReleasesJSON" | jq -r --arg version "$appNewVersion" --arg platform "$inkscapePlatform" 'first(.[0].releases[] | select(.version == $version) | .platforms[] | select(.name == $platform) | .download) // empty')
+    downloadURL=$(getJSONValue "$inkscapeReleasesJSON" "[0].releases[0].platforms.find(platform => platform.name === \"${inkscapePlatform}\").download")
     if [[ -z "$downloadURL" ]]; then
         cleanupAndExit 2 "Inkscape: could not determine download URL from releases JSON" ERROR
     fi

--- a/fragments/labels/inkscape.sh
+++ b/fragments/labels/inkscape.sh
@@ -2,11 +2,24 @@ inkscape)
     name="Inkscape"
     type="dmg"
     appCustomVersion() { /Applications/Inkscape.app/Contents/MacOS/inkscape --version | cut -d " " -f2 }
-    appNewVersion=$(curl -fsL https://inkscape.org/release/  | grep "<title>" | grep -o -e "[0-9.]*")
+    inkscapeReleasesJSON=$(curl -fsL -A "Installomator/$VERSION (+https://github.com/Installomator/Installomator)" "https://media.inkscape.org/media/releases.json")
+    if ! printf '%s' "$inkscapeReleasesJSON" | jq -e . > /dev/null 2>&1; then
+        cleanupAndExit 2 "Inkscape: could not fetch or parse releases JSON" ERROR
+    fi
+    appNewVersion=$(jq -r '.[0].releases | map(select(.released != null)) | max_by(.released) | .version' <<< "$inkscapeReleasesJSON")
+    if [[ -z "$appNewVersion" ]]; then
+        cleanupAndExit 2 "Inkscape: could not determine version from releases JSON" ERROR
+    fi
     if [[ $(arch) == arm64 ]]; then
-        downloadURL="https://media.inkscape.org/dl/resources/file/$(curl -fsL https://inkscape.org/release/inkscape-{$appNewVersion}/mac-os-x/dmg-arm64/dl/ | grep -o -m1 "Inkscape-.*.dmg")"
+        inkscapePlatform="macOS : dmg (arm64)"
     elif [[ $(arch) == i386 ]]; then
-        downloadURL="https://media.inkscape.org/dl/resources/file/$(curl -fsL https://inkscape.org/release/inkscape-{$appNewVersion}/mac-os-x/dmg/dl/ | grep -o -m1 "Inkscape-.*.dmg")"
+        inkscapePlatform="macOS : dmg (Intel)"
+    else
+        cleanupAndExit 99 "Inkscape: unsupported architecture $(arch)" ERROR
+    fi
+    downloadURL=$(printf '%s' "$inkscapeReleasesJSON" | jq -r --arg version "$appNewVersion" --arg platform "$inkscapePlatform" 'first(.[0].releases[] | select(.version == $version) | .platforms[] | select(.name == $platform) | .download) // empty')
+    if [[ -z "$downloadURL" ]]; then
+        cleanupAndExit 2 "Inkscape: could not determine download URL from releases JSON" ERROR
     fi
     expectedTeamID="SW3D6BB6A6"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
There is another inkscape PR, but mine is much more thorough. We worked with inkscape directly to make these changes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.
Rewrote inkscape label to use a new releases.json file that they are now publishing for use with automation tools like installomater. This will also make it so installomater is only hitting their CDN and not their main web server which was causing problems.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

Script result: 2026-07-31 13:47:55 : REQ   :  : shifting arguments for Jamf
2026-07-31 13:47:55 : INFO  : inkscape : Total items in argumentsArray: 0
2026-07-31 13:47:55 : INFO  : inkscape : argumentsArray: 
2026-07-31 13:47:55 : REQ   : inkscape : ################## Start Installomator v. 10.9, date 2026-07-03
2026-07-31 13:47:55 : INFO  : inkscape : ################## Version: 10.9
2026-07-31 13:47:55 : INFO  : inkscape : ################## Date: 2026-07-03
2026-07-31 13:47:55 : INFO  : inkscape : ################## inkscape
2026-07-31 13:47:56 : INFO  : inkscape : Reading arguments again: 
2026-07-31 13:47:56 : INFO  : inkscape : BLOCKING_PROCESS_ACTION=prompt_user
2026-07-31 13:47:56 : INFO  : inkscape : NOTIFY=success
2026-07-31 13:47:56 : INFO  : inkscape : LOGGING=INFO
2026-07-31 13:47:56 : INFO  : inkscape : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-07-31 13:47:56 : INFO  : inkscape : Label type: dmg
2026-07-31 13:47:56 : INFO  : inkscape : archiveName: Inkscape.dmg
2026-07-31 13:47:57 : INFO  : inkscape : no blocking processes defined, using Inkscape as default
appCustomVersion: no such file or directory: /Applications/Inkscape.app/Contents/MacOS/inkscape
2026-07-31 13:47:57 : INFO  : inkscape : Custom App Version detection is used, found 
2026-07-31 13:47:57 : INFO  : inkscape : appversion: 
2026-07-31 13:47:57 : INFO  : inkscape : Latest version of Inkscape is 1.4.4
2026-07-31 13:47:57 : REQ   : inkscape : Downloading https://media.inkscape.org/dl/resources/file/Inkscape-1.4.4_arm64.dmg to Inkscape.dmg
2026-07-31 13:48:03 : INFO  : inkscape : Downloaded Inkscape.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 188bdfd9354bd5d270e4eb5bafec3bc10ad9b279 – Size is 164364 kB
2026-07-31 13:48:03 : REQ   : inkscape : no more blocking processes, continue with update
2026-07-31 13:48:03 : REQ   : inkscape : Installing Inkscape
2026-07-31 13:48:03 : INFO  : inkscape : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.E04az72AQR/Inkscape.dmg
2026-07-31 13:48:15 : INFO  : inkscape : Mounted: /Volumes/Inkscape
2026-07-31 13:48:15 : INFO  : inkscape : Verifying: /Volumes/Inkscape/Inkscape.app
2026-07-31 13:48:28 : INFO  : inkscape : Team ID matching: SW3D6BB6A6 (expected: SW3D6BB6A6 )
2026-07-31 13:48:28 : INFO  : inkscape : Installing Inkscape version 1.4.4 on versionKey CFBundleShortVersionString.
2026-07-31 13:48:28 : INFO  : inkscape : App has LSMinimumSystemVersion: 11.3
2026-07-31 13:48:28 : INFO  : inkscape : Copy /Volumes/Inkscape/Inkscape.app to /Applications
2026-07-31 13:48:45 : WARN  : inkscape : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2026-07-31 13:48:45 : INFO  : inkscape : Finishing...
2026-07-31 13:48:52 : INFO  : inkscape : Custom App Version detection is used, found 1.4.4
2026-07-31 13:48:52 : REQ   : inkscape : Installed Inkscape, version 1.4.4
2026-07-31 13:48:52 : INFO  : inkscape : notifying
WARNING: Sending notifications via Dialog.app is deprecated. Use --style banner or --style alert for new deployments.
2026-07-31 13:49:04 : INFO  : inkscape : Installomator did not close any apps, so no need to reopen any apps.
2026-07-31 13:49:04 : REQ   : inkscape : All done!
2026-07-31 13:49:04 : REQ   : inkscape : ################## End Installomator, exit code 0 
