### PR TITLE
Update 8x8.sh

### DIFF
--- a/fragments/labels/8x8.sh
+++ b/fragments/labels/8x8.sh
@@ -1,12 +1,16 @@
 8x8)
     name="8x8 Work"
     type="dmg"
+
+    pageContent=$(curl -fs -L 'https://help.8x8.com/docs/download-8x8-work-for-desktop' | sed 's/&quot;/"/g')
+
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -o "https.*arm64-dmg-v[0-9.-]*.dmg" | head -n 1 | sed 's/\"//' | awk '{print $1}')
+        downloadURL=$(echo "$pageContent" | grep -o "https[^\" ]*work-arm64-dmg-v[0-9.-]*\.dmg" | head -n 1)
     else
-        downloadURL=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}')
+        downloadURL=$(echo "$pageContent" | grep -o "https[^\" ]*work-dmg-v[0-9.-]*\.dmg" | head -n 1)
     fi
-    # Check newer version than 7.2.4
-    appNewVersion=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}' | sed -E 's/.*-v([0-9\.]*)[-\.]*.*/\1/' )
+
+    appNewVersion=$(echo "$downloadURL" | sed -E 's/.*-v([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/')
+
     expectedTeamID="FC967L3QRG"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Modifying a table in a fragment
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Took a look, didn't really understand
**Additional context** Add any other context about the label or fix here.
Existing indicated a download URL was needed
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

