### PR TITLE
Update 4kvideodownloader.sh

### DIFF
--- a/fragments/labels/4kvideodownloader.sh
+++ b/fragments/labels/4kvideodownloader.sh
@@ -1,8 +1,9 @@
 4kvideodownloader)
     name="4K Video Downloader"
     type="dmg"
-    downloadURL="$(curl -fsL "https://www.4kdownload.com/products/product-videodownloader" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloader_.*?.dmg\?source=website" | head -1)"
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[0-9a-zA-Z]*_([0-9.]*)\.dmg.*/\1/g')
-	versionKey="CFBundleVersion"
+    sparkleData=$(curl -fsL "https://dl.4kdownload.com/app/appcast/videodownloader.xml")
+    appNewVersion=$(xmllint --xpath 'normalize-space((//*[local-name()="enclosure" and @*[local-name()="os"]="mac-64"])[1]/@*[local-name()="version"])' - <<< "$sparkleData" | cut -d "." -f1-3)
+    downloadURL="https://dl.4kdownload.com/app/4kvideodownloader_${appNewVersion}_x64.dmg?source=website"
+    versionKey="CFBundleVersion"
     expectedTeamID="GHQ37VJF83"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the current merged label because it gets the current version from the vendor’s structured Sparkle appcast instead of scraping changing website HTML, while still using the verified vendor DMG naming pattern required by Installomator. It also fixes the macOS xpath parsing issue, keeps versionKey="CFBundleVersion" because the downloaded app’s real installable version is stored there, and preserves the verified Team ID GHQ37VJF83.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh 4kvideodownloader DEBUG=1
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : setting variable from argument DEBUG=1
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : Total items in argumentsArray: 1
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : argumentsArray: DEBUG=1
2026-08-31 12:01:01 : REQ   : 4kvideodownloader : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : ################## Version: 10.10beta
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : ################## Date: 2026-08-31
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : ################## 4kvideodownloader
2026-08-31 12:01:01 : DEBUG : 4kvideodownloader : DEBUG mode 1 enabled.
2026-08-31 12:01:01 : INFO  : 4kvideodownloader : Reading arguments again: DEBUG=1
2026-08-31 12:01:01 : DEBUG : 4kvideodownloader : argument: DEBUG=1
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : name=4K Video Downloader
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : appName=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : type=dmg
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : archiveName=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : downloadURL=https://dl.4kdownload.com/app/4kvideodownloader_4.33.5_x64.dmg?source=website
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : curlOptions=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : appNewVersion=4.33.5
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : appCustomVersion function: Not defined
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : versionKey=CFBundleVersion
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : packageID=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : pkgName=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : choiceChangesXML=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : expectedTeamID=GHQ37VJF83
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : blockingProcesses=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : installerTool=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : CLIInstaller=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : CLIArguments=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : updateTool=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : updateToolArguments=
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : updateToolRunAsCurrentUser=
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : NOTIFY=success
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : LOGGING=DEBUG
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : Label type: dmg
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : archiveName: 4K Video Downloader.dmg
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : no blocking processes defined, using 4K Video Downloader as default
2026-08-31 12:01:02 : DEBUG : 4kvideodownloader : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : name: 4K Video Downloader, appName: 4K Video Downloader.app
2026-08-31 12:01:02 : WARN  : 4kvideodownloader : No previous app found
2026-08-31 12:01:02 : WARN  : 4kvideodownloader : could not find 4K Video Downloader.app
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : appversion: 
2026-08-31 12:01:02 : INFO  : 4kvideodownloader : Latest version of 4K Video Downloader is 4.33.5
2026-08-31 12:01:03 : REQ   : 4kvideodownloader : Downloading https://dl.4kdownload.com/app/4kvideodownloader_4.33.5_x64.dmg?source=website to 4K Video Downloader.dmg
2026-08-31 12:01:03 : DEBUG : 4kvideodownloader : No Dialog connection, just download
2026-08-31 12:01:07 : INFO  : 4kvideodownloader : Downloaded 4K Video Downloader.dmg – Type is  zlib compressed data – SHA is f869fa78a7294cba8212e8378d11459678b780e2 – Size is 131644 kB
2026-08-31 12:01:07 : DEBUG : 4kvideodownloader : DEBUG mode 1, not checking for blocking processes
2026-08-31 12:01:07 : REQ   : 4kvideodownloader : Installing 4K Video Downloader
2026-08-31 12:01:07 : INFO  : 4kvideodownloader : Mounting /Users/u0105821/git/github/Installomator/build/4K Video Downloader.dmg
2026-08-31 12:01:12 : DEBUG : 4kvideodownloader : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $247C9704
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7673149D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5F4C2CBB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $DCD21FA4
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5F4C2CBB
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $C4AD0885
verified   CRC32 $5552F37C
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/4K Video Downloader

2026-08-31 12:01:12 : INFO  : 4kvideodownloader : Mounted: /Volumes/4K Video Downloader
2026-08-31 12:01:12 : INFO  : 4kvideodownloader : Verifying: /Volumes/4K Video Downloader/4K Video Downloader.app
2026-08-31 12:01:12 : DEBUG : 4kvideodownloader : App size: 357M	/Volumes/4K Video Downloader/4K Video Downloader.app
2026-08-31 12:01:14 : DEBUG : 4kvideodownloader : Debugging enabled, App Verification output was:
/Volumes/4K Video Downloader/4K Video Downloader.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Open Media OOO (GHQ37VJF83)

2026-08-31 12:01:14 : INFO  : 4kvideodownloader : Team ID matching: GHQ37VJF83 (expected: GHQ37VJF83 )
2026-08-31 12:01:14 : INFO  : 4kvideodownloader : Installing 4K Video Downloader version 4.33.5 on versionKey CFBundleVersion.
2026-08-31 12:01:14 : INFO  : 4kvideodownloader : App has LSMinimumSystemVersion: 10.13.0
2026-08-31 12:01:14 : DEBUG : 4kvideodownloader : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 12:01:14 : INFO  : 4kvideodownloader : Finishing...
2026-08-31 12:01:18 : INFO  : 4kvideodownloader : name: 4K Video Downloader, appName: 4K Video Downloader.app
2026-08-31 12:01:18 : WARN  : 4kvideodownloader : No previous app found
2026-08-31 12:01:18 : WARN  : 4kvideodownloader : could not find 4K Video Downloader.app
2026-08-31 12:01:18 : REQ   : 4kvideodownloader : Installed 4K Video Downloader, version 4.33.5
2026-08-31 12:01:18 : INFO  : 4kvideodownloader : notifying
2026-08-31 12:01:18 : DEBUG : 4kvideodownloader : Unmounting /Volumes/4K Video Downloader
2026-08-31 12:01:18 : DEBUG : 4kvideodownloader : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 12:01:18 : DEBUG : 4kvideodownloader : DEBUG mode 1, not reopening anything
2026-08-31 12:01:18 : REQ   : 4kvideodownloader : All done!
2026-08-31 12:01:18 : REQ   : 4kvideodownloader : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
