### PR TITLE
antigravity-label-update

### DIFF
--- a/fragments/labels/antigravity.sh
+++ b/fragments/labels/antigravity.sh
@@ -1,0 +1,13 @@
+antigravity)
+    name="Antigravity"
+    type="dmg"
+    antigravityDownloadPage=$(curl -fsL --compressed "https://antigravity.google/download")
+    if [[ $(arch) == "arm64" ]]; then
+        antigravityArch="darwin-arm"
+    else
+        antigravityArch="darwin-x64"
+    fi
+    downloadURL=$(echo "$antigravityDownloadPage" | grep -Eo "https://storage\\.googleapis\\.com/antigravity-public/antigravity-hub/[0-9]+(\\.[0-9]+)+-[0-9]+/${antigravityArch}/Antigravity\\.dmg" | head -n 1)
+    appNewVersion=$(echo "$downloadURL" | sed -E 's#.*/antigravity-hub/([0-9]+(\.[0-9]+)+)-[0-9]+/darwin-.*/Antigravity\.dmg$#\1#')
+    expectedTeamID="EQHXZ8M8AV"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better than the original because it uses the current direct DMG URLs exposed on Google’s official Antigravity download page instead of chasing a hashed JavaScript bundle and matching an older edgedl URL pattern. Verification showed the current page provides separate darwin-arm and darwin-x64 DMGs for version 2.11.0, the selected DMG contains Antigravity.app, the app reports version 2.11.0, and the signature matches Google’s Team ID EQHXZ8M8AV.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh antigravity DEBUG=1
2026-09-02 08:11:59 : INFO  : antigravity : setting variable from argument DEBUG=1
2026-09-02 08:11:59 : INFO  : antigravity : Total items in argumentsArray: 1
2026-09-02 08:11:59 : INFO  : antigravity : argumentsArray: DEBUG=1
2026-09-02 08:11:59 : REQ   : antigravity : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 08:11:59 : INFO  : antigravity : ################## Version: 10.10beta
2026-09-02 08:11:59 : INFO  : antigravity : ################## Date: 2026-09-02
2026-09-02 08:11:59 : INFO  : antigravity : ################## antigravity
2026-09-02 08:11:59 : DEBUG : antigravity : DEBUG mode 1 enabled.
2026-09-02 08:12:00 : INFO  : antigravity : Reading arguments again: DEBUG=1
2026-09-02 08:12:00 : DEBUG : antigravity : argument: DEBUG=1
2026-09-02 08:12:00 : DEBUG : antigravity : name=Antigravity
2026-09-02 08:12:00 : DEBUG : antigravity : appName=
2026-09-02 08:12:00 : DEBUG : antigravity : type=dmg
2026-09-02 08:12:00 : DEBUG : antigravity : archiveName=
2026-09-02 08:12:00 : DEBUG : antigravity : downloadURL=https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/darwin-arm/Antigravity.dmg
2026-09-02 08:12:00 : DEBUG : antigravity : curlOptions=
2026-09-02 08:12:00 : DEBUG : antigravity : appNewVersion=2.11.0
2026-09-02 08:12:00 : DEBUG : antigravity : appCustomVersion function: Not defined
2026-09-02 08:12:00 : DEBUG : antigravity : versionKey=CFBundleShortVersionString
2026-09-02 08:12:00 : DEBUG : antigravity : packageID=
2026-09-02 08:12:00 : DEBUG : antigravity : pkgName=
2026-09-02 08:12:00 : DEBUG : antigravity : choiceChangesXML=
2026-09-02 08:12:00 : DEBUG : antigravity : expectedTeamID=EQHXZ8M8AV
2026-09-02 08:12:00 : DEBUG : antigravity : blockingProcesses=
2026-09-02 08:12:00 : DEBUG : antigravity : installerTool=
2026-09-02 08:12:00 : DEBUG : antigravity : CLIInstaller=
2026-09-02 08:12:00 : DEBUG : antigravity : CLIArguments=
2026-09-02 08:12:00 : DEBUG : antigravity : updateTool=
2026-09-02 08:12:00 : DEBUG : antigravity : updateToolArguments=
2026-09-02 08:12:00 : DEBUG : antigravity : updateToolRunAsCurrentUser=
2026-09-02 08:12:00 : INFO  : antigravity : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 08:12:00 : INFO  : antigravity : NOTIFY=success
2026-09-02 08:12:00 : INFO  : antigravity : LOGGING=DEBUG
2026-09-02 08:12:00 : INFO  : antigravity : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 08:12:00 : INFO  : antigravity : Label type: dmg
2026-09-02 08:12:00 : INFO  : antigravity : archiveName: Antigravity.dmg
2026-09-02 08:12:00 : INFO  : antigravity : no blocking processes defined, using Antigravity as default
2026-09-02 08:12:00 : DEBUG : antigravity : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 08:12:00 : INFO  : antigravity : name: Antigravity, appName: Antigravity.app
2026-09-02 08:12:01 : WARN  : antigravity : No previous app found
2026-09-02 08:12:01 : WARN  : antigravity : could not find Antigravity.app
2026-09-02 08:12:01 : INFO  : antigravity : appversion: 
2026-09-02 08:12:01 : INFO  : antigravity : Latest version of Antigravity is 2.11.0
2026-09-02 08:12:01 : REQ   : antigravity : Downloading https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/darwin-arm/Antigravity.dmg to Antigravity.dmg
2026-09-02 08:12:01 : DEBUG : antigravity : No Dialog connection, just download
2026-09-02 08:12:04 : INFO  : antigravity : Downloaded Antigravity.dmg – Type is  zlib compressed data – SHA is ba10a23da811fd9a9da77b1bf5d0d345195bcb0e – Size is 194968 kB
2026-09-02 08:12:04 : DEBUG : antigravity : DEBUG mode 1, not checking for blocking processes
2026-09-02 08:12:04 : REQ   : antigravity : Installing Antigravity
2026-09-02 08:12:04 : INFO  : antigravity : Mounting /Users/u0105821/git/github/Installomator/build/Antigravity.dmg
2026-09-02 08:12:08 : DEBUG : antigravity : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $08A9B4A7
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $8DB0C8CA
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $CF225776
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_APFS : 4)…
disk image (Apple_APFS : 4): verified   CRC32 $EC135383
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $CF225776
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $29234BB0
verified   CRC32 $0AD6CEF5
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_APFS
/dev/disk9          	EF57347C-0000-11AA-AA11-0030654
/dev/disk9s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Antigravity

