### PR TITLE
Add Nexus Shell label

### DIFF
--- a/fragments/labels/nexusshell.sh
+++ b/fragments/labels/nexusshell.sh
@@ -1,0 +1,12 @@
+nexusshell)
+    name="Nexus Shell"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL=$(downloadURLFromGit viewer12 Nexus-Shell-Releases)
+        appNewVersion=$(versionFromGit viewer12 Nexus-Shell-Releases)
+    else
+        printlog "Nexus Shell is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "Nexus Shell requires Apple Silicon" ERROR
+    fi
+    expectedTeamID="5MBFAB57U2"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**

Yes. I checked the current `main` branch and existing label filenames before submitting.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes. This PR only adds `fragments/labels/nexusshell.sh`.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes.

**Additional context**

This adds a label for Nexus Shell, a native macOS SSH workspace for Apple silicon Macs. The label resolves both the current version and DMG from the official `viewer12/Nexus-Shell-Releases` GitHub repository, exits explicitly on Intel Macs, and verifies Developer Team ID `5MBFAB57U2`.

The GitHub release is used instead of the website update manifest so the label cannot select an older website-manifest version when a newer signed GitHub release is already available.

Disclosure: I am the developer of Nexus Shell.

**Installomator log**

Tested from the current `main` branch on macOS 26.5.2 (25F84), Apple silicon, with Nexus Shell 1.6.9 already installed. `DEBUG=1` was used so the current DMG would still be downloaded and verified without replacing the installed app.

```text
$ ./assemble.sh nexusshell NOTIFY=silent DEBUG=1
2026-08-08 02:52:54 : REQ   : nexusshell : ################## Start Installomator v. 10.10beta, date 2026-08-08
2026-08-08 02:52:54 : INFO  : nexusshell : ################## nexusshell
2026-08-08 02:52:54 : DEBUG : nexusshell : DEBUG mode 1 enabled.
2026-08-08 02:52:57 : DEBUG : nexusshell : name=Nexus Shell
2026-08-08 02:52:57 : DEBUG : nexusshell : type=dmg
2026-08-08 02:52:57 : DEBUG : nexusshell : downloadURL=https://github.com/viewer12/Nexus-Shell-Releases/releases/download/v1.6.9/Nexus-Shell-v1.6.9.dmg
2026-08-08 02:52:57 : DEBUG : nexusshell : appNewVersion=1.6.9
2026-08-08 02:52:57 : DEBUG : nexusshell : expectedTeamID=5MBFAB57U2
2026-08-08 02:52:58 : INFO  : nexusshell : found app at /Applications/Nexus Shell.app, version 1.6.9, on versionKey CFBundleShortVersionString
2026-08-08 02:52:58 : INFO  : nexusshell : Latest version of Nexus Shell is 1.6.9
2026-08-08 02:52:58 : REQ   : nexusshell : Downloading https://github.com/viewer12/Nexus-Shell-Releases/releases/download/v1.6.9/Nexus-Shell-v1.6.9.dmg to Nexus Shell.dmg
2026-08-08 02:53:07 : INFO  : nexusshell : Downloaded Nexus Shell.dmg - Type is zlib compressed data - SHA is 32bb14091a989b04a3a51b6662cab96a83f8d12f - Size is 12316 kB
2026-08-08 02:53:10 : INFO  : nexusshell : Mounted: /Volumes/Nexus Shell
2026-08-08 02:53:10 : INFO  : nexusshell : Verifying: /Volumes/Nexus Shell/Nexus Shell.app
/Volumes/Nexus Shell/Nexus Shell.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: JUAN XIAO (5MBFAB57U2)
2026-08-08 02:53:11 : INFO  : nexusshell : Team ID matching: 5MBFAB57U2 (expected: 5MBFAB57U2 )
2026-08-08 02:53:11 : INFO  : nexusshell : Downloaded version of Nexus Shell is 1.6.9 on versionKey CFBundleShortVersionString, same as installed.
2026-08-08 02:53:11 : REG   : nexusshell : No new version to install
2026-08-08 02:53:11 : REQ   : nexusshell : ################## End Installomator, exit code 0
```

The assembled script also passed `zsh -n build/Installomator.sh` and the change passed `git diff --check`.
