### PR TITLE
Update oktaverify.sh

### DIFF
--- a/fragments/labels/oktaverify.sh
+++ b/fragments/labels/oktaverify.sh
@@ -2,6 +2,6 @@ oktaverify)
     name="Okta Verify"
     type="pkg"
     downloadURL="https://okta.okta.com/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA&packageType=PKG"
-    appNewVersion=$(curl -fsLIXGET "$downloadURL" | grep -i "^location" | sed -e 's/location\: //' | sed -e 's/.*OktaVerify-\(.*\).pkg/\1/' | sed -e 's/-.*$//')
+    appNewVersion=$(curl -fsI "$downloadURL" | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | sed -E 's#.*/OktaVerify-([0-9]+(\.[0-9]+)+)-.*\.pkg#\1#')
     expectedTeamID="B7F62B65BN"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

Why it is better: it gets the same verified result, 9.69.0, but uses a simpler HEAD request instead of -LIXGET, avoids following the redirect to the full package just to read the Location header, and uses one clearer version regex that extracts only the version portion from the package filename. The merged label works, but this is cleaner and lighter.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh oktaverify DEBUG=1
2026-08-31 12:44:23 : INFO  : oktaverify : setting variable from argument DEBUG=1
2026-08-31 12:44:23 : INFO  : oktaverify : Total items in argumentsArray: 1
2026-08-31 12:44:23 : INFO  : oktaverify : argumentsArray: DEBUG=1
2026-08-31 12:44:23 : REQ   : oktaverify : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 12:44:23 : INFO  : oktaverify : ################## Version: 10.10beta
2026-08-31 12:44:23 : INFO  : oktaverify : ################## Date: 2026-08-31
2026-08-31 12:44:23 : INFO  : oktaverify : ################## oktaverify
2026-08-31 12:44:23 : DEBUG : oktaverify : DEBUG mode 1 enabled.
2026-08-31 12:44:24 : INFO  : oktaverify : Reading arguments again: DEBUG=1
2026-08-31 12:44:24 : DEBUG : oktaverify : argument: DEBUG=1
2026-08-31 12:44:24 : DEBUG : oktaverify : name=Okta Verify
2026-08-31 12:44:24 : DEBUG : oktaverify : appName=
2026-08-31 12:44:24 : DEBUG : oktaverify : type=pkg
2026-08-31 12:44:24 : DEBUG : oktaverify : archiveName=
2026-08-31 12:44:24 : DEBUG : oktaverify : downloadURL=https://okta.okta.com/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA&packageType=PKG
2026-08-31 12:44:24 : DEBUG : oktaverify : curlOptions=
2026-08-31 12:44:24 : DEBUG : oktaverify : appNewVersion=9.69.0
2026-08-31 12:44:24 : DEBUG : oktaverify : appCustomVersion function: Not defined
2026-08-31 12:44:24 : DEBUG : oktaverify : versionKey=CFBundleShortVersionString
2026-08-31 12:44:24 : DEBUG : oktaverify : packageID=
2026-08-31 12:44:24 : DEBUG : oktaverify : pkgName=
2026-08-31 12:44:24 : DEBUG : oktaverify : choiceChangesXML=
2026-08-31 12:44:24 : DEBUG : oktaverify : expectedTeamID=B7F62B65BN
2026-08-31 12:44:24 : DEBUG : oktaverify : blockingProcesses=
2026-08-31 12:44:24 : DEBUG : oktaverify : installerTool=
2026-08-31 12:44:24 : DEBUG : oktaverify : CLIInstaller=
2026-08-31 12:44:25 : DEBUG : oktaverify : CLIArguments=
2026-08-31 12:44:25 : DEBUG : oktaverify : updateTool=
2026-08-31 12:44:25 : DEBUG : oktaverify : updateToolArguments=
2026-08-31 12:44:25 : DEBUG : oktaverify : updateToolRunAsCurrentUser=
2026-08-31 12:44:25 : INFO  : oktaverify : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 12:44:25 : INFO  : oktaverify : NOTIFY=success
2026-08-31 12:44:25 : INFO  : oktaverify : LOGGING=DEBUG
2026-08-31 12:44:25 : INFO  : oktaverify : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 12:44:25 : INFO  : oktaverify : Label type: pkg
2026-08-31 12:44:25 : INFO  : oktaverify : archiveName: Okta Verify.pkg
2026-08-31 12:44:25 : INFO  : oktaverify : no blocking processes defined, using Okta Verify as default
2026-08-31 12:44:25 : DEBUG : oktaverify : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 12:44:25 : INFO  : oktaverify : name: Okta Verify, appName: Okta Verify.app
2026-08-31 12:44:25 : WARN  : oktaverify : No previous app found
2026-08-31 12:44:25 : WARN  : oktaverify : could not find Okta Verify.app
2026-08-31 12:44:25 : INFO  : oktaverify : appversion: 
2026-08-31 12:44:25 : INFO  : oktaverify : Latest version of Okta Verify is 9.69.0
2026-08-31 12:44:25 : REQ   : oktaverify : Downloading https://okta.okta.com/api/v1/artifacts/OKTA_VERIFY_MACOS/download?releaseChannel=GA&packageType=PKG to Okta Verify.pkg
2026-08-31 12:44:25 : DEBUG : oktaverify : No Dialog connection, just download
2026-08-31 12:44:28 : INFO  : oktaverify : Downloaded Okta Verify.pkg – Type is  xar archive compressed TOC – SHA is cb3f88275340cf1f63057b0a71ae6fba3968af8a – Size is 114796 kB
2026-08-31 12:44:28 : DEBUG : oktaverify : DEBUG mode 1, not checking for blocking processes
2026-08-31 12:44:28 : REQ   : oktaverify : Installing Okta Verify
2026-08-31 12:44:28 : INFO  : oktaverify : Verifying: Okta Verify.pkg
2026-08-31 12:44:28 : DEBUG : oktaverify : File list: -rw-r--r--  1 root  staff   101M Aug 31 12:44 Okta Verify.pkg
2026-08-31 12:44:28 : DEBUG : oktaverify : File type: Okta Verify.pkg: xar archive compressed TOC: 4664, SHA-1 checksum
2026-08-31 12:44:29 : DEBUG : oktaverify : spctlOut is Okta Verify.pkg: accepted
2026-08-31 12:44:29 : DEBUG : oktaverify : source=Notarized Developer ID
2026-08-31 12:44:29 : DEBUG : oktaverify : origin=Developer ID Installer: Okta, Inc. (B7F62B65BN)
2026-08-31 12:44:29 : INFO  : oktaverify : Team ID: B7F62B65BN (expected: B7F62B65BN )
2026-08-31 12:44:29 : DEBUG : oktaverify : DEBUG enabled, skipping installation
2026-08-31 12:44:29 : INFO  : oktaverify : Finishing...
2026-08-31 12:44:32 : INFO  : oktaverify : name: Okta Verify, appName: Okta Verify.app
2026-08-31 12:44:32 : WARN  : oktaverify : No previous app found
2026-08-31 12:44:32 : WARN  : oktaverify : could not find Okta Verify.app
2026-08-31 12:44:32 : REQ   : oktaverify : Installed Okta Verify, version 9.69.0
2026-08-31 12:44:32 : INFO  : oktaverify : notifying
2026-08-31 12:44:32 : DEBUG : oktaverify : DEBUG mode 1, not reopening anything
2026-08-31 12:44:32 : REQ   : oktaverify : All done!
2026-08-31 12:44:32 : REQ   : oktaverify : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
