### PR TITLE
Create zbrush2026.sh

### DIFF
--- a/fragments/labels/zbrush2026.sh
+++ b/fragments/labels/zbrush2026.sh
@@ -1,0 +1,25 @@
+zbrush2026)
+    name="ZBrush"
+    type="dmg"
+    zbrushJSON=$(curl -fsL "https://support.maxon.net/api/v2/help_center/en-us/sections/7456686788252/articles.json")
+    i=0; appNewVersion=""
+    while articleTitle=$(getJSONValue "$zbrushJSON" "articles[$i].title" 2>/dev/null); do
+        zbrushVersion=$(echo "$articleTitle" | sed -nE 's/^ZBrush (2026[.][0-9]+([.][0-9]+)?) Release Notes.*/\1/p')
+        if [[ -n "$zbrushVersion" ]]; then
+            zbrushURL="https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/${zbrushVersion}/Maxon_ZBrush_${zbrushVersion}_Installer_mac.dmg"
+            if curl -fsIL "$zbrushURL" >/dev/null; then
+                appNewVersion="$zbrushVersion"
+                downloadURL="$zbrushURL"
+                break
+            fi
+        fi
+        i=$((i + 1))
+    done
+    [[ -n "$downloadURL" ]] || cleanupAndExit 95 "could not determine latest verified ZBrush 2026 download URL" ERROR
+    targetDir="/Applications/Maxon ZBrush 2026"
+    installerTool="Maxon ZBrush ${appNewVersion} Installer.app"
+    CLIInstaller="Maxon ZBrush ${appNewVersion} Installer.app/Contents/MacOS/installbuilder.sh"
+    CLIArguments=(--mode unattended --unattendedmodeui none)
+    appCustomVersion(){ if [[ -f "/Applications/Maxon ZBrush 2026/ZBrush.app/Contents/Info.plist" ]]; then defaults read "/Applications/Maxon ZBrush 2026/ZBrush.app/Contents/Info.plist" CFBundleVersion 2>/dev/null | grep -Eo '2026[.][0-9]+([.][0-9]+)?'; fi; }
+    expectedTeamID="4ZY22YGXQG"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh zbrush2026 DEBUG=1
2026-09-02 15:50:13 : INFO  : zbrush2026 : setting variable from argument DEBUG=1
2026-09-02 15:50:13 : INFO  : zbrush2026 : Total items in argumentsArray: 1
2026-09-02 15:50:13 : INFO  : zbrush2026 : argumentsArray: DEBUG=1
2026-09-02 15:50:13 : REQ   : zbrush2026 : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 15:50:13 : INFO  : zbrush2026 : ################## Version: 10.10beta
2026-09-02 15:50:13 : INFO  : zbrush2026 : ################## Date: 2026-09-02
2026-09-02 15:50:13 : INFO  : zbrush2026 : ################## zbrush2026
2026-09-02 15:50:13 : DEBUG : zbrush2026 : DEBUG mode 1 enabled.
2026-09-02 15:50:14 : INFO  : zbrush2026 : Reading arguments again: DEBUG=1
2026-09-02 15:50:14 : DEBUG : zbrush2026 : argument: DEBUG=1
2026-09-02 15:50:14 : DEBUG : zbrush2026 : name=ZBrush
2026-09-02 15:50:14 : DEBUG : zbrush2026 : appName=
2026-09-02 15:50:14 : DEBUG : zbrush2026 : type=dmg
2026-09-02 15:50:14 : DEBUG : zbrush2026 : archiveName=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : downloadURL=https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/2026.2.1/Maxon_ZBrush_2026.2.1_Installer_mac.dmg
2026-09-02 15:50:15 : DEBUG : zbrush2026 : curlOptions=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : appNewVersion=2026.2.1
2026-09-02 15:50:15 : DEBUG : zbrush2026 : appCustomVersion function: Defined. 
2026-09-02 15:50:15 : DEBUG : zbrush2026 : versionKey=CFBundleShortVersionString
2026-09-02 15:50:15 : DEBUG : zbrush2026 : packageID=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : pkgName=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : choiceChangesXML=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : expectedTeamID=4ZY22YGXQG
2026-09-02 15:50:15 : DEBUG : zbrush2026 : blockingProcesses=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : installerTool=Maxon ZBrush 2026.2.1 Installer.app
2026-09-02 15:50:15 : DEBUG : zbrush2026 : CLIInstaller=Maxon ZBrush 2026.2.1 Installer.app/Contents/MacOS/installbuilder.sh
2026-09-02 15:50:15 : DEBUG : zbrush2026 : CLIArguments=--mode unattended --unattendedmodeui none
2026-09-02 15:50:15 : DEBUG : zbrush2026 : updateTool=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : updateToolArguments=
2026-09-02 15:50:15 : DEBUG : zbrush2026 : updateToolRunAsCurrentUser=
2026-09-02 15:50:15 : INFO  : zbrush2026 : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 15:50:15 : INFO  : zbrush2026 : NOTIFY=success
2026-09-02 15:50:15 : INFO  : zbrush2026 : LOGGING=DEBUG
2026-09-02 15:50:15 : INFO  : zbrush2026 : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 15:50:15 : INFO  : zbrush2026 : Label type: dmg
2026-09-02 15:50:15 : INFO  : zbrush2026 : archiveName: ZBrush.dmg
2026-09-02 15:50:15 : INFO  : zbrush2026 : no blocking processes defined, using ZBrush as default
2026-09-02 15:50:15 : DEBUG : zbrush2026 : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 15:50:15 : INFO  : zbrush2026 : Custom App Version detection is used, found 
2026-09-02 15:50:15 : INFO  : zbrush2026 : appversion: 
2026-09-02 15:50:15 : INFO  : zbrush2026 : Latest version of ZBrush is 2026.2.1
2026-09-02 15:50:15 : REQ   : zbrush2026 : Downloading https://mx-app-blob-prod.maxon.net/mx-package-production/installer/macos/maxon/zbrush/releases/2026.2.1/Maxon_ZBrush_2026.2.1_Installer_mac.dmg to ZBrush.dmg
2026-09-02 15:50:15 : DEBUG : zbrush2026 : No Dialog connection, just download
2026-09-02 15:51:35 : INFO  : zbrush2026 : Downloaded ZBrush.dmg – Type is  zlib compressed data – SHA is bdee91b880a3089b7676a42ea6975b3a4d79e917 – Size is 2753468 kB
2026-09-02 15:51:35 : DEBUG : zbrush2026 : DEBUG mode 1, not checking for blocking processes
2026-09-02 15:51:35 : REQ   : zbrush2026 : Installing ZBrush
2026-09-02 15:51:35 : REQ   : zbrush2026 : installerTool used: Maxon ZBrush 2026.2.1 Installer.app
2026-09-02 15:51:35 : INFO  : zbrush2026 : Mounting /Users/u0105821/git/github/Installomator/build/ZBrush.dmg
2026-09-02 15:51:38 : DEBUG : zbrush2026 : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $B77120D8
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $399860B1
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $73A94BD3
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming EFI System Partition (C12A7328-F81F-11D2-BA4B-00A0C93EC93B : 4)…
EFI System Partition (C12A7328-F81F-: verified   CRC32 $B54B659C
Checksumming disk image (Apple_HFS : 5)…
disk image (Apple_HFS : 5): verified   CRC32 $5AB06A5F
Checksumming  (Apple_Free : 6)…
(Apple_Free : 6): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 7)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $73A94BD3
Checksumming GPT Header (Backup GPT Header : 8)…
GPT Header (Backup GPT Header : 8): verified   CRC32 $9DBE98CE
verified   CRC32 $F2C340FA
/dev/disk11         	GUID_partition_scheme
/dev/disk11s1       	EFI
/dev/disk11s2       	Apple_HFS                      	/Volumes/ZBrush 2026.2.1

