### PR TITLE
fix(polylens): update expectedTeamID after Poly's HP acquisition re-sign

### DIFF
--- a/fragments/labels/polylens.sh
+++ b/fragments/labels/polylens.sh
@@ -4,5 +4,5 @@ polylens)
     polyDetails="$(curl -fs 'https://api.silica-prod01.io.lens.poly.com/graphql' -X POST -H 'Content-Type: application/json' --data-raw '{"operationName":"LensSoftwareUpdateAvailable","variables":{"productId":"lens-desktop-mac","releaseChannel":null},"query":"query LensSoftwareUpdateAvailable($productId: ID!, $releaseChannel: String) {availableProductSoftwareByPid(pid: $productId, releaseChannel: $releaseChannel) {version productBuild {build archiveUrl __typename} __typename}}"}')"
     appNewVersion=$(getJSONValue "$polyDetails" "data.availableProductSoftwareByPid.version")
     downloadURL=$(getJSONValue "$polyDetails" "data.availableProductSoftwareByPid.productBuild.archiveUrl")
-    expectedTeamID="WJCM3F7AQ4"
+    expectedTeamID="6HB5Y2QTA3"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?** Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes — only `fragments/labels/polylens.sh`.

**Did you use our editorconfig file?** Yes.

**Additional context**
Poly Lens/Studio was re-signed under HP Inc.'s certificate following Poly's acquisition by HP. This is the label's third `expectedTeamID` in its history (`SKWK2Q7JJV` → `WJCM3F7AQ4` in #2405 → now stale again). Confirmed the current signing identity directly with `pkgutil --check-signature` on the downloaded pkg:
```
Certificate Chain:
 1. Developer ID Installer: HP Inc. (6HB5Y2QTA3)
```
Before this fix the mismatch hit `cleanupAndExit` before any install step, matching the reported failures.

**Installomator log**
```
2026-08-14 16:22:42 : INFO  : polylens : Label type: pkgInDmg
2026-08-14 16:22:42 : INFO  : polylens : archiveName: Lens Desktop.dmg
2026-08-14 16:22:42 : WARN  : polylens : could not find Lens Desktop.app
2026-08-14 16:22:42 : INFO  : polylens : Latest version of Lens Desktop is 5.1.0.1803
2026-08-14 16:22:45 : INFO  : polylens : Downloaded Lens Desktop.dmg – Type is  zlib compressed data – SHA is 7a845a3318a29f907498c93d607d2039d7b1207b – Size is 252284 kB
2026-08-14 16:22:49 : INFO  : polylens : found pkg: /Volumes/Lens Desktop 5.1.0.1803/PolyStudio-5.1.0.1803.pkg
2026-08-14 16:22:49 : INFO  : polylens : Team ID: 6HB5Y2QTA3 (expected: 6HB5Y2QTA3 )
2026-08-14 16:22:49 : INFO  : polylens : Installing /Volumes/Lens Desktop 5.1.0.1803/PolyStudio-5.1.0.1803.pkg to /
2026-08-14 16:23:11 : REQ   : polylens : Installed Lens Desktop, version 5.1.0.1803
2026-08-14 16:23:11 : REQ   : polylens : All done!
2026-08-14 16:23:11 : REQ   : polylens : ################## End Installomator, exit code 0
```

Fixes #3076