### PR TITLE
Create ankerwork.sh

### DIFF
--- a/fragments/labels/ankerwork.sh
+++ b/fragments/labels/ankerwork.sh
@@ -1,0 +1,11 @@
+ankerwork)
+	name="AnkerWork"
+	type="dmg"
+	if [[ "$(arch)" == "arm64" ]]; then
+		downloadURL="https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-arm64.dmg"
+	else
+		downloadURL="https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-x64.dmg"
+	fi
+	appNewVersion=$(curl -fsL "https://us.ankerwork.com/pages/download-software" | tr -d '\n' | grep -oE 'For Mac 10\.14 and above.*Headset Version' | grep -oE 'V[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^V//')
+	expectedTeamID="BVL93LPC7F"
+	;;


### PR DESCRIPTION
Add the AnkerWork app to Installomator

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes. There was an attempt with #1661 but it was closed out and never validated and this version has more logic in it for both chipsets.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
➜  ~ /Users/amartin/Documents/GitHub/Installomator/assemble.sh ankerwork
2026-08-06 08:49:40 : INFO  : ankerwork : Total items in argumentsArray: 0
2026-08-06 08:49:40 : INFO  : ankerwork : argumentsArray: 
2026-08-06 08:49:40 : REQ   : ankerwork : ################## Start Installomator v. 10.10beta, date 2026-08-06
2026-08-06 08:49:40 : INFO  : ankerwork : ################## Version: 10.10beta
2026-08-06 08:49:40 : INFO  : ankerwork : ################## Date: 2026-08-06
2026-08-06 08:49:40 : INFO  : ankerwork : ################## ankerwork
2026-08-06 08:49:40 : DEBUG : ankerwork : DEBUG mode 1 enabled.
2026-08-06 08:49:42 : INFO  : ankerwork : Reading arguments again: 
2026-08-06 08:49:42 : DEBUG : ankerwork : name=AnkerWork
2026-08-06 08:49:42 : DEBUG : ankerwork : appName=
2026-08-06 08:49:42 : DEBUG : ankerwork : type=dmg
2026-08-06 08:49:42 : DEBUG : ankerwork : archiveName=
2026-08-06 08:49:42 : DEBUG : ankerwork : downloadURL=https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-arm64.dmg
2026-08-06 08:49:42 : DEBUG : ankerwork : curlOptions=
2026-08-06 08:49:42 : DEBUG : ankerwork : appNewVersion=3.0.4
2026-08-06 08:49:42 : DEBUG : ankerwork : appCustomVersion function: Not defined
2026-08-06 08:49:42 : DEBUG : ankerwork : versionKey=CFBundleShortVersionString
2026-08-06 08:49:42 : DEBUG : ankerwork : packageID=
2026-08-06 08:49:42 : DEBUG : ankerwork : pkgName=
2026-08-06 08:49:42 : DEBUG : ankerwork : choiceChangesXML=
2026-08-06 08:49:42 : DEBUG : ankerwork : expectedTeamID=BVL93LPC7F
2026-08-06 08:49:42 : DEBUG : ankerwork : blockingProcesses=
2026-08-06 08:49:42 : DEBUG : ankerwork : installerTool=
2026-08-06 08:49:42 : DEBUG : ankerwork : CLIInstaller=
2026-08-06 08:49:42 : DEBUG : ankerwork : CLIArguments=
2026-08-06 08:49:43 : DEBUG : ankerwork : updateTool=
2026-08-06 08:49:43 : DEBUG : ankerwork : updateToolArguments=
2026-08-06 08:49:43 : DEBUG : ankerwork : updateToolRunAsCurrentUser=
2026-08-06 08:49:43 : INFO  : ankerwork : BLOCKING_PROCESS_ACTION=tell_user
2026-08-06 08:49:43 : INFO  : ankerwork : NOTIFY=success
2026-08-06 08:49:43 : INFO  : ankerwork : LOGGING=DEBUG
2026-08-06 08:49:43 : INFO  : ankerwork : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-06 08:49:43 : INFO  : ankerwork : Label type: dmg
2026-08-06 08:49:43 : INFO  : ankerwork : archiveName: AnkerWork.dmg
2026-08-06 08:49:43 : INFO  : ankerwork : no blocking processes defined, using AnkerWork as default
2026-08-06 08:49:43 : DEBUG : ankerwork : Changing directory to /Users/amartin/Documents/GitHub/Installomator/build
2026-08-06 08:49:43 : INFO  : ankerwork : name: AnkerWork, appName: AnkerWork.app
2026-08-06 08:49:43 : WARN  : ankerwork : No previous app found
2026-08-06 08:49:43 : WARN  : ankerwork : could not find AnkerWork.app
2026-08-06 08:49:43 : INFO  : ankerwork : appversion: 
2026-08-06 08:49:43 : INFO  : ankerwork : Latest version of AnkerWork is 3.0.4
2026-08-06 08:49:43 : REQ   : ankerwork : Downloading https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-arm64.dmg to AnkerWork.dmg
2026-08-06 08:49:43 : DEBUG : ankerwork : No Dialog connection, just download
2026-08-06 08:49:49 : INFO  : ankerwork : Downloaded AnkerWork.dmg – Type is  zlib compressed data – SHA is 81b780e2449daf5e61ba95f83273634f7d7046fa – Size is 131268 kB
2026-08-06 08:49:49 : DEBUG : ankerwork : DEBUG mode 1, not checking for blocking processes
2026-08-06 08:49:49 : REQ   : ankerwork : Installing AnkerWork
2026-08-06 08:49:49 : INFO  : ankerwork : Mounting /Users/amartin/Documents/GitHub/Installomator/build/AnkerWork.dmg
2026-08-06 08:49:52 : DEBUG : ankerwork : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record（MBR：0）…
Protective Master Boot Record（MBR：0）: verified   CRC32 $4E7875C8
Checksumming GPT Header（Primary GPT Header：1）…
GPT Header（Primary GPT Header：1）: verified   CRC32 $219BB015
Checksumming GPT Partition Data（Primary GPT Table：2）…
GPT Partition Data（Primary GPT Table: verified   CRC32 $09A73624
Checksumming （Apple_Free：3）…
（Apple_Free：3）: verified   CRC32 $00000000
Checksumming disk image（Apple_APFS：4）…
disk image（Apple_APFS：4）: verified   CRC32 $DD5C139A
Checksumming （Apple_Free：5）…
（Apple_Free：5）: verified   CRC32 $00000000
Checksumming GPT Partition Data（Backup GPT Table：6）…
GPT Partition Data（Backup GPT Table：: verified   CRC32 $09A73624
Checksumming GPT Header（Backup GPT Header：7）…
GPT Header（Backup GPT Header：7）: verified   CRC32 $D73591A2
verified   CRC32 $FB6E37EC
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/AnkerWork 3.0.4

