### PR TITLE
Create tesseraremote.sh

### DIFF
--- a/fragments/labels/tesseraremote.sh
+++ b/fragments/labels/tesseraremote.sh
@@ -1,0 +1,9 @@
+tesseraremote)
+    name="Tessera Remote"
+    type="dmg"
+    tesseraReleasePage=$(curl -fsL "https://www.bromptontech.com/support/downloads/" | xmllint --html --xpath 'string(//div[@id="downloads"]//a[contains(@href, "http") and contains(@href, "tessera") and not(contains(@href, "beta"))]/@href)' - 2>/dev/null)
+    downloadURL=$(curl -fsL "$tesseraReleasePage" | xmllint --html --xpath 'string(//div[@id="releaseDetailsBlock"]//a[contains(@href, "Tessera_Remote") and substring(@href, string-length(@href)-3, 4) = ".dmg"]/@href)' - 2>/dev/null)
+    appNewVersion=$(sed -E 's#.*Tessera_Remote_v([0-9]+\.[0-9]+\.[0-9]+)_installer\.dmg#\1#' <<< "$downloadURL")
+    appName="Tessera Remote $appNewVersion.app"
+    expectedTeamID="7J5M6EPN5V"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated label is better because it keeps the verified working installer path while making the logic more reliable and easier to review. The original used a long nested pipeline with an unnecessary browser User-Agent and did not explicitly exclude the No_Footage installer. The updated version separates the two Resolume web lookups into clear helper variables, selects the full Arena installer, uses the supported pkgInDmg type, keeps the required nested appName, and extracts appNewVersion as 7.27.1, which matches the installed Arena.app version.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
sudo Installomator/utils/assemble.sh tesseraremote DEBUG=1
2026-08-31 11:02:44 : INFO  : tesseraremote : setting variable from argument DEBUG=1
2026-08-31 11:02:44 : INFO  : tesseraremote : Total items in argumentsArray: 1
2026-08-31 11:02:44 : INFO  : tesseraremote : argumentsArray: DEBUG=1
2026-08-31 11:02:44 : REQ   : tesseraremote : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 11:02:44 : INFO  : tesseraremote : ################## Version: 10.10beta
2026-08-31 11:02:44 : INFO  : tesseraremote : ################## Date: 2026-08-31
2026-08-31 11:02:44 : INFO  : tesseraremote : ################## tesseraremote
2026-08-31 11:02:44 : DEBUG : tesseraremote : DEBUG mode 1 enabled.
2026-08-31 11:02:48 : INFO  : tesseraremote : Reading arguments again: DEBUG=1
2026-08-31 11:02:48 : DEBUG : tesseraremote : argument: DEBUG=1
2026-08-31 11:02:48 : DEBUG : tesseraremote : name=Tessera Remote
2026-08-31 11:02:48 : DEBUG : tesseraremote : appName=Tessera Remote 3.5.2.app
2026-08-31 11:02:48 : DEBUG : tesseraremote : type=dmg
2026-08-31 11:02:48 : DEBUG : tesseraremote : archiveName=
2026-08-31 11:02:48 : DEBUG : tesseraremote : downloadURL=https://dl.bromptontech.com/tessera/management_app/Tessera_Remote_v3.5.2_installer.dmg
2026-08-31 11:02:48 : DEBUG : tesseraremote : curlOptions=
2026-08-31 11:02:48 : DEBUG : tesseraremote : appNewVersion=3.5.2
2026-08-31 11:02:48 : DEBUG : tesseraremote : appCustomVersion function: Not defined
2026-08-31 11:02:48 : DEBUG : tesseraremote : versionKey=CFBundleShortVersionString
2026-08-31 11:02:48 : DEBUG : tesseraremote : packageID=
2026-08-31 11:02:48 : DEBUG : tesseraremote : pkgName=
2026-08-31 11:02:48 : DEBUG : tesseraremote : choiceChangesXML=
2026-08-31 11:02:48 : DEBUG : tesseraremote : expectedTeamID=7J5M6EPN5V
2026-08-31 11:02:48 : DEBUG : tesseraremote : blockingProcesses=
2026-08-31 11:02:48 : DEBUG : tesseraremote : installerTool=
2026-08-31 11:02:48 : DEBUG : tesseraremote : CLIInstaller=
2026-08-31 11:02:48 : DEBUG : tesseraremote : CLIArguments=
2026-08-31 11:02:48 : DEBUG : tesseraremote : updateTool=
2026-08-31 11:02:48 : DEBUG : tesseraremote : updateToolArguments=
2026-08-31 11:02:48 : DEBUG : tesseraremote : updateToolRunAsCurrentUser=
2026-08-31 11:02:48 : INFO  : tesseraremote : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 11:02:48 : INFO  : tesseraremote : NOTIFY=success
2026-08-31 11:02:48 : INFO  : tesseraremote : LOGGING=DEBUG
2026-08-31 11:02:48 : INFO  : tesseraremote : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 11:02:48 : INFO  : tesseraremote : Label type: dmg
2026-08-31 11:02:48 : INFO  : tesseraremote : archiveName: Tessera Remote.dmg
2026-08-31 11:02:48 : INFO  : tesseraremote : no blocking processes defined, using Tessera Remote as default
2026-08-31 11:02:48 : DEBUG : tesseraremote : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 11:02:48 : INFO  : tesseraremote : name: Tessera Remote, appName: Tessera Remote 3.5.2.app
2026-08-31 11:02:48 : WARN  : tesseraremote : No previous app found
2026-08-31 11:02:48 : WARN  : tesseraremote : could not find Tessera Remote 3.5.2.app
2026-08-31 11:02:49 : INFO  : tesseraremote : appversion: 
2026-08-31 11:02:49 : INFO  : tesseraremote : Latest version of Tessera Remote is 3.5.2
2026-08-31 11:02:49 : REQ   : tesseraremote : Downloading https://dl.bromptontech.com/tessera/management_app/Tessera_Remote_v3.5.2_installer.dmg to Tessera Remote.dmg
2026-08-31 11:02:49 : DEBUG : tesseraremote : No Dialog connection, just download
2026-08-31 11:20:18 : INFO  : tesseraremote : Downloaded Tessera Remote.dmg – Type is  zlib compressed data – SHA is 07c6e9466e1a302f69763cdd9802361598badef8 – Size is 442832 kB
2026-08-31 11:20:18 : DEBUG : tesseraremote : DEBUG mode 1, not checking for blocking processes
2026-08-31 11:20:18 : REQ   : tesseraremote : Installing Tessera Remote
2026-08-31 11:20:18 : INFO  : tesseraremote : Mounting /Users/u0105821/git/github/Installomator/build/Tessera Remote.dmg
2026-08-31 11:20:21 : DEBUG : tesseraremote : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $537108FB
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $1C5840BA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $67ECA36A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $DE873869
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $67ECA36A
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $EA06EA01
verified   CRC32 $96734327
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Tessera Remote 3.5.2

