### PR TITLE
Create intunelogwatch.sh

### DIFF
--- a/fragments/labels/intunelogwatch.sh
+++ b/fragments/labels/intunelogwatch.sh
@@ -1,0 +1,7 @@
+intunelogwatch)
+    name="IntuneLogWatch"
+    type="dmg"
+    downloadURL="$(downloadURLFromGit gilburns IntuneLogWatch)"
+    appNewVersion="$(versionFromGit gilburns IntuneLogWatch)"
+    expectedTeamID="G4MQ57TVLE"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
IntuneLogWatch is a macOS application for analyzing Microsoft Intune device logs

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
./utils/assemble.sh intunelogwatch   
2026-08-03 20:11:55 : INFO  : intunelogwatch : Total items in argumentsArray: 0
2026-08-03 20:11:55 : INFO  : intunelogwatch : argumentsArray: 
2026-08-03 20:11:55 : REQ   : intunelogwatch : ################## Start Installomator v. 10.10beta, date 2026-08-03
2026-08-03 20:11:55 : INFO  : intunelogwatch : ################## Version: 10.10beta
2026-08-03 20:11:55 : INFO  : intunelogwatch : ################## Date: 2026-08-03
2026-08-03 20:11:55 : INFO  : intunelogwatch : ################## intunelogwatch
2026-08-03 20:11:55 : DEBUG : intunelogwatch : DEBUG mode 1 enabled.
2026-08-03 20:11:57 : INFO  : intunelogwatch : Reading arguments again: 
2026-08-03 20:11:57 : DEBUG : intunelogwatch : name=IntuneLogWatch
2026-08-03 20:11:57 : DEBUG : intunelogwatch : appName=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : type=dmg
2026-08-03 20:11:57 : DEBUG : intunelogwatch : archiveName=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : downloadURL=https://github.com/gilburns/IntuneLogWatch/releases/download/2.0.0/IntuneLogWatch-20251207-2.0.0.dmg
2026-08-03 20:11:57 : DEBUG : intunelogwatch : curlOptions=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : appNewVersion=2.0.0
2026-08-03 20:11:57 : DEBUG : intunelogwatch : appCustomVersion function: Not defined
2026-08-03 20:11:57 : DEBUG : intunelogwatch : versionKey=CFBundleShortVersionString
2026-08-03 20:11:57 : DEBUG : intunelogwatch : packageID=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : pkgName=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : choiceChangesXML=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : expectedTeamID=G4MQ57TVLE
2026-08-03 20:11:57 : DEBUG : intunelogwatch : blockingProcesses=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : installerTool=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : CLIInstaller=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : CLIArguments=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : updateTool=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : updateToolArguments=
2026-08-03 20:11:57 : DEBUG : intunelogwatch : updateToolRunAsCurrentUser=
2026-08-03 20:11:57 : INFO  : intunelogwatch : BLOCKING_PROCESS_ACTION=tell_user
2026-08-03 20:11:57 : INFO  : intunelogwatch : NOTIFY=success
2026-08-03 20:11:57 : INFO  : intunelogwatch : LOGGING=DEBUG
2026-08-03 20:11:57 : INFO  : intunelogwatch : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-03 20:11:57 : INFO  : intunelogwatch : Label type: dmg
2026-08-03 20:11:57 : INFO  : intunelogwatch : archiveName: IntuneLogWatch.dmg
2026-08-03 20:11:57 : INFO  : intunelogwatch : no blocking processes defined, using IntuneLogWatch as default
2026-08-03 20:11:57 : DEBUG : intunelogwatch : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-08-03 20:11:57 : INFO  : intunelogwatch : App(s) found: /Applications/IntuneLogWatch.app
2026-08-03 20:11:57 : INFO  : intunelogwatch : found app at /Applications/IntuneLogWatch.app, version 2.0.0, on versionKey CFBundleShortVersionString
2026-08-03 20:11:57 : INFO  : intunelogwatch : appversion: 2.0.0
2026-08-03 20:11:57 : INFO  : intunelogwatch : Latest version of IntuneLogWatch is 2.0.0
2026-08-03 20:11:57 : WARN  : intunelogwatch : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-03 20:11:57 : REQ   : intunelogwatch : Downloading https://github.com/gilburns/IntuneLogWatch/releases/download/2.0.0/IntuneLogWatch-20251207-2.0.0.dmg to IntuneLogWatch.dmg
2026-08-03 20:11:57 : DEBUG : intunelogwatch : No Dialog connection, just download
2026-08-03 20:12:02 : INFO  : intunelogwatch : Downloaded IntuneLogWatch.dmg – Type is  zlib compressed data – SHA is edb94e95e2f420ea4f5ba13cf93d28a7859d1edd – Size is 8380 kB
2026-08-03 20:12:02 : DEBUG : intunelogwatch : DEBUG mode 1, not checking for blocking processes
2026-08-03 20:12:02 : REQ   : intunelogwatch : Installing IntuneLogWatch
2026-08-03 20:12:02 : INFO  : intunelogwatch : Mounting /Users/gilburns/GitHub/Installomator/build/IntuneLogWatch.dmg
2026-08-03 20:12:06 : DEBUG : intunelogwatch : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $744C6492
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $FF5FA7FD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $E4F820C8
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $95124BB4
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $E4F820C8
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $7D677AFD
verified   CRC32 $B97BA86A
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/IntuneLogWatch

2026-08-03 20:12:06 : INFO  : intunelogwatch : Mounted: /Volumes/IntuneLogWatch
2026-08-03 20:12:06 : INFO  : intunelogwatch : Verifying: /Volumes/IntuneLogWatch/IntuneLogWatch.app
2026-08-03 20:12:06 : DEBUG : intunelogwatch : App size:  15M	/Volumes/IntuneLogWatch/IntuneLogWatch.app
2026-08-03 20:12:06 : DEBUG : intunelogwatch : Debugging enabled, App Verification output was:
/Volumes/IntuneLogWatch/IntuneLogWatch.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Gil Burns (G4MQ57TVLE)

2026-08-03 20:12:06 : INFO  : intunelogwatch : Team ID matching: G4MQ57TVLE (expected: G4MQ57TVLE )
2026-08-03 20:12:06 : INFO  : intunelogwatch : Downloaded version of IntuneLogWatch is 2.0.0 on versionKey CFBundleShortVersionString, same as installed.
2026-08-03 20:12:06 : DEBUG : intunelogwatch : Unmounting /Volumes/IntuneLogWatch
2026-08-03 20:12:17 : DEBUG : intunelogwatch : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-03 20:12:17 : DEBUG : intunelogwatch : DEBUG mode 1, not reopening anything
2026-08-03 20:12:17 : REG   : intunelogwatch : No new version to install
2026-08-03 20:12:17 : REQ   : intunelogwatch : ################## End Installomator, exit code 0 

```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
