### PR TITLE
Create netbird.sh

### DIFF
--- a/fragments/labels/netbird.sh
+++ b/fragments/labels/netbird.sh
@@ -1,0 +1,12 @@
+netbird)
+    name="NetBird"
+    type="pkg"
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="_darwin_arm64.pkg"
+    elif [[ $(arch) == "i386" ]]; then
+        archiveName="_darwin_amd64.pkg"
+    fi
+    downloadURL=$(downloadURLFromGit netbirdio netbird)
+    appNewVersion=$(versionFromGit netbirdio netbird)
+    expectedTeamID="TA739QLA7A"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated label is better because it uses Installomator’s built-in GitHub helper functions against NetBird’s official release assets instead of manually following redirects and scraping the version from a temporary signed URL. It also fixes the non-portable grep -E "\d" version extraction, removes the unnecessary dURL variable, keeps the architecture selection explicit with archiveName, and validates cleanly against the current 0.77.1 package. The downloaded package is a real signed/notarized macOS installer, installs NetBird.app, reports version 0.77.1, and is signed by NetBird GmbH with Team ID TA739QLA7A.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh netbird DEBUG=1
2026-08-31 09:13:03 : INFO  : netbird : setting variable from argument DEBUG=1
2026-08-31 09:13:03 : INFO  : netbird : Total items in argumentsArray: 1
2026-08-31 09:13:03 : INFO  : netbird : argumentsArray: DEBUG=1
2026-08-31 09:13:03 : REQ   : netbird : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 09:13:03 : INFO  : netbird : ################## Version: 10.10beta
2026-08-31 09:13:03 : INFO  : netbird : ################## Date: 2026-08-31
2026-08-31 09:13:03 : INFO  : netbird : ################## netbird
2026-08-31 09:13:03 : DEBUG : netbird : DEBUG mode 1 enabled.
2026-08-31 09:13:05 : INFO  : netbird : Reading arguments again: DEBUG=1
2026-08-31 09:13:05 : DEBUG : netbird : argument: DEBUG=1
2026-08-31 09:13:05 : DEBUG : netbird : name=NetBird
2026-08-31 09:13:05 : DEBUG : netbird : appName=
2026-08-31 09:13:05 : DEBUG : netbird : type=pkg
2026-08-31 09:13:05 : DEBUG : netbird : archiveName=_darwin_arm64.pkg
2026-08-31 09:13:05 : DEBUG : netbird : downloadURL=https://github.com/netbirdio/netbird/releases/download/v0.77.1/netbird_0.77.1_darwin_arm64.pkg
2026-08-31 09:13:05 : DEBUG : netbird : curlOptions=
2026-08-31 09:13:05 : DEBUG : netbird : appNewVersion=0.77.1
2026-08-31 09:13:05 : DEBUG : netbird : appCustomVersion function: Not defined
2026-08-31 09:13:05 : DEBUG : netbird : versionKey=CFBundleShortVersionString
2026-08-31 09:13:05 : DEBUG : netbird : packageID=
2026-08-31 09:13:05 : DEBUG : netbird : pkgName=
2026-08-31 09:13:05 : DEBUG : netbird : choiceChangesXML=
2026-08-31 09:13:05 : DEBUG : netbird : expectedTeamID=TA739QLA7A
2026-08-31 09:13:05 : DEBUG : netbird : blockingProcesses=
2026-08-31 09:13:05 : DEBUG : netbird : installerTool=
2026-08-31 09:13:05 : DEBUG : netbird : CLIInstaller=
2026-08-31 09:13:05 : DEBUG : netbird : CLIArguments=
2026-08-31 09:13:05 : DEBUG : netbird : updateTool=
2026-08-31 09:13:05 : DEBUG : netbird : updateToolArguments=
2026-08-31 09:13:06 : DEBUG : netbird : updateToolRunAsCurrentUser=
2026-08-31 09:13:06 : INFO  : netbird : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 09:13:06 : INFO  : netbird : NOTIFY=success
2026-08-31 09:13:06 : INFO  : netbird : LOGGING=DEBUG
2026-08-31 09:13:06 : INFO  : netbird : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 09:13:06 : INFO  : netbird : Label type: pkg
2026-08-31 09:13:06 : INFO  : netbird : archiveName: _darwin_arm64.pkg
2026-08-31 09:13:06 : INFO  : netbird : no blocking processes defined, using NetBird as default
2026-08-31 09:13:06 : DEBUG : netbird : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 09:13:06 : INFO  : netbird : name: NetBird, appName: NetBird.app
2026-08-31 09:13:06 : WARN  : netbird : No previous app found
2026-08-31 09:13:06 : WARN  : netbird : could not find NetBird.app
2026-08-31 09:13:06 : INFO  : netbird : appversion: 
2026-08-31 09:13:06 : INFO  : netbird : Latest version of NetBird is 0.77.1
2026-08-31 09:13:06 : REQ   : netbird : Downloading https://github.com/netbirdio/netbird/releases/download/v0.77.1/netbird_0.77.1_darwin_arm64.pkg to _darwin_arm64.pkg
2026-08-31 09:13:06 : DEBUG : netbird : No Dialog connection, just download
2026-08-31 09:13:07 : INFO  : netbird : Downloaded _darwin_arm64.pkg – Type is  xar archive compressed TOC
2026-08-31 09:13:07 : INFO  : netbird : - OpenPGP Public Key – SHA is dec12038bf27de785879b02fe7db412278e5ae0a – Size is 21568 kB
2026-08-31 09:13:07 : DEBUG : netbird : DEBUG mode 1, not checking for blocking processes
2026-08-31 09:13:07 : REQ   : netbird : Installing NetBird
2026-08-31 09:13:07 : INFO  : netbird : Verifying: _darwin_arm64.pkg
2026-08-31 09:13:07 : DEBUG : netbird : File list: -rw-r--r--  1 root  staff    21M Aug 31 09:13 _darwin_arm64.pkg
2026-08-31 09:13:07 : DEBUG : netbird : File type: _darwin_arm64.pkg: xar archive compressed TOC: 4480, SHA-1 checksum, contains 
2026-08-31 09:13:07 : DEBUG : netbird : - OpenPGP Public Key
2026-08-31 09:13:07 : DEBUG : netbird : spctlOut is _darwin_arm64.pkg: accepted
2026-08-31 09:13:07 : DEBUG : netbird : source=Notarized Developer ID
2026-08-31 09:13:07 : DEBUG : netbird : origin=Developer ID Installer: NetBird GmbH (TA739QLA7A)
2026-08-31 09:13:07 : INFO  : netbird : Team ID: TA739QLA7A (expected: TA739QLA7A )
2026-08-31 09:13:07 : DEBUG : netbird : DEBUG enabled, skipping installation
2026-08-31 09:13:07 : INFO  : netbird : Finishing...
2026-08-31 09:13:10 : INFO  : netbird : name: NetBird, appName: NetBird.app
2026-08-31 09:13:11 : WARN  : netbird : No previous app found
2026-08-31 09:13:11 : WARN  : netbird : could not find NetBird.app
2026-08-31 09:13:11 : REQ   : netbird : Installed NetBird, version 0.77.1
2026-08-31 09:13:11 : INFO  : netbird : notifying
2026-08-31 09:13:11 : DEBUG : netbird : DEBUG mode 1, not reopening anything
2026-08-31 09:13:11 : REQ   : netbird : All done!
2026-08-31 09:13:11 : REQ   : netbird : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
