### PR TITLE
labchartreader8-label-update

### DIFF
--- a/fragments/labels/labchartreader8.sh
+++ b/fragments/labels/labchartreader8.sh
@@ -1,0 +1,9 @@
+labchartreader8)
+    name="LabChart Reader"
+    appName="LabChart 8 Reader/LabChart Reader.app"
+    type="pkg"
+    curlOptions=(-A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15")
+    downloadURL=$(curl -fsL "${curlOptions[@]}" "https://www.adinstruments.com/support/downloads/mac/labchart-reader" | grep -Eo "https://go\.adinstruments\.com/Installers/mac/LabChartReader_[0-9]+(\.[0-9]+)+\.pkg" | head -1)
+    appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*LabChartReader_([0-9]+(\.[0-9]+)+)\.pkg#\1#p')
+    expectedTeamID="M74NZ7VL2C"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The labchartreader8 label is better because it tracks the vendor’s current LabChart Reader 8 installer from the ADInstruments download page, uses a browser-style curlOptions value because the site blocks generic curl, and derives appNewVersion directly from the selected package URL so the version and download stay aligned. It also sets appName="LabChart 8 Reader/LabChart Reader.app" because the pkg installs the app inside that versioned folder, and it avoids packageID because the receipt ID is version-specific while the pkg receipt version is 0, making the app bundle version the more reliable comparison source.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh labchartreader8 DEBUG=2
2026-09-01 11:55:00 : INFO  : labchartreader8 : setting variable from argument DEBUG=2
2026-09-01 11:55:00 : INFO  : labchartreader8 : Total items in argumentsArray: 1
2026-09-01 11:55:00 : INFO  : labchartreader8 : argumentsArray: DEBUG=2
2026-09-01 11:55:00 : REQ   : labchartreader8 : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 11:55:00 : INFO  : labchartreader8 : ################## Version: 10.10beta
2026-09-01 11:55:00 : INFO  : labchartreader8 : ################## Date: 2026-09-01
2026-09-01 11:55:00 : INFO  : labchartreader8 : ################## labchartreader8
2026-09-01 11:55:00 : DEBUG : labchartreader8 : DEBUG mode 2 enabled.
2026-09-01 11:55:01 : INFO  : labchartreader8 : Reading arguments again: DEBUG=2
2026-09-01 11:55:01 : DEBUG : labchartreader8 : argument: DEBUG=2
2026-09-01 11:55:01 : DEBUG : labchartreader8 : name=LabChart Reader
2026-09-01 11:55:01 : DEBUG : labchartreader8 : appName=LabChart 8 Reader/LabChart Reader.app
2026-09-01 11:55:01 : DEBUG : labchartreader8 : type=pkg
2026-09-01 11:55:01 : DEBUG : labchartreader8 : archiveName=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : downloadURL=https://go.adinstruments.com/Installers/mac/LabChartReader_8.1.30.pkg
2026-09-01 11:55:01 : DEBUG : labchartreader8 : curlOptions=-A Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15
2026-09-01 11:55:01 : DEBUG : labchartreader8 : appNewVersion=8.1.30
2026-09-01 11:55:01 : DEBUG : labchartreader8 : appCustomVersion function: Not defined
2026-09-01 11:55:01 : DEBUG : labchartreader8 : versionKey=CFBundleShortVersionString
2026-09-01 11:55:01 : DEBUG : labchartreader8 : packageID=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : pkgName=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : choiceChangesXML=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : expectedTeamID=M74NZ7VL2C
2026-09-01 11:55:01 : DEBUG : labchartreader8 : blockingProcesses=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : installerTool=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : CLIInstaller=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : CLIArguments=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : updateTool=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : updateToolArguments=
2026-09-01 11:55:01 : DEBUG : labchartreader8 : updateToolRunAsCurrentUser=
2026-09-01 11:55:01 : INFO  : labchartreader8 : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 11:55:01 : INFO  : labchartreader8 : NOTIFY=success
2026-09-01 11:55:01 : INFO  : labchartreader8 : LOGGING=DEBUG
2026-09-01 11:55:01 : INFO  : labchartreader8 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 11:55:01 : INFO  : labchartreader8 : Label type: pkg
2026-09-01 11:55:01 : INFO  : labchartreader8 : archiveName: LabChart Reader.pkg
2026-09-01 11:55:01 : INFO  : labchartreader8 : no blocking processes defined, using LabChart Reader as default
2026-09-01 11:55:01 : DEBUG : labchartreader8 : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JljVhdHWgH
2026-09-01 11:55:01 : INFO  : labchartreader8 : name: LabChart Reader, appName: LabChart 8 Reader/LabChart Reader.app
2026-09-01 11:55:01 : WARN  : labchartreader8 : No previous app found
2026-09-01 11:55:01 : WARN  : labchartreader8 : could not find LabChart 8 Reader/LabChart Reader.app
2026-09-01 11:55:01 : INFO  : labchartreader8 : appversion: 
2026-09-01 11:55:01 : INFO  : labchartreader8 : Latest version of LabChart Reader is 8.1.30
2026-09-01 11:55:01 : REQ   : labchartreader8 : Downloading https://go.adinstruments.com/Installers/mac/LabChartReader_8.1.30.pkg to LabChart Reader.pkg
2026-09-01 11:55:01 : DEBUG : labchartreader8 : No Dialog connection, just download
2026-09-01 11:55:03 : INFO  : labchartreader8 : Downloaded LabChart Reader.pkg – Type is  xar archive compressed TOC – SHA is c4aab87f8cfa5682d8aabfff59186b8658edccd1 – Size is 33236 kB
2026-09-01 11:55:03 : REQ   : labchartreader8 : no more blocking processes, continue with update
2026-09-01 11:55:03 : REQ   : labchartreader8 : Installing LabChart Reader
2026-09-01 11:55:03 : INFO  : labchartreader8 : Verifying: LabChart Reader.pkg
2026-09-01 11:55:03 : DEBUG : labchartreader8 : File list: -rw-r--r--  1 root  wheel    32M Sep  1 11:55 LabChart Reader.pkg
2026-09-01 11:55:03 : DEBUG : labchartreader8 : File type: LabChart Reader.pkg: xar archive compressed TOC: 5061, SHA-1 checksum
2026-09-01 11:55:03 : DEBUG : labchartreader8 : spctlOut is LabChart Reader.pkg: accepted
2026-09-01 11:55:03 : DEBUG : labchartreader8 : source=Notarized Developer ID
2026-09-01 11:55:03 : DEBUG : labchartreader8 : origin=Developer ID Installer: ADInstruments Ltd (M74NZ7VL2C)
2026-09-01 11:55:03 : INFO  : labchartreader8 : Team ID: M74NZ7VL2C (expected: M74NZ7VL2C )
2026-09-01 11:55:03 : DEBUG : labchartreader8 : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JljVhdHWgH
2026-09-01 11:55:03 : DEBUG : labchartreader8 : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JljVhdHWgH/LabChart Reader.pkg
2026-09-01 11:55:03 : DEBUG : labchartreader8 : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.JljVhdHWgH
2026-09-01 11:55:03 : INFO  : labchartreader8 : Installomator did not close any apps, so no need to reopen any apps.
2026-09-01 11:55:03 : DEBUG : labchartreader8 : DEBUG mode 2 enabled, exiting
2026-09-01 11:55:03 : REQ   : labchartreader8 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
