### PR TITLE
Create testnav.sh

### DIFF
--- a/fragments/labels/testnav.sh
+++ b/fragments/labels/testnav.sh
@@ -1,0 +1,12 @@
+testnav)
+    name="TestNav"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        fileName=$(getJSONValue "$(curl -fs "https://download.testnav.com/installerVersions.json")" "mac_arm")
+    else
+        fileName=$(getJSONValue "$(curl -fs "https://download.testnav.com/installerVersions.json")" "mac_intel")
+    fi
+    downloadURL="https://download.testnav.com/_testnavinstallers/${fileName}"
+    appNewVersion=$(echo "$fileName" | sed -E 's/^testnav-([0-9]+(\.[0-9]+)+)-(x64|arm64)\.dmg$/\1/')
+    expectedTeamID="9EGT93JZWD"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it keeps the good vendor JSON approach and built-in Installomator getJSONValue function, but fixes the now-stale mac key by selecting the verified Intel or Apple Silicon installer from mac_intel and mac_arm. Both DMGs downloaded successfully, mounted as valid app DMGs, contained TestNav.app, reported CFBundleShortVersionString 1.15.7, and were notarized with the expected Pearson Team ID 9EGT93JZWD.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh testnav DEBUG=1
2026-08-31 14:31:09 : INFO  : testnav : setting variable from argument DEBUG=1
2026-08-31 14:31:09 : INFO  : testnav : Total items in argumentsArray: 1
2026-08-31 14:31:09 : INFO  : testnav : argumentsArray: DEBUG=1
2026-08-31 14:31:09 : REQ   : testnav : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 14:31:09 : INFO  : testnav : ################## Version: 10.10beta
2026-08-31 14:31:09 : INFO  : testnav : ################## Date: 2026-08-31
2026-08-31 14:31:09 : INFO  : testnav : ################## testnav
2026-08-31 14:31:09 : DEBUG : testnav : DEBUG mode 1 enabled.
2026-08-31 14:31:10 : INFO  : testnav : Reading arguments again: DEBUG=1
2026-08-31 14:31:10 : DEBUG : testnav : argument: DEBUG=1
2026-08-31 14:31:10 : DEBUG : testnav : name=TestNav
2026-08-31 14:31:10 : DEBUG : testnav : appName=
2026-08-31 14:31:10 : DEBUG : testnav : type=dmg
2026-08-31 14:31:10 : DEBUG : testnav : archiveName=
2026-08-31 14:31:10 : DEBUG : testnav : downloadURL=https://download.testnav.com/_testnavinstallers/testnav-1.15.7-arm64.dmg
2026-08-31 14:31:10 : DEBUG : testnav : curlOptions=
2026-08-31 14:31:10 : DEBUG : testnav : appNewVersion=1.15.7
2026-08-31 14:31:10 : DEBUG : testnav : appCustomVersion function: Not defined
2026-08-31 14:31:10 : DEBUG : testnav : versionKey=CFBundleShortVersionString
2026-08-31 14:31:10 : DEBUG : testnav : packageID=
2026-08-31 14:31:10 : DEBUG : testnav : pkgName=
2026-08-31 14:31:10 : DEBUG : testnav : choiceChangesXML=
2026-08-31 14:31:10 : DEBUG : testnav : expectedTeamID=9EGT93JZWD
2026-08-31 14:31:10 : DEBUG : testnav : blockingProcesses=
2026-08-31 14:31:10 : DEBUG : testnav : installerTool=
2026-08-31 14:31:10 : DEBUG : testnav : CLIInstaller=
2026-08-31 14:31:10 : DEBUG : testnav : CLIArguments=
2026-08-31 14:31:10 : DEBUG : testnav : updateTool=
2026-08-31 14:31:10 : DEBUG : testnav : updateToolArguments=
2026-08-31 14:31:10 : DEBUG : testnav : updateToolRunAsCurrentUser=
2026-08-31 14:31:10 : INFO  : testnav : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 14:31:10 : INFO  : testnav : NOTIFY=success
2026-08-31 14:31:10 : INFO  : testnav : LOGGING=DEBUG
2026-08-31 14:31:10 : INFO  : testnav : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 14:31:10 : INFO  : testnav : Label type: dmg
2026-08-31 14:31:10 : INFO  : testnav : archiveName: TestNav.dmg
2026-08-31 14:31:10 : INFO  : testnav : no blocking processes defined, using TestNav as default
2026-08-31 14:31:10 : DEBUG : testnav : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 14:31:10 : INFO  : testnav : name: TestNav, appName: TestNav.app
2026-08-31 14:31:11 : WARN  : testnav : No previous app found
2026-08-31 14:31:11 : WARN  : testnav : could not find TestNav.app
2026-08-31 14:31:11 : INFO  : testnav : appversion: 
2026-08-31 14:31:11 : INFO  : testnav : Latest version of TestNav is 1.15.7
2026-08-31 14:31:11 : REQ   : testnav : Downloading https://download.testnav.com/_testnavinstallers/testnav-1.15.7-arm64.dmg to TestNav.dmg
2026-08-31 14:31:11 : DEBUG : testnav : No Dialog connection, just download
2026-08-31 14:31:16 : INFO  : testnav : Downloaded TestNav.dmg – Type is  zlib compressed data – SHA is 621093dcb6d063e07c76c31cce7e85d63ae62f91 – Size is 180256 kB
2026-08-31 14:31:16 : DEBUG : testnav : DEBUG mode 1, not checking for blocking processes
2026-08-31 14:31:16 : REQ   : testnav : Installing TestNav
2026-08-31 14:31:16 : INFO  : testnav : Mounting /Users/u0105821/git/github/Installomator/build/TestNav.dmg
2026-08-31 14:31:20 : DEBUG : testnav : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $DD171927
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $812C9EA9
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $BC580E3B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $A972D91E
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $BC580E3B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $C75811D3
verified   CRC32 $52F75564
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/TestNav

2026-08-31 14:31:20 : INFO  : testnav : Mounted: /Volumes/TestNav
2026-08-31 14:31:20 : INFO  : testnav : Verifying: /Volumes/TestNav/TestNav.app
2026-08-31 14:31:20 : DEBUG : testnav : App size: 274M	/Volumes/TestNav/TestNav.app
2026-08-31 14:31:21 : DEBUG : testnav : Debugging enabled, App Verification output was:
/Volumes/TestNav/TestNav.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Pearson (9EGT93JZWD)

2026-08-31 14:31:21 : INFO  : testnav : Team ID matching: 9EGT93JZWD (expected: 9EGT93JZWD )
2026-08-31 14:31:21 : INFO  : testnav : Installing TestNav version 1.15.7 on versionKey CFBundleShortVersionString.
2026-08-31 14:31:21 : INFO  : testnav : App has LSMinimumSystemVersion: 10.9
2026-08-31 14:31:21 : DEBUG : testnav : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 14:31:21 : INFO  : testnav : Finishing...
2026-08-31 14:31:24 : INFO  : testnav : name: TestNav, appName: TestNav.app
2026-08-31 14:31:24 : WARN  : testnav : No previous app found
2026-08-31 14:31:24 : WARN  : testnav : could not find TestNav.app
2026-08-31 14:31:24 : REQ   : testnav : Installed TestNav, version 1.15.7
2026-08-31 14:31:24 : INFO  : testnav : notifying
2026-08-31 14:31:24 : DEBUG : testnav : Unmounting /Volumes/TestNav
2026-08-31 14:31:25 : DEBUG : testnav : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 14:31:25 : DEBUG : testnav : DEBUG mode 1, not reopening anything
2026-08-31 14:31:25 : REQ   : testnav : All done!
2026-08-31 14:31:25 : REQ   : testnav : ################## End Installomator, exit code 0
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
