### PR TITLE
Added version check and new Team ID to Disk Drill

### DIFF
--- a/fragments/labels/diskdrill.sh
+++ b/fragments/labels/diskdrill.sh
@@ -1,7 +1,6 @@
 diskdrill)
     name="Disk Drill"
     type="dmg"
-    appname="Disk Drill.app"
     downloadURL="https://dl.cleverfiles.com/diskdrill.dmg"
     appNewVersion=$( curl -fsL "https://www.cleverfiles.com/releases/auto-update/dd5-newestr.xml" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null)
     versionKey="CFBundleVersion"

--- a/fragments/labels/diskdrill.sh
+++ b/fragments/labels/diskdrill.sh
@@ -4,5 +4,6 @@ diskdrill)
     appname="Disk Drill.app"
     downloadURL="https://dl.cleverfiles.com/diskdrill.dmg"
     appNewVersion=$( curl -fsL "https://www.cleverfiles.com/releases/auto-update/dd5-newestr.xml" | xpath 'string(//rss/channel/item/enclosure/@sparkle:version)' 2>/dev/null)
-    expectedTeamID="A3W62KZY8Z"
+    versionKey="CFBundleVersion"
+    expectedTeamID="Z6C22PNU8R"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** 
I can't find any information from Cleverfiles on them changing Team ID, but the latest versions is signed by this new Team ID.
As a bonus I also corrected the app version check.

**Installomator log**
With no app installed:
```
➜  Installomator git:(change_expectedTeamID_on_diskdrill) ✗ sudo ./assemble.sh diskdrill NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:34:02 : INFO  : diskdrill : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-08-11 09:34:02 : INFO  : diskdrill : setting variable from argument NOTIFY=success
2026-08-11 09:34:02 : INFO  : diskdrill : setting variable from argument NOTIFY_DIALOG=1
2026-08-11 09:34:02 : INFO  : diskdrill : setting variable from argument DEBUG=0
2026-08-11 09:34:02 : INFO  : diskdrill : setting variable from argument SYSTEMOWNER=1
2026-08-11 09:34:02 : INFO  : diskdrill : Total items in argumentsArray: 5
2026-08-11 09:34:02 : INFO  : diskdrill : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:34:02 : REQ   : diskdrill : ################## Start Installomator v. 10.10beta, date 2026-08-11
2026-08-11 09:34:02 : INFO  : diskdrill : ################## Version: 10.10beta
2026-08-11 09:34:02 : INFO  : diskdrill : ################## Date: 2026-08-11
2026-08-11 09:34:02 : INFO  : diskdrill : ################## diskdrill
2026-08-11 09:34:03 : INFO  : diskdrill : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:34:03 : INFO  : diskdrill : BLOCKING_PROCESS_ACTION=tell_user
2026-08-11 09:34:03 : INFO  : diskdrill : NOTIFY=success
2026-08-11 09:34:03 : INFO  : diskdrill : LOGGING=INFO
2026-08-11 09:34:03 : INFO  : diskdrill : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-11 09:34:03 : INFO  : diskdrill : Label type: dmg
2026-08-11 09:34:03 : INFO  : diskdrill : archiveName: Disk Drill.dmg
2026-08-11 09:34:03 : INFO  : diskdrill : no blocking processes defined, using Disk Drill as default
2026-08-11 09:34:03 : INFO  : diskdrill : name: Disk Drill, appName: Disk Drill.app
2026-08-11 09:34:03 : WARN  : diskdrill : No previous app found
2026-08-11 09:34:03 : WARN  : diskdrill : could not find Disk Drill.app
2026-08-11 09:34:03 : INFO  : diskdrill : appversion: 
2026-08-11 09:34:03 : INFO  : diskdrill : Latest version of Disk Drill is 6.3.2326
2026-08-11 09:34:03 : REQ   : diskdrill : Downloading https://dl.cleverfiles.com/diskdrill.dmg to Disk Drill.dmg
2026-08-11 09:34:04 : INFO  : diskdrill : Downloaded Disk Drill.dmg – Type is  lzfse encoded, lzvn compressed – SHA is ca7dd0209b2eddfb84faf4a1f8828a603ad17f08 – Size is 68868 kB
2026-08-11 09:34:05 : REQ   : diskdrill : no more blocking processes, continue with update
2026-08-11 09:34:05 : REQ   : diskdrill : Installing Disk Drill
2026-08-11 09:34:05 : INFO  : diskdrill : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.l9gUTQ42VA/Disk Drill.dmg
2026-08-11 09:34:06 : INFO  : diskdrill : Mounted: /Volumes/DiskDrill
2026-08-11 09:34:06 : INFO  : diskdrill : Verifying: /Volumes/DiskDrill/Disk Drill.app
2026-08-11 09:34:07 : INFO  : diskdrill : Team ID matching: Z6C22PNU8R (expected: Z6C22PNU8R )
2026-08-11 09:34:07 : INFO  : diskdrill : Installing Disk Drill version 6.3.2326 on versionKey CFBundleVersion.
2026-08-11 09:34:07 : INFO  : diskdrill : App has LSMinimumSystemVersion: 10.15
2026-08-11 09:34:07 : INFO  : diskdrill : Copy /Volumes/DiskDrill/Disk Drill.app to /Applications
2026-08-11 09:34:07 : WARN  : diskdrill : No user logged in or SYSTEMOWNER=1, setting owner to root:wheel
2026-08-11 09:34:07 : INFO  : diskdrill : Finishing...
2026-08-11 09:34:11 : INFO  : diskdrill : App(s) found: /Applications/Disk Drill.app
2026-08-11 09:34:11 : INFO  : diskdrill : found app at /Applications/Disk Drill.app, version 6.3.2326, on versionKey CFBundleVersion
2026-08-11 09:34:11 : REQ   : diskdrill : Installed Disk Drill, version 6.3.2326
2026-08-11 09:34:11 : INFO  : diskdrill : notifying
WARNING: Sending notifications via Dialog.app is deprecated. Use --style banner or --style alert for new deployments.
2026-08-11 09:34:12 : INFO  : diskdrill : Installomator did not close any apps, so no need to reopen any apps.
2026-08-11 09:34:12 : REQ   : diskdrill : All done!
2026-08-11 09:34:12 : REQ   : diskdrill : ################## End Installomator, exit code 0 
```


