### PR TITLE
Fix googlechromeenterprise.sh: url-encode > in versionhistory filter

### DIFF
--- a/fragments/labels/googlechromeenterprise.sh
+++ b/fragments/labels/googlechromeenterprise.sh
@@ -2,7 +2,7 @@ googlechromeenterprise)
     name="Google Chrome"
     type="pkg"
     downloadURL="https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg"
-    appNewVersion=$(getJSONValue "$(curl -fsL "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=fraction>0.01,endtime=none&order_by=version%20desc" )" "releases[0].version" )
+    appNewVersion=$(getJSONValue "$(curl -fsL "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=fraction%3E0.01,endtime=none&order_by=version%20desc" )" "releases[0].version" )
     expectedTeamID="EQHXZ8M8AV"
     updateTool="/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent"
     updateToolArguments=( -runMode oneshot -userInitiated YES )


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use our editorconfig file?** Yes

**Additional context**

Fixes #2931 (duplicate: #2151).

`appNewVersion` builds a query string with a literal `>` in `filter=fraction>0.01`. An unencoded `>` in a URL is invalid and breaks the version lookup — confirmed against the actual bug report. Both sibling Chrome labels (`googlechrome.sh`, `googlechromepkg.sh`) already use the correctly-encoded `%3E` for the exact same query — this brings `googlechromeenterprise.sh` in line with that existing convention. One-character fix, no other changes.

**Installomator log**

```
2026-08-24 15:27:37 : INFO  : googlechromeenterprise : App(s) found: /Applications/Google Chrome.app
2026-08-24 15:27:37 : INFO  : googlechromeenterprise : found app at /Applications/Google Chrome.app, version 151.0.7922.170, on versionKey CFBundleShortVersionString
2026-08-24 15:27:37 : INFO  : googlechromeenterprise : appversion: 151.0.7922.170
2026-08-24 15:27:37 : INFO  : googlechromeenterprise : Latest version of Google Chrome is 151.0.7922.174
2026-08-24 15:27:37 : INFO  : googlechromeenterprise : App needs to be updated and uses /Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent. Ignoring BLOCKING_PROCESS_ACTION and running updateTool now.
2026-08-24 15:27:37 : WARN  : googlechromeenterprise : DEBUG mode 1 enabled, not running update tool
2026-08-24 15:27:37 : REQ   : googlechromeenterprise : Downloading https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg to Google Chrome.pkg
2026-08-24 15:27:41 : INFO  : googlechromeenterprise : Downloaded Google Chrome.pkg – Type is  xar archive compressed TOC – SHA is 7b15befb9ab4eb88a67fccd90e854cd0e4ae713f – Size is 266812 kB
2026-08-24 15:27:41 : REQ   : googlechromeenterprise : Installing Google Chrome
2026-08-24 15:27:41 : INFO  : googlechromeenterprise : Team ID: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2026-08-24 15:27:44 : REQ   : googlechromeenterprise : Installed Google Chrome, version 151.0.7922.174
2026-08-24 15:27:44 : REQ   : googlechromeenterprise : All done!
2026-08-24 15:27:44 : REQ   : googlechromeenterprise : ################## End Installomator, exit code 0
```