### PR TITLE
Fix devin.sh: stale downloadURL regex captures backtick-delimited JS, not URL

### DIFF
--- a/fragments/labels/devin.sh
+++ b/fragments/labels/devin.sh
@@ -3,9 +3,9 @@ windsurf)
     name="Devin"
     type="dmg"
     if [[ "$(arch)" == "arm64" ]]; then
-        downloadURL="$(curl -fsL "https://docs.devin.ai/desktop/releases" | grep -Eo 'https://[^"\]*-darwin-arm64-[0-9.]+\.dmg' | head -n 1)"
+        downloadURL="$(curl -fsL "https://docs.devin.ai/desktop/releases" | grep -Eo 'https://[^"`\]*-darwin-arm64-[0-9.]+\.dmg' | head -n 1)"
     else
-        downloadURL="$(curl -fsL "https://docs.devin.ai/desktop/releases" | grep -Eo 'https://[^"\]*-darwin-x64-[0-9.]+\.dmg' | head -n 1)"
+        downloadURL="$(curl -fsL "https://docs.devin.ai/desktop/releases" | grep -Eo 'https://[^"`\]*-darwin-x64-[0-9.]+\.dmg' | head -n 1)"
     fi
     appNewVersion="$(basename "$downloadURL" .dmg | awk -F- '{print $NF}')"
     expectedTeamID="83Z2LHX6XW"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — only `fragments/labels/devin.sh` is touched.

**Did you use our editorconfig file?**
Yes.

**Additional context**

Root cause of #3150: the vendor releases page (`https://docs.devin.ai/desktop/releases`) embeds its React/JS source directly in the HTML, using backtick template literals, e.g.:

```
darwinArm64:`https://.../Devin-darwin-arm64-3.6.27.zip`,darwinArm64Dmg:`https://.../Devin-darwin-arm64-3.6.27.dmg`
```

The label's `downloadURL` regex (`[^"\]*-darwin-arm64-[0-9.]+\.dmg`) excludes `"` and `\` but not backtick. With no quote/backslash between the `.zip` URL and the `.dmg` URL, the match runs straight through the first URL's closing backtick, the `,darwinArm64Dmg:` key, and the second backtick, only stopping at the *next* URL's `-darwin-arm64-<digits>.dmg` suffix. `downloadURL` ends up as the whole mangled string (`...zip\`,darwinArm64Dmg:\`https://...dmg`) — exactly what's in the issue's log — and curl 404s since that isn't a real path.

Fix: exclude backtick from the character class too (same change on both the arm64 and x64 lines). With backtick excluded, matching from the `.zip` URL's position now fails before it can reach a `.dmg` suffix, so the regex falls through to the next `https://` occurrence — the actual `.dmg` URL — and matches cleanly within its own backtick-delimited span.

No other label in the repo scrapes this vendor page, so this is fully scoped to `devin.sh`.

**Installomator log**

Before the fix (reproduces the reported bug):
```
2026-08-07 13:56:28 : INFO  : devin : Latest version of Devin is 3.6.27
2026-08-07 13:56:28 : REQ   : devin : Downloading https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/0becb483ee8498d49deadf6aefe8c24f58b8007e/Devin-darwin-arm64-3.6.27.zip`,darwinArm64Dmg:`https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/0becb483ee8498d49deadf6aefe8c24f58b8007e/Devin-darwin-arm64-3.6.27.dmg to Devin.dmg
2026-08-07 13:56:28 : ERROR : devin : error downloading ...
curl: (56) The requested URL returned error: 404
2026-08-07 13:56:28 : REQ   : devin : ################## End Installomator, exit code 2
```

After the fix (fresh install):
```
2026-08-07 14:00:00 : INFO  : devin : Latest version of Devin is 3.6.27
2026-08-07 14:00:00 : REQ   : devin : Downloading https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/0becb483ee8498d49deadf6aefe8c24f58b8007e/Devin-darwin-arm64-3.6.27.dmg to Devin.dmg
2026-08-07 14:00:06 : INFO  : devin : Downloaded Devin.dmg – Type is  zlib compressed data – SHA is b12e27ff77be0d86c5f0158f89618b2f6d8c6718 – Size is 344924 kB
2026-08-07 14:00:09 : INFO  : devin : Mounted: /Volumes/Devin
2026-08-07 14:00:12 : INFO  : devin : Team ID matching: 83Z2LHX6XW (expected: 83Z2LHX6XW )
2026-08-07 14:00:12 : INFO  : devin : Installing Devin version 3.6.27 on versionKey CFBundleShortVersionString.
2026-08-07 14:00:19 : INFO  : devin : App(s) found: /Applications/Devin.app
2026-08-07 14:00:19 : REQ   : devin : Installed Devin, version 3.6.27
2026-08-07 14:00:29 : REQ   : devin : All done!
2026-08-07 14:00:29 : REQ   : devin : ################## End Installomator, exit code 0
```

Re-run afterward (idempotency) correctly reports no newer version rather than re-downloading, and the `windsurf` alias resolves against the same install without issue.

Fixes #3150