### PR TITLE
Update tropy.sh

### DIFF
--- a/fragments/labels/tropy.sh
+++ b/fragments/labels/tropy.sh
@@ -1,12 +1,12 @@
 tropy)
     name="Tropy"
     type="dmg"
-    if [[ $(arch) == arm64 ]]; then
-        archiveName="tropy-[0-9.]*-arm64.dmg"
-    elif [[ $(arch) == i386 ]]; then
-        archiveName="tropy-[0-9.]*.dmg"
+    appNewVersion=$(versionFromGit tropy tropy)
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="${appNewVersion}-arm64.dmg"
+    else
+        archiveName="${appNewVersion}.dmg"
     fi
-    appNewVersion="$(versionFromGit tropy tropy)"
-    downloadURL="$(downloadURLFromGit tropy tropy)"
+    downloadURL=$(downloadURLFromGit tropy tropy)
     expectedTeamID="8LAYR367YV"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the merged label because it uses Installomator’s built-in GitHub helpers against Tropy’s official tropy/tropy releases instead of relying on brittle manual URL parsing or a generic DMG match. It also handles architecture correctly: Apple Silicon gets tropy-${version}-arm64.dmg, while Intel gets tropy-${version}.dmg. That matters because a broad .dmg selector can accidentally choose the arm64 DMG first. The label also keeps version comparison clean with versionFromGit, matches the installed app version, and avoids unnecessary appName, versionKey, packageID, blockingProcesses, or custom version logic.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh tropy DEBUG=1
2026-08-31 15:39:10 : INFO  : tropy : setting variable from argument DEBUG=1
2026-08-31 15:39:10 : INFO  : tropy : Total items in argumentsArray: 1
2026-08-31 15:39:10 : INFO  : tropy : argumentsArray: DEBUG=1
2026-08-31 15:39:10 : REQ   : tropy : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 15:39:10 : INFO  : tropy : ################## Version: 10.10beta
2026-08-31 15:39:10 : INFO  : tropy : ################## Date: 2026-08-31
2026-08-31 15:39:10 : INFO  : tropy : ################## tropy
2026-08-31 15:39:10 : DEBUG : tropy : DEBUG mode 1 enabled.
2026-08-31 15:39:12 : INFO  : tropy : Reading arguments again: DEBUG=1
2026-08-31 15:39:12 : DEBUG : tropy : argument: DEBUG=1
2026-08-31 15:39:12 : DEBUG : tropy : name=Tropy
2026-08-31 15:39:12 : DEBUG : tropy : appName=
2026-08-31 15:39:12 : DEBUG : tropy : type=dmg
2026-08-31 15:39:12 : DEBUG : tropy : archiveName=1.17.3-arm64.dmg
2026-08-31 15:39:12 : DEBUG : tropy : downloadURL=https://github.com/tropy/tropy/releases/download/v1.17.3/tropy-1.17.3-arm64.dmg
2026-08-31 15:39:12 : DEBUG : tropy : curlOptions=
2026-08-31 15:39:12 : DEBUG : tropy : appNewVersion=1.17.3
2026-08-31 15:39:12 : DEBUG : tropy : appCustomVersion function: Not defined
2026-08-31 15:39:12 : DEBUG : tropy : versionKey=CFBundleShortVersionString
2026-08-31 15:39:12 : DEBUG : tropy : packageID=
2026-08-31 15:39:12 : DEBUG : tropy : pkgName=
2026-08-31 15:39:12 : DEBUG : tropy : choiceChangesXML=
2026-08-31 15:39:12 : DEBUG : tropy : expectedTeamID=8LAYR367YV
2026-08-31 15:39:13 : DEBUG : tropy : blockingProcesses=
2026-08-31 15:39:13 : DEBUG : tropy : installerTool=
2026-08-31 15:39:13 : DEBUG : tropy : CLIInstaller=
2026-08-31 15:39:13 : DEBUG : tropy : CLIArguments=
2026-08-31 15:39:13 : DEBUG : tropy : updateTool=
2026-08-31 15:39:13 : DEBUG : tropy : updateToolArguments=
2026-08-31 15:39:13 : DEBUG : tropy : updateToolRunAsCurrentUser=
2026-08-31 15:39:13 : INFO  : tropy : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 15:39:13 : INFO  : tropy : NOTIFY=success
2026-08-31 15:39:13 : INFO  : tropy : LOGGING=DEBUG
2026-08-31 15:39:13 : INFO  : tropy : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 15:39:13 : INFO  : tropy : Label type: dmg
2026-08-31 15:39:13 : INFO  : tropy : archiveName: 1.17.3-arm64.dmg
2026-08-31 15:39:13 : INFO  : tropy : no blocking processes defined, using Tropy as default
2026-08-31 15:39:13 : DEBUG : tropy : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 15:39:13 : INFO  : tropy : name: Tropy, appName: Tropy.app
2026-08-31 15:39:13 : WARN  : tropy : No previous app found
2026-08-31 15:39:13 : WARN  : tropy : could not find Tropy.app
2026-08-31 15:39:13 : INFO  : tropy : appversion: 
2026-08-31 15:39:13 : INFO  : tropy : Latest version of Tropy is 1.17.3
2026-08-31 15:39:13 : REQ   : tropy : Downloading https://github.com/tropy/tropy/releases/download/v1.17.3/tropy-1.17.3-arm64.dmg to 1.17.3-arm64.dmg
2026-08-31 15:39:13 : DEBUG : tropy : No Dialog connection, just download
2026-08-31 15:39:17 : INFO  : tropy : Downloaded 1.17.3-arm64.dmg – Type is  zlib compressed data – SHA is 641635ceef190ec9a9fadff3d3346a9f993eea9c – Size is 131804 kB
2026-08-31 15:39:17 : DEBUG : tropy : DEBUG mode 1, not checking for blocking processes
2026-08-31 15:39:17 : REQ   : tropy : Installing Tropy
2026-08-31 15:39:17 : INFO  : tropy : Mounting /Users/u0105821/git/github/Installomator/build/1.17.3-arm64.dmg
2026-08-31 15:39:21 : DEBUG : tropy : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $285BF29A
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $76830EAB
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $950815C4
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $47AF2BFA
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $950815C4
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $46D72FDD
verified   CRC32 $480C3A99
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Tropy

