### PR TITLE
mixxx-label-update

### DIFF
--- a/fragments/labels/mixxx.sh
+++ b/fragments/labels/mixxx.sh
@@ -1,8 +1,8 @@
 mixxx)
     name="Mixxx"
     type="dmg"
-    appNewVersion="$(curl -fsL "https://downloads.mixxx.org/releases/" | grep -Eo 'href="[0-9]+(\.[0-9]+)+/"' | sed -E 's/href="([^"]+)\/"/\1/' | sort -V | tail -n 1)"
-    if [[ "$(arch)" == "arm64" ]]; then
+    appNewVersion=$(versionFromGit mixxxdj mixxx)
+    if [[ $(arch) == "arm64" ]]; then
         downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosarm.dmg"
     else
         downloadURL="https://downloads.mixxx.org/releases/$appNewVersion/mixxx-$appNewVersion-macosintel.dmg"


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it keeps the reliable GitHub latest-version source and official Mixxx download URLs while removing redundant or misleading variables. Live verification confirmed version 2.5.6, valid ARM and Intel DMG URLs, Mixxx.app in the DMG, matching bundle version fields, and Team ID JBLRSP95FC.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh mixxx DEBUG=1
2026-09-02 11:44:18 : INFO  : mixxx : setting variable from argument DEBUG=1
2026-09-02 11:44:18 : INFO  : mixxx : Total items in argumentsArray: 1
2026-09-02 11:44:18 : INFO  : mixxx : argumentsArray: DEBUG=1
2026-09-02 11:44:18 : REQ   : mixxx : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 11:44:19 : INFO  : mixxx : ################## Version: 10.10beta
2026-09-02 11:44:19 : INFO  : mixxx : ################## Date: 2026-09-02
2026-09-02 11:44:19 : INFO  : mixxx : ################## mixxx
2026-09-02 11:44:19 : DEBUG : mixxx : DEBUG mode 1 enabled.
2026-09-02 11:44:20 : INFO  : mixxx : Reading arguments again: DEBUG=1
2026-09-02 11:44:20 : DEBUG : mixxx : argument: DEBUG=1
2026-09-02 11:44:20 : DEBUG : mixxx : name=Mixxx
2026-09-02 11:44:20 : DEBUG : mixxx : appName=
2026-09-02 11:44:20 : DEBUG : mixxx : type=dmg
2026-09-02 11:44:20 : DEBUG : mixxx : archiveName=
2026-09-02 11:44:20 : DEBUG : mixxx : downloadURL=https://downloads.mixxx.org/releases/2.5.6/mixxx-2.5.6-macosarm.dmg
2026-09-02 11:44:20 : DEBUG : mixxx : curlOptions=
2026-09-02 11:44:20 : DEBUG : mixxx : appNewVersion=2.5.6
2026-09-02 11:44:20 : DEBUG : mixxx : appCustomVersion function: Not defined
2026-09-02 11:44:20 : DEBUG : mixxx : versionKey=CFBundleShortVersionString
2026-09-02 11:44:20 : DEBUG : mixxx : packageID=
2026-09-02 11:44:20 : DEBUG : mixxx : pkgName=
2026-09-02 11:44:20 : DEBUG : mixxx : choiceChangesXML=
2026-09-02 11:44:20 : DEBUG : mixxx : expectedTeamID=JBLRSP95FC
2026-09-02 11:44:20 : DEBUG : mixxx : blockingProcesses=
2026-09-02 11:44:20 : DEBUG : mixxx : installerTool=
2026-09-02 11:44:20 : DEBUG : mixxx : CLIInstaller=
2026-09-02 11:44:20 : DEBUG : mixxx : CLIArguments=
2026-09-02 11:44:20 : DEBUG : mixxx : updateTool=
2026-09-02 11:44:20 : DEBUG : mixxx : updateToolArguments=
2026-09-02 11:44:20 : DEBUG : mixxx : updateToolRunAsCurrentUser=
2026-09-02 11:44:20 : INFO  : mixxx : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 11:44:20 : INFO  : mixxx : NOTIFY=success
2026-09-02 11:44:20 : INFO  : mixxx : LOGGING=DEBUG
2026-09-02 11:44:20 : INFO  : mixxx : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 11:44:20 : INFO  : mixxx : Label type: dmg
2026-09-02 11:44:20 : INFO  : mixxx : archiveName: Mixxx.dmg
2026-09-02 11:44:20 : INFO  : mixxx : no blocking processes defined, using Mixxx as default
2026-09-02 11:44:20 : DEBUG : mixxx : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 11:44:20 : INFO  : mixxx : name: Mixxx, appName: Mixxx.app
2026-09-02 11:44:21 : WARN  : mixxx : No previous app found
2026-09-02 11:44:21 : WARN  : mixxx : could not find Mixxx.app
2026-09-02 11:44:21 : INFO  : mixxx : appversion: 
2026-09-02 11:44:21 : INFO  : mixxx : Latest version of Mixxx is 2.5.6
2026-09-02 11:44:21 : INFO  : mixxx : Mixxx.dmg exists and DEBUG mode 1 enabled, skipping download
2026-09-02 11:44:21 : DEBUG : mixxx : DEBUG mode 1, not checking for blocking processes
2026-09-02 11:44:21 : REQ   : mixxx : Installing Mixxx
2026-09-02 11:44:21 : INFO  : mixxx : Mounting /Users/u0105821/git/github/Installomator/build/Mixxx.dmg
2026-09-02 11:44:22 : DEBUG : mixxx : Debugging enabled, dmgmount output was:
Mixxx 2.5.6, Digital DJ'ing software.  Copyright (C) 2001-2026 Mixxx
.
.
.
expected   CRC32 $DBB07058
/dev/disk8          	GUID_partition_scheme
/dev/disk8s1        	Apple_HFS                      	/Volumes/mixxx-2.5.6-arm64

