### PR TITLE
fix(openvpnconnectv3): strip build number from appNewVersion

### DIFF
--- a/fragments/labels/openvpnconnectv3.sh
+++ b/fragments/labels/openvpnconnectv3.sh
@@ -7,7 +7,7 @@ openvpnconnectv3)
         pkgName="OpenVPN_Connect_[0-9_()]*_x86_64_Installer_signed.pkg"
     fi
     downloadURL="https://openvpn.net/downloads/openvpn-connect-v3-macos.dmg"
-    appNewVersion=$(curl -sI "${downloadURL}" | awk -F'openvpn-connect-|_' '/^[Ll]ocation:/{print $2}')
+    appNewVersion=$(curl -sI "${downloadURL}" | awk -F'openvpn-connect-|_' '/^[Ll]ocation:/{print $2}' | cut -d'.' -f1-3)
     curlOptions=( -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15" )
     expectedTeamID="ACV7L3WCD8"
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?** Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes — only `fragments/labels/openvpnconnectv3.sh`.

**Did you use our editorconfig file?** Yes.

**Additional context**
`appNewVersion` scrapes the download redirect's `Location` header, which includes the build number (e.g. `3.8.2.6009`). The installed app only exposes `3.8.2` via `CFBundleShortVersionString` — the two formats never compared equal, so the label reinstalled the identical 262MB dmg on every run (reporter observed 9 reinstalls over 8 days, invisible to monitoring since exit code stayed 0).

Stripped the build number from `appNewVersion` to match the installed app's version format — simpler than adding a custom version function, since the default `CFBundleShortVersionString` comparison already works once both sides are in the same format.

**Installomator log**
```
2026-08-20 16:07:13 : INFO  : openvpnconnectv3 : Latest version of OpenVPN Connect is 3.8.2
2026-08-20 16:07:17 : REQ   : openvpnconnectv3 : Downloading https://openvpn.net/downloads/openvpn-connect-v3-macos.dmg to OpenVPN Connect.dmg
2026-08-20 16:07:22 : INFO  : openvpnconnectv3 : Team ID: ACV7L3WCD8 (expected: ACV7L3WCD8 )
2026-08-20 16:07:30 : INFO  : openvpnconnectv3 : Finishing...
2026-08-20 16:07:33 : REQ   : openvpnconnectv3 : Installed OpenVPN Connect, version 3.8.2
2026-08-20 16:07:40 : REQ   : openvpnconnectv3 : All done!
2026-08-20 16:07:40 : REQ   : openvpnconnectv3 : ################## End Installomator, exit code 0

[re-run immediately after:]
2026-08-20 16:07:49 : INFO  : openvpnconnectv3 : found app at /Applications/OpenVPN Connect.app, version 3.8.2, on versionKey CFBundleShortVersionString
2026-08-20 16:07:49 : INFO  : openvpnconnectv3 : Latest version of OpenVPN Connect is 3.8.2
2026-08-20 16:07:49 : INFO  : openvpnconnectv3 : There is no newer version available.
2026-08-20 16:07:49 : REQ   : openvpnconnectv3 : No newer version.
2026-08-20 16:07:49 : REQ   : openvpnconnectv3 : ################## End Installomator, exit code 0
```

Fixes #3172