### PR TITLE
Update prusaslicer.sh

### DIFF
--- a/fragments/labels/prusaslicer.sh
+++ b/fragments/labels/prusaslicer.sh
@@ -1,9 +1,10 @@
 prusaslicer)
     name="PrusaSlicer"
     type="dmg"
-    downloadURL="$(curl -sfL "https://api.github.com/repos/prusa3d/PrusaSlicer/releases" | grep "browser_download_url" | grep -i "macos-universal.dmg" | grep -v -- "-rc\|-beta\|-alpha" | head -1 | tr -d ' "' | sed 's/browser_download_url://')"
-    appNewVersion="$(echo "$downloadURL" | sed 's/.*PrusaSlicer-//;s/-macos.*//')"
+    downloadURL=$(downloadURLFromGit prusa3d PrusaSlicer)
+    appNewVersion="PrusaSlicer-$(versionFromGit prusa3d PrusaSlicer)"
     folderName="Original Prusa Drivers"
     appName="${folderName}/PrusaSlicer.app"
+    versionKey="CFBundleVersion"
     expectedTeamID="DKPB65N43Z"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated label is better because it uses Installomator’s built-in GitHub helpers against the current PrusaSlicer release, correctly handles the nested app layout inside the DMG, and makes appNewVersion match the app’s actual installed CFBundleVersion. The older merged logic is now stale because it searches for macos-universal.dmg assets and currently finds older 2.9.2, 2.9.1, and 2.9.0 releases instead of the latest 2.9.6 DMG.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh prusaslicer DEBUG=1
2026-08-31 09:37:13 : INFO  : prusaslicer : setting variable from argument DEBUG=1
2026-08-31 09:37:13 : INFO  : prusaslicer : Total items in argumentsArray: 1
2026-08-31 09:37:13 : INFO  : prusaslicer : argumentsArray: DEBUG=1
2026-08-31 09:37:13 : REQ   : prusaslicer : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 09:37:13 : INFO  : prusaslicer : ################## Version: 10.10beta
2026-08-31 09:37:13 : INFO  : prusaslicer : ################## Date: 2026-08-31
2026-08-31 09:37:13 : INFO  : prusaslicer : ################## prusaslicer
2026-08-31 09:37:13 : DEBUG : prusaslicer : DEBUG mode 1 enabled.
2026-08-31 09:37:15 : INFO  : prusaslicer : Reading arguments again: DEBUG=1
2026-08-31 09:37:15 : DEBUG : prusaslicer : argument: DEBUG=1
2026-08-31 09:37:15 : DEBUG : prusaslicer : name=PrusaSlicer
2026-08-31 09:37:15 : DEBUG : prusaslicer : appName=Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:15 : DEBUG : prusaslicer : type=dmg
2026-08-31 09:37:15 : DEBUG : prusaslicer : archiveName=
2026-08-31 09:37:15 : DEBUG : prusaslicer : downloadURL=https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.9.6/PrusaSlicer-2.9.6.dmg
2026-08-31 09:37:15 : DEBUG : prusaslicer : curlOptions=
2026-08-31 09:37:15 : DEBUG : prusaslicer : appNewVersion=PrusaSlicer-2.9.6
2026-08-31 09:37:15 : DEBUG : prusaslicer : appCustomVersion function: Not defined
2026-08-31 09:37:15 : DEBUG : prusaslicer : versionKey=CFBundleVersion
2026-08-31 09:37:15 : DEBUG : prusaslicer : packageID=
2026-08-31 09:37:15 : DEBUG : prusaslicer : pkgName=
2026-08-31 09:37:15 : DEBUG : prusaslicer : choiceChangesXML=
2026-08-31 09:37:15 : DEBUG : prusaslicer : expectedTeamID=DKPB65N43Z
2026-08-31 09:37:15 : DEBUG : prusaslicer : blockingProcesses=
2026-08-31 09:37:15 : DEBUG : prusaslicer : installerTool=
2026-08-31 09:37:15 : DEBUG : prusaslicer : CLIInstaller=
2026-08-31 09:37:15 : DEBUG : prusaslicer : CLIArguments=
2026-08-31 09:37:15 : DEBUG : prusaslicer : updateTool=
2026-08-31 09:37:15 : DEBUG : prusaslicer : updateToolArguments=
2026-08-31 09:37:15 : DEBUG : prusaslicer : updateToolRunAsCurrentUser=
2026-08-31 09:37:15 : INFO  : prusaslicer : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 09:37:15 : INFO  : prusaslicer : NOTIFY=success
2026-08-31 09:37:15 : INFO  : prusaslicer : LOGGING=DEBUG
2026-08-31 09:37:15 : INFO  : prusaslicer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 09:37:15 : INFO  : prusaslicer : Label type: dmg
2026-08-31 09:37:15 : INFO  : prusaslicer : archiveName: PrusaSlicer.dmg
2026-08-31 09:37:15 : INFO  : prusaslicer : no blocking processes defined, using PrusaSlicer as default
2026-08-31 09:37:15 : DEBUG : prusaslicer : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 09:37:15 : INFO  : prusaslicer : name: PrusaSlicer, appName: Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:15 : WARN  : prusaslicer : No previous app found
2026-08-31 09:37:15 : WARN  : prusaslicer : could not find Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:15 : INFO  : prusaslicer : appversion: 
2026-08-31 09:37:15 : INFO  : prusaslicer : Latest version of PrusaSlicer is PrusaSlicer-2.9.6
2026-08-31 09:37:16 : REQ   : prusaslicer : Downloading https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.9.6/PrusaSlicer-2.9.6.dmg to PrusaSlicer.dmg
2026-08-31 09:37:16 : DEBUG : prusaslicer : No Dialog connection, just download
2026-08-31 09:37:20 : INFO  : prusaslicer : Downloaded PrusaSlicer.dmg – Type is  zlib compressed data – SHA is def84560af75aef02d4dd61a23aaafdab56ee1bb – Size is 148236 kB
2026-08-31 09:37:20 : DEBUG : prusaslicer : DEBUG mode 1, not checking for blocking processes
2026-08-31 09:37:20 : REQ   : prusaslicer : Installing PrusaSlicer
2026-08-31 09:37:20 : INFO  : prusaslicer : Mounting /Users/u0105821/git/github/Installomator/build/PrusaSlicer.dmg
2026-08-31 09:37:24 : DEBUG : prusaslicer : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $8E90F3E3
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $810B1B27
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $3D8F1C80
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $3BF6D419
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $3D8F1C80
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $710F120D
verified   CRC32 $E8CC6B14
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Original Prusa Drivers

