### PR TITLE
fix(logseq): update expectedTeamID after signing cert change

### DIFF
--- a/fragments/labels/logseq.sh
+++ b/fragments/labels/logseq.sh
@@ -9,5 +9,5 @@ logseq)
         downloadURL=$(downloadURLFromGit logseq logseq)
     fi
     appNewVersion=$(versionFromGit logseq logseq)
-    expectedTeamID="3K44EUN829"
+    expectedTeamID="K378MFWK59"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — only `fragments/labels/logseq.sh`.

**Did you use our editorconfig file?**
Yes.

**Additional context**
Fixes the bug reported in #3162: Logseq switched Apple Developer signing certificates, so the label's `expectedTeamID` was stale and every install aborted with "Team IDs do not match" (exit 5), even though the download itself was fine.

Verified the new Team ID independently instead of just taking the report at face value — downloaded the current release (`Logseq-darwin-arm64-2.0.1.dmg`) and ran `codesign -dv --verbose=4` directly, which confirmed `TeamIdentifier=K378MFWK59`, matching the issue.

Updated `expectedTeamID` from `3K44EUN829` to `K378MFWK59`. One-line change, no other label logic affected.

Tested on a real Mac: ran the fixed label end-to-end, Team ID matched, `Logseq.app` installed to `/Applications` at version 2.0.1, exit code 0. Removed the app afterward.

Fixes #3162

**Installomator log**
```
2026-08-12 13:09:43 : REQ   : logseq : ################## Start Installomator v. 10.10beta, date 2026-08-12
2026-08-12 13:09:44 : INFO  : logseq : name: Logseq, appName: Logseq.app
2026-08-12 13:09:44 : WARN  : logseq : could not find Logseq.app
2026-08-12 13:09:44 : INFO  : logseq : Latest version of Logseq is 2.0.1
2026-08-12 13:09:44 : REQ   : logseq : Downloading https://github.com/logseq/logseq/releases/download/2.0.1/Logseq-darwin-arm64-2.0.1.dmg to darwin-arm64-[0-9.]*.dmg
2026-08-12 13:09:47 : INFO  : logseq : Downloaded darwin-arm64-[0-9.]*.dmg – Type is  lzfse encoded, lzvn compressed – SHA is bdda5b0068f0d47a0884263731c51ed8bd6984c2 – Size is 180892 kB
2026-08-12 13:09:48 : REQ   : logseq : Installing Logseq
2026-08-12 13:09:51 : INFO  : logseq : Mounted: /Volumes/Logseq 2.0.1-arm64
2026-08-12 13:09:51 : INFO  : logseq : Verifying: /Volumes/Logseq 2.0.1-arm64/Logseq.app
2026-08-12 13:09:52 : INFO  : logseq : Team ID matching: K378MFWK59 (expected: K378MFWK59 )
2026-08-12 13:09:52 : INFO  : logseq : Installing Logseq version 2.0.1 on versionKey CFBundleShortVersionString.
2026-08-12 13:09:52 : INFO  : logseq : Copy /Volumes/Logseq 2.0.1-arm64/Logseq.app to /Applications
2026-08-12 13:09:53 : WARN  : logseq : Changing owner to itadmin
2026-08-12 13:09:56 : INFO  : logseq : found app at /Applications/Logseq.app, version 2.0.1, on versionKey CFBundleShortVersionString
2026-08-12 13:09:56 : REQ   : logseq : Installed Logseq, version 2.0.1
2026-08-12 13:09:56 : REQ   : logseq : All done!
2026-08-12 13:09:56 : REQ   : logseq : ################## End Installomator, exit code 0
```
