### PR TITLE
pcoipclient-label-update

### DIFF
--- a/fragments/labels/pcoipclient.sh
+++ b/fragments/labels/pcoipclient.sh
@@ -1,9 +1,6 @@
 pcoipclient)
-    # Note that the sed match removes 'pcoip-client_' and '.dmg' 
     name="PCoIPClient"
     type="dmg"
-    downloadURL="https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg"
-    appNewVersion="$(curl -fsIL ${downloadURL} | grep -i ^content-disposition | sed -e 's/.*pcoip-client_//' -e 's/.dmg"//')"
+    downloadURL="https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg"
     expectedTeamID="RU4LW7W32C"
-    blockingProcesses=( "Teradici PCoIP Client" )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This updated pcoipclient label is better because it removes the broken appNewVersion logic that depends on a content-disposition header HP no longer provides. The vendor’s latest DMG URL still downloads a valid PCoIPClient.app, and the app bundle itself contains the correct version, so Installomator can read the version after mounting the DMG instead of relying on an empty or stale pre-download parser. The label also avoids unnecessary custom variables: name="PCoIPClient" maps correctly to PCoIPClient.app, the default version key works, and the verified Team ID is RU4LW7W32C.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh pcoipclient DEBUG=1
2026-09-01 11:32:50 : INFO  : pcoipclient : setting variable from argument DEBUG=1
2026-09-01 11:32:50 : INFO  : pcoipclient : Total items in argumentsArray: 1
2026-09-01 11:32:50 : INFO  : pcoipclient : argumentsArray: DEBUG=1
2026-09-01 11:32:50 : REQ   : pcoipclient : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 11:32:50 : INFO  : pcoipclient : ################## Version: 10.10beta
2026-09-01 11:32:50 : INFO  : pcoipclient : ################## Date: 2026-09-01
2026-09-01 11:32:50 : INFO  : pcoipclient : ################## pcoipclient
2026-09-01 11:32:50 : DEBUG : pcoipclient : DEBUG mode 1 enabled.
2026-09-01 11:32:51 : INFO  : pcoipclient : Reading arguments again: DEBUG=1
2026-09-01 11:32:51 : DEBUG : pcoipclient : argument: DEBUG=1
2026-09-01 11:32:51 : DEBUG : pcoipclient : name=PCoIPClient
2026-09-01 11:32:51 : DEBUG : pcoipclient : appName=
2026-09-01 11:32:51 : DEBUG : pcoipclient : type=dmg
2026-09-01 11:32:51 : DEBUG : pcoipclient : archiveName=
2026-09-01 11:32:51 : DEBUG : pcoipclient : downloadURL=https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg
2026-09-01 11:32:51 : DEBUG : pcoipclient : curlOptions=
2026-09-01 11:32:51 : DEBUG : pcoipclient : appNewVersion=
2026-09-01 11:32:51 : DEBUG : pcoipclient : appCustomVersion function: Not defined
2026-09-01 11:32:51 : DEBUG : pcoipclient : versionKey=CFBundleShortVersionString
2026-09-01 11:32:51 : DEBUG : pcoipclient : packageID=
2026-09-01 11:32:51 : DEBUG : pcoipclient : pkgName=
2026-09-01 11:32:51 : DEBUG : pcoipclient : choiceChangesXML=
2026-09-01 11:32:51 : DEBUG : pcoipclient : expectedTeamID=RU4LW7W32C
2026-09-01 11:32:51 : DEBUG : pcoipclient : blockingProcesses=
2026-09-01 11:32:51 : DEBUG : pcoipclient : installerTool=
2026-09-01 11:32:51 : DEBUG : pcoipclient : CLIInstaller=
2026-09-01 11:32:51 : DEBUG : pcoipclient : CLIArguments=
2026-09-01 11:32:51 : DEBUG : pcoipclient : updateTool=
2026-09-01 11:32:51 : DEBUG : pcoipclient : updateToolArguments=
2026-09-01 11:32:51 : DEBUG : pcoipclient : updateToolRunAsCurrentUser=
2026-09-01 11:32:51 : INFO  : pcoipclient : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 11:32:51 : INFO  : pcoipclient : NOTIFY=success
2026-09-01 11:32:51 : INFO  : pcoipclient : LOGGING=DEBUG
2026-09-01 11:32:51 : INFO  : pcoipclient : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 11:32:51 : INFO  : pcoipclient : Label type: dmg
2026-09-01 11:32:51 : INFO  : pcoipclient : archiveName: PCoIPClient.dmg
2026-09-01 11:32:51 : INFO  : pcoipclient : no blocking processes defined, using PCoIPClient as default
2026-09-01 11:32:51 : DEBUG : pcoipclient : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 11:32:51 : INFO  : pcoipclient : name: PCoIPClient, appName: PCoIPClient.app
2026-09-01 11:32:51 : WARN  : pcoipclient : No previous app found
2026-09-01 11:32:51 : WARN  : pcoipclient : could not find PCoIPClient.app
2026-09-01 11:32:51 : INFO  : pcoipclient : appversion: 
2026-09-01 11:32:51 : INFO  : pcoipclient : Latest version not specified.
2026-09-01 11:32:51 : REQ   : pcoipclient : Downloading https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg to PCoIPClient.dmg
2026-09-01 11:32:51 : DEBUG : pcoipclient : No Dialog connection, just download
2026-09-01 11:32:54 : INFO  : pcoipclient : Downloaded PCoIPClient.dmg – Type is  zlib compressed data – SHA is cdea8d99cd7a73baf590ea1b5c3b5e38d5e7ba61 – Size is 99228 kB
2026-09-01 11:32:55 : DEBUG : pcoipclient : DEBUG mode 1, not checking for blocking processes
2026-09-01 11:32:55 : REQ   : pcoipclient : Installing PCoIPClient
2026-09-01 11:32:55 : INFO  : pcoipclient : Mounting /Users/u0105821/git/github/Installomator/build/PCoIPClient.dmg
2026-09-01 11:32:58 : DEBUG : pcoipclient : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $78E87B23
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $9FC89E07
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CB0460E5
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $9F19E452
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CB0460E5
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $E7CEBD8A
verified   CRC32 $948B9B11
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/pcoip-client_26.05.3

