### PR TITLE
Update starface90x.sh

### DIFF
--- a/fragments/labels/starface90x.sh
+++ b/fragments/labels/starface90x.sh
@@ -1,9 +1,9 @@
 starface90x)
     name="STARFACE"
-    # Downloads the latest 9.0.x version of the STARFACE Client. The client depends on the version of the PBX, so the correct version should be selected for installation
     type="dmg"
-    downloadURL=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 10)
-    appNewVersion=$(curl -fs "https://www.starface-cdn.de/starface/clients/mac/appcast.xml" | grep -i 'enclosure ' | grep -i 'url=' | grep -m 1 "9.0" | cut -d '"' -f 4)
+    sparkleData=$(curl -fsL "https://www.starface-cdn.de/starface/clients/mac/appcast.xml")
+    downloadURL=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.0.")])[1]/@url)' -)
+    appNewVersion=$(echo "$sparkleData" | xmllint --xpath 'string((//*[local-name()="enclosure" and starts-with(@*[local-name()="shortVersionString"], "9.0.")])[1]/@*[local-name()="version"])' -)
     expectedTeamID="Q965D3UXEW"
     versionKey="CFBundleVersion"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh starface90x DEBUG=1
2026-08-31 07:52:41 : INFO  : starface90x : setting variable from argument DEBUG=1
2026-08-31 07:52:41 : INFO  : starface90x : Total items in argumentsArray: 1
2026-08-31 07:52:41 : INFO  : starface90x : argumentsArray: DEBUG=1
2026-08-31 07:52:41 : REQ   : starface90x : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 07:52:41 : INFO  : starface90x : ################## Version: 10.10beta
2026-08-31 07:52:41 : INFO  : starface90x : ################## Date: 2026-08-31
2026-08-31 07:52:41 : INFO  : starface90x : ################## starface90x
2026-08-31 07:52:41 : DEBUG : starface90x : DEBUG mode 1 enabled.
2026-08-31 07:52:43 : INFO  : starface90x : Reading arguments again: DEBUG=1
2026-08-31 07:52:43 : DEBUG : starface90x : argument: DEBUG=1
2026-08-31 07:52:43 : DEBUG : starface90x : name=STARFACE
2026-08-31 07:52:43 : DEBUG : starface90x : appName=
2026-08-31 07:52:43 : DEBUG : starface90x : type=dmg
2026-08-31 07:52:43 : DEBUG : starface90x : archiveName=
2026-08-31 07:52:43 : DEBUG : starface90x : downloadURL=https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.1_1181_1f18d85.dmg
2026-08-31 07:52:43 : DEBUG : starface90x : curlOptions=
2026-08-31 07:52:43 : DEBUG : starface90x : appNewVersion=1181
2026-08-31 07:52:43 : DEBUG : starface90x : appCustomVersion function: Not defined
2026-08-31 07:52:43 : DEBUG : starface90x : versionKey=CFBundleVersion
2026-08-31 07:52:43 : DEBUG : starface90x : packageID=
2026-08-31 07:52:43 : DEBUG : starface90x : pkgName=
2026-08-31 07:52:43 : DEBUG : starface90x : choiceChangesXML=
2026-08-31 07:52:43 : DEBUG : starface90x : expectedTeamID=Q965D3UXEW
2026-08-31 07:52:43 : DEBUG : starface90x : blockingProcesses=
2026-08-31 07:52:43 : DEBUG : starface90x : installerTool=
2026-08-31 07:52:43 : DEBUG : starface90x : CLIInstaller=
2026-08-31 07:52:43 : DEBUG : starface90x : CLIArguments=
2026-08-31 07:52:43 : DEBUG : starface90x : updateTool=
2026-08-31 07:52:43 : DEBUG : starface90x : updateToolArguments=
2026-08-31 07:52:43 : DEBUG : starface90x : updateToolRunAsCurrentUser=
2026-08-31 07:52:43 : INFO  : starface90x : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 07:52:43 : INFO  : starface90x : NOTIFY=success
2026-08-31 07:52:43 : INFO  : starface90x : LOGGING=DEBUG
2026-08-31 07:52:43 : INFO  : starface90x : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 07:52:43 : INFO  : starface90x : Label type: dmg
2026-08-31 07:52:43 : INFO  : starface90x : archiveName: STARFACE.dmg
2026-08-31 07:52:43 : INFO  : starface90x : no blocking processes defined, using STARFACE as default
2026-08-31 07:52:43 : DEBUG : starface90x : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 07:52:43 : INFO  : starface90x : name: STARFACE, appName: STARFACE.app
2026-08-31 07:52:44 : WARN  : starface90x : No previous app found
2026-08-31 07:52:44 : WARN  : starface90x : could not find STARFACE.app
2026-08-31 07:52:44 : INFO  : starface90x : appversion: 
2026-08-31 07:52:44 : INFO  : starface90x : Latest version of STARFACE is 1181
2026-08-31 07:52:44 : REQ   : starface90x : Downloading https://www.starface-cdn.de/starface/clients/mac/STARFACE_9.0.1_1181_1f18d85.dmg to STARFACE.dmg
2026-08-31 07:52:44 : DEBUG : starface90x : No Dialog connection, just download
2026-08-31 07:52:54 : INFO  : starface90x : Downloaded STARFACE.dmg – Type is  zlib compressed data – SHA is 3011c04eb1599df082d5696f039e3844e9c73953 – Size is 213556 kB
2026-08-31 07:52:54 : DEBUG : starface90x : DEBUG mode 1, not checking for blocking processes
2026-08-31 07:52:54 : REQ   : starface90x : Installing STARFACE
2026-08-31 07:52:54 : INFO  : starface90x : Mounting /Users/u0105821/git/github/Installomator/build/STARFACE.dmg
2026-08-31 07:52:56 : DEBUG : starface90x : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $39C0F99E
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $CBDA0B07
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified   CRC32 $E5B62C1A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
verified   CRC32 $EF89E6DA
/dev/disk6          	Apple_partition_scheme
/dev/disk6s1        	Apple_partition_map
/dev/disk6s2        	Apple_HFS                      	/Volumes/STARFACE Installer