2026-08-31 11:20:21 : INFO  : tesseraremote : Mounted: /Volumes/Tessera Remote 3.5.2
2026-08-31 11:20:21 : INFO  : tesseraremote : Verifying: /Volumes/Tessera Remote 3.5.2/Tessera Remote 3.5.2.app
2026-08-31 11:20:21 : DEBUG : tesseraremote : App size: 446M	/Volumes/Tessera Remote 3.5.2/Tessera Remote 3.5.2.app
2026-08-31 11:20:22 : DEBUG : tesseraremote : Debugging enabled, App Verification output was:
/Volumes/Tessera Remote 3.5.2/Tessera Remote 3.5.2.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Carallon ltd (7J5M6EPN5V)

2026-08-31 11:20:22 : INFO  : tesseraremote : Team ID matching: 7J5M6EPN5V (expected: 7J5M6EPN5V )
2026-08-31 11:20:22 : INFO  : tesseraremote : Installing Tessera Remote version 3.5.2 on versionKey CFBundleShortVersionString.
2026-08-31 11:20:22 : DEBUG : tesseraremote : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 11:20:22 : INFO  : tesseraremote : Finishing...
2026-08-31 11:20:25 : INFO  : tesseraremote : name: Tessera Remote, appName: Tessera Remote 3.5.2.app
2026-08-31 11:20:25 : WARN  : tesseraremote : No previous app found
2026-08-31 11:20:25 : WARN  : tesseraremote : could not find Tessera Remote 3.5.2.app
2026-08-31 11:20:25 : REQ   : tesseraremote : Installed Tessera Remote, version 3.5.2
2026-08-31 11:20:25 : INFO  : tesseraremote : notifying
2026-08-31 11:20:26 : DEBUG : tesseraremote : Unmounting /Volumes/Tessera Remote 3.5.2
2026-08-31 11:20:26 : DEBUG : tesseraremote : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 11:20:26 : DEBUG : tesseraremote : DEBUG mode 1, not reopening anything
2026-08-31 11:20:26 : REQ   : tesseraremote : All done!
2026-08-31 11:20:26 : REQ   : tesseraremote : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
