### PR TITLE
Created headlamp.sh

### DIFF
--- a/fragments/labels/headlamp.sh
+++ b/fragments/labels/headlamp.sh
@@ -10,3 +10,4 @@ headlamp)
     appNewVersion=$(versionFromGit kubernetes-sigs headlamp)
     expectedTeamID="5N2JF58U87"
     ;;
+    

--- a/fragments/labels/headlamp.sh
+++ b/fragments/labels/headlamp.sh
@@ -10,4 +10,3 @@ headlamp)
     appNewVersion=$(versionFromGit kubernetes-sigs headlamp)
     expectedTeamID="5N2JF58U87"
     ;;
-    

--- a/fragments/labels/headlamp.sh
+++ b/fragments/labels/headlamp.sh
@@ -1,7 +1,7 @@
 headlamp)
     name="Headlamp"
     type="dmg"
-    if [[ "$arch" == "arm64" ]]; then
+    if [[ "$(arch)" == "arm64" ]]; then
         archiveName="mac-arm64.dmg"
     else
         archiveName="mac-x64.dmg"

--- a/fragments/labels/headlamp.sh
+++ b/fragments/labels/headlamp.sh
@@ -1,0 +1,13 @@
+headlamp)
+    name="Headlamp"
+    type="dmg"
+    if [[ "$arch" == "arm64" ]]; then
+        archiveName="mac-arm64.dmg"
+    else
+        archiveName="mac-x64.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit kubernetes-sigs headlamp)
+    appNewVersion=$(versionFromGit kubernetes-sigs headlamp)
+    expectedTeamID="5N2JF58U87"
+    ;;
+    


### PR DESCRIPTION
Output:
```
jose.garcia_test@Jose Garcia FNMQ72WT04 utils % sudo /Users/jose.garcia_test/Github/Installomator/utils/assemble.sh headlamp DEBUG=0
Password:
2026-08-14 13:08:30 : INFO  : headlamp : setting variable from argument DEBUG=0
2026-08-14 13:08:30 : INFO  : headlamp : Total items in argumentsArray: 1
2026-08-14 13:08:30 : INFO  : headlamp : argumentsArray: DEBUG=0
2026-08-14 13:08:30 : REQ   : headlamp : ################## Start Installomator v. 10.10beta, date 2026-08-14
2026-08-14 13:08:30 : INFO  : headlamp : ################## Version: 10.10beta
2026-08-14 13:08:30 : INFO  : headlamp : ################## Date: 2026-08-14
2026-08-14 13:08:30 : INFO  : headlamp : ################## headlamp
2026-08-14 13:08:32 : INFO  : headlamp : Reading arguments again: DEBUG=0
2026-08-14 13:08:32 : INFO  : headlamp : BLOCKING_PROCESS_ACTION=tell_user
2026-08-14 13:08:32 : INFO  : headlamp : NOTIFY=success
2026-08-14 13:08:32 : INFO  : headlamp : LOGGING=INFO
2026-08-14 13:08:32 : INFO  : headlamp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-14 13:08:32 : INFO  : headlamp : Label type: dmg
2026-08-14 13:08:32 : INFO  : headlamp : archiveName: mac-x64.dmg
2026-08-14 13:08:32 : INFO  : headlamp : no blocking processes defined, using Headlamp as default
2026-08-14 13:08:32 : INFO  : headlamp : name: Headlamp, appName: Headlamp.app
2026-08-14 13:08:32 : WARN  : headlamp : No previous app found
2026-08-14 13:08:32 : WARN  : headlamp : could not find Headlamp.app
2026-08-14 13:08:32 : INFO  : headlamp : appversion:
2026-08-14 13:08:32 : INFO  : headlamp : Latest version of Headlamp is 0.44.0
2026-08-14 13:08:32 : REQ   : headlamp : Downloading https://github.com/kubernetes-sigs/headlamp/releases/download/v0.44.0/Headlamp-0.44.0-mac-x64.dmg to mac-x64.dmg
2026-08-14 13:08:41 : INFO  : headlamp : Downloaded mac-x64.dmg – Type is  zlib compressed data – SHA is 70ed51ff2debff6b2fabdc817f649abd1a2e9401 – Size is 180572 kB
2026-08-14 13:08:41 : REQ   : headlamp : no more blocking processes, continue with update
2026-08-14 13:08:41 : REQ   : headlamp : Installing Headlamp
2026-08-14 13:08:41 : INFO  : headlamp : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.7aIpVaDmkt/mac-x64.dmg
2026-08-14 13:08:43 : INFO  : headlamp : Mounted: /Volumes/Headlamp 0.44.0
2026-08-14 13:08:43 : INFO  : headlamp : Verifying: /Volumes/Headlamp 0.44.0/Headlamp.app
2026-08-14 13:08:45 : INFO  : headlamp : Team ID matching: 5N2JF58U87 (expected: 5N2JF58U87 )
2026-08-14 13:08:45 : INFO  : headlamp : Installing Headlamp version 0.44.0 on versionKey CFBundleShortVersionString.
2026-08-14 13:08:45 : INFO  : headlamp : App has LSMinimumSystemVersion: 12.0
2026-08-14 13:08:45 : INFO  : headlamp : Copy /Volumes/Headlamp 0.44.0/Headlamp.app to /Applications
2026-08-14 13:08:46 : WARN  : headlamp : Changing owner to jose.garcia_test
2026-08-14 13:08:46 : INFO  : headlamp : Finishing...
2026-08-14 13:08:49 : INFO  : headlamp : App(s) found: /Applications/Headlamp.app
2026-08-14 13:08:49 : INFO  : headlamp : found app at /Applications/Headlamp.app, version 0.44.0, on versionKey CFBundleShortVersionString
2026-08-14 13:08:49 : REQ   : headlamp : Installed Headlamp, version 0.44.0
2026-08-14 13:08:49 : INFO  : headlamp : notifying
2026-08-14 13:09:00 : INFO  : headlamp : Installomator did not close any apps, so no need to reopen any apps.
2026-08-14 13:09:00 : REQ   : headlamp : All done!
2026-08-14 13:09:00 : REQ   : headlamp : ################## End Installomator, exit code 0

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
