### PR TITLE
ltspice-new-label

### DIFF
--- a/fragments/labels/ltspice.sh
+++ b/fragments/labels/ltspice.sh
@@ -1,8 +1,8 @@
 ltspice)
     name="LTspice"
     type="pkg"
-    packageID="com.analog.ltspice"
     downloadURL="https://ltspice.analog.com/software/LTspice_26.pkg"
-    appNewVersion=$(curl -fsL "https://formulae.brew.sh/api/cask/ltspice.json" | sed -nE 's/.*"version":"([^"]+)".*/\1/p' | head -n 1)
+    appNewVersion=$(curl -fsL "https://formulae.brew.sh/api/cask/ltspice.json" | sed -nE 's/.*"version":"([^"]+)".*/\1.1/p' | head -n 1)
+    versionKey="CFBundleVersion"
     expectedTeamID="6ZM4J3A422"
     ;;

--- a/fragments/labels/ltspice.sh
+++ b/fragments/labels/ltspice.sh
@@ -1,0 +1,8 @@
+ltspice)
+    name="LTspice"
+    type="pkg"
+    packageID="com.analog.ltspice"
+    downloadURL="https://ltspice.analog.com/software/LTspice_26.pkg"
+    appNewVersion=$(curl -fsL "https://formulae.brew.sh/api/cask/ltspice.json" | sed -nE 's/.*"version":"([^"]+)".*/\1/p' | head -n 1)
+    expectedTeamID="6ZM4J3A422"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the original because it targets the current Analog-supported LTspice 26 macOS installer instead of the older LTspice.pkg package, which currently installs LTspice 17.2.4 and is listed by Analog as an end-of-support macOS download. It also avoids relying on the old package receipt ID com.analog.LTspice; since the LTspice 26 package installs LTspice.app into /Applications, Installomator can use standard app bundle version detection instead. The updated label sets versionKey="CFBundleVersion" and uses an appNewVersion value that matches the app bundle’s version format, 26.0.2.1, which helps prevent mismatched version comparisons. Overall, the revised label follows current Installomator conventions more closely, uses the current LTspice 26 package URL, verifies against the same Team ID, and avoids brittle HTML scraping of Analog’s product page.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh ltspice DEBUG=1
2026-09-01 16:44:24 : INFO  : ltspice : setting variable from argument DEBUG=1
2026-09-01 16:44:24 : INFO  : ltspice : Total items in argumentsArray: 1
2026-09-01 16:44:24 : INFO  : ltspice : argumentsArray: DEBUG=1
2026-09-01 16:44:24 : REQ   : ltspice : ################## Start Installomator v. 10.10beta, date 2026-09-01
2026-09-01 16:44:25 : INFO  : ltspice : ################## Version: 10.10beta
2026-09-01 16:44:25 : INFO  : ltspice : ################## Date: 2026-09-01
2026-09-01 16:44:25 : INFO  : ltspice : ################## ltspice
2026-09-01 16:44:25 : DEBUG : ltspice : DEBUG mode 1 enabled.
2026-09-01 16:44:25 : INFO  : ltspice : Reading arguments again: DEBUG=1
2026-09-01 16:44:25 : DEBUG : ltspice : argument: DEBUG=1
2026-09-01 16:44:25 : DEBUG : ltspice : name=LTspice
2026-09-01 16:44:25 : DEBUG : ltspice : appName=
2026-09-01 16:44:25 : DEBUG : ltspice : type=pkg
2026-09-01 16:44:25 : DEBUG : ltspice : archiveName=
2026-09-01 16:44:25 : DEBUG : ltspice : downloadURL=https://ltspice.analog.com/software/LTspice_26.pkg
2026-09-01 16:44:25 : DEBUG : ltspice : curlOptions=
2026-09-01 16:44:26 : DEBUG : ltspice : appNewVersion=26.0.2.1
2026-09-01 16:44:26 : DEBUG : ltspice : appCustomVersion function: Not defined
2026-09-01 16:44:26 : DEBUG : ltspice : versionKey=CFBundleVersion
2026-09-01 16:44:26 : DEBUG : ltspice : packageID=
2026-09-01 16:44:26 : DEBUG : ltspice : pkgName=
2026-09-01 16:44:26 : DEBUG : ltspice : choiceChangesXML=
2026-09-01 16:44:26 : DEBUG : ltspice : expectedTeamID=6ZM4J3A422
2026-09-01 16:44:26 : DEBUG : ltspice : blockingProcesses=
2026-09-01 16:44:26 : DEBUG : ltspice : installerTool=
2026-09-01 16:44:26 : DEBUG : ltspice : CLIInstaller=
2026-09-01 16:44:26 : DEBUG : ltspice : CLIArguments=
2026-09-01 16:44:26 : DEBUG : ltspice : updateTool=
2026-09-01 16:44:26 : DEBUG : ltspice : updateToolArguments=
2026-09-01 16:44:26 : DEBUG : ltspice : updateToolRunAsCurrentUser=
2026-09-01 16:44:26 : INFO  : ltspice : BLOCKING_PROCESS_ACTION=tell_user
2026-09-01 16:44:26 : INFO  : ltspice : NOTIFY=success
2026-09-01 16:44:26 : INFO  : ltspice : LOGGING=DEBUG
2026-09-01 16:44:26 : INFO  : ltspice : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-01 16:44:26 : INFO  : ltspice : Label type: pkg
2026-09-01 16:44:26 : INFO  : ltspice : archiveName: LTspice.pkg
2026-09-01 16:44:26 : INFO  : ltspice : no blocking processes defined, using LTspice as default
2026-09-01 16:44:26 : DEBUG : ltspice : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-01 16:44:26 : INFO  : ltspice : name: LTspice, appName: LTspice.app
2026-09-01 16:44:26 : WARN  : ltspice : No previous app found
2026-09-01 16:44:26 : WARN  : ltspice : could not find LTspice.app
2026-09-01 16:44:26 : INFO  : ltspice : appversion: 
2026-09-01 16:44:26 : INFO  : ltspice : Latest version of LTspice is 26.0.2.1
2026-09-01 16:44:26 : INFO  : ltspice : LTspice.pkg exists and DEBUG mode 1 enabled, skipping download
2026-09-01 16:44:26 : DEBUG : ltspice : DEBUG mode 1, not checking for blocking processes
2026-09-01 16:44:26 : REQ   : ltspice : Installing LTspice
2026-09-01 16:44:26 : INFO  : ltspice : Verifying: LTspice.pkg
2026-09-01 16:44:26 : DEBUG : ltspice : File list: -rw-r--r--  1 root  staff   369M Sep  1 16:36 LTspice.pkg
2026-09-01 16:44:26 : DEBUG : ltspice : File type: LTspice.pkg: xar archive compressed TOC: 4999, SHA-1 checksum
2026-09-01 16:44:26 : DEBUG : ltspice : spctlOut is LTspice.pkg: accepted
2026-09-01 16:44:26 : DEBUG : ltspice : source=Notarized Developer ID
2026-09-01 16:44:26 : DEBUG : ltspice : origin=Developer ID Installer: German Ergueta (6ZM4J3A422)
2026-09-01 16:44:27 : INFO  : ltspice : Team ID: 6ZM4J3A422 (expected: 6ZM4J3A422 )
2026-09-01 16:44:27 : DEBUG : ltspice : DEBUG enabled, skipping installation
2026-09-01 16:44:27 : INFO  : ltspice : Finishing...
2026-09-01 16:44:30 : INFO  : ltspice : name: LTspice, appName: LTspice.app
2026-09-01 16:44:30 : WARN  : ltspice : No previous app found
2026-09-01 16:44:30 : WARN  : ltspice : could not find LTspice.app
2026-09-01 16:44:30 : REQ   : ltspice : Installed LTspice, version 26.0.2.1
2026-09-01 16:44:30 : INFO  : ltspice : notifying
2026-09-01 16:44:30 : DEBUG : ltspice : DEBUG mode 1, not reopening anything
2026-09-01 16:44:30 : REQ   : ltspice : All done!
2026-09-01 16:44:30 : REQ   : ltspice : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
