### PR TITLE
Update 4kvideodownloaderplus.sh

### DIFF
--- a/fragments/labels/4kvideodownloaderplus.sh
+++ b/fragments/labels/4kvideodownloaderplus.sh
@@ -1,12 +1,13 @@
 4kvideodownloaderplus)
     name="4K Video Downloader+"
     type="dmg"
-    if [[ $(/usr/bin/arch) == "arm64" ]]; then 
-        downloadURL="$(curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36" -fsL "https://www.4kdownload.com/downloads/34" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloaderplus.*arm64.*?.dmg\?source=website" | head -1)"
+    sparkleData=$(curl -fsL "https://dl.4kdownload.com/app/appcast/videodownloaderplus.xml")
+    appNewVersion=$(xmllint --xpath 'normalize-space((//*[local-name()="enclosure" and @*[local-name()="os"]="mac-64"])[1]/@*[local-name()="version"])' - <<< "$sparkleData" | cut -d "." -f1-3)
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://dl.4kdownload.com/app/4kvideodownloaderplus_${appNewVersion}_arm64.dmg?source=website"
     else
-        downloadURL="$(curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36" -fsL "https://www.4kdownload.com/downloads/34" | grep -E -o "https:\/\/dl\.4kdownload\.com\/app\/4kvideodownloaderplus.*x64.*?.dmg\?source=website" | head -1)"
+        downloadURL="https://dl.4kdownload.com/app/4kvideodownloaderplus_${appNewVersion}_x64.dmg?source=website"
     fi
-    appNewVersion=$(echo "${downloadURL}" | sed -E 's/.*\/[0-9a-zA-Z]*_([0-9.]*)_arm64\.dmg.*/\1/g')
-	versionKey="CFBundleVersion"
+    versionKey="CFBundleVersion"
     expectedTeamID="GHQ37VJF83"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the current merged label because it uses the vendor’s structured Sparkle appcast for version detection instead of scraping website HTML, removes the unnecessary browser User-Agent, fixes the Intel version parsing bug, preserves proper architecture-specific downloads, and keeps versionKey="CFBundleVersion" based on the verified app bundle metadata.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh 4kvideodownloaderplus DEBUG=1
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : setting variable from argument DEBUG=1
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : Total items in argumentsArray: 1
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : argumentsArray: DEBUG=1
2026-08-31 12:09:14 : REQ   : 4kvideodownloaderplus : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : ################## Version: 10.10beta
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : ################## Date: 2026-08-31
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : ################## 4kvideodownloaderplus
2026-08-31 12:09:14 : DEBUG : 4kvideodownloaderplus : DEBUG mode 1 enabled.
2026-08-31 12:09:14 : INFO  : 4kvideodownloaderplus : Reading arguments again: DEBUG=1
2026-08-31 12:09:14 : DEBUG : 4kvideodownloaderplus : argument: DEBUG=1
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : name=4K Video Downloader+
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : appName=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : type=dmg
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : archiveName=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : downloadURL=https://dl.4kdownload.com/app/4kvideodownloaderplus_26.3.2_arm64.dmg?source=website
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : curlOptions=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : appNewVersion=26.3.2
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : appCustomVersion function: Not defined
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : versionKey=CFBundleVersion
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : packageID=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : pkgName=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : choiceChangesXML=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : expectedTeamID=GHQ37VJF83
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : blockingProcesses=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : installerTool=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : CLIInstaller=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : CLIArguments=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : updateTool=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : updateToolArguments=
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : updateToolRunAsCurrentUser=
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : NOTIFY=success
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : LOGGING=DEBUG
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : Label type: dmg
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : archiveName: 4K Video Downloader+.dmg
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : no blocking processes defined, using 4K Video Downloader+ as default
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : name: 4K Video Downloader+, appName: 4K Video Downloader+.app
2026-08-31 12:09:15 : WARN  : 4kvideodownloaderplus : No previous app found
2026-08-31 12:09:15 : WARN  : 4kvideodownloaderplus : could not find 4K Video Downloader+.app
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : appversion: 
2026-08-31 12:09:15 : INFO  : 4kvideodownloaderplus : Latest version of 4K Video Downloader+ is 26.3.2
2026-08-31 12:09:15 : REQ   : 4kvideodownloaderplus : Downloading https://dl.4kdownload.com/app/4kvideodownloaderplus_26.3.2_arm64.dmg?source=website to 4K Video Downloader+.dmg
2026-08-31 12:09:15 : DEBUG : 4kvideodownloaderplus : No Dialog connection, just download
2026-08-31 12:09:25 : INFO  : 4kvideodownloaderplus : Downloaded 4K Video Downloader+.dmg – Type is  zlib compressed data – SHA is 13b056a5f4fd6091c5eefa9a5abe8be9d977522c – Size is 278752 kB
2026-08-31 12:09:25 : DEBUG : 4kvideodownloaderplus : DEBUG mode 1, not checking for blocking processes
2026-08-31 12:09:25 : REQ   : 4kvideodownloaderplus : Installing 4K Video Downloader+
2026-08-31 12:09:25 : INFO  : 4kvideodownloaderplus : Mounting /Users/u0105821/git/github/Installomator/build/4K Video Downloader+.dmg
2026-08-31 12:09:29 : DEBUG : 4kvideodownloaderplus : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $848F3172
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $20CC065D
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $DD46F31E
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $0A154187
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $DD46F31E
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $157D0BC3
verified   CRC32 $E422EE33
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/4K Video Downloader+