2026-09-01 11:32:58 : INFO  : pcoipclient : Mounted: /Volumes/pcoip-client_26.05.3
2026-09-01 11:32:58 : INFO  : pcoipclient : Verifying: /Volumes/pcoip-client_26.05.3/PCoIPClient.app
2026-09-01 11:32:58 : DEBUG : pcoipclient : App size: 259M	/Volumes/pcoip-client_26.05.3/PCoIPClient.app
2026-09-01 11:33:02 : DEBUG : pcoipclient : Debugging enabled, App Verification output was:
/Volumes/pcoip-client_26.05.3/PCoIPClient.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: TERADICI CO (RU4LW7W32C)

2026-09-01 11:33:02 : INFO  : pcoipclient : Team ID matching: RU4LW7W32C (expected: RU4LW7W32C )
2026-09-01 11:33:02 : INFO  : pcoipclient : Installing PCoIPClient version 26.05.3 on versionKey CFBundleShortVersionString.
2026-09-01 11:33:02 : INFO  : pcoipclient : App has LSMinimumSystemVersion: 14.4
2026-09-01 11:33:02 : DEBUG : pcoipclient : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-01 11:33:02 : INFO  : pcoipclient : Finishing...
2026-09-01 11:33:05 : INFO  : pcoipclient : name: PCoIPClient, appName: PCoIPClient.app
2026-09-01 11:33:06 : WARN  : pcoipclient : No previous app found
2026-09-01 11:33:06 : WARN  : pcoipclient : could not find PCoIPClient.app
2026-09-01 11:33:06 : REQ   : pcoipclient : Installed PCoIPClient, version 26.05.3
2026-09-01 11:33:06 : INFO  : pcoipclient : notifying
2026-09-01 11:33:06 : DEBUG : pcoipclient : Unmounting /Volumes/pcoip-client_26.05.3
2026-09-01 11:33:06 : DEBUG : pcoipclient : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 11:33:06 : DEBUG : pcoipclient : DEBUG mode 1, not reopening anything
2026-09-01 11:33:06 : REQ   : pcoipclient : All done!
2026-09-01 11:33:06 : REQ   : pcoipclient : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
