### PR TITLE
Create prism11.sh

### DIFF
--- a/fragments/labels/prism11.sh
+++ b/fragments/labels/prism11.sh
@@ -1,0 +1,7 @@
+prism11)
+    name="Prism 11"
+    type="dmg"
+    downloadURL="https://cdn.graphpad.com/downloads/prism/11/InstallPrism11.dmg"
+    appNewVersion=$(curl -fs "https://www.graphpad.com/updates" | grep -Eio 'The latest Prism version is.*' | cut -d "(" -f 1 | awk -F '<!-- --> <!-- -->' '{print $2}' | cut -d "<" -f 1)
+    expectedTeamID="YQ2D36NS9M"
+    ;;

--- a/fragments/labels/prism11.sh
+++ b/fragments/labels/prism11.sh
@@ -1,7 +1,8 @@
 prism11)
     name="Prism 11"
     type="dmg"
-    downloadURL="https://cdn.graphpad.com/downloads/prism/11/InstallPrism11.dmg"
-    appNewVersion=$(curl -fs "https://www.graphpad.com/updates" | grep -Eio 'The latest Prism version is.*' | cut -d "(" -f 1 | awk -F '<!-- --> <!-- -->' '{print $2}' | cut -d "<" -f 1)
+    sparkleData=$(curl -fsL "https://licenses.graphpad.com/updates?version=11.0.0&configuration=full&platform=Mac&osVersion=26.0.0&osBitVersion=arm&appLanguageCode=en-us")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string(//*[local-name()="enclosure"]/@url)' -)
+    appNewVersion=$(echo "$downloadURL" | sed -E 's|.*/prism/11/([0-9]+(\.[0-9]+)+)/InstallPrism11\.dmg|\1|')
     expectedTeamID="YQ2D36NS9M"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**
```
2026-08-24 10:34:27 : INFO  : prism11 : Total items in argumentsArray: 0
2026-08-24 10:34:27 : INFO  : prism11 : argumentsArray: 
2026-08-24 10:34:27 : REQ   : prism11 : ################## Start Installomator v. 10.10beta, date 2026-08-24
2026-08-24 10:34:27 : INFO  : prism11 : ################## Version: 10.10beta
2026-08-24 10:34:27 : INFO  : prism11 : ################## Date: 2026-08-24
2026-08-24 10:34:27 : INFO  : prism11 : ################## prism11
2026-08-24 10:34:27 : DEBUG : prism11 : DEBUG mode 1 enabled.
2026-08-24 10:34:27 : INFO  : prism11 : SwiftDialog is not installed, clear cmd file var
2026-08-24 10:34:28 : INFO  : prism11 : Reading arguments again: 
2026-08-24 10:34:29 : DEBUG : prism11 : name=Prism 11
2026-08-24 10:34:29 : DEBUG : prism11 : appName=
2026-08-24 10:34:29 : DEBUG : prism11 : type=dmg
2026-08-24 10:34:29 : DEBUG : prism11 : archiveName=
2026-08-24 10:34:29 : DEBUG : prism11 : downloadURL=https://cdn.graphpad.com/downloads/prism/11/InstallPrism11.dmg
2026-08-24 10:34:29 : DEBUG : prism11 : curlOptions=
2026-08-24 10:34:29 : DEBUG : prism11 : appNewVersion=11.1.0
2026-08-24 10:34:29 : DEBUG : prism11 : appCustomVersion function: Not defined
2026-08-24 10:34:29 : DEBUG : prism11 : versionKey=CFBundleShortVersionString
2026-08-24 10:34:29 : DEBUG : prism11 : packageID=
2026-08-24 10:34:29 : DEBUG : prism11 : pkgName=
2026-08-24 10:34:29 : DEBUG : prism11 : choiceChangesXML=
2026-08-24 10:34:29 : DEBUG : prism11 : expectedTeamID=YQ2D36NS9M
2026-08-24 10:34:29 : DEBUG : prism11 : blockingProcesses=
2026-08-24 10:34:29 : DEBUG : prism11 : installerTool=
2026-08-24 10:34:29 : DEBUG : prism11 : CLIInstaller=
2026-08-24 10:34:29 : DEBUG : prism11 : CLIArguments=
2026-08-24 10:34:29 : DEBUG : prism11 : updateTool=
2026-08-24 10:34:29 : DEBUG : prism11 : updateToolArguments=
2026-08-24 10:34:29 : DEBUG : prism11 : updateToolRunAsCurrentUser=
2026-08-24 10:34:29 : INFO  : prism11 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-24 10:34:29 : INFO  : prism11 : NOTIFY=success
2026-08-24 10:34:29 : INFO  : prism11 : LOGGING=DEBUG
2026-08-24 10:34:29 : INFO  : prism11 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-24 10:34:29 : INFO  : prism11 : Label type: dmg
2026-08-24 10:34:29 : INFO  : prism11 : archiveName: Prism 11.dmg
2026-08-24 10:34:29 : INFO  : prism11 : no blocking processes defined, using Prism 11 as default
2026-08-24 10:34:29 : DEBUG : prism11 : Changing directory to /Users/kryptonit/Documents/github/Installomator/build
2026-08-24 10:34:29 : INFO  : prism11 : name: Prism 11, appName: Prism 11.app
2026-08-24 10:34:29 : WARN  : prism11 : No previous app found
2026-08-24 10:34:29 : WARN  : prism11 : could not find Prism 11.app
2026-08-24 10:34:29 : INFO  : prism11 : appversion: 
2026-08-24 10:34:29 : INFO  : prism11 : Latest version of Prism 11 is 11.1.0
2026-08-24 10:34:29 : REQ   : prism11 : Downloading https://cdn.graphpad.com/downloads/prism/11/InstallPrism11.dmg to Prism 11.dmg
2026-08-24 10:34:29 : DEBUG : prism11 : No Dialog connection, just download
2026-08-24 10:34:36 : INFO  : prism11 : Downloaded Prism 11.dmg – Type is  zlib compressed data – SHA is e5bb235d1a9076efb0324f3138387239f3d6f850 – Size is 180884 kB
2026-08-24 10:34:36 : DEBUG : prism11 : DEBUG mode 1, not checking for blocking processes
2026-08-24 10:34:36 : REQ   : prism11 : Installing Prism 11
2026-08-24 10:34:36 : INFO  : prism11 : Mounting /Users/kryptonit/Documents/github/Installomator/build/Prism 11.dmg
2026-08-24 10:34:39 : DEBUG : prism11 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $E4A85658
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $5DF4F2D0
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $9A973010
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $737ECCC9
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $9A973010
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $08D7F9EE
verified   CRC32 $48439B8B
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/GraphPad Prism 11

2026-08-24 10:34:39 : INFO  : prism11 : Mounted: /Volumes/GraphPad Prism 11
2026-08-24 10:34:39 : INFO  : prism11 : Verifying: /Volumes/GraphPad Prism 11/Prism 11.app
2026-08-24 10:34:39 : DEBUG : prism11 : App size: 472M	/Volumes/GraphPad Prism 11/Prism 11.app
2026-08-24 10:34:42 : DEBUG : prism11 : Debugging enabled, App Verification output was:
/Volumes/GraphPad Prism 11/Prism 11.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: GraphPad Software, Inc. (YQ2D36NS9M)

2026-08-24 10:34:42 : INFO  : prism11 : Team ID matching: YQ2D36NS9M (expected: YQ2D36NS9M )
2026-08-24 10:34:42 : INFO  : prism11 : Installing Prism 11 version 11.1.0 on versionKey CFBundleShortVersionString.
2026-08-24 10:34:42 : INFO  : prism11 : App has LSMinimumSystemVersion: 12.0
2026-08-24 10:34:42 : DEBUG : prism11 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-24 10:34:42 : INFO  : prism11 : Finishing...
2026-08-24 10:34:45 : INFO  : prism11 : name: Prism 11, appName: Prism 11.app
2026-08-24 10:34:45 : WARN  : prism11 : No previous app found
2026-08-24 10:34:45 : WARN  : prism11 : could not find Prism 11.app
2026-08-24 10:34:45 : REQ   : prism11 : Installed Prism 11, version 11.1.0
2026-08-24 10:34:45 : INFO  : prism11 : notifying
displaynotification:7: no such file or directory: /usr/local/bin/dialog
2026-08-24 10:34:45 : DEBUG : prism11 : Unmounting /Volumes/GraphPad Prism 11
2026-08-24 10:34:45 : DEBUG : prism11 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-24 10:34:45 : DEBUG : prism11 : DEBUG mode 1, not reopening anything
2026-08-24 10:34:45 : REQ   : prism11 : All done!
2026-08-24 10:34:45 : REQ   : prism11 : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
N/A