### PR TITLE
Update topazvideo.sh

### DIFF
--- a/fragments/labels/topazvideo.sh
+++ b/fragments/labels/topazvideo.sh
@@ -6,3 +6,4 @@ topazvideoai)
     appNewVersion=$(curl -fsIL "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's#.*/TopazVideoAI-([0-9]+(\.[0-9]+)+)\.dmg$#\1#')
     expectedTeamID="3G3JE37ZHF"
     ;;
+    

--- a/fragments/labels/topazvideo.sh
+++ b/fragments/labels/topazvideo.sh
@@ -3,7 +3,6 @@ topazvideoai)
     name="Topaz Video AI"
     type="dmg"
     downloadURL="https://topazlabs.com/d/tvai/latest/mac/full"
-    archiveName=$(curl -fsIL $downloadURL | grep -i ^location | awk -F "/" '{print $NF}' | tr -d '\r\n')
-    appNewVersion=$(grep -oi "[0-9].*[0-9]" <<< $archiveName)
+    appNewVersion=$(curl -fsIL "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | tail -n 1 | sed -E 's#.*/TopazVideoAI-([0-9]+(\.[0-9]+)+)\.dmg$#\1#')
     expectedTeamID="3G3JE37ZHF"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated label is better because it relies on verified vendor-supported sources, prefers structured update data when available, and avoids brittle parsing that can break when a download page or redirect changes. It also validates the full deployment chain: the selected download URL, extracted version, payload type, installed app or package version, and Team ID all have to match before the label is considered safe. When headers such as Referer are required, the label uses Installomator’s native curlOptions instead of relying on manual download behavior, which makes the label more reliable for automated Mac deployment workflows.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh topazvideoai DEBUG=1
2026-08-31 08:36:23 : INFO  : topazvideoai : setting variable from argument DEBUG=1
2026-08-31 08:36:24 : INFO  : topazvideoai : Total items in argumentsArray: 1
2026-08-31 08:36:24 : INFO  : topazvideoai : argumentsArray: DEBUG=1
2026-08-31 08:36:24 : REQ   : topazvideoai : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 08:36:24 : INFO  : topazvideoai : ################## Version: 10.10beta
2026-08-31 08:36:24 : INFO  : topazvideoai : ################## Date: 2026-08-31
2026-08-31 08:36:24 : INFO  : topazvideoai : ################## topazvideoai
2026-08-31 08:36:24 : DEBUG : topazvideoai : DEBUG mode 1 enabled.
2026-08-31 08:36:25 : INFO  : topazvideoai : Reading arguments again: DEBUG=1
2026-08-31 08:36:25 : DEBUG : topazvideoai : argument: DEBUG=1
2026-08-31 08:36:25 : DEBUG : topazvideoai : name=Topaz Video AI
2026-08-31 08:36:25 : DEBUG : topazvideoai : appName=
2026-08-31 08:36:25 : DEBUG : topazvideoai : type=dmg
2026-08-31 08:36:25 : DEBUG : topazvideoai : archiveName=
2026-08-31 08:36:25 : DEBUG : topazvideoai : downloadURL=https://topazlabs.com/d/tvai/latest/mac/full
2026-08-31 08:36:25 : DEBUG : topazvideoai : curlOptions=
2026-08-31 08:36:25 : DEBUG : topazvideoai : appNewVersion=7.1.5
2026-08-31 08:36:25 : DEBUG : topazvideoai : appCustomVersion function: Not defined
2026-08-31 08:36:25 : DEBUG : topazvideoai : versionKey=CFBundleShortVersionString
2026-08-31 08:36:25 : DEBUG : topazvideoai : packageID=
2026-08-31 08:36:25 : DEBUG : topazvideoai : pkgName=
2026-08-31 08:36:25 : DEBUG : topazvideoai : choiceChangesXML=
2026-08-31 08:36:25 : DEBUG : topazvideoai : expectedTeamID=3G3JE37ZHF
2026-08-31 08:36:25 : DEBUG : topazvideoai : blockingProcesses=
2026-08-31 08:36:25 : DEBUG : topazvideoai : installerTool=
2026-08-31 08:36:25 : DEBUG : topazvideoai : CLIInstaller=
2026-08-31 08:36:25 : DEBUG : topazvideoai : CLIArguments=
2026-08-31 08:36:25 : DEBUG : topazvideoai : updateTool=
2026-08-31 08:36:25 : DEBUG : topazvideoai : updateToolArguments=
2026-08-31 08:36:25 : DEBUG : topazvideoai : updateToolRunAsCurrentUser=
2026-08-31 08:36:25 : INFO  : topazvideoai : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 08:36:25 : INFO  : topazvideoai : NOTIFY=success
2026-08-31 08:36:25 : INFO  : topazvideoai : LOGGING=DEBUG
2026-08-31 08:36:25 : INFO  : topazvideoai : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 08:36:25 : INFO  : topazvideoai : Label type: dmg
2026-08-31 08:36:25 : INFO  : topazvideoai : archiveName: Topaz Video AI.dmg
2026-08-31 08:36:25 : INFO  : topazvideoai : no blocking processes defined, using Topaz Video AI as default
2026-08-31 08:36:25 : DEBUG : topazvideoai : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 08:36:25 : INFO  : topazvideoai : name: Topaz Video AI, appName: Topaz Video AI.app
2026-08-31 08:36:26 : WARN  : topazvideoai : No previous app found
2026-08-31 08:36:26 : WARN  : topazvideoai : could not find Topaz Video AI.app
2026-08-31 08:36:26 : INFO  : topazvideoai : appversion: 
2026-08-31 08:36:26 : INFO  : topazvideoai : Latest version of Topaz Video AI is 7.1.5
2026-08-31 08:36:26 : REQ   : topazvideoai : Downloading https://topazlabs.com/d/tvai/latest/mac/full to Topaz Video AI.dmg
2026-08-31 08:36:26 : DEBUG : topazvideoai : No Dialog connection, just download
2026-08-31 08:36:54 : INFO  : topazvideoai : Downloaded Topaz Video AI.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 06c2261bfd4b57b5111fded271e8ec49f4b1455e – Size is 852124 kB
2026-08-31 08:36:54 : DEBUG : topazvideoai : DEBUG mode 1, not checking for blocking processes
2026-08-31 08:36:54 : REQ   : topazvideoai : Installing Topaz Video AI
2026-08-31 08:36:54 : INFO  : topazvideoai : Mounting /Users/u0105821/git/github/Installomator/build/Topaz Video AI.dmg
2026-08-31 08:37:37 : DEBUG : topazvideoai : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $A2FD4401
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $D74550D8
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $50663311
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $DFC9518E
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $50663311
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $E97F0B9F
verified   CRC32 $220A9067
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	EFI
/dev/disk6s2        	Apple_HFS                      	/Volumes/Topaz Video AI 7.1.5

2026-08-31 08:37:37 : INFO  : topazvideoai : Mounted: /Volumes/Topaz Video AI 7.1.5
2026-08-31 08:37:37 : INFO  : topazvideoai : Verifying: /Volumes/Topaz Video AI 7.1.5/Topaz Video AI.app
2026-08-31 08:37:37 : DEBUG : topazvideoai : App size: 1.9G	/Volumes/Topaz Video AI 7.1.5/Topaz Video AI.app
2026-08-31 08:38:41 : DEBUG : topazvideoai : Debugging enabled, App Verification output was:
/Volumes/Topaz Video AI 7.1.5/Topaz Video AI.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Topaz Labs, LLC (3G3JE37ZHF)

2026-08-31 08:38:41 : INFO  : topazvideoai : Team ID matching: 3G3JE37ZHF (expected: 3G3JE37ZHF )
2026-08-31 08:38:41 : INFO  : topazvideoai : Installing Topaz Video AI version 7.1.5 on versionKey CFBundleShortVersionString.
2026-08-31 08:38:41 : INFO  : topazvideoai : App has LSMinimumSystemVersion: 10.14
2026-08-31 08:38:41 : DEBUG : topazvideoai : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 08:38:41 : INFO  : topazvideoai : Finishing...
2026-08-31 08:38:44 : INFO  : topazvideoai : name: Topaz Video AI, appName: Topaz Video AI.app
2026-08-31 08:38:45 : WARN  : topazvideoai : No previous app found
2026-08-31 08:38:45 : WARN  : topazvideoai : could not find Topaz Video AI.app
2026-08-31 08:38:45 : REQ   : topazvideoai : Installed Topaz Video AI, version 7.1.5
2026-08-31 08:38:45 : INFO  : topazvideoai : notifying
2026-08-31 08:38:45 : DEBUG : topazvideoai : Unmounting /Volumes/Topaz Video AI 7.1.5
2026-08-31 08:38:46 : DEBUG : topazvideoai : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 08:38:46 : DEBUG : topazvideoai : DEBUG mode 1, not reopening anything
2026-08-31 08:38:46 : REQ   : topazvideoai : All done!
2026-08-31 08:38:46 : REQ   : topazvideoai : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
