### PR TITLE
Update dbvisualizer.sh

### DIFF
--- a/fragments/labels/dbvisualizer.sh
+++ b/fragments/labels/dbvisualizer.sh
@@ -1,13 +1,12 @@
 dbvisualizer)
     name="DbVisualizer"
     type="dmg"
-    dbvisVersion=$(curl -fsL "https://www.dbvis.com/download/" | grep -oE 'Latest version [0-9]+(\.[0-9]+)+' | head -n 1 | awk '{print $3}')
-    appNewVersion=$(echo "$dbvisVersion" | awk -F. '{for (i = NF+1; i <= 3; i++) $i = 0; print $1"."$2"."$3}')
-    downloadVersion="${dbvisVersion//./_}"
+    downloadPage=$(curl -fsL "https://www.dbvis.com/download/")
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://www.dbvis.com/product_download/dbvis-${dbvisVersion}/media/dbvis_macos-aarch64_${downloadVersion}.dmg"
+        downloadURL="https://www.dbvis.com$(echo "$downloadPage" | grep -Eo '/product_download/dbvis-[0-9.]+/media/dbvis_macos-aarch64_[0-9_]+\.dmg' | head -1)"
     else
-        downloadURL="https://www.dbvis.com/product_download/dbvis-${dbvisVersion}/media/dbvis_macos-x64_${downloadVersion}.dmg"
+        downloadURL="https://www.dbvis.com$(echo "$downloadPage" | grep -Eo '/product_download/dbvis-[0-9.]+/media/dbvis_macos-x64_[0-9_]+\.dmg' | head -1)"
     fi
+    appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*/dbvis-([0-9]+(\.[0-9]+)+)/media/dbvis_macos-(aarch64|x64)_[0-9_]+\.dmg#\1#p')
     expectedTeamID="U9TP5KYV49"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label gets the architecture-specific Mac installer link from DbVisualizer’s official download page and derives appNewVersion from that same selected download URL. That keeps the version and payload tied together, avoids scraping the separate release notes page, removes the extra altVersion variable, and still supports separate Apple Silicon and Intel DMGs. No appName, versionKey, packageID, or blockingProcesses are needed because both DMGs contain DbVisualizer.app and the installed CFBundleShortVersionString matches appNewVersion.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh dbvisualizer DEBUG=1
