### PR TITLE
gitkraken-label-update

### DIFF
--- a/fragments/labels/gitkraken.sh
+++ b/fragments/labels/gitkraken.sh
@@ -1,11 +1,11 @@
 gitkraken)
-    name="gitkraken"
+    name="GitKraken"
     type="dmg"
-    appNewVersion=$( curl -sfL https://www.gitkraken.com/download | grep -oi 'Latest release: [0-9.]*' | grep -o '[0-9.]*' )
     if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://release.gitkraken.com/darwin-arm64/installGitKraken.dmg"
-    elif [[ $(arch) == "i386" ]]; then
+    else
         downloadURL="https://release.gitkraken.com/darwin/installGitKraken.dmg"
     fi
+    appNewVersion=$(curl -sI "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's#.*/darwin/(arm64|x64)/([0-9.]+)/.*#\2#')
     expectedTeamID="T7QVVUTZQ8"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This corrected label is better than the current label because it stops scraping a GitKraken marketing page that no longer exposes the expected Latest release: text and instead derives the version from GitKraken’s official redirect target for the selected macOS installer. The revised label keeps the vendor-supported stable download URLs, extracts 12.4.0 from the versioned CDN path, verifies that the downloaded GitKraken.app reports the same CFBundleShortVersionString, and removes redundant blockingProcesses because the default process handling already matches name="GitKraken".

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh gitkraken DEBUG=1
2026-08-29 13:36:48 : INFO  : gitkraken : setting variable from argument DEBUG=1
2026-08-29 13:36:48 : INFO  : gitkraken : Total items in argumentsArray: 1
2026-08-29 13:36:48 : INFO  : gitkraken : argumentsArray: DEBUG=1
2026-08-29 13:36:48 : REQ   : gitkraken : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-08-29 13:36:48 : INFO  : gitkraken : ################## Version: 10.10beta
2026-08-29 13:36:48 : INFO  : gitkraken : ################## Date: 2026-08-29
2026-08-29 13:36:48 : INFO  : gitkraken : ################## gitkraken
2026-08-29 13:36:48 : DEBUG : gitkraken : DEBUG mode 1 enabled.
2026-08-29 13:36:49 : INFO  : gitkraken : Reading arguments again: DEBUG=1
2026-08-29 13:36:49 : DEBUG : gitkraken : argument: DEBUG=1
2026-08-29 13:36:49 : DEBUG : gitkraken : name=GitKraken
2026-08-29 13:36:49 : DEBUG : gitkraken : appName=
2026-08-29 13:36:49 : DEBUG : gitkraken : type=dmg
2026-08-29 13:36:49 : DEBUG : gitkraken : archiveName=
2026-08-29 13:36:49 : DEBUG : gitkraken : downloadURL=https://release.gitkraken.com/darwin-arm64/installGitKraken.dmg
2026-08-29 13:36:49 : DEBUG : gitkraken : curlOptions=
2026-08-29 13:36:49 : DEBUG : gitkraken : appNewVersion=
2026-08-29 13:36:49 : DEBUG : gitkraken : appCustomVersion function: Not defined
2026-08-29 13:36:49 : DEBUG : gitkraken : versionKey=CFBundleShortVersionString
2026-08-29 13:36:49 : DEBUG : gitkraken : packageID=
2026-08-29 13:36:49 : DEBUG : gitkraken : pkgName=
2026-08-29 13:36:49 : DEBUG : gitkraken : choiceChangesXML=
2026-08-29 13:36:49 : DEBUG : gitkraken : expectedTeamID=T7QVVUTZQ8
2026-08-29 13:36:49 : DEBUG : gitkraken : blockingProcesses=
2026-08-29 13:36:49 : DEBUG : gitkraken : installerTool=
2026-08-29 13:36:49 : DEBUG : gitkraken : CLIInstaller=
2026-08-29 13:36:49 : DEBUG : gitkraken : CLIArguments=
2026-08-29 13:36:49 : DEBUG : gitkraken : updateTool=
2026-08-29 13:36:49 : DEBUG : gitkraken : updateToolArguments=
2026-08-29 13:36:49 : DEBUG : gitkraken : updateToolRunAsCurrentUser=
2026-08-29 13:36:49 : INFO  : gitkraken : BLOCKING_PROCESS_ACTION=tell_user
2026-08-29 13:36:49 : INFO  : gitkraken : NOTIFY=success
2026-08-29 13:36:49 : INFO  : gitkraken : LOGGING=DEBUG
2026-08-29 13:36:49 : INFO  : gitkraken : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-29 13:36:49 : INFO  : gitkraken : Label type: dmg
2026-08-29 13:36:49 : INFO  : gitkraken : archiveName: GitKraken.dmg
2026-08-29 13:36:49 : INFO  : gitkraken : no blocking processes defined, using GitKraken as default
2026-08-29 13:36:49 : DEBUG : gitkraken : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-29 13:36:49 : INFO  : gitkraken : name: GitKraken, appName: GitKraken.app
2026-08-29 13:36:49 : INFO  : gitkraken : App(s) found: /Applications/Programming/gitkraken.app
2026-08-29 13:36:49 : INFO  : gitkraken : found app at /Applications/Programming/gitkraken.app, version 12.4.0, on versionKey CFBundleShortVersionString
2026-08-29 13:36:49 : INFO  : gitkraken : appversion: 12.4.0
2026-08-29 13:36:49 : INFO  : gitkraken : Latest version not specified.
2026-08-29 13:36:49 : REQ   : gitkraken : Downloading https://release.gitkraken.com/darwin-arm64/installGitKraken.dmg to GitKraken.dmg
2026-08-29 13:36:49 : DEBUG : gitkraken : No Dialog connection, just download
2026-08-29 13:36:53 : INFO  : gitkraken : Downloaded GitKraken.dmg – Type is  zlib compressed data – SHA is ecb2ab85a8c93239d07195af53404dbc0a491266 – Size is 226384 kB
2026-08-29 13:36:53 : DEBUG : gitkraken : DEBUG mode 1, not checking for blocking processes
2026-08-29 13:36:53 : REQ   : gitkraken : Installing GitKraken
2026-08-29 13:36:53 : INFO  : gitkraken : Mounting /Users/u0105821/git/github/Installomator/build/GitKraken.dmg
2026-08-29 13:36:56 : DEBUG : gitkraken : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $9E3BDC3D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $48DA70E8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $39ACC021
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $FBC098AE
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $39ACC021
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $70B2CA5C
verified   CRC32 $D83FEE58
/dev/disk4          	GUID_partition_scheme
/dev/disk4s1        	Apple_HFS                      	/Volumes/Install GitKraken Desktop

2026-08-29 13:36:56 : INFO  : gitkraken : Mounted: /Volumes/Install GitKraken Desktop
2026-08-29 13:36:56 : INFO  : gitkraken : Verifying: /Volumes/Install GitKraken Desktop/GitKraken.app
2026-08-29 13:36:56 : DEBUG : gitkraken : App size: 627M	/Volumes/Install GitKraken Desktop/GitKraken.app
2026-08-29 13:36:58 : DEBUG : gitkraken : Debugging enabled, App Verification output was:
/Volumes/Install GitKraken Desktop/GitKraken.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Axosoft, LLC (T7QVVUTZQ8)

2026-08-29 13:36:58 : INFO  : gitkraken : Team ID matching: T7QVVUTZQ8 (expected: T7QVVUTZQ8 )
2026-08-29 13:36:58 : INFO  : gitkraken : Downloaded version of GitKraken is 12.4.0 on versionKey CFBundleShortVersionString, same as installed.
2026-08-29 13:36:58 : DEBUG : gitkraken : Unmounting /Volumes/Install GitKraken Desktop
2026-08-29 13:36:59 : DEBUG : gitkraken : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-29 13:36:59 : DEBUG : gitkraken : DEBUG mode 1, not reopening anything
2026-08-29 13:36:59 : REG   : gitkraken : No new version to install
2026-08-29 13:36:59 : REQ   : gitkraken : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
