### PR TITLE
LibreOffice Label Update

### DIFF
--- a/fragments/labels/libreoffice.sh
+++ b/fragments/labels/libreoffice.sh
@@ -1,13 +1,13 @@
 libreoffice)
     name="LibreOffice"
     type="dmg"
-    appNewVersion="$(curl -s https://download.documentfoundation.org/libreoffice/stable/ | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1)"
+    libreOfficeDownloadVersion=$(curl -fsL "https://download.documentfoundation.org/libreoffice/stable/" | grep -oE "[0-9]+[.][0-9]+[.][0-9]+/" | tr -d / | awk -F. 'max=="" || ($1+0)*1000000+($2+0)*1000+($3+0) > max { max=($1+0)*1000000+($2+0)*1000+($3+0); version=$0 } END { print version }')
+    appNewVersion=$(curl -fsL "https://download.documentfoundation.org/libreoffice/src/${libreOfficeDownloadVersion}/" | grep -oE "libreoffice-${libreOfficeDownloadVersion}[.][0-9]+[.]tar[.]xz" | sed -E "s/^libreoffice-//; s/[.]tar[.]xz$//" | head -1)
     if [[ $(arch) == "arm64" ]]; then
-    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/aarch64/LibreOffice_${appNewVersion}_MacOS_aarch64.dmg"
+        downloadURL="https://download.documentfoundation.org/libreoffice/stable/${libreOfficeDownloadVersion}/mac/aarch64/LibreOffice_${libreOfficeDownloadVersion}_MacOS_aarch64.dmg"
     elif [[ $(arch) == "i386" ]]; then
-    	downloadURL="https://download.documentfoundation.org/libreoffice/stable/${appNewVersion}/mac/x86_64/LibreOffice_${appNewVersion}_MacOS_x86-64.dmg"
+        downloadURL="https://download.documentfoundation.org/libreoffice/stable/${libreOfficeDownloadVersion}/mac/x86_64/LibreOffice_${libreOfficeDownloadVersion}_MacOS_x86-64.dmg"
     fi
-    versionKey="CFBundleVersion"
     expectedTeamID="7P5S3ZLCN7"
     blockingProcesses=( soffice )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This new libreoffice) label is better because it separates the vendor’s stable release directory version from the app’s actual full version, then uses both where they belong. libreOfficeDownloadVersion finds the newest stable LibreOffice release folder, such as a 24.x.x style directory, which is the value needed to build the macOS download URLs. appNewVersion then checks the source directory for the more precise LibreOffice build version, so Installomator reports a fuller version instead of relying only on the download-folder version. The label also handles Apple Silicon and Intel Macs explicitly with $(arch), sending arm64 devices to the aarch64 DMG and Intel devices to the x86_64 DMG, which avoids installing the wrong architecture package.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh obsidian DEBUG=1
