### PR TITLE
Update anki.sh

### DIFF
--- a/fragments/labels/anki.sh
+++ b/fragments/labels/anki.sh
@@ -1,7 +1,12 @@
 anki)
     name="Anki"
     type="dmg"
-    appNewVersion=$(curl -fs "https://apps.ankiweb.net" | grep -o '/download/[0-9.]\+/' | head -1 | sed 's|/download/||;s|/||')
-    downloadURL="https://github.com/ankitects/anki/releases/download/${appNewVersion}/anki-launcher-${appNewVersion}-mac.dmg"
-    expectedTeamID="7ZM8SLJM4P"
+    appNewVersion=$(versionFromGit ankitects anki | sed -E 's/\.0([0-9])/\.\1/g')
+    if [[ $(arch) == "arm64" ]]; then
+        archiveName="mac-apple.dmg"
+    else
+        archiveName="mac-intel.dmg"
+    fi
+    downloadURL=$(downloadURLFromGit ankitects anki)
+    expectedTeamID="ZL66D3NMZM"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it uses Installomator’s built-in GitHub helpers against Anki’s official ankitects/anki releases instead of scraping the website and manually constructing a now-broken anki-launcher URL. It also handles the current architecture-specific DMG assets, normalizes the GitHub version 26.08.1 to the installed app version 26.8.1, and updates the verified Team ID to ZL66D3NMZM.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh anki) DEBUG=1
bash: syntax error near unexpected token `)'
bash-3.2# 
bash-3.2# sudo Installomator/utils/assemble.sh anki DEBUG=1
2026-08-31 16:10:03 : INFO  : anki : setting variable from argument DEBUG=1
2026-08-31 16:10:03 : INFO  : anki : Total items in argumentsArray: 1
2026-08-31 16:10:03 : INFO  : anki : argumentsArray: DEBUG=1
2026-08-31 16:10:03 : REQ   : anki : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 16:10:03 : INFO  : anki : ################## Version: 10.10beta
2026-08-31 16:10:03 : INFO  : anki : ################## Date: 2026-08-31
2026-08-31 16:10:03 : INFO  : anki : ################## anki
2026-08-31 16:10:03 : DEBUG : anki : DEBUG mode 1 enabled.
2026-08-31 16:10:05 : INFO  : anki : Reading arguments again: DEBUG=1
2026-08-31 16:10:05 : DEBUG : anki : argument: DEBUG=1
2026-08-31 16:10:05 : DEBUG : anki : name=Anki
2026-08-31 16:10:05 : DEBUG : anki : appName=
2026-08-31 16:10:05 : DEBUG : anki : type=dmg
2026-08-31 16:10:05 : DEBUG : anki : archiveName=mac-apple.dmg
2026-08-31 16:10:05 : DEBUG : anki : downloadURL=https://github.com/ankitects/anki/releases/download/26.08.1/anki-26.08.1-mac-apple.dmg
2026-08-31 16:10:05 : DEBUG : anki : curlOptions=
2026-08-31 16:10:05 : DEBUG : anki : appNewVersion=26.8.1
2026-08-31 16:10:05 : DEBUG : anki : appCustomVersion function: Not defined
2026-08-31 16:10:05 : DEBUG : anki : versionKey=CFBundleShortVersionString
2026-08-31 16:10:05 : DEBUG : anki : packageID=
2026-08-31 16:10:05 : DEBUG : anki : pkgName=
2026-08-31 16:10:05 : DEBUG : anki : choiceChangesXML=
2026-08-31 16:10:05 : DEBUG : anki : expectedTeamID=ZL66D3NMZM
2026-08-31 16:10:05 : DEBUG : anki : blockingProcesses=
2026-08-31 16:10:05 : DEBUG : anki : installerTool=
2026-08-31 16:10:05 : DEBUG : anki : CLIInstaller=
2026-08-31 16:10:05 : DEBUG : anki : CLIArguments=
2026-08-31 16:10:05 : DEBUG : anki : updateTool=
2026-08-31 16:10:06 : DEBUG : anki : updateToolArguments=
2026-08-31 16:10:06 : DEBUG : anki : updateToolRunAsCurrentUser=
2026-08-31 16:10:06 : INFO  : anki : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 16:10:06 : INFO  : anki : NOTIFY=success
2026-08-31 16:10:06 : INFO  : anki : LOGGING=DEBUG
2026-08-31 16:10:06 : INFO  : anki : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 16:10:06 : INFO  : anki : Label type: dmg
2026-08-31 16:10:06 : INFO  : anki : archiveName: mac-apple.dmg
2026-08-31 16:10:06 : INFO  : anki : no blocking processes defined, using Anki as default
2026-08-31 16:10:06 : DEBUG : anki : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 16:10:06 : INFO  : anki : name: Anki, appName: Anki.app
2026-08-31 16:10:06 : WARN  : anki : No previous app found
2026-08-31 16:10:06 : WARN  : anki : could not find Anki.app
2026-08-31 16:10:06 : INFO  : anki : appversion: 
2026-08-31 16:10:06 : INFO  : anki : Latest version of Anki is 26.8.1
2026-08-31 16:10:06 : REQ   : anki : Downloading https://github.com/ankitects/anki/releases/download/26.08.1/anki-26.08.1-mac-apple.dmg to mac-apple.dmg
2026-08-31 16:10:06 : DEBUG : anki : No Dialog connection, just download
2026-08-31 16:10:13 : INFO  : anki : Downloaded mac-apple.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is a50e1f0286d480d33420716f3d3d2efd252541a9 – Size is 229964 kB
2026-08-31 16:10:13 : DEBUG : anki : DEBUG mode 1, not checking for blocking processes
2026-08-31 16:10:13 : REQ   : anki : Installing Anki
2026-08-31 16:10:13 : INFO  : anki : Mounting /Users/u0105821/git/github/Installomator/build/mac-apple.dmg
2026-08-31 16:10:26 : DEBUG : anki : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $79628B7F
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $4E5E27AD
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $5F2979DB
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $EC438CA4
Checksumming GPT Partition Data (Backup GPT Table : 5)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $5F2979DB
Checksumming GPT Header (Backup GPT Header : 6)…
GPT Header (Backup GPT Header : 6): verified   CRC32 $2B16E413
verified   CRC32 $B1DF9294
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Anki 26.8.1

2026-08-31 16:10:26 : INFO  : anki : Mounted: /Volumes/Anki 26.8.1
2026-08-31 16:10:26 : INFO  : anki : Verifying: /Volumes/Anki 26.8.1/Anki.app
2026-08-31 16:10:26 : DEBUG : anki : App size: 650M	/Volumes/Anki 26.8.1/Anki.app
2026-08-31 16:10:52 : DEBUG : anki : Debugging enabled, App Verification output was:
/Volumes/Anki 26.8.1/Anki.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Anki Software LLC (ZL66D3NMZM)

2026-08-31 16:10:52 : INFO  : anki : Team ID matching: ZL66D3NMZM (expected: ZL66D3NMZM )
2026-08-31 16:10:52 : INFO  : anki : Installing Anki version 26.8.1 on versionKey CFBundleShortVersionString.
2026-08-31 16:10:52 : INFO  : anki : App has LSMinimumSystemVersion: 13.0
2026-08-31 16:10:52 : DEBUG : anki : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-08-31 16:10:52 : INFO  : anki : Finishing...
2026-08-31 16:10:55 : INFO  : anki : name: Anki, appName: Anki.app
2026-08-31 16:10:55 : WARN  : anki : No previous app found
2026-08-31 16:10:55 : WARN  : anki : could not find Anki.app
2026-08-31 16:10:55 : REQ   : anki : Installed Anki, version 26.8.1
2026-08-31 16:10:55 : INFO  : anki : notifying
2026-08-31 16:10:56 : DEBUG : anki : Unmounting /Volumes/Anki 26.8.1
2026-08-31 16:10:56 : DEBUG : anki : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 16:10:56 : DEBUG : anki : DEBUG mode 1, not reopening anything
2026-08-31 16:10:56 : REQ   : anki : All done!
2026-08-31 16:10:56 : REQ   : anki : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
