### PR TITLE
Add glean label

### DIFF
--- a/fragments/labels/glean.sh
+++ b/fragments/labels/glean.sh
@@ -1,0 +1,7 @@
+glean)
+    name="Glean"
+    type="dmg"
+    appNewVersion=$(curl -sL "https://storage.googleapis.com/glean-downloads/glean-desktop-app/latest-mac.yml" | grep "^version:" | sed 's/^version:[[:space:]]*\([0-9.]*\).*/\1/')
+    downloadURL="https://storage.googleapis.com/glean-downloads/glean-desktop-app/Glean-${appNewVersion}-universal.dmg"
+    expectedTeamID="877XN49FUQ"
+    ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?**
Yes — there is no existing `glean` label.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes — this only adds `fragments/labels/glean.sh`. `Installomator.sh` is not touched.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes — LF line endings, 4-space indentation, trailing newline.

**Additional context**
Adds a label for **Glean** — the Glean desktop app (enterprise work assistant, publisher *Scio Technologies Inc*, Team ID `877XN49FUQ`).

The vendor publishes an Electron update feed at `https://storage.googleapis.com/glean-downloads/glean-desktop-app/latest-mac.yml`. The label reads `appNewVersion` from that feed and substitutes it into the universal `.dmg` filename, so the download URL and the version always come from the same source and stay in lockstep across releases (same pattern as the `claricopilot` label).

```
glean)
    name="Glean"
    type="dmg"
    appNewVersion=$(curl -sL "https://storage.googleapis.com/glean-downloads/glean-desktop-app/latest-mac.yml" | grep "^version:" | sed 's/^version:[[:space:]]*\([0-9.]*\).*/\1/')
    downloadURL="https://storage.googleapis.com/glean-downloads/glean-desktop-app/Glean-${appNewVersion}-universal.dmg"
    expectedTeamID="877XN49FUQ"
    ;;
```

**Installomator log**
Run with `DEBUG=2` (downloads to temp, verifies, does not install). `IGNORE_APP_STORE_APPS=yes` was used only because the test Mac happened to have the Mac App Store build of Glean installed.

```
glean : downloadURL=https://storage.googleapis.com/glean-downloads/glean-desktop-app/Glean-1.2026.21114-universal.dmg
glean : appNewVersion=1.2026.21114
glean : Label type: dmg
glean : archiveName: Glean.dmg
glean : found app at /Applications/Glean.app, version 1.2026.15222, on versionKey CFBundleShortVersionString
glean : Latest version of Glean is 1.2026.21114
glean : Downloading https://storage.googleapis.com/glean-downloads/glean-desktop-app/Glean-1.2026.21114-universal.dmg to Glean.dmg
glean : Team ID matching: 877XN49FUQ (expected: 877XN49FUQ )
glean : Downloaded version of Glean is 1.2026.21114 on versionKey CFBundleShortVersionString (replacing version 0).
glean : App has LSMinimumSystemVersion: 12.0
glean : ################## End Installomator, exit code 0
```
