### PR TITLE
vocevistavideopro-label-update

### DIFF
--- a/fragments/labels/vocevistavideopro.sh
+++ b/fragments/labels/vocevistavideopro.sh
@@ -1,0 +1,8 @@
+vocevistavideopro)
+    name="VoceVista Video Pro"
+    type="dmg"
+    voceVistaDownloadPage=$(curl --compressed -fsL "https://www.vocevista.com/en/download-mac/")
+    downloadURL=$(grep -Eo "https://download\.sygyt\.com/[^\"[:space:]]+/VoceVistaVideoPro_macOS_[0-9.]+\.dmg" <<< "$voceVistaDownloadPage" | head -1)
+    appNewVersion=$(echo "$downloadURL" | sed -nE 's#.*VoceVistaVideoPro_macOS_([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?\.dmg#\1#p')
+    expectedTeamID="MZ25LZ65AM"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh vocevistavideopro DEBUG=2
2026-09-01 12:45:57 : INFO  : vocevistavideopro : setting variable from argument DEBUG=2
2026-09-01 12:45:57 : INFO  : vocevistavideopro : Total items in argumentsArray: 1
2026-09-01 12:45:57 : INFO  : vocevistavideopro : argumentsArray: DEBUG=2
2026-09-01 12:45:57 : REQ   : vocevistavideopro : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 12:45:57 : INFO  : vocevistavideopro : ################## Version: 10.10beta
2026-09-01 12:45:57 : INFO  : vocevistavideopro : ################## Date: 2026-09-01
2026-09-01 12:45:57 : INFO  : vocevistavideopro : ################## vocevistavideopro
2026-09-01 12:45:57 : DEBUG : vocevistavideopro : DEBUG mode 2 enabled.
2026-09-01 12:45:58 : INFO  : vocevistavideopro : Reading arguments again: DEBUG=2
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : argument: DEBUG=2
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : name=VoceVista Video Pro
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : appName=
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : type=dmg
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : archiveName=
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : downloadURL=https://download.sygyt.com/6.0.0/VoceVistaVideoPro_macOS_6.0.0.9888.dmg
2026-09-01 12:45:58 : DEBUG : vocevistavideopro : curlOptions=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : appNewVersion=6.0.0
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : appCustomVersion function: Not defined
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : versionKey=CFBundleShortVersionString
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : packageID=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : pkgName=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : choiceChangesXML=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : expectedTeamID=MZ25LZ65AM
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : blockingProcesses=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : installerTool=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : CLIInstaller=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : CLIArguments=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : updateTool=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : updateToolArguments=
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : updateToolRunAsCurrentUser=
2026-09-01 12:45:59 : INFO  : vocevistavideopro : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 12:45:59 : INFO  : vocevistavideopro : NOTIFY=success
2026-09-01 12:45:59 : INFO  : vocevistavideopro : LOGGING=DEBUG
2026-09-01 12:45:59 : INFO  : vocevistavideopro : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 12:45:59 : INFO  : vocevistavideopro : Label type: dmg
2026-09-01 12:45:59 : INFO  : vocevistavideopro : archiveName: VoceVista Video Pro.dmg
2026-09-01 12:45:59 : INFO  : vocevistavideopro : no blocking processes defined, using VoceVista Video Pro as default
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : Changing directory to /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hqCF78IImY
2026-09-01 12:45:59 : INFO  : vocevistavideopro : name: VoceVista Video Pro, appName: VoceVista Video Pro.app
2026-09-01 12:45:59 : WARN  : vocevistavideopro : No previous app found
2026-09-01 12:45:59 : WARN  : vocevistavideopro : could not find VoceVista Video Pro.app
2026-09-01 12:45:59 : INFO  : vocevistavideopro : appversion: 
2026-09-01 12:45:59 : INFO  : vocevistavideopro : Latest version of VoceVista Video Pro is 6.0.0
2026-09-01 12:45:59 : REQ   : vocevistavideopro : Downloading https://download.sygyt.com/6.0.0/VoceVistaVideoPro_macOS_6.0.0.9888.dmg to VoceVista Video Pro.dmg
2026-09-01 12:45:59 : DEBUG : vocevistavideopro : No Dialog connection, just download
2026-09-01 12:46:22 : INFO  : vocevistavideopro : Downloaded VoceVista Video Pro.dmg – Type is  bzip2 compressed data, block size = 100k – SHA is d55d1681898f3291df116aa24557d7374281e942 – Size is 98316 kB
2026-09-01 12:46:22 : REQ   : vocevistavideopro : no more blocking processes, continue with update
2026-09-01 12:46:22 : REQ   : vocevistavideopro : Installing VoceVista Video Pro
2026-09-01 12:46:22 : INFO  : vocevistavideopro : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hqCF78IImY/VoceVista Video Pro.dmg
2026-09-01 12:46:29 : DEBUG : vocevistavideopro : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $93A3D4A0
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $CBE4F849
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $A3ACEB1A
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $14A60739
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $A3ACEB1A
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CFEE53CA
verified   CRC32 $70BDEBB2
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/Install VoceVista Video Pro

2026-09-01 12:46:29 : INFO  : vocevistavideopro : Mounted: /Volumes/Install VoceVista Video Pro
2026-09-01 12:46:29 : INFO  : vocevistavideopro : Verifying: /Volumes/Install VoceVista Video Pro/VoceVista Video Pro.app
2026-09-01 12:46:29 : DEBUG : vocevistavideopro : App size: 205M	/Volumes/Install VoceVista Video Pro/VoceVista Video Pro.app
2026-09-01 12:46:38 : DEBUG : vocevistavideopro : Debugging enabled, App Verification output was:
/Volumes/Install VoceVista Video Pro/VoceVista Video Pro.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bodo Maass (MZ25LZ65AM)

2026-09-01 12:46:38 : INFO  : vocevistavideopro : Team ID matching: MZ25LZ65AM (expected: MZ25LZ65AM )
2026-09-01 12:46:38 : INFO  : vocevistavideopro : Installing VoceVista Video Pro version 6.0.0 on versionKey CFBundleShortVersionString.
2026-09-01 12:46:38 : INFO  : vocevistavideopro : App has LSMinimumSystemVersion: 13
2026-09-01 12:46:38 : DEBUG : vocevistavideopro : DEBUG mode 2 enabled, not installing anything, exiting
2026-09-01 12:46:38 : DEBUG : vocevistavideopro : Unmounting /Volumes/Install VoceVista Video Pro
2026-09-01 12:46:39 : DEBUG : vocevistavideopro : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 12:46:39 : DEBUG : vocevistavideopro : Deleting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hqCF78IImY
2026-09-01 12:46:39 : DEBUG : vocevistavideopro : Debugging enabled, Deleting tmpDir output was:
/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hqCF78IImY/VoceVista Video Pro.dmg
2026-09-01 12:46:39 : DEBUG : vocevistavideopro : /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.hqCF78IImY
2026-09-01 12:46:39 : INFO  : vocevistavideopro : Installomator did not close any apps, so no need to reopen any apps.
2026-09-01 12:46:39 : INFO  : vocevistavideopro : 
2026-09-01 12:46:39 : REQ   : vocevistavideopro : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
