### PR TITLE
Create rokokostudio.sh

### DIFF
--- a/fragments/labels/rokokostudio.sh
+++ b/fragments/labels/rokokostudio.sh
@@ -6,3 +6,4 @@ rokokostudio)
     versionKey="CFBundleVersion"
     expectedTeamID="5K4RZM8SUS"
     ;;
+    

--- a/fragments/labels/rokokostudio.sh
+++ b/fragments/labels/rokokostudio.sh
@@ -1,7 +1,9 @@
 rokokostudio)
-    name="Rokoko Studio"
-    type="dmg"
-    downloadURL="https://cdn.rokoko.com/software/studio2-autoupdater/RokokoStudio.dmg"
-    blockingProcesses=( "Studio2Updater" )
+    name="RokokoStudio"
+    type="pkg"
+    packageID="com.rokoko.pkg.rokokostudio"
+    downloadURL="https://downloads.rokoko.com/studio-mac"
+    appNewVersion=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL" | grep -oE '[0-9]+(\.[0-9]+)+')
+    versionKey="CFBundleVersion"
     expectedTeamID="5K4RZM8SUS"
     ;;

--- a/fragments/labels/rokokostudio.sh
+++ b/fragments/labels/rokokostudio.sh
@@ -1,0 +1,7 @@
+rokokostudio)
+    name="Rokoko Studio"
+    type="dmg"
+    downloadURL="https://cdn.rokoko.com/software/studio2-autoupdater/RokokoStudio.dmg"
+    blockingProcesses=( "Studio2Updater" )
+    expectedTeamID="5K4RZM8SUS"
+    ;;

--- a/fragments/labels/rokokostudio.sh
+++ b/fragments/labels/rokokostudio.sh
@@ -1,7 +1,6 @@
 rokokostudio)
     name="RokokoStudio"
     type="pkg"
-    packageID="com.rokoko.pkg.rokokostudio"
     downloadURL="https://downloads.rokoko.com/studio-mac"
     appNewVersion=$(curl -fsL -o /dev/null -w "%{url_effective}" "$downloadURL" | grep -oE '[0-9]+(\.[0-9]+)+')
     versionKey="CFBundleVersion"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the original because it uses the verified installable macOS payload instead of a downloads.rokoko.com/studio-mac endpoint that currently returns 403, corrects the payload type from pkg to dmg, removes the invalid package ID, matches the actual installed app name, and preserves the verified Developer Team ID. The only limitation is that Rokoko’s reachable static CDN DMG does not expose a reliable pre-download version, so appNewVersion should be omitted unless the vendor provides a stable metadata source.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh rokokostudio DEBUG=1
