### PR TITLE
Create hpclick.sh

### DIFF
--- a/fragments/labels/hpclick.sh
+++ b/fragments/labels/hpclick.sh
@@ -1,0 +1,8 @@
+hpclick)
+    name="HP Click"
+    type="dmg"
+    hpClickData=$(curl -fsS -X POST "https://support.hp.com/wcc-services/swd-v2/driverDetails?authState=anonymous&template=SWDSeriesDownload" -H "Accept: application/json, text/plain, */*" -H "Content-Type: application/json" -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" -H "Origin: https://support.hp.com" -H "Referer: https://support.hp.com/us-en/drivers/hp-click-printing-software/15550865" -d '{"productLineCode":"GE","lc":"en","cc":"us","osTMSId":"18015185915131310124113888731054140111953115","osName":"Mac OS","productNumberOid":21355055,"productSeriesOid":15550865,"platformId":"275027708611380099388405694207665"}')
+    downloadURL=$(getJSONValue "$hpClickData" 'data.softwareTypes[0].softwareDriversList[0].latestVersionDriver.fileUrl')
+    appNewVersion=$(getJSONValue "$hpClickData" 'data.softwareTypes[0].softwareDriversList[0].latestVersionDriver.version')
+    expectedTeamID="6HB5Y2QTA3"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label uses HP’s structured support API, extracts the exact nested fileUrl and version fields with Installomator’s built-in getJSONValue, and removes unnecessary comments, conditionals, and redundant blockingProcesses. Live verification confirmed the API currently returns HP Click 4.8.117, downloads a real DMG, mounts HP Click.app, and matches Team ID 6HB5Y2QTA3.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh hpclick DEBUG=1
2026-09-02 10:42:05 : INFO  : hpclick : setting variable from argument DEBUG=1
2026-09-02 10:42:05 : INFO  : hpclick : Total items in argumentsArray: 1
2026-09-02 10:42:05 : INFO  : hpclick : argumentsArray: DEBUG=1
2026-09-02 10:42:05 : REQ   : hpclick : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 10:42:05 : INFO  : hpclick : ################## Version: 10.10beta
2026-09-02 10:42:05 : INFO  : hpclick : ################## Date: 2026-09-02
2026-09-02 10:42:05 : INFO  : hpclick : ################## hpclick
2026-09-02 10:42:05 : DEBUG : hpclick : DEBUG mode 1 enabled.
2026-09-02 10:42:06 : INFO  : hpclick : Reading arguments again: DEBUG=1
2026-09-02 10:42:06 : DEBUG : hpclick : argument: DEBUG=1
2026-09-02 10:42:06 : DEBUG : hpclick : name=HP Click
2026-09-02 10:42:06 : DEBUG : hpclick : appName=
2026-09-02 10:42:06 : DEBUG : hpclick : type=dmg
2026-09-02 10:42:06 : DEBUG : hpclick : archiveName=
2026-09-02 10:42:06 : DEBUG : hpclick : downloadURL=https://ftp.hp.com/pub/softlib/software13/printers/hpdesignjetclick/HPClick-4.8.117.dmg
2026-09-02 10:42:06 : DEBUG : hpclick : curlOptions=
2026-09-02 10:42:06 : DEBUG : hpclick : appNewVersion=4.8.117
2026-09-02 10:42:07 : DEBUG : hpclick : appCustomVersion function: Not defined
2026-09-02 10:42:07 : DEBUG : hpclick : versionKey=CFBundleShortVersionString
2026-09-02 10:42:07 : DEBUG : hpclick : packageID=
2026-09-02 10:42:07 : DEBUG : hpclick : pkgName=
2026-09-02 10:42:07 : DEBUG : hpclick : choiceChangesXML=
2026-09-02 10:42:07 : DEBUG : hpclick : expectedTeamID=6HB5Y2QTA3
2026-09-02 10:42:07 : DEBUG : hpclick : blockingProcesses=
2026-09-02 10:42:07 : DEBUG : hpclick : installerTool=
2026-09-02 10:42:07 : DEBUG : hpclick : CLIInstaller=
2026-09-02 10:42:07 : DEBUG : hpclick : CLIArguments=
2026-09-02 10:42:07 : DEBUG : hpclick : updateTool=
2026-09-02 10:42:07 : DEBUG : hpclick : updateToolArguments=
2026-09-02 10:42:07 : DEBUG : hpclick : updateToolRunAsCurrentUser=
2026-09-02 10:42:07 : INFO  : hpclick : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 10:42:07 : INFO  : hpclick : NOTIFY=success
2026-09-02 10:42:07 : INFO  : hpclick : LOGGING=DEBUG
2026-09-02 10:42:07 : INFO  : hpclick : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 10:42:07 : INFO  : hpclick : Label type: dmg
2026-09-02 10:42:07 : INFO  : hpclick : archiveName: HP Click.dmg
2026-09-02 10:42:07 : INFO  : hpclick : no blocking processes defined, using HP Click as default
2026-09-02 10:42:07 : DEBUG : hpclick : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 10:42:07 : INFO  : hpclick : name: HP Click, appName: HP Click.app
2026-09-02 10:42:07 : WARN  : hpclick : No previous app found
2026-09-02 10:42:07 : WARN  : hpclick : could not find HP Click.app
2026-09-02 10:42:07 : INFO  : hpclick : appversion: 
2026-09-02 10:42:07 : INFO  : hpclick : Latest version of HP Click is 4.8.117
2026-09-02 10:42:07 : REQ   : hpclick : Downloading https://ftp.hp.com/pub/softlib/software13/printers/hpdesignjetclick/HPClick-4.8.117.dmg to HP Click.dmg
2026-09-02 10:42:07 : DEBUG : hpclick : No Dialog connection, just download
2026-09-02 10:42:26 : INFO  : hpclick : Downloaded HP Click.dmg – Type is  zlib compressed data – SHA is 8af0dc2841d2364e15b52a67a0658adc2ee64841 – Size is 573476 kB
2026-09-02 10:42:26 : DEBUG : hpclick : DEBUG mode 1, not checking for blocking processes
2026-09-02 10:42:26 : REQ   : hpclick : Installing HP Click
2026-09-02 10:42:26 : INFO  : hpclick : Mounting /Users/u0105821/git/github/Installomator/build/HP Click.dmg
2026-09-02 10:42:30 : DEBUG : hpclick : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $5926A761
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $FC8EF971
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $E2628E68
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $7AF95841
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $E2628E68
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $AA44D4A9
verified   CRC32 $491D2D8D
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	EFI
/dev/disk8s2        	Apple_HFS                      	/Volumes/HP Click

2026-09-02 10:42:30 : INFO  : hpclick : Mounted: /Volumes/HP Click
2026-09-02 10:42:30 : INFO  : hpclick : Verifying: /Volumes/HP Click/HP Click.app
2026-09-02 10:42:30 : DEBUG : hpclick : App size: 1.4G	/Volumes/HP Click/HP Click.app
2026-09-02 10:42:35 : DEBUG : hpclick : Debugging enabled, App Verification output was:
/Volumes/HP Click/HP Click.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: HP Inc. (6HB5Y2QTA3)

2026-09-02 10:42:35 : INFO  : hpclick : Team ID matching: 6HB5Y2QTA3 (expected: 6HB5Y2QTA3 )
2026-09-02 10:42:35 : INFO  : hpclick : Installing HP Click version 4.8.117 on versionKey CFBundleShortVersionString.
2026-09-02 10:42:36 : INFO  : hpclick : App has LSMinimumSystemVersion: 12.0
2026-09-02 10:42:36 : DEBUG : hpclick : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 10:42:36 : INFO  : hpclick : Finishing...
2026-09-02 10:42:39 : INFO  : hpclick : name: HP Click, appName: HP Click.app
2026-09-02 10:42:39 : WARN  : hpclick : No previous app found
2026-09-02 10:42:39 : WARN  : hpclick : could not find HP Click.app
2026-09-02 10:42:39 : REQ   : hpclick : Installed HP Click, version 4.8.117
2026-09-02 10:42:39 : INFO  : hpclick : notifying
2026-09-02 10:42:39 : DEBUG : hpclick : Unmounting /Volumes/HP Click
2026-09-02 10:42:40 : DEBUG : hpclick : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-02 10:42:40 : DEBUG : hpclick : DEBUG mode 1, not reopening anything
2026-09-02 10:42:40 : REQ   : hpclick : All done!
2026-09-02 10:42:40 : REQ   : hpclick : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
