### PR TITLE
processing4-label-update

### DIFF
--- a/fragments/labels/processing4.sh
+++ b/fragments/labels/processing4.sh
@@ -1,8 +1,12 @@
 processing4)
     name="Processing"
     type="dmg"
-    archiveName="Processing-[0-9.]*-macOS-$( if [ "$( arch )" = "arm64" ]; then echo "aarch64" ; else echo "x64" ; fi ).dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="macos-aarch64.dmg"
+    else
+        archiveName="macos-x64.dmg"
+    fi
     downloadURL=$(downloadURLFromGit processing processing4)
-    appNewVersion="$( echo "$downloadURL" | awk -F '-' '{ print $4 }' )"
+    appNewVersion=$(echo "$downloadURL" | sed -E 's#.*/processing-([0-9.]+)-macos-(aarch64|x64)\.dmg$#\1#')
     expectedTeamID="6297K33652"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This revised processing4 label is better than the current merged label because it matches the release assets that Processing actually publishes today. The current label looks for mixed-case filenames like Processing-[version]-macOS-aarch64.dmg, but the current GitHub release assets are lowercase, such as processing-4.5.6-macos-aarch64.dmg and processing-4.5.6-macos-x64.dmg. Because downloadURLFromGit uses the archiveName pattern to select the correct asset, a casing mismatch can cause the current label to fail before it ever downloads the app. The revised label keeps the recommended Installomator helper path by using archiveName with downloadURLFromGit, but makes the architecture filter simpler and aligned with the real asset names. It also avoids versionFromGit because Processing’s tag format includes a build number, causing the helper to return 14344.5.6 instead of the installed app version 4.5.6; extracting the version from the selected download URL gives a value that matches Processing.app’s CFBundleShortVersionString.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh processing4 DEBUG=1
2026-08-29 13:04:12 : INFO  : processing4 : setting variable from argument DEBUG=1
2026-08-29 13:04:12 : INFO  : processing4 : Total items in argumentsArray: 1
2026-08-29 13:04:12 : INFO  : processing4 : argumentsArray: DEBUG=1
2026-08-29 13:04:12 : REQ   : processing4 : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-08-29 13:04:12 : INFO  : processing4 : ################## Version: 10.10beta
2026-08-29 13:04:12 : INFO  : processing4 : ################## Date: 2026-08-29
2026-08-29 13:04:12 : INFO  : processing4 : ################## processing4
2026-08-29 13:04:12 : DEBUG : processing4 : DEBUG mode 1 enabled.
2026-08-29 13:04:13 : INFO  : processing4 : Reading arguments again: DEBUG=1
2026-08-29 13:04:13 : DEBUG : processing4 : argument: DEBUG=1
2026-08-29 13:04:13 : DEBUG : processing4 : name=Processing
2026-08-29 13:04:13 : DEBUG : processing4 : appName=
2026-08-29 13:04:14 : DEBUG : processing4 : type=dmg
2026-08-29 13:04:14 : DEBUG : processing4 : archiveName=macos-aarch64.dmg
2026-08-29 13:04:14 : DEBUG : processing4 : downloadURL=https://github.com/processing/processing4/releases/download/processing-1434-4.5.6/processing-4.5.6-macos-aarch64.dmg
2026-08-29 13:04:14 : DEBUG : processing4 : curlOptions=
2026-08-29 13:04:14 : DEBUG : processing4 : appNewVersion=4.5.6
2026-08-29 13:04:14 : DEBUG : processing4 : appCustomVersion function: Not defined
2026-08-29 13:04:14 : DEBUG : processing4 : versionKey=CFBundleShortVersionString
2026-08-29 13:04:14 : DEBUG : processing4 : packageID=
2026-08-29 13:04:14 : DEBUG : processing4 : pkgName=
2026-08-29 13:04:14 : DEBUG : processing4 : choiceChangesXML=
2026-08-29 13:04:14 : DEBUG : processing4 : expectedTeamID=6297K33652
2026-08-29 13:04:14 : DEBUG : processing4 : blockingProcesses=
2026-08-29 13:04:14 : DEBUG : processing4 : installerTool=
2026-08-29 13:04:14 : DEBUG : processing4 : CLIInstaller=
2026-08-29 13:04:14 : DEBUG : processing4 : CLIArguments=
2026-08-29 13:04:14 : DEBUG : processing4 : updateTool=
2026-08-29 13:04:14 : DEBUG : processing4 : updateToolArguments=
2026-08-29 13:04:14 : DEBUG : processing4 : updateToolRunAsCurrentUser=
2026-08-29 13:04:14 : INFO  : processing4 : BLOCKING_PROCESS_ACTION=tell_user
2026-08-29 13:04:14 : INFO  : processing4 : NOTIFY=success
2026-08-29 13:04:14 : INFO  : processing4 : LOGGING=DEBUG
2026-08-29 13:04:14 : INFO  : processing4 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-29 13:04:14 : INFO  : processing4 : Label type: dmg
2026-08-29 13:04:14 : INFO  : processing4 : archiveName: macos-aarch64.dmg
2026-08-29 13:04:14 : INFO  : processing4 : no blocking processes defined, using Processing as default
2026-08-29 13:04:14 : DEBUG : processing4 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-29 13:04:14 : INFO  : processing4 : name: Processing, appName: Processing.app
2026-08-29 13:04:14 : INFO  : processing4 : App(s) found: /Library/Printers/hp/filter/hpPreProcessing.filter/Library/Application Support/Script Editor/Templates/Droplets/Recursive File Processing Droplet.app/Library/Application Support/Script Editor/Templates/Droplets/Recursive Image File Processing Droplet.app
2026-08-29 13:04:14 : WARN  : processing4 : could not determine location of Processing.app
2026-08-29 13:04:14 : INFO  : processing4 : appversion: 
2026-08-29 13:04:14 : INFO  : processing4 : Latest version of Processing is 4.5.6
2026-08-29 13:04:14 : REQ   : processing4 : Downloading https://github.com/processing/processing4/releases/download/processing-1434-4.5.6/processing-4.5.6-macos-aarch64.dmg to macos-aarch64.dmg
2026-08-29 13:04:15 : DEBUG : processing4 : No Dialog connection, just download
2026-08-29 13:04:22 : INFO  : processing4 : Downloaded macos-aarch64.dmg – Type is  zlib compressed data – SHA is 3867a8c7ed0eeec37761cc52a438161105bc5aa1 – Size is 525436 kB
2026-08-29 13:04:22 : DEBUG : processing4 : DEBUG mode 1, not checking for blocking processes
2026-08-29 13:04:22 : REQ   : processing4 : Installing Processing
2026-08-29 13:04:22 : INFO  : processing4 : Mounting /Users/u0105821/git/github/Installomator/build/macos-aarch64.dmg
2026-08-29 13:04:25 : DEBUG : processing4 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $65E8C7F9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9946C9AD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $466B8A15
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $F1823414
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $466B8A15
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $6D00DBD5
verified   CRC32 $6DC970FE
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Processing