2026-08-31 12:09:29 : INFO  : 4kvideodownloaderplus : Mounted: /Volumes/4K Video Downloader+
2026-08-31 12:09:29 : INFO  : 4kvideodownloaderplus : Verifying: /Volumes/4K Video Downloader+/4K Video Downloader+.app
2026-08-31 12:09:29 : DEBUG : 4kvideodownloaderplus : App size: 691M	/Volumes/4K Video Downloader+/4K Video Downloader+.app
2026-08-31 12:09:34 : DEBUG : 4kvideodownloaderplus : Debugging enabled, App Verification output was:
/Volumes/4K Video Downloader+/4K Video Downloader+.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Open Media OOO (GHQ37VJF83)

2026-08-31 12:09:34 : INFO  : 4kvideodownloaderplus : Team ID matching: GHQ37VJF83 (expected: GHQ37VJF83 )
2026-08-31 12:09:34 : INFO  : 4kvideodownloaderplus : Installing 4K Video Downloader+ version 26.3.2 on versionKey CFBundleVersion.
2026-08-31 12:09:34 : INFO  : 4kvideodownloaderplus : App has LSMinimumSystemVersion: 12.0.0
2026-08-31 12:09:34 : DEBUG : 4kvideodownloaderplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 12:09:34 : INFO  : 4kvideodownloaderplus : Finishing...
2026-08-31 12:09:37 : INFO  : 4kvideodownloaderplus : name: 4K Video Downloader+, appName: 4K Video Downloader+.app
2026-08-31 12:09:37 : WARN  : 4kvideodownloaderplus : No previous app found
2026-08-31 12:09:37 : WARN  : 4kvideodownloaderplus : could not find 4K Video Downloader+.app
2026-08-31 12:09:37 : REQ   : 4kvideodownloaderplus : Installed 4K Video Downloader+, version 26.3.2
2026-08-31 12:09:37 : INFO  : 4kvideodownloaderplus : notifying
2026-08-31 12:09:38 : DEBUG : 4kvideodownloaderplus : Unmounting /Volumes/4K Video Downloader+
2026-08-31 12:09:38 : DEBUG : 4kvideodownloaderplus : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 12:09:38 : DEBUG : 4kvideodownloaderplus : DEBUG mode 1, not reopening anything
2026-08-31 12:09:38 : REQ   : 4kvideodownloaderplus : All done!
2026-08-31 12:09:38 : REQ   : 4kvideodownloaderplus : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
