### PR TITLE
dbeaverteam-label-update

### DIFF
--- a/fragments/labels/dbeaverteam.sh
+++ b/fragments/labels/dbeaverteam.sh
@@ -2,11 +2,11 @@ dbeaverteam)
     name="DBeaverTeam"
     type="dmg"
     if [[ $(arch) == "arm64" ]]; then
-        downloadURL="https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg"
-    elif [[ $(arch) == "i386" ]]; then
-        downloadURL="https://dbeaver.com/files/dbeaver-te-latest-macos-x86_64.dmg"
+        dbeaverArch="aarch64"
+    else
+        dbeaverArch="x86_64"
     fi
-    appNewVersion=$(curl -fsI -o /dev/null -w '%{redirect_url}' "$downloadURL" | sed -E 's|.*/dbeaver-te-([0-9]+(\.[0-9]+)+)-macos-(aarch64|x86_64)\.dmg|\1|')
+    downloadURL="https://dbeaver.com/files/dbeaver-te-latest-macos-${dbeaverArch}.dmg"
+    appNewVersion=$(curl -fsIL -o /dev/null -w "%{url_effective}" "$downloadURL" | sed -E 's#.*/team/([0-9]+(\.[0-9]+)+)/.*#\1#')
     expectedTeamID="42B6MDKMW8"
