### PR TITLE
Update bitwarden.sh

### DIFF
--- a/fragments/labels/bitwarden.sh
+++ b/fragments/labels/bitwarden.sh
@@ -1,7 +1,7 @@
 bitwarden)
     name="Bitwarden"
     type="dmg"
-    appNewVersion=$(curl -s "https://github.com/bitwarden/clients/releases?q\=desktop" | xmllint --html --xpath 'substring-after(string(//h2[starts-with(text(),"Desktop v")]), " v")' - 2>/dev/null)
-    downloadURL="https://github.com/bitwarden/clients/releases/download/desktop-v${appNewVersion}/Bitwarden-${appNewVersion}-universal.dmg"
+    downloadURL="https://vault.bitwarden.com/download/?app=desktop&platform=macos"
+    appNewVersion=$(curl -fsIL "$downloadURL" -o /dev/null -D - | awk 'BEGIN{IGNORECASE=1}/^location:/{gsub("\r",""); print $2}' | grep '/bitwarden/clients/releases/download/desktop-v' | head -n 1 | sed -E 's|.*/desktop-v([0-9]+(\.[0-9]+)+)/.*|\1|')
     expectedTeamID="LTZ2PFU5D6"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label better than the original because the original depends on scraping GitHub’s HTML release search page, which is fragile and can break if GitHub changes the page layout, search result order, or heading text. It also relies on a filtered releases page rather than a structured or vendor-supported download source. The corrected label uses Bitwarden’s official macOS desktop download endpoint, which redirects directly to the current desktop DMG. This is safer because Bitwarden’s clients GitHub repository contains multiple release families, and GitHub’s latest release currently points to the CLI release instead of the desktop app. By using Bitwarden’s official desktop endpoint and extracting the version from the desktop release redirect, the label is more reliable, easier to maintain, and less likely to download the wrong product family.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh bitwarden DEBUG=1
2026-09-01 16:24:18 : INFO  : bitwarden : setting variable from argument DEBUG=1
2026-09-01 16:24:18 : INFO  : bitwarden : Total items in argumentsArray: 1
2026-09-01 16:24:18 : INFO  : bitwarden : argumentsArray: DEBUG=1
2026-09-01 16:24:18 : REQ   : bitwarden : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 16:24:18 : INFO  : bitwarden : ################## Version: 10.10beta
2026-09-01 16:24:18 : INFO  : bitwarden : ################## Date: 2026-09-01
2026-09-01 16:24:18 : INFO  : bitwarden : ################## bitwarden
2026-09-01 16:24:18 : DEBUG : bitwarden : DEBUG mode 1 enabled.
2026-09-01 16:24:20 : INFO  : bitwarden : Reading arguments again: DEBUG=1
2026-09-01 16:24:20 : DEBUG : bitwarden : argument: DEBUG=1
2026-09-01 16:24:20 : DEBUG : bitwarden : name=Bitwarden
2026-09-01 16:24:20 : DEBUG : bitwarden : appName=
2026-09-01 16:24:20 : DEBUG : bitwarden : type=dmg
2026-09-01 16:24:20 : DEBUG : bitwarden : archiveName=
2026-09-01 16:24:20 : DEBUG : bitwarden : downloadURL=https://vault.bitwarden.com/download/?app=desktop&platform=macos
2026-09-01 16:24:20 : DEBUG : bitwarden : curlOptions=
2026-09-01 16:24:20 : DEBUG : bitwarden : appNewVersion=2026.8.0
2026-09-01 16:24:20 : DEBUG : bitwarden : appCustomVersion function: Not defined
2026-09-01 16:24:20 : DEBUG : bitwarden : versionKey=CFBundleShortVersionString
2026-09-01 16:24:20 : DEBUG : bitwarden : packageID=
2026-09-01 16:24:20 : DEBUG : bitwarden : pkgName=
2026-09-01 16:24:20 : DEBUG : bitwarden : choiceChangesXML=
2026-09-01 16:24:20 : DEBUG : bitwarden : expectedTeamID=LTZ2PFU5D6
2026-09-01 16:24:20 : DEBUG : bitwarden : blockingProcesses=
2026-09-01 16:24:20 : DEBUG : bitwarden : installerTool=
2026-09-01 16:24:20 : DEBUG : bitwarden : CLIInstaller=
2026-09-01 16:24:20 : DEBUG : bitwarden : CLIArguments=
2026-09-01 16:24:20 : DEBUG : bitwarden : updateTool=
2026-09-01 16:24:20 : DEBUG : bitwarden : updateToolArguments=
2026-09-01 16:24:20 : DEBUG : bitwarden : updateToolRunAsCurrentUser=
2026-09-01 16:24:20 : INFO  : bitwarden : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 16:24:20 : INFO  : bitwarden : NOTIFY=success
2026-09-01 16:24:20 : INFO  : bitwarden : LOGGING=DEBUG
2026-09-01 16:24:20 : INFO  : bitwarden : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 16:24:20 : INFO  : bitwarden : Label type: dmg
2026-09-01 16:24:20 : INFO  : bitwarden : archiveName: Bitwarden.dmg
2026-09-01 16:24:21 : INFO  : bitwarden : no blocking processes defined, using Bitwarden as default
2026-09-01 16:24:21 : DEBUG : bitwarden : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 16:24:21 : INFO  : bitwarden : name: Bitwarden, appName: Bitwarden.app
2026-09-01 16:24:21 : WARN  : bitwarden : No previous app found
2026-09-01 16:24:21 : WARN  : bitwarden : could not find Bitwarden.app
2026-09-01 16:24:21 : INFO  : bitwarden : appversion: 
2026-09-01 16:24:21 : INFO  : bitwarden : Latest version of Bitwarden is 2026.8.0
2026-09-01 16:24:21 : REQ   : bitwarden : Downloading https://vault.bitwarden.com/download/?app=desktop&platform=macos to Bitwarden.dmg
2026-09-01 16:24:21 : DEBUG : bitwarden : No Dialog connection, just download
2026-09-01 16:24:30 : INFO  : bitwarden : Downloaded Bitwarden.dmg – Type is  zlib compressed data – SHA is 9a55e78d2d9c3f44debcfdb4ba0d2e18dff28af2 – Size is 279516 kB
2026-09-01 16:24:30 : DEBUG : bitwarden : DEBUG mode 1, not checking for blocking processes
2026-09-01 16:24:30 : REQ   : bitwarden : Installing Bitwarden
2026-09-01 16:24:30 : INFO  : bitwarden : Mounting /Users/u0105821/git/github/Installomator/build/Bitwarden.dmg
2026-09-01 16:24:34 : DEBUG : bitwarden : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $BCC0D0E6
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $7551EC5A
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $FE46A0E0
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $9CAF2EE2
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $FE46A0E0
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $CA4A5A3D
verified   CRC32 $0FDD7D0D
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/Bitwarden 2026.8.0-universal