2026-09-02 11:44:22 : INFO  : mixxx : Mounted: /Volumes/mixxx-2.5.6-arm64
2026-09-02 11:44:22 : INFO  : mixxx : Verifying: /Volumes/mixxx-2.5.6-arm64/Mixxx.app
2026-09-02 11:44:22 : DEBUG : mixxx : App size: 174M	/Volumes/mixxx-2.5.6-arm64/Mixxx.app
2026-09-02 11:44:24 : DEBUG : mixxx : Debugging enabled, App Verification output was:
/Volumes/mixxx-2.5.6-arm64/Mixxx.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Daniel Schuermann (JBLRSP95FC)

2026-09-02 11:44:24 : INFO  : mixxx : Team ID matching: JBLRSP95FC (expected: JBLRSP95FC )
2026-09-02 11:44:24 : INFO  : mixxx : Installing Mixxx version 2.5.6 on versionKey CFBundleShortVersionString.
2026-09-02 11:44:24 : INFO  : mixxx : App has LSMinimumSystemVersion: 11.0
2026-09-02 11:44:24 : DEBUG : mixxx : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 11:44:24 : INFO  : mixxx : Finishing...
2026-09-02 11:44:27 : INFO  : mixxx : name: Mixxx, appName: Mixxx.app
2026-09-02 11:44:27 : WARN  : mixxx : No previous app found
2026-09-02 11:44:27 : WARN  : mixxx : could not find Mixxx.app
2026-09-02 11:44:27 : REQ   : mixxx : Installed Mixxx, version 2.5.6
2026-09-02 11:44:28 : INFO  : mixxx : notifying
2026-09-02 11:44:28 : DEBUG : mixxx : Unmounting /Volumes/mixxx-2.5.6-arm64
2026-09-02 11:44:28 : DEBUG : mixxx : Debugging enabled, Unmounting output was:
"disk8" ejected.
2026-09-02 11:44:28 : DEBUG : mixxx : DEBUG mode 1, not reopening anything
2026-09-02 11:44:28 : REQ   : mixxx : All done!
2026-09-02 11:44:28 : REQ   : mixxx : ################## End Installomator, exit code 0 
```
Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
