### PR TITLE
Update zbrush2025.sh

### DIFF
--- a/fragments/labels/zbrush2025.sh
+++ b/fragments/labels/zbrush2025.sh
@@ -1,16 +1,25 @@
 zbrush2025)
-	#credit pmex for the building the framework used for Maxon apps
-	name="ZBrush"
+    name="ZBrush"
     type="dmg"
-    appCustomVersion(){
-    defaults read "/Applications/Maxon ZBrush 2025/ZBrush.app/Contents/Info.plist" CFBundleVersion | grep -Eo "2025+\.[0-9]+"
-    }
-	downloadURL=$(curl -fsL https://www.maxon.net/en/downloads | grep -oE '[^"]*zbrush[^"]*\.dmg' | grep -v "windows.net" | sort -r | head -1)
-	appNewVersion=$(sed -n 's/.*ZBrush_\([^_]*\).*/\1/p' <<< "${downloadURL}")
+    zbrushJSON=$(curl -fsL "https://support.maxon.net/api/v2/help_center/en-us/sections/7456686788252/articles.json")
+    i=0; appNewVersion=""
+    while articleTitle=$(getJSONValue "$zbrushJSON" "articles[$i].title" 2>/dev/null); do
+        zbrushVersion=$(echo "$articleTitle" | sed -nE 's/^ZBrush (2025[.][0-9]+([.][0-9]+)?) Release Notes.*/\1/p')
+        if [[ -n "$zbrushVersion" ]]; then
+            zbrushURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/${zbrushVersion}/ZBrush_${zbrushVersion}_Installer.dmg"
+            if curl -fsIL "$zbrushURL" >/dev/null; then
+                appNewVersion="$zbrushVersion"
+                downloadURL="$zbrushURL"
+                break
+            fi
+        fi
+        i=$((i + 1))
+    done
+    [[ -n "$downloadURL" ]] || cleanupAndExit 95 "could not determine latest verified ZBrush 2025 download URL" ERROR
     targetDir="/Applications/Maxon ZBrush 2025"
     installerTool="ZBrush_${appNewVersion}_Installer.app"
     CLIInstaller="ZBrush_${appNewVersion}_Installer.app/Contents/MacOS/installbuilder.sh"
     CLIArguments=(--mode unattended --unattendedmodeui none)
+    appCustomVersion(){ if [[ -f "/Applications/Maxon ZBrush 2025/ZBrush.app/Contents/Info.plist" ]]; then defaults read "/Applications/Maxon ZBrush 2025/ZBrush.app/Contents/Info.plist" CFBundleVersion 2>/dev/null | grep -Eo '2025[.][0-9]+([.][0-9]+)?'; fi; }
     expectedTeamID="4ZY22YGXQG"
     ;;
-


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

This label is better because it stays dynamic while preserving the zbrush2025 version family. It uses Maxon’s structured support API to find ZBrush 2025 release versions, then only selects a CDN DMG that actually exists, avoiding the current downloads page behavior that would jump to ZBrush 2026. It also verifies the installer path, uses unattended CLI install arguments, checks the installed 2025 app version safely, and keeps the verified Maxon Team ID 4ZY22YGXQG.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh zbrush2025 DEBUG=1
2026-09-02 15:33:20 : INFO  : zbrush2025 : setting variable from argument DEBUG=1
2026-09-02 15:33:20 : INFO  : zbrush2025 : Total items in argumentsArray: 1
2026-09-02 15:33:20 : INFO  : zbrush2025 : argumentsArray: DEBUG=1
2026-09-02 15:33:20 : REQ   : zbrush2025 : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 15:33:20 : INFO  : zbrush2025 : ################## Version: 10.10beta
2026-09-02 15:33:20 : INFO  : zbrush2025 : ################## Date: 2026-09-02
2026-09-02 15:33:20 : INFO  : zbrush2025 : ################## zbrush2025
2026-09-02 15:33:20 : DEBUG : zbrush2025 : DEBUG mode 1 enabled.
2026-09-02 15:33:23 : INFO  : zbrush2025 : Reading arguments again: DEBUG=1
2026-09-02 15:33:23 : DEBUG : zbrush2025 : argument: DEBUG=1
2026-09-02 15:33:23 : DEBUG : zbrush2025 : name=ZBrush
2026-09-02 15:33:23 : DEBUG : zbrush2025 : appName=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : type=dmg
2026-09-02 15:33:23 : DEBUG : zbrush2025 : archiveName=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/2025.2.2/ZBrush_2025.2.2_Installer.dmg
2026-09-02 15:33:23 : DEBUG : zbrush2025 : curlOptions=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : appNewVersion=2025.2.2
2026-09-02 15:33:23 : DEBUG : zbrush2025 : appCustomVersion function: Defined. 
2026-09-02 15:33:23 : DEBUG : zbrush2025 : versionKey=CFBundleShortVersionString
2026-09-02 15:33:23 : DEBUG : zbrush2025 : packageID=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : pkgName=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : choiceChangesXML=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : expectedTeamID=4ZY22YGXQG
2026-09-02 15:33:23 : DEBUG : zbrush2025 : blockingProcesses=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : installerTool=ZBrush_2025.2.2_Installer.app
2026-09-02 15:33:23 : DEBUG : zbrush2025 : CLIInstaller=ZBrush_2025.2.2_Installer.app/Contents/MacOS/installbuilder.sh
2026-09-02 15:33:23 : DEBUG : zbrush2025 : CLIArguments=--mode unattended --unattendedmodeui none
2026-09-02 15:33:23 : DEBUG : zbrush2025 : updateTool=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : updateToolArguments=
2026-09-02 15:33:23 : DEBUG : zbrush2025 : updateToolRunAsCurrentUser=
2026-09-02 15:33:23 : INFO  : zbrush2025 : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 15:33:23 : INFO  : zbrush2025 : NOTIFY=success
2026-09-02 15:33:23 : INFO  : zbrush2025 : LOGGING=DEBUG
2026-09-02 15:33:23 : INFO  : zbrush2025 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 15:33:23 : INFO  : zbrush2025 : Label type: dmg
2026-09-02 15:33:23 : INFO  : zbrush2025 : archiveName: ZBrush.dmg
2026-09-02 15:33:23 : INFO  : zbrush2025 : no blocking processes defined, using ZBrush as default
2026-09-02 15:33:23 : DEBUG : zbrush2025 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 15:33:23 : INFO  : zbrush2025 : Custom App Version detection is used, found 
2026-09-02 15:33:23 : INFO  : zbrush2025 : appversion: 
2026-09-02 15:33:23 : INFO  : zbrush2025 : Latest version of ZBrush is 2025.2.2
2026-09-02 15:33:23 : REQ   : zbrush2025 : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/2025.2.2/ZBrush_2025.2.2_Installer.dmg to ZBrush.dmg
2026-09-02 15:33:23 : DEBUG : zbrush2025 : No Dialog connection, just download
2026-09-02 15:34:59 : INFO  : zbrush2025 : Downloaded ZBrush.dmg – Type is  zlib compressed data – SHA is 002700f1e99b2c2a242a3899736e745d60ed7df2 – Size is 3130092 kB
2026-09-02 15:34:59 : DEBUG : zbrush2025 : DEBUG mode 1, not checking for blocking processes
2026-09-02 15:34:59 : REQ   : zbrush2025 : Installing ZBrush
2026-09-02 15:34:59 : REQ   : zbrush2025 : installerTool used: ZBrush_2025.2.2_Installer.app
2026-09-02 15:34:59 : INFO  : zbrush2025 : Mounting /Users/u0105821/git/github/Installomator/build/ZBrush.dmg
2026-09-02 15:35:03 : DEBUG : zbrush2025 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $7A674195
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $4846BD29
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $ABF00D92
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $1C304039
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $ABF00D92
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $48ADCF1D
verified   CRC32 $99890715
/dev/disk11         	GUID_partition_scheme
/dev/disk11s1       	EFI
/dev/disk11s2       	Apple_HFS                      	/Volumes/ZBrush 2025.2.2

2026-09-02 15:35:03 : INFO  : zbrush2025 : Mounted: /Volumes/ZBrush 2025.2.2
2026-09-02 15:35:03 : INFO  : zbrush2025 : Verifying: /Volumes/ZBrush 2025.2.2/ZBrush_2025.2.2_Installer.app
2026-09-02 15:35:03 : DEBUG : zbrush2025 : App size: 3.0G	/Volumes/ZBrush 2025.2.2/ZBrush_2025.2.2_Installer.app
2026-09-02 15:35:07 : DEBUG : zbrush2025 : Debugging enabled, App Verification output was:
/Volumes/ZBrush 2025.2.2/ZBrush_2025.2.2_Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2026-09-02 15:35:07 : INFO  : zbrush2025 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2026-09-02 15:35:07 : INFO  : zbrush2025 : Installing ZBrush version 2025.2.2 on versionKey CFBundleShortVersionString.
2026-09-02 15:35:07 : DEBUG : zbrush2025 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 15:35:07 : INFO  : zbrush2025 : Finishing...
2026-09-02 15:35:10 : INFO  : zbrush2025 : Custom App Version detection is used, found 
2026-09-02 15:35:10 : REQ   : zbrush2025 : Installed ZBrush, version 2025.2.2
2026-09-02 15:35:10 : INFO  : zbrush2025 : notifying
2026-09-02 15:35:10 : DEBUG : zbrush2025 : Unmounting /Volumes/ZBrush 2025.2.2
2026-09-02 15:35:11 : DEBUG : zbrush2025 : Debugging enabled, Unmounting output was:
"disk11" ejected.
2026-09-02 15:35:11 : DEBUG : zbrush2025 : DEBUG mode 1, not reopening anything
2026-09-02 15:35:11 : REQ   : zbrush2025 : All done!
2026-09-02 15:35:11 : REQ   : zbrush2025 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
