### PR TITLE
buzz-new-label

### DIFF
--- a/fragments/labels/buzz.sh
+++ b/fragments/labels/buzz.sh
@@ -1,0 +1,12 @@
+buzz)
+    name="Buzz"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="mac-ARM64.dmg"
+    else
+        archiveName="mac-X64.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit "chidiwilliams" "buzz")
+    appNewVersion=$(versionFromGit "chidiwilliams" "buzz")
+    expectedTeamID="G2V69FA555"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh buzz DEBUG=1
2026-08-28 15:54:59 : INFO  : buzz : setting variable from argument DEBUG=1
2026-08-28 15:54:59 : INFO  : buzz : Total items in argumentsArray: 1
2026-08-28 15:54:59 : INFO  : buzz : argumentsArray: DEBUG=1
2026-08-28 15:54:59 : REQ   : buzz : ################## Start Installomator v. 10.10beta, date 2026-08-28
2026-08-28 15:54:59 : INFO  : buzz : ################## Version: 10.10beta
2026-08-28 15:54:59 : INFO  : buzz : ################## Date: 2026-08-28
2026-08-28 15:54:59 : INFO  : buzz : ################## buzz
2026-08-28 15:54:59 : DEBUG : buzz : DEBUG mode 1 enabled.
2026-08-28 15:55:01 : INFO  : buzz : Reading arguments again: DEBUG=1
2026-08-28 15:55:01 : DEBUG : buzz : argument: DEBUG=1
2026-08-28 15:55:01 : DEBUG : buzz : name=Buzz
2026-08-28 15:55:01 : DEBUG : buzz : appName=
2026-08-28 15:55:01 : DEBUG : buzz : type=dmg
2026-08-28 15:55:01 : DEBUG : buzz : archiveName=mac-ARM64.dmg
2026-08-28 15:55:01 : DEBUG : buzz : downloadURL=https://github.com/chidiwilliams/buzz/releases/download/v1.4.5/Buzz-1.4.5-mac-ARM64.dmg
2026-08-28 15:55:01 : DEBUG : buzz : curlOptions=
2026-08-28 15:55:01 : DEBUG : buzz : appNewVersion=1.4.5
2026-08-28 15:55:01 : DEBUG : buzz : appCustomVersion function: Not defined
2026-08-28 15:55:01 : DEBUG : buzz : versionKey=CFBundleShortVersionString
2026-08-28 15:55:01 : DEBUG : buzz : packageID=
2026-08-28 15:55:01 : DEBUG : buzz : pkgName=
2026-08-28 15:55:01 : DEBUG : buzz : choiceChangesXML=
2026-08-28 15:55:01 : DEBUG : buzz : expectedTeamID=G2V69FA555
2026-08-28 15:55:01 : DEBUG : buzz : blockingProcesses=
2026-08-28 15:55:01 : DEBUG : buzz : installerTool=
2026-08-28 15:55:01 : DEBUG : buzz : CLIInstaller=
2026-08-28 15:55:01 : DEBUG : buzz : CLIArguments=
2026-08-28 15:55:01 : DEBUG : buzz : updateTool=
2026-08-28 15:55:01 : DEBUG : buzz : updateToolArguments=
2026-08-28 15:55:01 : DEBUG : buzz : updateToolRunAsCurrentUser=
2026-08-28 15:55:01 : INFO  : buzz : BLOCKING_PROCESS_ACTION=tell_user
2026-08-28 15:55:01 : INFO  : buzz : NOTIFY=success
2026-08-28 15:55:01 : INFO  : buzz : LOGGING=DEBUG
2026-08-28 15:55:01 : INFO  : buzz : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-28 15:55:01 : INFO  : buzz : Label type: dmg
2026-08-28 15:55:01 : INFO  : buzz : archiveName: mac-ARM64.dmg
2026-08-28 15:55:02 : INFO  : buzz : no blocking processes defined, using Buzz as default
2026-08-28 15:55:02 : DEBUG : buzz : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-28 15:55:02 : INFO  : buzz : name: Buzz, appName: Buzz.app
2026-08-28 15:55:02 : WARN  : buzz : No previous app found
2026-08-28 15:55:02 : WARN  : buzz : could not find Buzz.app
2026-08-28 15:55:02 : INFO  : buzz : appversion: 
2026-08-28 15:55:02 : INFO  : buzz : Latest version of Buzz is 1.4.5
2026-08-28 15:55:02 : REQ   : buzz : Downloading https://github.com/chidiwilliams/buzz/releases/download/v1.4.5/Buzz-1.4.5-mac-ARM64.dmg to mac-ARM64.dmg
2026-08-28 15:55:02 : DEBUG : buzz : No Dialog connection, just download
2026-08-28 15:55:16 : INFO  : buzz : Downloaded mac-ARM64.dmg – Type is  zlib compressed data – SHA is 39ccfeee477fb7c31882b406bb2e4095ba96170b – Size is 459116 kB
2026-08-28 15:55:16 : DEBUG : buzz : DEBUG mode 1, not checking for blocking processes
2026-08-28 15:55:16 : REQ   : buzz : Installing Buzz
2026-08-28 15:55:16 : INFO  : buzz : Mounting /Users/u0105821/git/github/Installomator/build/mac-ARM64.dmg
2026-08-28 15:55:22 : DEBUG : buzz : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $4F49A46E
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D35AE19A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $C387BEFF
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $013AD827
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $C387BEFF
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $8B1AFCF5
verified   CRC32 $E93DB199
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_APFS
/dev/disk5          	EF57347C-0000-11AA-AA11-0030654
/dev/disk5s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Buzz

2026-08-28 15:55:22 : INFO  : buzz : Mounted: /Volumes/Buzz
2026-08-28 15:55:22 : INFO  : buzz : Verifying: /Volumes/Buzz/Buzz.app
2026-08-28 15:55:23 : DEBUG : buzz : App size: 1.3G	/Volumes/Buzz/Buzz.app
2026-08-28 15:55:33 : DEBUG : buzz : Debugging enabled, App Verification output was:
/Volumes/Buzz/Buzz.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Chidi Williams (G2V69FA555)

2026-08-28 15:55:33 : INFO  : buzz : Team ID matching: G2V69FA555 (expected: G2V69FA555 )
2026-08-28 15:55:33 : INFO  : buzz : Installing Buzz version 1.4.5 on versionKey CFBundleShortVersionString.
2026-08-28 15:55:33 : DEBUG : buzz : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-28 15:55:33 : INFO  : buzz : Finishing...
2026-08-28 15:55:36 : INFO  : buzz : name: Buzz, appName: Buzz.app
2026-08-28 15:55:37 : WARN  : buzz : No previous app found
2026-08-28 15:55:37 : WARN  : buzz : could not find Buzz.app
2026-08-28 15:55:37 : REQ   : buzz : Installed Buzz, version 1.4.5
2026-08-28 15:55:37 : INFO  : buzz : notifying
2026-08-28 15:55:37 : DEBUG : buzz : Unmounting /Volumes/Buzz
2026-08-28 15:55:37 : DEBUG : buzz : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-28 15:55:37 : DEBUG : buzz : DEBUG mode 1, not reopening anything
2026-08-28 15:55:37 : REQ   : buzz : All done!
2026-08-28 15:55:37 : REQ   : buzz : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