With latest version installed:
```
➜  Installomator git:(change_expectedTeamID_on_diskdrill) ✗ sudo ./assemble.sh diskdrill NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1  DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:35:06 : INFO  : diskdrill : setting variable from argument NOTIFICATIONTYPE=swiftdialog
2026-08-11 09:35:06 : INFO  : diskdrill : setting variable from argument NOTIFY=success
2026-08-11 09:35:06 : INFO  : diskdrill : setting variable from argument NOTIFY_DIALOG=1
2026-08-11 09:35:06 : INFO  : diskdrill : setting variable from argument DEBUG=0
2026-08-11 09:35:06 : INFO  : diskdrill : setting variable from argument SYSTEMOWNER=1
2026-08-11 09:35:06 : INFO  : diskdrill : Total items in argumentsArray: 5
2026-08-11 09:35:06 : INFO  : diskdrill : argumentsArray: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:35:07 : REQ   : diskdrill : ################## Start Installomator v. 10.10beta, date 2026-08-11
2026-08-11 09:35:07 : INFO  : diskdrill : ################## Version: 10.10beta
2026-08-11 09:35:07 : INFO  : diskdrill : ################## Date: 2026-08-11
2026-08-11 09:35:07 : INFO  : diskdrill : ################## diskdrill
2026-08-11 09:35:07 : INFO  : diskdrill : Reading arguments again: NOTIFICATIONTYPE=swiftdialog NOTIFY=success NOTIFY_DIALOG=1 DEBUG=0 SYSTEMOWNER=1
2026-08-11 09:35:07 : INFO  : diskdrill : BLOCKING_PROCESS_ACTION=tell_user
2026-08-11 09:35:07 : INFO  : diskdrill : NOTIFY=success
2026-08-11 09:35:08 : INFO  : diskdrill : LOGGING=INFO
2026-08-11 09:35:08 : INFO  : diskdrill : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-11 09:35:08 : INFO  : diskdrill : Label type: dmg
2026-08-11 09:35:08 : INFO  : diskdrill : archiveName: Disk Drill.dmg
2026-08-11 09:35:08 : INFO  : diskdrill : no blocking processes defined, using Disk Drill as default
2026-08-11 09:35:08 : INFO  : diskdrill : App(s) found: /Applications/Disk Drill.app
2026-08-11 09:35:08 : INFO  : diskdrill : found app at /Applications/Disk Drill.app, version 6.3.2326, on versionKey CFBundleVersion
2026-08-11 09:35:08 : INFO  : diskdrill : appversion: 6.3.2326
2026-08-11 09:35:08 : INFO  : diskdrill : Latest version of Disk Drill is 6.3.2326
2026-08-11 09:35:08 : INFO  : diskdrill : There is no newer version available.
2026-08-11 09:35:08 : INFO  : diskdrill : Installomator did not close any apps, so no need to reopen any apps.
2026-08-11 09:35:08 : REQ   : diskdrill : No newer version.
2026-08-11 09:35:08 : REQ   : diskdrill : ################## End Installomator, exit code 0 
```