### PR TITLE
logitechoptionsplus-label-update

### DIFF
--- a/fragments/labels/logitechoptionsplus.sh
+++ b/fragments/labels/logitechoptionsplus.sh
@@ -1,13 +1,22 @@
 logitechoptionsplus)
     name="Logi Options+"
-    appName="logioptionsplus.app"
-    archiveName="logioptionsplus_installer.zip"
-    installerTool="logioptionsplus_installer.app"
+    appName="logioptionsplus_installer.app"
     type="zip"
-    osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print$1}')
-    downloadURL="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n"  | grep  -o "https://.*logioptionsplus.*zip" | head -1)"
-    appNewVersion=$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osMajorVersion}.0" | tr "," "\n" | grep -A 10 "macOS" | grep -B 5 -ie "https.*/.*/optionsplus/.*\.zip" | grep "Software Version" | sed 's/\\u[0-9a-z][0-9a-z][0-9a-z][0-9a-z]//g' | grep -ioe "Software Version.*[0-9.]*" | tr "/" "\n" | grep -oe "[0-9.]*" | head -1)
+    osMajorVersion=$(sw_vers -productVersion | awk -F "." '{print $1}')
+    osVersion=$(sw_vers -productVersion | awk -F "." '{if ($1 == "10") print $1"."$2; else print $1".0"}')
+    if [[ "$osMajorVersion" -lt 11 ]]; then
+        printlog "Logi Options+ download could not be safely verified for this macOS version." ERROR
+        cleanupAndExit 95 "Logi Options+ requires a verified macOS 11 or later download" ERROR
+    fi
+    appNewVersion="$(curl -fs "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-${osVersion}" | sed $'s/},{"id"/}\\\n{"id"/g' | awk -F '"body":"' 'index($0, "\"title\":\"Logi Options+\"") {print $2; exit}' | sed 's/\\n/ /g;s/<[^>]*>//g;s/\\"/"/g' | grep -oE 'Software Version: *[0-9]+([.][0-9]+)+' | head -1 | grep -oE '[0-9]+([.][0-9]+)+')"
+    if [[ "$osMajorVersion" -ge 14 ]]; then
+        downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip"
+    else
+        downloadURL="https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_${appNewVersion}.zip"
+    fi
     CLIInstaller="logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer"
     CLIArguments=(--quiet)
+    appCustomVersion(){ if [[ -f "/Applications/logioptionsplus.app/Contents/Info.plist" ]]; then /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "/Applications/logioptionsplus.app/Contents/Info.plist" 2>/dev/null; fi; }
+    versionKey="CFBundleVersion"
     expectedTeamID="QED4VVPZWA"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
yes