2026-08-26 14:22:21 : REQ   : obsidian : ################## Start Installomator v. 10.6beta, date 2026-08-26
2026-08-26 14:22:21 : INFO  : obsidian : ################## Version: 10.6beta
2026-08-26 14:22:21 : INFO  : obsidian : ################## Date: 2026-08-26
2026-08-26 14:22:21 : INFO  : obsidian : ################## obsidian
2026-08-26 14:22:21 : DEBUG : obsidian : DEBUG mode 1 enabled.
2026-08-26 14:22:21 : INFO  : obsidian : setting variable from argument DEBUG=1
2026-08-26 14:22:21 : ERROR : obsidian : need to provide 'downloadURL'
bash-3.2# sudo Installomator/utils/assemble.sh libreoffice DEBUG=1
2026-08-27 11:19:52 : INFO  : libreoffice : setting variable from argument DEBUG=1
2026-08-27 11:19:52 : INFO  : libreoffice : Total items in argumentsArray: 1
2026-08-27 11:19:52 : INFO  : libreoffice : argumentsArray: DEBUG=1
2026-08-27 11:19:52 : REQ   : libreoffice : ################## Start Installomator v. 10.10beta, date 2026-08-27
2026-08-27 11:19:52 : INFO  : libreoffice : ################## Version: 10.10beta
2026-08-27 11:19:52 : INFO  : libreoffice : ################## Date: 2026-08-27
2026-08-27 11:19:52 : INFO  : libreoffice : ################## libreoffice
2026-08-27 11:19:52 : DEBUG : libreoffice : DEBUG mode 1 enabled.
2026-08-27 11:19:55 : INFO  : libreoffice : Reading arguments again: DEBUG=1
2026-08-27 11:19:55 : DEBUG : libreoffice : argument: DEBUG=1
2026-08-27 11:19:55 : DEBUG : libreoffice : name=LibreOffice
2026-08-27 11:19:55 : DEBUG : libreoffice : appName=
2026-08-27 11:19:55 : DEBUG : libreoffice : type=dmg
2026-08-27 11:19:55 : DEBUG : libreoffice : archiveName=
2026-08-27 11:19:55 : DEBUG : libreoffice : downloadURL=https://download.documentfoundation.org/libreoffice/stable/26.8.0/mac/aarch64/LibreOffice_26.8.0_MacOS_aarch64.dmg
2026-08-27 11:19:55 : DEBUG : libreoffice : curlOptions=
2026-08-27 11:19:55 : DEBUG : libreoffice : appNewVersion=26.8.0.3
2026-08-27 11:19:55 : DEBUG : libreoffice : appCustomVersion function: Not defined
2026-08-27 11:19:55 : DEBUG : libreoffice : versionKey=CFBundleShortVersionString
2026-08-27 11:19:55 : DEBUG : libreoffice : packageID=
2026-08-27 11:19:55 : DEBUG : libreoffice : pkgName=
2026-08-27 11:19:55 : DEBUG : libreoffice : choiceChangesXML=
2026-08-27 11:19:55 : DEBUG : libreoffice : expectedTeamID=7P5S3ZLCN7
2026-08-27 11:19:55 : DEBUG : libreoffice : blockingProcesses=soffice
2026-08-27 11:19:55 : DEBUG : libreoffice : installerTool=
2026-08-27 11:19:55 : DEBUG : libreoffice : CLIInstaller=
2026-08-27 11:19:55 : DEBUG : libreoffice : CLIArguments=
2026-08-27 11:19:55 : DEBUG : libreoffice : updateTool=
2026-08-27 11:19:55 : DEBUG : libreoffice : updateToolArguments=
2026-08-27 11:19:55 : DEBUG : libreoffice : updateToolRunAsCurrentUser=
2026-08-27 11:19:55 : INFO  : libreoffice : BLOCKING_PROCESS_ACTION=tell_user
2026-08-27 11:19:55 : INFO  : libreoffice : NOTIFY=success
2026-08-27 11:19:55 : INFO  : libreoffice : LOGGING=DEBUG
2026-08-27 11:19:55 : INFO  : libreoffice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-27 11:19:55 : INFO  : libreoffice : Label type: dmg
2026-08-27 11:19:55 : INFO  : libreoffice : archiveName: LibreOffice.dmg
2026-08-27 11:19:55 : DEBUG : libreoffice : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-27 11:19:55 : INFO  : libreoffice : name: LibreOffice, appName: LibreOffice.app
2026-08-27 11:19:56 : WARN  : libreoffice : No previous app found
2026-08-27 11:19:56 : WARN  : libreoffice : could not find LibreOffice.app
2026-08-27 11:19:56 : INFO  : libreoffice : appversion: 
2026-08-27 11:19:56 : INFO  : libreoffice : Latest version of LibreOffice is 26.8.0.3
2026-08-27 11:19:56 : REQ   : libreoffice : Downloading https://download.documentfoundation.org/libreoffice/stable/26.8.0/mac/aarch64/LibreOffice_26.8.0_MacOS_aarch64.dmg to LibreOffice.dmg
2026-08-27 11:19:56 : DEBUG : libreoffice : No Dialog connection, just download
2026-08-27 11:20:11 : INFO  : libreoffice : Downloaded LibreOffice.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 24f33b38bff9bf0a99040b63a10bd5f36bfea646 – Size is 295388 kB
2026-08-27 11:20:11 : DEBUG : libreoffice : DEBUG mode 1, not checking for blocking processes
2026-08-27 11:20:11 : REQ   : libreoffice : Installing LibreOffice
2026-08-27 11:20:11 : INFO  : libreoffice : Mounting /Users/u0105821/git/github/Installomator/build/LibreOffice.dmg
2026-08-27 11:20:14 : DEBUG : libreoffice : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $F7A82429
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $0B1E0B78
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CF6F6355
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $C75A2C44
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CF6F6355
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $45B505F0
verified   CRC32 $C86129AC
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/LibreOffice

2026-08-27 11:20:14 : INFO  : libreoffice : Mounted: /Volumes/LibreOffice
2026-08-27 11:20:14 : INFO  : libreoffice : Verifying: /Volumes/LibreOffice/LibreOffice.app
2026-08-27 11:20:14 : DEBUG : libreoffice : App size: 804M	/Volumes/LibreOffice/LibreOffice.app
2026-08-27 11:20:22 : DEBUG : libreoffice : Debugging enabled, App Verification output was:
/Volumes/LibreOffice/LibreOffice.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Document Foundation (7P5S3ZLCN7)

2026-08-27 11:20:22 : INFO  : libreoffice : Team ID matching: 7P5S3ZLCN7 (expected: 7P5S3ZLCN7 )
2026-08-27 11:20:22 : INFO  : libreoffice : Installing LibreOffice version 26.8.0.3 on versionKey CFBundleShortVersionString.
2026-08-27 11:20:22 : INFO  : libreoffice : App has LSMinimumSystemVersion: 11.0.0
2026-08-27 11:20:22 : DEBUG : libreoffice : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-27 11:20:22 : INFO  : libreoffice : Finishing...
2026-08-27 11:20:25 : INFO  : libreoffice : name: LibreOffice, appName: LibreOffice.app
2026-08-27 11:20:25 : WARN  : libreoffice : No previous app found
2026-08-27 11:20:25 : WARN  : libreoffice : could not find LibreOffice.app
2026-08-27 11:20:25 : REQ   : libreoffice : Installed LibreOffice, version 26.8.0.3
2026-08-27 11:20:25 : INFO  : libreoffice : notifying
2026-08-27 11:20:26 : DEBUG : libreoffice : Unmounting /Volumes/LibreOffice
2026-08-27 11:20:26 : DEBUG : libreoffice : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-27 11:20:26 : DEBUG : libreoffice : DEBUG mode 1, not reopening anything
2026-08-27 11:20:26 : REQ   : libreoffice : All done!
2026-08-27 11:20:26 : REQ   : libreoffice : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
