### PR TITLE
fix(1password8): detect version via appCustomVersion so the Safari extension isn't matched

### DIFF
--- a/fragments/labels/1password8.sh
+++ b/fragments/labels/1password8.sh
@@ -5,5 +5,6 @@
     appNewVersion=$(getJSONValue "${onepassDetails}" "version")
     downloadURL="https://cache.agilebits.com/dist/1P/mac8/1Password-${appNewVersion}.pkg"
     expectedTeamID="2BUA8C4S2C"
+    appCustomVersion(){ defaults read "/Applications/1Password.app/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null; }
     blockingProcesses=( "1Password Extension Helper" "1Password 7" "1Password 8" "1Password" "1PasswordNativeMessageHost" "1PasswordSafariAppExtension" )
     ;;


### PR DESCRIPTION
**Have you confirmed this pull request is not a duplicate?** Yes.

**Is this pull request creating or modifying a label in the fragments/labels folder, and not Installomator.sh itself?** Yes — only `fragments/labels/1password8.sh`.

**Did you use our editorconfig file?** Yes.

**Additional context**
On macOS 27 with *1Password for Safari.app* installed, the `1password8` label exits 23 ("App previously installed from App Store, and we respect that") and never installs or updates 1Password.

Root cause (framework, an instance of #2658): `getAppVersion()`'s fallback searches by `$name` ("1Password") via `mdfind`, which word-prefix-matches *1Password for Safari.app*. That bundle carries a Mac App Store receipt, so the exit-23 branch fires against the wrong app. The correct `$appName` query sits commented-out one line below in `functions.sh` — a framework change out of scope for a label PR, noted here for #2658 if a maintainer wants the framework-level cure separately.

Fix (label-level): define `appCustomVersion` to read the real `/Applications/1Password.app`. A defined `appCustomVersion` makes `getAppVersion()` early-return before the disk search, the `mdfind` fallback, and the exit-23 branch — so the Safari bundle is never matched. This uses Installomator's own detection mechanism and matches the majority `appCustomVersion` idiom (74 labels use the same no-space form).

Behavior notes (all inherited from the `appCustomVersion` idiom, shared by ~93 existing labels):
- A Mac-App-Store–installed *1Password.app* would now be replaced by the direct pkg rather than respected (the exit-23 App Store check is no longer reached for this label).
- `IGNORE_APP_STORE_APPS=yes` becomes a no-op for this label (subsumed by the above).
- The notification reads "Installing" rather than "Updating" on an upgrade (`updateDetected` is not set by the early return).

None of these affect whether the correct 1Password installs.

**Installomator log**
`DEBUG=1` run on macOS with the real 1Password.app (v8.12.34) present:
```
2026-09-11 21:47:36 : INFO  : 1password8 : Label type: pkg
2026-09-11 21:47:36 : INFO  : 1password8 : archiveName: 1Password.pkg
2026-09-11 21:47:36 : INFO  : 1password8 : Custom App Version detection is used, found 8.12.34
2026-09-11 21:47:36 : INFO  : 1password8 : appversion: 8.12.34
2026-09-11 21:47:36 : INFO  : 1password8 : Latest version of 1Password is 8.12.36
2026-09-11 21:47:36 : REQ   : 1password8 : Downloading https://cache.agilebits.com/dist/1P/mac8/1Password-8.12.36.pkg to 1Password.pkg
2026-09-11 21:47:41 : INFO  : 1password8 : Downloaded 1Password.pkg – Type is  xar archive compressed TOC – SHA is efe41e7ba6b0185cd546cf587d81e6aec13d0023 – Size is 388784 kB
2026-09-11 21:47:41 : REQ   : 1password8 : Installing 1Password
2026-09-11 21:47:41 : INFO  : 1password8 : Verifying: 1Password.pkg
2026-09-11 21:47:41 : INFO  : 1password8 : Team ID: 2BUA8C4S2C (expected: 2BUA8C4S2C )
2026-09-11 21:47:41 : INFO  : 1password8 : Finishing...
2026-09-11 21:47:44 : INFO  : 1password8 : Custom App Version detection is used, found 8.12.34
2026-09-11 21:47:44 : REQ   : 1password8 : Installed 1Password, version 8.12.36
2026-09-11 21:47:44 : REQ   : 1password8 : All done!
2026-09-11 21:47:44 : REQ   : 1password8 : ################## End Installomator, exit code 0
```
`appCustomVersion` fires, the `mdfind`/`App(s) found:` path is never reached, and there is no exit 23. (DEBUG=1 skips the actual install; the app-present version-detection path is what this exercises.)

Fixes #3284
