### PR TITLE
Update obsidian.sh

### DIFF
--- a/fragments/labels/obsidian.sh
+++ b/fragments/labels/obsidian.sh
@@ -1,8 +1,7 @@
 obsidian)
-    # credit: Søren Theilgaard (@theilgaard)
-    name="Obsidian"
+name="Obsidian"
     type="dmg"
-    downloadURL=$(curl -sfL --connect-timeout 10 --max-time 30 "https://api.github.com/repos/obsidianmd/obsidian-releases/releases?per_page=10" | awk -F '"' '/browser_download_url/ && /\.dmg"/ { print $4; exit }')
-    appNewVersion=$(echo "$downloadURL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    appNewVersion=$(curl -sfL --connect-timeout 10 --max-time 30 "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json" | awk -F'"' '/"beta"/{exit} /"latestVersion"/{print $4; exit}')
+    downloadURL="https://github.com/obsidianmd/obsidian-releases/releases/download/v${appNewVersion}/Obsidian-${appNewVersion}.dmg"
     expectedTeamID="6JSW4SJWN9"
     ;;

--- a/fragments/labels/obsidian.sh
+++ b/fragments/labels/obsidian.sh
@@ -1,7 +1,8 @@
 obsidian)
-name="Obsidian"
+    name="Obsidian"
     type="dmg"
-    appNewVersion=$(curl -sfL --connect-timeout 10 --max-time 30 "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json" | awk -F'"' '/"beta"/{exit} /"latestVersion"/{print $4; exit}')
+    obsidianData=$(curl -fsL "https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json")
+    appNewVersion=$(getJSONValue "$obsidianData" "latestVersion")
     downloadURL="https://github.com/obsidianmd/obsidian-releases/releases/download/v${appNewVersion}/Obsidian-${appNewVersion}.dmg"
     expectedTeamID="6JSW4SJWN9"
     ;;

--- a/fragments/labels/obsidian.sh
+++ b/fragments/labels/obsidian.sh
@@ -2,7 +2,7 @@ obsidian)
     # credit: Søren Theilgaard (@theilgaard)
     name="Obsidian"
     type="dmg"
