### PR TITLE
starface90x-label-update

### DIFF
--- a/fragments/labels/starface90x.sh
+++ b/fragments/labels/starface90x.sh
@@ -1,9 +1,9 @@
 starface90x)
     name="STARFACE"
-    # Downloads the latest 9.0.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
     type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 4)
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.0.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.0.")])[1]/@*[local-name()="version"])' -)
     expectedTeamID="Q965D3UXEW"
     versionKey="CFBundleVersion"
     ;;

--- a/fragments/labels/starface91x.sh
+++ b/fragments/labels/starface91x.sh
@@ -1,0 +1,9 @@
+starface91x)
+    name="STARFACE"
+    type="dmg"
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@*[local-name()="version"])' -)
+    expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
+    ;;

--- a/fragments/labels/starface91x.sh
+++ b/fragments/labels/starface91x.sh
@@ -1,8 +1,9 @@
 starface91x)
     name="STARFACE"
-    # Downloads the latest 9.1.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
     type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.1" | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.1" | cut -d '"' -f 4)
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@*[local-name()="version"])' -)
     expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
     ;;

--- a/fragments/labels/starface91x.sh
+++ b/fragments/labels/starface91x.sh
@@ -1,9 +1,0 @@
-starface91x)
-    name="STARFACE"
-    type="dmg"
-    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
-    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@url)' -)
-    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@*[local-name()="version"])' -)
-    expectedTeamID="Q965D3UXEW"
-    versionKey="CFBundleVersion"
-    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This corrected label is better because it preserves the requested STARFACE 9.0.x version family while parsing the vendor’s Sparkle feed as XML instead of relying on fragile grep and fixed cut fields. It explicitly selects entries whose sparkle:shortVersionString starts with 9.0., so it will not drift to 9.1, 9.2, or 10.0 releases. The verified DMG contains STARFACE.app with CFBundleShortVersionString=9.0.1 and CFBundleVersion=1181, so keeping versionKey="CFBundleVersion" makes appNewVersion=1181 match the installed app comparison key.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh starface90x DEBUG=1
2026-08-29 13:56:22 : INFO  : starface90x : setting variable from argument DEBUG=1
2026-08-29 13:56:22 : INFO  : starface90x : Total items in argumentsArray: 1
2026-08-29 13:56:22 : INFO  : starface90x : argumentsArray: DEBUG=1
2026-08-29 13:56:22 : REQ   : starface90x : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-08-29 13:56:23 : INFO  : starface90x : ################## Version: 10.10beta
2026-08-29 13:56:23 : INFO  : starface90x : ################## Date: 2026-08-29
2026-08-29 13:56:23 : INFO  : starface90x : ################## starface90x
2026-08-29 13:56:23 : DEBUG : starface90x : DEBUG mode 1 enabled.
2026-08-29 13:56:24 : INFO  : starface90x : Reading arguments again: DEBUG=1
2026-08-29 13:56:24 : DEBUG : starface90x : argument: DEBUG=1
2026-08-29 13:56:24 : DEBUG : starface90x : name=STARFACE
2026-08-29 13:56:24 : DEBUG : starface90x : appName=
2026-08-29 13:56:24 : DEBUG : starface90x : type=dmg
2026-08-29 13:56:24 : DEBUG : starface90x : archiveName=
2026-08-29 13:56:24 : DEBUG : starface90x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.1_1181_1f18d85.dmg
2026-08-29 13:56:24 : DEBUG : starface90x : curlOptions=
2026-08-29 13:56:24 : DEBUG : starface90x : appNewVersion=1181
2026-08-29 13:56:24 : DEBUG : starface90x : appCustomVersion function: Not defined
2026-08-29 13:56:24 : DEBUG : starface90x : versionKey=CFBundleVersion
2026-08-29 13:56:24 : DEBUG : starface90x : packageID=
2026-08-29 13:56:24 : DEBUG : starface90x : pkgName=
2026-08-29 13:56:24 : DEBUG : starface90x : choiceChangesXML=
2026-08-29 13:56:24 : DEBUG : starface90x : expectedTeamID=Q965D3UXEW
2026-08-29 13:56:24 : DEBUG : starface90x : blockingProcesses=
2026-08-29 13:56:24 : DEBUG : starface90x : installerTool=
2026-08-29 13:56:24 : DEBUG : starface90x : CLIInstaller=
2026-08-29 13:56:24 : DEBUG : starface90x : CLIArguments=
2026-08-29 13:56:24 : DEBUG : starface90x : updateTool=
2026-08-29 13:56:24 : DEBUG : starface90x : updateToolArguments=
2026-08-29 13:56:24 : DEBUG : starface90x : updateToolRunAsCurrentUser=
2026-08-29 13:56:24 : INFO  : starface90x : BLOCKING_PROCESS_ACTION=tell_user
2026-08-29 13:56:24 : INFO  : starface90x : NOTIFY=success
2026-08-29 13:56:24 : INFO  : starface90x : LOGGING=DEBUG
2026-08-29 13:56:24 : INFO  : starface90x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-29 13:56:24 : INFO  : starface90x : Label type: dmg
2026-08-29 13:56:24 : INFO  : starface90x : archiveName: STARFACE.dmg
2026-08-29 13:56:24 : INFO  : starface90x : no blocking processes defined, using STARFACE as default
2026-08-29 13:56:24 : DEBUG : starface90x : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-29 13:56:25 : INFO  : starface90x : name: STARFACE, appName: STARFACE.app
2026-08-29 13:56:25 : WARN  : starface90x : No previous app found
2026-08-29 13:56:25 : WARN  : starface90x : could not find STARFACE.app
2026-08-29 13:56:25 : INFO  : starface90x : appversion: 
2026-08-29 13:56:25 : INFO  : starface90x : Latest version of STARFACE is 1181
2026-08-29 13:56:25 : INFO  : starface90x : STARFACE.dmg exists and DEBUG mode 1 enabled, skipping download
2026-08-29 13:56:25 : DEBUG : starface90x : DEBUG mode 1, not checking for blocking processes
2026-08-29 13:56:25 : REQ   : starface90x : Installing STARFACE
2026-08-29 13:56:25 : INFO  : starface90x : Mounting /Users/u0105821/git/github/Installomator/build/STARFACE.dmg
2026-08-29 13:56:25 : DEBUG : starface90x : Debugging enabled, dmgmount output was:
expected   CRC32 $4930C7AF
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/STARFACE Installer

