### PR TITLE
parsec-label-update

### DIFF
--- a/fragments/labels/parsec.sh
+++ b/fragments/labels/parsec.sh
@@ -2,7 +2,6 @@ parsec)
     name="Parsec"
     type="pkg"
     downloadURL="https://builds.parsec.app/package/parsec-macos.pkg"
-    appNewVersion=$(tmpDir=$(mktemp -d); trap 'rm -rf "$tmpDir"' EXIT; curl -fsL "$downloadURL" -o "$tmpDir/parsec.pkg" && xar -xf "$tmpDir/parsec.pkg" -C "$tmpDir" PackageInfo && sed -nE 's/.*CFBundleShortVersionString="([^"]+)".*/\1/p' "$tmpDir/PackageInfo" | head -1)
     expectedTeamID="Y9MY52XZDB"
     blockingProcesses=( NONE )
     ;;

--- a/fragments/labels/parsec.sh
+++ b/fragments/labels/parsec.sh
@@ -1,7 +1,8 @@
 parsec)
     name="Parsec"
     type="pkg"
-    downloadURL="https://builds.parsecgaming.com/package/parsec-macos.pkg"
-    appNewVersion=$(curl -fsL https://parsec.app/changelog.xml | xmllint -xpath '//*[local-name()="build"]/text()' - | grep -oE '\d+-\d+$' | head -1 | sed -r 's/([0-9]+)-([0-9]+)/\1.\2.0/')
+    downloadURL="https://builds.parsec.app/package/parsec-macos.pkg"
+    appNewVersion=$(tmpDir=$(mktemp -d); trap 'rm -rf "$tmpDir"' EXIT; curl -fsL "$downloadURL" -o "$tmpDir/parsec.pkg" && xar -xf "$tmpDir/parsec.pkg" -C "$tmpDir" PackageInfo && sed -nE 's/.*CFBundleShortVersionString="([^"]+)".*/\1/p' "$tmpDir/PackageInfo" | head -1)
     expectedTeamID="Y9MY52XZDB"
+    blockingProcesses=( NONE )
     ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**

yes

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**

yes

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**

yes

**Additional context** Add any other context about the label or fix here.

The label is better because it removes an unreliable appNewVersion that is parsed from Parsec’s changelog rather than from the actual macOS installer. Current verification shows the changelog/appdata feed reports 150-104a, while the official PKG installs Parsec.app version 150.101.1, so the merged label can produce a version mismatch and trigger incorrect Installomator behavior. It also uses non-portable macOS shell syntax (grep -E '\d' and sed -r). The corrected label keeps only verified values, uses the current vendor package host, preserves the validated Team ID Y9MY52XZDB, and adds blockingProcesses=( NONE ) because the signed PKG already handles stopping Parsec processes in its preinstall script.

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**

```
# Installomator/utils/assemble.sh parsec DEBUG=1
2026-09-03 15:56:32 : INFO  : parsec : setting variable from argument DEBUG=1
2026-09-03 15:56:32 : INFO  : parsec : Total items in argumentsArray: 1
2026-09-03 15:56:32 : INFO  : parsec : argumentsArray: DEBUG=1
2026-09-03 15:56:32 : REQ   : parsec : ################## Start Installomator v. 10.10beta, date 2026-09-03
2026-09-03 15:56:32 : INFO  : parsec : ################## Version: 10.10beta
2026-09-03 15:56:32 : INFO  : parsec : ################## Date: 2026-09-03
2026-09-03 15:56:32 : INFO  : parsec : ################## parsec
2026-09-03 15:56:32 : DEBUG : parsec : DEBUG mode 1 enabled.
2026-09-03 15:56:33 : INFO  : parsec : Reading arguments again: DEBUG=1
2026-09-03 15:56:33 : DEBUG : parsec : argument: DEBUG=1
2026-09-03 15:56:33 : DEBUG : parsec : name=Parsec
2026-09-03 15:56:33 : DEBUG : parsec : appName=
2026-09-03 15:56:33 : DEBUG : parsec : type=pkg
2026-09-03 15:56:33 : DEBUG : parsec : archiveName=
2026-09-03 15:56:33 : DEBUG : parsec : downloadURL=https://builds.parsec.app/package/parsec-macos.pkg
2026-09-03 15:56:33 : DEBUG : parsec : curlOptions=
2026-09-03 15:56:33 : DEBUG : parsec : appNewVersion=150.101.1
2026-09-03 15:56:33 : DEBUG : parsec : appCustomVersion function: Not defined
2026-09-03 15:56:33 : DEBUG : parsec : versionKey=CFBundleShortVersionString
2026-09-03 15:56:33 : DEBUG : parsec : packageID=
2026-09-03 15:56:33 : DEBUG : parsec : pkgName=
2026-09-03 15:56:33 : DEBUG : parsec : choiceChangesXML=
2026-09-03 15:56:33 : DEBUG : parsec : expectedTeamID=Y9MY52XZDB
2026-09-03 15:56:33 : DEBUG : parsec : blockingProcesses=NONE
2026-09-03 15:56:33 : DEBUG : parsec : installerTool=
2026-09-03 15:56:33 : DEBUG : parsec : CLIInstaller=
2026-09-03 15:56:33 : DEBUG : parsec : CLIArguments=
2026-09-03 15:56:33 : DEBUG : parsec : updateTool=
2026-09-03 15:56:33 : DEBUG : parsec : updateToolArguments=
2026-09-03 15:56:33 : DEBUG : parsec : updateToolRunAsCurrentUser=
2026-09-03 15:56:33 : INFO  : parsec : BLOCKING_PROCESS_ACTION=tell_user
2026-09-03 15:56:33 : INFO  : parsec : NOTIFY=success
2026-09-03 15:56:33 : INFO  : parsec : LOGGING=DEBUG
2026-09-03 15:56:33 : INFO  : parsec : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-03 15:56:33 : INFO  : parsec : Label type: pkg
2026-09-03 15:56:33 : INFO  : parsec : archiveName: Parsec.pkg
2026-09-03 15:56:33 : DEBUG : parsec : Changing directory to /Users/u0105821/git/github/Installomator/build
2026-09-03 15:56:33 : INFO  : parsec : name: Parsec, appName: Parsec.app
2026-09-03 15:56:33 : WARN  : parsec : No previous app found
2026-09-03 15:56:33 : WARN  : parsec : could not find Parsec.app
2026-09-03 15:56:33 : INFO  : parsec : appversion: 
2026-09-03 15:56:33 : INFO  : parsec : Latest version of Parsec is 150.101.1
2026-09-03 15:56:33 : REQ   : parsec : Downloading https://builds.parsec.app/package/parsec-macos.pkg to Parsec.pkg
2026-09-03 15:56:33 : DEBUG : parsec : No Dialog connection, just download
2026-09-03 15:56:34 : INFO  : parsec : Downloaded Parsec.pkg – Type is  xar archive compressed TOC – SHA is 63db51215ab98270552df8e926333d4279ddfe75 – Size is 3352 kB
2026-09-03 15:56:34 : REQ   : parsec : Installing Parsec
2026-09-03 15:56:34 : INFO  : parsec : Verifying: Parsec.pkg
2026-09-03 15:56:34 : DEBUG : parsec : File list: -rw-r--r--  1 root  staff   3.3M Sep  3 15:56 Parsec.pkg
2026-09-03 15:56:34 : DEBUG : parsec : File type: Parsec.pkg: xar archive compressed TOC: 4246, SHA-1 checksum
2026-09-03 15:56:34 : DEBUG : parsec : spctlOut is Parsec.pkg: accepted
2026-09-03 15:56:34 : DEBUG : parsec : source=Notarized Developer ID
2026-09-03 15:56:34 : DEBUG : parsec : origin=Developer ID Installer: Parsec Cloud, Inc. (Y9MY52XZDB)
2026-09-03 15:56:34 : INFO  : parsec : Team ID: Y9MY52XZDB (expected: Y9MY52XZDB )
2026-09-03 15:56:34 : DEBUG : parsec : DEBUG enabled, skipping installation
2026-09-03 15:56:34 : INFO  : parsec : Finishing...
2026-09-03 15:56:37 : INFO  : parsec : name: Parsec, appName: Parsec.app
2026-09-03 15:56:37 : WARN  : parsec : No previous app found
2026-09-03 15:56:37 : WARN  : parsec : could not find Parsec.app
2026-09-03 15:56:37 : REQ   : parsec : Installed Parsec, version 150.101.1
2026-09-03 15:56:37 : INFO  : parsec : notifying
2026-09-03 15:56:38 : DEBUG : parsec : DEBUG mode 1, not reopening anything
2026-09-03 15:56:38 : REQ   : parsec : All done!
2026-09-03 15:56:38 : REQ   : parsec : ################## End Installomator, exit code 0
```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