2026-08-31 07:52:56 : INFO  : starface90x : Mounted: /Volumes/STARFACE Installer
2026-08-31 07:52:56 : INFO  : starface90x : Verifying: /Volumes/STARFACE Installer/STARFACE.app
2026-08-31 07:52:56 : DEBUG : starface90x : App size: 472M	/Volumes/STARFACE Installer/STARFACE.app
2026-08-31 07:52:58 : DEBUG : starface90x : Debugging enabled, App Verification output was:
/Volumes/STARFACE Installer/STARFACE.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: STARFACE GmbH (Q965D3UXEW)

2026-08-31 07:52:58 : INFO  : starface90x : Team ID matching: Q965D3UXEW (expected: Q965D3UXEW )
2026-08-31 07:52:58 : INFO  : starface90x : Installing STARFACE version 1181 on versionKey CFBundleVersion.
2026-08-31 07:52:58 : INFO  : starface90x : App has LSMinimumSystemVersion: 11.0
2026-08-31 07:52:58 : DEBUG : starface90x : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 07:52:58 : INFO  : starface90x : Finishing...
2026-08-31 07:53:01 : INFO  : starface90x : name: STARFACE, appName: STARFACE.app
2026-08-31 07:53:02 : WARN  : starface90x : No previous app found
2026-08-31 07:53:02 : WARN  : starface90x : could not find STARFACE.app
2026-08-31 07:53:02 : REQ   : starface90x : Installed STARFACE, version 1181
2026-08-31 07:53:02 : INFO  : starface90x : notifying
2026-08-31 07:53:02 : DEBUG : starface90x : Unmounting /Volumes/STARFACE Installer
2026-08-31 07:53:03 : DEBUG : starface90x : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 07:53:03 : DEBUG : starface90x : DEBUG mode 1, not reopening anything
2026-08-31 07:53:03 : REQ   : starface90x : All done!
2026-08-31 07:53:03 : REQ   : starface90x : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
