### PR TITLE
Update starface91x.sh

### DIFF
--- a/fragments/labels/starface91x.sh
+++ b/fragments/labels/starface91x.sh
@@ -1,8 +1,9 @@
 starface91x)
     name="STARFACE"
-    # Downloads the latest 9.1.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
     type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.1" | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.1" | cut -d '"' -f 4)
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.1.")])[1]/@*[local-name()="version"])' -)
     expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This corrected label is better because it keeps the requested STARFACE 9.1.x family while parsing the vendor’s Sparkle feed as structured XML instead of relying on brittle grep and fixed cut positions. It also fixes the version comparison by adding versionKey="CFBundleVersion", because the verified app reports CFBundleShortVersionString=9.1.0 and CFBundleVersion=1297, while the appcast’s install-tracking version is also 1297.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh starface91x DEBUG=1
2026-08-29 14:02:28 : INFO  : starface91x : setting variable from argument DEBUG=1
2026-08-29 14:02:28 : INFO  : starface91x : Total items in argumentsArray: 1
2026-08-29 14:02:28 : INFO  : starface91x : argumentsArray: DEBUG=1
2026-08-29 14:02:28 : REQ   : starface91x : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-08-29 14:02:28 : INFO  : starface91x : ################## Version: 10.10beta
2026-08-29 14:02:28 : INFO  : starface91x : ################## Date: 2026-08-29
2026-08-29 14:02:28 : INFO  : starface91x : ################## starface91x
2026-08-29 14:02:28 : DEBUG : starface91x : DEBUG mode 1 enabled.
2026-08-29 14:02:29 : INFO  : starface91x : Reading arguments again: DEBUG=1
2026-08-29 14:02:29 : DEBUG : starface91x : argument: DEBUG=1
2026-08-29 14:02:29 : DEBUG : starface91x : name=STARFACE
2026-08-29 14:02:29 : DEBUG : starface91x : appName=
2026-08-29 14:02:29 : DEBUG : starface91x : type=dmg
2026-08-29 14:02:29 : DEBUG : starface91x : archiveName=
2026-08-29 14:02:29 : DEBUG : starface91x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.1.0_1297_d67785e.dmg
2026-08-29 14:02:29 : DEBUG : starface91x : curlOptions=
2026-08-29 14:02:29 : DEBUG : starface91x : appNewVersion=1297
2026-08-29 14:02:29 : DEBUG : starface91x : appCustomVersion function: Not defined
2026-08-29 14:02:29 : DEBUG : starface91x : versionKey=CFBundleVersion
2026-08-29 14:02:29 : DEBUG : starface91x : packageID=
2026-08-29 14:02:30 : DEBUG : starface91x : pkgName=
2026-08-29 14:02:30 : DEBUG : starface91x : choiceChangesXML=
2026-08-29 14:02:30 : DEBUG : starface91x : expectedTeamID=Q965D3UXEW
2026-08-29 14:02:30 : DEBUG : starface91x : blockingProcesses=
2026-08-29 14:02:30 : DEBUG : starface91x : installerTool=
2026-08-29 14:02:30 : DEBUG : starface91x : CLIInstaller=
2026-08-29 14:02:30 : DEBUG : starface91x : CLIArguments=
2026-08-29 14:02:30 : DEBUG : starface91x : updateTool=
2026-08-29 14:02:30 : DEBUG : starface91x : updateToolArguments=
2026-08-29 14:02:30 : DEBUG : starface91x : updateToolRunAsCurrentUser=
2026-08-29 14:02:30 : INFO  : starface91x : BLOCKING_PROCESS_ACTION=tell_user
2026-08-29 14:02:30 : INFO  : starface91x : NOTIFY=success
2026-08-29 14:02:30 : INFO  : starface91x : LOGGING=DEBUG
2026-08-29 14:02:30 : INFO  : starface91x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-29 14:02:30 : INFO  : starface91x : Label type: dmg
2026-08-29 14:02:30 : INFO  : starface91x : archiveName: STARFACE.dmg
2026-08-29 14:02:30 : INFO  : starface91x : no blocking processes defined, using STARFACE as default
2026-08-29 14:02:30 : DEBUG : starface91x : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-29 14:02:30 : INFO  : starface91x : name: STARFACE, appName: STARFACE.app
2026-08-29 14:02:30 : WARN  : starface91x : No previous app found
2026-08-29 14:02:30 : WARN  : starface91x : could not find STARFACE.app
2026-08-29 14:02:30 : INFO  : starface91x : appversion: 
2026-08-29 14:02:30 : INFO  : starface91x : Latest version of STARFACE is 1297
2026-08-29 14:02:30 : INFO  : starface91x : STARFACE.dmg exists and DEBUG mode 1 enabled, skipping download
2026-08-29 14:02:30 : DEBUG : starface91x : DEBUG mode 1, not checking for blocking processes
2026-08-29 14:02:30 : REQ   : starface91x : Installing STARFACE
2026-08-29 14:02:30 : INFO  : starface91x : Mounting /Users/u0105821/git/github/Installomator/build/STARFACE.dmg
2026-08-29 14:02:31 : DEBUG : starface91x : Debugging enabled, dmgmount output was:
expected   CRC32 $4930C7AF
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/STARFACE Installer

2026-08-29 14:02:31 : INFO  : starface91x : Mounted: /Volumes/STARFACE Installer
2026-08-29 14:02:31 : INFO  : starface91x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2026-08-29 14:02:31 : DEBUG : starface91x : App size: 472M	/Volumes/STARFACE Installer/STARFACE.app
2026-08-29 14:02:32 : DEBUG : starface91x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2026-08-29 14:02:32 : INFO  : starface91x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2026-08-29 14:02:32 : INFO  : starface91x : Installing STARFACE version 1297 on versionKey CFBundleVersion.
2026-08-29 14:02:33 : INFO  : starface91x : App has LSMinimumSystemVersion: 13.0
2026-08-29 14:02:33 : DEBUG : starface91x : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-29 14:02:33 : INFO  : starface91x : Finishing...
2026-08-29 14:02:36 : INFO  : starface91x : name: STARFACE, appName: STARFACE.app
2026-08-29 14:02:36 : WARN  : starface91x : No previous app found
2026-08-29 14:02:36 : WARN  : starface91x : could not find STARFACE.app
2026-08-29 14:02:36 : REQ   : starface91x : Installed STARFACE, version 1297
2026-08-29 14:02:36 : INFO  : starface91x : notifying
2026-08-29 14:02:36 : DEBUG : starface91x : Unmounting /Volumes/STARFACE Installer
2026-08-29 14:02:36 : DEBUG : starface91x : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-29 14:02:36 : DEBUG : starface91x : DEBUG mode 1, not reopening anything
2026-08-29 14:02:36 : REQ   : starface91x : All done!
2026-08-29 14:02:36 : REQ   : starface91x : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