2026-08-31 12:35:47 : INFO  : rokokostudio : setting variable from argument DEBUG=1
2026-08-31 12:35:47 : INFO  : rokokostudio : Total items in argumentsArray: 1
2026-08-31 12:35:47 : INFO  : rokokostudio : argumentsArray: DEBUG=1
2026-08-31 12:35:47 : REQ   : rokokostudio : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 12:35:47 : INFO  : rokokostudio : ################## Version: 10.10beta
2026-08-31 12:35:47 : INFO  : rokokostudio : ################## Date: 2026-08-31
2026-08-31 12:35:47 : INFO  : rokokostudio : ################## rokokostudio
2026-08-31 12:35:47 : DEBUG : rokokostudio : DEBUG mode 1 enabled.
2026-08-31 12:35:47 : INFO  : rokokostudio : Reading arguments again: DEBUG=1
2026-08-31 12:35:47 : DEBUG : rokokostudio : argument: DEBUG=1
2026-08-31 12:35:47 : DEBUG : rokokostudio : name=Rokoko Studio
2026-08-31 12:35:47 : DEBUG : rokokostudio : appName=
2026-08-31 12:35:47 : DEBUG : rokokostudio : type=dmg
2026-08-31 12:35:47 : DEBUG : rokokostudio : archiveName=
2026-08-31 12:35:47 : DEBUG : rokokostudio : downloadURL=https://cdn.rokoko.com/software/studio2-autoupdater/RokokoStudio.dmg
2026-08-31 12:35:47 : DEBUG : rokokostudio : curlOptions=
2026-08-31 12:35:47 : DEBUG : rokokostudio : appNewVersion=
2026-08-31 12:35:47 : DEBUG : rokokostudio : appCustomVersion function: Not defined
2026-08-31 12:35:47 : DEBUG : rokokostudio : versionKey=CFBundleShortVersionString
2026-08-31 12:35:47 : DEBUG : rokokostudio : packageID=
2026-08-31 12:35:47 : DEBUG : rokokostudio : pkgName=
2026-08-31 12:35:47 : DEBUG : rokokostudio : choiceChangesXML=
2026-08-31 12:35:48 : DEBUG : rokokostudio : expectedTeamID=5K4RZM8SUS
2026-08-31 12:35:48 : DEBUG : rokokostudio : blockingProcesses=Studio2Updater
2026-08-31 12:35:48 : DEBUG : rokokostudio : installerTool=
2026-08-31 12:35:48 : DEBUG : rokokostudio : CLIInstaller=
2026-08-31 12:35:48 : DEBUG : rokokostudio : CLIArguments=
2026-08-31 12:35:48 : DEBUG : rokokostudio : updateTool=
2026-08-31 12:35:48 : DEBUG : rokokostudio : updateToolArguments=
2026-08-31 12:35:48 : DEBUG : rokokostudio : updateToolRunAsCurrentUser=
2026-08-31 12:35:48 : INFO  : rokokostudio : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 12:35:48 : INFO  : rokokostudio : NOTIFY=success
2026-08-31 12:35:48 : INFO  : rokokostudio : LOGGING=DEBUG
2026-08-31 12:35:48 : INFO  : rokokostudio : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 12:35:48 : INFO  : rokokostudio : Label type: dmg
2026-08-31 12:35:48 : INFO  : rokokostudio : archiveName: Rokoko Studio.dmg
2026-08-31 12:35:48 : DEBUG : rokokostudio : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 12:35:48 : INFO  : rokokostudio : name: Rokoko Studio, appName: Rokoko Studio.app
2026-08-31 12:35:48 : WARN  : rokokostudio : No previous app found
2026-08-31 12:35:48 : WARN  : rokokostudio : could not find Rokoko Studio.app
2026-08-31 12:35:48 : INFO  : rokokostudio : appversion: 
2026-08-31 12:35:48 : INFO  : rokokostudio : Latest version not specified.
2026-08-31 12:35:48 : REQ   : rokokostudio : Downloading https://cdn.rokoko.com/software/studio2-autoupdater/RokokoStudio.dmg to Rokoko Studio.dmg
2026-08-31 12:35:48 : DEBUG : rokokostudio : No Dialog connection, just download
2026-08-31 12:35:50 : INFO  : rokokostudio : Downloaded Rokoko Studio.dmg – Type is  zlib compressed data – SHA is d548b2a61efcfa6de14c919f7c3921b764e7afb8 – Size is 46444 kB
2026-08-31 12:35:50 : DEBUG : rokokostudio : DEBUG mode 1, not checking for blocking processes
2026-08-31 12:35:50 : REQ   : rokokostudio : Installing Rokoko Studio
2026-08-31 12:35:50 : INFO  : rokokostudio : Mounting /Users/u0105821/git/github/Installomator/build/Rokoko Studio.dmg
2026-08-31 12:35:54 : DEBUG : rokokostudio : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $FCE42A37
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $6BB8CE0A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $F97D3BD4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $DFD6861B
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $F97D3BD4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $BBB1D887
verified   CRC32 $36A52299
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Rokoko Studio

2026-08-31 12:35:54 : INFO  : rokokostudio : Mounted: /Volumes/Rokoko Studio
2026-08-31 12:35:54 : INFO  : rokokostudio : Verifying: /Volumes/Rokoko Studio/Rokoko Studio.app
2026-08-31 12:35:54 : DEBUG : rokokostudio : App size: 102M	/Volumes/Rokoko Studio/Rokoko Studio.app
2026-08-31 12:35:56 : DEBUG : rokokostudio : Debugging enabled, App Verification output was:
/Volumes/Rokoko Studio/Rokoko Studio.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Rokoko Electronics ApS (5K4RZM8SUS)

2026-08-31 12:35:56 : INFO  : rokokostudio : Team ID matching: 5K4RZM8SUS (expected: 5K4RZM8SUS )
2026-08-31 12:35:56 : INFO  : rokokostudio : Installing Rokoko Studio version 1.0.0.11850 on versionKey CFBundleShortVersionString.
2026-08-31 12:35:56 : DEBUG : rokokostudio : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 12:35:56 : INFO  : rokokostudio : Finishing...
2026-08-31 12:35:59 : INFO  : rokokostudio : name: Rokoko Studio, appName: Rokoko Studio.app
2026-08-31 12:36:00 : WARN  : rokokostudio : No previous app found
2026-08-31 12:36:00 : WARN  : rokokostudio : could not find Rokoko Studio.app
2026-08-31 12:36:00 : REQ   : rokokostudio : Installed Rokoko Studio, version 1.0.0.11850
2026-08-31 12:36:00 : INFO  : rokokostudio : notifying
2026-08-31 12:36:00 : DEBUG : rokokostudio : Unmounting /Volumes/Rokoko Studio
2026-08-31 12:36:01 : DEBUG : rokokostudio : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 12:36:01 : DEBUG : rokokostudio : DEBUG mode 1, not reopening anything
2026-08-31 12:36:01 : REQ   : rokokostudio : All done!
2026-08-31 12:36:01 : REQ   : rokokostudio : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