2026-09-02 15:51:38 : INFO  : zbrush2026 : Mounted: /Volumes/ZBrush 2026.2.1
2026-09-02 15:51:38 : INFO  : zbrush2026 : Verifying: /Volumes/ZBrush 2026.2.1/Maxon ZBrush 2026.2.1 Installer.app
2026-09-02 15:51:38 : DEBUG : zbrush2026 : App size: 2.6G	/Volumes/ZBrush 2026.2.1/Maxon ZBrush 2026.2.1 Installer.app
2026-09-02 15:51:41 : DEBUG : zbrush2026 : Debugging enabled, App Verification output was:
/Volumes/ZBrush 2026.2.1/Maxon ZBrush 2026.2.1 Installer.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Maxon Computer GmbH (4ZY22YGXQG)

2026-09-02 15:51:41 : INFO  : zbrush2026 : Team ID matching: 4ZY22YGXQG (expected: 4ZY22YGXQG )
2026-09-02 15:51:41 : INFO  : zbrush2026 : Installing ZBrush version 2026.2.1 on versionKey CFBundleShortVersionString.
2026-09-02 15:51:41 : DEBUG : zbrush2026 : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 15:51:41 : INFO  : zbrush2026 : Finishing...
2026-09-02 15:51:44 : INFO  : zbrush2026 : Custom App Version detection is used, found 
2026-09-02 15:51:45 : REQ   : zbrush2026 : Installed ZBrush, version 2026.2.1
2026-09-02 15:51:45 : INFO  : zbrush2026 : notifying
2026-09-02 15:51:45 : DEBUG : zbrush2026 : Unmounting /Volumes/ZBrush 2026.2.1
2026-09-02 15:51:45 : DEBUG : zbrush2026 : Debugging enabled, Unmounting output was:
"disk11" ejected.
2026-09-02 15:51:45 : DEBUG : zbrush2026 : DEBUG mode 1, not reopening anything
2026-09-02 15:51:45 : REQ   : zbrush2026 : All done!
2026-09-02 15:51:46 : REQ   : zbrush2026 : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
