### PR TITLE
Update notion.sh

### DIFF
--- a/fragments/labels/notion.sh
+++ b/fragments/labels/notion.sh
@@ -2,6 +2,6 @@ notion)
     name="Notion"
     type="dmg"
     downloadURL="https://www.notion.so/desktop/mac/download"
-    appNewVersion=$(curl -fsIL "https://www.notion.so/desktop/mac/download" | grep -i "^location" | awk '{print $2}' | sed -e 's/.*Notion-\(.*\).dmg.*/\1/' | cut -d '-' -f 1)
+    appNewVersion=$(curl -fsL "https://desktop-release.notion-static.com/latest-mac.yml" | awk -F': ' '/^version:/{print $2; exit}')
     expectedTeamID="LBQJ96FQ8D"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

Notion’s official download URL is still the best downloadURL because it redirects to the current universal DMG, so no architecture branching is needed. For appNewVersion, Notion publishes a structured Electron updater metadata file at https://desktop-release.notion-static.com/latest-mac.yml, and it currently reports version: 7.31.3, which matches the downloaded app’s CFBundleShortVersionString and CFBundleVersion. That is cleaner than parsing the redirect URL with awk/sed.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh notion DEBUG=1
2026-08-31 09:48:41 : INFO  : notion : setting variable from argument DEBUG=1
2026-08-31 09:48:41 : INFO  : notion : Total items in argumentsArray: 1
2026-08-31 09:48:42 : INFO  : notion : argumentsArray: DEBUG=1
2026-08-31 09:48:42 : REQ   : notion : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 09:48:42 : INFO  : notion : ################## Version: 10.10beta
2026-08-31 09:48:42 : INFO  : notion : ################## Date: 2026-08-31
2026-08-31 09:48:42 : INFO  : notion : ################## notion
2026-08-31 09:48:42 : DEBUG : notion : DEBUG mode 1 enabled.
2026-08-31 09:48:42 : INFO  : notion : Reading arguments again: DEBUG=1
2026-08-31 09:48:42 : DEBUG : notion : argument: DEBUG=1
2026-08-31 09:48:42 : DEBUG : notion : name=Notion
2026-08-31 09:48:42 : DEBUG : notion : appName=
2026-08-31 09:48:42 : DEBUG : notion : type=dmg
2026-08-31 09:48:42 : DEBUG : notion : archiveName=
2026-08-31 09:48:42 : DEBUG : notion : downloadURL=https://www.notion.so/desktop/mac/download
2026-08-31 09:48:42 : DEBUG : notion : curlOptions=
2026-08-31 09:48:42 : DEBUG : notion : appNewVersion=7.31.3
2026-08-31 09:48:42 : DEBUG : notion : appCustomVersion function: Not defined
2026-08-31 09:48:42 : DEBUG : notion : versionKey=CFBundleShortVersionString
2026-08-31 09:48:42 : DEBUG : notion : packageID=
2026-08-31 09:48:42 : DEBUG : notion : pkgName=
2026-08-31 09:48:43 : DEBUG : notion : choiceChangesXML=
2026-08-31 09:48:43 : DEBUG : notion : expectedTeamID=LBQJ96FQ8D
2026-08-31 09:48:43 : DEBUG : notion : blockingProcesses=
2026-08-31 09:48:43 : DEBUG : notion : installerTool=
2026-08-31 09:48:43 : DEBUG : notion : CLIInstaller=
2026-08-31 09:48:43 : DEBUG : notion : CLIArguments=
2026-08-31 09:48:43 : DEBUG : notion : updateTool=
2026-08-31 09:48:43 : DEBUG : notion : updateToolArguments=
2026-08-31 09:48:43 : DEBUG : notion : updateToolRunAsCurrentUser=
2026-08-31 09:48:43 : INFO  : notion : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 09:48:43 : INFO  : notion : NOTIFY=success
2026-08-31 09:48:43 : INFO  : notion : LOGGING=DEBUG
2026-08-31 09:48:43 : INFO  : notion : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 09:48:43 : INFO  : notion : Label type: dmg
2026-08-31 09:48:43 : INFO  : notion : archiveName: Notion.dmg
2026-08-31 09:48:43 : INFO  : notion : no blocking processes defined, using Notion as default
2026-08-31 09:48:43 : DEBUG : notion : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 09:48:43 : INFO  : notion : name: Notion, appName: Notion.app
2026-08-31 09:48:43 : WARN  : notion : No previous app found
2026-08-31 09:48:43 : WARN  : notion : could not find Notion.app
2026-08-31 09:48:43 : INFO  : notion : appversion: 
2026-08-31 09:48:43 : INFO  : notion : Latest version of Notion is 7.31.3
2026-08-31 09:48:43 : REQ   : notion : Downloading https://www.notion.so/desktop/mac/download to Notion.dmg
2026-08-31 09:48:43 : DEBUG : notion : No Dialog connection, just download
2026-08-31 09:48:50 : INFO  : notion : Downloaded Notion.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 9da0a183a5f5d3671dbd34d50594b32afdf58c84 – Size is 213348 kB
2026-08-31 09:48:50 : DEBUG : notion : DEBUG mode 1, not checking for blocking processes
2026-08-31 09:48:50 : REQ   : notion : Installing Notion
2026-08-31 09:48:50 : INFO  : notion : Mounting /Users/u0105821/git/github/Installomator/build/Notion.dmg
2026-08-31 09:48:52 : DEBUG : notion : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $BF853955
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $E8EB2177
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $34FE42E5
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E1A0AFCA
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $34FE42E5
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $97092C9D
verified   CRC32 $7006B041
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Notion Installer

2026-08-31 09:48:52 : INFO  : notion : Mounted: /Volumes/Notion Installer
2026-08-31 09:48:52 : INFO  : notion : Verifying: /Volumes/Notion Installer/Notion.app
2026-08-31 09:48:52 : DEBUG : notion : App size: 496M	/Volumes/Notion Installer/Notion.app
2026-08-31 09:48:54 : DEBUG : notion : Debugging enabled, App Verification output was:
/Volumes/Notion Installer/Notion.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Notion Labs, Incorporated (LBQJ96FQ8D)

2026-08-31 09:48:54 : INFO  : notion : Team ID matching: LBQJ96FQ8D (expected: LBQJ96FQ8D )
2026-08-31 09:48:54 : INFO  : notion : Installing Notion version 7.31.3 on versionKey CFBundleShortVersionString.
2026-08-31 09:48:54 : INFO  : notion : App has LSMinimumSystemVersion: 12.0
2026-08-31 09:48:54 : DEBUG : notion : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 09:48:54 : INFO  : notion : Finishing...
2026-08-31 09:48:57 : INFO  : notion : name: Notion, appName: Notion.app
2026-08-31 09:48:57 : WARN  : notion : No previous app found
2026-08-31 09:48:57 : WARN  : notion : could not find Notion.app
2026-08-31 09:48:57 : REQ   : notion : Installed Notion, version 7.31.3
2026-08-31 09:48:57 : INFO  : notion : notifying
2026-08-31 09:48:58 : DEBUG : notion : Unmounting /Volumes/Notion Installer
2026-08-31 09:48:58 : DEBUG : notion : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 09:48:58 : DEBUG : notion : DEBUG mode 1, not reopening anything
2026-08-31 09:48:58 : REQ   : notion : All done!
2026-08-31 09:48:58 : REQ   : notion : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
