### PR TITLE
fathom-label-update

### DIFF
--- a/fragments/labels/fathom.sh
+++ b/fragments/labels/fathom.sh
@@ -1,0 +1,11 @@
+fathom)
+    name="Fathom"
+    type="dmg"
+    if [[ $(arch) == "arm64" ]]; then
+        downloadURL="https://electron-update.fathom.video/download/dmg_arm64"
+    else
+        downloadURL="https://electron-update.fathom.video/download/dmg"
+    fi
+    appNewVersion=$(curl -fsL -r 0-0 -o /dev/null -w "%{url_effective}" "$downloadURL" | sed -nE 's#.*Fathom-darwin-(x64|arm64)-([0-9]+(\.[0-9]+)+)\.dmg(\?.*)?$#\2#p')
+    expectedTeamID="JH7GAYKCUH"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label uses the official download-page endpoints, handles Intel and Apple Silicon, installs the current DMG app build, matches the installed app version, avoids brittle page scraping, and avoids the conflicting updater ZIP feed.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh fathom DEBUG=1
2026-09-01 09:20:29 : INFO  : fathom : setting variable from argument DEBUG=1
2026-09-01 09:20:29 : INFO  : fathom : Total items in argumentsArray: 1
2026-09-01 09:20:29 : INFO  : fathom : argumentsArray: DEBUG=1
2026-09-01 09:20:29 : REQ   : fathom : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 09:20:29 : INFO  : fathom : ################## Version: 10.10beta
2026-09-01 09:20:29 : INFO  : fathom : ################## Date: 2026-09-01
2026-09-01 09:20:29 : INFO  : fathom : ################## fathom
2026-09-01 09:20:29 : DEBUG : fathom : DEBUG mode 1 enabled.
2026-09-01 09:20:30 : INFO  : fathom : Reading arguments again: DEBUG=1
2026-09-01 09:20:30 : DEBUG : fathom : argument: DEBUG=1
2026-09-01 09:20:30 : DEBUG : fathom : name=Fathom
2026-09-01 09:20:30 : DEBUG : fathom : appName=
2026-09-01 09:20:30 : DEBUG : fathom : type=dmg
2026-09-01 09:20:30 : DEBUG : fathom : archiveName=
2026-09-01 09:20:30 : DEBUG : fathom : downloadURL=https://electron-update.fathom.video/download/dmg_arm64
2026-09-01 09:20:30 : DEBUG : fathom : curlOptions=
2026-09-01 09:20:30 : DEBUG : fathom : appNewVersion=3.7.0
2026-09-01 09:20:30 : DEBUG : fathom : appCustomVersion function: Not defined
2026-09-01 09:20:30 : DEBUG : fathom : versionKey=CFBundleShortVersionString
2026-09-01 09:20:30 : DEBUG : fathom : packageID=
2026-09-01 09:20:30 : DEBUG : fathom : pkgName=
2026-09-01 09:20:30 : DEBUG : fathom : choiceChangesXML=
2026-09-01 09:20:30 : DEBUG : fathom : expectedTeamID=JH7GAYKCUH
2026-09-01 09:20:30 : DEBUG : fathom : blockingProcesses=
2026-09-01 09:20:30 : DEBUG : fathom : installerTool=
2026-09-01 09:20:30 : DEBUG : fathom : CLIInstaller=
2026-09-01 09:20:30 : DEBUG : fathom : CLIArguments=
2026-09-01 09:20:30 : DEBUG : fathom : updateTool=
2026-09-01 09:20:30 : DEBUG : fathom : updateToolArguments=
2026-09-01 09:20:30 : DEBUG : fathom : updateToolRunAsCurrentUser=
2026-09-01 09:20:30 : INFO  : fathom : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 09:20:30 : INFO  : fathom : NOTIFY=success
2026-09-01 09:20:30 : INFO  : fathom : LOGGING=DEBUG
2026-09-01 09:20:30 : INFO  : fathom : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 09:20:30 : INFO  : fathom : Label type: dmg
2026-09-01 09:20:30 : INFO  : fathom : archiveName: Fathom.dmg
2026-09-01 09:20:30 : INFO  : fathom : no blocking processes defined, using Fathom as default
2026-09-01 09:20:30 : DEBUG : fathom : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 09:20:30 : INFO  : fathom : name: Fathom, appName: Fathom.app
2026-09-01 09:20:31 : WARN  : fathom : No previous app found
2026-09-01 09:20:31 : WARN  : fathom : could not find Fathom.app
2026-09-01 09:20:31 : INFO  : fathom : appversion: 
2026-09-01 09:20:31 : INFO  : fathom : Latest version of Fathom is 3.7.0
2026-09-01 09:20:31 : REQ   : fathom : Downloading https://electron-update.fathom.video/download/dmg_arm64 to Fathom.dmg
2026-09-01 09:20:31 : DEBUG : fathom : No Dialog connection, just download
2026-09-01 09:20:36 : INFO  : fathom : Downloaded Fathom.dmg – Type is  lzfse encoded, lzvn compressed – SHA is 2cdae08a9d171ddf9df4222888196a48109d52fc – Size is 148064 kB
2026-09-01 09:20:36 : DEBUG : fathom : DEBUG mode 1, not checking for blocking processes
2026-09-01 09:20:36 : REQ   : fathom : Installing Fathom
2026-09-01 09:20:36 : INFO  : fathom : Mounting /Users/u0105821/git/github/Installomator/build/Fathom.dmg
2026-09-01 09:20:41 : DEBUG : fathom : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7B46FEDC
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $EB44E56C
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $847EF352
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $64C555B2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $847EF352
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $929DE516
verified   CRC32 $5854E583
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/Fathom

2026-09-01 09:20:41 : INFO  : fathom : Mounted: /Volumes/Fathom
2026-09-01 09:20:41 : INFO  : fathom : Verifying: /Volumes/Fathom/Fathom.app
2026-09-01 09:20:41 : DEBUG : fathom : App size: 352M	/Volumes/Fathom/Fathom.app
2026-09-01 09:20:43 : DEBUG : fathom : Debugging enabled, App Verification output was:
/Volumes/Fathom/Fathom.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Fathom Video Inc. (JH7GAYKCUH)

2026-09-01 09:20:43 : INFO  : fathom : Team ID matching: JH7GAYKCUH (expected: JH7GAYKCUH )
2026-09-01 09:20:43 : INFO  : fathom : Installing Fathom version 3.7.0 on versionKey CFBundleShortVersionString.
2026-09-01 09:20:43 : INFO  : fathom : App has LSMinimumSystemVersion: 12.0
2026-09-01 09:20:43 : DEBUG : fathom : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-01 09:20:43 : INFO  : fathom : Finishing...
2026-09-01 09:20:46 : INFO  : fathom : name: Fathom, appName: Fathom.app
2026-09-01 09:20:46 : WARN  : fathom : No previous app found
2026-09-01 09:20:46 : WARN  : fathom : could not find Fathom.app
2026-09-01 09:20:46 : REQ   : fathom : Installed Fathom, version 3.7.0
2026-09-01 09:20:46 : INFO  : fathom : notifying
2026-09-01 09:20:46 : DEBUG : fathom : Unmounting /Volumes/Fathom
2026-09-01 09:20:47 : DEBUG : fathom : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 09:20:47 : DEBUG : fathom : DEBUG mode 1, not reopening anything
2026-09-01 09:20:47 : REQ   : fathom : All done!
2026-09-01 09:20:47 : REQ   : fathom : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
