### PR TITLE
Create ilok.sh

### DIFF
--- a/fragments/labels/ilok.sh
+++ b/fragments/labels/ilok.sh
@@ -1,0 +1,7 @@
+ilok)
+    name="iLok License Manager"
+    type="pkgInDmgInZip"
+    downloadURL="https://installers.ilok.com/iloklicensemanager/LicenseSupportInstallerMac.zip"
+    appNewVersion=$(curl -fs "https://updates.ilok.com/iloklicensemanager/LicenseSupportInstallerMacAppcast.xml" | xpath 'string(//rss/channel/item/enclosure/@sparkle:shortVersionString)' 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    expectedTeamID="TFZ8226T6X"
+    ;;


### PR DESCRIPTION
All questions must be filled out or your Pull Request will be closed for lack of information. The first three questions should be answered `Yes` before submitting the pull request.
---
**Have you confirmed this pull request is not a duplicate?**
YES

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?**
YES

**Did you use [our editorconfig file](https://github.com/Installomator/Installomator/wiki/Contributing-to-Installomator)?**
YES

**Additional context** Add any other context about the label or fix here.
Adds support for iLok License Manager with the new `pkgInDmgInZip` functionality 

**Installomator log** At the bottom of this pull request, provide a log of a label run by running Installomator in Terminal and saving the output. `DEBUG=1` can be enabled but **do not enable [Debug logging level](https://github.com/Installomator/Installomator/wiki/Configuration-and-Variables#logging-level) and please format the log [using a code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)!**


```
./utils/assemble.sh ilok
2026-09-04 07:57:32 : INFO  : ilok : Total items in argumentsArray: 0
2026-09-04 07:57:32 : INFO  : ilok : argumentsArray: 
2026-09-04 07:57:32 : REQ   : ilok : ################## Start Installomator v. 10.10beta, date 2026-09-04
2026-09-04 07:57:32 : INFO  : ilok : ################## Version: 10.10beta
2026-09-04 07:57:32 : INFO  : ilok : ################## Date: 2026-09-04
2026-09-04 07:57:32 : INFO  : ilok : ################## ilok
2026-09-04 07:57:32 : DEBUG : ilok : DEBUG mode 1 enabled.
2026-09-04 07:57:32 : INFO  : ilok : Reading arguments again: 
2026-09-04 07:57:32 : DEBUG : ilok : name=iLok License Manager
2026-09-04 07:57:32 : DEBUG : ilok : appName=
2026-09-04 07:57:32 : DEBUG : ilok : type=pkgInDmgInZip
2026-09-04 07:57:32 : DEBUG : ilok : archiveName=
2026-09-04 07:57:32 : DEBUG : ilok : downloadURL=https://installers.ilok.com/iloklicensemanager/LicenseSupportInstallerMac.zip
2026-09-04 07:57:32 : DEBUG : ilok : curlOptions=
2026-09-04 07:57:32 : DEBUG : ilok : appNewVersion=6.0.1
2026-09-04 07:57:32 : DEBUG : ilok : appCustomVersion function: Not defined
2026-09-04 07:57:32 : DEBUG : ilok : versionKey=CFBundleShortVersionString
2026-09-04 07:57:32 : DEBUG : ilok : packageID=
2026-09-04 07:57:32 : DEBUG : ilok : pkgName=
2026-09-04 07:57:32 : DEBUG : ilok : choiceChangesXML=
2026-09-04 07:57:32 : DEBUG : ilok : expectedTeamID=TFZ8226T6X
2026-09-04 07:57:32 : DEBUG : ilok : blockingProcesses=
2026-09-04 07:57:32 : DEBUG : ilok : installerTool=
2026-09-04 07:57:32 : DEBUG : ilok : CLIInstaller=
2026-09-04 07:57:32 : DEBUG : ilok : CLIArguments=
2026-09-04 07:57:33 : DEBUG : ilok : updateTool=
2026-09-04 07:57:33 : DEBUG : ilok : updateToolArguments=
2026-09-04 07:57:33 : DEBUG : ilok : updateToolRunAsCurrentUser=
2026-09-04 07:57:33 : INFO  : ilok : BLOCKING_PROCESS_ACTION=tell_user
2026-09-04 07:57:33 : INFO  : ilok : NOTIFY=success
2026-09-04 07:57:33 : INFO  : ilok : LOGGING=DEBUG
2026-09-04 07:57:33 : INFO  : ilok : LOGO=/System/Applications/App Store.app/Contents/Resources/AppIcon.icns
2026-09-04 07:57:33 : INFO  : ilok : Label type: pkgInDmgInZip
2026-09-04 07:57:33 : INFO  : ilok : archiveName: iLok License Manager.zip
2026-09-04 07:57:33 : INFO  : ilok : no blocking processes defined, using iLok License Manager as default
2026-09-04 07:57:33 : DEBUG : ilok : Changing directory to /Users/gilburns/GitHub/Installomator/build
2026-09-04 07:57:33 : INFO  : ilok : name: iLok License Manager, appName: iLok License Manager.app
2026-09-04 07:57:33 : WARN  : ilok : No previous app found
2026-09-04 07:57:33 : WARN  : ilok : could not find iLok License Manager.app
2026-09-04 07:57:33 : INFO  : ilok : appversion: 
2026-09-04 07:57:33 : INFO  : ilok : Latest version of iLok License Manager is 6.0.1
2026-09-04 07:57:33 : REQ   : ilok : Downloading https://installers.ilok.com/iloklicensemanager/LicenseSupportInstallerMac.zip to iLok License Manager.zip
2026-09-04 07:57:33 : DEBUG : ilok : No Dialog connection, just download
2026-09-04 07:58:23 : INFO  : ilok : Downloaded iLok License Manager.zip – Type is  Zip archive data, at least v2.0 to extract, compression method=deflate – SHA is 727fa8f07dfd5ba7cd77d84bffafb95afa228c76 – Size is 262744 kB
2026-09-04 07:58:23 : DEBUG : ilok : DEBUG mode 1, not checking for blocking processes
2026-09-04 07:58:23 : REQ   : ilok : Installing iLok License Manager
2026-09-04 07:58:23 : INFO  : ilok : Unzipping iLok License Manager.zip
2026-09-04 07:58:24 : INFO  : ilok : found dmg: /Users/gilburns/GitHub/Installomator/build/LicenseSupportInstallerMac_v6.0.1_f802503d85.dmg
2026-09-04 07:58:24 : INFO  : ilok : Mounting /Users/gilburns/GitHub/Installomator/build/LicenseSupportInstallerMac_v6.0.1_f802503d85.dmg
2026-09-04 07:58:25 : DEBUG : ilok : Debugging enabled, dmgmount output was:
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified   CRC32 $85B083F9
Checksumming GPT Header (Primary GPT Header : 1)…
GPT Header (Primary GPT Header : 1): verified   CRC32 $940A447B
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified   CRC32 $68D4677B
Checksumming  (Apple_Free : 3)…
(Apple_Free : 3): verified   CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
disk image (Apple_HFS : 4): verified   CRC32 $22EDAE28
Checksumming  (Apple_Free : 5)…
(Apple_Free : 5): verified   CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified   CRC32 $68D4677B
Checksumming GPT Header (Backup GPT Header : 7)…
GPT Header (Backup GPT Header : 7): verified   CRC32 $C5D517FF
verified   CRC32 $F6A7CEC7
/dev/disk18         	GUID_partition_scheme
/dev/disk18s1       	Apple_HFS                      	/Volumes/License Support Installer v6.0.1 GM b6847 f802503d

2026-09-04 07:58:25 : INFO  : ilok : Mounted: /Volumes/License Support Installer v6.0.1 GM b6847 f802503d
2026-09-04 07:58:25 : DEBUG : ilok : Found pkg(s):
/Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg
2026-09-04 07:58:25 : INFO  : ilok : found pkg: /Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg
2026-09-04 07:58:25 : INFO  : ilok : Verifying: /Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg
2026-09-04 07:58:25 : DEBUG : ilok : File list: -rw-r--r--@ 1 gilburns  staff   254M Aug 25 13:45 /Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg
2026-09-04 07:58:25 : DEBUG : ilok : File type: /Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg: xar archive compressed TOC: 6622, SHA-1 checksum
2026-09-04 07:58:25 : DEBUG : ilok : spctlOut is /Volumes/License Support Installer v6.0.1 GM b6847 f802503d/License Support.pkg: accepted
2026-09-04 07:58:25 : DEBUG : ilok : source=Notarized Developer ID
2026-09-04 07:58:25 : DEBUG : ilok : origin=Developer ID Installer: PACE Anti-Piracy, Inc. (TFZ8226T6X)
2026-09-04 07:58:25 : INFO  : ilok : Team ID: TFZ8226T6X (expected: TFZ8226T6X )
2026-09-04 07:58:25 : DEBUG : ilok : DEBUG enabled, skipping installation
2026-09-04 07:58:25 : INFO  : ilok : Finishing...
2026-09-04 07:58:28 : INFO  : ilok : name: iLok License Manager, appName: iLok License Manager.app
2026-09-04 07:58:29 : WARN  : ilok : No previous app found
2026-09-04 07:58:29 : WARN  : ilok : could not find iLok License Manager.app
2026-09-04 07:58:29 : REQ   : ilok : Installed iLok License Manager, version 6.0.1
2026-09-04 07:58:29 : INFO  : ilok : notifying
2026-09-04 07:58:29 : DEBUG : ilok : Unmounting /Volumes/License Support Installer v6.0.1 GM b6847 f802503d
2026-09-04 07:58:29 : DEBUG : ilok : Debugging enabled, Unmounting output was:
"disk18" ejected.
2026-09-04 07:58:29 : DEBUG : ilok : DEBUG mode 1, not reopening anything
2026-09-04 07:58:29 : REQ   : ilok : All done!
2026-09-04 07:58:29 : REQ   : ilok : ################## End Installomator, exit code 0 

```

Please identify any issues fixed by your pull request by including the issue number. (Example: "Fixes #XXXX")
