### PR TITLE
starface10x-label-update

### DIFF
--- a/fragments/labels/starface10x.sh
+++ b/fragments/labels/starface10x.sh
@@ -1,7 +1,9 @@
 starface10x)
     name="STARFACE"
     type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 -F 'shortVersionString="10.' | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 -F 'shortVersionString="10.' | cut -d '"' -f 4)
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "10.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "10.")])[1]/@*[local-name()="version"])' -)
     expectedTeamID="Q965D3UXEW"
+    versionKey="CFBundleVersion"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This corrected label is better because it preserves the requested STARFACE 10.x version family while parsing the vendor’s Sparkle appcast as structured XML instead of relying on fixed quote positions from cut. It also fixes version comparison by adding versionKey="CFBundleVersion", because the verified app reports CFBundleShortVersionString=10.0.0 and CFBundleVersion=1789, while the Sparkle feed’s update version is also 1789.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh starface10x DEBUG=1
2026-08-29 14:14:03 : INFO  : starface10x : setting variable from argument DEBUG=1
2026-08-29 14:14:04 : INFO  : starface10x : Total items in argumentsArray: 1
2026-08-29 14:14:04 : INFO  : starface10x : argumentsArray: DEBUG=1
2026-08-29 14:14:04 : REQ   : starface10x : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-08-29 14:14:04 : INFO  : starface10x : ################## Version: 10.10beta
2026-08-29 14:14:04 : INFO  : starface10x : ################## Date: 2026-08-29
2026-08-29 14:14:04 : INFO  : starface10x : ################## starface10x
2026-08-29 14:14:04 : DEBUG : starface10x : DEBUG mode 1 enabled.
2026-08-29 14:14:05 : INFO  : starface10x : Reading arguments again: DEBUG=1
2026-08-29 14:14:05 : DEBUG : starface10x : argument: DEBUG=1
2026-08-29 14:14:05 : DEBUG : starface10x : name=STARFACE
2026-08-29 14:14:05 : DEBUG : starface10x : appName=
2026-08-29 14:14:05 : DEBUG : starface10x : type=dmg
2026-08-29 14:14:05 : DEBUG : starface10x : archiveName=
2026-08-29 14:14:05 : DEBUG : starface10x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_10.0.0_1789_d191cf7.dmg
2026-08-29 14:14:05 : DEBUG : starface10x : curlOptions=
2026-08-29 14:14:05 : DEBUG : starface10x : appNewVersion=1789
2026-08-29 14:14:05 : DEBUG : starface10x : appCustomVersion function: Not defined
2026-08-29 14:14:05 : DEBUG : starface10x : versionKey=CFBundleVersion
2026-08-29 14:14:05 : DEBUG : starface10x : packageID=
2026-08-29 14:14:05 : DEBUG : starface10x : pkgName=
2026-08-29 14:14:05 : DEBUG : starface10x : choiceChangesXML=
2026-08-29 14:14:05 : DEBUG : starface10x : expectedTeamID=Q965D3UXEW
2026-08-29 14:14:05 : DEBUG : starface10x : blockingProcesses=
2026-08-29 14:14:05 : DEBUG : starface10x : installerTool=
2026-08-29 14:14:05 : DEBUG : starface10x : CLIInstaller=
2026-08-29 14:14:05 : DEBUG : starface10x : CLIArguments=
2026-08-29 14:14:05 : DEBUG : starface10x : updateTool=
2026-08-29 14:14:05 : DEBUG : starface10x : updateToolArguments=
2026-08-29 14:14:06 : DEBUG : starface10x : updateToolRunAsCurrentUser=
2026-08-29 14:14:06 : INFO  : starface10x : BLOCKING_PROCESS_ACTION=tell_user
2026-08-29 14:14:06 : INFO  : starface10x : NOTIFY=success
2026-08-29 14:14:06 : INFO  : starface10x : LOGGING=DEBUG
2026-08-29 14:14:06 : INFO  : starface10x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-29 14:14:06 : INFO  : starface10x : Label type: dmg
2026-08-29 14:14:06 : INFO  : starface10x : archiveName: STARFACE.dmg
2026-08-29 14:14:06 : INFO  : starface10x : no blocking processes defined, using STARFACE as default
2026-08-29 14:14:06 : DEBUG : starface10x : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-29 14:14:06 : INFO  : starface10x : name: STARFACE, appName: STARFACE.app
2026-08-29 14:14:06 : WARN  : starface10x : No previous app found
2026-08-29 14:14:06 : WARN  : starface10x : could not find STARFACE.app
2026-08-29 14:14:06 : INFO  : starface10x : appversion: 
2026-08-29 14:14:06 : INFO  : starface10x : Latest version of STARFACE is 1789
2026-08-29 14:14:06 : INFO  : starface10x : STARFACE.dmg exists and DEBUG mode 1 enabled, skipping download
2026-08-29 14:14:06 : DEBUG : starface10x : DEBUG mode 1, not checking for blocking processes
2026-08-29 14:14:06 : REQ   : starface10x : Installing STARFACE
2026-08-29 14:14:06 : INFO  : starface10x : Mounting /Users/u0105821/git/github/Installomator/build/STARFACE.dmg
2026-08-29 14:14:07 : DEBUG : starface10x : Debugging enabled, dmgmount output was:
expected   CRC32 $4930C7AF
/dev/disk4          	Apple_partition_scheme
/dev/disk4s1        	Apple_partition_map
/dev/disk4s2        	Apple_HFS                      	/Volumes/STARFACE Installer

2026-08-29 14:14:07 : INFO  : starface10x : Mounted: /Volumes/STARFACE Installer
2026-08-29 14:14:07 : INFO  : starface10x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2026-08-29 14:14:07 : DEBUG : starface10x : App size: 472M	/Volumes/STARFACE Installer/STARFACE.app
2026-08-29 14:14:08 : DEBUG : starface10x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2026-08-29 14:14:08 : INFO  : starface10x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2026-08-29 14:14:08 : INFO  : starface10x : Installing STARFACE version 1297 on versionKey CFBundleVersion.
2026-08-29 14:14:09 : INFO  : starface10x : App has LSMinimumSystemVersion: 13.0
2026-08-29 14:14:09 : DEBUG : starface10x : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-29 14:14:09 : INFO  : starface10x : Finishing...
2026-08-29 14:14:12 : INFO  : starface10x : name: STARFACE, appName: STARFACE.app
2026-08-29 14:14:12 : WARN  : starface10x : No previous app found
2026-08-29 14:14:12 : WARN  : starface10x : could not find STARFACE.app
2026-08-29 14:14:12 : REQ   : starface10x : Installed STARFACE, version 1297
2026-08-29 14:14:12 : INFO  : starface10x : notifying
2026-08-29 14:14:12 : DEBUG : starface10x : Unmounting /Volumes/STARFACE Installer
2026-08-29 14:14:13 : DEBUG : starface10x : Debugging enabled, Unmounting output was:
"disk4" ejected.
2026-08-29 14:14:13 : DEBUG : starface10x : DEBUG mode 1, not reopening anything
2026-08-29 14:14:13 : REQ   : starface10x : All done!
2026-08-29 14:14:13 : REQ   : starface10x : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
