### PR TITLE
Update 8x8.sh

### DIFF
--- a/fragments/labels/8x8.sh
+++ b/fragments/labels/8x8.sh
@@ -1,12 +1,12 @@
 8x8)
     name="8x8 Work"
     type="dmg"
+    pageContent=$(curl -fsL "https://help.8x8.com/docs/download-8x8-work-for-desktop" | sed 's/&quot;/"/g')
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -o "https.*arm64-dmg-v[0-9.-]*.dmg" | head -n 1 | sed 's/\"//' | awk '{print $1}')
+        downloadURL=$(echo "$pageContent" | grep -o 'https://work-desktop-assets\.8x8\.com/prod-publish/ga/work-arm64-dmg-v[0-9][0-9.-]*\.dmg' | sort -Vr | head -n 1)
     else
-        downloadURL=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}')
+        downloadURL=$(echo "$pageContent" | grep -o 'https://work-desktop-assets\.8x8\.com/prod-publish/ga/work-dmg-v[0-9][0-9.-]*\.dmg' | sort -Vr | head -n 1)
     fi
-    # Check newer version than 7.2.4
-    appNewVersion=$(curl -fs -L 'https://support-portal.8x8.com/helpcenter/viewArticle.html?d=8bff4970-6fbf-4daf-842d-8ae9b533153d' | grep -m 1 -o "https.*dmg" | sed 's/\"//' | awk '{print $1}' | sed -E 's/.*-v([0-9\.]*)[-\.]*.*/\1/' )
+    appNewVersion=$(echo "$downloadURL" | sed -E 's/.*-v([0-9]+\.[0-9]+\.[0-9]+)-.*/\1/')
     expectedTeamID="FC967L3QRG"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Well, I submitted one earlier, but then was asked to do it again.
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes
**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

