### PR TITLE
Fix logitechoptionsplusoffline, fix: removing non-reliable version check

### DIFF
--- a/fragments/labels/logitechoptionsplusoffline.sh
+++ b/fragments/labels/logitechoptionsplusoffline.sh
@@ -5,10 +5,12 @@ logitechoptionsplusoffline)
     installerTool="logioptionsplus_installer_offline.app"
     type="zip"
     downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip"
-    # Latest version of Logi Options+ requires macOS 13+
-    # If older macOS is specified in the url for appNewVersion, it will never correspond to the installed version
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-13.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    # No reliable version source exists for the offline package specifically —
+    # the Logi support API only reflects the online installer's version, which
+    # is usually ahead of what's bundled in the offline zip. Leaving appNewVersion unset
     CLIInstaller="logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"
+    versionKey="CFBundleShortVersionString"
     ;;
+    

--- a/fragments/labels/logitechoptionsplusoffline.sh
+++ b/fragments/labels/logitechoptionsplusoffline.sh
@@ -11,5 +11,5 @@ logitechoptionsplusoffline)
     CLIInstaller="logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
     expectedTeamID="QED4VVPZWA"
-    versionKey="CFBundleShortVersionString"
+    versionKey="CFBundleVersion"
     ;;

--- a/fragments/labels/logitechoptionsplusoffline.sh
+++ b/fragments/labels/logitechoptionsplusoffline.sh
@@ -13,4 +13,3 @@ logitechoptionsplusoffline)
     expectedTeamID="QED4VVPZWA"
     versionKey="CFBundleShortVersionString"
     ;;
-    


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.
Removing the version check from this label has it's not reliable. The provided URL checks the version of the "online" app rather than the "offline" version. There is no equivalent page for the offline version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
sudo ./assemble.sh logitechoptionsplusoffline DEBUG=0
Password:
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : setting variable from argument DEBUG=0
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : Total items in argumentsArray: 1
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : argumentsArray: DEBUG=0
2026-08-05 14:47:41 : REQ   : logitechoptionsplusoffline : ################## Start Installomator v. 10.10beta, date 2026-08-05
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : ################## Version: 10.10beta
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : ################## Date: 2026-08-05
2026-08-05 14:47:41 : INFO  : logitechoptionsplusoffline : ################## logitechoptionsplusoffline
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : Reading arguments again: DEBUG=0
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : BLOCKING_PROCESS_ACTION=tell_user
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : NOTIFY=success
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : LOGGING=INFO
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : Label type: zip
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : archiveName: logioptionsplus_installer_offline.zip
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : no blocking processes defined, using Logi Options+ as default
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : App(s) found: /Applications/logioptionsplus.app
2026-08-05 14:47:42 : INFO  : logitechoptionsplusoffline : found app at /Applications/logioptionsplus.app, version 2.4.903778, on versionKey CFBundleShortVersionString
2026-08-05 14:47:43 : INFO  : logitechoptionsplusoffline : appversion: 2.4.903778
2026-08-05 14:47:43 : INFO  : logitechoptionsplusoffline : Latest version not specified.
2026-08-05 14:47:43 : REQ   : logitechoptionsplusoffline : Downloading https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_offline.zip to logioptionsplus_installer_offline.zip
2026-08-05 14:55:58 : INFO  : logitechoptionsplusoffline : Downloaded logioptionsplus_installer_offline.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=store – SHA is 94ca5e9b31adebde5e576c63533e511050a38191 – Size is 1327460 kB
2026-08-05 14:55:58 : REQ   : logitechoptionsplusoffline : no more blocking processes, continue with update
2026-08-05 14:55:59 : REQ   : logitechoptionsplusoffline : Installing Logi Options+
2026-08-05 14:55:59 : REQ   : logitechoptionsplusoffline : installerTool used: logioptionsplus_installer_offline.app
2026-08-05 14:55:59 : INFO  : logitechoptionsplusoffline : Unzipping logioptionsplus_installer_offline.zip
2026-08-05 14:55:59 : INFO  : logitechoptionsplusoffline : Verifying: /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n5Zz1sG0Se/logioptionsplus_installer_offline.app
2026-08-05 14:56:00 : INFO  : logitechoptionsplusoffline : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-08-05 14:56:00.698 defaults[39579:443517]
The domain/default pair of (/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n5Zz1sG0Se/logioptionsplus_installer_offline.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-08-05 14:56:00 : INFO  : logitechoptionsplusoffline : Downloaded version of Logi Options+ is  on versionKey CFBundleShortVersionString (replacing version 2.4.903778).
2026-08-05 14:56:00 : INFO  : logitechoptionsplusoffline : App has LSMinimumSystemVersion: 14.0
2026-08-05 14:56:00 : INFO  : logitechoptionsplusoffline : CLIInstaller exists, running installer command /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n5Zz1sG0Se/logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer --quiet
2026-08-05 14:56:34 : INFO  : logitechoptionsplusoffline : Succesfully ran /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.n5Zz1sG0Se/logioptionsplus_installer_offline.app/Contents/MacOS/logioptionsplus_installer --quiet
2026-08-05 14:56:34 : INFO  : logitechoptionsplusoffline : Finishing...
2026-08-05 14:56:37 : INFO  : logitechoptionsplusoffline : name: Logi Options+, appName: logioptionsplus_installer_offline.app
2026-08-05 14:56:37 : WARN  : logitechoptionsplusoffline : No previous app found
2026-08-05 14:56:37 : WARN  : logitechoptionsplusoffline : could not find logioptionsplus_installer_offline.app
2026-08-05 14:56:37 : REQ   : logitechoptionsplusoffline : Installed Logi Options+
2026-08-05 14:56:38 : INFO  : logitechoptionsplusoffline : notifying
2026-08-05 14:56:38 : INFO  : logitechoptionsplusoffline : Installomator did not close any apps, so no need to reopen any apps.
2026-08-05 14:56:38 : REQ   : logitechoptionsplusoffline : All done!
2026-08-05 14:56:38 : REQ   : logitechoptionsplusoffline : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
