### PR TITLE
Update tableaupublic.sh

### DIFF
--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -1,8 +1,7 @@
 tableaupublic)
     name="Tableau Public"
     type="pkgInDmg"
-    packageID="com.tableausoftware.tableaudesktop"
-    downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
-    appNewVersion=$( echo $downloadURL | sed -E 's/.*TableauPublic-([-0-9]*)\.dmg/\1/g' | tr "-" "." )
+    downloadURL=$(curl -fsIL -o /dev/null -w "%{url_effective}" "https://www.tableau.com/downloads/public/mac")
+    appNewVersion=$(echo "$downloadURL" | sed -E 's#.*TableauPublic-([0-9]+)-([0-9]+)-([0-9]+)\.dmg#\1.\2.\3#')
     expectedTeamID="QJ4XPRK37C"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is an improvement as it uses Tableau’s official Public Mac URL now redirects directly to the current versioned DMG, so redirect extraction is cleaner than the merged label’s awk | xmllint HTML parsing. The DMG still contains Tableau Public.pkg, so type="pkgInDmg" is correct. The package metadata confirms the installed app is Tableau Public.app with CFBundleShortVersionString="2026.2.2", matching appNewVersion.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh tableaupublic DEBUG=1
2026-08-31 17:03:15 : INFO  : tableaupublic : setting variable from argument DEBUG=1
2026-08-31 17:03:15 : INFO  : tableaupublic : Total items in argumentsArray: 1
2026-08-31 17:03:15 : INFO  : tableaupublic : argumentsArray: DEBUG=1
2026-08-31 17:03:15 : REQ   : tableaupublic : ################## Start Installomator v. 10.10beta, date 2026-08-31
2026-08-31 17:03:15 : INFO  : tableaupublic : ################## Version: 10.10beta
2026-08-31 17:03:15 : INFO  : tableaupublic : ################## Date: 2026-08-31
2026-08-31 17:03:15 : INFO  : tableaupublic : ################## tableaupublic
2026-08-31 17:03:15 : DEBUG : tableaupublic : DEBUG mode 1 enabled.
2026-08-31 17:03:16 : INFO  : tableaupublic : Reading arguments again: DEBUG=1
2026-08-31 17:03:16 : DEBUG : tableaupublic : argument: DEBUG=1
2026-08-31 17:03:16 : DEBUG : tableaupublic : name=Tableau Public
2026-08-31 17:03:16 : DEBUG : tableaupublic : appName=
2026-08-31 17:03:16 : DEBUG : tableaupublic : type=pkgInDmg
2026-08-31 17:03:16 : DEBUG : tableaupublic : archiveName=
2026-08-31 17:03:16 : DEBUG : tableaupublic : downloadURL=https://downloads.tableau.com/public/TableauPublic-2026-2-2.dmg
2026-08-31 17:03:16 : DEBUG : tableaupublic : curlOptions=
2026-08-31 17:03:16 : DEBUG : tableaupublic : appNewVersion=2026.2.2
2026-08-31 17:03:16 : DEBUG : tableaupublic : appCustomVersion function: Not defined
2026-08-31 17:03:16 : DEBUG : tableaupublic : versionKey=CFBundleShortVersionString
2026-08-31 17:03:16 : DEBUG : tableaupublic : packageID=
2026-08-31 17:03:16 : DEBUG : tableaupublic : pkgName=
2026-08-31 17:03:16 : DEBUG : tableaupublic : choiceChangesXML=
2026-08-31 17:03:16 : DEBUG : tableaupublic : expectedTeamID=QJ4XPRK37C
2026-08-31 17:03:17 : DEBUG : tableaupublic : blockingProcesses=
2026-08-31 17:03:17 : DEBUG : tableaupublic : installerTool=
2026-08-31 17:03:17 : DEBUG : tableaupublic : CLIInstaller=
2026-08-31 17:03:17 : DEBUG : tableaupublic : CLIArguments=
2026-08-31 17:03:17 : DEBUG : tableaupublic : updateTool=
2026-08-31 17:03:17 : DEBUG : tableaupublic : updateToolArguments=
2026-08-31 17:03:17 : DEBUG : tableaupublic : updateToolRunAsCurrentUser=
2026-08-31 17:03:17 : INFO  : tableaupublic : BLOCKING_PROCESS_ACTION=tell_user
2026-08-31 17:03:17 : INFO  : tableaupublic : NOTIFY=success
2026-08-31 17:03:17 : INFO  : tableaupublic : LOGGING=DEBUG
2026-08-31 17:03:17 : INFO  : tableaupublic : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-08-31 17:03:17 : INFO  : tableaupublic : Label type: pkgInDmg
2026-08-31 17:03:17 : INFO  : tableaupublic : archiveName: Tableau Public.dmg
2026-08-31 17:03:17 : INFO  : tableaupublic : no blocking processes defined, using Tableau Public as default
2026-08-31 17:03:17 : DEBUG : tableaupublic : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-08-31 17:03:17 : INFO  : tableaupublic : name: Tableau Public, appName: Tableau Public.app
2026-08-31 17:03:17 : WARN  : tableaupublic : No previous app found
2026-08-31 17:03:17 : WARN  : tableaupublic : could not find Tableau Public.app
2026-08-31 17:03:17 : INFO  : tableaupublic : appversion: 
2026-08-31 17:03:17 : INFO  : tableaupublic : Latest version of Tableau Public is 2026.2.2
2026-08-31 17:03:17 : REQ   : tableaupublic : Downloading https://downloads.tableau.com/public/TableauPublic-2026-2-2.dmg to Tableau Public.dmg
2026-08-31 17:03:17 : DEBUG : tableaupublic : No Dialog connection, just download
2026-08-31 17:03:42 : INFO  : tableaupublic : Downloaded Tableau Public.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is e4130dbd85f0670fb3b84804b95499e6e628bd80 – Size is 835660 kB
2026-08-31 17:03:42 : DEBUG : tableaupublic : DEBUG mode 1, not checking for blocking processes
2026-08-31 17:03:42 : REQ   : tableaupublic : Installing Tableau Public
2026-08-31 17:03:43 : INFO  : tableaupublic : Mounting /Users/u0105821/git/github/Installomator/build/Tableau Public.dmg
2026-08-31 17:04:16 : DEBUG : tableaupublic : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0CA25C42
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B1707CCF
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $7A5EF92B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $BC9DD475
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $7A5EF92B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $0817ABAC
verified   CRC32 $A62B9986
/dev/disk6          	GUID_partition_scheme
/dev/disk6s1        	Apple_HFS                      	/Volumes/Tableau Public