2026-08-29 13:04:25 : INFO  : processing4 : Mounted: /Volumes/Processing
2026-08-29 13:04:25 : INFO  : processing4 : Verifying: /Volumes/Processing/Processing.app
2026-08-29 13:04:25 : DEBUG : processing4 : App size: 740M	/Volumes/Processing/Processing.app
2026-08-29 13:04:28 : DEBUG : processing4 : Debugging enabled, App Verification output was:
/Volumes/Processing/Processing.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Processing Foundation, Inc. (6297K33652)

2026-08-29 13:04:28 : INFO  : processing4 : Team ID matching: 6297K33652 (expected: 6297K33652 )
2026-08-29 13:04:28 : INFO  : processing4 : Installing Processing version 4.5.6 on versionKey CFBundleShortVersionString.
2026-08-29 13:04:28 : INFO  : processing4 : App has LSMinimumSystemVersion: 10.13
2026-08-29 13:04:28 : DEBUG : processing4 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-29 13:04:28 : INFO  : processing4 : Finishing...
2026-08-29 13:04:31 : INFO  : processing4 : name: Processing, appName: Processing.app
2026-08-29 13:04:31 : INFO  : processing4 : App(s) found: /Library/Printers/hp/filter/hpPreProcessing.filter/Library/Application Support/Script Editor/Templates/Droplets/Recursive File Processing Droplet.app/Library/Application Support/Script Editor/Templates/Droplets/Recursive Image File Processing Droplet.app
2026-08-29 13:04:32 : WARN  : processing4 : could not determine location of Processing.app
2026-08-29 13:04:32 : REQ   : processing4 : Installed Processing, version 4.5.6
2026-08-29 13:04:32 : INFO  : processing4 : notifying
2026-08-29 13:04:32 : DEBUG : processing4 : Unmounting /Volumes/Processing
2026-08-29 13:04:32 : DEBUG : processing4 : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-29 13:04:32 : DEBUG : processing4 : DEBUG mode 1, not reopening anything
2026-08-29 13:04:32 : REQ   : processing4 : All done!
2026-08-29 13:04:32 : REQ   : processing4 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
