### PR TITLE
Create firefoxesr_next_intl.sh

### DIFF
--- a/fragments/labels/firefoxesr_next_intl.sh
+++ b/fragments/labels/firefoxesr_next_intl.sh
@@ -1,0 +1,24 @@
+firefoxesr_next_intl)
+    name="Firefox"
+    type="dmg"
+    userLanguage=$(runAsUser defaults read .GlobalPreferences AppleLocale | tr '_' '-')
+    printlog "Found language $userLanguage to be used for $name."
+    releaseURL="https://ftp.mozilla.org/pub/firefox/releases/latest-esr/README.txt"
+    until curl -fs "$releaseURL" | grep -q "=$userLanguage"; do
+        if [[ ${#userLanguage} -eq 2 ]]; then
+            break
+        fi
+        printlog "No locale matching '$userLanguage', trying '${userLanguage:0:2}'"
+        userLanguage=${userLanguage:0:2}
+    done
+    printlog "Using language '$userLanguage' for download."
+    downloadURL="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang=$userLanguage"
+    if ! curl -sfL --output /dev/null -r 0-0 "$downloadURL"; then
+        printlog "Download not found for '$userLanguage', using default ('en-US')."
+        downloadURL="https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx"
+    fi
+    firefoxVersions=$(curl -fs "https://product-details.mozilla.org/1.0/firefox_versions.json")
+    appNewVersion=$(getJSONValue "$firefoxVersions" "FIREFOX_ESR_NEXT" | sed 's/esr$//')
+    expectedTeamID="43AQ936H96"
+    blockingProcesses=( firefox )
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The updated label is better because it fixes the version mismatch by stripping the esr suffix from FIREFOX_ESR_NEXT, so appNewVersion=153.2.0 matches the mounted Firefox.app version instead of returning 153.2.0esr.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# sudo Installomator/utils/assemble.sh firefoxesr_next_intl DEBUG=1
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : setting variable from argument DEBUG=1
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : Total items in argumentsArray: 1
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : argumentsArray: DEBUG=1
2026-09-02 17:07:21 : REQ   : firefoxesr_next_intl : ################## Start Installomator v. 10.10beta, date 2026-09-02
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : ################## Version: 10.10beta
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : ################## Date: 2026-09-02
2026-09-02 17:07:21 : INFO  : firefoxesr_next_intl : ################## firefoxesr_next_intl
2026-09-02 17:07:21 : DEBUG : firefoxesr_next_intl : DEBUG mode 1 enabled.
2026-09-02 17:07:22 : INFO  : firefoxesr_next_intl : Found language en-US to be used for Firefox.
2026-09-02 17:07:22 : INFO  : firefoxesr_next_intl : Using language 'en-US' for download.
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : Reading arguments again: DEBUG=1
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : argument: DEBUG=1
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : name=Firefox
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : appName=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : type=dmg
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : archiveName=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : downloadURL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang=en-US
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : curlOptions=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : appNewVersion=153.2.0
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : appCustomVersion function: Not defined
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : versionKey=CFBundleShortVersionString
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : packageID=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : pkgName=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : choiceChangesXML=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : expectedTeamID=43AQ936H96
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : blockingProcesses=firefox
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : installerTool=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : CLIInstaller=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : CLIArguments=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : updateTool=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : updateToolArguments=
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : updateToolRunAsCurrentUser=
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : BLOCKING_PROCESS_ACTION=tell_user
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : NOTIFY=success
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : LOGGING=DEBUG
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : Label type: dmg
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : archiveName: Firefox.dmg
2026-09-02 17:07:23 : DEBUG : firefoxesr_next_intl : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : name: Firefox, appName: Firefox.app
2026-09-02 17:07:23 : INFO  : firefoxesr_next_intl : App(s) found: /Applications/Web Browsers/Firefox.app
2026-09-02 17:07:24 : INFO  : firefoxesr_next_intl : found app at /Applications/Web Browsers/Firefox.app, version 155.0, on versionKey CFBundleShortVersionString
2026-09-02 17:07:24 : INFO  : firefoxesr_next_intl : appversion: 155.0
2026-09-02 17:07:24 : INFO  : firefoxesr_next_intl : Latest version of Firefox is 153.2.0
2026-09-02 17:07:24 : REQ   : firefoxesr_next_intl : Downloading https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&os=osx&lang=en-US to Firefox.dmg
2026-09-02 17:07:24 : DEBUG : firefoxesr_next_intl : No Dialog connection, just download
2026-09-02 17:08:23 : INFO  : firefoxesr_next_intl : Downloaded Firefox.dmg – Type is  XZ compressed data, checksum NONE – SHA is 37eeb4ad75f4955db942dd1d553ec3e29fd5c74f – Size is 164124 kB
2026-09-02 17:08:23 : DEBUG : firefoxesr_next_intl : DEBUG mode 1, not checking for blocking processes
2026-09-02 17:08:23 : REQ   : firefoxesr_next_intl : Installing Firefox
2026-09-02 17:08:24 : INFO  : firefoxesr_next_intl : Mounting /Users/u0105821/git/github/Installomator/build/Firefox.dmg
2026-09-02 17:08:30 : DEBUG : firefoxesr_next_intl : Debugging enabled, dmgmount output was:
Checksumming Driver Descriptor Map (DDM : 0)…
Driver Descriptor Map (DDM : 0): verified   CRC32 $BE160630
Checksumming Apple (Apple_partition_map : 1)…
Apple (Apple_partition_map : 1): verified   CRC32 $D07DDD76
Checksumming Macintosh (Apple_Driver_ATAPI : 2)…
Macintosh (Apple_Driver_ATAPI : 2): verified   CRC32 $C71C0011
Checksumming Mac_OS_X (Apple_HFSX : 3)…
Mac_OS_X (Apple_HFSX : 3): verified   CRC32 $6BE34F47
Checksumming  (Apple_Free : 4)…
(Apple_Free : 4): verified   CRC32 $00000000
verified   CRC32 $C9EC3B98
/dev/disk11         	Apple_partition_scheme
/dev/disk11s1       	Apple_partition_map
/dev/disk11s2       	Apple_Driver_ATAPI
/dev/disk11s3       	Apple_HFSX                     	/Volumes/Firefox

2026-09-02 17:08:30 : INFO  : firefoxesr_next_intl : Mounted: /Volumes/Firefox
2026-09-02 17:08:30 : INFO  : firefoxesr_next_intl : Verifying: /Volumes/Firefox/Firefox.app
2026-09-02 17:08:30 : DEBUG : firefoxesr_next_intl : App size: 488M	/Volumes/Firefox/Firefox.app
2026-09-02 17:08:39 : DEBUG : firefoxesr_next_intl : Debugging enabled, App Verification output was:
/Volumes/Firefox/Firefox.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Mozilla Corporation (43AQ936H96)

2026-09-02 17:08:39 : INFO  : firefoxesr_next_intl : Team ID matching: 43AQ936H96 (expected: 43AQ936H96 )
2026-09-02 17:08:39 : INFO  : firefoxesr_next_intl : Downloaded version of Firefox is 153.2.0 on versionKey CFBundleShortVersionString (replacing version 155.0).
2026-09-02 17:08:39 : INFO  : firefoxesr_next_intl : App has LSMinimumSystemVersion: 10.15.0
2026-09-02 17:08:39 : DEBUG : firefoxesr_next_intl : DEBUG mode 1 enabled, skipping remove, copy and chown steps
2026-09-02 17:08:39 : INFO  : firefoxesr_next_intl : Finishing...
2026-09-02 17:08:42 : INFO  : firefoxesr_next_intl : name: Firefox, appName: Firefox.app
2026-09-02 17:08:42 : INFO  : firefoxesr_next_intl : App(s) found: /Applications/Web Browsers/Firefox.app
2026-09-02 17:08:42 : INFO  : firefoxesr_next_intl : found app at /Applications/Web Browsers/Firefox.app, version 155.0, on versionKey CFBundleShortVersionString
2026-09-02 17:08:42 : REQ   : firefoxesr_next_intl : Installed Firefox, version 153.2.0
2026-09-02 17:08:42 : INFO  : firefoxesr_next_intl : notifying
2026-09-02 17:08:43 : DEBUG : firefoxesr_next_intl : Unmounting /Volumes/Firefox
2026-09-02 17:08:43 : DEBUG : firefoxesr_next_intl : Debugging enabled, Unmounting output was:
"disk11" ejected.
2026-09-02 17:08:43 : DEBUG : firefoxesr_next_intl : DEBUG mode 1, not reopening anything
2026-09-02 17:08:43 : REQ   : firefoxesr_next_intl : All done!
2026-09-02 17:08:43 : REQ   : firefoxesr_next_intl : ################## End Installomator, exit code 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