2026-08-06 08:49:52 : INFO  : ankerwork : Mounted: /Volumes/AnkerWork 3.0.4
2026-08-06 08:49:52 : INFO  : ankerwork : Verifying: /Volumes/AnkerWork 3.0.4/AnkerWork.app
2026-08-06 08:49:52 : DEBUG : ankerwork : App size: 237M	/Volumes/AnkerWork 3.0.4/AnkerWork.app
2026-08-06 08:49:54 : DEBUG : ankerwork : Debugging enabled, App Verification output was:
/Volumes/AnkerWork 3.0.4/AnkerWork.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Power Mobile Life LLC (BVL93LPC7F)

2026-08-06 08:49:54 : INFO  : ankerwork : Team ID matching: BVL93LPC7F (expected: BVL93LPC7F )
2026-08-06 08:49:54 : INFO  : ankerwork : Installing AnkerWork version 3.0.4 on versionKey CFBundleShortVersionString.
2026-08-06 08:49:54 : INFO  : ankerwork : App has LSMinimumSystemVersion: 10.11.0
2026-08-06 08:49:54 : DEBUG : ankerwork : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-06 08:49:54 : INFO  : ankerwork : Finishing...
2026-08-06 08:49:57 : INFO  : ankerwork : name: AnkerWork, appName: AnkerWork.app
2026-08-06 08:49:58 : WARN  : ankerwork : No previous app found
2026-08-06 08:49:58 : WARN  : ankerwork : could not find AnkerWork.app
2026-08-06 08:49:58 : REQ   : ankerwork : Installed AnkerWork, version 3.0.4
2026-08-06 08:49:58 : INFO  : ankerwork : notifying
2026-08-06 08:49:58 : DEBUG : ankerwork : Unmounting /Volumes/AnkerWork 3.0.4
2026-08-06 08:49:58 : DEBUG : ankerwork : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-06 08:49:58 : DEBUG : ankerwork : DEBUG mode 1, not reopening anything
2026-08-06 08:49:59 : REQ   : ankerwork : All done!
2026-08-06 08:49:59 : REQ   : ankerwork : ################## End Installomator, exit code 0 
```