2026-09-01 09:45:54 : INFO  : dbvisualizer : setting variable from argument DEBUG=1
2026-09-01 09:45:54 : INFO  : dbvisualizer : Total items in argumentsArray: 1
2026-09-01 09:45:54 : INFO  : dbvisualizer : argumentsArray: DEBUG=1
2026-09-01 09:45:54 : REQ   : dbvisualizer : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 09:45:54 : INFO  : dbvisualizer : ################## Version: 10.10beta
2026-09-01 09:45:54 : INFO  : dbvisualizer : ################## Date: 2026-09-01
2026-09-01 09:45:54 : INFO  : dbvisualizer : ################## dbvisualizer
2026-09-01 09:45:54 : DEBUG : dbvisualizer : DEBUG mode 1 enabled.
2026-09-01 09:45:55 : INFO  : dbvisualizer : Reading arguments again: DEBUG=1
2026-09-01 09:45:55 : DEBUG : dbvisualizer : argument: DEBUG=1
2026-09-01 09:45:55 : DEBUG : dbvisualizer : name=DbVisualizer
2026-09-01 09:45:55 : DEBUG : dbvisualizer : appName=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : type=dmg
2026-09-01 09:45:55 : DEBUG : dbvisualizer : archiveName=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : downloadURL=https://www.dbvis.com/product_download/dbvis-26.2.2/media/dbvis_macos-aarch64_26_2_2.dmg
2026-09-01 09:45:55 : DEBUG : dbvisualizer : curlOptions=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : appNewVersion=26.2.2
2026-09-01 09:45:55 : DEBUG : dbvisualizer : appCustomVersion function: Not defined
2026-09-01 09:45:55 : DEBUG : dbvisualizer : versionKey=CFBundleShortVersionString
2026-09-01 09:45:55 : DEBUG : dbvisualizer : packageID=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : pkgName=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : choiceChangesXML=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : expectedTeamID=U9TP5KYV49
2026-09-01 09:45:55 : DEBUG : dbvisualizer : blockingProcesses=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : installerTool=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : CLIInstaller=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : CLIArguments=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : updateTool=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : updateToolArguments=
2026-09-01 09:45:55 : DEBUG : dbvisualizer : updateToolRunAsCurrentUser=
2026-09-01 09:45:55 : INFO  : dbvisualizer : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 09:45:55 : INFO  : dbvisualizer : NOTIFY=success
2026-09-01 09:45:55 : INFO  : dbvisualizer : LOGGING=DEBUG
2026-09-01 09:45:55 : INFO  : dbvisualizer : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 09:45:55 : INFO  : dbvisualizer : Label type: dmg
2026-09-01 09:45:56 : INFO  : dbvisualizer : archiveName: DbVisualizer.dmg
2026-09-01 09:45:56 : INFO  : dbvisualizer : no blocking processes defined, using DbVisualizer as default
2026-09-01 09:45:56 : DEBUG : dbvisualizer : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 09:45:56 : INFO  : dbvisualizer : name: DbVisualizer, appName: DbVisualizer.app
2026-09-01 09:45:56 : WARN  : dbvisualizer : No previous app found
2026-09-01 09:45:56 : WARN  : dbvisualizer : could not find DbVisualizer.app
2026-09-01 09:45:56 : INFO  : dbvisualizer : appversion: 
2026-09-01 09:45:56 : INFO  : dbvisualizer : Latest version of DbVisualizer is 26.2.2
2026-09-01 09:45:56 : REQ   : dbvisualizer : Downloading https://www.dbvis.com/product_download/dbvis-26.2.2/media/dbvis_macos-aarch64_26_2_2.dmg to DbVisualizer.dmg
2026-09-01 09:45:56 : DEBUG : dbvisualizer : No Dialog connection, just download
2026-09-01 09:46:09 : INFO  : dbvisualizer : Downloaded DbVisualizer.dmg – Type is  zlib compressed data – SHA is 46ffeb2a904aee7faf269d088b17fd18334a3c03 – Size is 229568 kB
2026-09-01 09:46:09 : DEBUG : dbvisualizer : DEBUG mode 1, not checking for blocking processes
2026-09-01 09:46:09 : REQ   : dbvisualizer : Installing DbVisualizer
2026-09-01 09:46:09 : INFO  : dbvisualizer : Mounting /Users/u0105821/git/github/Installomator/build/DbVisualizer.dmg
2026-09-01 09:46:10 : DEBUG : dbvisualizer : Debugging enabled, dmgmount output was:
Checksumming whole disk (Apple_HFS : 0)…
whole disk (Apple_HFS : 0): verified   CRC32 $72838BA6
verified   CRC32 $E4C3558F
/dev/disk8          	Apple_partition_scheme
/dev/disk8s1        	Apple_partition_map
/dev/disk8s2        	Apple_HFS                      	/Volumes/DbVisualizer

2026-09-01 09:46:10 : INFO  : dbvisualizer : Mounted: /Volumes/DbVisualizer
2026-09-01 09:46:10 : INFO  : dbvisualizer : Verifying: /Volumes/DbVisualizer/DbVisualizer.app
2026-09-01 09:46:10 : DEBUG : dbvisualizer : App size: 328M	/Volumes/DbVisualizer/DbVisualizer.app
2026-09-01 09:46:11 : DEBUG : dbvisualizer : Debugging enabled, App Verification output was:
/Volumes/DbVisualizer/DbVisualizer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DbVis Software AB (U9TP5KYV49)

2026-09-01 09:46:11 : INFO  : dbvisualizer : Team ID matching: U9TP5KYV49 (expected: U9TP5KYV49 )
2026-09-01 09:46:11 : INFO  : dbvisualizer : Installing DbVisualizer version 26.2.2 on versionKey CFBundleShortVersionString.
2026-09-01 09:46:12 : INFO  : dbvisualizer : App has LSMinimumSystemVersion: 10.15
2026-09-01 09:46:12 : DEBUG : dbvisualizer : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-01 09:46:12 : INFO  : dbvisualizer : Finishing...
2026-09-01 09:46:15 : INFO  : dbvisualizer : name: DbVisualizer, appName: DbVisualizer.app
2026-09-01 09:46:15 : WARN  : dbvisualizer : No previous app found
2026-09-01 09:46:15 : WARN  : dbvisualizer : could not find DbVisualizer.app
2026-09-01 09:46:15 : REQ   : dbvisualizer : Installed DbVisualizer, version 26.2.2
2026-09-01 09:46:15 : INFO  : dbvisualizer : notifying
2026-09-01 09:46:15 : DEBUG : dbvisualizer : Unmounting /Volumes/DbVisualizer
2026-09-01 09:46:15 : DEBUG : dbvisualizer : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 09:46:15 : DEBUG : dbvisualizer : DEBUG mode 1, not reopening anything
2026-09-01 09:46:15 : REQ   : dbvisualizer : All done!
2026-09-01 09:46:15 : REQ   : dbvisualizer : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