2026-09-02 08:12:08 : INFO  : antigravity : Mounted: /Volumes/Antigravity
2026-09-02 08:12:08 : INFO  : antigravity : Verifying: /Volumes/Antigravity/Antigravity.app
2026-09-02 08:12:08 : DEBUG : antigravity : App size: 436M	/Volumes/Antigravity/Antigravity.app
2026-09-02 08:12:10 : DEBUG : antigravity : Debugging enabled, App Verification output was:
/Volumes/Antigravity/Antigravity.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Google LLC (EQHXZ8M8AV)

2026-09-02 08:12:10 : INFO  : antigravity : Team ID matching: EQHXZ8M8AV (expected: EQHXZ8M8AV )
2026-09-02 08:12:10 : INFO  : antigravity : Installing Antigravity version 2.11.0 on versionKey CFBundleShortVersionString.
2026-09-02 08:12:10 : INFO  : antigravity : App has LSMinimumSystemVersion: 12.0
2026-09-02 08:12:10 : DEBUG : antigravity : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 08:12:10 : INFO  : antigravity : Finishing...
2026-09-02 08:12:13 : INFO  : antigravity : name: Antigravity, appName: Antigravity.app
2026-09-02 08:12:13 : WARN  : antigravity : No previous app found
2026-09-02 08:12:13 : WARN  : antigravity : could not find Antigravity.app
2026-09-02 08:12:13 : REQ   : antigravity : Installed Antigravity, version 2.11.0
2026-09-02 08:12:13 : INFO  : antigravity : notifying
2026-09-02 08:12:13 : DEBUG : antigravity : Unmounting /Volumes/Antigravity
2026-09-02 08:12:13 : DEBUG : antigravity : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-02 08:12:13 : DEBUG : antigravity : DEBUG mode 1, not reopening anything
2026-09-02 08:12:13 : REQ   : antigravity : All done!
2026-09-02 08:12:13 : REQ   : antigravity : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