2026-08-31 15:39:21 : INFO  : tropy : Mounted: /Volumes/Tropy
2026-08-31 15:39:21 : INFO  : tropy : Verifying: /Volumes/Tropy/Tropy.app
2026-08-31 15:39:21 : DEBUG : tropy : App size: 307M	/Volumes/Tropy/Tropy.app
2026-08-31 15:39:22 : DEBUG : tropy : Debugging enabled, App Verification output was:
/Volumes/Tropy/Tropy.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Corporation for Digital Scholarship (8LAYR367YV)

2026-08-31 15:39:22 : INFO  : tropy : Team ID matching: 8LAYR367YV (expected: 8LAYR367YV )
2026-08-31 15:39:22 : INFO  : tropy : Installing Tropy version 1.17.3 on versionKey CFBundleShortVersionString.
2026-08-31 15:39:22 : INFO  : tropy : App has LSMinimumSystemVersion: 10.13.0
2026-08-31 15:39:22 : DEBUG : tropy : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 15:39:22 : INFO  : tropy : Finishing...
2026-08-31 15:39:26 : INFO  : tropy : name: Tropy, appName: Tropy.app
2026-08-31 15:39:26 : WARN  : tropy : No previous app found
2026-08-31 15:39:26 : WARN  : tropy : could not find Tropy.app
2026-08-31 15:39:26 : REQ   : tropy : Installed Tropy, version 1.17.3
2026-08-31 15:39:26 : INFO  : tropy : notifying
2026-08-31 15:39:26 : DEBUG : tropy : Unmounting /Volumes/Tropy
2026-08-31 15:39:26 : DEBUG : tropy : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 15:39:26 : DEBUG : tropy : DEBUG mode 1, not reopening anything
2026-08-31 15:39:26 : REQ   : tropy : All done!
2026-08-31 15:39:26 : REQ   : tropy : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
