### PR TITLE
Update foxitpdfeditor.sh

### DIFF
--- a/fragments/labels/foxitpdfeditor.sh
+++ b/fragments/labels/foxitpdfeditor.sh
@@ -1,12 +1,8 @@
 foxitpdfeditor)
     name="Foxit PDF Editor"
     type="pkg"
-    #packageID="com.foxit.pkg.pdfeditor"
     downloadURL="https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac"
-    appNewVersion=$(curl -fsL "https://www.foxit.com/pdf-editor/version-history.html" \
-        | grep -oE 'Subscription Release\s+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
-        | head -n1 \
-        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+')
+    appNewVersion=$(curl -fsL "https://www.foxit.com/pdf-editor/version-history.html" | grep -Eo 'Version_[0-9]{4}\.[0-9]+\.[0-9]+\.7[0-9]+' | head -1 | sed 's/Version_//')
     expectedTeamID="8GN47HTP75"
     blockingProcesses=( "Foxit PDF Editor" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated label is better than the merged label because it removes the brittle multi-line HTML text scrape for Subscription Release and instead extracts the verified Mac bundle-style version directly from Foxit’s version-history IDs. In testing, the updated logic returned appNewVersion=2026.1.3.70306, which matches the default CFBundleShortVersionString comparison path, so no packageID, versionKey, or appCustomVersion() is needed. The download route stays on the same official Foxit PDF Editor Suite Pro Teams Mac endpoint, and verification confirmed the package downloads as a valid notarized PKG signed by FOXIT SOFTWARE INCORPORATED with Team ID 8GN47HTP75.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh foxitpdfeditor DEBUG=1
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : setting variable from argument DEBUG=1
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : Total items in argumentsArray: 1
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : argumentsArray: DEBUG=1
2026-08-31 13:51:48 : REQ   : foxitpdfeditor : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : ################## Version: 10.10beta
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : ################## Date: 2026-08-31
2026-08-31 13:51:48 : INFO  : foxitpdfeditor : ################## foxitpdfeditor
2026-08-31 13:51:48 : DEBUG : foxitpdfeditor : DEBUG mode 1 enabled.
2026-08-31 13:51:49 : INFO  : foxitpdfeditor : Reading arguments again: DEBUG=1
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : argument: DEBUG=1
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : name=Foxit PDF Editor
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : appName=
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : type=pkg
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : archiveName=
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : downloadURL=https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : curlOptions=
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : appNewVersion=2026.1.3.70306
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : appCustomVersion function: Not defined
2026-08-31 13:51:49 : DEBUG : foxitpdfeditor : versionKey=CFBundleShortVersionString
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : packageID=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : pkgName=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : choiceChangesXML=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : expectedTeamID=8GN47HTP75
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : blockingProcesses=Foxit PDF Editor
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : installerTool=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : CLIInstaller=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : CLIArguments=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : updateTool=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : updateToolArguments=
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : updateToolRunAsCurrentUser=
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : NOTIFY=success
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : LOGGING=DEBUG
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : Label type: pkg
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : archiveName: Foxit PDF Editor.pkg
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : name: Foxit PDF Editor, appName: Foxit PDF Editor.app
2026-08-31 13:51:50 : WARN  : foxitpdfeditor : No previous app found
2026-08-31 13:51:50 : WARN  : foxitpdfeditor : could not find Foxit PDF Editor.app
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : appversion: 
2026-08-31 13:51:50 : INFO  : foxitpdfeditor : Latest version of Foxit PDF Editor is 2026.1.3.70306
2026-08-31 13:51:50 : REQ   : foxitpdfeditor : Downloading https://www.foxit.com/downloads/latest.html?product=Foxit-PDF-Editor-Suite-Pro-Teams-Mac to Foxit PDF Editor.pkg
2026-08-31 13:51:50 : DEBUG : foxitpdfeditor : No Dialog connection, just download
2026-08-31 13:52:33 : INFO  : foxitpdfeditor : Downloaded Foxit PDF Editor.pkg – Type is  xar archive compressed TOC – SHA is 9bcc065c1b5936da996ecc79b80727411f03dad7 – Size is 1507340 kB
2026-08-31 13:52:33 : DEBUG : foxitpdfeditor : DEBUG mode 1, not checking for blocking processes
2026-08-31 13:52:33 : REQ   : foxitpdfeditor : Installing Foxit PDF Editor
2026-08-31 13:52:33 : INFO  : foxitpdfeditor : Verifying: Foxit PDF Editor.pkg
2026-08-31 13:52:33 : DEBUG : foxitpdfeditor : File list: -rw-r--r--  1 root  staff   1.4G Aug 31 13:52 Foxit PDF Editor.pkg
2026-08-31 13:52:33 : DEBUG : foxitpdfeditor : File type: Foxit PDF Editor.pkg: xar archive compressed TOC: 7050, SHA-1 checksum
2026-08-31 13:52:34 : DEBUG : foxitpdfeditor : spctlOut is Foxit PDF Editor.pkg: accepted
2026-08-31 13:52:34 : DEBUG : foxitpdfeditor : source=Notarized Developer ID
2026-08-31 13:52:34 : DEBUG : foxitpdfeditor : origin=Developer ID Installer: FOXIT SOFTWARE INCORPORATED (8GN47HTP75)
2026-08-31 13:52:34 : INFO  : foxitpdfeditor : Team ID: 8GN47HTP75 (expected: 8GN47HTP75 )
2026-08-31 13:52:34 : DEBUG : foxitpdfeditor : DEBUG enabled, skipping installation
2026-08-31 13:52:34 : INFO  : foxitpdfeditor : Finishing...
2026-08-31 13:52:37 : INFO  : foxitpdfeditor : name: Foxit PDF Editor, appName: Foxit PDF Editor.app
2026-08-31 13:52:37 : WARN  : foxitpdfeditor : No previous app found
2026-08-31 13:52:37 : WARN  : foxitpdfeditor : could not find Foxit PDF Editor.app
2026-08-31 13:52:37 : REQ   : foxitpdfeditor : Installed Foxit PDF Editor, version 2026.1.3.70306
2026-08-31 13:52:37 : INFO  : foxitpdfeditor : notifying
2026-08-31 13:52:37 : DEBUG : foxitpdfeditor : DEBUG mode 1, not reopening anything
2026-08-31 13:52:37 : REQ   : foxitpdfeditor : All done!
2026-08-31 13:52:37 : REQ   : foxitpdfeditor : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
