### PR TITLE
citrixworkspace-label-update

### DIFF
--- a/fragments/labels/citrixworkspace.sh
+++ b/fragments/labels/citrixworkspace.sh
@@ -1,9 +1,11 @@
 citrixworkspace)
     name="Citrix Workspace"
-    type="pkg"
-    parseURL=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/DownloadURL)' -)
-    downloadURL=https://downloadplugins.citrix.com/ReceiverUpdates/Prod/$parseURL
-    appNewVersion=$(curl -fs "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos.xml" | xmllint --xpath 'string(//Installer/Version)' -)
+    type="pkgInDmg"
+    pkgName="Install Citrix Workspace.pkg"
+    curlOptions=( --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36" )
+    citrixWorkspaceData=$(curl -fsL "https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html" "${curlOptions[@]}")
+    downloadURL="https:$(xmllint --html --xpath "string(//a[contains(@class, 'ctx-dl-link')]/@rel)" 2>/dev/null <(print "$citrixWorkspaceData"))"
+    appNewVersion=$(xmllint --html --xpath "string(//div[@class='ctx-dl-content']/p[starts-with(., 'Version')])" 2>/dev/null <(print "$citrixWorkspaceData") | sed -nE 's/.*Version[[:space:]]+([0-9.]+).*/\1/p')
     versionKey="CitrixVersionString"
     expectedTeamID="S272Y5R93J"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This version is better because it keeps the verified Citrix source and parsing approach, but only fetches the Citrix page once, uses the verified inner package name, and preserves the required CitrixVersionString version key. Live testing confirmed the current page resolves version 26.07.0.76, downloads a real DMG, contains Install Citrix Workspace.pkg, and verifies against Citrix Team ID S272Y5R93J.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh citrixworkspace) DEBUG=1
bash: syntax error near unexpected token `)'
bash-3.2# sudo Installomator/utils/assemble.sh citrixworkspace DEBUG=1
2026-09-02 11:02:44 : INFO  : citrixworkspace : setting variable from argument DEBUG=1
2026-09-02 11:02:44 : INFO  : citrixworkspace : Total items in argumentsArray: 1
2026-09-02 11:02:44 : INFO  : citrixworkspace : argumentsArray: DEBUG=1
2026-09-02 11:02:45 : REQ   : citrixworkspace : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 11:02:45 : INFO  : citrixworkspace : ################## Version: 10.10beta
2026-09-02 11:02:45 : INFO  : citrixworkspace : ################## Date: 2026-09-02
2026-09-02 11:02:45 : INFO  : citrixworkspace : ################## citrixworkspace
2026-09-02 11:02:45 : DEBUG : citrixworkspace : DEBUG mode 1 enabled.
2026-09-02 11:02:46 : INFO  : citrixworkspace : Reading arguments again: DEBUG=1
2026-09-02 11:02:46 : DEBUG : citrixworkspace : argument: DEBUG=1
2026-09-02 11:02:46 : DEBUG : citrixworkspace : name=Citrix Workspace
2026-09-02 11:02:46 : DEBUG : citrixworkspace : appName=
2026-09-02 11:02:46 : DEBUG : citrixworkspace : type=pkgInDmg
2026-09-02 11:02:46 : DEBUG : citrixworkspace : archiveName=
2026-09-02 11:02:46 : DEBUG : citrixworkspace : downloadURL=https://downloads.citrix.com/26634/CitrixWorkspaceApp.dmg?__gda__=exp=1788372166~acl=/*~hmac=fd385b0814ce041616629a986dd2d6130ca158bfae8731ad56598f5dc4061363
2026-09-02 11:02:46 : DEBUG : citrixworkspace : curlOptions=--user-agent Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
2026-09-02 11:02:46 : DEBUG : citrixworkspace : appNewVersion=26.07.0.76
2026-09-02 11:02:46 : DEBUG : citrixworkspace : appCustomVersion function: Not defined
2026-09-02 11:02:46 : DEBUG : citrixworkspace : versionKey=CitrixVersionString
2026-09-02 11:02:46 : DEBUG : citrixworkspace : packageID=
2026-09-02 11:02:46 : DEBUG : citrixworkspace : pkgName=Install Citrix Workspace.pkg
2026-09-02 11:02:46 : DEBUG : citrixworkspace : choiceChangesXML=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : expectedTeamID=S272Y5R93J
2026-09-02 11:02:47 : DEBUG : citrixworkspace : blockingProcesses=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : installerTool=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : CLIInstaller=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : CLIArguments=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : updateTool=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : updateToolArguments=
2026-09-02 11:02:47 : DEBUG : citrixworkspace : updateToolRunAsCurrentUser=
2026-09-02 11:02:47 : INFO  : citrixworkspace : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 11:02:47 : INFO  : citrixworkspace : NOTIFY=success
2026-09-02 11:02:47 : INFO  : citrixworkspace : LOGGING=DEBUG
2026-09-02 11:02:47 : INFO  : citrixworkspace : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 11:02:47 : INFO  : citrixworkspace : Label type: pkgInDmg
2026-09-02 11:02:47 : INFO  : citrixworkspace : archiveName: Citrix Workspace.dmg
2026-09-02 11:02:47 : INFO  : citrixworkspace : no blocking processes defined, using Citrix Workspace as default
2026-09-02 11:02:47 : DEBUG : citrixworkspace : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 11:02:47 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2026-09-02 11:02:47 : INFO  : citrixworkspace : App(s) found: /Users/u0105821/Work/CitrixWorkspaceAppUniversal25.11.1.42/CitrixWorkspaceAppUniversal25.11.1.42_20260407_155258.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Work/CitrixWorkspaceAppUniversal25.11.1.42/CitrixWorkspaceAppUniversal25.11.1.42_20260407_155258.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085338.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085338.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085616.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085616.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app
2026-09-02 11:02:47 : WARN  : citrixworkspace : could not determine location of Citrix Workspace.app
2026-09-02 11:02:47 : INFO  : citrixworkspace : appversion: 
2026-09-02 11:02:47 : INFO  : citrixworkspace : Latest version of Citrix Workspace is 26.07.0.76
2026-09-02 11:02:47 : REQ   : citrixworkspace : Downloading https://downloads.citrix.com/26634/CitrixWorkspaceApp.dmg?__gda__=exp=1788372166~acl=/*~hmac=fd385b0814ce041616629a986dd2d6130ca158bfae8731ad56598f5dc4061363 to Citrix Workspace.dmg
2026-09-02 11:02:47 : DEBUG : citrixworkspace : No Dialog connection, just download
2026-09-02 11:02:59 : INFO  : citrixworkspace : Downloaded Citrix Workspace.dmg – Type is  zlib compressed data – SHA is 55b92d5b06f0cddec05c55ab68408443b61f6fd5 – Size is 393744 kB
2026-09-02 11:02:59 : DEBUG : citrixworkspace : DEBUG mode 1, not checking for blocking processes
2026-09-02 11:02:59 : REQ   : citrixworkspace : Installing Citrix Workspace
2026-09-02 11:02:59 : INFO  : citrixworkspace : Mounting /Users/u0105821/git/github/Installomator/build/Citrix Workspace.dmg
2026-09-02 11:03:00 : DEBUG : citrixworkspace : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $3E211AA6
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $40B48DED
Checksumming DiscRecording 9.0.3d5 (Apple_HFS : 2)…
DiscRecording 9.0.3d5 (Apple_HFS : 2: verified   CRC32 $727798D0
verified   CRC32 $46E3F017
/dev/disk8          	Apple_partition_scheme
/dev/disk8s1        	Apple_partition_map
/dev/disk8s2        	Apple_HFS                      	/Volumes/Citrix Workspace

2026-09-02 11:03:00 : INFO  : citrixworkspace : Mounted: /Volumes/Citrix Workspace
2026-09-02 11:03:00 : INFO  : citrixworkspace : found pkg: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-09-02 11:03:00 : INFO  : citrixworkspace : Verifying: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-09-02 11:03:00 : DEBUG : citrixworkspace : File list: -rw-r--r--@ 1 mac  wheel   360M Aug 13 00:11 /Volumes/Citrix Workspace/Install Citrix Workspace.pkg
2026-09-02 11:03:00 : DEBUG : citrixworkspace : File type: /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: xar archive compressed TOC: 7144, SHA-1 checksum
2026-09-02 11:03:00 : DEBUG : citrixworkspace : spctlOut is /Volumes/Citrix Workspace/Install Citrix Workspace.pkg: accepted
2026-09-02 11:03:00 : DEBUG : citrixworkspace : source=Notarized Developer ID
2026-09-02 11:03:00 : DEBUG : citrixworkspace : origin=Developer ID Installer: Citrix Systems, Inc. (S272Y5R93J)
2026-09-02 11:03:00 : INFO  : citrixworkspace : Team ID: S272Y5R93J (expected: S272Y5R93J )
2026-09-02 11:03:00 : DEBUG : citrixworkspace : DEBUG enabled, skipping installation
2026-09-02 11:03:00 : INFO  : citrixworkspace : Finishing...
2026-09-02 11:03:03 : INFO  : citrixworkspace : name: Citrix Workspace, appName: Citrix Workspace.app
2026-09-02 11:03:03 : INFO  : citrixworkspace : App(s) found: /Users/u0105821/Work/CitrixWorkspaceAppUniversal25.11.1.42/CitrixWorkspaceAppUniversal25.11.1.42_20260407_155258.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Work/CitrixWorkspaceAppUniversal25.11.1.42/CitrixWorkspaceAppUniversal25.11.1.42_20260407_155258.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085338.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085338.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085616.spkg-manifest.txt/All Files/Applications/Citrix Workspace.app/Users/u0105821/Desktop/spkg-output/Install Citrix Workspace/Install Citrix Workspace_20260619_085616.spkg-manifest.txt/All Files/Library/Application Support/Citrix Receiver/Uninstall Citrix Workspace.app
2026-09-02 11:03:03 : WARN  : citrixworkspace : could not determine location of Citrix Workspace.app
2026-09-02 11:03:03 : REQ   : citrixworkspace : Installed Citrix Workspace, version 26.07.0.76
2026-09-02 11:03:03 : INFO  : citrixworkspace : notifying
2026-09-02 11:03:04 : DEBUG : citrixworkspace : Unmounting /Volumes/Citrix Workspace
2026-09-02 11:03:04 : DEBUG : citrixworkspace : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-02 11:03:04 : DEBUG : citrixworkspace : DEBUG mode 1, not reopening anything
2026-09-02 11:03:04 : REQ   : citrixworkspace : All done!
2026-09-02 11:03:04 : REQ   : citrixworkspace : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