2026-08-31 09:37:24 : INFO  : prusaslicer : Mounted: /Volumes/Original Prusa Drivers
2026-08-31 09:37:24 : INFO  : prusaslicer : Verifying: /Volumes/Original Prusa Drivers/Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:24 : DEBUG : prusaslicer : App size: 346M	/Volumes/Original Prusa Drivers/Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:26 : DEBUG : prusaslicer : Debugging enabled, App Verification output was:
/Volumes/Original Prusa Drivers/Original Prusa Drivers/PrusaSlicer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Prusa Research a.s. (DKPB65N43Z)

2026-08-31 09:37:26 : INFO  : prusaslicer : Team ID matching: DKPB65N43Z (expected: DKPB65N43Z )
2026-08-31 09:37:26 : INFO  : prusaslicer : Installing PrusaSlicer version PrusaSlicer-2.9.6 on versionKey CFBundleVersion.
2026-08-31 09:37:26 : INFO  : prusaslicer : App has LSMinimumSystemVersion: 10.13
2026-08-31 09:37:26 : DEBUG : prusaslicer : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 09:37:26 : INFO  : prusaslicer : Finishing...
2026-08-31 09:37:29 : INFO  : prusaslicer : name: PrusaSlicer, appName: Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:29 : WARN  : prusaslicer : No previous app found
2026-08-31 09:37:29 : WARN  : prusaslicer : could not find Original Prusa Drivers/PrusaSlicer.app
2026-08-31 09:37:29 : REQ   : prusaslicer : Installed PrusaSlicer, version PrusaSlicer-2.9.6
2026-08-31 09:37:29 : INFO  : prusaslicer : notifying
2026-08-31 09:37:30 : DEBUG : prusaslicer : Unmounting /Volumes/Original Prusa Drivers
2026-08-31 09:37:30 : DEBUG : prusaslicer : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 09:37:30 : DEBUG : prusaslicer : DEBUG mode 1, not reopening anything
2026-08-31 09:37:30 : REQ   : prusaslicer : All done!
2026-08-31 09:37:30 : REQ   : prusaslicer : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
