### PR TITLE
Update expectedTeamID for Audacity label

### DIFF
--- a/fragments/labels/audacity.sh
+++ b/fragments/labels/audacity.sh
@@ -5,5 +5,5 @@ audacity)
     downloadURL=$(downloadURLFromGit audacity audacity)
     appNewVersion=$(versionFromGit audacity audacity)
     appCustomVersion(){ defaults read "/Applications/Audacity.app/Contents/Info.plist" CFBundleVersion | cut -d '.' -f 1-3 }
-    expectedTeamID="AWEYX923UX"
+    expectedTeamID="6EPAF2X3PR"
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
Yes
**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
Yes
**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
I think so?
**Additional context** Add any other context about the label or fix here.
Change in Developer ID, see: #3263 
**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
2026-09-03 11:31:47 : INFO  : audacity : Total items in argumentsArray: 0
2026-09-03 11:31:47 : INFO  : audacity : argumentsArray: 
2026-09-03 11:31:47 : REQ   : audacity : ################## Start Installomator v. 10.8, date 2025-03-28
2026-09-03 11:31:47 : INFO  : audacity : ################## Version: 10.8
2026-09-03 11:31:47 : INFO  : audacity : ################## Date: 2025-03-28
2026-09-03 11:31:47 : INFO  : audacity : ################## audacity
2026-09-03 11:31:49 : INFO  : audacity : Reading arguments again: 
2026-09-03 11:31:49 : INFO  : audacity : BLOCKING_PROCESS_ACTION=tell_user
2026-09-03 11:31:49 : INFO  : audacity : NOTIFY=silent
2026-09-03 11:31:49 : INFO  : audacity : LOGGING=INFO
2026-09-03 11:31:49 : INFO  : audacity : LOGO=/Library/Application Support/JAMF/Jamf.app/Contents/Resources/AppIcon.icns
2026-09-03 11:31:49 : INFO  : audacity : Label type: dmg
2026-09-03 11:31:49 : INFO  : audacity : archiveName: audacity-macOS-[0-9.]*-universal.dmg
2026-09-03 11:31:49 : INFO  : audacity : no blocking processes defined, using Audacity as default
2026-09-03 11:31:50.009 defaults[54189:490926] 
The domain/default pair of (/Applications/Audacity.app/Contents/Info.plist, CFBundleVersion) does not exist
2026-09-03 11:31:50 : INFO  : audacity : Custom App Version detection is used, found 
2026-09-03 11:31:50 : INFO  : audacity : appversion: 
2026-09-03 11:31:50 : INFO  : audacity : Latest version of Audacity is 3.7.9
2026-09-03 11:31:50 : REQ   : audacity : Downloading https://github.com/audacity/audacity/releases/download/Audacity-3.7.9/audacity-macOS-3.7.9-universal.dmg to audacity-macOS-[0-9.]*-universal.dmg
2026-09-03 11:31:52 : INFO  : audacity : Downloaded audacity-macOS-[0-9.]*-universal.dmg – Type is  zlib compressed data – SHA is 5ab3cee9366f9a4716c8b66539cbe6807e79f8fb – Size is 82620 kB
2026-09-03 11:31:52 : REQ   : audacity : no more blocking processes, continue with update
2026-09-03 11:31:52 : REQ   : audacity : Installing Audacity
2026-09-03 11:31:52 : INFO  : audacity : Mounting /var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T/tmp.wfgphttnbd/audacity-macOS-[0-9.]*-universal.dmg
2026-09-03 11:31:59 : INFO  : audacity : Mounted: /Volumes/Audacity
2026-09-03 11:31:59 : INFO  : audacity : Verifying: /Volumes/Audacity/Audacity.app
2026-09-03 11:32:08 : INFO  : audacity : Team ID matching: 6EPAF2X3PR (expected: 6EPAF2X3PR )
2026-09-03 11:32:08 : INFO  : audacity : Installing Audacity version 3.7.9.0 on versionKey CFBundleShortVersionString.
2026-09-03 11:32:08 : INFO  : audacity : App has LSMinimumSystemVersion: 10.13
2026-09-03 11:32:08 : INFO  : audacity : Copy /Volumes/Audacity/Audacity.app to /Applications
2026-09-03 11:32:09 : WARN  : audacity : Changing owner to timdejongtest
2026-09-03 11:32:10 : INFO  : audacity : Finishing...
2026-09-03 11:32:13 : INFO  : audacity : Custom App Version detection is used, found 3.7.9
2026-09-03 11:32:13 : REQ   : audacity : Installed Audacity, version 3.7.9.0
2026-09-03 11:32:14 : INFO  : audacity : Installomator did not close any apps, so no need to reopen any apps.
2026-09-03 11:32:14 : REQ   : audacity : All done!
2026-09-03 11:32:14 : REQ   : audacity : ################## End Installomator, exit code 0 
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
Fixes #3263 