### PR TITLE
fix(nudge): use fake app name so packageID drives version detection

### DIFF
--- a/fragments/labels/nudge.sh
+++ b/fragments/labels/nudge.sh
@@ -1,7 +1,8 @@
 nudge)
-    name="Nudge"
+    name="Nudge App"
     type="pkg"
     archiveName="Nudge-[0-9.]*.pkg"
+    packageID="com.github.macadmins.Nudge"
     downloadURL=$(downloadURLFromGit macadmins Nudge )
     appNewVersion=$(versionFromGit macadmins Nudge )
     expectedTeamID="T4SK8ZXCXG"


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?** Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes — only `fragments/labels/nudge.sh`.

**Did you use our editorconfig file?** Yes.

**Additional context**
`nudge` and `nudgesuite` both install the same `Nudge.app` bundle. `getAppVersion` falls back to matching any app at the default `appName` path when its `packageID` receipt isn't found — so if `nudgesuite` was installed first, plain `nudge` matched that fallback and silently reported "up to date" without ever installing anything of its own.

Per @gilburns/@uurazzle's discussion on the issue, this mirrors the `nudgesuite.sh` convention: `name="Nudge App"` isn't a real app name, so the fallback match never happens and `packageID=com.github.macadmins.Nudge` is what actually drives detection.

Verified on a real Mac, all three cases:
1. Suite installed first, then `nudge` run — previously falsely reported up to date, now correctly proceeds to install.
2. Fresh `nudge` install — succeeds, receipt recorded.
3. Re-run after install — correctly reports no newer version via the receipt.

**Installomator log**
```
2026-08-19 11:46:48 : INFO  : nudge : no blocking processes defined, using Nudge App as default
2026-08-19 11:46:48 : INFO  : nudge : No version found using packageID com.github.macadmins.Nudge
2026-08-19 11:46:48 : WARN  : nudge : could not find Nudge App.app
2026-08-19 11:46:48 : INFO  : nudge : Latest version of Nudge App is 2.1.3.81860
2026-08-19 11:46:49 : REQ   : nudge : Downloading https://github.com/macadmins/nudge/releases/download/v2.1.3.81860/Nudge-2.1.3.81860.pkg to Nudge-[0-9.]*.pkg
2026-08-19 11:46:50 : INFO  : nudge : Team ID: T4SK8ZXCXG (expected: T4SK8ZXCXG )
2026-08-19 11:46:57 : INFO  : nudge : found packageID com.github.macadmins.Nudge installed, version 2.1.3.81860
2026-08-19 11:46:57 : REQ   : nudge : Installed Nudge App, version 2.1.3.81860
2026-08-19 11:46:57 : REQ   : nudge : All done!
2026-08-19 11:46:57 : REQ   : nudge : ################## End Installomator, exit code 0

[re-run:]
2026-08-19 11:47:06 : INFO  : nudge : found packageID com.github.macadmins.Nudge installed, version 2.1.3.81860
2026-08-19 11:47:06 : INFO  : nudge : There is no newer version available.
2026-08-19 11:47:06 : REQ   : nudge : No newer version.
2026-08-19 11:47:06 : REQ   : nudge : ################## End Installomator, exit code 0
```

Fixes #3168