### PR TITLE
colourcontrastanalyser-label-update

### DIFF
--- a/fragments/labels/colourcontrastanalyser.sh
+++ b/fragments/labels/colourcontrastanalyser.sh
@@ -4,5 +4,4 @@ colourcontrastanalyser)
     downloadURL=$(downloadURLFromGit ThePacielloGroup CCAe)
     appNewVersion=$(versionFromGit ThePacielloGroup CCAe)
     expectedTeamID="34RS4UC3M6"
-    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This is better because it keeps the label on Installomator’s built-in GitHub helper path, which is appropriate because the project publishes real macOS DMG release assets on GitHub. It also removes the incorrect and unnecessary packageID, allowing Installomator to check the installed app bundle version normally, and removes blockingProcesses=( NONE ).

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh colourcontrastanalyser DEBUG=1
2026-09-01 08:40:52 : INFO  : colourcontrastanalyser : setting variable from argument DEBUG=1
2026-09-01 08:40:53 : INFO  : colourcontrastanalyser : Total items in argumentsArray: 1
2026-09-01 08:40:53 : INFO  : colourcontrastanalyser : argumentsArray: DEBUG=1
2026-09-01 08:40:53 : REQ   : colourcontrastanalyser : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 08:40:53 : INFO  : colourcontrastanalyser : ################## Version: 10.10beta
2026-09-01 08:40:53 : INFO  : colourcontrastanalyser : ################## Date: 2026-09-01
2026-09-01 08:40:53 : INFO  : colourcontrastanalyser : ################## colourcontrastanalyser
2026-09-01 08:40:53 : DEBUG : colourcontrastanalyser : DEBUG mode 1 enabled.
2026-09-01 08:40:54 : INFO  : colourcontrastanalyser : Reading arguments again: DEBUG=1
2026-09-01 08:40:54 : DEBUG : colourcontrastanalyser : argument: DEBUG=1
2026-09-01 08:40:54 : DEBUG : colourcontrastanalyser : name=Colour Contrast Analyser
2026-09-01 08:40:54 : DEBUG : colourcontrastanalyser : appName=
2026-09-01 08:40:54 : DEBUG : colourcontrastanalyser : type=dmg
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : archiveName=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : downloadURL=https://github.com/ThePacielloGroup/CCAe/releases/download/v3.5.5/CCA-3.5.5.dmg
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : curlOptions=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : appNewVersion=3.5.5
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : appCustomVersion function: Not defined
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : versionKey=CFBundleShortVersionString
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : packageID=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : pkgName=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : choiceChangesXML=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : expectedTeamID=34RS4UC3M6
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : blockingProcesses=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : installerTool=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : CLIInstaller=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : CLIArguments=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : updateTool=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : updateToolArguments=
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : updateToolRunAsCurrentUser=
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : NOTIFY=success
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : LOGGING=DEBUG
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : Label type: dmg
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : archiveName: Colour Contrast Analyser.dmg
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : no blocking processes defined, using Colour Contrast Analyser as default
2026-09-01 08:40:55 : DEBUG : colourcontrastanalyser : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : name: Colour Contrast Analyser, appName: Colour Contrast Analyser.app
2026-09-01 08:40:55 : WARN  : colourcontrastanalyser : No previous app found
2026-09-01 08:40:55 : WARN  : colourcontrastanalyser : could not find Colour Contrast Analyser.app
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : appversion: 
2026-09-01 08:40:55 : INFO  : colourcontrastanalyser : Latest version of Colour Contrast Analyser is 3.5.5
2026-09-01 08:40:56 : REQ   : colourcontrastanalyser : Downloading https://github.com/ThePacielloGroup/CCAe/releases/download/v3.5.5/CCA-3.5.5.dmg to Colour Contrast Analyser.dmg
2026-09-01 08:40:56 : DEBUG : colourcontrastanalyser : No Dialog connection, just download
2026-09-01 08:41:01 : INFO  : colourcontrastanalyser : Downloaded Colour Contrast Analyser.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is 3cb45f04c1f7eb6ff1378d9b8fb4b9d9889e778c – Size is 180540 kB
2026-09-01 08:41:01 : DEBUG : colourcontrastanalyser : DEBUG mode 1, not checking for blocking processes
2026-09-01 08:41:01 : REQ   : colourcontrastanalyser : Installing Colour Contrast Analyser
2026-09-01 08:41:01 : INFO  : colourcontrastanalyser : Mounting /Users/u0105821/git/github/Installomator/build/Colour Contrast Analyser.dmg
2026-09-01 08:41:12 : DEBUG : colourcontrastanalyser : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $0F0C573D
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $CEDBEE78
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $B3FACD92
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $5958A28C
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $B3FACD92
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $097953CF
verified   CRC32 $C4C1E040
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_APFS
/dev/disk9          	EF57347C-0000-11AA-AA11-0030654
/dev/disk9s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Colour Contrast Analyser 3.5.5-universal 1

2026-09-01 08:41:12 : INFO  : colourcontrastanalyser : Mounted: /Volumes/Colour Contrast Analyser 3.5.5-universal 1
2026-09-01 08:41:12 : INFO  : colourcontrastanalyser : Verifying: /Volumes/Colour Contrast Analyser 3.5.5-universal 1/Colour Contrast Analyser.app
2026-09-01 08:41:12 : DEBUG : colourcontrastanalyser : App size: 444M	/Volumes/Colour Contrast Analyser 3.5.5-universal 1/Colour Contrast Analyser.app
2026-09-01 08:41:24 : DEBUG : colourcontrastanalyser : Debugging enabled, App Verification output was:
/Volumes/Colour Contrast Analyser 3.5.5-universal 1/Colour Contrast Analyser.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: The Paciello Group, LLC (34RS4UC3M6)

2026-09-01 08:41:24 : INFO  : colourcontrastanalyser : Team ID matching: 34RS4UC3M6 (expected: 34RS4UC3M6 )
2026-09-01 08:41:24 : INFO  : colourcontrastanalyser : Installing Colour Contrast Analyser version 3.5.5 on versionKey CFBundleShortVersionString.
2026-09-01 08:41:24 : INFO  : colourcontrastanalyser : App has LSMinimumSystemVersion: 11.0
2026-09-01 08:41:24 : DEBUG : colourcontrastanalyser : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-01 08:41:24 : INFO  : colourcontrastanalyser : Finishing...
2026-09-01 08:41:27 : INFO  : colourcontrastanalyser : name: Colour Contrast Analyser, appName: Colour Contrast Analyser.app
2026-09-01 08:41:27 : WARN  : colourcontrastanalyser : No previous app found
2026-09-01 08:41:27 : WARN  : colourcontrastanalyser : could not find Colour Contrast Analyser.app
2026-09-01 08:41:27 : REQ   : colourcontrastanalyser : Installed Colour Contrast Analyser, version 3.5.5
2026-09-01 08:41:27 : INFO  : colourcontrastanalyser : notifying
2026-09-01 08:41:28 : DEBUG : colourcontrastanalyser : Unmounting /Volumes/Colour Contrast Analyser 3.5.5-universal 1
2026-09-01 08:41:28 : DEBUG : colourcontrastanalyser : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 08:41:28 : DEBUG : colourcontrastanalyser : DEBUG mode 1, not reopening anything
2026-09-01 08:41:28 : REQ   : colourcontrastanalyser : All done!
2026-09-01 08:41:28 : REQ   : colourcontrastanalyser : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