`/usr/local/Installomator/Installomator.sh 8x8
2026-08-06 11:43:47 : INFO  : 8x8 : Total items in argumentsArray: 0
2026-08-06 11:43:47 : INFO  : 8x8 : argumentsArray:
2026-08-06 11:43:47 : REQ   : 8x8 : ################## Start Installomator v. 10.9.1, date 2026-07-03
2026-08-06 11:43:47 : INFO  : 8x8 : ################## Version: 10.9.1
2026-08-06 11:43:47 : INFO  : 8x8 : ################## Date: 2026-07-03
2026-08-06 11:43:47 : INFO  : 8x8 : ################## 8x8
2026-08-06 11:43:48 : INFO  : 8x8 : Reading arguments again:
2026-08-06 11:43:48 : INFO  : 8x8 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-06 11:43:48 : INFO  : 8x8 : NOTIFY=success
2026-08-06 11:43:48 : INFO  : 8x8 : LOGGING=INFO
2026-08-06 11:43:48 : INFO  : 8x8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-06 11:43:48 : INFO  : 8x8 : Label type: dmg
2026-08-06 11:43:48 : INFO  : 8x8 : archiveName: 8x8 Work.dmg
2026-08-06 11:43:48 : INFO  : 8x8 : no blocking processes defined, using 8x8 Work as default
2026-08-06 11:43:48 : INFO  : 8x8 : App(s) found: /Applications/8x8 Work.app
2026-08-06 11:43:48 : INFO  : 8x8 : found app at /Applications/8x8 Work.app, version 8.36.2, on versionKey CFBundleShortVersionString
2026-08-06 11:43:48 : INFO  : 8x8 : appversion: 8.36.2
2026-08-06 11:43:48 : INFO  : 8x8 : Latest version of 8x8 Work is 8.36.2
2026-08-06 11:43:48 : INFO  : 8x8 : There is no newer version available.
2026-08-06 11:43:48 : INFO  : 8x8 : Installomator did not close any apps, so no need to reopen any apps.
2026-08-06 11:43:48 : REQ   : 8x8 : No newer version.
2026-08-06 11:43:48 : REQ   : 8x8 : ################## End Installomator, exit code 0

jamess-mbp-6:~ root# /usr/local/Installomator/Installomator.sh 8x8 DEBUG=1
2026-08-06 11:44:00 : INFO  : 8x8 : setting variable from argument DEBUG=1
2026-08-06 11:44:00 : INFO  : 8x8 : Total items in argumentsArray: 1
2026-08-06 11:44:00 : INFO  : 8x8 : argumentsArray: DEBUG=1
2026-08-06 11:44:00 : REQ   : 8x8 : ################## Start Installomator v. 10.9.1, date 2026-07-03
2026-08-06 11:44:00 : INFO  : 8x8 : ################## Version: 10.9.1
2026-08-06 11:44:00 : INFO  : 8x8 : ################## Date: 2026-07-03
2026-08-06 11:44:00 : INFO  : 8x8 : ################## 8x8
2026-08-06 11:44:00 : DEBUG : 8x8 : DEBUG mode 1 enabled.
2026-08-06 11:44:01 : INFO  : 8x8 : Reading arguments again: DEBUG=1
2026-08-06 11:44:01 : DEBUG : 8x8 : argument: DEBUG=1
2026-08-06 11:44:01 : DEBUG : 8x8 : name=8x8 Work
2026-08-06 11:44:01 : DEBUG : 8x8 : appName=
2026-08-06 11:44:01 : DEBUG : 8x8 : type=dmg
2026-08-06 11:44:01 : DEBUG : 8x8 : archiveName=
2026-08-06 11:44:01 : DEBUG : 8x8 : downloadURL=https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.36.2-3.dmg
2026-08-06 11:44:01 : DEBUG : 8x8 : curlOptions=
2026-08-06 11:44:01 : DEBUG : 8x8 : appNewVersion=8.36.2
2026-08-06 11:44:01 : DEBUG : 8x8 : appCustomVersion function: Not defined
2026-08-06 11:44:01 : DEBUG : 8x8 : versionKey=CFBundleShortVersionString
2026-08-06 11:44:02 : DEBUG : 8x8 : packageID=
2026-08-06 11:44:02 : DEBUG : 8x8 : pkgName=
2026-08-06 11:44:02 : DEBUG : 8x8 : choiceChangesXML=
2026-08-06 11:44:02 : DEBUG : 8x8 : expectedTeamID=FC967L3QRG
2026-08-06 11:44:02 : DEBUG : 8x8 : blockingProcesses=
2026-08-06 11:44:02 : DEBUG : 8x8 : installerTool=
2026-08-06 11:44:02 : DEBUG : 8x8 : CLIInstaller=
2026-08-06 11:44:02 : DEBUG : 8x8 : CLIArguments=
2026-08-06 11:44:02 : DEBUG : 8x8 : updateTool=
2026-08-06 11:44:02 : DEBUG : 8x8 : updateToolArguments=
2026-08-06 11:44:02 : DEBUG : 8x8 : updateToolRunAsCurrentUser=
2026-08-06 11:44:02 : INFO  : 8x8 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-06 11:44:02 : INFO  : 8x8 : NOTIFY=success
2026-08-06 11:44:02 : INFO  : 8x8 : LOGGING=DEBUG
2026-08-06 11:44:02 : INFO  : 8x8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-06 11:44:02 : INFO  : 8x8 : Label type: dmg
2026-08-06 11:44:02 : INFO  : 8x8 : archiveName: 8x8 Work.dmg
2026-08-06 11:44:02 : INFO  : 8x8 : no blocking processes defined, using 8x8 Work as default
2026-08-06 11:44:02 : DEBUG : 8x8 : Changing directory to /usr/local/Installomator
2026-08-06 11:44:02 : INFO  : 8x8 : App(s) found: /Applications/8x8 Work.app
2026-08-06 11:44:02 : INFO  : 8x8 : found app at /Applications/8x8 Work.app, version 8.36.2, on versionKey CFBundleShortVersionString
2026-08-06 11:44:02 : INFO  : 8x8 : appversion: 8.36.2
2026-08-06 11:44:02 : INFO  : 8x8 : Latest version of 8x8 Work is 8.36.2
2026-08-06 11:44:02 : WARN  : 8x8 : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-06 11:44:02 : INFO  : 8x8 : 8x8 Work.dmg exists and DEBUG mode 1 enabled, skipping download
2026-08-06 11:44:02 : DEBUG : 8x8 : DEBUG mode 1, not checking for blocking processes
2026-08-06 11:44:02 : REQ   : 8x8 : Installing 8x8 Work
2026-08-06 11:44:02 : INFO  : 8x8 : Mounting /usr/local/Installomator/8x8 Work.dmg
2026-08-06 11:44:02 : DEBUG : 8x8 : Debugging enabled, dmgmount output was:
expected   CRC32 $5DFBAFDA
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/8x8 Work

2026-08-06 11:44:02 : INFO  : 8x8 : Mounted: /Volumes/8x8 Work
2026-08-06 11:44:03 : INFO  : 8x8 : Verifying: /Volumes/8x8 Work/8x8 Work.app
2026-08-06 11:44:03 : DEBUG : 8x8 : App size: 642M	/Volumes/8x8 Work/8x8 Work.app
2026-08-06 11:44:10 : DEBUG : 8x8 : Debugging enabled, App Verification output was:
/Volumes/8x8 Work/8x8 Work.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: 8x8, Inc. (FC967L3QRG)

2026-08-06 11:44:10 : INFO  : 8x8 : Team ID matching: FC967L3QRG (expected: FC967L3QRG )
2026-08-06 11:44:10 : INFO  : 8x8 : Downloaded version of 8x8 Work is 8.36.2 on versionKey CFBundleShortVersionString, same as installed.
2026-08-06 11:44:11 : DEBUG : 8x8 : Unmounting /Volumes/8x8 Work
2026-08-06 11:44:11 : DEBUG : 8x8 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-06 11:44:11 : DEBUG : 8x8 : DEBUG mode 1, not reopening anything
2026-08-06 11:44:11 : REG   : 8x8 : No new version to install
2026-08-06 11:44:11 : REQ   : 8x8 : ################## End Installomator, exit code 0

jamess-mbp-6:~ root# /usr/local/Installomator/Installomator.sh 8x8 INSTALL=force NOTIFY=silent
2026-08-06 11:44:35 : INFO  : 8x8 : setting variable from argument INSTALL=force
2026-08-06 11:44:35 : INFO  : 8x8 : setting variable from argument NOTIFY=silent
2026-08-06 11:44:35 : INFO  : 8x8 : Total items in argumentsArray: 2
2026-08-06 11:44:35 : INFO  : 8x8 : argumentsArray: INSTALL=force NOTIFY=silent
2026-08-06 11:44:35 : REQ   : 8x8 : ################## Start Installomator v. 10.9.1, date 2026-07-03
2026-08-06 11:44:35 : INFO  : 8x8 : ################## Version: 10.9.1
2026-08-06 11:44:35 : INFO  : 8x8 : ################## Date: 2026-07-03
2026-08-06 11:44:35 : INFO  : 8x8 : ################## 8x8
2026-08-06 11:44:36 : INFO  : 8x8 : Reading arguments again: INSTALL=force NOTIFY=silent
2026-08-06 11:44:36 : INFO  : 8x8 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-06 11:44:36 : INFO  : 8x8 : NOTIFY=silent
2026-08-06 11:44:36 : INFO  : 8x8 : LOGGING=INFO
2026-08-06 11:44:36 : INFO  : 8x8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-06 11:44:37 : INFO  : 8x8 : Label type: dmg
2026-08-06 11:44:37 : INFO  : 8x8 : archiveName: 8x8 Work.dmg
2026-08-06 11:44:37 : INFO  : 8x8 : no blocking processes defined, using 8x8 Work as default
2026-08-06 11:44:37 : INFO  : 8x8 : App(s) found: /Applications/8x8 Work.app
2026-08-06 11:44:37 : INFO  : 8x8 : found app at /Applications/8x8 Work.app, version 8.36.2, on versionKey CFBundleShortVersionString
2026-08-06 11:44:37 : INFO  : 8x8 : appversion: 8.36.2
2026-08-06 11:44:37 : INFO  : 8x8 : Label is not of type “updateronly”, and it’s set to use force to install or ignoring app store apps, so not using updateTool.
2026-08-06 11:44:37 : INFO  : 8x8 : Latest version of 8x8 Work is 8.36.2
2026-08-06 11:44:37 : INFO  : 8x8 : There is no newer version available.
2026-08-06 11:44:37 : REQ   : 8x8 : Downloading https://work-desktop-assets.8x8.com/prod-publish/ga/work-arm64-dmg-v8.36.2-3.dmg to 8x8 Work.dmg
2026-08-06 11:44:39 : INFO  : 8x8 : Downloaded 8x8 Work.dmg – Type is  zlib compressed data – SHA is 35b74bad047d174bfc5740faafbfc58b3bd48163 – Size is 223588 kB
2026-08-06 11:44:40 : REQ   : 8x8 : no more blocking processes, continue with update
2026-08-06 11:44:40 : REQ   : 8x8 : Installing 8x8 Work
2026-08-06 11:44:40 : INFO  : 8x8 : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.xQsqQ63oVI/8x8 Work.dmg
2026-08-06 11:44:42 : INFO  : 8x8 : Mounted: /Volumes/8x8 Work
2026-08-06 11:44:42 : INFO  : 8x8 : Verifying: /Volumes/8x8 Work/8x8 Work.app
2026-08-06 11:44:44 : INFO  : 8x8 : Team ID matching: FC967L3QRG (expected: FC967L3QRG )
2026-08-06 11:44:44 : INFO  : 8x8 : Downloaded version of 8x8 Work is 8.36.2 on versionKey CFBundleShortVersionString, same as installed.
2026-08-06 11:44:44 : INFO  : 8x8 : Using force to install anyway.
2026-08-06 11:44:44 : INFO  : 8x8 : App has LSMinimumSystemVersion: 12.0
2026-08-06 11:44:44 : WARN  : 8x8 : Removing existing /Applications/8x8 Work.app
2026-08-06 11:44:45 : INFO  : 8x8 : Copy /Volumes/8x8 Work/8x8 Work.app to /Applications
2026-08-06 11:44:46 : WARN  : 8x8 : Changing owner to jamesorewiler
2026-08-06 11:44:46 : INFO  : 8x8 : Finishing...
2026-08-06 11:44:49 : INFO  : 8x8 : App(s) found: /Applications/8x8 Work.app
2026-08-06 11:44:49 : INFO  : 8x8 : found app at /Applications/8x8 Work.app, version 8.36.2, on versionKey CFBundleShortVersionString
2026-08-06 11:44:49 : REQ   : 8x8 : Installed 8x8 Work, version 8.36.2
2026-08-06 11:44:52 : INFO  : 8x8 : Installomator did not close any apps, so no need to reopen any apps.
2026-08-06 11:44:52 : REQ   : 8x8 : All done!
2026-08-06 11:44:52 : REQ   : 8x8 : ################## End Installomator, exit code 0`

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