-    blockingProcesses=( dbeaver )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label uses DBeaver’s official architecture-specific “latest” URLs while keeping the logic cleaner and more reliable. It supports both Apple Silicon and Intel Macs, extracts appNewVersion from the final effective redirect URL, and uses a stricter version-matching regex so Installomator can correctly compare installed versus current versions.
It also avoids unnecessary variables. The DMG was verified to contain DBeaverTeam.app, so name="DBeaverTeam" is enough and no appName is needed. The default version key works, the Team ID 42B6MDKMW8 was verified, and blockingProcesses can be omitted unless there is a proven need for a custom process name.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```# sudo Installomator/utils/assemble.sh dbeaverteam DEBUG=1
2026-09-02 09:24:51 : INFO  : dbeaverteam : setting variable from argument DEBUG=1
2026-09-02 09:24:51 : INFO  : dbeaverteam : Total items in argumentsArray: 1
2026-09-02 09:24:51 : INFO  : dbeaverteam : argumentsArray: DEBUG=1
2026-09-02 09:24:51 : REQ   : dbeaverteam : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 09:24:51 : INFO  : dbeaverteam : ################## Version: 10.10beta
2026-09-02 09:24:51 : INFO  : dbeaverteam : ################## Date: 2026-09-02
2026-09-02 09:24:51 : INFO  : dbeaverteam : ################## dbeaverteam
2026-09-02 09:24:51 : DEBUG : dbeaverteam : DEBUG mode 1 enabled.
2026-09-02 09:24:52 : INFO  : dbeaverteam : Reading arguments again: DEBUG=1
2026-09-02 09:24:52 : DEBUG : dbeaverteam : argument: DEBUG=1
2026-09-02 09:24:52 : DEBUG : dbeaverteam : name=DBeaverTeam
2026-09-02 09:24:52 : DEBUG : dbeaverteam : appName=
2026-09-02 09:24:52 : DEBUG : dbeaverteam : type=dmg
2026-09-02 09:24:52 : DEBUG : dbeaverteam : archiveName=
2026-09-02 09:24:52 : DEBUG : dbeaverteam : downloadURL=https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg
2026-09-02 09:24:52 : DEBUG : dbeaverteam : curlOptions=
2026-09-02 09:24:52 : DEBUG : dbeaverteam : appNewVersion=26.1.0
2026-09-02 09:24:52 : DEBUG : dbeaverteam : appCustomVersion function: Not defined
2026-09-02 09:24:52 : DEBUG : dbeaverteam : versionKey=CFBundleShortVersionString
2026-09-02 09:24:52 : DEBUG : dbeaverteam : packageID=
2026-09-02 09:24:52 : DEBUG : dbeaverteam : pkgName=
2026-09-02 09:24:52 : DEBUG : dbeaverteam : choiceChangesXML=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : expectedTeamID=42B6MDKMW8
2026-09-02 09:24:53 : DEBUG : dbeaverteam : blockingProcesses=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : installerTool=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : CLIInstaller=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : CLIArguments=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : updateTool=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : updateToolArguments=
2026-09-02 09:24:53 : DEBUG : dbeaverteam : updateToolRunAsCurrentUser=
2026-09-02 09:24:53 : INFO  : dbeaverteam : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 09:24:53 : INFO  : dbeaverteam : NOTIFY=success
2026-09-02 09:24:53 : INFO  : dbeaverteam : LOGGING=DEBUG
2026-09-02 09:24:53 : INFO  : dbeaverteam : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 09:24:53 : INFO  : dbeaverteam : Label type: dmg
2026-09-02 09:24:53 : INFO  : dbeaverteam : archiveName: DBeaverTeam.dmg
2026-09-02 09:24:53 : INFO  : dbeaverteam : no blocking processes defined, using DBeaverTeam as default
2026-09-02 09:24:53 : DEBUG : dbeaverteam : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 09:24:53 : INFO  : dbeaverteam : name: DBeaverTeam, appName: DBeaverTeam.app
2026-09-02 09:24:53 : WARN  : dbeaverteam : No previous app found
2026-09-02 09:24:53 : WARN  : dbeaverteam : could not find DBeaverTeam.app
2026-09-02 09:24:53 : INFO  : dbeaverteam : appversion: 
2026-09-02 09:24:53 : INFO  : dbeaverteam : Latest version of DBeaverTeam is 26.1.0
2026-09-02 09:24:53 : REQ   : dbeaverteam : Downloading https://dbeaver.com/files/dbeaver-te-latest-macos-aarch64.dmg to DBeaverTeam.dmg
2026-09-02 09:24:54 : DEBUG : dbeaverteam : No Dialog connection, just download
2026-09-02 09:24:59 : INFO  : dbeaverteam : Downloaded DBeaverTeam.dmg – Type is  zlib compressed data – SHA is eae689edc851c6db3fc07a2bf171896a64582ea2 – Size is 359516 kB
2026-09-02 09:24:59 : DEBUG : dbeaverteam : DEBUG mode 1, not checking for blocking processes
2026-09-02 09:24:59 : REQ   : dbeaverteam : Installing DBeaverTeam
2026-09-02 09:24:59 : INFO  : dbeaverteam : Mounting /Users/u0105821/git/github/Installomator/build/DBeaverTeam.dmg
2026-09-02 09:25:02 : DEBUG : dbeaverteam : Debugging enabled, dmgmount output was:
End-User License Agreement

IMPORTANT -  READ CAREFULLY: This End-User License Agreement ("EULA")
is a legal agreement between you and DBeaver Corporation to regulate
your use of the DBeaver software and its related components.
.
.
.
Licensor represents, warrants, and covenants that it and each of
its affiliates and their respective agents and subcontractors (i)
use and will continue to use commercially reasonable efforts to
ensure that there is no slavery, human trafficking, and/or child
or forced labor in any part of their respective businesses or supply
chain; (ii) have not, and their respective directors, officers, and
employees have not, been convicted of any offense involving slavery,
human trafficking, and/or child or forced labor; and (iii) are not
currently and have not in the past been the subject of any
investigation, inquiry, or enforcement proceedings in relation to
an alleged offense in connection with slavery, human trafficking,
and/or child or forced labor.
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $640FF198
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $B812F0FB
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $EB8CEEB0
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $89941E99
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $EB8CEEB0
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $FE644846
verified   CRC32 $34D12575
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/DBeaver Team

2026-09-02 09:25:02 : INFO  : dbeaverteam : Mounted: /Volumes/DBeaver Team
2026-09-02 09:25:02 : INFO  : dbeaverteam : Verifying: /Volumes/DBeaver Team/DBeaverTeam.app
2026-09-02 09:25:02 : DEBUG : dbeaverteam : App size: 449M	/Volumes/DBeaver Team/DBeaverTeam.app
2026-09-02 09:25:06 : DEBUG : dbeaverteam : Debugging enabled, App Verification output was:
/Volumes/DBeaver Team/DBeaverTeam.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: DBeaver Corporation (42B6MDKMW8)

2026-09-02 09:25:06 : INFO  : dbeaverteam : Team ID matching: 42B6MDKMW8 (expected: 42B6MDKMW8 )
2026-09-02 09:25:06 : INFO  : dbeaverteam : Installing DBeaverTeam version 26.1.0 on versionKey CFBundleShortVersionString.
2026-09-02 09:25:06 : DEBUG : dbeaverteam : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 09:25:06 : INFO  : dbeaverteam : Finishing...
2026-09-02 09:25:09 : INFO  : dbeaverteam : name: DBeaverTeam, appName: DBeaverTeam.app
2026-09-02 09:25:09 : WARN  : dbeaverteam : No previous app found
2026-09-02 09:25:09 : WARN  : dbeaverteam : could not find DBeaverTeam.app
2026-09-02 09:25:09 : REQ   : dbeaverteam : Installed DBeaverTeam, version 26.1.0
2026-09-02 09:25:09 : INFO  : dbeaverteam : notifying
2026-09-02 09:25:10 : DEBUG : dbeaverteam : Unmounting /Volumes/DBeaver Team
2026-09-02 09:25:10 : DEBUG : dbeaverteam : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-02 09:25:10 : DEBUG : dbeaverteam : DEBUG mode 1, not reopening anything
2026-09-02 09:25:10 : REQ   : dbeaverteam : All done!
2026-09-02 09:25:10 : REQ   : dbeaverteam : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