-    downloadURL=$( downloadURLFromGit obsidianmd obsidian-releases )
-    appNewVersion=$(versionFromGit obsidianmd obsidian-releases)
+    downloadURL=$(curl -sfL --connect-timeout 10 --max-time 30 "https://api.github.com/repos/obsidianmd/obsidian-releases/releases?per_page=10" | awk -F '"' '/browser_download_url/ && /\.dmg"/ { print $4; exit }')
+    appNewVersion=$(echo "$downloadURL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
     expectedTeamID="6JSW4SJWN9"
     ;;


### PR DESCRIPTION
Obsidian recently changed their releases to be mobile only (as of 08-20-26) which threw off how the current label is looking at the latest version available within the releases URL in GitHub since the latest only has a .apk file and not a .dmg. The added logic here fixes this

All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?** Yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?** Yes

**Additional context** Add any other context about the label or fix here: This fixes the appLatestVersion and DownloadURL logic to parse if the latest release version from GitHub contains a .dmg file within its contents or not and if not, will go to the next available version in the Releases that does.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")

```
➜  ~ /Users/amartin/Documents/GitHub/Installomator/assemble.sh obsidian
2026-08-26 09:34:44 : INFO  : obsidian : Total items in argumentsArray: 0
2026-08-26 09:34:44 : INFO  : obsidian : argumentsArray: 
2026-08-26 09:34:44 : REQ   : obsidian : ################## Start Installomator v. 10.10beta, date 2026-08-26
2026-08-26 09:34:44 : INFO  : obsidian : ################## Version: 10.10beta
2026-08-26 09:34:44 : INFO  : obsidian : ################## Date: 2026-08-26
2026-08-26 09:34:44 : INFO  : obsidian : ################## obsidian
2026-08-26 09:34:44 : DEBUG : obsidian : DEBUG mode 1 enabled.
2026-08-26 09:34:46 : INFO  : obsidian : Reading arguments again: 
2026-08-26 09:34:46 : DEBUG : obsidian : name=Obsidian
2026-08-26 09:34:46 : DEBUG : obsidian : appName=
2026-08-26 09:34:46 : DEBUG : obsidian : type=dmg
2026-08-26 09:34:46 : DEBUG : obsidian : archiveName=
2026-08-26 09:34:46 : DEBUG : obsidian : downloadURL=https://github.com/obsidianmd/obsidian-releases/releases/download/v1.13.7/Obsidian-1.13.7.dmg
2026-08-26 09:34:46 : DEBUG : obsidian : curlOptions=
2026-08-26 09:34:46 : DEBUG : obsidian : appNewVersion=1.13.7
2026-08-26 09:34:46 : DEBUG : obsidian : appCustomVersion function: Not defined
2026-08-26 09:34:46 : DEBUG : obsidian : versionKey=CFBundleShortVersionString
2026-08-26 09:34:46 : DEBUG : obsidian : packageID=
2026-08-26 09:34:46 : DEBUG : obsidian : pkgName=
2026-08-26 09:34:46 : DEBUG : obsidian : choiceChangesXML=
2026-08-26 09:34:46 : DEBUG : obsidian : expectedTeamID=6JSW4SJWN9
2026-08-26 09:34:46 : DEBUG : obsidian : blockingProcesses=
2026-08-26 09:34:46 : DEBUG : obsidian : installerTool=
2026-08-26 09:34:46 : DEBUG : obsidian : CLIInstaller=
2026-08-26 09:34:46 : DEBUG : obsidian : CLIArguments=
2026-08-26 09:34:46 : DEBUG : obsidian : updateTool=
2026-08-26 09:34:46 : DEBUG : obsidian : updateToolArguments=
2026-08-26 09:34:46 : DEBUG : obsidian : updateToolRunAsCurrentUser=
2026-08-26 09:34:46 : INFO  : obsidian : BLOCKING_PROCESS_ACTION=tell_user
2026-08-26 09:34:46 : INFO  : obsidian : NOTIFY=success
2026-08-26 09:34:46 : INFO  : obsidian : LOGGING=DEBUG
2026-08-26 09:34:46 : INFO  : obsidian : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-26 09:34:46 : INFO  : obsidian : Label type: dmg
2026-08-26 09:34:46 : INFO  : obsidian : archiveName: Obsidian.dmg
2026-08-26 09:34:47 : INFO  : obsidian : no blocking processes defined, using Obsidian as default
2026-08-26 09:34:47 : DEBUG : obsidian : Changing directory to /Users/amartin/Documents/GitHub/Installomator/build
2026-08-26 09:34:47 : INFO  : obsidian : App(s) found: /Applications/Obsidian.app
2026-08-26 09:34:47 : INFO  : obsidian : found app at /Applications/Obsidian.app, version 1.13.7, on versionKey CFBundleShortVersionString
2026-08-26 09:34:47 : INFO  : obsidian : appversion: 1.13.7
2026-08-26 09:34:47 : INFO  : obsidian : Latest version of Obsidian is 1.13.7
2026-08-26 09:34:47 : WARN  : obsidian : DEBUG mode 1 enabled, not exiting, but there is no new version of app.
2026-08-26 09:34:47 : REQ   : obsidian : Downloading https://github.com/obsidianmd/obsidian-releases/releases/download/v1.13.7/Obsidian-1.13.7.dmg to Obsidian.dmg
2026-08-26 09:34:47 : DEBUG : obsidian : No Dialog connection, just download
2026-08-26 09:34:59 : INFO  : obsidian : Downloaded Obsidian.dmg – Type is  zlib compressed data – SHA is df33d6d6748500ea91a5ade7ab8832bcbc9c816b – Size is 229596 kB
2026-08-26 09:34:59 : DEBUG : obsidian : DEBUG mode 1, not checking for blocking processes
2026-08-26 09:34:59 : REQ   : obsidian : Installing Obsidian
2026-08-26 09:34:59 : INFO  : obsidian : Mounting /Users/amartin/Documents/GitHub/Installomator/build/Obsidian.dmg
2026-08-26 09:35:03 : DEBUG : obsidian : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F548D2DA
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $23CBC7FC
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $A180CAFD
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A1BD54A1
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $A180CAFD
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $82B90DFA
verified   CRC32 $6A766D22
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Obsidian 1.13.7-universal

2026-08-26 09:35:03 : INFO  : obsidian : Mounted: /Volumes/Obsidian 1.13.7-universal
2026-08-26 09:35:03 : INFO  : obsidian : Verifying: /Volumes/Obsidian 1.13.7-universal/Obsidian.app
2026-08-26 09:35:03 : DEBUG : obsidian : App size: 515M	/Volumes/Obsidian 1.13.7-universal/Obsidian.app
2026-08-26 09:35:07 : DEBUG : obsidian : Debugging enabled, App Verification output was:
/Volumes/Obsidian 1.13.7-universal/Obsidian.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Dynalist Inc. (6JSW4SJWN9)

2026-08-26 09:35:07 : INFO  : obsidian : Team ID matching: 6JSW4SJWN9 (expected: 6JSW4SJWN9 )
2026-08-26 09:35:07 : INFO  : obsidian : Downloaded version of Obsidian is 1.13.7 on versionKey CFBundleShortVersionString, same as installed.
2026-08-26 09:35:07 : DEBUG : obsidian : Unmounting /Volumes/Obsidian 1.13.7-universal
2026-08-26 09:35:07 : DEBUG : obsidian : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-26 09:35:07 : DEBUG : obsidian : DEBUG mode 1, not reopening anything
2026-08-26 09:35:07 : REG   : obsidian : No new version to install
2026-08-26 09:35:07 : REQ   : obsidian : ################## End Installomator, exit code 0 
```
