### PR TITLE
Update appsanywhere.sh

### DIFF
--- a/fragments/labels/appsanywhere.sh
+++ b/fragments/labels/appsanywhere.sh
@@ -1,22 +1,9 @@
 appsanywhere)
-    name="AppsAnywhere Client (macOS)"
+    name="AppsAnywhere"
     type="pkg"
-    aaClientReleasePage="https://docs.appsanywhere.com/appsanywhere/3.2/appsanywhere-client-macos"
-    latestVersion="$(
-      /usr/bin/curl -fsSL "$aaClientReleasePage" \
-      | /usr/bin/sed -nE 's/.*id="AppsAnywhereClient\(macOS\)-Version([0-9]+\.[0-9]+\.[0-9]+)\(CurrentVersion\)".*/\1/p' \
-      | /usr/bin/head -n 1
-    )"
-    if [[ -z "$latestVersion" ]]; then
-        printlog "ERROR: Could not determine latest AppsAnywhere macOS client version from $aaClientReleasePage"
-        cleanupAndExit 99
-    fi
-    downloadURL="https://files.appsanywhere.com/clients/appsanywhere/mac/${latestVersion}/apps-anywhere-setup-InstitutionId-${latestVersion}.pkg"
-    pkgName="apps-anywhere-setup-InstitutionId-${latestVersion}.pkg"
+    appName="Applications/AppsAnywhere/AppsAnywhere.app"
+    appsAnywhereLatestPath=$(curl -fsSL "https://docs.appsanywhere.com/client/-/macos-client-release-notes" | tr -d '\n' | grep -Eo '<a[^>]+href="[^"]*macos(-client)?-[0-9]+-[0-9]+(-[0-9]+)?"[^>]*>[^<]*macOS[[:space:]]+Client[[:space:]]+[0-9]+\.[0-9]+' | sed -E 's/.*href="([^"]*)".*/\1/' | head -n 1)
+    appNewVersion=$(curl -fsSL "https://docs.appsanywhere.com${appsAnywhereLatestPath}" | sed -nE 's/.*Version[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1)
+    downloadURL="https://files.appsanywhere.com/clients/appsanywhere/mac/${appNewVersion}/apps-anywhere-setup-InstitutionId-${appNewVersion}.pkg"
     expectedTeamID="9ZNX23CMVD"
-    appCustomVersion(){
-        /usr/bin/defaults read "/Applications/AppsAnywhere/AppsAnywhere.app/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "0"
-    }
-    appNewVersion="$latestVersion"
-    updateTool="/Applications/AppsAnywhere/AppsAnywhere Updater.app/Contents/MacOS/AppsAnywhere Updater"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The updated AppsAnywhere label is better because it checks the actual installed app bundle instead of relying on the package receipt. Since the PKG installs AppsAnywhere.app at /Applications/AppsAnywhere/AppsAnywhere.app, using appName="Applications/AppsAnywhere/AppsAnywhere.app" lets Installomator find that exact app path when targetDir="/" is used for pkg installs.

This avoids packageID, which Installomator checks first and can return a version from a receipt even if the app was later removed. The updated label also keeps the version/download logic readable by first finding the latest macOS client release page, then extracting appNewVersion, then building the official download URL. Live verification confirmed version 2.3.0, a valid signed/notarized PKG, Team ID 9ZNX23CMVD, and the expected app payload path.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh appsanywhere DEBUG=1
2026-09-02 10:16:14 : INFO  : appsanywhere : setting variable from argument DEBUG=1
2026-09-02 10:16:14 : INFO  : appsanywhere : Total items in argumentsArray: 1
2026-09-02 10:16:14 : INFO  : appsanywhere : argumentsArray: DEBUG=1
2026-09-02 10:16:14 : REQ   : appsanywhere : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 10:16:14 : INFO  : appsanywhere : ################## Version: 10.10beta
2026-09-02 10:16:14 : INFO  : appsanywhere : ################## Date: 2026-09-02
2026-09-02 10:16:14 : INFO  : appsanywhere : ################## appsanywhere
2026-09-02 10:16:14 : DEBUG : appsanywhere : DEBUG mode 1 enabled.
2026-09-02 10:16:15 : INFO  : appsanywhere : Reading arguments again: DEBUG=1
2026-09-02 10:16:15 : DEBUG : appsanywhere : argument: DEBUG=1
2026-09-02 10:16:15 : DEBUG : appsanywhere : name=AppsAnywhere
2026-09-02 10:16:15 : DEBUG : appsanywhere : appName=Applications/AppsAnywhere/AppsAnywhere.app
2026-09-02 10:16:15 : DEBUG : appsanywhere : type=pkg
2026-09-02 10:16:15 : DEBUG : appsanywhere : archiveName=
2026-09-02 10:16:15 : DEBUG : appsanywhere : downloadURL=https://files.appsanywhere.com/clients/appsanywhere/mac/2.3.0/apps-anywhere-setup-InstitutionId-2.3.0.pkg
2026-09-02 10:16:15 : DEBUG : appsanywhere : curlOptions=
2026-09-02 10:16:15 : DEBUG : appsanywhere : appNewVersion=2.3.0
2026-09-02 10:16:15 : DEBUG : appsanywhere : appCustomVersion function: Not defined
2026-09-02 10:16:15 : DEBUG : appsanywhere : versionKey=CFBundleShortVersionString
2026-09-02 10:16:15 : DEBUG : appsanywhere : packageID=
2026-09-02 10:16:15 : DEBUG : appsanywhere : pkgName=
2026-09-02 10:16:15 : DEBUG : appsanywhere : choiceChangesXML=
2026-09-02 10:16:15 : DEBUG : appsanywhere : expectedTeamID=9ZNX23CMVD
2026-09-02 10:16:15 : DEBUG : appsanywhere : blockingProcesses=
2026-09-02 10:16:16 : DEBUG : appsanywhere : installerTool=
2026-09-02 10:16:16 : DEBUG : appsanywhere : CLIInstaller=
2026-09-02 10:16:16 : DEBUG : appsanywhere : CLIArguments=
2026-09-02 10:16:16 : DEBUG : appsanywhere : updateTool=
2026-09-02 10:16:16 : DEBUG : appsanywhere : updateToolArguments=
2026-09-02 10:16:16 : DEBUG : appsanywhere : updateToolRunAsCurrentUser=
2026-09-02 10:16:16 : INFO  : appsanywhere : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 10:16:16 : INFO  : appsanywhere : NOTIFY=success
2026-09-02 10:16:16 : INFO  : appsanywhere : LOGGING=DEBUG
2026-09-02 10:16:16 : INFO  : appsanywhere : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 10:16:16 : INFO  : appsanywhere : Label type: pkg
2026-09-02 10:16:16 : INFO  : appsanywhere : archiveName: AppsAnywhere.pkg
2026-09-02 10:16:16 : INFO  : appsanywhere : no blocking processes defined, using AppsAnywhere as default
2026-09-02 10:16:16 : DEBUG : appsanywhere : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 10:16:16 : INFO  : appsanywhere : name: AppsAnywhere, appName: Applications/AppsAnywhere/AppsAnywhere.app
2026-09-02 10:16:17 : WARN  : appsanywhere : No previous app found
2026-09-02 10:16:17 : WARN  : appsanywhere : could not find Applications/AppsAnywhere/AppsAnywhere.app
2026-09-02 10:16:17 : INFO  : appsanywhere : appversion: 
2026-09-02 10:16:17 : INFO  : appsanywhere : Latest version of AppsAnywhere is 2.3.0
2026-09-02 10:16:17 : INFO  : appsanywhere : AppsAnywhere.pkg exists and DEBUG mode 1 enabled, skipping download
2026-09-02 10:16:17 : DEBUG : appsanywhere : DEBUG mode 1, not checking for blocking processes
2026-09-02 10:16:17 : REQ   : appsanywhere : Installing AppsAnywhere
2026-09-02 10:16:17 : INFO  : appsanywhere : Verifying: AppsAnywhere.pkg
2026-09-02 10:16:17 : DEBUG : appsanywhere : File list: -rw-r--r--  1 root  staff   3.5M Sep  1 17:03 AppsAnywhere.pkg
2026-09-02 10:16:17 : DEBUG : appsanywhere : File type: AppsAnywhere.pkg: xar archive compressed TOC: 4496, SHA-1 checksum
2026-09-02 10:16:17 : DEBUG : appsanywhere : spctlOut is AppsAnywhere.pkg: accepted
2026-09-02 10:16:17 : DEBUG : appsanywhere : source=Notarized Developer ID
2026-09-02 10:16:17 : DEBUG : appsanywhere : origin=Developer ID Installer: AppsAnywhere Limited (9ZNX23CMVD)
2026-09-02 10:16:17 : INFO  : appsanywhere : Team ID: 9ZNX23CMVD (expected: 9ZNX23CMVD )
2026-09-02 10:16:17 : DEBUG : appsanywhere : DEBUG enabled, skipping installation
2026-09-02 10:16:17 : INFO  : appsanywhere : Finishing...
2026-09-02 10:16:20 : INFO  : appsanywhere : name: AppsAnywhere, appName: Applications/AppsAnywhere/AppsAnywhere.app
2026-09-02 10:16:21 : WARN  : appsanywhere : No previous app found
2026-09-02 10:16:21 : WARN  : appsanywhere : could not find Applications/AppsAnywhere/AppsAnywhere.app
2026-09-02 10:16:21 : REQ   : appsanywhere : Installed AppsAnywhere, version 2.3.0
2026-09-02 10:16:21 : INFO  : appsanywhere : notifying
2026-09-02 10:16:21 : DEBUG : appsanywhere : DEBUG mode 1, not reopening anything
2026-09-02 10:16:21 : REQ   : appsanywhere : All done!
2026-09-02 10:16:21 : REQ   : appsanywhere : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