2026-08-31 17:04:16 : INFO  : tableaupublic : Mounted: /Volumes/Tableau Public
2026-08-31 17:04:16 : DEBUG : tableaupublic : Found pkg(s):
/Volumes/Tableau Public/Tableau Public.pkg
2026-08-31 17:04:16 : INFO  : tableaupublic : found pkg: /Volumes/Tableau Public/Tableau Public.pkg
2026-08-31 17:04:16 : INFO  : tableaupublic : Verifying: /Volumes/Tableau Public/Tableau Public.pkg
2026-08-31 17:04:16 : DEBUG : tableaupublic : File list: -rw-r--r--@ 1 mac  admin   819M Aug 20 02:59 /Volumes/Tableau Public/Tableau Public.pkg
2026-08-31 17:04:16 : DEBUG : tableaupublic : File type: /Volumes/Tableau Public/Tableau Public.pkg: xar archive compressed TOC: 8253, SHA-1 checksum
2026-08-31 17:04:16 : DEBUG : tableaupublic : spctlOut is /Volumes/Tableau Public/Tableau Public.pkg: accepted
2026-08-31 17:04:16 : DEBUG : tableaupublic : source=Notarized Developer ID
2026-08-31 17:04:16 : DEBUG : tableaupublic : origin=Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)
2026-08-31 17:04:16 : INFO  : tableaupublic : Team ID: QJ4XPRK37C (expected: QJ4XPRK37C )
2026-08-31 17:04:16 : DEBUG : tableaupublic : DEBUG enabled, skipping installation
2026-08-31 17:04:16 : INFO  : tableaupublic : Finishing...
2026-08-31 17:04:19 : INFO  : tableaupublic : name: Tableau Public, appName: Tableau Public.app
2026-08-31 17:04:20 : WARN  : tableaupublic : No previous app found
2026-08-31 17:04:20 : WARN  : tableaupublic : could not find Tableau Public.app
2026-08-31 17:04:20 : REQ   : tableaupublic : Installed Tableau Public, version 2026.2.2
2026-08-31 17:04:20 : INFO  : tableaupublic : notifying
2026-08-31 17:04:20 : DEBUG : tableaupublic : Unmounting /Volumes/Tableau Public
2026-08-31 17:04:20 : DEBUG : tableaupublic : Debugging enabled, Unmounting output was:
"disk6" ejected.
2026-08-31 17:04:20 : DEBUG : tableaupublic : DEBUG mode 1, not reopening anything
2026-08-31 17:04:20 : REQ   : tableaupublic : All done!
2026-08-31 17:04:20 : REQ   : tableaupublic : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
