### PR TITLE
tableaupublic: Apple silicon build (download URL, app name, version)

### DIFF
--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -2,9 +2,6 @@ tableaupublic)
     name="Tableau Public"
     type="pkgInDmg"
     if [[ $(arch) == "arm64" ]]; then
-        # The Apple silicon build installs a differently named bundle. Without appName
-        # Installomator looks for "Tableau Public.app" and cannot read the installed
-        # version, so it reinstalls on every run.
         appName="Tableau Public (Apple silicon).app"
         downloadURL=$(curl -fsIL -o /dev/null -w "%{url_effective}" "https://www.tableau.com/downloads/public/mac-arm64")
     elif [[ $(arch) == "i386" ]]; then
@@ -12,5 +9,6 @@ tableaupublic)
         downloadURL=$(curl -fsIL -o /dev/null -w "%{url_effective}" "https://www.tableau.com/downloads/public/mac")
     fi
     appNewVersion=$(echo "$downloadURL" | sed -E 's#.*TableauPublic-([0-9]+)-([0-9]+)-([0-9]+)(-arm64)?\.dmg#\1.\2.\3#')
+    blockingProcesses=( "Tableau Public" )
     expectedTeamID="QJ4XPRK37C"
     ;;

--- a/fragments/labels/tableaupublic.sh
+++ b/fragments/labels/tableaupublic.sh
@@ -1,8 +1,16 @@
 tableaupublic)
     name="Tableau Public"
     type="pkgInDmg"
