### PR TITLE
Update lmstudio.sh

### DIFF
--- a/fragments/labels/lmstudio.sh
+++ b/fragments/labels/lmstudio.sh
@@ -1,8 +1,16 @@
 lmstudio)
     name="LM Studio"
     type="dmg"
-    appNewVersion=$(curl -fsL "https://versions-prod.lmstudio.ai/update/darwin/arm64/latest" | plutil -extract version raw -)
-    appBuild=$(curl -fsL "https://versions-prod.lmstudio.ai/update/darwin/arm64/${appNewVersion}" | plutil -extract build raw -)
-    downloadURL="https://installers.lmstudio.ai/darwin/arm64/${appNewVersion}-${appBuild}/LM-Studio-${appNewVersion}-${appBuild}-arm64.dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        versionData=$(curl -fsL "https://versions-prod.lmstudio.ai/update/darwin/arm64/latest")
+        appVersion=$(echo "$versionData" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')
+        appBuild=$(echo "$versionData" | sed -n 's/.*"build":"\([^"]*\)".*/\1/p')
+        downloadVersion="${appVersion}-${appBuild}"
+        downloadURL="https://installers.lmstudio.ai/darwin/arm64/${downloadVersion}/LM-Studio-${downloadVersion}-arm64.dmg"
+        appNewVersion="${appVersion}+${appBuild}"
+    else
+        printlog "LM Studio is only compatible with Apple Silicon (arm64) Macs." ERROR
+        cleanupAndExit 95 "LM Studio requires Apple Silicon" ERROR
+    fi
     expectedTeamID="D65G88RHWN"
     ;;


### PR DESCRIPTION
Fix for lack of Intel support and correctly getting appNewVersion

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Label directly

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
Worked through on Mac Admins slack editing the original label

**Additional context** Add any other context about the label or fix here.
The appNewVersion wasn't complete, potentially resulting in unneeded extra runs.  This fix refines that and adds an error message if run on Intel.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
Installomator-10.9 % sh ./assemble.sh lmstudio DEBUG=1     
./assemble.sh: line 16: zparseopts: command not found
./assemble.sh: line 18: (I)(-h|--help): syntax error in expression (error token is "(-h|--help)")
./assemble.sh: line 23: (I)(-s|--script): syntax error in expression (error token is "(-s|--script)")
./assemble.sh: line 25: (I)(-p|--pkg): syntax error in expression (error token is "(-p|--pkg)")
./assemble.sh: line 27: (I)(-n|--notarize): syntax error in expression (error token is "(-n|--notarize)")
./assemble.sh: line 30: (I)(-r|--run): syntax error in expression (error token is "(-r|--run)")
2026-08-25 15:36:29 : INFO  : lmstudio : setting variable from argument DEBUG=1
2026-08-25 15:36:29 : INFO  : lmstudio : Total items in argumentsArray: 1
2026-08-25 15:36:29 : INFO  : lmstudio : argumentsArray: DEBUG=1
2026-08-25 15:36:29 : REQ   : lmstudio : ################## Start Installomator v. 10.9, date 2026-08-25
2026-08-25 15:36:29 : INFO  : lmstudio : ################## Version: 10.9
2026-08-25 15:36:29 : INFO  : lmstudio : ################## Date: 2026-08-25
2026-08-25 15:36:29 : INFO  : lmstudio : ################## lmstudio
2026-08-25 15:36:29 : DEBUG : lmstudio : DEBUG mode 1 enabled.
2026-08-25 15:36:29 : INFO  : lmstudio : Reading arguments again: DEBUG=1
2026-08-25 15:36:29 : DEBUG : lmstudio : argument: DEBUG=1
2026-08-25 15:36:29 : DEBUG : lmstudio : name=LM Studio
2026-08-25 15:36:30 : DEBUG : lmstudio : appName=
2026-08-25 15:36:30 : DEBUG : lmstudio : type=dmg
2026-08-25 15:36:30 : DEBUG : lmstudio : archiveName=
2026-08-25 15:36:30 : DEBUG : lmstudio : downloadURL=https://installers.lmstudio.ai/darwin/arm64/0.4.21-2/LM-Studio-0.4.21-2-arm64.dmg
2026-08-25 15:36:30 : DEBUG : lmstudio : curlOptions=
2026-08-25 15:36:30 : DEBUG : lmstudio : appNewVersion=0.4.21+2
2026-08-25 15:36:30 : DEBUG : lmstudio : appCustomVersion function: Not defined
2026-08-25 15:36:30 : DEBUG : lmstudio : versionKey=CFBundleShortVersionString
2026-08-25 15:36:30 : DEBUG : lmstudio : packageID=
2026-08-25 15:36:30 : DEBUG : lmstudio : pkgName=
2026-08-25 15:36:30 : DEBUG : lmstudio : choiceChangesXML=
2026-08-25 15:36:30 : DEBUG : lmstudio : expectedTeamID=D65G88RHWN
2026-08-25 15:36:30 : DEBUG : lmstudio : blockingProcesses=
2026-08-25 15:36:30 : DEBUG : lmstudio : installerTool=
2026-08-25 15:36:30 : DEBUG : lmstudio : CLIInstaller=
2026-08-25 15:36:30 : DEBUG : lmstudio : CLIArguments=
2026-08-25 15:36:30 : DEBUG : lmstudio : updateTool=
2026-08-25 15:36:30 : DEBUG : lmstudio : updateToolArguments=
2026-08-25 15:36:30 : DEBUG : lmstudio : updateToolRunAsCurrentUser=
2026-08-25 15:36:30 : INFO  : lmstudio : BLOCKING_PROCESS_ACTION=tell_user
2026-08-25 15:36:30 : INFO  : lmstudio : NOTIFY=success
2026-08-25 15:36:30 : INFO  : lmstudio : LOGGING=DEBUG
2026-08-25 15:36:30 : INFO  : lmstudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-25 15:36:30 : INFO  : lmstudio : Label type: dmg
2026-08-25 15:36:30 : INFO  : lmstudio : archiveName: LM Studio.dmg
2026-08-25 15:36:30 : INFO  : lmstudio : no blocking processes defined, using LM Studio as default
2026-08-25 15:36:30 : DEBUG : lmstudio : Changing directory to ./build
2026-08-25 15:36:30 : INFO  : lmstudio : name: LM Studio, appName: LM Studio.app
2026-08-25 15:36:30 : WARN  : lmstudio : No previous app found
2026-08-25 15:36:30 : WARN  : lmstudio : could not find LM Studio.app
2026-08-25 15:36:30 : INFO  : lmstudio : appversion: 
2026-08-25 15:36:30 : INFO  : lmstudio : Latest version of LM Studio is 0.4.21+2
2026-08-25 15:36:30 : INFO  : lmstudio : LM Studio.dmg exists and DEBUG mode 1 enabled, skipping download
2026-08-25 15:36:30 : DEBUG : lmstudio : DEBUG mode 1, not checking for blocking processes
2026-08-25 15:36:31 : REQ   : lmstudio : Installing LM Studio
2026-08-25 15:36:31 : INFO  : lmstudio : Mounting ./build/LM Studio.dmg
hdiutil: attach failed - No such file or directory
2026-08-25 15:36:31 : DEBUG : lmstudio : DEBUG mode 1, not reopening anything
2026-08-25 15:36:31 : ERROR : lmstudio : ERROR: Error mounting ./build/LM Studio.dmg error:
Log

2026-08-25 15:36:31 : REQ   : lmstudio : ################## End Installomator, exit code 3 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