2026-08-29 13:56:25 : INFO  : starface90x : Mounted: /Volumes/STARFACE Installer
2026-08-29 13:56:25 : INFO  : starface90x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2026-08-29 13:56:25 : DEBUG : starface90x : App size: 472M	/Volumes/STARFACE Installer/STARFACE.app
2026-08-29 13:56:27 : DEBUG : starface90x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2026-08-29 13:56:27 : INFO  : starface90x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2026-08-29 13:56:27 : INFO  : starface90x : Installing STARFACE version 1297 on versionKey CFBundleVersion.
2026-08-29 13:56:27 : INFO  : starface90x : App has LSMinimumSystemVersion: 13.0
2026-08-29 13:56:27 : DEBUG : starface90x : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-29 13:56:27 : INFO  : starface90x : Finishing...
2026-08-29 13:56:30 : INFO  : starface90x : name: STARFACE, appName: STARFACE.app
2026-08-29 13:56:30 : WARN  : starface90x : No previous app found
2026-08-29 13:56:30 : WARN  : starface90x : could not find STARFACE.app
2026-08-29 13:56:30 : REQ   : starface90x : Installed STARFACE, version 1297
2026-08-29 13:56:30 : INFO  : starface90x : notifying
2026-08-29 13:56:31 : DEBUG : starface90x : Unmounting /Volumes/STARFACE Installer
2026-08-29 13:56:31 : DEBUG : starface90x : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-29 13:56:31 : DEBUG : starface90x : DEBUG mode 1, not reopening anything
2026-08-29 13:56:31 : REQ   : starface90x : All done!
2026-08-29 13:56:31 : REQ   : starface90x : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
