### PR TITLE
Add DFU Blaster Pro label

### DIFF
--- a/fragments/labels/dfublasterpro.sh
+++ b/fragments/labels/dfublasterpro.sh
@@ -1,0 +1,8 @@
+dfublasterpro)
+    name="DFU Blaster Pro"
+    type="pkgInDmg"
+    packageID="com.twocanoes.pkg.DFU-Blaster"
+    downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro.dmg"
+    appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/dfu-blaster/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build \(.*\)<\/h4>.*/\1.\2/p')
+    expectedTeamID="UXP6YEHSPW"
+    ;;

--- a/fragments/labels/dfublasterpro.sh
+++ b/fragments/labels/dfublasterpro.sh
@@ -1,8 +1,7 @@
 dfublasterpro)
     name="DFU Blaster Pro"
     type="pkgInDmg"
-    packageID="com.twocanoes.pkg.DFU-Blaster"
     downloadURL="https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro.dmg"
-    appNewVersion=$(curl -fs "https://twocanoes.com/products/mac/dfu-blaster/history/" | grep -A1 "<h3>Change Log</h3>" | sed -n 's/.*<h4>Version \(.*\) Build \(.*\)<\/h4>.*/\1.\2/p')
+    appNewVersion=$( getJSONValue "$(curl -fsL https://data.twocanoes.com/api/version_info)" "[\"com.twocanoes.DFU-Blaster-Pro\"].version" )
     expectedTeamID="UXP6YEHSPW"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes. Searched `Labels.txt` and `fragments/labels/*.sh` for `dfu` and found no existing label for DFU Blaster Pro.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes. This PR only adds `fragments/labels/dfublasterpro.sh`.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes.

**Additional context**

Adds a label for [DFU Blaster Pro](https://twocanoes.com/products/mac/dfu-blaster/) by Twocanoes Software — a `pkgInDmg` installer (the pkg sits at the root of the dmg, so no `pkgName` override is needed).

- `packageID` (`com.twocanoes.pkg.DFU-Blaster`) and `expectedTeamID` (`UXP6YEHSPW`) were confirmed by downloading the real dmg and running `pkgutil --expand` / `spctl -a -vv -t install` against the pkg inside it. The Team ID matches the existing `xcreds` and `passwordutility` labels, which are also Twocanoes products.
- `appNewVersion` is scraped from the public change log page at `https://twocanoes.com/products/mac/dfu-blaster/history/`, following the same pattern already used by the `xcreds` label (parsing `<h4>Version X Build Y</h4>` from the "Change Log" section). At the time of testing this returned `5.0.3567`, which matches the actual downloaded pkg version exactly.
- Since `packageID` is set, Installomator re-derives the authoritative version straight from the downloaded pkg at install time, so this label works correctly even if the change-log scrape ever lags behind.

**Installomator log**

```
2026-08-05 15:19:59 : INFO  : dfublasterpro : setting variable from argument DEBUG=1
2026-08-05 15:19:59 : INFO  : dfublasterpro : Total items in argumentsArray: 1
2026-08-05 15:19:59 : INFO  : dfublasterpro : argumentsArray: DEBUG=1
2026-08-05 15:19:59 : REQ   : dfublasterpro : ################## Start Installomator v. 10.10beta, date 2026-08-05
2026-08-05 15:19:59 : INFO  : dfublasterpro : ################## Version: 10.10beta
2026-08-05 15:19:59 : INFO  : dfublasterpro : ################## Date: 2026-08-05
2026-08-05 15:19:59 : INFO  : dfublasterpro : ################## dfublasterpro
2026-08-05 15:19:59 : DEBUG : dfublasterpro : DEBUG mode 1 enabled.
2026-08-05 15:20:00 : INFO  : dfublasterpro : Reading arguments again: DEBUG=1
2026-08-05 15:20:00 : INFO  : dfublasterpro : Label type: pkgInDmg
2026-08-05 15:20:00 : INFO  : dfublasterpro : archiveName: DFU Blaster Pro.dmg
2026-08-05 15:20:00 : INFO  : dfublasterpro : no blocking processes defined, using DFU Blaster Pro as default
2026-08-05 15:20:00 : INFO  : dfublasterpro : found packageID com.twocanoes.pkg.DFU-Blaster installed, version 5.0.3567
2026-08-05 15:20:00 : INFO  : dfublasterpro : appversion: 5.0.3567
2026-08-05 15:20:00 : INFO  : dfublasterpro : Latest version of DFU Blaster Pro is 5.0.3567
2026-08-05 15:20:00 : WARN  : dfublasterpro : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-05 15:20:00 : REQ   : dfublasterpro : Downloading https://twocanoes-software-updates.s3.amazonaws.com/DFU_Blaster_Pro.dmg to DFU Blaster Pro.dmg
2026-08-05 15:20:03 : INFO  : dfublasterpro : Downloaded DFU Blaster Pro.dmg – Type is  zlib compressed data – SHA is 0912eef3d701dd5a9dbd36fdeaaac006549bb100 – Size is 5172 kB
2026-08-05 15:20:03 : REQ   : dfublasterpro : Installing DFU Blaster Pro
2026-08-05 15:20:03 : INFO  : dfublasterpro : Mounting /Users/rquigley/git/external/Installomator/build/DFU Blaster Pro.dmg
2026-08-05 15:20:03 : INFO  : dfublasterpro : Mounted: /Volumes/DFU Blaster Pro 1
2026-08-05 15:20:04 : INFO  : dfublasterpro : found pkg: /Volumes/DFU Blaster Pro 1/DFU Blaster Pro.pkg
2026-08-05 15:20:04 : INFO  : dfublasterpro : Verifying: /Volumes/DFU Blaster Pro 1/DFU Blaster Pro.pkg
2026-08-05 15:20:04 : INFO  : dfublasterpro : Team ID: UXP6YEHSPW (expected: UXP6YEHSPW )
2026-08-05 15:20:04 : INFO  : dfublasterpro : Checking package version.
2026-08-05 15:20:04 : INFO  : dfublasterpro : Downloaded package com.twocanoes.pkg.DFU-Blaster version 5.0.3567
2026-08-05 15:20:04 : INFO  : dfublasterpro : Downloaded version of DFU Blaster Pro is the same as installed.
2026-08-05 15:20:04 : REQ   : dfublasterpro : No new version to install
2026-08-05 15:20:04 : REQ   : dfublasterpro : ################## End Installomator, exit code 0
```