### PR TITLE
fix: anotherredisdesktopmanager archive name

### DIFF
--- a/fragments/labels/anotherredisdesktopmanager.sh
+++ b/fragments/labels/anotherredisdesktopmanager.sh
@@ -1,13 +1,13 @@
 anotherredisdesktopmanager)
     name="Another Redis Desktop Manager"
+    type="dmg"
+    appNewVersion="$(versionFromGit qishibo AnotherRedisDesktopManager)"
     if [[ $(arch) == "arm64" ]]; then
-        archiveName="Another-Redis-Desktop-Manager-mac-1.7.1-arm64.dmg"
+        archiveName="Another-Redis-Desktop-Manager-mac-${appNewVersion}-arm64.dmg"
 
     elif [[ $(arch) == "i386" ]]; then
-        archiveName="Another-Redis-Desktop-Manager-win-1.7.1-x64.exe"
+        archiveName="Another-Redis-Desktop-Manager-mac-${appNewVersion}-x64.dmg"
     fi
-    type="dmg"
     downloadURL="$(downloadURLFromGit qishibo AnotherRedisDesktopManager)"
-    appNewVersion="$(versionFromGit qishibo AnotherRedisDesktopManager)"
     expectedTeamID="68JN8DV835"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.
Fixes two issues with how archiveName is formed with the current label:
- fixed version number was used (1.7.1) instead of variable or RegEx
- mac Intel case was using the Windows exe URL

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
sudo ./assemble.sh anotherredisdesktopmanager DEBUG=0
Password:
2026-08-03 15:31:46 : INFO  : anotherredisdesktopmanager : setting variable from argument DEBUG=0
2026-08-03 15:31:46 : INFO  : anotherredisdesktopmanager : Total items in argumentsArray: 1
2026-08-03 15:31:47 : INFO  : anotherredisdesktopmanager : argumentsArray: DEBUG=0
2026-08-03 15:31:47 : REQ   : anotherredisdesktopmanager : ################## Start Installomator v. 10.10beta, date 2026-08-03
2026-08-03 15:31:47 : INFO  : anotherredisdesktopmanager : ################## Version: 10.10beta
2026-08-03 15:31:47 : INFO  : anotherredisdesktopmanager : ################## Date: 2026-08-03
2026-08-03 15:31:47 : INFO  : anotherredisdesktopmanager : ################## anotherredisdesktopmanager
2026-08-03 15:31:48 : INFO  : anotherredisdesktopmanager : Reading arguments again: DEBUG=0
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : BLOCKING_PROCESS_ACTION=tell_user
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : NOTIFY=success
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : LOGGING=INFO
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : Label type: dmg
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : archiveName: Another-Redis-Desktop-Manager-mac-1.7.2-arm64.dmg
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : no blocking processes defined, using Another Redis Desktop Manager as default
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : App(s) found: /Applications/Another Redis Desktop Manager.app
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : found app at /Applications/Another Redis Desktop Manager.app, version 1.7.1, on versionKey CFBundleShortVersionString
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : appversion: 1.7.1
2026-08-03 15:31:49 : INFO  : anotherredisdesktopmanager : Latest version of Another Redis Desktop Manager is 1.7.2
2026-08-03 15:31:49 : REQ   : anotherredisdesktopmanager : Downloading https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v1.7.2/Another-Redis-Desktop-Manager-mac-1.7.2-arm64.dmg to Another-Redis-Desktop-Manager-mac-1.7.2-arm64.dmg
2026-08-03 15:31:52 : INFO  : anotherredisdesktopmanager : Downloaded Another-Redis-Desktop-Manager-mac-1.7.2-arm64.dmg – Type is  zlib compressed data – SHA is 9ec9166ce5701b24546bae0087f81f3936af97ff – Size is 98428 kB
2026-08-03 15:31:52 : REQ   : anotherredisdesktopmanager : no more blocking processes, continue with update
2026-08-03 15:31:52 : REQ   : anotherredisdesktopmanager : Installing Another Redis Desktop Manager
2026-08-03 15:31:52 : INFO  : anotherredisdesktopmanager : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.X5k1Y3nBXv/Another-Redis-Desktop-Manager-mac-1.7.2-arm64.dmg
2026-08-03 15:31:55 : INFO  : anotherredisdesktopmanager : Mounted: /Volumes/Another Redis Desktop Manager 1.7.2-arm64
2026-08-03 15:31:55 : INFO  : anotherredisdesktopmanager : Verifying: /Volumes/Another Redis Desktop Manager 1.7.2-arm64/Another Redis Desktop Manager.app
2026-08-03 15:31:56 : INFO  : anotherredisdesktopmanager : Team ID matching: 68JN8DV835 (expected: 68JN8DV835 )
2026-08-03 15:31:56 : INFO  : anotherredisdesktopmanager : Downloaded version of Another Redis Desktop Manager is 1.7.2 on versionKey CFBundleShortVersionString (replacing version 1.7.1).
2026-08-03 15:31:56 : INFO  : anotherredisdesktopmanager : App has LSMinimumSystemVersion: 10.11.0
2026-08-03 15:31:56 : WARN  : anotherredisdesktopmanager : Removing existing /Applications/Another Redis Desktop Manager.app
2026-08-03 15:31:56 : INFO  : anotherredisdesktopmanager : Copy /Volumes/Another Redis Desktop Manager 1.7.2-arm64/Another Redis Desktop Manager.app to /Applications
2026-08-03 15:31:57 : WARN  : anotherredisdesktopmanager : Changing owner to michael.debona
2026-08-03 15:31:57 : INFO  : anotherredisdesktopmanager : Finishing...
2026-08-03 15:32:00 : INFO  : anotherredisdesktopmanager : App(s) found: /Applications/Another Redis Desktop Manager.app
2026-08-03 15:32:00 : INFO  : anotherredisdesktopmanager : found app at /Applications/Another Redis Desktop Manager.app, version 1.7.2, on versionKey CFBundleShortVersionString
2026-08-03 15:32:00 : REQ   : anotherredisdesktopmanager : Installed Another Redis Desktop Manager, version 1.7.2
2026-08-03 15:32:00 : INFO  : anotherredisdesktopmanager : notifying
2026-08-03 15:32:01 : INFO  : anotherredisdesktopmanager : Installomator did not close any apps, so no need to reopen any apps.
2026-08-03 15:32:01 : REQ   : anotherredisdesktopmanager : All done!
2026-08-03 15:32:01 : REQ   : anotherredisdesktopmanager : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX") N/A
