### PR TITLE
Create missiveapp.sh

### DIFF
--- a/fragments/labels/missiveapp.sh
+++ b/fragments/labels/missiveapp.sh
@@ -1,0 +1,7 @@
+missiveapp)
+    name="Missive"
+    type="dmg"
+    downloadURL="https://mail.missiveapp.com/download/mac"
+    appNewVersion=$(curl -fsLI -o /dev/null -w '%{url_effective}' "$downloadURL" | sed -E 's#.*/Missive-([0-9]+(\.[0-9]+)+)\.dmg#\1#')
+    expectedTeamID="PXGQRRXCJN"
+    ;;

--- a/fragments/labels/missiveapp.sh
+++ b/fragments/labels/missiveapp.sh
@@ -1,4 +1,4 @@
-missiveapp)
+missive)
     name="Missive"
     type="dmg"
     downloadURL="https://mail.missiveapp.com/download/mac"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The simple official vendor download URL and stock Installomator dmg type, while adding verified version detection so Installomator can skip unnecessary reinstalls. The default name="Missive" correctly maps to Missive.app, and the default blocking process should already be Missive, so the helper process list is extra noise unless testing shows those helpers must be handled separately.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh missiveapp DEBUG=1
2026-08-31 11:27:56 : INFO  : missiveapp : setting variable from argument DEBUG=1
2026-08-31 11:27:56 : INFO  : missiveapp : Total items in argumentsArray: 1
2026-08-31 11:27:56 : INFO  : missiveapp : argumentsArray: DEBUG=1
2026-08-31 11:27:56 : REQ   : missiveapp : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 11:27:56 : INFO  : missiveapp : ################## Version: 10.10beta
2026-08-31 11:27:56 : INFO  : missiveapp : ################## Date: 2026-08-31
2026-08-31 11:27:56 : INFO  : missiveapp : ################## missiveapp
2026-08-31 11:27:56 : DEBUG : missiveapp : DEBUG mode 1 enabled.
2026-08-31 11:27:57 : INFO  : missiveapp : Reading arguments again: DEBUG=1
2026-08-31 11:27:57 : DEBUG : missiveapp : argument: DEBUG=1
2026-08-31 11:27:57 : DEBUG : missiveapp : name=Missive
2026-08-31 11:27:57 : DEBUG : missiveapp : appName=
2026-08-31 11:27:57 : DEBUG : missiveapp : type=dmg
2026-08-31 11:27:57 : DEBUG : missiveapp : archiveName=
2026-08-31 11:27:57 : DEBUG : missiveapp : downloadURL=https://mail.missiveapp.com/download/mac
2026-08-31 11:27:57 : DEBUG : missiveapp : curlOptions=
2026-08-31 11:27:57 : DEBUG : missiveapp : appNewVersion=11.33.0
2026-08-31 11:27:58 : DEBUG : missiveapp : appCustomVersion function: Not defined
2026-08-31 11:27:58 : DEBUG : missiveapp : versionKey=CFBundleShortVersionString
2026-08-31 11:27:58 : DEBUG : missiveapp : packageID=
2026-08-31 11:27:58 : DEBUG : missiveapp : pkgName=
2026-08-31 11:27:58 : DEBUG : missiveapp : choiceChangesXML=
2026-08-31 11:27:58 : DEBUG : missiveapp : expectedTeamID=PXGQRRXCJN
2026-08-31 11:27:58 : DEBUG : missiveapp : blockingProcesses=
2026-08-31 11:27:58 : DEBUG : missiveapp : installerTool=
2026-08-31 11:27:58 : DEBUG : missiveapp : CLIInstaller=
2026-08-31 11:27:58 : DEBUG : missiveapp : CLIArguments=
2026-08-31 11:27:58 : DEBUG : missiveapp : updateTool=
2026-08-31 11:27:58 : DEBUG : missiveapp : updateToolArguments=
2026-08-31 11:27:58 : DEBUG : missiveapp : updateToolRunAsCurrentUser=
2026-08-31 11:27:58 : INFO  : missiveapp : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 11:27:58 : INFO  : missiveapp : NOTIFY=success
2026-08-31 11:27:58 : INFO  : missiveapp : LOGGING=DEBUG
2026-08-31 11:27:58 : INFO  : missiveapp : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 11:27:58 : INFO  : missiveapp : Label type: dmg
2026-08-31 11:27:58 : INFO  : missiveapp : archiveName: Missive.dmg
2026-08-31 11:27:58 : INFO  : missiveapp : no blocking processes defined, using Missive as default
2026-08-31 11:27:58 : DEBUG : missiveapp : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 11:27:58 : INFO  : missiveapp : name: Missive, appName: Missive.app
2026-08-31 11:27:58 : WARN  : missiveapp : No previous app found
2026-08-31 11:27:58 : WARN  : missiveapp : could not find Missive.app
2026-08-31 11:27:58 : INFO  : missiveapp : appversion: 
2026-08-31 11:27:58 : INFO  : missiveapp : Latest version of Missive is 11.33.0
2026-08-31 11:27:58 : REQ   : missiveapp : Downloading https://mail.missiveapp.com/download/mac to Missive.dmg
2026-08-31 11:27:58 : DEBUG : missiveapp : No Dialog connection, just download
2026-08-31 11:28:04 : INFO  : missiveapp : Downloaded Missive.dmg – Type is  zlib compressed data – SHA is 88dec949b2f8d349edd8d9955c9988e1807829d0 – Size is 213260 kB
2026-08-31 11:28:04 : DEBUG : missiveapp : DEBUG mode 1, not checking for blocking processes
2026-08-31 11:28:04 : REQ   : missiveapp : Installing Missive
2026-08-31 11:28:04 : INFO  : missiveapp : Mounting /Users/u0105821/git/github/Installomator/build/Missive.dmg
2026-08-31 11:28:09 : DEBUG : missiveapp : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $503A9650
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $4B00BA1E
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $4C386349
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $E7F8452E
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $4C386349
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $BE15A516
verified   CRC32 $465DAE04
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Install Missive 11.33.0

