### PR TITLE
foxitpdfreader.sh Label

### DIFF
--- a/fragments/labels/foxitpdfreader.sh
+++ b/fragments/labels/foxitpdfreader.sh
@@ -1,0 +1,9 @@
+foxitpdfreader)
+    name="Foxit PDF Reader"
+    type="pkg"
+    foxitReaderJSON=$(curl -fsL "https://www.foxit.com/portal/download/getdownloadform.html?formId=download-reader&retJson=1&platform=Mac-OS-X")
+    downloadURL="https://cdn01.foxitsoftware.com$(getJSONValue "$foxitReaderJSON" "package_info.down")"
+    appNewVersion=$(sed -E 's#.*/([0-9]{4}\.[0-9]+\.[0-9]+)/.*#\1#' <<< "$downloadURL")
+    appCustomVersion(){ /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "/Applications/Foxit PDF Reader.app/Contents/Info.plist" 2>/dev/null | cut -d "." -f1-3; }
+    expectedTeamID="8GN47HTP75"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

his label is better because it uses Foxit’s JSON download endpoint instead of scraping HTML or hardcoding an old package URL. The JSON returns the current Mac package path, and the label derives appNewVersion from that same package URL, so the download and version stay tied together. It also uses Installomator’s built-in getJSONValue helper and avoids Foxit’s Reader version-history value, which uses a different version scheme than the macOS app. The small appCustomVersion normalizes the installed app’s full bundle version, such as 2026.1.3.70306, down to 2026.1.3, so Installomator compares matching version formats and avoids unnecessary reinstalls.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh foxitpdfreader DEBUG=1
2026-08-31 13:31:18 : INFO  : foxitpdfreader : setting variable from argument DEBUG=1
2026-08-31 13:31:18 : INFO  : foxitpdfreader : Total items in argumentsArray: 1
2026-08-31 13:31:18 : INFO  : foxitpdfreader : argumentsArray: DEBUG=1
2026-08-31 13:31:18 : REQ   : foxitpdfreader : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 13:31:18 : INFO  : foxitpdfreader : ################## Version: 10.10beta
2026-08-31 13:31:18 : INFO  : foxitpdfreader : ################## Date: 2026-08-31
2026-08-31 13:31:18 : INFO  : foxitpdfreader : ################## foxitpdfreader
2026-08-31 13:31:18 : DEBUG : foxitpdfreader : DEBUG mode 1 enabled.
2026-08-31 13:31:19 : INFO  : foxitpdfreader : Reading arguments again: DEBUG=1
2026-08-31 13:31:19 : DEBUG : foxitpdfreader : argument: DEBUG=1
2026-08-31 13:31:19 : DEBUG : foxitpdfreader : name=Foxit PDF Reader
2026-08-31 13:31:19 : DEBUG : foxitpdfreader : appName=
2026-08-31 13:31:19 : DEBUG : foxitpdfreader : type=pkg
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : archiveName=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : downloadURL=https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/mac/2026.1.3/FoxitPDFReader202613.L10N.Setup.pkg
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : curlOptions=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : appNewVersion=2026.1.3
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : appCustomVersion function: Defined. 
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : versionKey=CFBundleShortVersionString
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : packageID=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : pkgName=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : choiceChangesXML=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : expectedTeamID=8GN47HTP75
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : blockingProcesses=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : installerTool=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : CLIInstaller=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : CLIArguments=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : updateTool=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : updateToolArguments=
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : updateToolRunAsCurrentUser=
2026-08-31 13:31:20 : INFO  : foxitpdfreader : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 13:31:20 : INFO  : foxitpdfreader : NOTIFY=success
2026-08-31 13:31:20 : INFO  : foxitpdfreader : LOGGING=DEBUG
2026-08-31 13:31:20 : INFO  : foxitpdfreader : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 13:31:20 : INFO  : foxitpdfreader : Label type: pkg
2026-08-31 13:31:20 : INFO  : foxitpdfreader : archiveName: Foxit PDF Reader.pkg
2026-08-31 13:31:20 : INFO  : foxitpdfreader : no blocking processes defined, using Foxit PDF Reader as default
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 13:31:20 : INFO  : foxitpdfreader : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/Foxit PDF Reader.app/Contents/Info.plist
2026-08-31 13:31:20 : INFO  : foxitpdfreader : appversion: File Doesn't Exist, Will Create: /Applications/Foxit PDF Reader.app/Contents/Info.plist
2026-08-31 13:31:20 : INFO  : foxitpdfreader : Latest version of Foxit PDF Reader is 2026.1.3
2026-08-31 13:31:20 : REQ   : foxitpdfreader : Downloading https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/mac/2026.1.3/FoxitPDFReader202613.L10N.Setup.pkg to Foxit PDF Reader.pkg
2026-08-31 13:31:20 : DEBUG : foxitpdfreader : No Dialog connection, just download
2026-08-31 13:35:26 : INFO  : foxitpdfreader : Downloaded Foxit PDF Reader.pkg – Type is  xar archive compressed TOC – SHA is 78908a23e67ba7e93c153c2d5cb6d03d2f339bd4 – Size is 410188 kB
2026-08-31 13:35:26 : DEBUG : foxitpdfreader : DEBUG mode 1, not checking for blocking processes
2026-08-31 13:35:26 : REQ   : foxitpdfreader : Installing Foxit PDF Reader
2026-08-31 13:35:27 : INFO  : foxitpdfreader : Verifying: Foxit PDF Reader.pkg
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : File list: -rw-r--r--  1 root  staff   389M Aug 31 13:35 Foxit PDF Reader.pkg
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : File type: Foxit PDF Reader.pkg: xar archive compressed TOC: 7031, SHA-1 checksum
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : spctlOut is Foxit PDF Reader.pkg: accepted
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : source=Notarized Developer ID
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : origin=Developer ID Installer: FOXIT SOFTWARE INCORPORATED (8GN47HTP75)
2026-08-31 13:35:27 : INFO  : foxitpdfreader : Team ID: 8GN47HTP75 (expected: 8GN47HTP75 )
2026-08-31 13:35:27 : DEBUG : foxitpdfreader : DEBUG enabled, skipping installation
2026-08-31 13:35:27 : INFO  : foxitpdfreader : Finishing...
2026-08-31 13:35:30 : INFO  : foxitpdfreader : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/Foxit PDF Reader.app/Contents/Info.plist
2026-08-31 13:35:30 : REQ   : foxitpdfreader : Installed Foxit PDF Reader, version 2026.1.3
2026-08-31 13:35:30 : INFO  : foxitpdfreader : notifying
2026-08-31 13:35:31 : DEBUG : foxitpdfreader : DEBUG mode 1, not reopening anything
2026-08-31 13:35:31 : REQ   : foxitpdfreader : All done!
2026-08-31 13:35:31 : REQ   : foxitpdfreader : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