2026-09-01 16:24:34 : INFO  : bitwarden : Mounted: /Volumes/Bitwarden 2026.8.0-universal
2026-09-01 16:24:34 : INFO  : bitwarden : Verifying: /Volumes/Bitwarden 2026.8.0-universal/Bitwarden.app
2026-09-01 16:24:34 : DEBUG : bitwarden : App size: 709M	/Volumes/Bitwarden 2026.8.0-universal/Bitwarden.app
2026-09-01 16:24:38 : DEBUG : bitwarden : Debugging enabled, App Verification output was:
/Volumes/Bitwarden 2026.8.0-universal/Bitwarden.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Bitwarden Inc (LTZ2PFU5D6)

2026-09-01 16:24:38 : INFO  : bitwarden : Team ID matching: LTZ2PFU5D6 (expected: LTZ2PFU5D6 )
2026-09-01 16:24:38 : INFO  : bitwarden : Installing Bitwarden version 2026.8.0 on versionKey CFBundleShortVersionString.
2026-09-01 16:24:38 : INFO  : bitwarden : App has LSMinimumSystemVersion: 12.0
2026-09-01 16:24:38 : DEBUG : bitwarden : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-01 16:24:38 : INFO  : bitwarden : Finishing...
2026-09-01 16:24:41 : INFO  : bitwarden : name: Bitwarden, appName: Bitwarden.app
2026-09-01 16:24:41 : WARN  : bitwarden : No previous app found
2026-09-01 16:24:41 : WARN  : bitwarden : could not find Bitwarden.app
2026-09-01 16:24:41 : REQ   : bitwarden : Installed Bitwarden, version 2026.8.0
2026-09-01 16:24:41 : INFO  : bitwarden : notifying
2026-09-01 16:24:42 : DEBUG : bitwarden : Unmounting /Volumes/Bitwarden 2026.8.0-universal
2026-09-01 16:24:42 : DEBUG : bitwarden : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-01 16:24:42 : DEBUG : bitwarden : DEBUG mode 1, not reopening anything
2026-09-01 16:24:42 : REQ   : bitwarden : All done!
2026-09-01 16:24:42 : REQ   : bitwarden : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