`sudo /usr/local/Installomator/Installomator.sh 8x8 DEBUG=1
Password:
2026-08-06 10:37:58 : INFO  : 8x8 : setting variable from argument DEBUG=1
2026-08-06 10:37:58 : INFO  : 8x8 : Total items in argumentsArray: 1
2026-08-06 10:37:58 : INFO  : 8x8 : argumentsArray: DEBUG=1
2026-08-06 10:37:58 : REQ   : 8x8 : ################## Start Installomator v. 10.9.1, date 2026-07-03
2026-08-06 10:37:58 : INFO  : 8x8 : ################## Version: 10.9.1
2026-08-06 10:37:58 : INFO  : 8x8 : ################## Date: 2026-07-03
2026-08-06 10:37:58 : INFO  : 8x8 : ################## 8x8
2026-08-06 10:37:58 : DEBUG : 8x8 : DEBUG mode 1 enabled.
2026-08-06 10:37:59 : INFO  : 8x8 : Reading arguments again: DEBUG=1
2026-08-06 10:37:59 : DEBUG : 8x8 : argument: DEBUG=1
2026-08-06 10:37:59 : DEBUG : 8x8 : name=8x8 Work
2026-08-06 10:37:59 : DEBUG : 8x8 : appName=
2026-08-06 10:37:59 : DEBUG : 8x8 : type=dmg
2026-08-06 10:37:59 : DEBUG : 8x8 : archiveName=
2026-08-06 10:37:59 : DEBUG : 8x8 : downloadURL=https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.36.2-3.dmg
2026-08-06 10:37:59 : DEBUG : 8x8 : curlOptions=
2026-08-06 10:37:59 : DEBUG : 8x8 : appNewVersion=8.36.2
2026-08-06 10:37:59 : DEBUG : 8x8 : appCustomVersion function: Not defined
2026-08-06 10:37:59 : DEBUG : 8x8 : versionKey=CFBundleShortVersionString
2026-08-06 10:37:59 : DEBUG : 8x8 : packageID=
2026-08-06 10:37:59 : DEBUG : 8x8 : pkgName=
2026-08-06 10:37:59 : DEBUG : 8x8 : choiceChangesXML=
2026-08-06 10:38:00 : DEBUG : 8x8 : expectedTeamID=FC967L3QRG
2026-08-06 10:38:00 : DEBUG : 8x8 : blockingProcesses=
2026-08-06 10:38:00 : DEBUG : 8x8 : installerTool=
2026-08-06 10:38:00 : DEBUG : 8x8 : CLIInstaller=
2026-08-06 10:38:00 : DEBUG : 8x8 : CLIArguments=
2026-08-06 10:38:00 : DEBUG : 8x8 : updateTool=
2026-08-06 10:38:00 : DEBUG : 8x8 : updateToolArguments=
2026-08-06 10:38:00 : DEBUG : 8x8 : updateToolRunAsCurrentUser=
2026-08-06 10:38:00 : INFO  : 8x8 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-06 10:38:00 : INFO  : 8x8 : NOTIFY=success
2026-08-06 10:38:00 : INFO  : 8x8 : LOGGING=DEBUG
2026-08-06 10:38:00 : INFO  : 8x8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-06 10:38:00 : INFO  : 8x8 : Label type: dmg
2026-08-06 10:38:00 : INFO  : 8x8 : archiveName: 8x8 Work.dmg
2026-08-06 10:38:00 : INFO  : 8x8 : no blocking processes defined, using 8x8 Work as default
2026-08-06 10:38:00 : DEBUG : 8x8 : Changing directory to /usr/local/Installomator
2026-08-06 10:38:00 : INFO  : 8x8 : App(s) found: /Applications/8x8 Work.app
2026-08-06 10:38:00 : INFO  : 8x8 : found app at /Applications/8x8 Work.app, version 8.36.2, on versionKey CFBundleShortVersionString
2026-08-06 10:38:00 : INFO  : 8x8 : appversion: 8.36.2
2026-08-06 10:38:00 : INFO  : 8x8 : Latest version of 8x8 Work is 8.36.2
2026-08-06 10:38:00 : WARN  : 8x8 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-06 10:38:00 : REQ   : 8x8 : Downloading https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.36.2-3.dmg to 8x8 Work.dmg
2026-08-06 10:38:00 : DEBUG : 8x8 : No Dialog connection, just download
2026-08-06 10:38:02 : INFO  : 8x8 : Downloaded 8x8 Work.dmg – Type is  zlib compressed data – SHA is 35b74bad047d174bfc5740faafbfc58b3bd48163 – Size is 226184 kB
2026-08-06 10:38:02 : DEBUG : 8x8 : DEBUG mode 1, not checking for blocking processes
2026-08-06 10:38:02 : REQ   : 8x8 : Installing 8x8 Work
2026-08-06 10:38:02 : INFO  : 8x8 : Mounting /usr/local/Installomator/8x8 Work.dmg
2026-08-06 10:38:07 : DEBUG : 8x8 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $379FB3AE
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D14B6613
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $3F715939
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $FB7A845D
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $3F715939
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $D5E85796
verified   CRC32 $5DFBAFDA
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/8x8 Work

2026-08-06 10:38:07 : INFO  : 8x8 : Mounted: /Volumes/8x8 Work
2026-08-06 10:38:07 : INFO  : 8x8 : Verifying: /Volumes/8x8 Work/8x8 Work.app
2026-08-06 10:38:07 : DEBUG : 8x8 : App size: 642M	/Volumes/8x8 Work/8x8 Work.app
2026-08-06 10:38:09 : DEBUG : 8x8 : Debugging enabled, App Verification output was:
/Volumes/8x8 Work/8x8 Work.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: 8x8, Inc. (FC967L3QRG)

2026-08-06 10:38:09 : INFO  : 8x8 : Team ID matching: FC967L3QRG (expected: FC967L3QRG )
2026-08-06 10:38:09 : INFO  : 8x8 : Downloaded version of 8x8 Work is 8.36.2 on versionKey CFBundleShortVersionString, same as installed.
2026-08-06 10:38:09 : DEBUG : 8x8 : Unmounting /Volumes/8x8 Work
2026-08-06 10:38:10 : DEBUG : 8x8 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-06 10:38:10 : DEBUG : 8x8 : DEBUG mode 1, not reopening anything
2026-08-06 10:38:10 : REG   : 8x8 : No new version to install
2026-08-06 10:38:10 : REQ   : 8x8 : ################## End Installomator, exit code 0`

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
