### PR TITLE
fix(nudgesuite): detect suite via packageID receipt instead of app version

### DIFF
--- a/fragments/labels/nudgesuite.sh
+++ b/fragments/labels/nudgesuite.sh
@@ -1,10 +1,10 @@
 nudgesuite)
     name="Nudge Suite"
-    appName="Nudge.app"
     type="pkg"
     archiveName="Nudge_Suite-[0-9.]*.pkg"
-    appNewVersion=$(versionFromGit macadmins Nudge )
+    packageID="com.github.macadmins.Nudge.Suite"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
+    appNewVersion=$(versionFromGit macadmins Nudge )
     expectedTeamID="T4SK8ZXCXG"
     blockingProcesses=( "Nudge" )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — only `fragments/labels/nudgesuite.sh`.

**Did you use our editorconfig file?**
Yes.

**Additional context**
Fixes the bug reported in #3038: `nudgesuite` shared app-version detection with the plain `nudge` label, so if `Nudge.app` was already installed (e.g. via `nudge`, or a Jamf App Installer shipping only the core app), `nudgesuite` saw the app at the current version and skipped installing entirely — the suite's LaunchAgent/LaunchDaemon files never got laid down.

Per @uurazzle's suggestion on the issue thread, switched detection to Installomator's `packageID` mechanism, keyed on the Suite pkg's own identifier (`com.github.macadmins.Nudge.Suite`), confirmed distinct from the plain pkg's `com.github.macadmins.Nudge`. `appName` is intentionally omitted so the fallback app-search can't accidentally match the already-installed `Nudge.app` by name and short-circuit the receipt check.

Tested on a real Mac: installed the core app via `nudge` alone, then ran the fixed `nudgesuite` — it correctly ignored the pre-existing app, installed the Suite pkg (Team ID `T4SK8ZXCXG` matches), and both `/Library/LaunchAgents/com.github.macadmins.Nudge.plist` and `/Library/LaunchDaemons/com.github.macadmins.Nudge.logger.plist` were present afterward. A second run correctly reported no update needed.

Fixes #3038

**Installomator log**
```
2026-08-11 12:19:07 : REQ   : nudgesuite : ################## Start Installomator v. 10.10beta, date 2026-08-11
2026-08-11 12:19:07 : DEBUG : nudgesuite : packageID=com.github.macadmins.Nudge.Suite
2026-08-11 12:19:07 : INFO  : nudgesuite : found packageID com.github.macadmins.Nudge.Suite installed, version 2.1.3.81860
2026-08-11 12:19:08 : DEBUG : nudgesuite : origin=Developer ID Installer: Mac Admins Open Source (T4SK8ZXCXG)
2026-08-11 12:19:08 : INFO  : nudgesuite : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2026-08-11 12:19:08 : INFO  : nudgesuite : Checking package version.
2026-08-11 12:19:08 : INFO  : nudgesuite : Downloaded package com.github.macadmins.Nudge.Suite version 2.1.3.81860
2026-08-11 12:19:08 : INFO  : nudgesuite : Downloaded version of Nudge Suite is the same as installed.
2026-08-11 12:19:08 : REQ   : nudgesuite : No new version to install
2026-08-11 12:19:08 : REQ   : nudgesuite : ################## End Installomator, exit code 0
```