2026-08-31 11:28:09 : INFO  : missiveapp : Mounted: /Volumes/Install Missive 11.33.0
2026-08-31 11:28:09 : INFO  : missiveapp : Verifying: /Volumes/Install Missive 11.33.0/Missive.app
2026-08-31 11:28:09 : DEBUG : missiveapp : App size: 459M	/Volumes/Install Missive 11.33.0/Missive.app
2026-08-31 11:28:12 : DEBUG : missiveapp : Debugging enabled, App Verification output was:
/Volumes/Install Missive 11.33.0/Missive.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Heliom Inc. (PXGQRRXCJN)

2026-08-31 11:28:12 : INFO  : missiveapp : Team ID matching: PXGQRRXCJN (expected: PXGQRRXCJN )
2026-08-31 11:28:12 : INFO  : missiveapp : Installing Missive version 11.33.0 on versionKey CFBundleShortVersionString.
2026-08-31 11:28:12 : INFO  : missiveapp : App has LSMinimumSystemVersion: 10.13
2026-08-31 11:28:12 : DEBUG : missiveapp : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 11:28:12 : INFO  : missiveapp : Finishing...
2026-08-31 11:28:15 : INFO  : missiveapp : name: Missive, appName: Missive.app
2026-08-31 11:28:15 : WARN  : missiveapp : No previous app found
2026-08-31 11:28:15 : WARN  : missiveapp : could not find Missive.app
2026-08-31 11:28:15 : REQ   : missiveapp : Installed Missive, version 11.33.0
2026-08-31 11:28:15 : INFO  : missiveapp : notifying
2026-08-31 11:28:16 : DEBUG : missiveapp : Unmounting /Volumes/Install Missive 11.33.0
2026-08-31 11:28:16 : DEBUG : missiveapp : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 11:28:16 : DEBUG : missiveapp : DEBUG mode 1, not reopening anything
2026-08-31 11:28:16 : REQ   : missiveapp : All done!
2026-08-31 11:28:16 : REQ   : missiveapp : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
