### PR TITLE
Update eclipsetemurin25 label

### DIFF
--- a/fragments/labels/eclipsetemurin25.sh
+++ b/fragments/labels/eclipsetemurin25.sh
@@ -8,7 +8,7 @@ eclipsetemurin25)
     fi
     downloadURL=$(getJSONValue "$(curl -fsSL "https://api.adoptium.net/v3/assets/latest/25/hotspot?os=mac&image_type=jdk&vendor=eclipse&architecture=${cpu_arch}")" '[0].binary.installer.link')
     archiveName="$(basename "$downloadURL")"
-    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-21(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
+    appNewVersion="$(echo "$downloadURL" | grep -oE 'jdk-25(\.0\.)?([0-9]+)?(\.[0-9]+)?%2B[0-9]+(\.[0-9]+)?' | sed 's/jdk-//; s/%2B/+/g')"
     expectedTeamID="JCDTMS22B4"
     appCustomVersion(){ if [ -f "/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Info.plist" ]; then /usr/bin/defaults read "/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Info.plist" "CFBundleGetInfoString" | sed 's/OpenJDK //; s/-LTS//'; fi }
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
yes

**Additional context** 
Copy paste typo in appNewVersion regex matching `jdk-21` instead of `jdk-25`. Result was app was always downloaded/reinstalled even if at current version. See log line
```
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : appNewVersion=25.0.4+7
```
previously was 
```
2026-08-03 14:49:11: DEBUG : eclipsetemurin25 : appNewVersion=
```

**Installomator log**

```
./assemble.sh eclipsetemurin25
2026-08-03 14:49:10 : INFO  : eclipsetemurin25 : Total items in argumentsArray: 0
2026-08-03 14:49:10 : INFO  : eclipsetemurin25 : argumentsArray: 
2026-08-03 14:49:10 : REQ   : eclipsetemurin25 : ################## Start Installomator v. 10.10beta, date 2026-08-03
2026-08-03 14:49:10 : INFO  : eclipsetemurin25 : ################## Version: 10.10beta
2026-08-03 14:49:10 : INFO  : eclipsetemurin25 : ################## Date: 2026-08-03
2026-08-03 14:49:10 : INFO  : eclipsetemurin25 : ################## eclipsetemurin25
2026-08-03 14:49:10 : DEBUG : eclipsetemurin25 : DEBUG mode 1 enabled.
2026-08-03 14:49:11 : INFO  : eclipsetemurin25 : Reading arguments again: 
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : name=Temurin 25
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : appName=
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : type=pkg
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : archiveName=OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : downloadURL=https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : curlOptions=
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : appNewVersion=25.0.4+7
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : appCustomVersion function: Defined. 
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : versionKey=CFBundleShortVersionString
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : packageID=
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : pkgName=
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : choiceChangesXML=
2026-08-03 14:49:11 : DEBUG : eclipsetemurin25 : expectedTeamID=JCDTMS22B4
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : blockingProcesses=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : installerTool=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : CLIInstaller=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : CLIArguments=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : updateTool=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : updateToolArguments=
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : updateToolRunAsCurrentUser=
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : NOTIFY=success
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : LOGGING=DEBUG
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : Label type: pkg
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : archiveName: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : no blocking processes defined, using Temurin 25 as default
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : Changing directory to /Users/<USER>/git/github/Installomator/Installomator/build
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : Custom App Version detection is used, found 25.0.4+7
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : appversion: 25.0.4+7
2026-08-03 14:49:12 : INFO  : eclipsetemurin25 : Latest version of Temurin 25 is 25.0.4+7
2026-08-03 14:49:12 : WARN  : eclipsetemurin25 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-03 14:49:12 : REQ   : eclipsetemurin25 : Downloading https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg to OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:12 : DEBUG : eclipsetemurin25 : No Dialog connection, just download
2026-08-03 14:49:24 : INFO  : eclipsetemurin25 : Downloaded OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg – Type is  xar archive compressed TOC – SHA is 954fff2e711a8cad7790bd31c1c4d37c55f755a7 – Size is 147596 kB
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : DEBUG mode 1, not checking for blocking processes
2026-08-03 14:49:24 : REQ   : eclipsetemurin25 : Installing Temurin 25
2026-08-03 14:49:24 : INFO  : eclipsetemurin25 : Verifying: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : File list: -rw-r--r--@ 1 <USER>  staff   131M Aug  3 14:49 OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : File type: OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg: xar archive compressed TOC: 5567, SHA-1 checksum
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : spctlOut is OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.pkg: accepted
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : source=Notarized Developer ID
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : origin=Developer ID Installer: Eclipse Foundation, Inc. (JCDTMS22B4)
2026-08-03 14:49:24 : INFO  : eclipsetemurin25 : Team ID: JCDTMS22B4 (expected: JCDTMS22B4 )
2026-08-03 14:49:24 : DEBUG : eclipsetemurin25 : DEBUG enabled, skipping installation
2026-08-03 14:49:24 : INFO  : eclipsetemurin25 : Finishing...
2026-08-03 14:49:27 : INFO  : eclipsetemurin25 : Custom App Version detection is used, found 25.0.4+7
2026-08-03 14:49:28 : REQ   : eclipsetemurin25 : Installed Temurin 25, version 25.0.4+7
2026-08-03 14:49:28 : INFO  : eclipsetemurin25 : notifying
2026-08-03 14:49:28 : DEBUG : eclipsetemurin25 : DEBUG mode 1, not reopening anything
2026-08-03 14:49:28 : REQ   : eclipsetemurin25 : All done!
2026-08-03 14:49:28 : REQ   : eclipsetemurin25 : ################## End Installomator, exit code 0 
```