**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it keeps Logitech’s OS-specific version feed aligned with the downloaded payload. The merged label hardcodes the macOS 11 feed but downloads the latest ZIP, which can compare one version and install another.
It also fixes Installomator ZIP handling by using appName="logioptionsplus_installer.app" for the extracted installer app, checks the installed app separately with guarded appCustomVersion, uses versionKey="CFBundleVersion", and keeps the verified Logitech Team ID QED4VVPZWA.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh logitechoptionsplus DEBUG=1
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=1
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : Total items in argumentsArray: 1
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : argumentsArray: DEBUG=1
2026-09-02 13:08:39 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : ################## Version: 10.10beta
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : ################## Date: 2026-09-02
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled.
2026-09-02 13:08:39 : INFO  : logitechoptionsplus : Reading arguments again: DEBUG=1
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : argument: DEBUG=1
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : name=Logi Options+
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : appName=logioptionsplus_installer.app
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : type=zip
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : archiveName=
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : curlOptions=
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : appNewVersion=2.7.961922
2026-09-02 13:08:39 : DEBUG : logitechoptionsplus : appCustomVersion function: Defined. 
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : versionKey=CFBundleShortVersionString
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : packageID=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : pkgName=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : choiceChangesXML=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : expectedTeamID=QED4VVPZWA
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : blockingProcesses=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : installerTool=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : CLIInstaller=logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : CLIArguments=--quiet
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : updateTool=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : updateToolArguments=
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : updateToolRunAsCurrentUser=
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : NOTIFY=success
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : LOGGING=DEBUG
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : Label type: zip
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : archiveName: Logi Options+.zip
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/logioptionsplus.app/Contents/Info.plist
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : appversion: File Doesn't Exist, Will Create: /Applications/logioptionsplus.app/Contents/Info.plist
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 2.7.961922
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : Logi Options+.zip exists and DEBUG mode 1 enabled, skipping download
2026-09-02 13:08:40 : DEBUG : logitechoptionsplus : DEBUG mode 1, not checking for blocking processes
2026-09-02 13:08:40 : REQ   : logitechoptionsplus : Installing Logi Options+
2026-09-02 13:08:40 : INFO  : logitechoptionsplus : Unzipping Logi Options+.zip
2026-09-02 13:08:41 : INFO  : logitechoptionsplus : Verifying: /Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app
2026-09-02 13:08:41 : DEBUG : logitechoptionsplus : App size:  46M	/Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app
2026-09-02 13:08:41 : DEBUG : logitechoptionsplus : Debugging enabled, App Verification output was:
/Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2026-09-02 13:08:41 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-09-02 13:08:41.507 defaults[71877:96834664] 
The domain/default pair of (/Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app/Contents/Info.plist, CFBundleShortVersionString) does not exist
2026-09-02 13:08:41 : INFO  : logitechoptionsplus : Downloaded version of Logi Options+ is  on versionKey CFBundleShortVersionString (replacing version File Doesn't Exist, Will Create: /Applications/logioptionsplus.app/Contents/Info.plist).
2026-09-02 13:08:41 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 14.0
2026-09-02 13:08:41 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 13:08:41 : INFO  : logitechoptionsplus : Finishing...
2026-09-02 13:08:44 : INFO  : logitechoptionsplus : Custom App Version detection is used, found File Doesn't Exist, Will Create: /Applications/logioptionsplus.app/Contents/Info.plist
2026-09-02 13:08:44 : REQ   : logitechoptionsplus : Installed Logi Options+
2026-09-02 13:08:44 : INFO  : logitechoptionsplus : notifying
2026-09-02 13:08:45 : DEBUG : logitechoptionsplus : DEBUG mode 1, not reopening anything
2026-09-02 13:08:45 : REQ   : logitechoptionsplus : All done!
2026-09-02 13:08:45 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0 

bash-3.2# sudo Installomator/utils/assemble.sh logitechoptionsplus DEBUG=1
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : setting variable from argument DEBUG=1
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : Total items in argumentsArray: 1
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : argumentsArray: DEBUG=1
2026-09-02 13:10:33 : REQ   : logitechoptionsplus : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : ################## Version: 10.10beta
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : ################## Date: 2026-09-02
2026-09-02 13:10:33 : INFO  : logitechoptionsplus : ################## logitechoptionsplus
2026-09-02 13:10:33 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled.
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : Reading arguments again: DEBUG=1
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : argument: DEBUG=1
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : name=Logi Options+
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : appName=logioptionsplus_installer.app
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : type=zip
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : archiveName=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : downloadURL=https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : curlOptions=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : appNewVersion=2.7.961922
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : appCustomVersion function: Defined. 
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : versionKey=CFBundleVersion
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : packageID=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : pkgName=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : choiceChangesXML=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : expectedTeamID=QED4VVPZWA
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : blockingProcesses=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : installerTool=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : CLIInstaller=logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : CLIArguments=--quiet
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : updateTool=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : updateToolArguments=
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : updateToolRunAsCurrentUser=
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : NOTIFY=success
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : LOGGING=DEBUG
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : Label type: zip
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : archiveName: Logi Options+.zip
2026-09-02 13:10:34 : INFO  : logitechoptionsplus : no blocking processes defined, using Logi Options+ as default
2026-09-02 13:10:34 : DEBUG : logitechoptionsplus : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : Custom App Version detection is used, found 
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : appversion: 
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : Latest version of Logi Options+ is 2.7.961922
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : Logi Options+.zip exists and DEBUG mode 1 enabled, skipping download
2026-09-02 13:10:35 : DEBUG : logitechoptionsplus : DEBUG mode 1, not checking for blocking processes
2026-09-02 13:10:35 : REQ   : logitechoptionsplus : Installing Logi Options+
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : Unzipping Logi Options+.zip
2026-09-02 13:10:35 : INFO  : logitechoptionsplus : Verifying: /Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app
2026-09-02 13:10:35 : DEBUG : logitechoptionsplus : App size:  46M	/Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app
2026-09-02 13:10:36 : DEBUG : logitechoptionsplus : Debugging enabled, App Verification output was:
/Users/u0105821/git/github/Installomator/build/logioptionsplus_installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Logitech Inc. (QED4VVPZWA)

2026-09-02 13:10:36 : INFO  : logitechoptionsplus : Team ID matching: QED4VVPZWA (expected: QED4VVPZWA )
2026-09-02 13:10:36 : INFO  : logitechoptionsplus : Installing Logi Options+ version 2.7.961922 on versionKey CFBundleVersion.
2026-09-02 13:10:36 : INFO  : logitechoptionsplus : App has LSMinimumSystemVersion: 14.0
2026-09-02 13:10:36 : DEBUG : logitechoptionsplus : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 13:10:36 : INFO  : logitechoptionsplus : Finishing...
2026-09-02 13:10:39 : INFO  : logitechoptionsplus : Custom App Version detection is used, found 
2026-09-02 13:10:39 : REQ   : logitechoptionsplus : Installed Logi Options+, version 2.7.961922
2026-09-02 13:10:39 : INFO  : logitechoptionsplus : notifying
2026-09-02 13:10:39 : DEBUG : logitechoptionsplus : DEBUG mode 1, not reopening anything
2026-09-02 13:10:39 : REQ   : logitechoptionsplus : All done!
2026-09-02 13:10:39 : REQ   : logitechoptionsplus : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