-    packageID="com.tableausoftware.tableaudesktop"
-    downloadURL=$(curl -fs https://www.tableau.com/downloads/public/mac | awk '/TableauPublic/' | xmllint --recover --html --xpath "//a/text()" -)
-    appNewVersion=$( echo $downloadURL | sed -E 's/.*TableauPublic-([-0-9]*)\.dmg/\1/g' | tr "-" "." )
+    if [[ $(arch) == "arm64" ]]; then
+        # The Apple silicon build installs a differently named bundle. Without appName
+        # Installomator looks for "Tableau Public.app" and cannot read the installed
+        # version, so it reinstalls on every run.
+        appName="Tableau Public (Apple silicon).app"
+        downloadURL=$(curl -fsIL -o /dev/null -w "%{url_effective}" "https://www.tableau.com/downloads/public/mac-arm64")
+    elif [[ $(arch) == "i386" ]]; then
+        appName="Tableau Public.app"
+        downloadURL=$(curl -fsIL -o /dev/null -w "%{url_effective}" "https://www.tableau.com/downloads/public/mac")
+    fi
+    appNewVersion=$(echo "$downloadURL" | sed -E 's#.*TableauPublic-([0-9]+)-([0-9]+)-([0-9]+)(-arm64)?\.dmg#\1.\2.\3#')
     expectedTeamID="QJ4XPRK37C"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information.

**Have you confirmed this pull request is not a duplicate?**

Yes. It is a deliberate follow-up on top of #3230 (which itself superseded #2418). #3230 fixes the download URL resolution and the wrong `packageID`; this PR adds the Apple silicon handling that is still missing. Happy to have it folded into #3230 instead, whichever is easier for review.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

Yes — only `fragments/labels/tableaupublic.sh`.

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

Yes — LF, final newline, no trailing whitespace, 4-space indentation.

**Additional context**

Three things are still missing for Apple silicon. All verified against the live URLs:

*1. Download URL* — Tableau serves separate builds:

```
/downloads/public/mac        -> https://downloads.tableau.com/public/TableauPublic-2026-2-2.dmg
/downloads/public/mac-arm64  -> https://downloads.tableau.com/public/TableauPublic-2026-2-2-arm64.dmg
```

Without the `mac-arm64` branch, Apple silicon Macs download the Intel build.

*2. Installed app name* — the Apple silicon build installs `Tableau Public (Apple silicon).app`. Without `appName`, Installomator looks for `Tableau Public.app`, so it either finds nothing or reads a leftover Intel bundle, and cannot determine the installed version.

*3. Version regex* — with the `-arm64` suffix the substitution does not match at all, so `appNewVersion` ends up as the whole filename:

```
TableauPublic-2026-2-2.dmg        -> 2026.2.2
TableauPublic-2026-2-2-arm64.dmg  -> TableauPublic-2026-2-2-arm64.dmg
```

The version comparison then never matches and the app is reinstalled on every run. With `(-arm64)?` in the pattern both URLs yield `2026.2.2`.

Seen in the field on a managed Mac carrying both bundles — Apple silicon 2026.2.2 (current) next to a leftover Intel 2026.2.0. The label reported the Intel version, so an up-to-date machine was flagged as outdated.

The `$(arch)` / `arm64` / `i386` pattern follows existing labels such as `jasp`.

**Installomator log**

Run on an Apple silicon Mac (M-series, macOS 26.6) with `DEBUG=1`, so nothing was actually installed:

```
2026-09-01 07:23:07 : REQ   : tableaupublic : ################## Start Installomator v. 10.10beta, date 2026-08-29
2026-09-01 07:23:07 : INFO  : tableaupublic : ################## Version: 10.10beta
2026-09-01 07:23:07 : INFO  : tableaupublic : ################## Date: 2026-08-29
2026-09-01 07:23:07 : INFO  : tableaupublic : ################## tableaupublic
2026-09-01 07:23:07 : DEBUG : tableaupublic : DEBUG mode 1 enabled.
2026-09-01 07:23:08 : INFO  : tableaupublic : Reading arguments again: DEBUG=1 LOGGING=INFO NOTIFY=silent
2026-09-01 07:23:08 : DEBUG : tableaupublic : argument: DEBUG=1
2026-09-01 07:23:08 : DEBUG : tableaupublic : argument: LOGGING=INFO
2026-09-01 07:23:08 : INFO  : tableaupublic : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 07:23:08 : INFO  : tableaupublic : NOTIFY=silent
2026-09-01 07:23:08 : INFO  : tableaupublic : LOGGING=INFO
2026-09-01 07:23:08 : INFO  : tableaupublic : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 07:23:08 : INFO  : tableaupublic : Label type: pkgInDmg
2026-09-01 07:23:08 : INFO  : tableaupublic : archiveName: Tableau Public.dmg
2026-09-01 07:23:08 : INFO  : tableaupublic : no blocking processes defined, using Tableau Public as default
2026-09-01 07:23:08 : INFO  : tableaupublic : name: Tableau Public, appName: Tableau Public (Apple silicon).app
2026-09-01 07:23:09 : WARN  : tableaupublic : No previous app found
2026-09-01 07:23:09 : WARN  : tableaupublic : could not find Tableau Public (Apple silicon).app
2026-09-01 07:23:09 : INFO  : tableaupublic : appversion: 
2026-09-01 07:23:09 : INFO  : tableaupublic : Latest version of Tableau Public is 2026.2.2
2026-09-01 07:23:09 : INFO  : tableaupublic : Tableau Public.dmg exists and DEBUG mode 1 enabled, skipping download
2026-09-01 07:23:09 : REQ   : tableaupublic : Installing Tableau Public
2026-09-01 07:23:09 : INFO  : tableaupublic : Mounting ./Tableau Public.dmg
2026-09-01 07:23:09 : INFO  : tableaupublic : Mounted: /Volumes/Tableau Public
2026-09-01 07:23:09 : INFO  : tableaupublic : found pkg: /Volumes/Tableau Public/Tableau Public.pkg
2026-09-01 07:23:09 : INFO  : tableaupublic : Verifying: /Volumes/Tableau Public/Tableau Public.pkg
2026-09-01 07:23:09 : INFO  : tableaupublic : Team ID: QJ4XPRK37C (expected: QJ4XPRK37C )
2026-09-01 07:23:09 : INFO  : tableaupublic : Finishing...
2026-09-01 07:23:12 : INFO  : tableaupublic : name: Tableau Public, appName: Tableau Public (Apple silicon).app
2026-09-01 07:23:13 : WARN  : tableaupublic : No previous app found
2026-09-01 07:23:13 : WARN  : tableaupublic : could not find Tableau Public (Apple silicon).app
2026-09-01 07:23:13 : REQ   : tableaupublic : Installed Tableau Public, version 2026.2.2
2026-09-01 07:23:13 : REQ   : tableaupublic : All done!
2026-09-01 07:23:13 : REQ   : tableaupublic : ################## End Installomator, exit code 0
```
